### PR TITLE
fix: keep LIMIT/OFFSET even when merging UNION queries

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -429,6 +429,7 @@ func stripDownQuery(from, to sqlparser.TableStatement) {
 		stripDownQuery(node.Left, toNode.Left)
 		stripDownQuery(node.Right, toNode.Right)
 		toNode.OrderBy = node.OrderBy
+		toNode.Limit = node.Limit
 	default:
 		panic(vterrors.VT13001(fmt.Sprintf("this should not happen - we have covered all implementations of SelectStatement %T", from)))
 	}

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -1929,5 +1929,83 @@
         "user.user_extra"
       ]
     }
+  },
+  {
+    "comment": "Merged UNION with limit and offset",
+    "query": "(select id from user where id = 42) union (select id from user where id = 42) limit 3 offset 7",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "(select id from user where id = 42) union (select id from user where id = 42) limit 3 offset 7",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from `user` where 1 != 1 union select id from `user` where 1 != 1",
+        "Query": "select id from `user` where id = 42 union select id from `user` where id = 42 limit 7, 3",
+        "Values": [
+          "42"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "Un-merged UNION with limit and offset",
+    "query": "(select id from user where id = 42) union all (select id from user where id = 234) limit 3 offset 7",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "(select id from user where id = 42) union all (select id from user where id = 234) limit 3 offset 7",
+      "Instructions": {
+        "OperatorType": "Limit",
+        "Count": "3",
+        "Offset": "7",
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "EqualUnique",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select id from `user` where 1 != 1",
+                "Query": "select id from `user` where id = 42 limit :__upper_limit",
+                "Values": [
+                  "42"
+                ],
+                "Vindex": "user_index"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "EqualUnique",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select id from `user` where 1 != 1",
+                "Query": "select id from `user` where id = 234 limit :__upper_limit",
+                "Values": [
+                  "234"
+                ],
+                "Vindex": "user_index"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Description
Make sure to not miss LIMIT/OFFSET when merging UNION queries

## Related Issue(s)
Fixes #18360

## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
