### PR TITLE
VStreamer: change in filter logic

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
@@ -245,16 +245,20 @@ func (plan *Plan) shouldFilter(values []sqltypes.Value, charsets []collations.ID
 	if len(values) == 0 {
 		return false, false, nil
 	}
+	log.Infof("In shouldFilter")
 	for _, filter := range plan.Filters {
+		log.Infof("Filter: %v", filter)
 		switch filter.Opcode {
 		case VindexMatch:
+			log.Infof("VIndex match filter: %v", filter.Vindex.String())
 			ksid, err := getKeyspaceID(values, filter.Vindex, filter.VindexColumns, plan.Table.Fields)
 			if err != nil {
 				return false, false, err
 			}
+			log.Infof("VIndex match ksid: %v", ksid)
 			hasVindex = true
 			if !key.KeyRangeContains(filter.KeyRange, ksid) {
-				return false, false, nil
+				return false, true, nil
 			}
 		case IsNotNull:
 			if values[filter.ColNum].IsNull() {
@@ -312,6 +316,7 @@ func (plan *Plan) shouldFilter(values []sqltypes.Value, charsets []collations.ID
 			}
 		}
 	}
+	log.Infof("Finally returning from shouldFilter with ok %t, hasVindex %v", true, hasVindex)
 	return true, hasVindex, nil
 }
 

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
@@ -318,7 +318,7 @@ func (plan *Plan) shouldFilter(values []sqltypes.Value, charsets []collations.ID
 	return true, hasVindex, nil
 }
 
-// filter maps the row values against the plan.
+// mapValues maps the row values against the plan.
 // The output of the filtering operation is stored in the 'result' argument because
 // filtering cannot be performed in-place. The result argument must be a slice of
 // length equal to ColExprs

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
@@ -239,7 +239,10 @@ func compare(comparison Opcode, columnValue, filterValue sqltypes.Value, collati
 	return false, nil
 }
 
-// shouldFilter returns true if the row passes the filter, if specified, and matches the target shard's keyrange, if applicable
+// shouldFilter evaluates whether a binlog (before or after) image should be included in the stream based on the plan's filters.
+// It returns:
+// - bool: true if the row should be included in the stream (passes all filters)
+// - bool: true if a vindex filter was applied (indicates sharded filtering)
 func (plan *Plan) shouldFilter(values []sqltypes.Value, charsets []collations.ID) (bool, bool, error) {
 	hasVindex := false
 	if len(values) == 0 {
@@ -315,11 +318,11 @@ func (plan *Plan) shouldFilter(values []sqltypes.Value, charsets []collations.ID
 	return true, hasVindex, nil
 }
 
-// filter filters the row against the plan. It returns false if the row did not match.
+// filter maps the row values against the plan.
 // The output of the filtering operation is stored in the 'result' argument because
 // filtering cannot be performed in-place. The result argument must be a slice of
 // length equal to ColExprs
-func (plan *Plan) filter(values []sqltypes.Value) ([]sqltypes.Value, error) {
+func (plan *Plan) mapValues(values []sqltypes.Value) ([]sqltypes.Value, error) {
 
 	result := make([]sqltypes.Value, len(plan.ColExprs))
 

--- a/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/planbuilder.go
@@ -245,17 +245,13 @@ func (plan *Plan) shouldFilter(values []sqltypes.Value, charsets []collations.ID
 	if len(values) == 0 {
 		return false, false, nil
 	}
-	log.Infof("In shouldFilter")
 	for _, filter := range plan.Filters {
-		log.Infof("Filter: %v", filter)
 		switch filter.Opcode {
 		case VindexMatch:
-			log.Infof("VIndex match filter: %v", filter.Vindex.String())
 			ksid, err := getKeyspaceID(values, filter.Vindex, filter.VindexColumns, plan.Table.Fields)
 			if err != nil {
 				return false, false, err
 			}
-			log.Infof("VIndex match ksid: %v", ksid)
 			hasVindex = true
 			if !key.KeyRangeContains(filter.KeyRange, ksid) {
 				return false, true, nil
@@ -316,7 +312,6 @@ func (plan *Plan) shouldFilter(values []sqltypes.Value, charsets []collations.ID
 			}
 		}
 	}
-	log.Infof("Finally returning from shouldFilter with ok %t, hasVindex %v", true, hasVindex)
 	return true, hasVindex, nil
 }
 

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -441,8 +441,8 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 		for i, pk := range rs.pkColumns {
 			lastpk[i] = mysqlrow[pk]
 		}
-		// Reuse the vstreamer's filter.
-		ok, err := rs.plan.filter(mysqlrow, filtered, charsets)
+
+		ok, err := rs.plan.checkFilters(mysqlrow, charsets)
 		if err != nil {
 			return err
 		}

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -446,7 +446,6 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 		if err != nil {
 			return err
 		}
-		log.Infof("rowstreamer filter returned ok %v", ok)
 		if ok {
 			filtered, err := rs.plan.filter(mysqlrow)
 			if err != nil {

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -447,7 +447,7 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 			return err
 		}
 		if ok {
-			filtered, err := rs.plan.filter(mysqlrow)
+			filtered, err := rs.plan.mapValues(mysqlrow)
 			if err != nil {
 				return err
 			}

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -407,7 +407,6 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 		mysqlrow []sqltypes.Value
 	)
 
-	filtered := make([]sqltypes.Value, len(rs.plan.ColExprs))
 	lastpk := make([]sqltypes.Value, len(rs.pkColumns))
 	byteCount := 0
 	logger := logutil.NewThrottledLogger(rs.vse.GetTabletInfo(), throttledLoggerInterval)
@@ -447,7 +446,12 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 		if err != nil {
 			return err
 		}
+		log.Infof("rowstreamer filter returned ok %v", ok)
 		if ok {
+			filtered, err := rs.plan.filter(mysqlrow)
+			if err != nil {
+				return err
+			}
 			if rowCount >= len(rows) {
 				rows = append(rows, &querypb.Row{})
 			}

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -442,7 +442,8 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 			lastpk[i] = mysqlrow[pk]
 		}
 
-		ok, err := rs.plan.checkFilters(mysqlrow, charsets)
+		// verify that the row should be sent
+		ok, _, err := rs.plan.shouldFilter(mysqlrow, charsets)
 		if err != nil {
 			return err
 		}

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -977,14 +977,12 @@ func (vs *vstreamer) processJournalEvent(vevents []*binlogdatapb.VEvent, plan *s
 	}
 nextrow:
 	for _, row := range rows.Rows {
-		afterOK, afterValues, _, err := vs.extractRowAndFilter(plan, row.Data, rows.DataColumns, row.NullColumns, row.JSONPartialValues)
+		afterValues, _, _, err := vs.getValues(plan, row.Data, rows.DataColumns, row.NullColumns, row.JSONPartialValues)
 		if err != nil {
 			return nil, vterrors.Wrap(err, "failed to extract journal from binlog event and apply filters")
 		}
-		if !afterOK {
-			// This can happen if someone manually deleted rows.
-			continue
-		}
+		//FIXME (Rohit): there was a check for afterOK, understand and restore if required
+
 		// Exclude events that don't match the db_name.
 		for i, fld := range plan.fields() {
 			if fld.Name == "db_name" && afterValues[i].ToString() != params.DbName {
@@ -1016,24 +1014,44 @@ func (vs *vstreamer) processRowEvent(vevents []*binlogdatapb.VEvent, plan *strea
 	rowChanges := make([]*binlogdatapb.RowChange, 0, len(rows.Rows))
 	for _, row := range rows.Rows {
 		// The BEFORE image does not have partial JSON values so we pass an empty bitmap.
-		beforeOK, beforeValues, _, err := vs.extractRowAndFilter(plan, row.Identify, rows.IdentifyColumns, row.NullIdentifyColumns, mysql.Bitmap{})
+		beforeRawValues, beforeCharsets, _, err := vs.getValues(plan, row.Identify, rows.IdentifyColumns, row.NullIdentifyColumns, mysql.Bitmap{})
 		if err != nil {
-			return nil, vterrors.Wrap(err, "failed to extract row's before values from binlog event and apply filters")
+			return nil, err
 		}
+		beforeOK, err := plan.checkFilters(beforeRawValues, beforeCharsets)
+		if err != nil {
+			return nil, err
+		}
+
 		// The AFTER image is where we may have partial JSON values, as reflected in the
 		// row's JSONPartialValues bitmap.
-		afterOK, afterValues, partial, err := vs.extractRowAndFilter(plan, row.Data, rows.DataColumns, row.NullColumns, row.JSONPartialValues)
+		afterRawValues, afterCharsets, partial, err := vs.getValues(plan, row.Data, rows.DataColumns, row.NullColumns, row.JSONPartialValues)
 		if err != nil {
-			return nil, vterrors.Wrap(err, "failed to extract row's after values from binlog event and apply filters")
+			return nil, err
 		}
-		if !beforeOK && !afterOK {
+		afterOK, err := plan.checkFilters(afterRawValues, afterCharsets)
+		if err != nil {
+			return nil, err
+		}
+
+		if !afterOK && !beforeOK {
+			// both before and after images are filtered out
 			continue
 		}
+
 		rowChange := &binlogdatapb.RowChange{}
-		if beforeOK {
+		if len(beforeRawValues) > 0 {
+			beforeValues, err := plan.filter(beforeRawValues)
+			if err != nil {
+				return nil, err
+			}
 			rowChange.Before = sqltypes.RowToProto3(beforeValues)
 		}
-		if afterOK {
+		if len(afterRawValues) > 0 {
+			afterValues, err := plan.filter(afterRawValues)
+			if err != nil {
+				return nil, err
+			}
 			rowChange.After = sqltypes.RowToProto3(afterValues)
 			if ((vs.config.ExperimentalFlags /**/ & /**/ vttablet.VReplicationExperimentalFlagAllowNoBlobBinlogRowImage != 0) && partial) ||
 				(row.JSONPartialValues.Count() > 0) {
@@ -1090,13 +1108,10 @@ func (vs *vstreamer) rebuildPlans() error {
 	return nil
 }
 
-// extractRowAndFilter takes the data and bitmaps from the binlog events and returns the following
-//   - true, if row needs to be skipped because of workflow filter rules
-//   - data values, array of one value per column
-//   - true, if the row image was partial (i.e. binlog_row_image=noblob and dml doesn't update one or more blob/text columns)
-func (vs *vstreamer) extractRowAndFilter(plan *streamerPlan, data []byte, dataColumns, nullColumns mysql.Bitmap, jsonPartialValues mysql.Bitmap) (bool, []sqltypes.Value, bool, error) {
+func (vs *vstreamer) getValues(plan *streamerPlan, data []byte,
+	dataColumns, nullColumns mysql.Bitmap, jsonPartialValues mysql.Bitmap) ([]sqltypes.Value, []collations.ID, bool, error) {
 	if len(data) == 0 {
-		return false, nil, false, nil
+		return nil, nil, false, nil
 	}
 	values := make([]sqltypes.Value, dataColumns.Count())
 	charsets := make([]collations.ID, len(values))
@@ -1107,7 +1122,7 @@ func (vs *vstreamer) extractRowAndFilter(plan *streamerPlan, data []byte, dataCo
 	for colNum := 0; colNum < dataColumns.Count(); colNum++ {
 		if !dataColumns.Bit(colNum) {
 			if vs.config.ExperimentalFlags /**/ & /**/ vttablet.VReplicationExperimentalFlagAllowNoBlobBinlogRowImage == 0 {
-				return false, nil, false, fmt.Errorf("partial row image encountered: ensure binlog_row_image is set to 'full'")
+				return nil, nil, false, fmt.Errorf("partial row image encountered: ensure binlog_row_image is set to 'full'")
 			} else {
 				partial = true
 			}
@@ -1129,7 +1144,7 @@ func (vs *vstreamer) extractRowAndFilter(plan *streamerPlan, data []byte, dataCo
 		if err != nil {
 			log.Errorf("extractRowAndFilter: %s, table: %s, colNum: %d, fields: %+v, current values: %+v",
 				err, plan.Table.Name, colNum, plan.Table.Fields, values)
-			return false, nil, false, vterrors.Wrapf(err, "failed to extract row's value for column %s from binlog event",
+			return nil, nil, false, vterrors.Wrapf(err, "failed to extract row's value for column %s from binlog event",
 				plan.Table.Fields[colNum].Name)
 		}
 		pos += l
@@ -1147,13 +1162,13 @@ func (vs *vstreamer) extractRowAndFilter(plan *streamerPlan, data []byte, dataCo
 			if plan.Table.Fields[colNum].Type == querypb.Type_ENUM || mysqlType == mysqlbinlog.TypeEnum {
 				value, err = buildEnumStringValue(vs.se.Environment(), plan, colNum, value)
 				if err != nil {
-					return false, nil, false, vterrors.Wrapf(err, "failed to perform ENUM column integer to string value mapping")
+					return nil, nil, false, vterrors.Wrapf(err, "failed to perform ENUM column integer to string value mapping")
 				}
 			}
 			if plan.Table.Fields[colNum].Type == querypb.Type_SET || mysqlType == mysqlbinlog.TypeSet {
 				value, err = buildSetStringValue(vs.se.Environment(), plan, colNum, value)
 				if err != nil {
-					return false, nil, false, vterrors.Wrapf(err, "failed to perform SET column integer to string value mapping")
+					return nil, nil, false, vterrors.Wrapf(err, "failed to perform SET column integer to string value mapping")
 				}
 			}
 		}
@@ -1162,9 +1177,7 @@ func (vs *vstreamer) extractRowAndFilter(plan *streamerPlan, data []byte, dataCo
 		values[colNum] = value
 		valueIndex++
 	}
-	filtered := make([]sqltypes.Value, len(plan.ColExprs))
-	ok, err := plan.filter(values, filtered, charsets)
-	return ok, filtered, partial, err
+	return values, charsets, partial, nil
 }
 
 // addEnumAndSetMappingstoPlan sets up any necessary ENUM and SET integer to string mappings.

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -805,16 +805,16 @@ func TestFilteredVarBinary(t *testing.T) {
 		{"insert into t1 values (4, 'kepler')", noEvents},
 		{"insert into t1 values (5, 'newton')", nil},
 		{"update t1 set val = 'newton' where id1 = 1", []TestRowEvent{
-			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{after: []string{"1", "newton"}}}}},
+			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{before: []string{"1", "kepler"}, after: []string{"1", "newton"}}}}},
 		}},
 		{"update t1 set val = 'kepler' where id1 = 2", []TestRowEvent{
-			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{before: []string{"2", "newton"}}}}},
+			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{before: []string{"2", "newton"}, after: []string{"2", "kepler"}}}}},
 		}},
 		{"update t1 set val = 'newton' where id1 = 2", []TestRowEvent{
-			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{after: []string{"2", "newton"}}}}},
+			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{before: []string{"2", "kepler"}, after: []string{"2", "newton"}}}}},
 		}},
 		{"update t1 set val = 'kepler' where id1 = 1", []TestRowEvent{
-			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{before: []string{"1", "newton"}}}}},
+			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{before: []string{"1", "newton"}, after: []string{"1", "kepler"}}}}},
 		}},
 		{"delete from t1 where id1 in (2,3)", []TestRowEvent{
 			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{before: []string{"2", "newton"}}, {before: []string{"3", "newton"}}}}},

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -857,6 +857,10 @@ func TestPartialFilteredInt(t *testing.T) {
 		{"update t1 set id2 = 100 where id1 = 1", []TestRowEvent{
 			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{before: []string{"1", "150"}, after: []string{"1", "100"}}}}},
 		}},
