### PR TITLE
make xtrabackup ShouldDrainForBackup configurable

### DIFF
--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -253,6 +253,7 @@ Flags:
       --xtrabackup-backup-flags string                              Flags to pass to backup command. These should be space separated and will be added to the end of the command
       --xtrabackup-prepare-flags string                             Flags to pass to prepare command. These should be space separated and will be added to the end of the command
       --xtrabackup-root-path string                                 Directory location of the xtrabackup and xbstream executables, e.g., /usr/bin
+      --xtrabackup-should-drain                                     Decide if we should drain while taking a backup or continue to serving traffic
       --xtrabackup-stream-mode string                               Which mode to use if streaming, valid values are tar and xbstream. Please note that tar is not supported in XtraBackup 8.0 (default "tar")
       --xtrabackup-stripe-block-size uint                           Size in bytes of each block that gets sent to a given stripe before rotating to the next stripe (default 102400)
       --xtrabackup-stripes uint                                     If greater than 0, use data striping across this many destination files to parallelize data transfer and decompression

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -444,6 +444,7 @@ Flags:
       --xtrabackup-backup-flags string                                   Flags to pass to backup command. These should be space separated and will be added to the end of the command
       --xtrabackup-prepare-flags string                                  Flags to pass to prepare command. These should be space separated and will be added to the end of the command
       --xtrabackup-root-path string                                      Directory location of the xtrabackup and xbstream executables, e.g., /usr/bin
+      --xtrabackup-should-drain                                          Decide if we should drain while taking a backup or continue to serving traffic
       --xtrabackup-stream-mode string                                    Which mode to use if streaming, valid values are tar and xbstream. Please note that tar is not supported in XtraBackup 8.0 (default "tar")
       --xtrabackup-stripe-block-size uint                                Size in bytes of each block that gets sent to a given stripe before rotating to the next stripe (default 102400)
       --xtrabackup-stripes uint                                          If greater than 0, use data striping across this many destination files to parallelize data transfer and decompression

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -431,6 +431,7 @@ Flags:
       --xtrabackup-backup-flags string                                   Flags to pass to backup command. These should be space separated and will be added to the end of the command
       --xtrabackup-prepare-flags string                                  Flags to pass to prepare command. These should be space separated and will be added to the end of the command
       --xtrabackup-root-path string                                      Directory location of the xtrabackup and xbstream executables, e.g., /usr/bin
+      --xtrabackup-should-drain                                          Decide if we should drain while taking a backup or continue to serving traffic
       --xtrabackup-stream-mode string                                    Which mode to use if streaming, valid values are tar and xbstream. Please note that tar is not supported in XtraBackup 8.0 (default "tar")
       --xtrabackup-stripe-block-size uint                                Size in bytes of each block that gets sent to a given stripe before rotating to the next stripe (default 102400)
       --xtrabackup-stripes uint                                          If greater than 0, use data striping across this many destination files to parallelize data transfer and decompression

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -169,6 +169,7 @@ Flags:
       --xtrabackup-backup-flags string                                   Flags to pass to backup command. These should be space separated and will be added to the end of the command
       --xtrabackup-prepare-flags string                                  Flags to pass to prepare command. These should be space separated and will be added to the end of the command
       --xtrabackup-root-path string                                      Directory location of the xtrabackup and xbstream executables, e.g., /usr/bin
