### PR TITLE
Topo: Add NamedLock test for zk2 and consul and get them passing

### DIFF
--- a/go/test/endtoend/topotest/zk2/main_test.go
+++ b/go/test/endtoend/topotest/zk2/main_test.go
@@ -19,21 +19,20 @@ package zk2
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"testing"
 	"time"
-
-	topoutils "vitess.io/vitess/go/test/endtoend/topotest/utils"
-	"vitess.io/vitess/go/test/endtoend/utils"
-	"vitess.io/vitess/go/vt/topo"
-
-	"vitess.io/vitess/go/vt/log"
 
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/endtoend/cluster"
+	topoutils "vitess.io/vitess/go/test/endtoend/topotest/utils"
+	"vitess.io/vitess/go/test/endtoend/utils"
+	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/topo"
 )
 
 var (
@@ -95,6 +94,53 @@ func TestMain(m *testing.M) {
 		return m.Run()
 	}()
 	os.Exit(exitCode)
+}
+
+// TestNamedLocking tests that named locking works as intended.
+func TestNamedLocking(t *testing.T) {
+	// Create topo server connection.
+	ts, err := topo.OpenServer(*clusterInstance.TopoFlavorString(), clusterInstance.VtctldClientProcess.TopoGlobalAddress, clusterInstance.VtctldClientProcess.TopoGlobalRoot)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	lockName := "TestNamedLocking"
+	action := "Testing"
+
+	// Acquire a named lock.
+	ctx, unlock, err := ts.LockName(ctx, lockName, action)
+	require.NoError(t, err)
+
+	// Check that we can't reacquire it from the same context.
+	_, _, err = ts.LockName(ctx, lockName, action)
+	require.ErrorContains(t, err, fmt.Sprintf("lock for named %s is already held", lockName))
+
+	// Check that CheckNameLocked doesn't return an error as we should still be
+	// holding the lock.
+	err = topo.CheckNameLocked(ctx, lockName)
+	require.NoError(t, err)
+
+	// We'll now try to acquire the lock from a different goroutine.
+	secondCallerAcquired := false
+	go func() {
+		_, unlock, err := ts.LockName(context.Background(), lockName, action)
+		defer unlock(&err)
+		require.NoError(t, err)
+		secondCallerAcquired = true
+	}()
+
+	// Wait for some time and ensure that the second attempt at acquiring the lock
+	// is blocked.
+	time.Sleep(100 * time.Millisecond)
+	require.False(t, secondCallerAcquired)
+
+	// Unlock the name.
+	unlock(&err)
+	// Check that we no longer have the named lock.
+	err = topo.CheckNameLocked(ctx, lockName)
+	require.ErrorContains(t, err, fmt.Sprintf("named %s is not locked (no lockInfo in map)", lockName))
+
+	// Wait to see that the second goroutine WAS now able to acquire the named lock.
+	topoutils.WaitForBoolValue(t, &secondCallerAcquired, true)
 }
 
 func TestTopoDownServingQuery(t *testing.T) {

--- a/go/vt/topo/test/lock.go
+++ b/go/vt/topo/test/lock.go
@@ -47,9 +47,6 @@ func checkLock(t *testing.T, ctx context.Context, ts *topo.Server) {
 	t.Log("===      checkLockTimeout")
 	checkLockTimeout(ctx, t, conn)
 
-	t.Log("===      checkLockMissing")
-	checkLockMissing(ctx, t, conn)
-
 	t.Log("===      checkLockUnblocks")
 	checkLockUnblocks(ctx, t, conn)
 }
@@ -118,14 +115,6 @@ func checkLockTimeout(ctx context.Context, t *testing.T, conn topo.Conn) {
 	// test we can't unlock again
 	if err := lockDescriptor.Unlock(ctx); err == nil {
 		t.Fatalf("Unlock(again) worked")
-	}
-}
-
-// checkLockMissing makes sure we can't lock a non-existing directory.
-func checkLockMissing(ctx context.Context, t *testing.T, conn topo.Conn) {
-	keyspacePath := path.Join(topo.KeyspacesPath, "test_keyspace_666")
-	if _, err := conn.Lock(ctx, keyspacePath, "missing"); err == nil {
-		t.Fatalf("Lock(test_keyspace_666) worked for non-existing keyspace")
 	}
 }
 

--- a/go/vt/topo/test/trylock.go
+++ b/go/vt/topo/test/trylock.go
@@ -44,9 +44,6 @@ func checkTryLock(t *testing.T, ctx context.Context, ts *topo.Server) {
 	t.Log("===      checkTryLockTimeout")
 	checkTryLockTimeout(ctx, t, conn)
 
-	t.Log("===      checkTryLockMissing")
-	checkTryLockMissing(ctx, t, conn)
-
 	t.Log("===      checkTryLockUnblocks")
 	checkTryLockUnblocks(ctx, t, conn)
 }
@@ -139,14 +136,6 @@ func checkTryLockTimeout(ctx context.Context, t *testing.T, conn topo.Conn) {
 	// test we can't unlock again
 	if err := lockDescriptor.Unlock(ctx); err == nil {
 		require.Fail(t, "Unlock succeeded but should not have")
-	}
-}
-
-// checkTryLockMissing makes sure we can't lock a non-existing directory.
-func checkTryLockMissing(ctx context.Context, t *testing.T, conn topo.Conn) {
-	keyspacePath := path.Join(topo.KeyspacesPath, "test_keyspace_666")
-	if _, err := conn.TryLock(ctx, keyspacePath, "missing"); err == nil {
-		require.Fail(t, "TryLock(test_keyspace_666) worked for non-existing keyspace")
 	}
 }
 

--- a/go/vt/topo/zk2topo/lock.go
+++ b/go/vt/topo/zk2topo/lock.go
@@ -88,7 +88,7 @@ func (zs *Server) lock(ctx context.Context, dirPath, contents string) (topo.Lock
 	// sequential nodes, they are created as children, not siblings.
 	locksDir := path.Join(zs.root, dirPath, locksPath) + "/"
 
-	// Create the locks path, possibly creating the parent.
+	// Create the lock path, creating the parents as needed.
 	nodePath, err := CreateRecursive(ctx, zs.conn, locksDir, []byte(contents), zk.FlagSequence|zk.FlagEphemeral, zk.WorldACL(PermFile), -1)
 	if err != nil {
 		return nil, convertError(err, locksDir)

--- a/go/vt/topo/zk2topo/lock.go
+++ b/go/vt/topo/zk2topo/lock.go
@@ -89,7 +89,7 @@ func (zs *Server) lock(ctx context.Context, dirPath, contents string) (topo.Lock
 	locksDir := path.Join(zs.root, dirPath, locksPath) + "/"
 
 	// Create the locks path, possibly creating the parent.
-	nodePath, err := CreateRecursive(ctx, zs.conn, locksDir, []byte(contents), zk.FlagSequence|zk.FlagEphemeral, zk.WorldACL(PermFile), 1)
+	nodePath, err := CreateRecursive(ctx, zs.conn, locksDir, []byte(contents), zk.FlagSequence|zk.FlagEphemeral, zk.WorldACL(PermFile), -1)
 	if err != nil {
 		return nil, convertError(err, locksDir)
 	}

--- a/go/vt/topo/zk2topo/utils.go
+++ b/go/vt/topo/zk2topo/utils.go
@@ -17,20 +17,18 @@ limitations under the License.
 package zk2topo
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"sort"
 	"strings"
 	"sync"
 
-	"context"
-
 	"github.com/z-division/go-zookeeper/zk"
 
+	"vitess.io/vitess/go/fileutil"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vterrors"
-
-	"vitess.io/vitess/go/fileutil"
 )
 
 // CreateRecursive is a helper function on top of Create. It will


### PR DESCRIPTION
## Description

This PR is a follow-up to: https://github.com/vitessio/vitess/pull/16260

I did not add the `NamedLock` test for `zk2` and `consul`. 🤦 Because of that... it was not until a Vitess user that is using ZooKeeper upgraded to v21 and reported the issue here that the problem was known: https://vitess.slack.com/archives/CMKTCUYNQ/p1750981149992529

In this PR we correct my initial mistake, adding the `NamedLock` test to the `zk2` and `consul` tests. 

I then fixed the `zk2` lock implementation so that it will always create the path that we're trying to lock (as I had initially expected it to behave). The issue was that it was only creating the lock paths recursively *one* level deep, which was enough for `Keyspace` and `Shard` locks, but not enough for the named locks. With this `zk2` locking  behavior change, I also removed two no longer relevant unit test checks as they relied on the fact that `lock` would only create 1 parent dir. This change makes the lock behavior effectively the same for `zk2` as it is for `etcd` and `consul` (where it's just a key name).

The [manual test noted in the issue](https://github.com/vitessio/vitess/issues/18408) then works as expected, along with the new endtoend test.

>[!NOTE]
>I think that we should backport this fix all the way to v21, as that's when this new named locks feature was added.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/18408

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required