+		{"update t1 set id2 = 200 where id1 = 1", noEvents},
+		{"update t1 set id2 = 110 where id1 = 1", []TestRowEvent{
+			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{before: []string{"1", "200"}, after: []string{"1", "110"}}}}},
+		}},
 		{"commit", nil},
 	}}
 	ts.Run()

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -892,16 +892,16 @@ func TestFilteredInt(t *testing.T) {
 			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{before: []string{"4", "ddd"}, after: []string{"4", "newddd"}}}}},
 		}},
 		{"update t1 set id2 = 200 where id1 = 1", []TestRowEvent{
-			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{after: []string{"1", "aaa"}}}}},
+			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{before: []string{"1", "aaa"}, after: []string{"1", "aaa"}}}}},
 		}},
 		{"update t1 set id2 = 100 where id1 = 2", []TestRowEvent{
-			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{before: []string{"2", "bbb"}}}}},
+			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{before: []string{"2", "bbb"}, after: []string{"2", "bbb"}}}}},
 		}},
 		{"update t1 set id2 = 100 where id1 = 1", []TestRowEvent{
-			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{before: []string{"1", "aaa"}}}}},
+			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{before: []string{"1", "aaa"}, after: []string{"1", "aaa"}}}}},
 		}},
 		{"update t1 set id2 = 200 where id1 = 2", []TestRowEvent{
-			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{after: []string{"2", "bbb"}}}}},
+			{spec: &TestRowEventSpec{table: "t1", changes: []TestRowChange{{before: []string{"2", "bbb"}, after: []string{"2", "bbb"}}}}},
 		}},
 		{"commit", nil},
 	}}


### PR DESCRIPTION
## Description

⚠️ This is currently an experimental change. It is a breaking change in Vitess, so we need to evaluate any failing tests that need to be modified for this logic and validate that we are not breaking core Vitess workflows.

This PR changes the filter logic in vstreamer filters to send both Before and After images, if filter matches either for non-sharded workflows. Currently only the image which passes is sent, causing downstream consumers to treat the event incorrectly as an insert or delete, when it is actually an update.

For sharded workflows, the current behaviour continues, to support rows that migrate from one shard to another.

⚠️  Breaking Change
The following tests had to be updated: `TestFilteredInt` and `TestFilteredVarBinary`. The changes were to add both after/before images where the previous implementation would result in only one of the before/after images to be sent in the RowEvent.

This will not impact `MoveTables` or `Reshard` or any flows where the columns participating in the filter does not change.  

## Related Issue(s)

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
