### PR TITLE
Fix flaky test by being more permissive with the error message in `TestOverallQueryTimeout`

### DIFF
--- a/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
+++ b/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
@@ -198,7 +198,7 @@ func TestOverallQueryTimeout(t *testing.T) {
 	_, err := utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=4000 */ sleep(u2.id2), u1.id2 from t1 u1 join t1 u2 where u1.id2 = u2.id1")
 	assert.Error(t, err)
 	// We can get two different error messages based on whether it is coming from vttablet or vtgate
-	deadLineExceeded := "DeadlineExceeded desc = stream terminated by RST_STREAM"
+	deadLineExceeded := "DeadlineExceeded desc"
 	if !strings.Contains(err.Error(), "Query execution was interrupted, maximum statement execution time exceeded") {
 		assert.ErrorContains(t, err, deadLineExceeded)
 	}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes the flaky test `TestOverallQueryTimeout`, by being more permissive with the error messages.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
