### PR TITLE
Fix: Deadlock in `Close` and `write` in semi-sync monitor.

### DIFF
--- a/go/vt/vttablet/tabletmanager/semisyncmonitor/monitor.go
+++ b/go/vt/vttablet/tabletmanager/semisyncmonitor/monitor.go
@@ -357,8 +357,8 @@ func (m *Monitor) write() {
 		log.Errorf("SemiSync Monitor: failed to get a connection when writing to semisync_heartbeat table: %v", err)
 		return
 	}
-	defer conn.Recycle()
 	_, err = conn.Conn.ExecuteFetch(m.bindSideCarDBName(semiSyncHeartbeatWrite), 0, false)
+	conn.Recycle()
 	if err != nil {
 		m.errorCount.Add(1)
 		log.Errorf("SemiSync Monitor: failed to write to semisync_heartbeat table: %v", err)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
It was noticed in the CI, that the test `TestDeadlockOnClose` was failing. We had added logs to print the stack traces to see what was going on, and now we have found the issue.

The problem was as follows - 
1. SemiSyncMonitor triggers a `write` operation after finding semi-sync is blocked. This write gets a connection and does a write.
2. Before the monitor can change the state of the monitor in `setIsBlocked`, the monitor is closed. This causes it to acquire the mutex and try and close the appPool.
3. This however creates a deadlock because the appPool can't close until the capacity reaches 0, and that won't happen because an active connection (held in the write method), hasn't yet been recycled, and that thread is blocked on trying to acquire the mutex in `setIsBlocked`.

The fix is easy. It is to recycle the connection before waiting for the mutex to be acquired for the state change. 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
