### PR TITLE
test: Fix race condition in TestStreamRowsHeartbeat

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -579,7 +580,7 @@ func TestStreamRowsHeartbeat(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	heartbeatCount := 0
+	var heartbeatCount int32
 	dataReceived := false
 
 	var options binlogdatapb.VStreamOptions
@@ -589,9 +590,9 @@ func TestStreamRowsHeartbeat(t *testing.T) {
 
 	err := engine.StreamRows(ctx, "select * from t1", nil, func(rows *binlogdatapb.VStreamRowsResponse) error {
 		if rows.Heartbeat {
-			heartbeatCount++
+			atomic.AddInt32(&heartbeatCount, 1)
 			// After receiving at least 3 heartbeats, we can be confident the fix is working
-			if heartbeatCount >= 3 {
+			if atomic.LoadInt32(&heartbeatCount) >= 3 {
 				cancel()
 				return nil
 			}
@@ -616,7 +617,7 @@ func TestStreamRowsHeartbeat(t *testing.T) {
 	// This is the critical test: we should receive multiple heartbeats
 	// Without the fix (missing for loop), we would only get 1 heartbeat
 	// With the fix, we should get at least 3 heartbeats
-	if heartbeatCount < 3 {
+	if atomic.LoadInt32(&heartbeatCount) < 3 {
 		t.Errorf("expected at least 3 heartbeats, got %d. This indicates the heartbeat goroutine is not running continuously", heartbeatCount)
 	}
 }


### PR DESCRIPTION
## Description 
Tests that were added in https://github.com/vitessio/vitess/pull/18390 were having race conditions.

Hence in this PR we have replaced non-atomic heartbeat counter with atomic operations to prevent race conditions when accessing the counter from multiple goroutines.

Changes:
- Use int32 with sync/atomic instead of regular int
- Replace direct increment with atomic.AddInt32()
- Replace direct reads with atomic.LoadInt32()

This ensures thread-safe access to the heartbeat counter in the test.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
