### PR TITLE
Flags Refactor - Part 6

### DIFF
--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -138,7 +138,7 @@ services:
     - -c
     - ' /vt/bin/vtctld --topo-implementation consul --topo-global-server-address consul1:8500
       --topo-global-root vitess/global --cell test
-      --service-map ''grpc-vtctl,grpc-vtctld'' --backup-storage-implementation file --file_backup_storage_root
+      --service-map ''grpc-vtctl,grpc-vtctld'' --backup-storage-implementation file --file-backup-storage-root
       /vt/vtdataroot/backups --logtostderr=true --port 8080 --grpc-port 15999 '
     depends_on:
       external_db_host:

--- a/examples/compose/vtcompose/docker-compose.test.yml
+++ b/examples/compose/vtcompose/docker-compose.test.yml
@@ -154,7 +154,7 @@ services:
       - ' /vt/bin/vtctld --topo-implementation consul --topo-global-server-address consul1:8500
         --topo-global-root vitess/global --cell test
         --service-map ''grpc-vtctl,grpc-vtctld'' --backup-storage-implementation file
-        --file_backup_storage_root /vt/vtdataroot/backups --logtostderr=true --port
+        --file-backup-storage-root /vt/vtdataroot/backups --logtostderr=true --port
         8080 --grpc-port 15999 '
     depends_on:
       external_db_host:

