### PR TITLE
`vtorc`: rename `isClusterWideRecovery` -> `isShardWideRecovery`

### DIFF
--- a/go/vt/vtorc/inst/analysis_dao.go
+++ b/go/vt/vtorc/inst/analysis_dao.go
@@ -397,7 +397,7 @@ func GetReplicationAnalysis(keyspace string, shard string, hints *ReplicationAna
 		// Increment the total number of tablets.
 		ca.totalTablets += 1
 		if ca.hasShardWideAction {
-			// We can only take one cluster level action at a time.
+			// We can only take one shard level action at a time.
 			return nil
 		}
 		if ca.durability == nil {

--- a/go/vt/vtorc/logic/topology_recovery.go
+++ b/go/vt/vtorc/logic/topology_recovery.go
@@ -485,8 +485,8 @@ func getRecoverFunctionName(recoveryFunctionCode recoveryFunction) string {
 	}
 }
 
-// isClusterWideRecovery returns whether the given recovery is a cluster-wide recovery or not
-func isClusterWideRecovery(recoveryFunctionCode recoveryFunction) bool {
+// isShardWideRecovery returns whether the given recovery is a recovery that affects all tablets in a shard
+func isShardWideRecovery(recoveryFunctionCode recoveryFunction) bool {
 	switch recoveryFunctionCode {
 	case recoverDeadPrimaryFunc, electNewPrimaryFunc, recoverPrimaryTabletDeletedFunc:
 		return true
@@ -553,13 +553,13 @@ func executeCheckAndRecoverFunction(analysisEntry *inst.ReplicationAnalysis) (er
 
 	// Prioritise primary recovery.
 	// If we are performing some other action, first ensure that it is not because of primary issues.
-	// This step is only meant to improve the time taken to detect and fix cluster wide recoveries, it does not impact correctness.
+	// This step is only meant to improve the time taken to detect and fix shard-wide recoveries, it does not impact correctness.
 	// If a VTOrc detects an issue on a replica like ReplicationStopped, the underlying cause could be a dead primary instead.
 	// So, we try to reload that primary's information before proceeding with the replication stopped fix. We do this before acquiring the shard lock
 	// to allow another VTOrc instance to proceed with the dead primary recovery if it is indeed the case and it detects it before us. If however, the primary
 	// is not dead, then we will proceed with the fix for the replica. Essentially, we are trading off speed in replica recoveries (by doing an additional primary tablet reload)
-	// for speed in cluster-wide recoveries (by not holding the shard lock before reloading the primary tablet information).
-	if !isClusterWideRecovery(checkAndRecoverFunctionCode) {
+	// for speed in shard-wide recoveries (by not holding the shard lock before reloading the primary tablet information).
+	if !isShardWideRecovery(checkAndRecoverFunctionCode) {
 		if err = recheckPrimaryHealth(analysisEntry, DiscoverInstance); err != nil {
 			return err
 		}
@@ -591,10 +591,10 @@ func executeCheckAndRecoverFunction(analysisEntry *inst.ReplicationAnalysis) (er
 			logger.Errorf("Failed to refresh keyspace and shard, aborting recovery: %v", err)
 			return err
 		}
-		// If we are about to run a cluster-wide recovery, it is imperative to first refresh all the tablets
-		// of a shard because a new tablet could have been promoted, and we need to have this visibility before we
-		// run a cluster operation of our own.
-		if isClusterWideRecovery(checkAndRecoverFunctionCode) {
+		// If we are about to run a shard-wide recovery, it is imperative to first refresh all the tablets
+		// of a shard because a new tablet could have been promoted, and we need to have this visibility
+		// before we run a shard-wide operation of our own.
+		if isShardWideRecovery(checkAndRecoverFunctionCode) {
 			var tabletsToIgnore []string
 			if checkAndRecoverFunctionCode == recoverDeadPrimaryFunc {
 				tabletsToIgnore = append(tabletsToIgnore, analysisEntry.AnalyzedInstanceAlias)
@@ -604,7 +604,7 @@ func executeCheckAndRecoverFunction(analysisEntry *inst.ReplicationAnalysis) (er
 			logger.Info("Force refreshing all shard tablets")
 			forceRefreshAllTabletsInShard(ctx, analysisEntry.AnalyzedKeyspace, analysisEntry.AnalyzedShard, tabletsToIgnore)
 		} else {
-			// If we are not running a cluster-wide recovery, then it is only concerned with the specific tablet
+			// If we are not running a shard-wide recovery, then it is only concerned with the specific tablet
 			// on which the failure occurred and the primary instance of the shard.
 			// For example, ConnectedToWrongPrimary analysis only cares for whom the current primary tablet is
 			// and the host-port set on the tablet in question.
@@ -668,11 +668,11 @@ func executeCheckAndRecoverFunction(analysisEntry *inst.ReplicationAnalysis) (er
 	} else {
 		logger.Infof("Topology recovery: %+v", topologyRecovery)
 	}
-	// If we ran a cluster wide recovery and actually attempted it, then we know that the replication state for all the tablets in this cluster
+	// If we ran a shard-wide recovery and actually attempted it, then we know that the replication state for all the tablets in this cluster
 	// would have changed. So we can go ahead and pre-emptively refresh them.
 	// For this refresh we don't use the same context that we used for the recovery, since that context might have expired or could expire soon
 	// Instead we pass the background context. The call forceRefreshAllTabletsInShard handles adding a timeout to it for us.
-	if isClusterWideRecovery(checkAndRecoverFunctionCode) {
+	if isShardWideRecovery(checkAndRecoverFunctionCode) {
 		logger.Info("Forcing refresh of all tablets post recovery")
 		forceRefreshAllTabletsInShard(context.Background(), analysisEntry.AnalyzedKeyspace, analysisEntry.AnalyzedShard, nil)
 	} else {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR renames the VTOrc term "cluster-wide" to "shard-wide" for clarity

Referring to a shard as a "cluster" seems to be a byproduct of old-Orchestrator, which referred to "groups" of instances as "clusters" _(and shards would be a "cluster")_

In Vitess, a "cluster" typically refers to all keyspaces/shards/`vtgate`s/topo, which makes the terminology (to me) at-odds

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