+      --xtrabackup-should-drain                                          Decide if we should drain while taking a backup or continue to serving traffic
       --xtrabackup-stream-mode string                                    Which mode to use if streaming, valid values are tar and xbstream. Please note that tar is not supported in XtraBackup 8.0 (default "tar")
       --xtrabackup-stripe-block-size uint                                Size in bytes of each block that gets sent to a given stripe before rotating to the next stripe (default 102400)
       --xtrabackup-stripes uint                                          If greater than 0, use data striping across this many destination files to parallelize data transfer and decompression

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -137,7 +137,7 @@ func registerXtraBackupEngineFlags(fs *pflag.FlagSet) {
 	utils.SetFlagStringVar(fs, &xtrabackupUser, "xtrabackup-user", xtrabackupUser, "User that xtrabackup will use to connect to the database server. This user must have all necessary privileges. For details, please refer to xtrabackup documentation.")
 	utils.SetFlagUintVar(fs, &xtrabackupStripes, "xtrabackup-stripes", xtrabackupStripes, "If greater than 0, use data striping across this many destination files to parallelize data transfer and decompression")
 	utils.SetFlagUintVar(fs, &xtrabackupStripeBlockSize, "xtrabackup-stripe-block-size", xtrabackupStripeBlockSize, "Size in bytes of each block that gets sent to a given stripe before rotating to the next stripe")
-	utils.SetFlagBoolVar(fs, &xtrabackupShouldDrain, "xtrabackup-should-drain", xtrabackupShouldDrain, "decide if we should drain while taking a backup or continue to serving traffic")
+	utils.SetFlagBoolVar(fs, &xtrabackupShouldDrain, "xtrabackup-should-drain", xtrabackupShouldDrain, "Decide if we should drain while taking a backup or continue to serving traffic")
 }
 
 func (be *XtrabackupEngine) backupFileName() string {

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -65,6 +65,8 @@ var (
 	// striping mode
 	xtrabackupStripes         uint
 	xtrabackupStripeBlockSize = uint(102400)
+	// drain a tablet when taking a backup
+	xtrabackupShouldDrain = false
 )
 
 const (
@@ -135,6 +137,7 @@ func registerXtraBackupEngineFlags(fs *pflag.FlagSet) {
 	utils.SetFlagStringVar(fs, &xtrabackupUser, "xtrabackup-user", xtrabackupUser, "User that xtrabackup will use to connect to the database server. This user must have all necessary privileges. For details, please refer to xtrabackup documentation.")
 	utils.SetFlagUintVar(fs, &xtrabackupStripes, "xtrabackup-stripes", xtrabackupStripes, "If greater than 0, use data striping across this many destination files to parallelize data transfer and decompression")
 	utils.SetFlagUintVar(fs, &xtrabackupStripeBlockSize, "xtrabackup-stripe-block-size", xtrabackupStripeBlockSize, "Size in bytes of each block that gets sent to a given stripe before rotating to the next stripe")
+	utils.SetFlagBoolVar(fs, &xtrabackupShouldDrain, "xtrabackup-should-drain", xtrabackupShouldDrain, "decide if we should drain while taking a backup or continue to serving traffic")
 }
 
 func (be *XtrabackupEngine) backupFileName() string {
@@ -945,9 +948,9 @@ func stripeReader(readers []io.Reader, blockSize int64) io.Reader {
 }
 
 // ShouldDrainForBackup satisfies the BackupEngine interface
-// xtrabackup can run while tablet is serving, hence false
+// xtrabackup can run while tablet is serving, so we can control this via a flag.
 func (be *XtrabackupEngine) ShouldDrainForBackup(req *tabletmanagerdatapb.BackupRequest) bool {
-	return false
+	return xtrabackupShouldDrain
 }
 
 // ShouldStartMySQLAfterRestore signifies if this backup engine needs to restart MySQL once the restore is completed.

--- a/go/vt/mysqlctl/xtrabackupengine_test.go
+++ b/go/vt/mysqlctl/xtrabackupengine_test.go
@@ -135,6 +135,16 @@ func TestStripeRoundTrip(t *testing.T) {
 func TestShouldDrainForBackupXtrabackup(t *testing.T) {
 	be := &XtrabackupEngine{}
 
+	// Test default behavior (should not drain)
+	originalValue := xtrabackupShouldDrain
+	defer func() { xtrabackupShouldDrain = originalValue }()
+
+	xtrabackupShouldDrain = false
 	assert.False(t, be.ShouldDrainForBackup(nil))
 	assert.False(t, be.ShouldDrainForBackup(&tabletmanagerdatapb.BackupRequest{}))
+
+	// Test configurable behavior (should drain when flag is set)
+	xtrabackupShouldDrain = true
+	assert.True(t, be.ShouldDrainForBackup(nil))
+	assert.True(t, be.ShouldDrainForBackup(&tabletmanagerdatapb.BackupRequest{}))
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This will let the operator choose if they wish to drain a tablet when taking an `xtrabackup` as discussed in https://github.com/vitessio/vitess/issues/18430

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Fixes #18430

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
