### PR TITLE
[main] Copy `v20.0.8` release notes

### DIFF
--- a/changelog/20.0/20.0.8/changelog.md
+++ b/changelog/20.0/20.0.8/changelog.md
@@ -1,0 +1,23 @@
+# Changelog of Vitess v20.0.8
+
+### Bug fixes 
+#### Evalengine
+ * [release-20.0] fix: Preserve multi-column TupleExpr in tuple simplifier (#18216) [#18218](https://github.com/vitessio/vitess/pull/18218)
+ * [release-20.0] Fix evalengine crashes on unexpected types (#18254) [#18256](https://github.com/vitessio/vitess/pull/18256) 
+#### Query Serving
+ * [release-20.0] Fix: Ensure Consistent Lookup Vindex Handles Duplicate Rows in Single Query (#17974) [#18077](https://github.com/vitessio/vitess/pull/18077)
+ * [release-20.0] make sure to give MEMBER OF the correct precedence (#18237) [#18243](https://github.com/vitessio/vitess/pull/18243)
+ * [release-20.0] Fix subquery merging regression introduced in #11379 (#18260) [#18261](https://github.com/vitessio/vitess/pull/18261) 
+#### Throttler
+ * [release-20.0] Properly handle grpc dial errors in the throttler metric aggregation (#18073) [#18229](https://github.com/vitessio/vitess/pull/18229)
+ * [release-20.0] Throttler: keep watching topo even on error (#18223) [#18320](https://github.com/vitessio/vitess/pull/18320) 
+#### VReplication
+ * [release-20.0] Atomic Copy: Handle error that was ignored while streaming tables and log it (#18313) [#18314](https://github.com/vitessio/vitess/pull/18314)
+### Release 
+#### General
+ * [release-20.0] Bump to `v20.0.8-SNAPSHOT` after the `v20.0.7` release [#18147](https://github.com/vitessio/vitess/pull/18147)
+ * [release-20.0] Code Freeze for `v20.0.8` [#18377](https://github.com/vitessio/vitess/pull/18377)
+### Testing 
+#### Query Serving
+ * [release-20.0] test: TestQueryTimeoutWithShardTargeting fix flaky test (#18242) [#18248](https://github.com/vitessio/vitess/pull/18248)
+

--- a/changelog/20.0/20.0.8/release_notes.md
+++ b/changelog/20.0/20.0.8/release_notes.md
@@ -1,0 +1,7 @@
+# Release of Vitess v20.0.8
+The entire changelog for this release can be found [here](https://github.com/vitessio/vitess/blob/main/changelog/20.0/20.0.8/changelog.md).
+
+The release includes 11 merged Pull Requests.
+
+Thanks to all our contributors: @GuptaManan100, @app/vitess-bot, @frouioui
+

--- a/changelog/20.0/README.md
+++ b/changelog/20.0/README.md
@@ -1,4 +1,8 @@
 ## v20.0
+* **[20.0.8](20.0.8)**
+	* [Changelog](20.0.8/changelog.md)
+	* [Release Notes](20.0.8/release_notes.md)
+
 * **[20.0.7](20.0.7)**
 	* [Changelog](20.0.7/changelog.md)
 	* [Release Notes](20.0.7/release_notes.md)


### PR DESCRIPTION
This Pull Request copies the release notes found on `release-20.0` to keep release notes up-to-date after the `v20.0.8` release.