### PR TITLE
Perform post copy actions in atomic copy

### DIFF
--- a/go/test/endtoend/vreplication/fk_config_test.go
+++ b/go/test/endtoend/vreplication/fk_config_test.go
@@ -20,7 +20,7 @@ package vreplication
 // (child before parent), t1,t2  are in lexical order, and t11,t12  have valid circular foreign key constraints.
 var (
 	initialFKSchema = `
-create table parent(id int, name varchar(128), primary key(id)) engine=innodb;
+create table parent(id int, name varchar(128), primary key(id), key(name)) engine=innodb;
 create table child(id int, parent_id int, name varchar(128), primary key(id), foreign key(parent_id) references parent(id) on delete cascade) engine=innodb;
 create view vparent as select * from parent;
 create table t1(id int, name varchar(128), primary key(id)) engine=innodb;

--- a/go/test/endtoend/vreplication/fk_test.go
+++ b/go/test/endtoend/vreplication/fk_test.go
@@ -28,6 +28,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/vt/log"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -135,6 +136,8 @@ func TestFKWorkflow(t *testing.T) {
 		require.Greater(t, t11Count, 1)
 		require.Greater(t, t12Count, 1)
 		require.Equal(t, t11Count, t12Count)
+		// Check for the secondary key
+		confirmTablesHaveSecondaryKeys(t, []*cluster.VttabletProcess{targetTab}, targetKeyspace, "parent")
 	}
 
 }

--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -474,7 +474,8 @@ func confirmTablesHaveSecondaryKeys(t *testing.T, tablets []*cluster.VttabletPro
 		}
 		select {
 		case <-timer.C:
-			require.FailNow(t, "The following table(s) do not have any secondary keys: %s", strings.Join(tablesWithoutSecondaryKeys, ", "))
+			failureMessage := fmt.Sprintf("The following table(s) do not have any secondary keys: %s", strings.Join(tablesWithoutSecondaryKeys, ", "))
+			require.FailNow(t, failureMessage)
 		default:
 			time.Sleep(defaultTick)
 		}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR
- fixes the atomic copy behaviour (specifically in `copyAll()`) where we missed executing post copy actions.
- Also, modifies the test `TestFKWorkflow` to confirm secondary keys in the target schema. 
- Also deletes the executed post copy actions from `_vt. post_copy_action` along with the existing state deletion from `_vt.copy_state`
 
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
- Fixes https://github.com/vitessio/vitess/issues/18353
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
