### PR TITLE
Improve `UNION` query merging

### DIFF
--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -45,6 +45,7 @@ type (
 		bindVars  map[string]*querypb.BindVariable
 		reserved  *ReservedVars
 		vals      map[Literal]string
+		tupleVals map[string]string
 		err       error
 		inDerived int
 		inSelect  int
@@ -145,6 +146,7 @@ func newNormalizer(
 		bindVars:      bindVars,
 		reserved:      reserved,
 		vals:          make(map[Literal]string),
+		tupleVals:     make(map[string]string),
 		bindVarNeeds:  &BindVarNeeds{},
 		keyspace:      keyspace,
 		selectLimit:   selectLimit,
@@ -470,8 +472,22 @@ func (nz *normalizer) rewriteInComparisons(node *ComparisonExpr) {
 			Value: bval.Value,
 		})
 	}
-	bvname := nz.reserved.nextUnusedVar()
-	nz.bindVars[bvname] = bvals
+
+	var bvname string
+
+	if key, err := bvals.MarshalVT(); err != nil {
+		bvname = nz.reserved.nextUnusedVar()
+		nz.bindVars[bvname] = bvals
+	} else {
+		// Check if we can find key in tuplevals
+		if bvname, ok = nz.tupleVals[string(key)]; !ok {
+			bvname = nz.reserved.nextUnusedVar()
+		}
+
+		nz.bindVars[bvname] = bvals
+		nz.tupleVals[string(key)] = bvname
+	}
+
 	node.Right = ListArg(bvname)
 }
 

