### PR TITLE
Fix `SET` and `START TRANSACTION` in create procedure statements

### DIFF
--- a/go/test/endtoend/vtgate/unsharded/main_test.go
+++ b/go/test/endtoend/vtgate/unsharded/main_test.go
@@ -151,7 +151,10 @@ BEGIN
 	insert into allDefaults(id) values (128);
 	select 128 into val from dual;
 END;
-`}
+`,
+		`CREATE PROCEDURE p1 (in x BIGINT) BEGIN declare y DECIMAL(14,2); set y = 4.2; END`,
+		`CREATE PROCEDURE p2 (in x BIGINT) BEGIN START TRANSACTION; SELECT 128 from dual; COMMIT; END`,
+	}
 )
 
 func TestMain(m *testing.M) {

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -640,8 +640,15 @@ type (
 	// TxAccessMode is an enum for Transaction Access Mode
 	TxAccessMode int8
 
+	// BeginType is an enum for the type of BEGIN statement.
+	BeginType int8
+
 	// Begin represents a Begin statement.
 	Begin struct {
+		// We need to differentiate between BEGIN and START TRANSACTION statements
+		// because inside a stored procedure the former is considered part of a BEGIN...END statement,
+		// while the latter starts a transaction.
+		Type          BeginType
 		TxAccessModes []TxAccessMode
 	}
 

--- a/go/vt/sqlparser/ast_equals.go
+++ b/go/vt/sqlparser/ast_equals.go
@@ -2071,7 +2071,8 @@ func (cmp *Comparator) RefOfBegin(a, b *Begin) bool {
 	if a == nil || b == nil {
 		return false
 	}
-	return cmp.SliceOfTxAccessMode(a.TxAccessModes, b.TxAccessModes)
+	return a.Type == b.Type &&
+		cmp.SliceOfTxAccessMode(a.TxAccessModes, b.TxAccessModes)
 }
 
 // RefOfBeginEndStatement does deep equals between the two objects.

--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -1188,7 +1188,7 @@ func (node *Commit) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node *Begin) Format(buf *TrackedBuffer) {
-	if node.TxAccessModes == nil {
+	if node.Type == BeginStmt {
 		buf.literal("begin")
 		return
 	}

--- a/go/vt/sqlparser/ast_format_fast.go
+++ b/go/vt/sqlparser/ast_format_fast.go
@@ -1564,7 +1564,7 @@ func (node *Commit) FormatFast(buf *TrackedBuffer) {
 
 // FormatFast formats the node.
 func (node *Begin) FormatFast(buf *TrackedBuffer) {
-	if node.TxAccessModes == nil {
+	if node.Type == BeginStmt {
 		buf.WriteString("begin")
 		return
 	}

--- a/go/vt/sqlparser/cached_size.go
+++ b/go/vt/sqlparser/cached_size.go
@@ -421,7 +421,7 @@ func (cached *Begin) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(24)
+		size += int64(32)
 	}
 	// field TxAccessModes []vitess.io/vitess/go/vt/sqlparser.TxAccessMode
 	{

--- a/go/vt/sqlparser/constants.go
+++ b/go/vt/sqlparser/constants.go
@@ -997,6 +997,12 @@ const (
 	ReadOnly
 )
 
+// BEGIN statement type
+const (
+	BeginStmt BeginType = iota
+	StartTransactionStmt
+)
+
 // Enum Types of WKT functions
 const (
 	GeometryFromText GeomFromWktType = iota

--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -174,7 +174,7 @@ func (nz *normalizer) determineQueryRewriteStrategy(in Statement) {
 func (nz *normalizer) walkDown(node, _ SQLNode) bool {
 	switch node := node.(type) {
 	case *Begin, *Commit, *Rollback, *Savepoint, *SRollback, *Release, *OtherAdmin, *Analyze,
-		*PrepareStmt, *ExecuteStmt, *FramePoint, *ColName, TableName, *ConvertType:
+		*PrepareStmt, *ExecuteStmt, *FramePoint, *ColName, TableName, *ConvertType, *CreateProcedure:
 		// These statement do not need normalizing
 		return false
 	case *AssignmentExpr:

--- a/go/vt/sqlparser/normalizer_test.go
+++ b/go/vt/sqlparser/normalizer_test.go
@@ -441,6 +441,11 @@ func TestNormalize(t *testing.T) {
 			"bv1": sqltypes.Int64BindVariable(1),
 			"bv2": sqltypes.Int64BindVariable(0),
 		},
+	}, {
+		// Verify we don't change anything in the normalization of create procedures.
+		in:      "CREATE PROCEDURE p2 (in x BIGINT) BEGIN declare y DECIMAL(14,2); START TRANSACTION; set y = 4.2; SELECT 128 from dual; COMMIT; END",
+		outstmt: "create procedure p2 (in x BIGINT) begin declare y DECIMAL(14,2); start transaction; set y = 4.2; select 128 from dual; commit; end;",
+		outbv:   map[string]*querypb.BindVariable{},
 	}}
 	parser := NewTestParser()
 	for _, tc := range testcases {

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -2227,6 +2227,8 @@ var (
 		input:  "create procedure ConditionWithSignalAndHandler() begin declare custom_error condition for sqlstate '45000'; declare exit handler for custom_error begin select 'Handled with custom condition and signal'; end; signal sqlstate '45000' set message_text = 'Custom signal triggered'; end;",
 		output: "create procedure ConditionWithSignalAndHandler () begin declare custom_error condition for sqlstate '45000'; declare exit handler for custom_error begin select 'Handled with custom condition and signal' from dual; end; signal sqlstate '45000' set message_text = 'Custom signal triggered'; end;",
 	}, {
+		input: "create procedure t1 (in x BIGINT) begin start transaction; insert into unsharded_a values (1, 'a', 'a'); commit; end;",
+	}, {
 		input: "create /*vt+ strategy=online */ or replace view v as select a, b, c from t",
 	}, {
 		input: "alter view a as select * from t",
@@ -2907,8 +2909,7 @@ var (
 		input:  "begin;",
 		output: "begin",
 	}, {
-		input:  "start transaction",
-		output: "begin",
+		input: "start transaction",
 	}, {
 		input: "start transaction with consistent snapshot",
 	}, {

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -17443,7 +17443,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:4783
 		{
-			yyLOCAL = &Begin{}
+			yyLOCAL = &Begin{Type: BeginStmt}
 		}
 		yyVAL.union = yyLOCAL
 	case 884:
@@ -17451,7 +17451,7 @@ yydefault:
 		var yyLOCAL Statement
 //line sql.y:4787
 		{
-			yyLOCAL = &Begin{TxAccessModes: yyDollar[3].txAccessModesUnion()}
+			yyLOCAL = &Begin{Type: StartTransactionStmt, TxAccessModes: yyDollar[3].txAccessModesUnion()}
 		}
 		yyVAL.union = yyLOCAL
 	case 885:

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -4781,11 +4781,11 @@ use_table_name:
 begin_statement:
   BEGIN
   {
-    $$ = &Begin{}
+    $$ = &Begin{Type: BeginStmt}
   }
 | START TRANSACTION tx_chacteristics_opt
   {
-    $$ = &Begin{TxAccessModes: $3}
+    $$ = &Begin{Type: StartTransactionStmt, TxAccessModes: $3}
   }
 
 tx_chacteristics_opt:

--- a/go/vt/vtgate/planbuilder/testdata/ddl_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/ddl_cases.json
@@ -140,6 +140,46 @@
     }
   },
   {
+    "comment": "Create procedure with set statement",
+    "query": "create procedure main.t1 (in x BIGINT) begin declare y DECIMAL(14,2); set y = 4.2; end;",
+    "plan": {
+      "Type": "DirectDDL",
+      "QueryType": "DDL",
+      "Original": "create procedure main.t1 (in x BIGINT) begin declare y DECIMAL(14,2); set y = 4.2; end;",
+      "Instructions": {
+        "OperatorType": "DDL",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "Query": "create procedure t1 (in x BIGINT) begin declare y DECIMAL(14,2); set y = 4.2; end;"
+      },
+      "TablesUsed": [
+        "main.t1"
+      ]
+    }
+  },
+  {
+    "comment": "Create procedure with a transaction inside",
+    "query": "create procedure main.t1 (in x BIGINT) begin start transaction; insert into unsharded_a values (1, 'a', 'a'); commit; end;",
+    "plan": {
+      "Type": "DirectDDL",
+      "QueryType": "DDL",
+      "Original": "create procedure main.t1 (in x BIGINT) begin start transaction; insert into unsharded_a values (1, 'a', 'a'); commit; end;",
+      "Instructions": {
+        "OperatorType": "DDL",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "Query": "create procedure t1 (in x BIGINT) begin start transaction; insert into unsharded_a values (1, 'a', 'a'); commit; end;"
+      },
+      "TablesUsed": [
+        "main.t1"
+      ]
+    }
+  },
+  {
     "comment": "DDL",
     "query": "create table a(id int)",
     "plan": {


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
As stated in https://github.com/vitessio/vitess/issues/18278, when we added support for create procedures in https://github.com/vitessio/vitess/pull/17946, we made a couple of mistakes - 

1. `SET y = 4` statements get converted to `SET @@y = 4` which is incorrect. This was happening in the normalisation step of the planner. This has been fixed in this PR by skipping the entire normalisation step for create procedure statements.
2. `START TRANSACTION` statements get converted to `BEGIN` which eventually throw a parsing error. In a stored procedure a `BEGIN` statement is considered part of a `BEGIN...END` statement, so we need to preserve `START TRANSACTION` statements as is, and not change them to `BEGIN`. This is done by storing a new field in the AST to preserve the original type of the statement.

Tests for both of these have been added to the planner as well as e2e tested that we are indeed able to create the procedures with these statements.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #18278 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
