### PR TITLE
Allow empty passwords for unmanaged tablet configuration

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -933,7 +933,7 @@ func (c *TabletConfig) verifyUnmanagedTabletConfig() error {
 	}
 	if c.DB.App.Password == "" {
 		_, pass, err := dbconfigs.GetCredentialsServer().GetUserAndPassword(c.DB.App.User)
-		if err == nil && pass != "" {
+		if err == nil {
 			c.DB.App.Password = pass
 		} else {
 			return errors.New("database app user password not specified")

--- a/go/vt/vttablet/tabletserver/tabletenv/config_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tabletenv
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -495,11 +496,28 @@ func TestVerifyUnmanagedTabletConfig(t *testing.T) {
 	err = config.verifyUnmanagedTabletConfig()
 	assert.Nil(t, err)
 
-	dbconfigs.SetDbCredentialsFilePath("./data/db_credentials.json")
-	defer dbconfigs.SetDbCredentialsFilePath("")
-	config.DB.App.Password = ""
+	// creates a temporary credentials file.
+	tmpFile, err := os.CreateTemp("", "db_credentials.json")
+	require.NoError(t, err)
+	_, err = tmpFile.Write([]byte(`{"testUser": ["testPassword"], "testUserWithEmptyPassword": [""]}`))
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+	defer os.Remove(tmpFile.Name())
 
+	// use this same json file for the following test cases because the file is read only once.
+	dbconfigs.SetDbCredentialsFilePath(tmpFile.Name())
+	defer dbconfigs.SetDbCredentialsFilePath("")
+
+	// verify password from credentials file is used
+	config.DB.App.Password = ""
 	err = config.verifyUnmanagedTabletConfig()
 	assert.Nil(t, err)
 	assert.Equal(t, "testPassword", config.DB.App.Password)
+
+	// verify empty password from credentials file is accepted
+	config.DB.App.User = "testUserWithEmptyPassword"
+	config.DB.App.Password = ""
+	err = config.verifyUnmanagedTabletConfig()
+	assert.Nil(t, err)
+	assert.Equal(t, "", config.DB.App.Password)
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

[The logic in `verifyUnmanagedTabletConfig`](https://github.com/vitessio/vitess/blob/69f5a2bd57c8b8e47294131d590524a9552ea0cc/go/vt/vttablet/tabletserver/tabletenv/config.go#L934-L941) only accepts credentials from the credentials server when the password is non‑empty:

```go
if c.DB.App.Password == "" {
    _, pass, err := dbconfigs.GetCredentialsServer().GetUserAndPassword(c.DB.App.User)
    if err == nil && pass != "" {        // <== requires non-empty password
        c.DB.App.Password = pass
    } else {
        return errors.New("database app user password not specified")
    }
}
```

With this logic, an external MySQL account that intentionally has an empty password cannot be used even if the credentials server returns that empty password. 

MySQL supports users with empty passwords, so rejecting an empty string appears unnecessary and prevents a valid configuration. 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

https://github.com/vitessio/vitess/pull/17984

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
