### PR TITLE
Fix watcher storm during topo outages

### DIFF
--- a/go/vt/srvtopo/watch_test.go
+++ b/go/vt/srvtopo/watch_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package srvtopo
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/stats"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
+)
+
+// TestWatcherOutageBehavior tests that watchers remain silent during topo outages.
+func TestWatcherOutageBehavior(t *testing.T) {
+	originalCacheTTL := srvTopoCacheTTL
+	originalCacheRefresh := srvTopoCacheRefresh
+	srvTopoCacheTTL = 100 * time.Millisecond
+	srvTopoCacheRefresh = 50 * time.Millisecond
+	defer func() {
+		srvTopoCacheTTL = originalCacheTTL
+		srvTopoCacheRefresh = originalCacheRefresh
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ts, factory := memorytopo.NewServerAndFactory(ctx, "test_cell")
+	counts := stats.NewCountersWithSingleLabel("", "Watcher outage test", "type")
+	rs := NewResilientServer(ctx, ts, counts)
+
+	initialVSchema := &vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{
+			"ks1": {Sharded: false},
+		},
+	}
+	err := ts.UpdateSrvVSchema(ctx, "test_cell", initialVSchema)
+	require.NoError(t, err)
+
+	var watcherCallCount atomic.Int32
+	var lastWatcherError error
+
+	rs.WatchSrvVSchema(ctx, "test_cell", func(v *vschemapb.SrvVSchema, e error) bool {
+		watcherCallCount.Add(1)
+		lastWatcherError = e
+		return true
+	})
+
+	// Wait for initial callback
+	assert.Eventually(t, func() bool {
+		return watcherCallCount.Load() >= 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	initialWatcherCalls := watcherCallCount.Load()
+	require.GreaterOrEqual(t, initialWatcherCalls, int32(1))
+	require.NoError(t, lastWatcherError)
+
+	// Verify Get operations work normally
+	vschema, err := rs.GetSrvVSchema(ctx, "test_cell")
+	require.NoError(t, err)
+	require.NotNil(t, vschema)
+
+	// Simulate topo outage
+	factory.SetError(fmt.Errorf("simulated topo error"))
+
+	// Get should still work from cache during outage
+	vschema, err = rs.GetSrvVSchema(ctx, "test_cell")
+	assert.NoError(t, err)
+	assert.NotNil(t, vschema)
+
+	// Wait during outage period
+	outageDuration := 500 * time.Millisecond
+	time.Sleep(outageDuration)
+
+	// Watchers should remain silent during outage
+	watcherCallsDuringOutage := watcherCallCount.Load() - initialWatcherCalls
+	assert.Equal(t, int32(0), watcherCallsDuringOutage, "watchers should be silent during outage")
+
+	// Get operations should continue working from cache
+	vschema, err = rs.GetSrvVSchema(ctx, "test_cell")
+	assert.NoError(t, err)
+	assert.NotNil(t, vschema)
+
+	// Clear the error and update VSchema
+	factory.SetError(nil)
+	updatedVSchema := &vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{
+			"ks2": {Sharded: false},
+		},
+	}
+	err = ts.UpdateSrvVSchema(ctx, "test_cell", updatedVSchema)
+	require.NoError(t, err)
+
+	// Verify recovery callback occurs
+	watcherCallsBeforeRecovery := watcherCallCount.Load()
+	assert.Eventually(t, func() bool {
+		return watcherCallCount.Load() > watcherCallsBeforeRecovery && lastWatcherError == nil
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Verify recovery worked
+	vschema, err = rs.GetSrvVSchema(ctx, "test_cell")
+	assert.NoError(t, err)
+	assert.NotNil(t, vschema)
+}
+
+// TestVSchemaWatcherCacheExpiryBehavior tests cache behavior during different error types.
+func TestVSchemaWatcherCacheExpiryBehavior(t *testing.T) {
+	originalCacheTTL := srvTopoCacheTTL
+	originalCacheRefresh := srvTopoCacheRefresh
+	srvTopoCacheTTL = 100 * time.Millisecond
+	srvTopoCacheRefresh = 50 * time.Millisecond
+	defer func() {
+		srvTopoCacheTTL = originalCacheTTL
+		srvTopoCacheRefresh = originalCacheRefresh
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ts, factory := memorytopo.NewServerAndFactory(ctx, "test_cell")
+	counts := stats.NewCountersWithSingleLabel("", "Cache expiry test", "type")
+	rs := NewResilientServer(ctx, ts, counts)
+
+	// Set initial VSchema
+	initialVSchema := &vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{
+			"ks1": {Sharded: false},
+		},
+	}
+	err := ts.UpdateSrvVSchema(ctx, "test_cell", initialVSchema)
+	require.NoError(t, err)
+
+	// Get the initial value to populate cache
+	vschema, err := rs.GetSrvVSchema(ctx, "test_cell")
+	require.NoError(t, err)
+	require.NotNil(t, vschema)
+
+	// Wait for cache TTL to expire
+	time.Sleep(srvTopoCacheTTL + 10*time.Millisecond)
+
+	// Set a non-topo error (like 500 HTTP error)
+	nonTopoErr := fmt.Errorf("HTTP 500 internal server error")
+	factory.SetError(nonTopoErr)
+
+	// Get VSchema after TTL expiry with non-topo error
+	// Should still serve cached value (not the error)
+	vschema, err = rs.GetSrvVSchema(ctx, "test_cell")
+	assert.NoError(t, err, "Should serve cached value for non-topo errors even after TTL")
+	assert.NotNil(t, vschema, "Should return cached VSchema")
+
+	// Now test with a topo error
+	factory.SetError(topo.NewError(topo.Timeout, "topo timeout error"))
+	time.Sleep(srvTopoCacheTTL + 10*time.Millisecond) // Let TTL expire again
+
+	// With topo error after TTL expiry, cache should be cleared
+	vschema, err = rs.GetSrvVSchema(ctx, "test_cell")
+	assert.Error(t, err, "Should return error for topo errors after TTL expiry")
+	assert.True(t, topo.IsErrType(err, topo.Timeout), "Should return the topo error")
+	assert.Nil(t, vschema, "Should not return vschema when error occurs")
+}
+
+// TestWatcherShouldOnlyNotifyOnActualChanges tests that watchers are called when VSchema content changes.
+func TestWatcherShouldOnlyNotifyOnActualChanges(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ts := memorytopo.NewServer(ctx, "test_cell")
+	counts := stats.NewCountersWithSingleLabel("", "Change detection test", "type")
+	rs := NewResilientServer(ctx, ts, counts)
+
+	vschema := &vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{
+			"ks1": {Sharded: false},
+		},
+	}
+	err := ts.UpdateSrvVSchema(ctx, "test_cell", vschema)
+	require.NoError(t, err)
+
+	var callCount atomic.Int32
+	rs.WatchSrvVSchema(ctx, "test_cell", func(v *vschemapb.SrvVSchema, e error) bool {
+		callCount.Add(1)
+		return true
+	})
+
+	// Wait for initial call
+	assert.Eventually(t, func() bool {
+		return callCount.Load() >= 1
+	}, 1*time.Second, 10*time.Millisecond)
+
+	initialCalls := callCount.Load()
+
+	// Update with same vschema content
+	err = ts.UpdateSrvVSchema(ctx, "test_cell", vschema)
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+	callsAfterSameUpdate := callCount.Load()
+
+	t.Logf("Calls after same content update: %d", callsAfterSameUpdate-initialCalls)
+
+	// Update with different vschema
+	differentVSchema := &vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{
+			"ks2": {Sharded: true},
+		},
+	}
+	err = ts.UpdateSrvVSchema(ctx, "test_cell", differentVSchema)
+	require.NoError(t, err)
+
+	// Should trigger a call for actual changes
+	assert.Eventually(t, func() bool {
+		return callCount.Load() > callsAfterSameUpdate
+	}, 1*time.Second, 10*time.Millisecond)
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

The resilient watcher in go/vt/srvtopo/watch.go was notifying listeners during every refresh cycle, even when serving cached data during outages. This violated the expectation that watchers should only notify on actual value changes.

###  Solution

  Modified the update() method in watch.go to only notify listeners when:
  1. Successful updates - Always notify on new data
  2. First-time failures - Only notify on initial errors when no cached data exists

During outages with cached data available, watchers remain silent while Get operations continue working from cache.


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/18433

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