--- a/examples/compose/vtcompose/vtcompose.go
+++ b/examples/compose/vtcompose/vtcompose.go
@@ -634,7 +634,7 @@ func generateVtctld(opts vtOptions) string {
         --cell %[4]s \
         --service-map 'grpc-vtctl,grpc-vtctld' \
         --backup-storage-implementation file \
-        --file_backup_storage_root /vt/vtdataroot/backups \
+        --file-backup-storage-root /vt/vtdataroot/backups \
         --logtostderr=true \
         --port %[1]d \
         --grpc-port %[2]d \

--- a/go/cmd/vtctlclient/main.go
+++ b/go/cmd/vtctlclient/main.go
@@ -32,6 +32,7 @@ import (
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/utils"
 	"vitess.io/vitess/go/vt/vtctl/vtctlclient"
 
 	logutilpb "vitess.io/vitess/go/vt/proto/logutil"
@@ -47,7 +48,7 @@ var (
 
 func init() {
 	servenv.OnParse(func(fs *pflag.FlagSet) {
-		fs.DurationVar(&actionTimeout, "action_timeout", actionTimeout, "timeout for the total command")
+		utils.SetFlagDurationVar(fs, &actionTimeout, "action-timeout", actionTimeout, "timeout for the total command")
 		fs.StringVar(&server, "server", server, "server to use for connection")
 
 		acl.RegisterFlags(fs)

--- a/go/cmd/vtctld/cli/cli.go
+++ b/go/cmd/vtctld/cli/cli.go
@@ -45,7 +45,7 @@ This is demonstrated in the example usage below.`,
 	--topo-global-root /vitess/ \
 	--service-map 'grpc-vtctl,grpc-vtctld' \
 	--backup-storage-implementation file \
-	--file_backup_storage_root $VTDATAROOT/backups \
+	--file-backup-storage-root $VTDATAROOT/backups \
 	--port 15000 \
 	--grpc-port 15999`,
 		Args:    cobra.NoArgs,

--- a/go/cmd/vtctldclient/command/root.go
+++ b/go/cmd/vtctldclient/command/root.go
@@ -32,6 +32,7 @@ import (
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/utils"
 	"vitess.io/vitess/go/vt/vtctl/grpcvtctldserver"
 	"vitess.io/vitess/go/vt/vtctl/localvtctldclient"
 	"vitess.io/vitess/go/vt/vtctl/vtctldclient"
@@ -223,7 +224,7 @@ func getClientForCommand(cmd *cobra.Command) (vtctldclient.VtctldClient, error) 
 
 func init() {
 	Root.PersistentFlags().StringVar(&server, "server", "", "server to use for the connection (required)")
-	Root.PersistentFlags().DurationVar(&actionTimeout, "action_timeout", time.Hour, "timeout to use for the command")
+	utils.SetFlagDurationVar(Root.PersistentFlags(), &actionTimeout, "action-timeout", time.Hour, "timeout to use for the command")
 	Root.PersistentFlags().BoolVar(&compactOutput, "compact", false, "use compact format for otherwise verbose outputs")
 	Root.PersistentFlags().StringVar(&topoOptions.implementation, "topo-implementation", topoOptions.implementation, "the topology implementation to use")
 	Root.PersistentFlags().StringSliceVar(&topoOptions.globalServerAddresses, "topo-global-server-address", topoOptions.globalServerAddresses, "the address of the global topology server(s)")

--- a/go/cmd/vtctldclient/command/vreplication/common/cancel.go
+++ b/go/cmd/vtctldclient/command/vreplication/common/cancel.go
@@ -70,7 +70,7 @@ func commandCancel(cmd *cobra.Command, args []string) error {
 	resp, err := GetClient().WorkflowDelete(GetCommandCtx(), req)
 	if err != nil {
 		if grpcerr, ok := status.FromError(err); ok && (grpcerr.Code() == codes.DeadlineExceeded) {
-			return fmt.Errorf("Cancel action timed out. Please try again and the work will pick back up where it left off. Note that you can control the timeout using the --action_timeout flag and the delete batch size with --delete-batch-size.")
+			return fmt.Errorf("Cancel action timed out. Please try again and the work will pick back up where it left off. Note that you can control the timeout using the --action-timeout flag and the delete batch size with --delete-batch-size.")
 		}
 		return err
 	}

--- a/go/cmd/vttestserver/cli/main.go
+++ b/go/cmd/vttestserver/cli/main.go
@@ -204,9 +204,9 @@ func New() (cmd *cobra.Command) {
 	cmd.Flags().StringVar(&config.SnapshotFile, "snapshot_file", "",
 		"A MySQL DB snapshot file")
 
-	utils.SetFlagBoolVar(cmd.Flags(), &config.EnableSystemSettings, "enable-system-settings", true, "This will enable the system settings to be changed per session at the database connection level")
+	utils.SetFlagBoolVar(cmd.Flags(), &config.EnableSystemSettingsFlag, "enable-system-settings", true, "This will enable the system settings to be changed per session at the database connection level")
 
-	utils.SetFlagStringVar(cmd.Flags(), &config.TransactionMode, "transaction-mode", "MULTI", "Transaction mode MULTI (default), SINGLE or TWOPC ")
+	utils.SetFlagStringVar(cmd.Flags(), &config.TransactionModeFlag, "transaction-mode", "MULTI", "Transaction mode MULTI (default), SINGLE or TWOPC ")
 	cmd.Flags().DurationVar(&config.TransactionTimeout, "queryserver-config-transaction-timeout", 30*time.Second, "query server transaction timeout, a transaction will be killed if it takes longer than this value")
 
 	utils.SetFlagStringVar(cmd.Flags(), &config.TabletHostName, "tablet-hostname", "localhost", "The hostname to use for the tablet otherwise it will be derived from OS' hostname")

--- a/go/cmd/vttestserver/cli/main.go
+++ b/go/cmd/vttestserver/cli/main.go
@@ -204,18 +204,18 @@ func New() (cmd *cobra.Command) {
 	cmd.Flags().StringVar(&config.SnapshotFile, "snapshot_file", "",
 		"A MySQL DB snapshot file")
 
-	cmd.Flags().BoolVar(&config.EnableSystemSettings, "enable_system_settings", true, "This will enable the system settings to be changed per session at the database connection level")
+	utils.SetFlagBoolVar(cmd.Flags(), &config.EnableSystemSettings, "enable-system-settings", true, "This will enable the system settings to be changed per session at the database connection level")
 
-	cmd.Flags().StringVar(&config.TransactionMode, "transaction_mode", "MULTI", "Transaction mode MULTI (default), SINGLE or TWOPC ")
+	utils.SetFlagStringVar(cmd.Flags(), &config.TransactionMode, "transaction-mode", "MULTI", "Transaction mode MULTI (default), SINGLE or TWOPC ")
 	cmd.Flags().DurationVar(&config.TransactionTimeout, "queryserver-config-transaction-timeout", 30*time.Second, "query server transaction timeout, a transaction will be killed if it takes longer than this value")
 
 	utils.SetFlagStringVar(cmd.Flags(), &config.TabletHostName, "tablet-hostname", "localhost", "The hostname to use for the tablet otherwise it will be derived from OS' hostname")
 
-	cmd.Flags().StringVar(&config.VSchemaDDLAuthorizedUsers, "vschema_ddl_authorized_users", "", "Comma separated list of users authorized to execute vschema ddl operations via vtgate")
+	utils.SetFlagStringVar(cmd.Flags(), &config.VSchemaDDLAuthorizedUsers, "vschema-ddl-authorized-users", "", "Comma separated list of users authorized to execute vschema ddl operations via vtgate")
 
 	cmd.Flags().StringVar(&config.ForeignKeyMode, "foreign_key_mode", "allow", "This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow, disallow")
-	cmd.Flags().BoolVar(&config.EnableOnlineDDL, "enable_online_ddl", true, "Allow users to submit, review and control Online DDL")
-	cmd.Flags().BoolVar(&config.EnableDirectDDL, "enable_direct_ddl", true, "Allow users to submit direct DDL statements")
+	utils.SetFlagBoolVar(cmd.Flags(), &config.EnableOnlineDDL, "enable-online-ddl", true, "Allow users to submit, review and control Online DDL")
+	utils.SetFlagBoolVar(cmd.Flags(), &config.EnableDirectDDL, "enable-direct-ddl", true, "Allow users to submit direct DDL statements")
 
 	// flags for using an actual topo implementation for vtcombo instead of in-memory topo. useful for test setup where an external topo server is shared across multiple vtcombo processes or other components
 	cmd.Flags().StringVar(&config.ExternalTopoImplementation, "external_topo_implementation", "", "the topology implementation to use for vtcombo process")

--- a/go/cmd/vttestserver/cli/main_test.go
+++ b/go/cmd/vttestserver/cli/main_test.go
@@ -137,7 +137,7 @@ func TestForeignKeysAndDDLModes(t *testing.T) {
 	conf := config
 	defer resetConfig(conf)
 
-	cluster, err := startCluster("--foreign_key_mode=allow", "--enable_online_ddl=true", "--enable_direct_ddl=true")
+	cluster, err := startCluster("--foreign_key_mode=allow", "--enable-online-ddl=true", "--enable-direct-ddl=true")
 	require.NoError(t, err)
 	defer cluster.TearDown()
 
@@ -163,7 +163,7 @@ func TestForeignKeysAndDDLModes(t *testing.T) {
 	assert.NoError(t, err)
 
 	cluster.TearDown()
-	cluster, err = startCluster("--foreign_key_mode=disallow", "--enable_online_ddl=false", "--enable_direct_ddl=false")
+	cluster, err = startCluster("--foreign_key_mode=disallow", "--enable-online-ddl=false", "--enable-direct-ddl=false")
 	require.NoError(t, err)
 	defer cluster.TearDown()
 
@@ -380,7 +380,7 @@ func startCluster(flags ...string) (cluster vttest.LocalCluster, err error) {
 	tabletHostname := fmt.Sprintf("%s=localhost", utils.GetFlagVariantForTests("--tablet-hostname"))
 	keyspaceArg := "--keyspaces=" + strings.Join(clusterKeyspaces, ",")
 	numShardsArg := "--num_shards=2,2"
-	vschemaDDLAuthorizedUsers := "--vschema_ddl_authorized_users=%"
+	vschemaDDLAuthorizedUsers := utils.GetFlagVariantForTests("--vschema-ddl-authorized-users") + "=%"
 	alsoLogToStderr := "--alsologtostderr" // better debugging
 	args = append(args, []string{schemaDirArg, keyspaceArg, numShardsArg, tabletHostname, vschemaDDLAuthorizedUsers, alsoLogToStderr}...)
 	args = append(args, flags...)

--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -131,7 +131,7 @@ Flags:
       --external-compressor string                                  command with arguments to use when compressing a backup.
       --external-compressor-extension string                        extension to use when using an external compressor.
       --external-decompressor string                                command with arguments to use when decompressing a backup.
-      --file_backup_storage_root string                             Root directory for the file backup storage.
+      --file-backup-storage-root string                             Root directory for the file backup storage.
       --gcs-backup-storage-bucket string                            Google Cloud Storage bucket to use for backups.
       --gcs-backup-storage-root string                              Root prefix for all backup-related object names.
       --grpc-auth-static-client-creds string                        When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -107,23 +107,23 @@ Flags:
       --disk-write-interval duration                                     how often to write to the disk to check whether it is stalled (default 5s)
       --disk-write-timeout duration                                      if writes exceed this duration, the disk is considered stalled (default 30s)
       --emit-stats                                                       If set, emit stats to push-based monitoring and stats backends
+      --enable-buffer                                                    Enable buffering (stalling) of primary traffic during failovers.
       --enable-consolidator                                              Synonym to -enable_consolidator (default true)
       --enable-consolidator-replicas                                     Synonym to -enable_consolidator_replicas
+      --enable-direct-ddl                                                Allow users to submit direct DDL statements (default true)
+      --enable-online-ddl                                                Allow users to submit, review and control Online DDL (default true)
       --enable-partial-keyspace-migration                                (Experimental) Follow shard routing rules: enable only while migrating a keyspace shard by shard. See documentation on Partial MoveTables for more. (default false)
       --enable-per-workload-table-metrics                                If true, query counts and query error metrics include a label that identifies the workload
+      --enable-system-settings                                           This will enable the system settings to be changed per session at the database connection level (default true)
       --enable-tx-throttler                                              Synonym to -enable_tx_throttler
       --enable-views                                                     Enable views support in vtgate. (default true)
-      --enable-buffer                                                    Enable buffering (stalling) of primary traffic during failovers.
       --enable_buffer_dry_run                                            Detect and log failover events, but do not actually buffer requests.
       --enable_consolidator                                              This option enables the query consolidator. (default true)
       --enable_consolidator_replicas                                     This option enables the query consolidator only on replicas.
-      --enable-direct-ddl                                                Allow users to submit direct DDL statements (default true)
       --enable_hot_row_protection                                        If true, incoming transactions for the same row (range) will be queued and cannot consume all txpool slots.
       --enable_hot_row_protection_dry_run                                If true, hot row protection is not enforced but logs if transactions would have been queued.
-      --enable-online-ddl                                                Allow users to submit, review and control Online DDL (default true)
       --enable_replication_reporter                                      Use polling to track replication lag.
       --enable_set_var                                                   This will enable the use of MySQL's SET_VAR query hint for certain system variables instead of using reserved connections (default true)
-      --enable-system-settings                                           This will enable the system settings to be changed per session at the database connection level (default true)
       --enable_transaction_limit                                         If true, limit on number of transactions open at the same time will be enforced for all users. User trying to open a new transaction after exhausting their limit will receive an error immediately, regardless of whether there are available slots or not.
       --enable_transaction_limit_dry_run                                 If true, limit on number of transactions open at the same time will be tracked for all users, but not enforced.
       --enable_tx_throttler                                              If true replication-lag-based throttling on transactions will be enabled.
@@ -385,12 +385,12 @@ Flags:
       --track-udfs                                                       Track UDFs in vtgate.
       --track_schema_versions                                            When enabled, vttablet will store versions of schemas at each position that a DDL is applied and allow retrieval of the schema corresponding to a position
       --transaction-log-stream-handler string                            URL handler for streaming transactions log (default "/debug/txlog")
+      --transaction-mode string                                          SINGLE: disallow multi-db transactions, MULTI: allow multi-db transactions with best effort commit, TWOPC: allow multi-db transactions with 2pc commit (default "MULTI")
       --transaction_limit_by_component                                   Include CallerID.component when considering who the user is for the purpose of transaction limit.
       --transaction_limit_by_principal                                   Include CallerID.principal when considering who the user is for the purpose of transaction limit. (default true)
       --transaction_limit_by_subcomponent                                Include CallerID.subcomponent when considering who the user is for the purpose of transaction limit.
       --transaction_limit_by_username                                    Include VTGateCallerID.username when considering who the user is for the purpose of transaction limit. (default true)
       --transaction_limit_per_user float                                 Maximum number of transactions a single user is allowed to use at any time, represented as fraction of -transaction_cap. (default 0.4)
-      --transaction-mode string                                          SINGLE: disallow multi-db transactions, MULTI: allow multi-db transactions with best effort commit, TWOPC: allow multi-db transactions with 2pc commit (default "MULTI")
       --truncate-error-len int                                           truncate errors sent to client if they are longer than this value (0 means do not truncate)
       --twopc_abandon_age time.Duration                                  Any unresolved transaction older than this time will be sent to the coordinator to be resolved. NOTE: Providing time as seconds (float64) is deprecated. Use time.Duration format (e.g., '1s', '2m', '1h'). (default 15m0s)
       --tx-throttler-config string                                       Synonym to -tx_throttler_config (default "target_replication_lag_sec:2 max_replication_lag_sec:10 initial_rate:100 max_increase:1 emergency_decrease:0.5 min_duration_between_increases_sec:40 max_duration_between_increases_sec:62 min_duration_between_decreases_sec:20 spread_backlog_across_sec:20 age_bad_rate_after_sec:180 bad_rate_increase:0.1 max_rate_approach_threshold:0.9")
@@ -419,8 +419,8 @@ Flags:
       --vreplication_replica_lag_tolerance duration                      Replica lag threshold duration: once lag is below this we switch from copy phase to the replication (streaming) phase (default 1m0s)
       --vreplication_retry_delay duration                                delay before retrying a failed workflow event in the replication phase (default 5s)
       --vreplication_store_compressed_gtid                               Store compressed gtids in the pos column of the sidecar database's vreplication table
-      --vschema-persistence-dir string                                   If set, per-keyspace vschema will be persisted in this directory and reloaded into the in-memory topology server across restarts. Bookkeeping is performed using a simple watcher goroutine. This is useful when running vtcombo as an application development container (e.g. vttestserver) where you want to keep the same vschema even if developer's machine reboots. This works in tandem with vttestserver's --persistent_mode flag. Needless to say, this is neither a perfect nor a production solution for vschema persistence. Consider using the --external_topo_server flag if you require a more complete solution. This flag is ignored if --external_topo_server is set.
       --vschema-ddl-authorized-users string                              List of users authorized to execute vschema ddl operations, or '%' to allow all users.
+      --vschema-persistence-dir string                                   If set, per-keyspace vschema will be persisted in this directory and reloaded into the in-memory topology server across restarts. Bookkeeping is performed using a simple watcher goroutine. This is useful when running vtcombo as an application development container (e.g. vttestserver) where you want to keep the same vschema even if developer's machine reboots. This works in tandem with vttestserver's --persistent_mode flag. Needless to say, this is neither a perfect nor a production solution for vschema persistence. Consider using the --external_topo_server flag if you require a more complete solution. This flag is ignored if --external_topo_server is set.
       --vstream-binlog-rotation-threshold int                            Byte size at which a VStreamer will attempt to rotate the source's open binary log before starting a GTID snapshot based stream (e.g. a ResultStreamer or RowStreamer) (default 67108864)
       --vstream-dynamic-packet-size                                      Enable dynamic packet sizing for vstreamers. This will adjust the packet size in vreplication workflows to improve performance. (default true)
       --vstream-packet-size int                                          Suggested packet size for vstreamers. The actual packet size may be more or less than this amount. (default 250000)

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -10,7 +10,7 @@ Usage:
   vtcombo [flags]
 
 Flags:
-      --action_timeout duration                                          time to wait for an action before resorting to force (default 1m0s)
+      --action-timeout duration                                          time to wait for an action before resorting to force (default 1m0s)
       --allow-kill-statement                                             Allows the execution of kill statement
       --allowed_tablet_types strings                                     Specifies the tablet types this vtgate is allowed to route queries to. Should be provided as a comma-separated set of tablet types.
       --alsologtostderr                                                  log to standard error as well as files
@@ -24,7 +24,7 @@ Flags:
       --binlog-in-memory-decompressor-max-size uint                      This value sets the uncompressed transaction payload size at which we switch from in-memory buffer based decompression to the slower streaming mode. (default 134217728)
       --binlog_player_protocol string                                    the protocol to download binlogs from a vttablet (default "grpc")
       --buffer_drain_concurrency int                                     Maximum number of requests retried simultaneously. More concurrency will increase the load on the PRIMARY vttablet when draining the buffer. (default 1)
-      --buffer_keyspace_shards string                                    If not empty, limit buffering to these entries (comma separated). Entry format: keyspace or keyspace/shard. Requires --enable_buffer=true.
+      --buffer_keyspace_shards string                                    If not empty, limit buffering to these entries (comma separated). Entry format: keyspace or keyspace/shard. Requires --enable-buffer=true.
       --buffer_max_failover_duration duration                            Stop buffering completely if a failover takes longer than this duration. (default 20s)
       --buffer_min_time_between_failovers duration                       Minimum time between the end of a failover and the start of the next one (tracked per shard). Faster consecutive failovers will not trigger buffering. (default 1m0s)
       --buffer_size int                                                  Maximum number of buffered requests in flight (across all ongoing failovers). (default 1000)
@@ -101,7 +101,7 @@ Flags:
       --dba_pool_size int                                                Size of the connection pool for dba connections (default 20)
       --dbddl_plugin string                                              controls how to handle CREATE/DROP DATABASE. use it if you are using your own database provisioning service (default "fail")
       --ddl_strategy string                                              Set default strategy for DDL statements. Override with @@ddl_strategy session variable (default "direct")
-      --default_tablet_type topodatapb.TabletType                        The default tablet type to set for queries, when one is not explicitly selected. (default PRIMARY)
+      --default-tablet-type topodatapb.TabletType                        The default tablet type to set for queries, when one is not explicitly selected. (default PRIMARY)
       --degraded_threshold duration                                      replication lag after which a replica is considered degraded (default 30s)
       --disk-write-dir string                                            if provided, tablet will attempt to write a file to this directory to check if the disk is stalled
       --disk-write-interval duration                                     how often to write to the disk to check whether it is stalled (default 5s)
@@ -113,17 +113,17 @@ Flags:
       --enable-per-workload-table-metrics                                If true, query counts and query error metrics include a label that identifies the workload
       --enable-tx-throttler                                              Synonym to -enable_tx_throttler
       --enable-views                                                     Enable views support in vtgate. (default true)
-      --enable_buffer                                                    Enable buffering (stalling) of primary traffic during failovers.
+      --enable-buffer                                                    Enable buffering (stalling) of primary traffic during failovers.
       --enable_buffer_dry_run                                            Detect and log failover events, but do not actually buffer requests.
       --enable_consolidator                                              This option enables the query consolidator. (default true)
       --enable_consolidator_replicas                                     This option enables the query consolidator only on replicas.
-      --enable_direct_ddl                                                Allow users to submit direct DDL statements (default true)
+      --enable-direct-ddl                                                Allow users to submit direct DDL statements (default true)
       --enable_hot_row_protection                                        If true, incoming transactions for the same row (range) will be queued and cannot consume all txpool slots.
       --enable_hot_row_protection_dry_run                                If true, hot row protection is not enforced but logs if transactions would have been queued.
-      --enable_online_ddl                                                Allow users to submit, review and control Online DDL (default true)
+      --enable-online-ddl                                                Allow users to submit, review and control Online DDL (default true)
       --enable_replication_reporter                                      Use polling to track replication lag.
       --enable_set_var                                                   This will enable the use of MySQL's SET_VAR query hint for certain system variables instead of using reserved connections (default true)
-      --enable_system_settings                                           This will enable the system settings to be changed per session at the database connection level (default true)
+      --enable-system-settings                                           This will enable the system settings to be changed per session at the database connection level (default true)
       --enable_transaction_limit                                         If true, limit on number of transactions open at the same time will be enforced for all users. User trying to open a new transaction after exhausting their limit will receive an error immediately, regardless of whether there are available slots or not.
       --enable_transaction_limit_dry_run                                 If true, limit on number of transactions open at the same time will be tracked for all users, but not enforced.
       --enable_tx_throttler                                              If true replication-lag-based throttling on transactions will be enabled.
@@ -390,7 +390,7 @@ Flags:
       --transaction_limit_by_subcomponent                                Include CallerID.subcomponent when considering who the user is for the purpose of transaction limit.
       --transaction_limit_by_username                                    Include VTGateCallerID.username when considering who the user is for the purpose of transaction limit. (default true)
       --transaction_limit_per_user float                                 Maximum number of transactions a single user is allowed to use at any time, represented as fraction of -transaction_cap. (default 0.4)
-      --transaction_mode string                                          SINGLE: disallow multi-db transactions, MULTI: allow multi-db transactions with best effort commit, TWOPC: allow multi-db transactions with 2pc commit (default "MULTI")
+      --transaction-mode string                                          SINGLE: disallow multi-db transactions, MULTI: allow multi-db transactions with best effort commit, TWOPC: allow multi-db transactions with 2pc commit (default "MULTI")
       --truncate-error-len int                                           truncate errors sent to client if they are longer than this value (0 means do not truncate)
       --twopc_abandon_age time.Duration                                  Any unresolved transaction older than this time will be sent to the coordinator to be resolved. NOTE: Providing time as seconds (float64) is deprecated. Use time.Duration format (e.g., '1s', '2m', '1h'). (default 15m0s)
       --tx-throttler-config string                                       Synonym to -tx_throttler_config (default "target_replication_lag_sec:2 max_replication_lag_sec:10 initial_rate:100 max_increase:1 emergency_decrease:0.5 min_duration_between_increases_sec:40 max_duration_between_increases_sec:62 min_duration_between_decreases_sec:20 spread_backlog_across_sec:20 age_bad_rate_after_sec:180 bad_rate_increase:0.1 max_rate_approach_threshold:0.9")
@@ -420,7 +420,7 @@ Flags:
       --vreplication_retry_delay duration                                delay before retrying a failed workflow event in the replication phase (default 5s)
       --vreplication_store_compressed_gtid                               Store compressed gtids in the pos column of the sidecar database's vreplication table
       --vschema-persistence-dir string                                   If set, per-keyspace vschema will be persisted in this directory and reloaded into the in-memory topology server across restarts. Bookkeeping is performed using a simple watcher goroutine. This is useful when running vtcombo as an application development container (e.g. vttestserver) where you want to keep the same vschema even if developer's machine reboots. This works in tandem with vttestserver's --persistent_mode flag. Needless to say, this is neither a perfect nor a production solution for vschema persistence. Consider using the --external_topo_server flag if you require a more complete solution. This flag is ignored if --external_topo_server is set.
-      --vschema_ddl_authorized_users string                              List of users authorized to execute vschema ddl operations, or '%' to allow all users.
+      --vschema-ddl-authorized-users string                              List of users authorized to execute vschema ddl operations, or '%' to allow all users.
       --vstream-binlog-rotation-threshold int                            Byte size at which a VStreamer will attempt to rotate the source's open binary log before starting a GTID snapshot based stream (e.g. a ResultStreamer or RowStreamer) (default 67108864)
       --vstream-dynamic-packet-size                                      Enable dynamic packet sizing for vstreamers. This will adjust the packet size in vreplication workflows to improve performance. (default true)
       --vstream-packet-size int                                          Suggested packet size for vstreamers. The actual packet size may be more or less than this amount. (default 250000)

--- a/go/flags/endtoend/vtctlclient.txt
+++ b/go/flags/endtoend/vtctlclient.txt
@@ -1,5 +1,5 @@
 Usage of vtctlclient:
-      --action_timeout duration                                     timeout for the total command (default 1h0m0s)
+      --action-timeout duration                                     timeout for the total command (default 1h0m0s)
       --alsologtostderr                                             log to standard error as well as files
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -16,12 +16,12 @@ vtctld \
 	--topo-global-root /vitess/ \
 	--service-map 'grpc-vtctl,grpc-vtctld' \
 	--backup-storage-implementation file \
-	--file_backup_storage_root $VTDATAROOT/backups \
+	--file-backup-storage-root $VTDATAROOT/backups \
 	--port 15000 \
 	--grpc-port 15999
 
 Flags:
-      --action_timeout duration                                          time to wait for an action before resorting to force (default 1m0s)
+      --action-timeout duration                                          time to wait for an action before resorting to force (default 1m0s)
       --alsologtostderr                                                  log to standard error as well as files
       --azblob-backup-account-key-file string                            Path to a file containing the Azure Storage account key; if this flag is unset, the environment variable VT_AZBLOB_ACCOUNT_KEY will be used as the key itself (NOT a file path).
       --azblob-backup-account-name string                                Azure Storage Account name for backups; if this flag is unset, the environment variable VT_AZBLOB_ACCOUNT_NAME will be used.
@@ -54,7 +54,7 @@ Flags:
       --datadog-agent-port string                                        port to send spans to. if empty, no tracing will be done
       --disable_active_reparents                                         if set, do not allow active reparents. Use this to protect a cluster using external reparents.
       --emit-stats                                                       If set, emit stats to push-based monitoring and stats backends
-      --file_backup_storage_root string                                  Root directory for the file backup storage.
+      --file-backup-storage-root string                                  Root directory for the file backup storage.
       --gcs-backup-storage-bucket string                                 Google Cloud Storage bucket to use for backups.
       --gcs-backup-storage-root string                                   Root prefix for all backup-related object names.
       --grpc-auth-mode string                                            Which auth plugin implementation to use (eg: static)

--- a/go/flags/endtoend/vtctldclient.txt
+++ b/go/flags/endtoend/vtctldclient.txt
@@ -118,7 +118,7 @@ Available Commands:
   help                        Help about any command
 
 Flags:
-      --action_timeout duration                  timeout to use for the command (default 1h0m0s)
+      --action-timeout duration                  timeout to use for the command (default 1h0m0s)
       --alsologtostderr                          log to standard error as well as files
       --compact                                  use compact format for otherwise verbose outputs
       --grpc-auth-static-client-creds string     When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.

--- a/go/flags/endtoend/vtexplain.txt
+++ b/go/flags/endtoend/vtexplain.txt
@@ -47,7 +47,7 @@ Flags:
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --dbname string                                               Optional database target to override normal routing
-      --default_tablet_type topodatapb.TabletType                   The default tablet type to set for queries, when one is not explicitly selected. (default PRIMARY)
+      --default-tablet-type topodatapb.TabletType                   The default tablet type to set for queries, when one is not explicitly selected. (default PRIMARY)
       --execution-mode string                                       The execution mode to simulate -- must be set to multi, legacy-autocommit, or twopc (default "multi")
   -h, --help                                                        help for vtexplain
       --keep-logs duration                                          keep logs for this long (using ctime) (zero to keep forever)

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -56,14 +56,14 @@ Flags:
       --discovery_low_replication_lag duration                           Threshold below which replication lag is considered low enough to be healthy. (default 30s)
       --emit-stats                                                       If set, emit stats to push-based monitoring and stats backends
       --enable-balancer                                                  Enable the tablet balancer to evenly spread query load for a given tablet type
-      --enable-partial-keyspace-migration                                (Experimental) Follow shard routing rules: enable only while migrating a keyspace shard by shard. See documentation on Partial MoveTables for more. (default false)
-      --enable-views                                                     Enable views support in vtgate. (default true)
       --enable-buffer                                                    Enable buffering (stalling) of primary traffic during failovers.
-      --enable_buffer_dry_run                                            Detect and log failover events, but do not actually buffer requests.
       --enable-direct-ddl                                                Allow users to submit direct DDL statements (default true)
       --enable-online-ddl                                                Allow users to submit, review and control Online DDL (default true)
-      --enable_set_var                                                   This will enable the use of MySQL's SET_VAR query hint for certain system variables instead of using reserved connections (default true)
+      --enable-partial-keyspace-migration                                (Experimental) Follow shard routing rules: enable only while migrating a keyspace shard by shard. See documentation on Partial MoveTables for more. (default false)
       --enable-system-settings                                           This will enable the system settings to be changed per session at the database connection level (default true)
+      --enable-views                                                     Enable views support in vtgate. (default true)
+      --enable_buffer_dry_run                                            Detect and log failover events, but do not actually buffer requests.
+      --enable_set_var                                                   This will enable the use of MySQL's SET_VAR query hint for certain system variables instead of using reserved connections (default true)
       --foreign_key_mode string                                          This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow, disallow (default "allow")
       --gate_query_cache_memory int                                      gate server query cache size in bytes, maximum amount of memory to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 33554432)
       --gateway_initial_tablet_timeout duration                          At startup, the tabletGateway will wait up to this duration to get at least one tablet per keyspace/shard/tablet type (default 30s)

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -32,7 +32,7 @@ Flags:
       --balancer-vtgate-cells strings                                    When in balanced mode, a comma-separated list of cells that contain vtgates (required)
       --bind-address string                                              Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --buffer_drain_concurrency int                                     Maximum number of requests retried simultaneously. More concurrency will increase the load on the PRIMARY vttablet when draining the buffer. (default 1)
-      --buffer_keyspace_shards string                                    If not empty, limit buffering to these entries (comma separated). Entry format: keyspace or keyspace/shard. Requires --enable_buffer=true.
+      --buffer_keyspace_shards string                                    If not empty, limit buffering to these entries (comma separated). Entry format: keyspace or keyspace/shard. Requires --enable-buffer=true.
       --buffer_max_failover_duration duration                            Stop buffering completely if a failover takes longer than this duration. (default 20s)
       --buffer_min_time_between_failovers duration                       Minimum time between the end of a failover and the start of the next one (tracked per shard). Faster consecutive failovers will not trigger buffering. (default 1m0s)
       --buffer_size int                                                  Maximum number of buffered requests in flight (across all ongoing failovers). (default 1000)
@@ -51,19 +51,19 @@ Flags:
       --datadog-agent-port string                                        port to send spans to. if empty, no tracing will be done
       --dbddl_plugin string                                              controls how to handle CREATE/DROP DATABASE. use it if you are using your own database provisioning service (default "fail")
       --ddl_strategy string                                              Set default strategy for DDL statements. Override with @@ddl_strategy session variable (default "direct")
-      --default_tablet_type topodatapb.TabletType                        The default tablet type to set for queries, when one is not explicitly selected. (default PRIMARY)
+      --default-tablet-type topodatapb.TabletType                        The default tablet type to set for queries, when one is not explicitly selected. (default PRIMARY)
       --discovery_high_replication_lag_minimum_serving duration          Threshold above which replication lag is considered too high when applying the min_number_serving_vttablets flag. (default 2h0m0s)
       --discovery_low_replication_lag duration                           Threshold below which replication lag is considered low enough to be healthy. (default 30s)
       --emit-stats                                                       If set, emit stats to push-based monitoring and stats backends
       --enable-balancer                                                  Enable the tablet balancer to evenly spread query load for a given tablet type
       --enable-partial-keyspace-migration                                (Experimental) Follow shard routing rules: enable only while migrating a keyspace shard by shard. See documentation on Partial MoveTables for more. (default false)
       --enable-views                                                     Enable views support in vtgate. (default true)
-      --enable_buffer                                                    Enable buffering (stalling) of primary traffic during failovers.
+      --enable-buffer                                                    Enable buffering (stalling) of primary traffic during failovers.
       --enable_buffer_dry_run                                            Detect and log failover events, but do not actually buffer requests.
-      --enable_direct_ddl                                                Allow users to submit direct DDL statements (default true)
-      --enable_online_ddl                                                Allow users to submit, review and control Online DDL (default true)
+      --enable-direct-ddl                                                Allow users to submit direct DDL statements (default true)
+      --enable-online-ddl                                                Allow users to submit, review and control Online DDL (default true)
       --enable_set_var                                                   This will enable the use of MySQL's SET_VAR query hint for certain system variables instead of using reserved connections (default true)
-      --enable_system_settings                                           This will enable the system settings to be changed per session at the database connection level (default true)
+      --enable-system-settings                                           This will enable the system settings to be changed per session at the database connection level (default true)
       --foreign_key_mode string                                          This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow, disallow (default "allow")
       --gate_query_cache_memory int                                      gate server query cache size in bytes, maximum amount of memory to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 33554432)
       --gateway_initial_tablet_timeout duration                          At startup, the tabletGateway will wait up to this duration to get at least one tablet per keyspace/shard/tablet type (default 30s)
@@ -235,12 +235,12 @@ Flags:
       --tracing-sampling-rate float                                      sampling rate for the probabilistic jaeger sampler (default 0.1)
       --tracing-sampling-type string                                     sampling strategy to use for jaeger. possible values are 'const', 'probabilistic', 'rateLimiting', or 'remote' (default "const")
       --track-udfs                                                       Track UDFs in vtgate.
-      --transaction_mode string                                          SINGLE: disallow multi-db transactions, MULTI: allow multi-db transactions with best effort commit, TWOPC: allow multi-db transactions with 2pc commit (default "MULTI")
+      --transaction-mode string                                          SINGLE: disallow multi-db transactions, MULTI: allow multi-db transactions with best effort commit, TWOPC: allow multi-db transactions with 2pc commit (default "MULTI")
       --truncate-error-len int                                           truncate errors sent to client if they are longer than this value (0 means do not truncate)
       --v Level                                                          log level for V logs
   -v, --version                                                          print binary version
       --vmodule vModuleFlag                                              comma-separated list of pattern=N settings for file-filtered logging
-      --vschema_ddl_authorized_users string                              List of users authorized to execute vschema ddl operations, or '%' to allow all users.
+      --vschema-ddl-authorized-users string                              List of users authorized to execute vschema ddl operations, or '%' to allow all users.
       --vtgate-config-terse-errors                                       prevent bind vars from escaping in returned errors
       --warming-reads-concurrency int                                    Number of concurrent warming reads allowed (default 500)
       --warming-reads-percent int                                        Percentage of reads on the primary to forward to replicas. Useful for keeping buffer pools warm

--- a/go/flags/endtoend/vtgateclienttest.txt
+++ b/go/flags/endtoend/vtgateclienttest.txt
@@ -13,7 +13,7 @@ Flags:
       --config-path strings                                              Paths to search for config files in. (default [{{ .Workdir }}])
       --config-persistence-min-interval duration                         minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                               Config file type (omit to infer config type from file extension).
-      --default_tablet_type topodatapb.TabletType                        The default tablet type to set for queries, when one is not explicitly selected. (default PRIMARY)
+      --default-tablet-type topodatapb.TabletType                        The default tablet type to set for queries, when one is not explicitly selected. (default PRIMARY)
       --grpc-auth-mode string                                            Which auth plugin implementation to use (eg: static)
       --grpc-auth-mtls-allowed-substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc-auth-static-client-creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
@@ -68,4 +68,4 @@ Flags:
       --v Level                                                          log level for V logs
   -v, --version                                                          print binary version
       --vmodule vModuleFlag                                              comma-separated list of pattern=N settings for file-filtered logging
-      --vschema_ddl_authorized_users string                              List of users authorized to execute vschema ddl operations, or '%' to allow all users.
+      --vschema-ddl-authorized-users string                              List of users authorized to execute vschema ddl operations, or '%' to allow all users.

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -155,7 +155,7 @@ Flags:
       --external-compressor string                                       command with arguments to use when compressing a backup.
       --external-compressor-extension string                             extension to use when using an external compressor.
       --external-decompressor string                                     command with arguments to use when decompressing a backup.
-      --file_backup_storage_root string                                  Root directory for the file backup storage.
+      --file-backup-storage-root string                                  Root directory for the file backup storage.
       --filecustomrules string                                           file based custom rule path
       --filecustomrules_watch                                            set up a watch on the target file and reload query rules when it changes
       --gc_check_interval duration                                       Interval between garbage collection checks (default 1h0m0s)

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -32,9 +32,9 @@ Flags:
       --dba_idle_timeout duration                                        Idle timeout for dba connections (default 1m0s)
       --dba_pool_size int                                                Size of the connection pool for dba connections (default 20)
       --default_schema_dir string                                        Default directory for initial schema files. If no schema is found in schema_dir, default to this location.
-      --enable_direct_ddl                                                Allow users to submit direct DDL statements (default true)
-      --enable_online_ddl                                                Allow users to submit, review and control Online DDL (default true)
-      --enable_system_settings                                           This will enable the system settings to be changed per session at the database connection level (default true)
+      --enable-direct-ddl                                                Allow users to submit direct DDL statements (default true)
+      --enable-online-ddl                                                Allow users to submit, review and control Online DDL (default true)
+      --enable-system-settings                                           This will enable the system settings to be changed per session at the database connection level (default true)
       --external-compressor string                                       command with arguments to use when compressing a backup.
       --external-compressor-extension string                             extension to use when using an external compressor.
       --external-decompressor string                                     command with arguments to use when decompressing a backup.
@@ -147,11 +147,11 @@ Flags:
       --topo-zk-tls-ca string                                            the server ca to use to validate servers when connecting to the zk topo server
       --topo-zk-tls-cert string                                          the cert to use to connect to the zk topo server, requires topo-zk-tls-key, enables TLS
       --topo-zk-tls-key string                                           the key to use to connect to the zk topo server, enables TLS
-      --transaction_mode string                                          Transaction mode MULTI (default), SINGLE or TWOPC  (default "MULTI")
+      --transaction-mode string                                          Transaction mode MULTI (default), SINGLE or TWOPC  (default "MULTI")
       --v Level                                                          log level for V logs
   -v, --version                                                          print binary version
       --vmodule vModuleFlag                                              comma-separated list of pattern=N settings for file-filtered logging
-      --vschema_ddl_authorized_users string                              Comma separated list of users authorized to execute vschema ddl operations via vtgate
+      --vschema-ddl-authorized-users string                              Comma separated list of users authorized to execute vschema ddl operations via vtgate
       --vtcombo-bind-host string                                         which host to bind vtcombo servenv listener to (default "localhost")
       --vtctl_client_protocol string                                     Protocol to use to talk to the vtctl server. (default "grpc")
       --vtctld_grpc_ca string                                            the server ca to use to validate servers when connecting

--- a/go/test/endtoend/cluster/vtbackup_process.go
+++ b/go/test/endtoend/cluster/vtbackup_process.go
@@ -71,7 +71,7 @@ func (vtbackup *VtbackupProcess) Setup() (err error) {
 
 		//Backup Arguments are not optional
 		"--backup-storage-implementation": vtbackup.BackupStorageImplementation,
-		"--file_backup_storage_root":      vtbackup.FileBackupStorageRoot,
+		"--file-backup-storage-root":      vtbackup.FileBackupStorageRoot,
 	}
 
 	utils.SetFlagVariantsForTests(flags, "--topo-implementation", vtbackup.TopoImplementation)
@@ -81,6 +81,7 @@ func (vtbackup *VtbackupProcess) Setup() (err error) {
 	utils.SetFlagVariantsForTests(flags, "--init-keyspace", vtbackup.Keyspace)
 	utils.SetFlagVariantsForTests(flags, "--init-shard", vtbackup.Shard)
 	utils.SetFlagVariantsForTests(flags, "--backup-storage-implementation", vtbackup.BackupStorageImplementation)
+	utils.SetFlagVariantsForTests(flags, "--file-backup-storage-root", vtbackup.FileBackupStorageRoot)
 
 	vtbackup.proc = exec.Command(vtbackup.Binary)
 	for k, v := range flags {

--- a/go/test/endtoend/cluster/vtgate_process.go
+++ b/go/test/endtoend/cluster/vtgate_process.go
@@ -209,6 +209,7 @@ func (vtgate *VtgateProcess) Setup() (err error) {
 		args = append(args, "--planner-version", vtgate.PlannerVersion.String())
 	}
 	if vtgate.SysVarSetEnabled {
+		// TODO: Replace flag with dashed version in v25
 		args = append(args, "--enable_system_settings")
 	}
 	vtgate.proc = exec.Command(

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -110,7 +110,7 @@ func (vttablet *VttabletProcess) Setup() (err error) {
 		"--health_check_interval", fmt.Sprintf("%ds", vttablet.HealthCheckInterval),
 		"--enable_replication_reporter",
 		"--backup_storage_implementation", vttablet.BackupStorageImplementation,
-		"--file_backup_storage_root", vttablet.FileBackupStorageRoot,
+		"--file-backup-storage-root", vttablet.FileBackupStorageRoot,
 		"--service_map", vttablet.ServiceMap,
 		"--db_charset", vttablet.Charset,
 		"--bind-address", "127.0.0.1",

--- a/go/test/endtoend/mysqlserver/main_test.go
+++ b/go/test/endtoend/mysqlserver/main_test.go
@@ -109,7 +109,7 @@ func TestMain(m *testing.M) {
 		}
 
 		clusterInstance.VtGateExtraArgs = []string{
-			"--vschema_ddl_authorized_users=%",
+			utils.GetFlagVariantForTests("--vschema-ddl-authorized-users") + "=%",
 			"--mysql_server_query_timeout", "1s",
 			utils.GetFlagVariantForTests("--mysql-auth-server-impl"), "static",
 			"--mysql_auth_server_static_file", clusterInstance.TmpDirectory + mysqlAuthServerStatic,

--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/utils"
 	"vitess.io/vitess/go/vt/vtctl/reparentutil/policy"
 	"vitess.io/vitess/go/vt/vttablet/tabletconn"
 
@@ -89,7 +90,7 @@ func SetupShardedReparentCluster(t *testing.T, durability string) *cluster.Local
 		"--track_schema_versions=true",
 		"--queryserver_enable_online_ddl=false")
 	clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,
-		"--enable_buffer",
+		"--enable-buffer",
 		// Long timeout in case failover is slow.
 		"--buffer_window", "10m",
 		"--buffer_max_failover_duration", "10m",
@@ -356,7 +357,7 @@ func PrsWithTimeout(t *testing.T, clusterInstance *cluster.LocalProcessCluster, 
 		"PlannedReparentShard",
 		fmt.Sprintf("%s/%s", KeyspaceName, ShardName)}
 	if actionTimeout != "" {
-		args = append(args, "--action_timeout", actionTimeout)
+		args = append(args, utils.GetFlagVariantForTests("--action-timeout"), actionTimeout)
 	}
 	if waitTimeout != "" {
 		args = append(args, "--wait-replicas-timeout", waitTimeout)
@@ -381,7 +382,7 @@ func Ers(clusterInstance *cluster.LocalProcessCluster, tab *cluster.Vttablet, to
 func ErsIgnoreTablet(clusterInstance *cluster.LocalProcessCluster, tab *cluster.Vttablet, timeout, waitReplicasTimeout string, tabletsToIgnore []*cluster.Vttablet, preventCrossCellPromotion bool) (string, error) {
 	var args []string
 	if timeout != "" {
-		args = append(args, "--action_timeout", timeout)
+		args = append(args, utils.GetFlagVariantForTests("--action-timeout"), timeout)
 	}
 	args = append(args, "EmergencyReparentShard", fmt.Sprintf("%s/%s", KeyspaceName, ShardName))
 	if tab != nil {

--- a/go/test/endtoend/tabletgateway/buffer/buffer_test_helpers.go
+++ b/go/test/endtoend/tabletgateway/buffer/buffer_test_helpers.go
@@ -237,7 +237,7 @@ func (bt *BufferingTest) createCluster() (*cluster.LocalProcessCluster, int) {
 	}
 
 	clusterInstance.VtGateExtraArgs = []string{
-		"--enable_buffer",
+		vtutils.GetFlagVariantForTests("--enable-buffer"),
 		// Long timeout in case failover is slow.
 		"--buffer_window", "10m",
 		"--buffer_max_failover_duration", "10m",

--- a/go/test/endtoend/tabletmanager/main_test.go
+++ b/go/test/endtoend/tabletmanager/main_test.go
@@ -94,7 +94,7 @@ func TestMain(m *testing.M) {
 
 		// List of users authorized to execute vschema ddl operations
 		clusterInstance.VtGateExtraArgs = []string{
-			"--vschema_ddl_authorized_users=%",
+			utils.GetFlagVariantForTests("--vschema-ddl-authorized-users") + "=%",
 			"--enable-views",
 			"--discovery_low_replication_lag", tabletUnhealthyThreshold.String(),
 		}

--- a/go/test/endtoend/transaction/single/main_test.go
+++ b/go/test/endtoend/transaction/single/main_test.go
@@ -29,6 +29,7 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
+	vtutils "vitess.io/vitess/go/vt/utils"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder"
 )
 
@@ -71,7 +72,7 @@ func TestMain(m *testing.M) {
 
 		// Start vtgate
 		clusterInstance.VtGatePlannerVersion = planbuilder.Gen4
-		clusterInstance.VtGateExtraArgs = []string{"--transaction_mode", "SINGLE"}
+		clusterInstance.VtGateExtraArgs = []string{vtutils.GetFlagVariantForTests("--transaction-mode"), "SINGLE"}
 		err = clusterInstance.StartVtgate()
 		if err != nil {
 			return 1

--- a/go/test/endtoend/transaction/twopc/fuzz/main_test.go
+++ b/go/test/endtoend/transaction/twopc/fuzz/main_test.go
@@ -66,7 +66,7 @@ func TestMain(m *testing.M) {
 
 		// Set extra args for twopc
 		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,
-			"--transaction_mode", "TWOPC",
+			vtutils.GetFlagVariantForTests("--transaction-mode"), "TWOPC",
 			vtutils.GetFlagVariantForTests("--grpc-use-effective-callerid"),
 			vtutils.GetFlagVariantForTests("--tablet-refresh-interval"), "2s",
 		)

--- a/go/test/endtoend/transaction/twopc/metric/main_test.go
+++ b/go/test/endtoend/transaction/twopc/metric/main_test.go
@@ -66,7 +66,7 @@ func TestMain(m *testing.M) {
 
 		// Set extra args for twopc
 		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,
-			"--transaction_mode", "TWOPC",
+			utils.GetFlagVariantForTests("--transaction-mode"), "TWOPC",
 			utils.GetFlagVariantForTests("--grpc-use-effective-callerid"),
 		)
 		clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs,

--- a/go/test/endtoend/transaction/twopc/stress/main_test.go
+++ b/go/test/endtoend/transaction/twopc/stress/main_test.go
@@ -66,7 +66,7 @@ func TestMain(m *testing.M) {
 
 		// Set extra args for twopc
 		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,
-			"--transaction_mode", "TWOPC",
+			vtutils.GetFlagVariantForTests("--transaction-mode"), "TWOPC",
 			vtutils.GetFlagVariantForTests("--grpc-use-effective-callerid"),
 			vtutils.GetFlagVariantForTests("--tablet-refresh-interval"), "2s",
 		)

--- a/go/test/endtoend/utils/mysqlvsvitess/main_test.go
+++ b/go/test/endtoend/utils/mysqlvsvitess/main_test.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
+	vtutils "vitess.io/vitess/go/vt/utils"
 )
 
 var (
@@ -88,7 +89,8 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
-		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, "--enable_system_settings=true")
+		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, fmt.Sprintf("%s=true", vtutils.GetFlagVariantForTests("--enable-system-settings")))
+
 		// Start vtgate
 		err = clusterInstance.StartVtgate()
 		if err != nil {

--- a/go/test/endtoend/vreplication/cluster_test.go
+++ b/go/test/endtoend/vreplication/cluster_test.go
@@ -55,7 +55,7 @@ var (
 	sidecarDBIdentifier   = sqlparser.String(sqlparser.NewIdentifierCS(sidecarDBName))
 	mainClusterConfig     *ClusterConfig
 	externalClusterConfig *ClusterConfig
-	extraVTGateArgs       = []string{utils.GetFlagVariantForTests("--tablet-refresh-interval"), "10ms", "--enable_buffer", "--buffer_window", loadTestBufferingWindowDuration.String(),
+	extraVTGateArgs       = []string{utils.GetFlagVariantForTests("--tablet-refresh-interval"), "10ms", utils.GetFlagVariantForTests("--enable-buffer"), "--buffer_window", loadTestBufferingWindowDuration.String(),
 		"--buffer_size", "250000", "--buffer_min_time_between_failovers", "1s", "--buffer_max_failover_duration", loadTestBufferingWindowDuration.String(),
 		"--buffer_drain_concurrency", "10"}
 	extraVtctldArgs = []string{utils.GetFlagVariantForTests("--remote-operation-timeout"), "600s", "--topo-etcd-lease-ttl", "120"}

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -37,6 +37,7 @@ import (
 	"vitess.io/vitess/go/test/endtoend/throttler"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/utils"
 	"vitess.io/vitess/go/vt/wrangler"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -171,7 +172,7 @@ func tstWorkflowExec(t *testing.T, cells, workflow, sourceKs, targetKs, tables, 
 	if action != workflowActionComplete && tabletTypes != "" {
 		args = append(args, "--tablet-types", tabletTypes)
 	}
-	args = append(args, "--action_timeout=10m") // At this point something is up so fail the test
+	args = append(args, fmt.Sprintf("%s=10m", utils.GetFlagVariantForTests("--action-timeout"))) // At this point something is up so fail the test
 	t.Logf("Executing workflow command: vtctldclient %s", strings.Join(args, " "))
 	output, err := vc.VtctldClient.ExecuteCommandWithOutput(args...)
 	lastOutput = output

--- a/go/test/endtoend/vtgate/keyspace_watches/keyspace_watch_test.go
+++ b/go/test/endtoend/vtgate/keyspace_watches/keyspace_watch_test.go
@@ -31,6 +31,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/vt/utils"
 )
 
 var (
@@ -141,7 +142,7 @@ func TestRoutingWithKeyspacesToWatch(t *testing.T) {
 func TestVSchemaDDLWithKeyspacesToWatch(t *testing.T) {
 
 	extraVTGateArgs := []string{
-		"--vschema_ddl_authorized_users", "%",
+		utils.GetFlagVariantForTests("--vschema-ddl-authorized-users"), "%",
 	}
 	clusterInstance, exitCode := createCluster(extraVTGateArgs)
 	defer clusterInstance.Teardown()

--- a/go/test/endtoend/vtgate/main_test.go
+++ b/go/test/endtoend/vtgate/main_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/test/endtoend/utils"
+	vtutils "vitess.io/vitess/go/vt/utils"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
@@ -90,7 +91,7 @@ func TestMain(m *testing.M) {
 		}
 
 		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,
-			"--vschema_ddl_authorized_users", "%")
+			vtutils.GetFlagVariantForTests("--vschema-ddl-authorized-users"), "%")
 		// Start vtgate
 		err = clusterInstance.StartVtgate()
 		if err != nil {

--- a/go/test/endtoend/vtgate/mysql80/main_test.go
+++ b/go/test/endtoend/vtgate/mysql80/main_test.go
@@ -59,7 +59,7 @@ func TestMain(m *testing.M) {
 
 		clusterInstance.VtGatePlannerVersion = querypb.ExecuteOptions_Gen4
 		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,
-			"--enable_system_settings=true",
+			utils.GetFlagVariantForTests("--enable-system-settings")+"=true",
 			utils.GetFlagVariantForTests("--mysql-server-version")+"=8.0.16-7",
 		)
 		// Start vtgate

--- a/go/test/endtoend/vtgate/queries/aggregation/main_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/main_test.go
@@ -27,6 +27,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	vtutils "vitess.io/vitess/go/vt/utils"
 )
 
 var (
@@ -69,7 +70,7 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
-		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, "--enable_system_settings=true")
+		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, fmt.Sprintf("%s=true", vtutils.GetFlagVariantForTests("--enable-system-settings")))
 		// Start vtgate
 		err = clusterInstance.StartVtgate()
 		if err != nil {

--- a/go/test/endtoend/vtgate/queries/derived/main_test.go
+++ b/go/test/endtoend/vtgate/queries/derived/main_test.go
@@ -27,6 +27,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	vtutils "vitess.io/vitess/go/vt/utils"
 )
 
 var (
@@ -67,7 +68,7 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
-		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, "--enable_system_settings=true")
+		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, fmt.Sprintf("%s=true", vtutils.GetFlagVariantForTests("--enable-system-settings")))
 		// Start vtgate
 		err = clusterInstance.StartVtgate()
 		if err != nil {

--- a/go/test/endtoend/vtgate/queries/foundrows/main_test.go
+++ b/go/test/endtoend/vtgate/queries/foundrows/main_test.go
@@ -27,6 +27,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	vtutils "vitess.io/vitess/go/vt/utils"
 )
 
 var (
@@ -71,7 +72,7 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
-		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, "--enable_system_settings=true")
+		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, fmt.Sprintf("%s=true", vtutils.GetFlagVariantForTests("--enable-system-settings")))
 		// Start vtgate
 		err = clusterInstance.StartVtgate()
 		if err != nil {

--- a/go/test/endtoend/vtgate/queries/orderby/main_test.go
+++ b/go/test/endtoend/vtgate/queries/orderby/main_test.go
@@ -27,6 +27,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	vtutils "vitess.io/vitess/go/vt/utils"
 )
 
 var (
@@ -69,7 +70,7 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
-		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, "--enable_system_settings=true")
+		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, fmt.Sprintf("%s=true", vtutils.GetFlagVariantForTests("--enable-system-settings")))
 		// Start vtgate
 		err = clusterInstance.StartVtgate()
 		if err != nil {

--- a/go/test/endtoend/vtgate/queries/orderby/without_schematracker/main_test.go
+++ b/go/test/endtoend/vtgate/queries/orderby/without_schematracker/main_test.go
@@ -27,6 +27,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	vtutils "vitess.io/vitess/go/vt/utils"
 )
 
 var (
@@ -68,7 +69,7 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
-		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, "--enable_system_settings=true")
+		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, fmt.Sprintf("%s=true", vtutils.GetFlagVariantForTests("--enable-system-settings")))
 		// Start vtgate
 		err = clusterInstance.StartVtgate()
 		if err != nil {

--- a/go/test/endtoend/vtgate/queries/random/main_test.go
+++ b/go/test/endtoend/vtgate/queries/random/main_test.go
@@ -27,6 +27,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	vtutils "vitess.io/vitess/go/vt/utils"
 )
 
 var (
@@ -69,7 +70,7 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
-		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, "--enable_system_settings=true")
+		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, fmt.Sprintf("%s=true", vtutils.GetFlagVariantForTests("--enable-system-settings")))
 		// Start vtgate
 		err = clusterInstance.StartVtgate()
 		if err != nil {

--- a/go/test/endtoend/vtgate/queries/subquery/main_test.go
+++ b/go/test/endtoend/vtgate/queries/subquery/main_test.go
@@ -27,6 +27,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	vtutils "vitess.io/vitess/go/vt/utils"
 )
 
 var (
@@ -69,7 +70,7 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
-		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, "--enable_system_settings=true")
+		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, fmt.Sprintf("%s=true", vtutils.GetFlagVariantForTests("--enable-system-settings")))
 		// Start vtgate
 		err = clusterInstance.StartVtgate()
 		if err != nil {

--- a/go/test/endtoend/vtgate/queries/union/main_test.go
+++ b/go/test/endtoend/vtgate/queries/union/main_test.go
@@ -26,6 +26,7 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
+	vtutils "vitess.io/vitess/go/vt/utils"
 )
 
 var (
@@ -68,7 +69,7 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
-		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, "--enable_system_settings=true")
+		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, fmt.Sprintf("%s=true", vtutils.GetFlagVariantForTests("--enable-system-settings")))
 		// Start vtgate
 		err = clusterInstance.StartVtgate()
 		if err != nil {

--- a/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
@@ -32,6 +32,7 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
+	vtutils "vitess.io/vitess/go/vt/utils"
 )
 
 var (
@@ -84,7 +85,7 @@ func TestMain(m *testing.M) {
 		}
 		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,
 			"--schema_change_signal",
-			"--vschema_ddl_authorized_users", "%")
+			vtutils.GetFlagVariantForTests("--vschema-ddl-authorized-users"), "%")
 		clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-config-schema-change-signal")
 
 		if vtgateVer >= 16 && vttabletVer >= 16 {

--- a/go/test/endtoend/vtgate/schematracker/unsharded/st_unsharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/unsharded/st_unsharded_test.go
@@ -28,6 +28,7 @@ import (
 
 	"vitess.io/vitess/go/constants/sidecar"
 	"vitess.io/vitess/go/test/endtoend/utils"
+	vtutils "vitess.io/vitess/go/vt/utils"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
@@ -89,7 +90,7 @@ func TestMain(m *testing.M) {
 		}
 
 		// Start vtgate
-		clusterInstance.VtGateExtraArgs = []string{"--schema_change_signal", "--vschema_ddl_authorized_users", "%"}
+		clusterInstance.VtGateExtraArgs = []string{"--schema_change_signal", vtutils.GetFlagVariantForTests("--vschema-ddl-authorized-users"), "%"}
 		err = clusterInstance.StartVtgate()
 		if err != nil {
 			return 1

--- a/go/test/endtoend/vtgate/vschema/vschema_test.go
+++ b/go/test/endtoend/vtgate/vschema/vschema_test.go
@@ -78,7 +78,7 @@ func TestMain(m *testing.M) {
 			timeNow := time.Now().Unix()
 			configFile = path.Join(os.TempDir(), fmt.Sprintf("vtgate-config-%d.json", timeNow))
 			err := writeConfig(configFile, map[string]string{
-				"vschema_ddl_authorized_users": "%",
+				"vschema-ddl-authorized-users": "%",
 			})
 			if err != nil {
 				return 1, err
@@ -87,7 +87,7 @@ func TestMain(m *testing.M) {
 
 			clusterInstance.VtGateExtraArgs = []string{fmt.Sprintf("--config-file=%s", configFile), "--schema_change_signal=false"}
 		} else {
-			clusterInstance.VtGateExtraArgs = []string{"--vschema_ddl_authorized_users=%", "--schema_change_signal=false"}
+			clusterInstance.VtGateExtraArgs = []string{"--vschema-ddl-authorized-users=%", "--schema_change_signal=false"}
 		}
 
 		// Start keyspace
@@ -172,13 +172,13 @@ func TestVSchema(t *testing.T) {
 		// Don't allow any users to modify the vschema via the SQL API
 		// in order to test that behavior.
 		writeConfig(configFile, map[string]string{
-			"vschema_ddl_authorized_users": "",
+			"vschema-ddl-authorized-users": "",
 		})
 		// Allow anyone to modify the vschema via the SQL API again when
 		// the test completes.
 		defer func() {
 			writeConfig(configFile, map[string]string{
-				"vschema_ddl_authorized_users": "%",
+				"vschema-ddl-authorized-users": "%",
 			})
 		}()
 		require.EventuallyWithT(t, func(t *assert.CollectT) {

--- a/go/vt/mysqlctl/filebackupstorage/file.go
+++ b/go/vt/mysqlctl/filebackupstorage/file.go
@@ -29,6 +29,7 @@ import (
 
 	"vitess.io/vitess/go/os2"
 	"vitess.io/vitess/go/vt/mysqlctl/errors"
+	"vitess.io/vitess/go/vt/utils"
 
 	"vitess.io/vitess/go/ioutil"
 	stats "vitess.io/vitess/go/vt/mysqlctl/backupstats"
@@ -45,7 +46,7 @@ var (
 )
 
 func registerFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&FileBackupStorageRoot, "file_backup_storage_root", "", "Root directory for the file backup storage.")
+	utils.SetFlagStringVar(fs, &FileBackupStorageRoot, "file-backup-storage-root", "", "Root directory for the file backup storage.")
 }
 
 func init() {

--- a/go/vt/proto/vtgate/vtgate.pb.go
+++ b/go/vt/proto/vtgate/vtgate.pb.go
@@ -47,7 +47,7 @@ const (
 type TransactionMode int32
 
 const (
-	// UNSPECIFIED uses the transaction mode set by the VTGate flag 'transaction_mode'.
+	// UNSPECIFIED uses the transaction mode set by the VTGate flag 'transaction-mode'.
 	TransactionMode_UNSPECIFIED TransactionMode = 0
 	// SINGLE disallows distributed transactions.
 	TransactionMode_SINGLE TransactionMode = 1

--- a/go/vt/utils/flags.go
+++ b/go/vt/utils/flags.go
@@ -111,6 +111,34 @@ func SetFlagVar(fs *pflag.FlagSet, value pflag.Value, name, usage string) {
 	_ = fs.MarkDeprecated(underscored, fmt.Sprintf("use %s instead", dashed))
 }
 
+// SetFlagStringWithViperVar registers a string flag with both dash and underscore variants
+// This is designed to work with viper-managed flags
+func SetFlagStringWithViperVar(fs *pflag.FlagSet, name string, def string, usage string) {
+	underscored, dashed := flagVariants(name)
+	if name == underscored {
+		fmt.Printf("[WARNING] Please use flag names with dashes instead of underscores, preparing for deprecation of underscores in flag names")
+	}
+
+	fs.String(dashed, def, usage)
+	fs.String(underscored, def, "")
+	_ = fs.MarkHidden(underscored)
+	_ = fs.MarkDeprecated(underscored, fmt.Sprintf("use %s instead", dashed))
+}
+
+// SetFlagBoolWithViperVar registers a boolean flag with both dash and underscore variants
+// This is designed to work with viper-managed flags
+func SetFlagBoolWithViperVar(fs *pflag.FlagSet, name string, def bool, usage string) {
+	underscored, dashed := flagVariants(name)
+	if name == underscored {
+		fmt.Printf("[WARNING] Please use flag names with dashes instead of underscores, preparing for deprecation of underscores in flag names")
+	}
+
+	fs.Bool(dashed, def, usage)
+	fs.Bool(underscored, def, "")
+	_ = fs.MarkHidden(underscored)
+	_ = fs.MarkDeprecated(underscored, fmt.Sprintf("use %s instead", dashed))
+}
+
 // SetFlagVariantsForTests randomly assigns either the underscored or dashed version of the flag name to the map.
 // This is designed to help catch cases where code does not properly handle both formats during testing.
 func SetFlagVariantsForTests(m map[string]string, key, value string) {

--- a/go/vt/vtctld/action_repository.go
+++ b/go/vt/vtctld/action_repository.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"vitess.io/vitess/go/vt/utils"
 	"vitess.io/vitess/go/vt/vtenv"
 
 	"vitess.io/vitess/go/acl"
@@ -60,7 +61,7 @@ func init() {
 }
 
 func registerActionRepositoryFlags(fs *pflag.FlagSet) {
-	fs.DurationVar(&actionTimeout, "action_timeout", actionTimeout, "time to wait for an action before resorting to force")
+	utils.SetFlagDurationVar(fs, &actionTimeout, "action-timeout", actionTimeout, "time to wait for an action before resorting to force")
 }
 
 // action{Keyspace,Shard,Tablet}Method is a function that performs

--- a/go/vt/vtgate/buffer/flags.go
+++ b/go/vt/vtgate/buffer/flags.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/utils"
 )
 
 var (
@@ -43,7 +44,7 @@ var (
 )
 
 func registerFlags(fs *pflag.FlagSet) {
-	fs.BoolVar(&bufferEnabled, "enable_buffer", false, "Enable buffering (stalling) of primary traffic during failovers.")
+	utils.SetFlagBoolVar(fs, &bufferEnabled, "enable-buffer", false, "Enable buffering (stalling) of primary traffic during failovers.")
 	fs.BoolVar(&bufferEnabledDryRun, "enable_buffer_dry_run", false, "Detect and log failover events, but do not actually buffer requests.")
 
 	fs.DurationVar(&bufferWindow, "buffer_window", 10*time.Second, "Duration for how long a request should be buffered at most.")
@@ -52,7 +53,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&bufferMinTimeBetweenFailovers, "buffer_min_time_between_failovers", 1*time.Minute, "Minimum time between the end of a failover and the start of the next one (tracked per shard). Faster consecutive failovers will not trigger buffering.")
 
 	fs.IntVar(&bufferDrainConcurrency, "buffer_drain_concurrency", 1, "Maximum number of requests retried simultaneously. More concurrency will increase the load on the PRIMARY vttablet when draining the buffer.")
-	fs.StringVar(&bufferKeyspaceShards, "buffer_keyspace_shards", "", "If not empty, limit buffering to these entries (comma separated). Entry format: keyspace or keyspace/shard. Requires --enable_buffer=true.")
+	fs.StringVar(&bufferKeyspaceShards, "buffer_keyspace_shards", "", "If not empty, limit buffering to these entries (comma separated). Entry format: keyspace or keyspace/shard. Requires --enable-buffer=true.")
 }
 
 func init() {
@@ -79,7 +80,7 @@ func verifyFlags() error {
 	}
 
 	if bufferKeyspaceShards != "" && !bufferEnabled {
-		return fmt.Errorf("--buffer_keyspace_shards=%v also requires that --enable_buffer is set", bufferKeyspaceShards)
+		return fmt.Errorf("--buffer_keyspace_shards=%v also requires that --enable-buffer is set", bufferKeyspaceShards)
 	}
 	if bufferEnabled && bufferEnabledDryRun && bufferKeyspaceShards == "" {
 		return errors.New("both the dry-run mode and actual buffering is enabled. To avoid ambiguity, keyspaces and shards for actual buffering must be explicitly listed in --buffer_keyspace_shards")

--- a/go/vt/vtgate/buffer/flags_test.go
+++ b/go/vt/vtgate/buffer/flags_test.go
@@ -42,13 +42,13 @@ func TestVerifyFlags(t *testing.T) {
 
 	parse([]string{"--buffer_keyspace_shards", "ks1/0"})
 	if err := verifyFlags(); err == nil || !strings.Contains(err.Error(), "also requires that") {
-		t.Fatalf("List of shards requires --enable_buffer. err: %v", err)
+		t.Fatalf("List of shards requires --enable-buffer. err: %v", err)
 	}
 
 	resetFlagsForTesting()
 
 	parse([]string{
-		"--enable_buffer",
+		"--enable-buffer",
 		"--enable_buffer_dry_run",
 	})
 	if err := verifyFlags(); err == nil || !strings.Contains(err.Error(), "To avoid ambiguity") {
@@ -58,7 +58,7 @@ func TestVerifyFlags(t *testing.T) {
 	resetFlagsForTesting()
 
 	parse([]string{
-		"--enable_buffer",
+		"--enable-buffer",
 		"--buffer_keyspace_shards", "ks1//0",
 	})
 	if err := verifyFlags(); err == nil || !strings.Contains(err.Error(), "invalid shard path") {
@@ -68,7 +68,7 @@ func TestVerifyFlags(t *testing.T) {
 	resetFlagsForTesting()
 
 	parse([]string{
-		"--enable_buffer",
+		"--enable-buffer",
 		"--buffer_keyspace_shards", "ks1,ks1/0",
 	})
 	if err := verifyFlags(); err == nil || !strings.Contains(err.Error(), "has overlapping entries") {

--- a/go/vt/vtgate/buffer/test_util.go
+++ b/go/vt/vtgate/buffer/test_util.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package buffer
 
-// SetBufferingModeInTestingEnv should only be used from testing code to change the flag (enable_buffer) default value
+// SetBufferingModeInTestingEnv should only be used from testing code to change the flag (enable-buffer) default value
 func SetBufferingModeInTestingEnv(enabled bool) {
 	bufferEnabled = enabled
 }

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -55,6 +55,7 @@ import (
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/sysvars"
 	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/utils"
 	"vitess.io/vitess/go/vt/vtenv"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/dynamicconfig"
@@ -98,7 +99,7 @@ const (
 
 func init() {
 	registerTabletTypeFlag := func(fs *pflag.FlagSet) {
-		fs.Var((*topoproto.TabletTypeFlag)(&defaultTabletType), "default_tablet_type", "The default tablet type to set for queries, when one is not explicitly selected.")
+		utils.SetFlagVar(fs, (*topoproto.TabletTypeFlag)(&defaultTabletType), "default-tablet-type", "The default tablet type to set for queries, when one is not explicitly selected.")
 	}
 
 	servenv.OnParseFor("vtgate", registerTabletTypeFlag)

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -502,7 +502,7 @@ func (e *Executor) addNeededBindVars(vcursor *econtext.VCursorImpl, bindVarNeeds
 		case sysvars.TransactionMode.Name:
 			txMode := session.TransactionMode
 			if txMode == vtgatepb.TransactionMode_UNSPECIFIED {
-				txMode = transactionMode.Get()
+				txMode = transactionModeFlag.Get()
 			}
 			bindVars[key] = sqltypes.StringBindVariable(txMode.String())
 		case sysvars.Workload.Name:

--- a/go/vt/vtgate/viper_config.go
+++ b/go/vt/vtgate/viper_config.go
@@ -33,7 +33,7 @@ func NewDynamicViperConfig() *DynamicViperConfig {
 	return &DynamicViperConfig{
 		onlineDDL: enableOnlineDDL,
 		directDDL: enableDirectDDL,
-		txMode:    transactionMode,
+		txMode:    transactionModeFlag,
 	}
 }
 

--- a/go/vt/vtgate/vschemaacl/vschemaacl.go
+++ b/go/vt/vtgate/vschemaacl/vschemaacl.go
@@ -25,6 +25,7 @@ import (
 	"vitess.io/vitess/go/viperutil"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/utils"
 )
 
 type authorizedDDLUsers struct {
@@ -62,9 +63,9 @@ func (a *authorizedDDLUsers) String() string {
 var (
 	// AuthorizedDDLUsers specifies the users that can perform ddl operations
 	AuthorizedDDLUsers = viperutil.Configure(
-		"vschema_ddl_authorized_users",
+		"vschema-ddl-authorized-users",
 		viperutil.Options[*authorizedDDLUsers]{
-			FlagName: "vschema_ddl_authorized_users",
+			FlagName: "vschema-ddl-authorized-users",
 			Default:  &authorizedDDLUsers{},
 			Dynamic:  true,
 			GetFunc: func(v *viper.Viper) func(key string) *authorizedDDLUsers {
@@ -87,7 +88,7 @@ var (
 // calls this function, or call this function directly before parsing
 // command-line arguments.
 func RegisterSchemaACLFlags(fs *pflag.FlagSet) {
-	fs.String("vschema_ddl_authorized_users", "", "List of users authorized to execute vschema ddl operations, or '%' to allow all users.")
+	utils.SetFlagStringWithViperVar(fs, "vschema-ddl-authorized-users", "", "List of users authorized to execute vschema ddl operations, or '%' to allow all users.")
 	viperutil.BindFlags(fs, AuthorizedDDLUsers)
 }
 

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -51,6 +51,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
+	"vitess.io/vitess/go/vt/utils"
 	"vitess.io/vitess/go/vt/vtenv"
 	"vitess.io/vitess/go/vt/vterrors"
 	econtext "vitess.io/vitess/go/vt/vtgate/executorcontext"
@@ -99,27 +100,27 @@ var (
 	defaultDDLStrategy = string(schema.DDLStrategyDirect)
 
 	enableOnlineDDL = viperutil.Configure(
-		"enable_online_ddl",
+		"enable-online-ddl",
 		viperutil.Options[bool]{
-			FlagName: "enable_online_ddl",
+			FlagName: "enable-online-ddl",
 			Default:  true,
 			Dynamic:  true,
 		},
 	)
 
 	enableDirectDDL = viperutil.Configure(
-		"enable_direct_ddl",
+		"enable-direct-ddl",
 		viperutil.Options[bool]{
-			FlagName: "enable_direct_ddl",
+			FlagName: "enable-direct-ddl",
 			Default:  true,
 			Dynamic:  true,
 		},
 	)
 
 	transactionMode = viperutil.Configure(
-		"transaction_mode",
+		"transaction-mode",
 		viperutil.Options[vtgatepb.TransactionMode]{
-			FlagName: "transaction_mode",
+			FlagName: "transaction-mode",
 			Default:  vtgatepb.TransactionMode_MULTI,
 			Dynamic:  true,
 			GetFunc: func(v *viper.Viper) func(key string) vtgatepb.TransactionMode {
@@ -134,7 +135,7 @@ var (
 						return vtgatepb.TransactionMode_TWOPC
 					default:
 						fmt.Printf("Invalid option: %v\n", txMode)
-						fmt.Println("Usage: -transaction_mode {SINGLE | MULTI | TWOPC}")
+						fmt.Println("Usage: -transaction-mode {SINGLE | MULTI | TWOPC}")
 						os.Exit(1)
 						return -1
 					}
@@ -167,7 +168,7 @@ var (
 )
 
 func registerFlags(fs *pflag.FlagSet) {
-	fs.String("transaction_mode", "MULTI", "SINGLE: disallow multi-db transactions, MULTI: allow multi-db transactions with best effort commit, TWOPC: allow multi-db transactions with 2pc commit")
+	utils.SetFlagStringWithViperVar(fs, "transaction-mode", "MULTI", "SINGLE: disallow multi-db transactions, MULTI: allow multi-db transactions with best effort commit, TWOPC: allow multi-db transactions with 2pc commit")
 	fs.BoolVar(&normalizeQueries, "normalize_queries", normalizeQueries, "Rewrite queries with bind vars. Turn this off if the app itself sends normalized queries with bind vars.")
 	fs.BoolVar(&terseErrors, "vtgate-config-terse-errors", terseErrors, "prevent bind vars from escaping in returned errors")
 	fs.IntVar(&truncateErrorLen, "truncate-error-len", truncateErrorLen, "truncate errors sent to client if they are longer than this value (0 means do not truncate)")
@@ -188,8 +189,8 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&lockHeartbeatTime, "lock_heartbeat_time", lockHeartbeatTime, "If there is lock function used. This will keep the lock connection active by using this heartbeat")
 	fs.BoolVar(&warnShardedOnly, "warn_sharded_only", warnShardedOnly, "If any features that are only available in unsharded mode are used, query execution warnings will be added to the session")
 	fs.StringVar(&foreignKeyMode, "foreign_key_mode", foreignKeyMode, "This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow, disallow")
-	fs.Bool("enable_online_ddl", enableOnlineDDL.Default(), "Allow users to submit, review and control Online DDL")
-	fs.Bool("enable_direct_ddl", enableDirectDDL.Default(), "Allow users to submit direct DDL statements")
+	utils.SetFlagBoolWithViperVar(fs, "enable-online-ddl", enableOnlineDDL.Default(), "Allow users to submit, review and control Online DDL")
+	utils.SetFlagBoolWithViperVar(fs, "enable-direct-ddl", enableDirectDDL.Default(), "Allow users to submit direct DDL statements")
 	fs.BoolVar(&enableSchemaChangeSignal, "schema_change_signal", enableSchemaChangeSignal, "Enable the schema tracker; requires queryserver-config-schema-change-signal to be enabled on the underlying vttablets for this to work")
 	fs.IntVar(&queryTimeout, "query-timeout", queryTimeout, "Sets the default query timeout (in ms). Can be overridden by session variable (query_timeout) or comment directive (QUERY_TIMEOUT_MS)")
 	fs.StringVar(&queryLogToFile, "log_queries_to_file", queryLogToFile, "Enable query logging to the specified file")

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -87,8 +87,9 @@ var (
 	healthCheckTimeout = time.Minute
 
 	// System settings related flags
-	sysVarSetEnabled = true
-	setVarEnabled    = true
+	sysVarSetEnabled         = true
+	setVarEnabled            = true
+	enableSystemSettingsFlag = true
 
 	// lockHeartbeatTime is used to set the next heartbeat time.
 	lockHeartbeatTime = 5 * time.Second
@@ -117,7 +118,7 @@ var (
 		},
 	)
 
-	transactionMode = viperutil.Configure(
+	transactionModeFlag = viperutil.Configure(
 		"transaction-mode",
 		viperutil.Options[vtgatepb.TransactionMode]{
 			FlagName: "transaction-mode",
@@ -184,7 +185,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&healthCheckTimeout, "healthcheck_timeout", healthCheckTimeout, "the health check timeout period")
 	fs.IntVar(&maxPayloadSize, "max_payload_size", maxPayloadSize, "The threshold for query payloads in bytes. A payload greater than this threshold will result in a failure to handle the query.")
 	fs.IntVar(&warnPayloadSize, "warn_payload_size", warnPayloadSize, "The warning threshold for query payloads in bytes. A payload greater than this threshold will cause the VtGateWarnings.WarnPayloadSizeExceeded counter to be incremented.")
-	fs.BoolVar(&sysVarSetEnabled, "enable_system_settings", sysVarSetEnabled, "This will enable the system settings to be changed per session at the database connection level")
+	utils.SetFlagBoolVar(fs, &enableSystemSettingsFlag, "enable-system-settings", enableSystemSettingsFlag, "This will enable the system settings to be changed per session at the database connection level")
 	fs.BoolVar(&setVarEnabled, "enable_set_var", setVarEnabled, "This will enable the use of MySQL's SET_VAR query hint for certain system variables instead of using reserved connections")
 	fs.DurationVar(&lockHeartbeatTime, "lock_heartbeat_time", lockHeartbeatTime, "If there is lock function used. This will keep the lock connection active by using this heartbeat")
 	fs.BoolVar(&warnShardedOnly, "warn_sharded_only", warnShardedOnly, "If any features that are only available in unsharded mode are used, query execution warnings will be added to the session")
@@ -206,12 +207,15 @@ func registerFlags(fs *pflag.FlagSet) {
 	viperutil.BindFlags(fs,
 		enableOnlineDDL,
 		enableDirectDDL,
-		transactionMode,
+		transactionModeFlag,
 	)
 }
 
 func init() {
-	servenv.OnParseFor("vtgate", registerFlags)
+	servenv.OnParseFor("vtgate", func(fs *pflag.FlagSet) {
+		registerFlags(fs)
+		sysVarSetEnabled = enableSystemSettingsFlag
+	})
 	servenv.OnParseFor("vtcombo", registerFlags)
 }
 

--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -700,11 +700,13 @@ func TestSelectBooleanSystemVariables(t *testing.T) {
 		return testCase{Variable: varname, Value: value, Type: vartype}
 	}
 
+	enableSystemSettings := "enable_system_settings"
+
 	tcs := []testCase{
 		newTestCase("autocommit", querypb.Type_INT64, true),
 		newTestCase("autocommit", querypb.Type_INT64, false),
-		newTestCase("enable_system_settings", querypb.Type_INT64, true),
-		newTestCase("enable_system_settings", querypb.Type_INT64, false),
+		newTestCase(enableSystemSettings, querypb.Type_INT64, true),
+		newTestCase(enableSystemSettings, querypb.Type_INT64, false),
 	}
 
 	for _, tc := range tcs {

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -123,10 +123,10 @@ type Config struct {
 	SnapshotFile string
 
 	// Enable system settings to be changed per session at the database connection level
-	EnableSystemSettings bool
+	EnableSystemSettingsFlag bool
 
-	// TransactionMode is SINGLE, MULTI or TWOPC
-	TransactionMode string
+	// TransactionModeFlag is SINGLE, MULTI or TWOPC
+	TransactionModeFlag string
 
 	TransactionTimeout time.Duration
 

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -269,7 +269,7 @@ func VtcomboProcess(environment Environment, args *Config, mysql MySQLManager) (
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--vschema-persistence-dir", path.Join(args.DataDir, "vschema_data")}...)
 	}
 	if args.TransactionMode != "" {
-		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--transaction_mode", args.TransactionMode}...)
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--transaction-mode", args.TransactionMode}...)
 	}
 	if args.TransactionTimeout != 0 {
 		vt.ExtraArgs = append(vt.ExtraArgs, "--queryserver-config-transaction-timeout", fmt.Sprintf("%v", args.TransactionTimeout))
@@ -281,7 +281,7 @@ func VtcomboProcess(environment Environment, args *Config, mysql MySQLManager) (
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--grpc-auth-mode", servenv.GRPCAuth(), "--grpc-key", servenv.GRPCKey(), "--grpc-cert", servenv.GRPCCert(), "--grpc-ca", servenv.GRPCCertificateAuthority(), "--grpc-auth-mtls-allowed-substrings", servenv.ClientCertSubstrings()}...)
 	}
 	if args.VSchemaDDLAuthorizedUsers != "" {
-		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--vschema_ddl_authorized_users", args.VSchemaDDLAuthorizedUsers}...)
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--vschema-ddl-authorized-users", args.VSchemaDDLAuthorizedUsers}...)
 	}
 	vt.ExtraArgs = append(vt.ExtraArgs, "--mysql-server-version", servenv.MySQLServerVersion())
 	if socket != "" {

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -246,7 +246,7 @@ func VtcomboProcess(environment Environment, args *Config, mysql MySQLManager) (
 		"--planner-version", args.PlannerVersion,
 		fmt.Sprintf("--enable_online_ddl=%t", args.EnableOnlineDDL),
 		fmt.Sprintf("--enable_direct_ddl=%t", args.EnableDirectDDL),
-		fmt.Sprintf("--enable_system_settings=%t", args.EnableSystemSettings),
+		fmt.Sprintf("--enable_system_settings=%t", args.EnableSystemSettingsFlag),
 		fmt.Sprintf("--no_scatter=%t", args.NoScatter),
 	}...)
 
@@ -268,8 +268,8 @@ func VtcomboProcess(environment Environment, args *Config, mysql MySQLManager) (
 	if args.PersistentMode && args.DataDir != "" {
 		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--vschema-persistence-dir", path.Join(args.DataDir, "vschema_data")}...)
 	}
-	if args.TransactionMode != "" {
-		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--transaction-mode", args.TransactionMode}...)
+	if args.TransactionModeFlag != "" {
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{"--transaction_mode", args.TransactionModeFlag}...)
 	}
 	if args.TransactionTimeout != 0 {
 		vt.ExtraArgs = append(vt.ExtraArgs, "--queryserver-config-transaction-timeout", fmt.Sprintf("%v", args.TransactionTimeout))

--- a/proto/vtgate.proto
+++ b/proto/vtgate.proto
@@ -31,7 +31,7 @@ import "vtrpc.proto";
 // TransactionMode controls the execution of distributed transaction
 // across multiple shards.
 enum TransactionMode {
-  // UNSPECIFIED uses the transaction mode set by the VTGate flag 'transaction_mode'.
+  // UNSPECIFIED uses the transaction mode set by the VTGate flag 'transaction-mode'.
   UNSPECIFIED = 0;
   // SINGLE disallows distributed transactions.
   SINGLE = 1;


### PR DESCRIPTION
## Description
This PR is a part of an ongoing change to support the transition from underscores (`_`) to dashes (`-`) in flag naming conventions. 

**Flags Updated in This PR:**
--vschema-ddl-authorized-users  
--file-backup-storage-root  
--enable-buffer  
--default-tablet-type  
--action-timeout  
--transaction-mode  
--enable-system-settings  
--enable-online-ddl  
--enable-direct-ddl  

### Flag Count Before vs After:

|   | Flags with `_` | Flags with `-` |  
|---|--------------|--------------|  
| **Before** | 410 | 1670 |  
| **After** | 381 |  1699|  

**# of migrated flags: 29**

## Related Issue(s)
#17880

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required
