### PR TITLE
go/vt/vtgate: handle dual tables in traffic mirroring

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -372,10 +372,15 @@ func findVSchemaTableAndCreateRoute(
 		err          error
 	)
 
-	if ctx.IsMirrored() {
+	vschemaTable, _, _, tabletType, target, err = ctx.VSchema.FindTableOrVindex(tableName)
+
+	// If we're processing the target-side of a mirror operator, look up the
+	// mirror target table by using FindTable, which bypasses routing rules.
+	//
+	// Exclude dual tables, which do not get a mirror rule, and are not known to
+	// the VSchema.
+	if ctx.IsMirrored() && !(vschemaTable.Type == vindexes.TypeReference && vschemaTable.Name.String() == "dual") {
 		vschemaTable, _, tabletType, target, err = ctx.VSchema.FindTable(tableName)
-	} else {
-		vschemaTable, _, _, tabletType, target, err = ctx.VSchema.FindTableOrVindex(tableName)
 	}
 
 	if err != nil {

--- a/go/vt/vtgate/planbuilder/testdata/mirror_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/mirror_cases.json
@@ -40,6 +40,89 @@
     }
   },
   {
+    "comment": "select unsharded, qualified, table mirrored to unsharded table with dual table",
+    "query": "select t1.id, 'hello' from unsharded_src1.t1 where t1.id = 1",
+    "plan": {
+      "Instructions": {
+        "Inputs": [
+          {
+            "FieldQuery": "select t1.id, 'hello' from t1 where 1 != 1",
+            "Keyspace": {
+              "Name": "unsharded_src1",
+              "Sharded": false
+            },
+            "OperatorType": "Route",
+            "Query": "select t1.id, 'hello' from t1 where t1.id = 1",
+            "Table": "t1",
+            "Variant": "Unsharded"
+          },
+          {
+            "FieldQuery": "select t1.id, 'hello' from t1 where 1 != 1",
+            "Keyspace": {
+              "Name": "unsharded_dst1",
+              "Sharded": false
+            },
+            "OperatorType": "Route",
+            "Query": "select t1.id, 'hello' from t1 where t1.id = 1",
+            "Table": "t1",
+            "Variant": "Unsharded"
+          }
+        ],
+        "OperatorType": "Mirror",
+        "Percent": 1,
+        "Variant": "PercentBased"
+      },
+      "Original": "select t1.id, 'hello' from unsharded_src1.t1 where t1.id = 1",
+      "QueryType": "SELECT",
+      "TablesUsed": [
+        "unsharded_dst1.t1",
+        "unsharded_src1.t1"
+      ]
+    }
+  },
+  {
+    "comment": "select unsharded, qualified, table mirrored to unsharded table ifnull dual",
+    "query": "select ifnull((select t1.id from unsharded_src1.t1 where t1.id = 1), 0)",
+    "plan": {
+      "Instructions": {
+        "Inputs": [
+          {
+            "FieldQuery": "select ifnull((select t1.id from t1 where 1 != 1), 0) as `ifnull((select t1.id from unsharded_src1.t1 where t1.id = 1), 0)` from dual where 1 != 1",
+            "Keyspace": {
+              "Name": "unsharded_src1",
+              "Sharded": false
+            },
+            "OperatorType": "Route",
+            "Query": "select ifnull((select t1.id from t1 where t1.id = 1), 0) as `ifnull((select t1.id from unsharded_src1.t1 where t1.id = 1), 0)` from dual",
+            "Table": "dual",
+            "Variant": "Unsharded"
+          },
+          {
+            "FieldQuery": "select ifnull((select t1.id from t1 where 1 != 1), 0) from dual where 1 != 1",
+            "Keyspace": {
+              "Name": "unsharded_dst1",
+              "Sharded": false
+            },
+            "OperatorType": "Route",
+            "Query": "select ifnull((select t1.id from t1 where t1.id = 1), 0) from dual",
+            "Table": "dual",
+            "Variant": "Unsharded"
+          }
+        ],
+        "OperatorType": "Mirror",
+        "Percent": 1,
+        "Variant": "PercentBased"
+      },
+      "Original": "select ifnull((select t1.id from unsharded_src1.t1 where t1.id = 1), 0)",
+      "QueryType": "SELECT",
+      "TablesUsed": [
+        "main.dual",
+        "unsharded_dst1.t1",
+        "unsharded_src1.t1"
+      ]
+    }
+  },
+  {
     "comment": "select from source of unsharded, unqualified, table mirrored to unsharded table with routing rules",
     "query": "select t4.id from t4 where t4.id = 1",
     "plan": {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Add support for `dual` tables in traffic mirroring.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Fixes #18457

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
