### PR TITLE
Online DDL: resume vreplication after cut-over/RENAME failure

### DIFF
--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -1352,7 +1352,7 @@ func testScheduler(t *testing.T) {
 			onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusCancelled)
 		})
 
-		// now, we submit the exact same migratoin again: same UUID, same migration context.
+		// now, we submit the exact same migration again: same UUID, same migration context.
 		t.Run("resubmit migration", func(t *testing.T) {
 			executedUUID := testOnlineDDLStatement(t, createParams(trivialAlterT1Statement, ddlStrategy, "vtctl", "", "", true)) // skip wait
 			require.Equal(t, uuid, executedUUID)

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -630,7 +630,7 @@ func (e *Executor) terminateVReplMigration(ctx context.Context, uuid string, del
 	return nil
 }
 
-func (e *Executor) startVreplication(ctx context.Context, tablet *topodatapb.Tablet, workflow string) (err error) {
+func (e *Executor) startVReplication(ctx context.Context, tablet *topodatapb.Tablet, workflow string) (err error) {
 	query, err := sqlparser.ParseAndBind(sqlStartVReplStream,
 		sqltypes.StringBindVariable(e.dbName),
 		sqltypes.StringBindVariable(workflow),

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -1090,7 +1090,7 @@ func (e *Executor) cutOverVReplMigration(ctx context.Context, s *VReplStream, sh
 	defer func() {
 		if !renameWasSuccessful {
 			// Restarting vreplication
-			if err := e.startVreplication(ctx, tablet.Tablet, s.workflow); err != nil {
+			if err := e.startVReplication(ctx, tablet.Tablet, s.workflow); err != nil {
 				log.Errorf("cutOverVReplMigration %v: failed restarting vreplication after cutover failure: %v", s.workflow, err)
 			}
 			go log.Infof("cutOverVReplMigration %v: started vreplication after cutover failure", s.workflow)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

In Online DDL cut-over, and once vreplication is stopped just before renaming the tables, ensure to restart vreplication in case the cut-over ends up failing (specifically there is one remaining operation, the `RENAME`).

Another thing in this PR: when canceling a vreplication migration (can be due to user's explicit `CANCEL`, or due to failure), do not delete the vreplication entry, as it is useful for debugging/analysis purposes.

## Backport

This is a bug that needs to be backported to supported versions.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/18427

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
