### PR TITLE
chore: remove loopclosure captures from tests

### DIFF
--- a/go/cmd/zk/internal/zkfs/zkfs_test.go
+++ b/go/cmd/zk/internal/zkfs/zkfs_test.go
@@ -75,7 +75,6 @@ func TestFormatACL(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expected, FormatACL(tc.acl))
 		})

--- a/go/vt/topo/shard_test.go
+++ b/go/vt/topo/shard_test.go
@@ -350,7 +350,6 @@ func TestValidateShardName(t *testing.T) {
 	}
 
 	for _, tcase := range cases {
-		tcase := tcase
 		t.Run(tcase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/topo/topoproto/tablet_test.go
+++ b/go/vt/topo/topoproto/tablet_test.go
@@ -121,7 +121,6 @@ func TestIsTabletsInList(t *testing.T) {
 		// We create an explicit copy of the range variable for each parallel runner
 		// to be sure that they each run as expected. You can see more information on
 		// this here: https://pkg.go.dev/testing#hdr-Subtests_and_Sub_benchmarks
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			out := IsTabletInList(testcase.tablet, testcase.allTablets)

--- a/go/vt/vtadmin/cluster/cluster_test.go
+++ b/go/vt/vtadmin/cluster/cluster_test.go
@@ -1694,7 +1694,6 @@ func TestGetSchema(t *testing.T) {
 	ctx := context.Background()
 
 	for i, tt := range tests {
-		i := i
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vtadmin/http/api_test.go
+++ b/go/vt/vtadmin/http/api_test.go
@@ -72,7 +72,6 @@ func TestDeprecateQueryParam(t *testing.T) {
 	}
 
 	for _, tcase := range cases {
-		tcase := tcase
 		t.Run("", func(t *testing.T) {
 			query := url.Values(tcase.in)
 

--- a/go/vt/vtadmin/http/handlers/panic_recovery_test.go
+++ b/go/vt/vtadmin/http/handlers/panic_recovery_test.go
@@ -55,7 +55,6 @@ func TestPanicRecoveryHandler(t *testing.T) {
 	}
 
 	for _, tcase := range cases {
-		tcase := tcase
 		t.Run(tcase.route, func(t *testing.T) {
 			rec := httptest.ResponseRecorder{
 				Body: bytes.NewBuffer(nil),

--- a/go/vt/vtctl/schematools/schematools_test.go
+++ b/go/vt/vtctl/schematools/schematools_test.go
@@ -50,7 +50,6 @@ func TestSchemaMigrationStrategyName(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.out, func(t *testing.T) {
 			t.Parallel()
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -69,7 +69,6 @@ func testVcopierTestCases(t *testing.T, test func(*testing.T), cases []vcopierTe
 	}()
 
 	for _, tc := range cases {
-		tc := tc // Avoid export loop bugs.
 		// Set test flags.
 		vttablet.DefaultVReplicationConfig.ExperimentalFlags = tc.vreplicationExperimentalFlags
 		vttablet.DefaultVReplicationConfig.ParallelInsertWorkers = tc.vreplicationParallelInsertWorkers


### PR DESCRIPTION
Fixes #15183

Remove redundant loop variable captures like 'tc := tc' and 'test := test' from test files. These are no longer needed in Go 1.22+ due to the fixed loop variable behavior.

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR removes redundant loopclosure captures from test files that are no longer needed with Go 1.22's fixed loop variable behavior.
Background: Prior to Go 1.22, loop variables were reused across iterations, requiring explicit captures like tc := tc when using the variable in closures (e.g., with t.Run() and t.Parallel()). Go 1.22 fixed this by giving each iteration its own variable scope, making these captures unnecessary.

## Related Issue(s)

Fixes #15183 - Remove loopclosure captures from tests

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
