### PR TITLE
fix: update go-upgrade tool to check patch number (#18252)

### DIFF
--- a/go/tools/go-upgrade/go-upgrade.go
+++ b/go/tools/go-upgrade/go-upgrade.go
@@ -318,7 +318,7 @@ func getLatestStableGolangReleases() (version.Collection, error) {
 func chooseNewVersion(curVersion *version.Version, latestVersions version.Collection, allowMajorUpgrade bool) *version.Version {
 	selectedVersion := curVersion
 	for _, latestVersion := range latestVersions {
-		if !allowMajorUpgrade && !isSameMajorMinorVersion(latestVersion, selectedVersion) {
+		if !allowMajorUpgrade && !isSameVersion(latestVersion, selectedVersion) {
 			continue
 		}
 		if latestVersion.GreaterThan(selectedVersion) {
@@ -365,12 +365,12 @@ func replaceGoVersionInCodebase(old, new *version.Version) error {
 		}
 	}
 
-	if !isSameMajorMinorVersion(old, new) {
+	if !isSameVersion(old, new) {
 		goModFiles := []string{"./go.mod"}
 		for _, file := range goModFiles {
 			err = replaceInFile(
 				[]*regexp.Regexp{regexp.MustCompile(regexpReplaceGoModGoVersion)},
-				[]string{fmt.Sprintf("go %d.%d", new.Segments()[0], new.Segments()[1])},
+				[]string{fmt.Sprintf("go %d.%d.%d", new.Segments()[0], new.Segments()[1], new.Segments()[2])},
 				file,
 			)
 			if err != nil {
@@ -451,8 +451,8 @@ func updateBootstrapChangelog(new string, goVersion *version.Version) error {
 	return nil
 }
 
-func isSameMajorMinorVersion(a, b *version.Version) bool {
-	return a.Segments()[0] == b.Segments()[0] && a.Segments()[1] == b.Segments()[1]
+func isSameVersion(a, b *version.Version) bool {
+	return a.Segments()[0] == b.Segments()[0] && a.Segments()[1] == b.Segments()[1] && a.Segments()[2] == b.Segments()[2]
 }
 
 func getListOfFilesInPaths(pathsToExplore []string) ([]string, error) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
```
func isSameVersion(a, b *version.Version) bool {
	return a.Segments()[0] == b.Segments()[0] && a.Segments()[1] == b.Segments()[1] && a.Segments()[2] == b.Segments()[2]
}
```
This `isSameVersion` function also checks for the patch number.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
#18252

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
