### PR TITLE
Add TabletType to prometheus vttablet_tablet_server_stat…

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -216,9 +216,19 @@ func NewTabletServer(ctx context.Context, env *vtenv.Environment, name string, c
 
 	// TabletServerState exports the same information as the above two stats (TabletState / TabletStateName),
 	// but exported with TabletStateName as a label for Prometheus, which doesn't support exporting strings as stat values.
-	tsv.exporter.NewGaugesFuncWithMultiLabels("TabletServerState", "Tablet server state labeled by state name", []string{"name"}, func() map[string]int64 {
-		return map[string]int64{tsv.sm.IsServingString(): 1}
+	tsv.exporter.NewGaugesFuncWithMultiLabels("TabletServerState", "Tablet server state with dimensions", []string{"name", "type", "keyspace", "shard"}, func() map[string]int64 {
+		target := tsv.sm.Target()
+		tabletServerState := strings.Join([]string{
+			tsv.sm.IsServingString(),
+			target.TabletType.String(),
+			target.Keyspace,
+			target.Shard,
+		}, ".")
+		return map[string]int64{
+			tabletServerState: 1,
+		}
 	})
+
 	tsv.exporter.NewGaugeDurationFunc("QueryTimeout", "Tablet server query timeout", func() time.Duration {
 		return time.Duration(tsv.QueryTimeout.Load())
 	})


### PR DESCRIPTION
…e metric as type label

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This just adds `TabletType`, `TabletKeyspace`, and `TabletShard` labels to the `vttablet_tablet_server_state` metric.  These pieces of information are available via `/debug/vars` but were never included in the prometheus output.  Creating separate metrics for them seemed frivolous/wasteful, and therefore just added to a metric that is purely informational.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes #14300 

## Checklist

-   [?] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [?] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ n/a ] Did the new or modified tests pass consistently locally and on CI?
-   [?] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
