### PR TITLE
Flags Refactor - Part 5

### DIFF
--- a/go/cmd/vtcombo/cli/main.go
+++ b/go/cmd/vtcombo/cli/main.go
@@ -108,15 +108,15 @@ func init() {
 	Main.Flags().StringVar(&schemaDir, "schema_dir", schemaDir, "Schema base directory. Should contain one directory per keyspace, with a vschema.json file if necessary.")
 	Main.Flags().BoolVar(&startMysql, "start_mysql", startMysql, "Should vtcombo also start mysql")
 	utils.SetFlagIntVar(Main.Flags(), &mysqlPort, "mysql-port", mysqlPort, "mysql port")
-	Main.Flags().BoolVar(&externalTopoServer, "external_topo_server", externalTopoServer, "Should vtcombo use an external topology server instead of starting its own in-memory topology server. "+
+	utils.SetFlagBoolVar(Main.Flags(), &externalTopoServer, "external-topo-server", externalTopoServer, "Should vtcombo use an external topology server instead of starting its own in-memory topology server. "+
 		"If true, vtcombo will use the flags defined in topo/server.go to open topo server")
 	Main.Flags().StringVar(&plannerName, "planner-version", plannerName, "Sets the default planner to use when the session has not changed it. Valid values are: Gen4, Gen4Greedy, Gen4Left2Right")
 	Main.Flags().StringVar(&vschemaPersistenceDir, "vschema-persistence-dir", vschemaPersistenceDir, "If set, per-keyspace vschema will be persisted in this directory "+
 		"and reloaded into the in-memory topology server across restarts. Bookkeeping is performed using a simple watcher goroutine. "+
 		"This is useful when running vtcombo as an application development container (e.g. vttestserver) where you want to keep the same "+
 		"vschema even if developer's machine reboots. This works in tandem with vttestserver's --persistent_mode flag. Needless to say, "+
-		"this is neither a perfect nor a production solution for vschema persistence. Consider using the --external_topo_server flag if "+
-		"you require a more complete solution. This flag is ignored if --external_topo_server is set.")
+		"this is neither a perfect nor a production solution for vschema persistence. Consider using the --external-topo-server flag if "+
+		"you require a more complete solution. This flag is ignored if --external-topo-server is set.")
 
 	Main.Flags().Var(vttest.TextTopoData(&tpb), "proto_topo", "vttest proto definition of the topology, encoded in compact text format. See vttest.proto for more information.")
 	Main.Flags().Var(vttest.JSONTopoData(&tpb), "json_topo", "vttest proto definition of the topology, encoded in json format. See vttest.proto for more information.")

--- a/go/cmd/vttestserver/cli/main_test.go
+++ b/go/cmd/vttestserver/cli/main_test.go
@@ -307,9 +307,9 @@ func TestMtlsAuth(t *testing.T) {
 		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--grpc-key"), key),
 		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--grpc-cert"), cert),
 		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--grpc-ca"), caCert),
-		fmt.Sprintf("--vtctld_grpc_key=%s", clientKey),
-		fmt.Sprintf("--vtctld_grpc_cert=%s", clientCert),
-		fmt.Sprintf("--vtctld_grpc_ca=%s", caCert),
+		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--vtctld-grpc-key"), clientKey),
+		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--vtctld-grpc-cert"), clientCert),
+		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--vtctld-grpc-ca="), caCert),
 		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--grpc-auth-mtls-allowed-substrings"), "CN=ClientApp"))
 	require.NoError(t, err)
 	defer func() {
@@ -349,9 +349,9 @@ func TestMtlsAuthUnauthorizedFails(t *testing.T) {
 		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--grpc-key"), key),
 		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--grpc-cert"), cert),
 		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--grpc-ca"), caCert),
-		fmt.Sprintf("--vtctld_grpc_key=%s", clientKey),
-		fmt.Sprintf("--vtctld_grpc_cert=%s", clientCert),
-		fmt.Sprintf("--vtctld_grpc_ca=%s", caCert),
+		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--vtctld-grpc-key"), clientKey),
+		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--vtctld-grpc-cert"), clientCert),
+		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--vtctld-grpc-ca"), caCert),
 		fmt.Sprintf("--grpc-auth-mtls-allowed-substrings=%s", "CN=ClientApp"))
 	defer cluster.TearDown()
 

--- a/go/cmd/vttestserver/cli/main_test.go
+++ b/go/cmd/vttestserver/cli/main_test.go
@@ -309,7 +309,7 @@ func TestMtlsAuth(t *testing.T) {
 		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--grpc-ca"), caCert),
 		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--vtctld-grpc-key"), clientKey),
 		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--vtctld-grpc-cert"), clientCert),
-		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--vtctld-grpc-ca="), caCert),
+		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--vtctld-grpc-ca"), caCert),
 		fmt.Sprintf("%s=%s", utils.GetFlagVariantForTests("--grpc-auth-mtls-allowed-substrings"), "CN=ClientApp"))
 	require.NoError(t, err)
 	defer func() {

--- a/go/flags/endtoend/mysqlctl.txt
+++ b/go/flags/endtoend/mysqlctl.txt
@@ -58,8 +58,8 @@ Flags:
       --db-ssl-key string                                           connection ssl key
       --db-ssl-mode SslMode                                         SSL mode to connect with. One of disabled, preferred, required, verify_ca & verify_identity.
       --db-tls-min-version string                                   Configures the minimal TLS version negotiated when SSL is enabled. Defaults to TLSv1.2. Options: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.
-      --dba_idle_timeout duration                                   Idle timeout for dba connections (default 1m0s)
-      --dba_pool_size int                                           Size of the connection pool for dba connections (default 20)
+      --dba-idle-timeout duration                                   Idle timeout for dba connections (default 1m0s)
+      --dba-pool-size int                                           Size of the connection pool for dba connections (default 20)
   -h, --help                                                        help for mysqlctl
       --keep-logs duration                                          keep logs for this long (using ctime) (zero to keep forever)
       --keep-logs-by-mtime duration                                 keep logs for this long (using mtime) (zero to keep forever)

--- a/go/flags/endtoend/mysqlctld.txt
+++ b/go/flags/endtoend/mysqlctld.txt
@@ -59,8 +59,8 @@ Flags:
       --db-ssl-key string                                                connection ssl key
       --db-ssl-mode SslMode                                              SSL mode to connect with. One of disabled, preferred, required, verify_ca & verify_identity.
       --db-tls-min-version string                                        Configures the minimal TLS version negotiated when SSL is enabled. Defaults to TLSv1.2. Options: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.
-      --dba_idle_timeout duration                                        Idle timeout for dba connections (default 1m0s)
-      --dba_pool_size int                                                Size of the connection pool for dba connections (default 20)
+      --dba-idle-timeout duration                                        Idle timeout for dba connections (default 1m0s)
+      --dba-pool-size int                                                Size of the connection pool for dba connections (default 20)
       --grpc-auth-mode string                                            Which auth plugin implementation to use (eg: static)
       --grpc-auth-mtls-allowed-substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc-auth-static-client-creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.

--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -67,7 +67,7 @@ Flags:
       --builtinbackup-incremental-restore-path string               the directory where incremental restore files, namely binlog files, are extracted to. In k8s environments, this should be set to a directory that is shared between the vttablet and mysqld pods. The path should exist. When empty, the default OS temp dir is assumed.
       --builtinbackup-mysqld-timeout duration                       how long to wait for mysqld to shutdown at the start of the backup. (default 10m0s)
       --builtinbackup-progress duration                             how often to send progress updates when backing up large files. (default 5s)
-      --ceph_backup_storage_config string                           Path to JSON config file for ceph backup storage. (default "ceph_backup_config.json")
+      --ceph-backup-storage-config string                           Path to JSON config file for ceph backup storage. (default "ceph_backup_config.json")
       --compression-engine-name string                              compressor engine used for compression. (default "pargzip")
       --compression-level int                                       what level to pass to the compressor. (default 1)
       --concurrency int                                             (init restore parameter) how many concurrent files to restore at once (default 4)

--- a/go/flags/endtoend/vtbench.txt
+++ b/go/flags/endtoend/vtbench.txt
@@ -92,8 +92,8 @@ Flags:
       --v Level                                                     log level for V logs
   -v, --version                                                     print binary version
       --vmodule vModuleFlag                                         comma-separated list of pattern=N settings for file-filtered logging
-      --vtgate_grpc_ca string                                       the server ca to use to validate servers when connecting
-      --vtgate_grpc_cert string                                     the cert to use to connect
-      --vtgate_grpc_crl string                                      the server crl to use to validate server certificates when connecting
-      --vtgate_grpc_key string                                      the key to use to connect
-      --vtgate_grpc_server_name string                              the server name to use to validate server certificate
+      --vtgate-grpc-ca string                                       the server ca to use to validate servers when connecting
+      --vtgate-grpc-cert string                                     the cert to use to connect
+      --vtgate-grpc-crl string                                      the server crl to use to validate server certificates when connecting
+      --vtgate-grpc-key string                                      the key to use to connect
+      --vtgate-grpc-server-name string                              the server name to use to validate server certificate

--- a/go/flags/endtoend/vtclient.txt
+++ b/go/flags/endtoend/vtclient.txt
@@ -65,9 +65,9 @@ Flags:
       --v Level                                                     log level for V logs
   -v, --version                                                     print binary version
       --vmodule vModuleFlag                                         comma-separated list of pattern=N settings for file-filtered logging
-      --vtgate_grpc_ca string                                       the server ca to use to validate servers when connecting
-      --vtgate_grpc_cert string                                     the cert to use to connect
-      --vtgate_grpc_crl string                                      the server crl to use to validate server certificates when connecting
-      --vtgate_grpc_key string                                      the key to use to connect
-      --vtgate_grpc_server_name string                              the server name to use to validate server certificate
+      --vtgate-grpc-ca string                                       the server ca to use to validate servers when connecting
+      --vtgate-grpc-cert string                                     the cert to use to connect
+      --vtgate-grpc-crl string                                      the server crl to use to validate server certificates when connecting
+      --vtgate-grpc-key string                                      the key to use to connect
+      --vtgate-grpc-server-name string                              the server name to use to validate server certificate
       --vtgate_protocol string                                      how to talk to vtgate (default "grpc")

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -97,8 +97,8 @@ Flags:
       --db-ssl-key string                                                connection ssl key
       --db-ssl-mode SslMode                                              SSL mode to connect with. One of disabled, preferred, required, verify_ca & verify_identity.
       --db-tls-min-version string                                        Configures the minimal TLS version negotiated when SSL is enabled. Defaults to TLSv1.2. Options: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.
-      --dba_idle_timeout duration                                        Idle timeout for dba connections (default 1m0s)
-      --dba_pool_size int                                                Size of the connection pool for dba connections (default 20)
+      --dba-idle-timeout duration                                        Idle timeout for dba connections (default 1m0s)
+      --dba-pool-size int                                                Size of the connection pool for dba connections (default 20)
       --dbddl_plugin string                                              controls how to handle CREATE/DROP DATABASE. use it if you are using your own database provisioning service (default "fail")
       --ddl_strategy string                                              Set default strategy for DDL statements. Override with @@ddl_strategy session variable (default "direct")
       --default_tablet_type topodatapb.TabletType                        The default tablet type to set for queries, when one is not explicitly selected. (default PRIMARY)
@@ -131,7 +131,7 @@ Flags:
       --external-compressor string                                       command with arguments to use when compressing a backup.
       --external-compressor-extension string                             extension to use when using an external compressor.
       --external-decompressor string                                     command with arguments to use when decompressing a backup.
-      --external_topo_server                                             Should vtcombo use an external topology server instead of starting its own in-memory topology server. If true, vtcombo will use the flags defined in topo/server.go to open topo server
+      --external-topo-server                                             Should vtcombo use an external topology server instead of starting its own in-memory topology server. If true, vtcombo will use the flags defined in topo/server.go to open topo server
       --foreign_key_mode string                                          This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow, disallow (default "allow")
       --gate_query_cache_memory int                                      gate server query cache size in bytes, maximum amount of memory to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 33554432)
       --gc_check_interval duration                                       Interval between garbage collection checks (default 1h0m0s)
@@ -187,10 +187,10 @@ Flags:
       --lock_heartbeat_time duration                                     If there is lock function used. This will keep the lock connection active by using this heartbeat (default 5s)
       --lock_tables_timeout duration                                     How long to keep the table locked before timing out (default 1m0s)
       --log-err-stacks                                                   log stack traces for errors
+      --log-queries-to-file string                                       Enable query logging to the specified file
       --log-rotate-max-size uint                                         size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --log_backtrace_at traceLocations                                  when logging hits line file:N, emit a stack trace
       --log_dir string                                                   If non-empty, write log files in this directory
-      --log_queries_to_file string                                       Enable query logging to the specified file
       --logtostderr                                                      log to standard error instead of files
       --manifest-external-decompressor string                            command with arguments to store in the backup manifest when compressing a backup with an external compression engine.
       --max-stack-size int                                               configure the maximum stack size in bytes (default 67108864)
@@ -419,18 +419,18 @@ Flags:
       --vreplication_replica_lag_tolerance duration                      Replica lag threshold duration: once lag is below this we switch from copy phase to the replication (streaming) phase (default 1m0s)
       --vreplication_retry_delay duration                                delay before retrying a failed workflow event in the replication phase (default 5s)
       --vreplication_store_compressed_gtid                               Store compressed gtids in the pos column of the sidecar database's vreplication table
-      --vschema-persistence-dir string                                   If set, per-keyspace vschema will be persisted in this directory and reloaded into the in-memory topology server across restarts. Bookkeeping is performed using a simple watcher goroutine. This is useful when running vtcombo as an application development container (e.g. vttestserver) where you want to keep the same vschema even if developer's machine reboots. This works in tandem with vttestserver's --persistent_mode flag. Needless to say, this is neither a perfect nor a production solution for vschema persistence. Consider using the --external_topo_server flag if you require a more complete solution. This flag is ignored if --external_topo_server is set.
+      --vschema-persistence-dir string                                   If set, per-keyspace vschema will be persisted in this directory and reloaded into the in-memory topology server across restarts. Bookkeeping is performed using a simple watcher goroutine. This is useful when running vtcombo as an application development container (e.g. vttestserver) where you want to keep the same vschema even if developer's machine reboots. This works in tandem with vttestserver's --persistent_mode flag. Needless to say, this is neither a perfect nor a production solution for vschema persistence. Consider using the --external-topo-server flag if you require a more complete solution. This flag is ignored if --external-topo-server is set.
       --vschema_ddl_authorized_users string                              List of users authorized to execute vschema ddl operations, or '%' to allow all users.
       --vstream-binlog-rotation-threshold int                            Byte size at which a VStreamer will attempt to rotate the source's open binary log before starting a GTID snapshot based stream (e.g. a ResultStreamer or RowStreamer) (default 67108864)
       --vstream-dynamic-packet-size                                      Enable dynamic packet sizing for vstreamers. This will adjust the packet size in vreplication workflows to improve performance. (default true)
       --vstream-packet-size int                                          Suggested packet size for vstreamers. The actual packet size may be more or less than this amount. (default 250000)
       --vtctld_sanitize_log_messages                                     When true, vtctld sanitizes logging.
       --vtgate-config-terse-errors                                       prevent bind vars from escaping in returned errors
-      --vtgate_grpc_ca string                                            the server ca to use to validate servers when connecting
-      --vtgate_grpc_cert string                                          the cert to use to connect
-      --vtgate_grpc_crl string                                           the server crl to use to validate server certificates when connecting
-      --vtgate_grpc_key string                                           the key to use to connect
-      --vtgate_grpc_server_name string                                   the server name to use to validate server certificate
+      --vtgate-grpc-ca string                                            the server ca to use to validate servers when connecting
+      --vtgate-grpc-cert string                                          the cert to use to connect
+      --vtgate-grpc-crl string                                           the server crl to use to validate server certificates when connecting
+      --vtgate-grpc-key string                                           the key to use to connect
+      --vtgate-grpc-server-name string                                   the server name to use to validate server certificate
       --vttablet_skip_buildinfo_tags string                              comma-separated list of buildinfo tags to skip from merging with --init-tags. each tag is either an exact match or a regular expression of the form '/regexp/'. (default "/.*/")
       --wait_for_backup_interval duration                                (init restore parameter) if this is greater than 0, instead of starting up empty when no backups are found, keep checking at this interval for a backup to appear
       --warming-reads-concurrency int                                    Number of concurrent warming reads allowed (default 500)

--- a/go/flags/endtoend/vtctlclient.txt
+++ b/go/flags/endtoend/vtctlclient.txt
@@ -43,9 +43,9 @@ Usage of vtctlclient:
       --v Level                                                     log level for V logs
   -v, --version                                                     print binary version
       --vmodule vModuleFlag                                         comma-separated list of pattern=N settings for file-filtered logging
-      --vtctl_client_protocol string                                Protocol to use to talk to the vtctl server. (default "grpc")
-      --vtctld_grpc_ca string                                       the server ca to use to validate servers when connecting
-      --vtctld_grpc_cert string                                     the cert to use to connect
-      --vtctld_grpc_crl string                                      the server crl to use to validate server certificates when connecting
-      --vtctld_grpc_key string                                      the key to use to connect
-      --vtctld_grpc_server_name string                              the server name to use to validate server certificate
+      --vtctl-client-protocol string                                Protocol to use to talk to the vtctl server. (default "grpc")
+      --vtctld-grpc-ca string                                       the server ca to use to validate servers when connecting
+      --vtctld-grpc-cert string                                     the cert to use to connect
+      --vtctld-grpc-crl string                                      the server crl to use to validate server certificates when connecting
+      --vtctld-grpc-key string                                      the key to use to connect
+      --vtctld-grpc-server-name string                              the server name to use to validate server certificate

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -42,7 +42,7 @@ Flags:
       --builtinbackup-progress duration                                  how often to send progress updates when backing up large files. (default 5s)
       --catch-sigpipe                                                    catch and ignore SIGPIPE on stdout and stderr if specified
       --cell string                                                      cell to use
-      --ceph_backup_storage_config string                                Path to JSON config file for ceph backup storage. (default "ceph_backup_config.json")
+      --ceph-backup-storage-config string                                Path to JSON config file for ceph backup storage. (default "ceph_backup_config.json")
       --config-file string                                               Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling        Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                               Name of the config file (without extension) to search for. (default "vtconfig")

--- a/go/flags/endtoend/vtctldclient.txt
+++ b/go/flags/endtoend/vtctldclient.txt
@@ -157,11 +157,11 @@ Flags:
   -v, --v Level                                  log level for V logs
       --version                                  version for vtctldclient
       --vmodule vModuleFlag                      comma-separated list of pattern=N settings for file-filtered logging
-      --vtctl_client_protocol string             Protocol to use to talk to the vtctl server. (default "grpc")
-      --vtctld_grpc_ca string                    the server ca to use to validate servers when connecting
-      --vtctld_grpc_cert string                  the cert to use to connect
-      --vtctld_grpc_crl string                   the server crl to use to validate server certificates when connecting
-      --vtctld_grpc_key string                   the key to use to connect
-      --vtctld_grpc_server_name string           the server name to use to validate server certificate
+      --vtctl-client-protocol string             Protocol to use to talk to the vtctl server. (default "grpc")
+      --vtctld-grpc-ca string                    the server ca to use to validate servers when connecting
+      --vtctld-grpc-cert string                  the cert to use to connect
+      --vtctld-grpc-crl string                   the server crl to use to validate server certificates when connecting
+      --vtctld-grpc-key string                   the key to use to connect
+      --vtctld-grpc-server-name string           the server name to use to validate server certificate
 
 Use "vtctldclient [command] --help" for more information about a command.

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -111,10 +111,10 @@ Flags:
       --lock-timeout duration                                            Maximum time to wait when attempting to acquire a lock from the topo server (default 45s)
       --lock_heartbeat_time duration                                     If there is lock function used. This will keep the lock connection active by using this heartbeat (default 5s)
       --log-err-stacks                                                   log stack traces for errors
+      --log-queries-to-file string                                       Enable query logging to the specified file
       --log-rotate-max-size uint                                         size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --log_backtrace_at traceLocations                                  when logging hits line file:N, emit a stack trace
       --log_dir string                                                   If non-empty, write log files in this directory
-      --log_queries_to_file string                                       Enable query logging to the specified file
       --logtostderr                                                      log to standard error instead of files
       --max-stack-size int                                               configure the maximum stack size in bytes (default 67108864)
       --max_memory_rows int                                              Maximum number of rows that will be held in memory for intermediate results as well as the final result. (default 300000)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -75,7 +75,7 @@ Flags:
       --config-file string                                               Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling        Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                               Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                              Paths to search for config files in. (default [/home/mounica/Desktop/vitess/go/flags/endtoend])
+      --config-path strings                                              Paths to search for config files in. (default [{{ .Workdir }}])
       --config-persistence-min-interval duration                         minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                               Config file type (omit to infer config type from file extension).
       --consolidator-query-waiter-cap int                                Configure the maximum number of clients allowed to wait on the consolidator.

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -69,13 +69,13 @@ Flags:
       --builtinbackup-mysqld-timeout duration                            how long to wait for mysqld to shutdown at the start of the backup. (default 10m0s)
       --builtinbackup-progress duration                                  how often to send progress updates when backing up large files. (default 5s)
       --catch-sigpipe                                                    catch and ignore SIGPIPE on stdout and stderr if specified
-      --ceph_backup_storage_config string                                Path to JSON config file for ceph backup storage. (default "ceph_backup_config.json")
+      --ceph-backup-storage-config string                                Path to JSON config file for ceph backup storage. (default "ceph_backup_config.json")
       --compression-engine-name string                                   compressor engine used for compression. (default "pargzip")
       --compression-level int                                            what level to pass to the compressor. (default 1)
       --config-file string                                               Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling        Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                               Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                              Paths to search for config files in. (default [{{ .Workdir }}])
+      --config-path strings                                              Paths to search for config files in. (default [/home/mounica/Desktop/vitess/go/flags/endtoend])
       --config-persistence-min-interval duration                         minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                               Config file type (omit to infer config type from file extension).
       --consolidator-query-waiter-cap int                                Configure the maximum number of clients allowed to wait on the consolidator.
@@ -131,8 +131,8 @@ Flags:
       --db-ssl-key string                                                connection ssl key
       --db-ssl-mode SslMode                                              SSL mode to connect with. One of disabled, preferred, required, verify_ca & verify_identity.
       --db-tls-min-version string                                        Configures the minimal TLS version negotiated when SSL is enabled. Defaults to TLSv1.2. Options: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.
-      --dba_idle_timeout duration                                        Idle timeout for dba connections (default 1m0s)
-      --dba_pool_size int                                                Size of the connection pool for dba connections (default 20)
+      --dba-idle-timeout duration                                        Idle timeout for dba connections (default 1m0s)
+      --dba-pool-size int                                                Size of the connection pool for dba connections (default 20)
       --degraded_threshold duration                                      replication lag after which a replica is considered degraded (default 30s)
       --disk-write-dir string                                            if provided, tablet will attempt to write a file to this directory to check if the disk is stalled
       --disk-write-interval duration                                     how often to write to the disk to check whether it is stalled (default 5s)
@@ -212,11 +212,11 @@ Flags:
       --lock-timeout duration                                            Maximum time to wait when attempting to acquire a lock from the topo server (default 45s)
       --lock_tables_timeout duration                                     How long to keep the table locked before timing out (default 1m0s)
       --log-err-stacks                                                   log stack traces for errors
+      --log-queries-to-file string                                       Enable query logging to the specified file
       --log-rotate-max-size uint                                         size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --log_backtrace_at traceLocations                                  when logging hits line file:N, emit a stack trace
       --log_dir string                                                   If non-empty, write log files in this directory
       --log_queries                                                      Enable query logging to syslog.
-      --log_queries_to_file string                                       Enable query logging to the specified file
       --logtostderr                                                      log to standard error instead of files
       --manifest-external-decompressor string                            command with arguments to store in the backup manifest when compressing a backup with an external compression engine.
       --max-stack-size int                                               configure the maximum stack size in bytes (default 67108864)

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -29,8 +29,8 @@ Flags:
       --config-type string                                               Config file type (omit to infer config type from file extension).
       --consul-auth-static-file string                                   JSON File to read the topos/tokens from.
       --data_dir string                                                  Directory where the data files will be placed, defaults to a random directory under /vt/vtdataroot
-      --dba_idle_timeout duration                                        Idle timeout for dba connections (default 1m0s)
-      --dba_pool_size int                                                Size of the connection pool for dba connections (default 20)
+      --dba-idle-timeout duration                                        Idle timeout for dba connections (default 1m0s)
+      --dba-pool-size int                                                Size of the connection pool for dba connections (default 20)
       --default_schema_dir string                                        Default directory for initial schema files. If no schema is found in schema_dir, default to this location.
       --enable_direct_ddl                                                Allow users to submit direct DDL statements (default true)
       --enable_online_ddl                                                Allow users to submit, review and control Online DDL (default true)
@@ -153,17 +153,17 @@ Flags:
       --vmodule vModuleFlag                                              comma-separated list of pattern=N settings for file-filtered logging
       --vschema_ddl_authorized_users string                              Comma separated list of users authorized to execute vschema ddl operations via vtgate
       --vtcombo-bind-host string                                         which host to bind vtcombo servenv listener to (default "localhost")
-      --vtctl_client_protocol string                                     Protocol to use to talk to the vtctl server. (default "grpc")
-      --vtctld_grpc_ca string                                            the server ca to use to validate servers when connecting
-      --vtctld_grpc_cert string                                          the cert to use to connect
-      --vtctld_grpc_crl string                                           the server crl to use to validate server certificates when connecting
-      --vtctld_grpc_key string                                           the key to use to connect
-      --vtctld_grpc_server_name string                                   the server name to use to validate server certificate
-      --vtgate_grpc_ca string                                            the server ca to use to validate servers when connecting
-      --vtgate_grpc_cert string                                          the cert to use to connect
-      --vtgate_grpc_crl string                                           the server crl to use to validate server certificates when connecting
-      --vtgate_grpc_key string                                           the key to use to connect
-      --vtgate_grpc_server_name string                                   the server name to use to validate server certificate
+      --vtctl-client-protocol string                                     Protocol to use to talk to the vtctl server. (default "grpc")
+      --vtctld-grpc-ca string                                            the server ca to use to validate servers when connecting
+      --vtctld-grpc-cert string                                          the cert to use to connect
+      --vtctld-grpc-crl string                                           the server crl to use to validate server certificates when connecting
+      --vtctld-grpc-key string                                           the key to use to connect
+      --vtctld-grpc-server-name string                                   the server name to use to validate server certificate
+      --vtgate-grpc-ca string                                            the server ca to use to validate servers when connecting
+      --vtgate-grpc-cert string                                          the cert to use to connect
+      --vtgate-grpc-crl string                                           the server crl to use to validate server certificates when connecting
+      --vtgate-grpc-key string                                           the key to use to connect
+      --vtgate-grpc-server-name string                                   the server name to use to validate server certificate
       --xbstream_restore_flags string                                    Flags to pass to xbstream command during restore. These should be space separated and will be added to the end of the command. These need to match the ones used for backup e.g. --compress / --decompress, --encrypt / --decrypt
       --xtrabackup-backup-flags string                                   Flags to pass to backup command. These should be space separated and will be added to the end of the command
       --xtrabackup-prepare-flags string                                  Flags to pass to prepare command. These should be space separated and will be added to the end of the command

--- a/go/test/endtoend/cluster/vtgate_process.go
+++ b/go/test/endtoend/cluster/vtgate_process.go
@@ -154,7 +154,7 @@ func (vtgate *VtgateProcess) Setup() (err error) {
 		"--topo_global_root", vtgate.TopoGlobalRoot,
 		"--config-file", vtgate.ConfigFile,
 		"--log_dir", vtgate.LogDir,
-		"--log_queries_to_file", vtgate.FileToLogQueries,
+		"--log-queries-to-file", vtgate.FileToLogQueries,
 		"--port", fmt.Sprintf("%d", vtgate.Port),
 		"--grpc_port", fmt.Sprintf("%d", vtgate.GrpcPort),
 		"--mysql_server_port", fmt.Sprintf("%d", vtgate.MySQLServerPort),

--- a/go/test/endtoend/cluster/vtgate_process.go
+++ b/go/test/endtoend/cluster/vtgate_process.go
@@ -154,7 +154,7 @@ func (vtgate *VtgateProcess) Setup() (err error) {
 		"--topo_global_root", vtgate.TopoGlobalRoot,
 		"--config-file", vtgate.ConfigFile,
 		"--log_dir", vtgate.LogDir,
-		"--log-queries-to-file", vtgate.FileToLogQueries,
+		"--log_queries_to_file", vtgate.FileToLogQueries,
 		"--port", fmt.Sprintf("%d", vtgate.Port),
 		"--grpc_port", fmt.Sprintf("%d", vtgate.GrpcPort),
 		"--mysql_server_port", fmt.Sprintf("%d", vtgate.MySQLServerPort),

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -98,7 +98,7 @@ func (vttablet *VttabletProcess) Setup() (err error) {
 		"--topo_implementation", vttablet.TopoImplementation,
 		"--topo_global_server_address", vttablet.TopoGlobalAddress,
 		"--topo_global_root", vttablet.TopoGlobalRoot,
-		"--log_queries_to_file", vttablet.FileToLogQueries,
+		"--log-queries-to-file", vttablet.FileToLogQueries,
 		"--tablet-path", vttablet.TabletPath,
 		"--port", fmt.Sprintf("%d", vttablet.Port),
 		"--grpc_port", fmt.Sprintf("%d", vttablet.GrpcPort),

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -98,7 +98,7 @@ func (vttablet *VttabletProcess) Setup() (err error) {
 		"--topo_implementation", vttablet.TopoImplementation,
 		"--topo_global_server_address", vttablet.TopoGlobalAddress,
 		"--topo_global_root", vttablet.TopoGlobalRoot,
-		"--log-queries-to-file", vttablet.FileToLogQueries,
+		"--log_queries_to_file", vttablet.FileToLogQueries,
 		"--tablet-path", vttablet.TabletPath,
 		"--port", fmt.Sprintf("%d", vttablet.Port),
 		"--grpc_port", fmt.Sprintf("%d", vttablet.GrpcPort),

--- a/go/vt/mysqlctl/cephbackupstorage/ceph.go
+++ b/go/vt/mysqlctl/cephbackupstorage/ceph.go
@@ -33,6 +33,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/vt/mysqlctl/backupstorage"
+	"vitess.io/vitess/go/vt/utils"
 
 	"vitess.io/vitess/go/vt/log"
 	errorsbackup "vitess.io/vitess/go/vt/mysqlctl/errors"
@@ -45,7 +46,7 @@ var (
 )
 
 func registerFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&configFilePath, "ceph_backup_storage_config", "ceph_backup_config.json",
+	utils.SetFlagStringVar(fs, &configFilePath, "ceph-backup-storage-config", "ceph_backup_config.json",
 		"Path to JSON config file for ceph backup storage.")
 }
 

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -159,8 +159,8 @@ func registerDeprecatedReparentFlags(fs *pflag.FlagSet) {
 }
 
 func registerPoolFlags(fs *pflag.FlagSet) {
-	fs.IntVar(&dbaPoolSize, "dba_pool_size", dbaPoolSize, "Size of the connection pool for dba connections")
-	fs.DurationVar(&DbaIdleTimeout, "dba_idle_timeout", DbaIdleTimeout, "Idle timeout for dba connections")
+	utils.SetFlagIntVar(fs, &dbaPoolSize, "dba-pool-size", dbaPoolSize, "Size of the connection pool for dba connections")
+	utils.SetFlagDurationVar(fs, &DbaIdleTimeout, "dba-idle-timeout", DbaIdleTimeout, "Idle timeout for dba connections")
 	fs.DurationVar(&appIdleTimeout, "app_idle_timeout", appIdleTimeout, "Idle timeout for app connections")
 	fs.IntVar(&appPoolSize, "app_pool_size", appPoolSize, "Size of the connection pool for app connections")
 }

--- a/go/vt/vtctl/grpcclientcommon/dial_option.go
+++ b/go/vt/vtctl/grpcclientcommon/dial_option.go
@@ -24,6 +24,7 @@ import (
 
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/utils"
 )
 
 var cert, key, ca, crl, name string
@@ -36,11 +37,11 @@ func init() {
 }
 
 func RegisterFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&cert, "vtctld_grpc_cert", cert, "the cert to use to connect")
-	fs.StringVar(&key, "vtctld_grpc_key", key, "the key to use to connect")
-	fs.StringVar(&ca, "vtctld_grpc_ca", ca, "the server ca to use to validate servers when connecting")
-	fs.StringVar(&crl, "vtctld_grpc_crl", crl, "the server crl to use to validate server certificates when connecting")
-	fs.StringVar(&name, "vtctld_grpc_server_name", name, "the server name to use to validate server certificate")
+	utils.SetFlagStringVar(fs, &cert, "vtctld-grpc-cert", cert, "the cert to use to connect")
+	utils.SetFlagStringVar(fs, &key, "vtctld-grpc-key", key, "the key to use to connect")
+	utils.SetFlagStringVar(fs, &ca, "vtctld-grpc-ca", ca, "the server ca to use to validate servers when connecting")
+	utils.SetFlagStringVar(fs, &crl, "vtctld-grpc-crl", crl, "the server crl to use to validate server certificates when connecting")
+	utils.SetFlagStringVar(fs, &name, "vtctld-grpc-server-name", name, "the server name to use to validate server certificate")
 }
 
 // SecureDialOption returns a grpc.DialOption configured to use TLS (or

--- a/go/vt/vtctl/vtctlclient/interface.go
+++ b/go/vt/vtctl/vtctlclient/interface.go
@@ -27,13 +27,14 @@ import (
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/utils"
 )
 
 // vtctlClientProtocol specifics which RPC client implementation should be used.
 var vtctlClientProtocol = "grpc"
 
 func RegisterFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&vtctlClientProtocol, "vtctl_client_protocol", vtctlClientProtocol, "Protocol to use to talk to the vtctl server.")
+	utils.SetFlagStringVar(fs, &vtctlClientProtocol, "vtctl-client-protocol", vtctlClientProtocol, "Protocol to use to talk to the vtctl server.")
 }
 
 func init() {

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/utils"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
 
@@ -60,11 +61,11 @@ func init() {
 }
 
 func registerFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&cert, "vtgate_grpc_cert", "", "the cert to use to connect")
-	fs.StringVar(&key, "vtgate_grpc_key", "", "the key to use to connect")
-	fs.StringVar(&ca, "vtgate_grpc_ca", "", "the server ca to use to validate servers when connecting")
-	fs.StringVar(&crl, "vtgate_grpc_crl", "", "the server crl to use to validate server certificates when connecting")
-	fs.StringVar(&name, "vtgate_grpc_server_name", "", "the server name to use to validate server certificate")
+	utils.SetFlagStringVar(fs, &cert, "vtgate-grpc-cert", "", "the cert to use to connect")
+	utils.SetFlagStringVar(fs, &key, "vtgate-grpc-key", "", "the key to use to connect")
+	utils.SetFlagStringVar(fs, &ca, "vtgate-grpc-ca", "", "the server ca to use to validate servers when connecting")
+	utils.SetFlagStringVar(fs, &crl, "vtgate-grpc-crl", "", "the server crl to use to validate server certificates when connecting")
+	utils.SetFlagStringVar(fs, &name, "vtgate-grpc-server-name", "", "the server name to use to validate server certificate")
 }
 
 type vtgateConn struct {

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -51,6 +51,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/utils"
 	"vitess.io/vitess/go/vt/vtenv"
 	"vitess.io/vitess/go/vt/vterrors"
 	econtext "vitess.io/vitess/go/vt/vtgate/executorcontext"
@@ -192,7 +193,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.Bool("enable_direct_ddl", enableDirectDDL.Default(), "Allow users to submit direct DDL statements")
 	fs.BoolVar(&enableSchemaChangeSignal, "schema_change_signal", enableSchemaChangeSignal, "Enable the schema tracker; requires queryserver-config-schema-change-signal to be enabled on the underlying vttablets for this to work")
 	fs.IntVar(&queryTimeout, "query-timeout", queryTimeout, "Sets the default query timeout (in ms). Can be overridden by session variable (query_timeout) or comment directive (QUERY_TIMEOUT_MS)")
-	fs.StringVar(&queryLogToFile, "log_queries_to_file", queryLogToFile, "Enable query logging to the specified file")
+	utils.SetFlagStringVar(fs, &queryLogToFile, "log-queries-to-file", queryLogToFile, "Enable query logging to the specified file")
 	fs.IntVar(&queryLogBufferSize, "querylog-buffer-size", queryLogBufferSize, "Maximum number of buffered query logs before throttling log output")
 	fs.DurationVar(&messageStreamGracePeriod, "message_stream_grace_period", messageStreamGracePeriod, "the amount of time to give for a vttablet to resume if it ends a message stream, usually because of a reparent.")
 	fs.BoolVar(&enableViews, "enable-views", enableViews, "Enable views support in vtgate.")

--- a/go/vt/vttablet/filelogger/filelogger.go
+++ b/go/vt/vttablet/filelogger/filelogger.go
@@ -23,6 +23,7 @@ import (
 	"vitess.io/vitess/go/streamlog"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/utils"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
@@ -30,7 +31,7 @@ var logQueriesToFile string
 
 func registerFlags(fs *pflag.FlagSet) {
 	// logQueriesToFile is the vttablet startup flag that must be set for this plugin to be active.
-	fs.StringVar(&logQueriesToFile, "log_queries_to_file", logQueriesToFile, "Enable query logging to the specified file")
+	utils.SetFlagStringVar(fs, &logQueriesToFile, "log-queries-to-file", logQueriesToFile, "Enable query logging to the specified file")
 }
 
 func init() {

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -312,7 +312,7 @@ func VtcomboProcess(environment Environment, args *Config, mysql MySQLManager) (
 
 	if args.ExternalTopoImplementation != "" {
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{
-			"--external_topo_server",
+			"--external-topo-server",
 			"--topo-implementation", args.ExternalTopoImplementation,
 			"--topo-global-server-address", args.ExternalTopoGlobalServerAddress,
 			"--topo-global-root", args.ExternalTopoGlobalRoot,

--- a/go/vt/wrangler/testlib/vtctl_pipe.go
+++ b/go/vt/wrangler/testlib/vtctl_pipe.go
@@ -61,10 +61,10 @@ func NewVtctlPipe(ctx context.Context, t *testing.T, ts *topo.Server) *VtctlPipe
 		vtctlclient.RegisterFlags(fs)
 
 		err := fs.Parse([]string{
-			"--vtctl_client_protocol",
+			"--vtctl-client-protocol",
 			"grpc",
 		})
-		require.NoError(t, err, "failed to set `--vtctl_client_protocol=%s`", "grpc")
+		require.NoError(t, err, "failed to set `--vtctl-client-protocol=%s`", "grpc")
 
 		servenv.FireRunHooks()
 	})


### PR DESCRIPTION
## Description
This PR is a part of an ongoing change to support the transition from underscores (`_`) to dashes (`-`) in flag naming conventions. 

**Flags Updated in This PR:**
--dba-pool-size  
--dba-idle-timeout  
--vtgate-grpc-server-name  
--vtgate-grpc-key  
--vtgate-grpc-crl  
--vtgate-grpc-cert  
--vtgate-grpc-ca  
--vtctld-grpc-server-name  
--vtctld-grpc-key  
--vtctld-grpc-crl  
--vtctld-grpc-cert  
--vtctld-grpc-ca  
--vtctl-client-protocol  
--log-queries-to-file  
--external-topo-server  
--ceph-backup-storage-config  


### Flag Count Before vs After:

|   | Flags with `_` | Flags with `-` |  
|---|--------------|--------------|  
| **Before** | 465 | 1615 |  
| **After** | 410 |  1670|  

**# of migrated flags: 55**

## Related Issue(s)
#17880

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required
