### PR TITLE
Update `operator.yaml`

### DIFF
--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -3894,6 +3894,10 @@ spec:
                                               type: object
                                             mysqldExporter:
                                               properties:
+                                                extraFlags:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
                                                 resources:
                                                   properties:
                                                     claims:
@@ -3927,8 +3931,6 @@ spec:
                                                         x-kubernetes-int-or-string: true
                                                       type: object
                                                   type: object
-                                              required:
-                                                - resources
                                               type: object
                                             name:
                                               default: ""
@@ -4335,6 +4337,10 @@ spec:
                                             type: object
                                           mysqldExporter:
                                             properties:
+                                              extraFlags:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
                                               resources:
                                                 properties:
                                                   claims:
@@ -4368,8 +4374,6 @@ spec:
                                                       x-kubernetes-int-or-string: true
                                                     type: object
                                                 type: object
-                                            required:
-                                              - resources
                                             type: object
                                           name:
                                             default: ""
@@ -5713,6 +5717,10 @@ spec:
                                         type: object
                                       mysqldExporter:
                                         properties:
+                                          extraFlags:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
                                           resources:
                                             properties:
                                               claims:
@@ -5746,8 +5754,6 @@ spec:
                                                   x-kubernetes-int-or-string: true
                                                 type: object
                                             type: object
-                                        required:
-                                          - resources
                                         type: object
                                       name:
                                         default: ""
@@ -6154,6 +6160,10 @@ spec:
                                       type: object
                                     mysqldExporter:
                                       properties:
+                                        extraFlags:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
                                         resources:
                                           properties:
                                             claims:
@@ -6187,8 +6197,6 @@ spec:
                                                 x-kubernetes-int-or-string: true
                                               type: object
                                           type: object
-                                      required:
-                                        - resources
                                       type: object
                                     name:
                                       default: ""
@@ -7148,6 +7156,10 @@ spec:
                         type: object
                       mysqldExporter:
                         properties:
+                          extraFlags:
+                            additionalProperties:
+                              type: string
+                            type: object
                           resources:
                             properties:
                               claims:
@@ -7181,8 +7193,6 @@ spec:
                                   x-kubernetes-int-or-string: true
                                 type: object
                             type: object
-                        required:
-                          - resources
                         type: object
                       name:
                         default: ""


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Pulls latest updates to the `operator.yaml` from upstream related to [adding support of extra flags for mysqld_exporter](https://github.com/planetscale/vitess-operator/pull/629).

Previous stale/closed PR: https://github.com/vitessio/vitess/pull/17184

## Related Issue(s)

* https://github.com/planetscale/vitess-operator/pull/629

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

* Should only be merged after https://github.com/planetscale/vitess-operator/pull/629 is merged.
