### PR TITLE
Fix deadlock in semi-sync monitor

### DIFF
--- a/go/vt/vttablet/tabletmanager/semisyncmonitor/monitor.go
+++ b/go/vt/vttablet/tabletmanager/semisyncmonitor/monitor.go
@@ -66,6 +66,10 @@ type Monitor struct {
 	// the semisync_heartbeat table.
 	clearTicks *timer.Timer
 
+	// timerMu protects operations on the timers to prevent deadlocks
+	// This must be acquired before mu if both are needed.
+	timerMu sync.Mutex
+
 	// mu protects the fields below.
 	mu      sync.Mutex
 	appPool *dbconnpool.ConnectionPool
@@ -123,8 +127,13 @@ func CreateTestSemiSyncMonitor(db *fakesqldb.DB, exporter *servenv.Exporter) *Mo
 
 // Open starts the monitor.
 func (m *Monitor) Open() {
+	// First acquire the timer mutex to prevent deadlock - we acquire in a consistent order
+	m.timerMu.Lock()
+	defer m.timerMu.Unlock()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
 	// The check for config being nil is only requried for tests.
 	if m.isOpen || m.config == nil || m.config.DB == nil {
 		// If we are already open, then there is nothing to do
@@ -145,16 +154,19 @@ func (m *Monitor) Open() {
 
 // Close stops the monitor.
 func (m *Monitor) Close() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if !m.isOpen {
-		// If we are already closed, then there is nothing to do
-		return
-	}
-	m.isOpen = false
+	// First acquire the timer mutex to prevent deadlock - we acquire in a consistent order
+	m.timerMu.Lock()
+	defer m.timerMu.Unlock()
 	log.Info("SemiSync Monitor: closing")
+	// We close the ticks before we acquire the mu mutex to prevent deadlock.
+	// The timer Close should not be called while holding a mutex that the function
+	// the timer runs also acquires.
 	m.clearTicks.Stop()
 	m.ticks.Stop()
+	// Acquire the mu mutex to update the isOpen field.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.isOpen = false
 	m.appPool.Close()
 }
 

--- a/go/vt/vttablet/tabletmanager/semisyncmonitor/monitor_test.go
+++ b/go/vt/vttablet/tabletmanager/semisyncmonitor/monitor_test.go
@@ -643,6 +643,7 @@ func TestDeadlockOnClose(t *testing.T) {
 
 	// Open the monitor
 	m.Open()
+	defer m.Close()
 
 	// We will now try to close and open the monitor multiple times to see if we can trigger a deadlock.
 	finishCh := make(chan int)

--- a/go/vt/vttablet/tabletmanager/semisyncmonitor/monitor_test.go
+++ b/go/vt/vttablet/tabletmanager/semisyncmonitor/monitor_test.go
@@ -619,6 +619,52 @@ func TestWaitUntilSemiSyncUnblocked(t *testing.T) {
 	require.True(t, m.isClosed())
 }
 
+// TestDeadlockOnClose tests the deadlock that can occur when calling Close().
+// Look at https://github.com/vitessio/vitess/issues/18275 for more details.
+func TestDeadlockOnClose(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+	params := db.ConnParams()
+	cp := *params
+	dbc := dbconfigs.NewTestDBConfigs(cp, cp, "")
+	config := &tabletenv.TabletConfig{
+		DB: dbc,
+		SemiSyncMonitor: tabletenv.SemiSyncMonitorConfig{
+			// Extremely low interval to trigger the deadlock quickly.
+			// This makes the monitor try and write that it is still blocked quite aggressively.
+			Interval: 10 * time.Millisecond,
+		},
+	}
+	m := NewMonitor(config, exporter)
+
+	// Set up for semisync to be blocked
+	db.SetNeverFail(true)
+	db.AddQuery(semiSyncWaitSessionsRead, sqltypes.MakeTestResult(sqltypes.MakeTestFields("variable_value", "varchar"), "1"))
+
+	// Open the monitor
+	m.Open()
+
+	// We will now try to close and open the monitor multiple times to see if we can trigger a deadlock.
+	finishCh := make(chan int)
+	go func() {
+		count := 100
+		for i := 0; i < count; i++ {
+			m.Close()
+			m.Open()
+			time.Sleep(20 * time.Millisecond)
+		}
+		close(finishCh)
+	}()
+
+	select {
+	case <-finishCh:
+		// The test finished without deadlocking.
+	case <-time.After(5 * time.Second):
+		// The test timed out, which means we deadlocked.
+		t.Fatalf("Deadlock occurred while closing the monitor")
+	}
+}
+
 // TestSemiSyncMonitor tests the semi-sync monitor as a black box.
 // It only calls the exported methods to see they work as intended.
 func TestSemiSyncMonitor(t *testing.T) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the deadlock described in https://github.com/vitessio/vitess/issues/18275. As the issue stated, the deadlock happens because we hold the mutex `mu` when closing the timer. We should prevent this because, the keephouse function (`checkAndFixSemiSyncBlocked`) also acquires that mutex.

This PR fixes this. In order to prevent acquiring the `mu` mutex but still guaranteeing that only one of Close and Open runs at a point in time, we had to introduce another mutex just for this purpose. A test has also been added that initially verified that the deadlock exists, and now verifies that the fix in this PR resolves the deadlock.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #18275 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
