### PR TITLE
fix: handle dml query for None opcode

### DIFF
--- a/go/test/endtoend/preparestmt/stmt_methods_test.go
+++ b/go/test/endtoend/preparestmt/stmt_methods_test.go
@@ -31,6 +31,33 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/engine"
 )
 
+// TestDMLNone tests that impossible query run without an error.
+func TestDMLNone(t *testing.T) {
+	dbo := Connect(t)
+	defer dbo.Close()
+
+	t.Run("delete none", func(t *testing.T) {
+		dmlquery(t, dbo, "delete from sks.t1 where 1 = 0")
+	})
+	t.Run("update none", func(t *testing.T) {
+		dmlquery(t, dbo, "update sks.t1 set age = 5 where 1 = 0")
+	})
+}
+
+func dmlquery(t *testing.T, dbo *sql.DB, query string) {
+	stmt, err := dbo.Prepare(query)
+	require.NoError(t, err)
+	defer stmt.Close()
+
+	qr, err := stmt.Exec()
+	require.NoError(t, err)
+
+	ra, err := qr.RowsAffected()
+	require.NoError(t, err)
+
+	require.Zero(t, ra)
+}
+
 // TestSelect simple select the data without any condition.
 func TestSelect(t *testing.T) {
 	dbo := Connect(t)

--- a/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
+++ b/go/test/endtoend/vtgate/queries/timeout/timeout_test.go
@@ -99,7 +99,7 @@ func TestQueryTimeoutWithTables(t *testing.T) {
 	utils.Exec(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=500 */ sleep(0.1) from t1 where id1 = 1")
 	_, err = utils.ExecAllowError(t, mcmp.VtConn, "select /*vt+ QUERY_TIMEOUT_MS=20 */ sleep(0.1) from t1 where id1 = 1")
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "context deadline exceeded")
+	assert.ErrorContains(t, err, "DeadlineExceeded")
 	assert.ErrorContains(t, err, "(errno 1317) (sqlstate 70100)")
 }
 

--- a/go/vt/vtgate/engine/delete.go
+++ b/go/vt/vtgate/engine/delete.go
@@ -51,6 +51,8 @@ func (del *Delete) TryExecute(ctx context.Context, vcursor VCursor, bindVars map
 	}
 
 	switch del.Opcode {
+	case None:
+		return &sqltypes.Result{}, nil
 	case Unsharded:
 		return del.execUnsharded(ctx, del, vcursor, bindVars, rss)
 	case Equal, IN, Scatter, ByDestination, SubShard, EqualUnique, MultiEqual:

--- a/go/vt/vtgate/engine/update.go
+++ b/go/vt/vtgate/engine/update.go
@@ -61,6 +61,8 @@ func (upd *Update) TryExecute(ctx context.Context, vcursor VCursor, bindVars map
 	}
 
 	switch upd.Opcode {
+	case None:
+		return &sqltypes.Result{}, nil
 	case Unsharded:
 		return upd.execUnsharded(ctx, upd, vcursor, bindVars, rss)
 	case Equal, EqualUnique, IN, Scatter, ByDestination, SubShard, MultiEqual:

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -755,6 +755,10 @@ func buildUpdatePrimitive(
 	upd := dmlOp.(*operators.Update)
 	var vindexes []*vindexes.ColumnVindex
 	vQuery := ""
+	if rb.Routing.OpCode() == engine.None {
+		// reset as no modification will happen for an impossible query.
+		upd.ChangedVindexValues = nil
+	}
 	if len(upd.ChangedVindexValues) > 0 {
 		upd.OwnedVindexQuery.From = stmt.GetFrom()
 		upd.OwnedVindexQuery.Where = stmt.Where
@@ -805,7 +809,12 @@ func createDMLPrimitive(ctx *plancontext.PlanningContext, rb *operators.Route, h
 		FetchLastInsertID: ctx.SemTable.ShouldFetchLastInsertID(),
 	}
 
-	if rb.Routing.OpCode() != engine.Unsharded && vindexQuery != "" {
+	if rb.Routing.OpCode() == engine.None {
+		// reset as no modification will happen for an impossible query.
+		edml.OwnedVindexQuery = ""
+		edml.Vindex = nil
+		edml.Values = nil
+	} else if rb.Routing.OpCode() != engine.Unsharded && vindexQuery != "" {
 		primary := vTbl.ColumnVindexes[0]
 		edml.KsidVindex = primary.Vindex
 		edml.KsidLength = len(primary.Columns)

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -12,6 +12,50 @@
     "skip_e2e": true
   },
   {
+    "comment": "delete none",
+    "query": "delete from user where 1 = 0",
+    "plan": {
+      "Type": "Local",
+      "QueryType": "DELETE",
+      "Original": "delete from user where 1 = 0",
+      "Instructions": {
+        "OperatorType": "Delete",
+        "Variant": "None",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "delete from `user` where 0",
+        "Table": "user"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "update none",
+    "query": "update user set name = 'xyz' where 1 = 0",
+    "plan": {
+      "Type": "Local",
+      "QueryType": "UPDATE",
+      "Original": "update user set name = 'xyz' where 1 = 0",
+      "Instructions": {
+        "OperatorType": "Update",
+        "Variant": "None",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "update `user` set `name` = 'xyz' where 0",
+        "Table": "user"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
     "comment": "explicit keyspace reference",
     "query": "update main.m1 set val = 1",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -25,8 +25,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "delete from `user` where 0",
-        "Table": "user"
+        "Query": "delete from `user` where 0"
       },
       "TablesUsed": [
         "user.user"
@@ -47,8 +46,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "update `user` set `name` = 'xyz' where 0",
-        "Table": "user"
+        "Query": "update `user` set `name` = 'xyz' where 0"
       },
       "TablesUsed": [
         "user.user"


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the issue with DML query (update / delete) generating None opcode.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/18271

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
