### PR TITLE
Fix race conditions in the connection pool code.

### DIFF
--- a/go/pools/smartconnpool/waitlist_test.go
+++ b/go/pools/smartconnpool/waitlist_test.go
@@ -38,7 +38,11 @@ func TestWaitlistExpireWithMultipleWaiters(t *testing.T) {
 
 	for i := 0; i < waiterCount; i++ {
 		go func() {
-			_, err := wait.waitForConn(ctx, nil)
+			_, err := wait.waitForConn(ctx, nil, func() bool {
+				// This function is called to check if the pool is closed.
+				return ctx.Err() != nil
+			})
+
 			if err != nil {
 				expireCount.Add(1)
 			}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This fixes the two race conditions described in https://github.com/vitessio/vitess/issues/18202#issuecomment-3068638651

## Related Issue(s)

https://github.com/vitessio/vitess/issues/18202

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