--- a/go/vt/sqlparser/normalizer_test.go
+++ b/go/vt/sqlparser/normalizer_test.go
@@ -317,7 +317,13 @@ func TestNormalize(t *testing.T) {
 			"bv1": sqltypes.TestBindVariable([]any{1, "2"}),
 		},
 	}, {
-		// EXPLAIN query will be normalized and not parameterized
+		// repeated IN clause with vals
+		in:      "select * from t where v1 in (1, '2') OR v2 in (1, '2')",
+		outstmt: "select * from t where v1 in ::bv1 or v2 in ::bv1",
+		outbv: map[string]*querypb.BindVariable{
+			"bv1": sqltypes.TestBindVariable([]any{1, "2"}),
+		},
+	}, { // EXPLAIN query will be normalized and not parameterized
 		in:      "explain select @x from t where v1 in (1, '2')",
 		outstmt: "explain select :__vtudvx as `@x` from t where v1 in (1, '2')",
 		outbv:   map[string]*querypb.BindVariable{},
@@ -1325,9 +1331,9 @@ JOIN warehouse%d AS w ON c_w_id=w_id
 WHERE w_id = %d
 AND c_d_id = %d
 AND c_id = %d`,
-		`SELECT d_next_o_id, d_tax 
-FROM district%d 
-WHERE d_w_id = %d 
+		`SELECT d_next_o_id, d_tax
+FROM district%d
+WHERE d_w_id = %d
 AND d_id = %d FOR UPDATE`,
 		`UPDATE district%d
 SET d_next_o_id = %d
@@ -1337,58 +1343,58 @@ WHERE d_id = %d AND d_w_id= %d`,
 VALUES (%d,%d,%d,%d,NOW(),%d,%d)`,
 		`INSERT INTO new_orders%d (no_o_id, no_d_id, no_w_id)
 VALUES (%d,%d,%d)`,
-		`SELECT i_price, i_name, i_data 
+		`SELECT i_price, i_name, i_data
 FROM item%d
 WHERE i_id = %d`,
-		`SELECT s_quantity, s_data, s_dist_%s s_dist 
-FROM stock%d  
+		`SELECT s_quantity, s_data, s_dist_%s s_dist
+FROM stock%d
 WHERE s_i_id = %d AND s_w_id= %d FOR UPDATE`,
 		`UPDATE stock%d
 SET s_quantity = %d
-WHERE s_i_id = %d 
+WHERE s_i_id = %d
 AND s_w_id= %d`,
 		`INSERT INTO order_line%d
 (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info)
 VALUES (%d,%d,%d,%d,%d,%d,%d,%d,'%s')`,
 		`UPDATE warehouse%d
-SET w_ytd = w_ytd + %d 
+SET w_ytd = w_ytd + %d
 WHERE w_id = %d`,
 		`SELECT w_street_1, w_street_2, w_city, w_state, w_zip, w_name
 FROM warehouse%d
 WHERE w_id = %d`,
-		`UPDATE district%d 
-SET d_ytd = d_ytd + %d 
-WHERE d_w_id = %d 
+		`UPDATE district%d
+SET d_ytd = d_ytd + %d
+WHERE d_w_id = %d
 AND d_id= %d`,
-		`SELECT d_street_1, d_street_2, d_city, d_state, d_zip, d_name 
+		`SELECT d_street_1, d_street_2, d_city, d_state, d_zip, d_name
 FROM district%d
-WHERE d_w_id = %d 
+WHERE d_w_id = %d
 AND d_id = %d`,
 		`SELECT count(c_id) namecnt
 FROM customer%d
-WHERE c_w_id = %d 
+WHERE c_w_id = %d
 AND c_d_id= %d
 AND c_last='%s'`,
 		`SELECT c_first, c_middle, c_last, c_street_1,
 c_street_2, c_city, c_state, c_zip, c_phone,
 c_credit, c_credit_lim, c_discount, c_balance, c_ytd_payment, c_since
 FROM customer%d
-WHERE c_w_id = %d 
+WHERE c_w_id = %d
 AND c_d_id= %d
 AND c_id=%d FOR UPDATE`,
 		`SELECT c_data
 FROM customer%d
-WHERE c_w_id = %d 
+WHERE c_w_id = %d
 AND c_d_id=%d
 AND c_id= %d`,
 		`UPDATE customer%d
 SET c_balance=%f, c_ytd_payment=%f, c_data='%s'
-WHERE c_w_id = %d 
+WHERE c_w_id = %d
 AND c_d_id=%d
 AND c_id=%d`,
 		`UPDATE customer%d
 SET c_balance=%f, c_ytd_payment=%f
-WHERE c_w_id = %d 
+WHERE c_w_id = %d
 AND c_d_id=%d
 AND c_id=%d`,
 		`INSERT INTO history%d
@@ -1396,71 +1402,71 @@ AND c_id=%d`,
 VALUES (%d,%d,%d,%d,%d,NOW(),%d,'%s')`,
 		`SELECT count(c_id) namecnt
 FROM customer%d
-WHERE c_w_id = %d 
+WHERE c_w_id = %d
 AND c_d_id= %d
 AND c_last='%s'`,
 		`SELECT c_balance, c_first, c_middle, c_id
 FROM customer%d
-WHERE c_w_id = %d 
+WHERE c_w_id = %d
 AND c_d_id= %d
 AND c_last='%s' ORDER BY c_first`,
 		`SELECT c_balance, c_first, c_middle, c_last
 FROM customer%d
-WHERE c_w_id = %d 
+WHERE c_w_id = %d
 AND c_d_id=%d
 AND c_id=%d`,
 		`SELECT o_id, o_carrier_id, o_entry_d
-FROM orders%d 
-WHERE o_w_id = %d 
-AND o_d_id = %d 
-AND o_c_id = %d 
+FROM orders%d
+WHERE o_w_id = %d
+AND o_d_id = %d
+AND o_c_id = %d
 ORDER BY o_id DESC`,
 		`SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
 FROM order_line%d WHERE ol_w_id = %d AND ol_d_id = %d  AND ol_o_id = %d`,
 		`SELECT no_o_id
-FROM new_orders%d 
-WHERE no_d_id = %d 
-AND no_w_id = %d 
+FROM new_orders%d
+WHERE no_d_id = %d
+AND no_w_id = %d
 ORDER BY no_o_id ASC LIMIT 1 FOR UPDATE`,
 		`DELETE FROM new_orders%d
-WHERE no_o_id = %d 
-AND no_d_id = %d  
+WHERE no_o_id = %d
+AND no_d_id = %d
 AND no_w_id = %d`,
 		`SELECT o_c_id
-FROM orders%d 
-WHERE o_id = %d 
-AND o_d_id = %d 
+FROM orders%d
+WHERE o_id = %d
+AND o_d_id = %d
 AND o_w_id = %d`,
-		`UPDATE orders%d 
+		`UPDATE orders%d
 SET o_carrier_id = %d
-WHERE o_id = %d 
-AND o_d_id = %d 
+WHERE o_id = %d
+AND o_d_id = %d
 AND o_w_id = %d`,
-		`UPDATE order_line%d 
+		`UPDATE order_line%d
 SET ol_delivery_d = NOW()
-WHERE ol_o_id = %d 
-AND ol_d_id = %d 
+WHERE ol_o_id = %d
+AND ol_d_id = %d
 AND ol_w_id = %d`,
 		`SELECT SUM(ol_amount) sm
-FROM order_line%d 
-WHERE ol_o_id = %d 
-AND ol_d_id = %d 
+FROM order_line%d
+WHERE ol_o_id = %d
+AND ol_d_id = %d
 AND ol_w_id = %d`,
-		`UPDATE customer%d 
+		`UPDATE customer%d
 SET c_balance = c_balance + %f,
 c_delivery_cnt = c_delivery_cnt + 1
-WHERE c_id = %d 
-AND c_d_id = %d 
+WHERE c_id = %d
+AND c_d_id = %d
 AND c_w_id = %d`,
-		`SELECT d_next_o_id 
+		`SELECT d_next_o_id
 FROM district%d
 WHERE d_id = %d AND d_w_id= %d`,
 		`SELECT COUNT(DISTINCT(s.s_i_id))
 FROM stock%d AS s
-JOIN order_line%d AS ol ON ol.ol_w_id=s.s_w_id AND ol.ol_i_id=s.s_i_id			
-WHERE ol.ol_w_id = %d 
+JOIN order_line%d AS ol ON ol.ol_w_id=s.s_w_id AND ol.ol_i_id=s.s_i_id
+WHERE ol.ol_w_id = %d
 AND ol.ol_d_id = %d
-AND ol.ol_o_id < %d 
+AND ol.ol_o_id < %d
 AND ol.ol_o_id >= %d
 AND s.s_w_id= %d
 AND s.s_quantity < %d `,
@@ -1471,7 +1477,7 @@ AND ol_o_id < %d AND ol_o_id >= %d`,
 WHERE s_w_id = %d AND s_i_id = %d
 AND s_quantity < %d`,
 		`SELECT min(no_o_id) mo
-FROM new_orders%d 
+FROM new_orders%d
 WHERE no_w_id = %d AND no_d_id = %d`,
 		`SELECT o_id FROM orders%d o, (SELECT o_c_id,o_w_id,o_d_id,count(distinct o_id) FROM orders%d WHERE o_w_id=%d AND o_d_id=%d AND o_id > 2100 AND o_id < %d GROUP BY o_c_id,o_d_id,o_w_id having count( distinct o_id) > 1 limit 1) t WHERE t.o_w_id=o.o_w_id and t.o_d_id=o.o_d_id and t.o_c_id=o.o_c_id limit 1 `,
 		`DELETE FROM order_line%d where ol_w_id=%d AND ol_d_id=%d AND ol_o_id=%d`,

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -3333,33 +3333,17 @@ func TestSelectWithUnionAll(t *testing.T) {
 	bv1, _ := sqltypes.BuildBindVariable([]int64{1, 2})
 	bv2, _ := sqltypes.BuildBindVariable([]int64{3})
 	sbc1WantQueries := []*querypb.BoundQuery{{
-		Sql: "select id from `user` where id in ::__vals",
+		Sql: "select id from `user` where id in ::__vals union all select id from `user` where id in ::vtg1",
 		BindVariables: map[string]*querypb.BindVariable{
 			"__vals": bv1,
 			"vtg1":   bv,
-			"vtg2":   bv,
-		},
-	}, {
-		Sql: "select id from `user` where id in ::__vals",
-		BindVariables: map[string]*querypb.BindVariable{
-			"__vals": bv1,
-			"vtg1":   bv,
-			"vtg2":   bv,
 		},
 	}}
 	sbc2WantQueries := []*querypb.BoundQuery{{
-		Sql: "select id from `user` where id in ::__vals",
+		Sql: "select id from `user` where id in ::__vals union all select id from `user` where id in ::vtg1",
 		BindVariables: map[string]*querypb.BindVariable{
 			"__vals": bv2,
 			"vtg1":   bv,
-			"vtg2":   bv,
-		},
-	}, {
-		Sql: "select id from `user` where id in ::__vals",
-		BindVariables: map[string]*querypb.BindVariable{
-			"__vals": bv2,
-			"vtg1":   bv,
-			"vtg2":   bv,
 		},
 	}}
 	session := &vtgatepb.Session{

--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -478,14 +478,26 @@ func gen4ValuesEqual(ctx *plancontext.PlanningContext, a, b []sqlparser.Expr) (b
 			return false, nil
 		}
 		if c != nil {
-			conditions = append(conditions, *c)
+			conditions = append(conditions, c...)
 		}
 	}
 	return true, conditions
 }
 
-func gen4ValEqual(ctx *plancontext.PlanningContext, a, b sqlparser.Expr) (bool, *engine.Condition) {
+func gen4ValEqual(ctx *plancontext.PlanningContext, a, b sqlparser.Expr) (bool, []engine.Condition) {
 	switch a := a.(type) {
+	case sqlparser.ValTuple:
+		if b, ok := b.(sqlparser.ValTuple); ok {
+			return gen4ValuesEqual(ctx, a, b)
+		}
+
+		return false, nil
+
+	case sqlparser.ListArg:
+		if b, ok := b.(sqlparser.ListArg); ok {
+			return a == b, nil
+		}
+
 	case *sqlparser.ColName:
 		if b, ok := b.(*sqlparser.ColName); ok {
 			if !a.Name.Equal(b.Name) {
@@ -518,7 +530,7 @@ func gen4ValEqual(ctx *plancontext.PlanningContext, a, b sqlparser.Expr) (bool, 
 		}
 
 		return aVal.Type == bVal.Type && bytes.Equal(aVal.Value, bVal.Value),
-			&engine.Condition{A: a.Name, B: b.Name}
+			[]engine.Condition{{A: a.Name, B: b.Name}}
 
 	case *sqlparser.Literal:
 		b, ok := b.(*sqlparser.Literal)

--- a/go/vt/vtgate/planbuilder/operators/union_merging.go
+++ b/go/vt/vtgate/planbuilder/operators/union_merging.go
@@ -146,8 +146,6 @@ func tryMergeUnionShardedRouting(
 
 	scatterA := tblA.RouteOpCode == engine.Scatter
 	scatterB := tblB.RouteOpCode == engine.Scatter
-	uniqueA := tblA.RouteOpCode == engine.EqualUnique
-	uniqueB := tblB.RouteOpCode == engine.EqualUnique
 
 	switch {
 	case scatterA:
@@ -156,7 +154,11 @@ func tryMergeUnionShardedRouting(
 	case scatterB:
 		return createMergedUnion(ctx, routeA, routeB, exprsA, exprsB, distinct, tblB, nil)
 
-	case uniqueA && uniqueB:
+	case tblA.RouteOpCode == engine.EqualUnique && tblB.RouteOpCode == engine.EqualUnique:
+		fallthrough
+	case tblA.RouteOpCode == engine.Equal && tblB.RouteOpCode == engine.Equal:
+		fallthrough
+	case tblA.RouteOpCode == engine.IN && tblB.RouteOpCode == engine.IN:
 		aVdx := tblA.SelectedVindex()
 		bVdx := tblB.SelectedVindex()
 		aExpr := tblA.VindexExpressions()

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -1680,6 +1680,103 @@
     "skip_e2e": true
   },
   {
+    "comment": "union with the same target shard (using `IN` with multiple matching values)",
+    "query": "SELECT id FROM music WHERE music.user_id IN (1, 2, 3) UNION SELECT id FROM music WHERE music.user_id IN (1, 2, 3)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "SELECT id FROM music WHERE music.user_id IN (1, 2, 3) UNION SELECT id FROM music WHERE music.user_id IN (1, 2, 3)",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "IN",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from music where 1 != 1 union select id from music where 1 != 1) as dt(c0) where 1 != 1",
+            "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from music where music.user_id in ::__vals union select id from music where music.user_id in (1, 2, 3)) as dt(c0)",
+            "Values": [
+              "(1, 2, 3)"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music"
+      ]
+    }
+  },
+  {
+    "comment": "union with the same target shard (using `IN` with the same normalized value)",
+    "query": "SELECT id FROM music WHERE music.user_id IN ::vtg1 UNION SELECT id FROM music WHERE music.user_id IN ::vtg1",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "SELECT id FROM music WHERE music.user_id IN ::vtg1 UNION SELECT id FROM music WHERE music.user_id IN ::vtg1",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "IN",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from music where 1 != 1 union select id from music where 1 != 1) as dt(c0) where 1 != 1",
+            "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from music where music.user_id in ::__vals union select id from music where music.user_id in ::vtg1) as dt(c0)",
+            "Values": [
+              "::vtg1"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "union with the same target shard (using a mix of `IN` and `=` conditions)",
+    "query": "SELECT id FROM music WHERE music.user_id IN (1) UNION SELECT id FROM music WHERE music.user_id = 1",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "SELECT id FROM music WHERE music.user_id IN (1) UNION SELECT id FROM music WHERE music.user_id = 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from music where 1 != 1 union select id from music where 1 != 1",
+        "Query": "select id from music where music.user_id in (1) union select id from music where music.user_id = 1",
+        "Values": [
+          "1"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music"
+      ]
+    }
+  },
+  {
     "comment": "union with the same target shard last_insert_id",
     "query": "select *, last_insert_id() from music where user_id = 1 union select * from user where id = 1",
     "plan": {


### PR DESCRIPTION
## Description

This PR adds two "naive" improvements to allow `UNION` queries to be merged in more cases.

The first change allows `UNION` subqueries that use `IN` conditions to be merged together correctly. It only works if tuples on the two subqueries we try to merge match exactly (same elements in the exact same order), or the tuple was normalized to the same bind variable (see the change below). This could be improved upon by doing a true "set" comparison (so that the order of values and duplicates don't affect the merge result).

~This probably should also be extended to allow merging queries where one side uses `foobar IN (1)` and the other side uses `foobar = 1`.~ Merging `foobar IN (1)` with `foobar = 1` already works, so I just added a test case to make sure it's covered.

~This change is currently missing test coverage, but I'll make sure to add some.~
Various test cases to cover this change have been added.

The second change improves bind variable normalization so that bind variables for `ValTuple` get de-duplicated, similar to other bind variables. That de-duplication only happens if the tuples contain exactly the same values (with matching types) in the same order.

This could probably be improved upon by pre-sorting and de-duplicating the tuple values, to ensure that tuples like `(1, 2, 3)` `(1, 1, 2, 3)` and `(3, 2, 1)` all end up with the same bind variable value (and thus allow `UNION` queries that use such tuples for routing to be merged).

## Related Issue(s)

#18288 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
