### PR TITLE
[Bugfix] Broken Heartbeat system in Row Streamer

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -392,11 +392,13 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 	heartbeatTicker := time.NewTicker(rowStreamertHeartbeatInterval)
 	defer heartbeatTicker.Stop()
 	go func() {
-		select {
-		case <-rs.ctx.Done():
-			return
-		case <-heartbeatTicker.C:
-			safeSend(&binlogdatapb.VStreamRowsResponse{Heartbeat: true})
+		for {
+			select {
+			case <-rs.ctx.Done():
+				return
+			case <-heartbeatTicker.C:
+				safeSend(&binlogdatapb.VStreamRowsResponse{Heartbeat: true})
+			}
 		}
 	}()
 

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
@@ -561,11 +561,15 @@ func TestStreamRowsHeartbeat(t *testing.T) {
 	}()
 
 	// Set a very short heartbeat interval for testing (100ms)
-	rowStreamertHeartbeatInterval = 100 * time.Millisecond
+	rowStreamertHeartbeatInterval = 10 * time.Millisecond
 
 	execStatements(t, []string{
 		"create table t1(id int, val varchar(128), primary key(id))",
-		"insert into t1 values (1, 'test')",
+		"insert into t1 values (1, 'test1')",
+		"insert into t1 values (2, 'test2')",
+		"insert into t1 values (3, 'test3')",
+		"insert into t1 values (4, 'test4')",
+		"insert into t1 values (5, 'test5')",
 	})
 
 	defer execStatements(t, []string{
@@ -581,7 +585,7 @@ func TestStreamRowsHeartbeat(t *testing.T) {
 	var options binlogdatapb.VStreamOptions
 	options.ConfigOverrides = make(map[string]string)
 	options.ConfigOverrides["vstream_dynamic_packet_size"] = "false"
-	options.ConfigOverrides["vstream_packet_size"] = "1000"
+	options.ConfigOverrides["vstream_packet_size"] = "10"
 
 	err := engine.StreamRows(ctx, "select * from t1", nil, func(rows *binlogdatapb.VStreamRowsResponse) error {
 		if rows.Heartbeat {

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
+	"time"
 
 	"vitess.io/vitess/go/vt/utils"
 
@@ -545,6 +546,74 @@ func TestStreamRowsCancel(t *testing.T) {
 	}, &options)
 	if got, want := err.Error(), "stream ended: context canceled"; got != want {
 		t.Errorf("err: %v, want %s", err, want)
+	}
+}
+
+func TestStreamRowsHeartbeat(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	// Save original heartbeat interval and restore it after test
+	originalInterval := rowStreamertHeartbeatInterval
+	defer func() {
+		rowStreamertHeartbeatInterval = originalInterval
+	}()
+
+	// Set a very short heartbeat interval for testing (100ms)
+	rowStreamertHeartbeatInterval = 100 * time.Millisecond
+
+	execStatements(t, []string{
+		"create table t1(id int, val varchar(128), primary key(id))",
+		"insert into t1 values (1, 'test')",
+	})
+
+	defer execStatements(t, []string{
+		"drop table t1",
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	heartbeatCount := 0
+	dataReceived := false
+
+	var options binlogdatapb.VStreamOptions
+	options.ConfigOverrides = make(map[string]string)
+	options.ConfigOverrides["vstream_dynamic_packet_size"] = "false"
+	options.ConfigOverrides["vstream_packet_size"] = "1000"
+
+	err := engine.StreamRows(ctx, "select * from t1", nil, func(rows *binlogdatapb.VStreamRowsResponse) error {
+		if rows.Heartbeat {
+			heartbeatCount++
+			// After receiving at least 3 heartbeats, we can be confident the fix is working
+			if heartbeatCount >= 3 {
+				cancel()
+				return nil
+			}
+		} else if len(rows.Rows) > 0 {
+			dataReceived = true
+		}
+		// Add a small delay to allow heartbeats to be sent
+		time.Sleep(50 * time.Millisecond)
+		return nil
+	}, &options)
+
+	// We expect context canceled error since we cancel after receiving heartbeats
+	if err != nil && err.Error() != "stream ended: context canceled" {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Verify we received data
+	if !dataReceived {
+		t.Error("expected to receive data rows")
+	}
+
+	// This is the critical test: we should receive multiple heartbeats
+	// Without the fix (missing for loop), we would only get 1 heartbeat
+	// With the fix, we should get at least 3 heartbeats
+	if heartbeatCount < 3 {
+		t.Errorf("expected at least 3 heartbeats, got %d. This indicates the heartbeat goroutine is not running continuously", heartbeatCount)
 	}
 }
 


### PR DESCRIPTION
_This PR implements the fix for the bug mentioned #18391_ 

TL;DR
VStreamRows uses a broken heartbeat mechanism that only sends one heartbeat and then exits. In contrast, VStream (used in normal binlog replication) sends heartbeats continuously. This PR fixes the issue by introducing a proper loop in the rowstreamer.go heartbeat goroutine to ensure heartbeats are sent throughout the copy phase. 

We found this out because Some of our long-running schema changes failed due to missing heartbeats during the copy phase of VReplication. 


### Description

**This is already patched in our internal fork of vitess and has been tested to work correctly for all the failing cases we saw.**

We've identified a **critical architectural inconsistency** in Vitess VReplication that explains this seemingly contradictory behavior. The reason some long-running schema changes don't get heartbeats while others do is because **different phases of the operation use different heartbeat mechanisms**.

## The Two Different Heartbeat Systems

### 1. **Working Heartbeat System** (vstreamer.go)
Used by **normal VReplication** (binlog streaming phase):

```go
// vstreamer.go lines 297-360
hbTimer := time.NewTimer(HeartbeatTime) // 900ms
defer hbTimer.Stop()

for {
    hbTimer.Reset(HeartbeatTime)  // ← Proper timer reset in loop
    select {
    case ev, ok := <-throttledEvents:
        // Process events
    case <-hbTimer.C:
        // Send heartbeat every 900ms
        if err := injectHeartbeat(false, ""); err != nil {
            return err
        }
    }
}
```

**This system works correctly** - it continuously sends heartbeats every 900ms.

### 2. **Broken Heartbeat System** (rowstreamer.go)
Used by **table copying phase** (VStreamRows):

```go
// rowstreamer.go lines 372-385
go func() {
    select {  // ← NO FOR LOOP! Only executes once!
    case <-rs.ctx.Done():
        return
    case <-heartbeatTicker.C:
        safeSend(&binlogdatapb.VStreamRowsResponse{Heartbeat: true})
    }  // ← Goroutine exits after first heartbeat
}()
```

**This system is broken** - it only sends one heartbeat and then the goroutine dies.

## Which Operations Use Which System

### Operations That **DO** Get Heartbeats:
- **Normal VReplication workflows** (MoveTables, Reshard after copy phase)
- **Catchup phase** during onlineDDL
- **Binlog streaming** operations
- **Short onlineDDL operations** (complete within 10 seconds)

These use `vplayer.go` → `VStream()` → `vstreamer.go` (working heartbeats)

### Operations That **DON'T** Get Heartbeats:
- **OnlineDDL copy phase** on large tables
- **Long-running VStreamRows operations**
- **Table copying during MoveTables/Reshard**

These use `vcopier.go` → `VStreamRows()` → `rowstreamer.go` (broken heartbeats)

## The Code Flow

### Copy Phase (Broken Heartbeats):
```
vcopier.copyTable() 
  → sourceVStreamer.VStreamRows() 
  → tabletConnector.VStreamRows() 
  → gRPC call to tablet 
  → tabletserver.VStreamRows() 
  → vstreamer.StreamRows() 
  → rowstreamer.streamQuery() 
  → BROKEN heartbeat goroutine
```

### Normal Replication (Working Heartbeats):
```
vplayer.play() 
  → sourceVStreamer.VStream() 
  → tabletConnector.VStream() 
  → gRPC call to tablet 
  → tabletserver.VStream() 
  → vstreamer.Stream() 
  → WORKING heartbeat timer
```

## Why You See This Pattern

1. **T=0**: OnlineDDL starts, enters copy phase using `VStreamRows`
2. **T=10s**: First (and only) heartbeat sent from broken rowstreamer
3. **T=10s+**: Heartbeat goroutine exits, no more heartbeats sent
4. **T=180min**: Operation fails due to "no heartbeat activity"

## The Fix

The immediate fix is to add a `for` loop to the rowstreamer heartbeat goroutine:

```go
// In rowstreamer.go lines 372-385
go func() {
    for {  // ← Add this loop!
        select {
        case <-rs.ctx.Done():
            return
        case <-heartbeatTicker.C:
            safeSend(&binlogdatapb.VStreamRowsResponse{Heartbeat: true})
        }
    }
}()
```

This explains the **inconsistent behavior** we observed - it's not random, it's **deterministic based on which code path the operation takes**. The bug only affects the table copying component, not the binlog streaming component.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required
