### PR TITLE
Add fetchCredentials to operator.yaml

### DIFF
--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -4984,6 +4984,8 @@ spec:
                       type: array
                     extraVolumes:
                       x-kubernetes-preserve-unknown-fields: true
+                    fetchCredentials:
+                      type: string
                     initContainers:
                       x-kubernetes-preserve-unknown-fields: true
                     rbac:


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Updates the example `operator.yaml` file to include the new CRD field for `fetchCredentials` introduced in https://github.com/planetscale/vitess-operator/pull/711.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

* https://github.com/planetscale/vitess-operator/issues/549

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

* Should only be merged after https://github.com/planetscale/vitess-operator/pull/711 is merged.