### PR TITLE
Online DDL metrics: `OnlineDDLStaleMigrationMinutes`

### DIFF
--- a/go/vt/vttablet/onlineddl/schema.go
+++ b/go/vt/vttablet/onlineddl/schema.go
@@ -357,7 +357,8 @@ const (
 		LIMIT 1
 	`
 	sqlSelectStaleMigrations = `SELECT
-			migration_uuid
+			migration_uuid,
+			timestampdiff(minute, liveness_timestamp, now()) as stale_minutes
 		FROM _vt.schema_migrations
 		WHERE
 			migration_status='running'


### PR DESCRIPTION

## Description

This PR introduces a new stats gauge for Online DDL, `OnlineDDLStaleMigrationMinutes`.
Vitess (vreplication based) migrations that are found `running` but show no vreplication liveness in the past `5` seconds are logged, and the metric `OnlineDDLStaleMigrationMinutes` is updates as the highest number of staleness minutes among them.
When all `running` migrations have liveness within the `5min` range, or if there's no running migrations, then `OnlineDDLStaleMigrationMinutes` is set to zero.


## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/18416

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
