### PR TITLE
Make sure to check if the server is closed in etcd2topo

### DIFF
--- a/go/vt/topo/etcd2topo/file.go
+++ b/go/vt/topo/etcd2topo/file.go
@@ -28,6 +28,9 @@ import (
 
 // Create is part of the topo.Conn interface.
 func (s *Server) Create(ctx context.Context, filePath string, contents []byte) (topo.Version, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, convertError(err, filePath)
+	}
 	nodePath := path.Join(s.root, filePath)
 
 	// We have to do a transaction, comparing existing version with 0.
@@ -47,6 +50,9 @@ func (s *Server) Create(ctx context.Context, filePath string, contents []byte) (
 
 // Update is part of the topo.Conn interface.
 func (s *Server) Update(ctx context.Context, filePath string, contents []byte, version topo.Version) (topo.Version, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, convertError(err, filePath)
+	}
 	nodePath := path.Join(s.root, filePath)
 
 	if version != nil {
@@ -75,6 +81,9 @@ func (s *Server) Update(ctx context.Context, filePath string, contents []byte, v
 
 // Get is part of the topo.Conn interface.
 func (s *Server) Get(ctx context.Context, filePath string) ([]byte, topo.Version, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, nil, convertError(err, filePath)
+	}
 	nodePath := path.Join(s.root, filePath)
 
 	resp, err := s.cli.Get(ctx, nodePath)
@@ -90,6 +99,9 @@ func (s *Server) Get(ctx context.Context, filePath string) ([]byte, topo.Version
 
 // GetVersion is part of the topo.Conn interface.
 func (s *Server) GetVersion(ctx context.Context, filePath string, version int64) ([]byte, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, convertError(err, filePath)
+	}
 	nodePath := path.Join(s.root, filePath)
 
 	resp, err := s.cli.Get(ctx, nodePath, clientv3.WithRev(version))
@@ -105,6 +117,9 @@ func (s *Server) GetVersion(ctx context.Context, filePath string, version int64)
 
 // List is part of the topo.Conn interface.
 func (s *Server) List(ctx context.Context, filePathPrefix string) ([]topo.KVInfo, error) {
+	if err := s.checkClosed(); err != nil {
+		return []topo.KVInfo{}, convertError(err, filePathPrefix)
+	}
 	nodePathPrefix := path.Join(s.root, filePathPrefix)
 
 	resp, err := s.cli.Get(ctx, nodePathPrefix, clientv3.WithPrefix())
@@ -127,6 +142,9 @@ func (s *Server) List(ctx context.Context, filePathPrefix string) ([]topo.KVInfo
 
 // Delete is part of the topo.Conn interface.
 func (s *Server) Delete(ctx context.Context, filePath string, version topo.Version) error {
+	if err := s.checkClosed(); err != nil {
+		return convertError(err, filePath)
+	}
 	nodePath := path.Join(s.root, filePath)
 
 	if version != nil {

--- a/go/vt/topo/etcd2topo/server.go
+++ b/go/vt/topo/etcd2topo/server.go
@@ -34,6 +34,7 @@ We follow these conventions within this package:
 package etcd2topo
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"strings"
@@ -91,6 +92,16 @@ func registerEtcd2TopoFlags(fs *pflag.FlagSet) {
 	utils.SetFlagStringVar(fs, &clientCertPath, "topo-etcd-tls-cert", clientCertPath, "path to the client cert to use to connect to the etcd topo server, requires topo-etcd-tls-key, enables TLS")
 	utils.SetFlagStringVar(fs, &clientKeyPath, "topo-etcd-tls-key", clientKeyPath, "path to the client key to use to connect to the etcd topo server, enables TLS")
 	utils.SetFlagStringVar(fs, &serverCaPath, "topo-etcd-tls-ca", serverCaPath, "path to the ca to use to validate the server cert when connecting to the etcd topo server")
+}
+
+// checkClosed returns context.Canceled if the server has been closed.
+// This mimics the pattern used for context cancellation which gets converted
+// to topo.Interrupted by convertError().
+func (s *Server) checkClosed() error {
+	if s.cli == nil {
+		return context.Canceled
+	}
+	return nil
 }
 
 // Close implements topo.Server.Close.

--- a/go/vt/topo/etcd2topo/watch.go
+++ b/go/vt/topo/etcd2topo/watch.go
@@ -34,6 +34,9 @@ import (
 
 // Watch is part of the topo.Conn interface.
 func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <-chan *topo.WatchData, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, nil, convertError(err, filePath)
+	}
 	nodePath := path.Join(s.root, filePath)
 
 	// Get the initial version of the file
@@ -160,6 +163,9 @@ func (s *Server) Watch(ctx context.Context, filePath string) (*topo.WatchData, <
 
 // WatchRecursive is part of the topo.Conn interface.
 func (s *Server) WatchRecursive(ctx context.Context, dirpath string) ([]*topo.WatchDataRecursive, <-chan *topo.WatchDataRecursive, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, nil, convertError(err, dirpath)
+	}
 	nodePath := path.Join(s.root, dirpath)
 	if !strings.HasSuffix(nodePath, "/") {
 		nodePath = nodePath + "/"


### PR DESCRIPTION
## Description

Fixes an issue during VTGate shutdown where `s.cli` is set to `nil` in `Close()` method while concurrent coroutines still try to access it, causing nil pointer dereference panics.

This fix replaces a panic (which crashes the process) with a graceful shutdown signal (which components handle cleanly). The error becomes part of the normal shutdown flow, not a failure condition.

## Related Issue(s)

Fixes #18350.

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [ ] Tests were added or are not required
- [ ] Did the new or modified tests pass consistently locally and on CI?
- [ ] Documentation was added or is not required

## Deployment Notes

None.
