### PR TITLE
A faster connection pool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -119,6 +119,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
+	github.com/loov/hrtime v1.0.3 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -380,6 +380,8 @@ github.com/krishicks/yaml-patch v0.0.10 h1:H4FcHpnNwVmw8u0MjPRjWyIXtco6zM2F78t+5
 github.com/krishicks/yaml-patch v0.0.10/go.mod h1:Sm5TchwZS6sm7RJoyg87tzxm2ZcKzdRE4Q7TjNhPrME=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/loov/hrtime v1.0.3 h1:LiWKU3B9skJwRPUf0Urs9+0+OE3TxdMuiRPOTwR0gcU=
+github.com/loov/hrtime v1.0.3/go.mod h1:yDY3Pwv2izeY4sq7YcPX/dtLwzg5NU1AxWuWxKwd0p0=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=

--- a/go/pools/smartconnpool/connection.go
+++ b/go/pools/smartconnpool/connection.go
@@ -40,11 +40,6 @@ const (
 	REMOVED
 )
 
-type ConnectionState struct {
-	state   uint
-	setting *Setting
-}
-
 type Pooled[C Connection] struct {
 	next        atomic.Pointer[Pooled[C]]
 	timeCreated timestamp

--- a/go/pools/smartconnpool/connection.go
+++ b/go/pools/smartconnpool/connection.go
@@ -30,11 +30,29 @@ type Connection interface {
 	Close()
 }
 
+type Pool[C Connection] interface {
+	put(conn *Pooled[C])
+}
+
+const (
+	NOT_IN_USE = iota
+	IN_USE
+	REMOVED
+)
+
+type ConnectionState struct {
+	state   uint
+	setting *Setting
+}
+
 type Pooled[C Connection] struct {
 	next        atomic.Pointer[Pooled[C]]
 	timeCreated timestamp
 	timeUsed    timestamp
-	pool        *ConnPool[C]
+	pool        Pool[C]
+
+	state             atomic.Value
+	markedForEviction atomic.Bool
 
 	Conn C
 }

--- a/go/pools/smartconnpool/connection.go
+++ b/go/pools/smartconnpool/connection.go
@@ -51,7 +51,7 @@ type Pooled[C Connection] struct {
 	timeUsed    timestamp
 	pool        Pool[C]
 
-	state             atomic.Value
+	state             atomic.Uint32 // NOT_IN_USE, IN_USE, REMOVED
 	markedForEviction atomic.Bool
 
 	Conn C

--- a/go/pools/smartconnpool/fast_pool.go
+++ b/go/pools/smartconnpool/fast_pool.go
@@ -1,0 +1,349 @@
+package smartconnpool
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type FastPool[C Connection] struct {
+	// connectionsMu protects modifying the connections slice
+	connectionsMu sync.Mutex
+	connections   atomic.Value
+
+	closed   atomic.Bool
+	capacity atomic.Int64
+	waiters  atomic.Int64
+
+	config struct {
+		// connect is the callback to create a new connection for the pool
+		connect Connector[C]
+		// refresh is the callback to check whether the pool needs to be refreshed
+		refresh RefreshCheck
+		// maxCapacity is the maximum value to which capacity can be set; when the pool
+		// is re-opened, it defaults to this capacity
+		maxCapacity int64
+		// maxIdleCount is the maximum idle connections in the pool
+		maxIdleCount int64
+		// maxLifetime is the maximum time a connection can be open
+		maxLifetime atomic.Int64
+		// idleTimeout is the maximum time a connection can remain idle
+		idleTimeout atomic.Int64
+		// refreshInterval is how often to call the refresh check
+		refreshInterval atomic.Int64
+		// logWait is called every time a client must block waiting for a connection
+		logWait func(time.Time)
+	}
+
+	wait waitlist[C]
+
+	// addConnectionChan is a channel to signal that a new connection should be opened
+	addConnectionChan chan struct{}
+
+	Metrics Metrics
+	Name    string
+}
+
+func NewFastPool[C Connection](config *Config[C]) *FastPool[C] {
+	pool := &FastPool[C]{}
+	pool.config.maxCapacity = config.Capacity
+	pool.config.maxIdleCount = config.MaxIdleCount
+	pool.config.maxLifetime.Store(config.MaxLifetime.Nanoseconds())
+	pool.config.idleTimeout.Store(config.IdleTimeout.Nanoseconds())
+	pool.config.refreshInterval.Store(config.RefreshInterval.Nanoseconds())
+	pool.config.logWait = config.LogWait
+
+	pool.connections.Store(make([]*Pooled[C], 0, pool.config.maxCapacity))
+	pool.addConnectionChan = make(chan struct{}, pool.config.maxCapacity)
+	pool.capacity.Store(pool.config.maxCapacity)
+
+	pool.wait.init()
+
+	return pool
+}
+
+func (pool *FastPool[C]) Open(connect Connector[C], refresh RefreshCheck) *FastPool[C] {
+	pool.config.connect = connect
+	pool.config.refresh = refresh
+
+	pool.open()
+
+	return pool
+}
+
+func (pool *FastPool[C]) shouldContinueCreating() bool {
+	if pool.closed.Load() {
+		return false
+	}
+
+	// Check if we have reached the maximum capacity
+	if int64(len(pool.connections.Load().([]*Pooled[C]))) >= pool.capacity.Load() {
+		return false
+	}
+
+	idleConnectionCount := int64(0)
+	connections := pool.connections.Load().([]*Pooled[C])
+	for _, conn := range connections {
+		if conn.state.Load().(ConnectionState).state == NOT_IN_USE {
+			idleConnectionCount += 1
+		}
+	}
+
+	// If we have too many idle connections, we should stop creating new ones
+	if idleConnectionCount >= pool.config.maxIdleCount {
+		return false
+	}
+
+	if idleConnectionCount > pool.waiters.Load() {
+		// If we have more idle connections than waiters, we should stop creating new ones
+		return false
+	}
+
+	return true
+}
+
+func (pool *FastPool[C]) open() {
+	ctx := context.Background()
+
+	// Connection adder
+	go func() {
+		for {
+			select {
+			case <-pool.addConnectionChan:
+				for pool.shouldContinueCreating() {
+					ctx := context.Background()
+					conn, err := pool.connNew(ctx)
+
+					//fmt.Println("New connection created:", conn)
+
+					if err != nil {
+						// If we couldn't create a new connection, sleep for a bit and then try again
+						time.Sleep(10 * time.Millisecond)
+						continue
+					}
+
+					// Add the new connection to the pool
+					conn.state.Store(ConnectionState{
+						state:   NOT_IN_USE,
+						setting: conn.Conn.Setting(),
+					})
+
+					// fmt.Println("Adding connection to pool:", conn, "State:", conn.state.Load())
+
+					pool.add(conn)
+				}
+			case <-ctx.Done():
+				// If the context is done, we stop adding connections
+				return
+			}
+		}
+	}()
+
+	// Connection closer
+
+	// Housekeeper
+}
+
+func (pool *FastPool[C]) connNew(ctx context.Context) (*Pooled[C], error) {
+	conn, err := pool.config.connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	pooled := &Pooled[C]{
+		pool: pool,
+		Conn: conn,
+	}
+	now := monotonicNow()
+	pooled.timeUsed.set(now)
+	pooled.timeCreated.set(now)
+	return pooled, nil
+}
+
+func (pool *FastPool[C]) add(conn *Pooled[C]) {
+	if pool.closed.Load() {
+		return
+	}
+
+	pool.connectionsMu.Lock()
+	connections := pool.connections.Load().([]*Pooled[C])
+	pool.connections.Store(append(connections, conn))
+	pool.connectionsMu.Unlock()
+
+	for pool.waiters.Load() > 0 {
+		if conn.state.Load().(ConnectionState).state != NOT_IN_USE {
+			// Someone else stole this connection, so we're no longer the owner
+			return
+		}
+
+		if pool.offer(conn) {
+			// If we successfully offered the connection, we can return
+			return
+		}
+
+		runtime.Gosched()
+	}
+}
+
+func (pool *FastPool[C]) offer(conn *Pooled[C]) bool {
+	return pool.wait.tryReturnConn(conn)
+}
+
+func (pool *FastPool[C]) put(conn *Pooled[C]) {
+	if conn.markedForEviction.Load() {
+		pool.closeConnection(conn)
+		return
+	}
+
+	// Mark the connection as not in use.
+	// This will allow other goroutines to grab ownership of this connection.
+	state := conn.state.Load().(ConnectionState)
+	conn.state.Store(ConnectionState{
+		state:   NOT_IN_USE,
+		setting: state.setting,
+	})
+
+	// If we have waiters waiting for a connection, we can try to offer this connection to them
+	for pool.waiters.Load() > 0 {
+		if conn.state.Load().(ConnectionState).state != NOT_IN_USE {
+			// Someone else was faster and stole this connection, so we can't offer it to anyone waiting
+			return
+		}
+
+		if pool.offer(conn) {
+			// If we successfully offered the connection, we can return
+			return
+		}
+
+		// Allow other goroutines to run
+		runtime.Gosched()
+	}
+}
+
+func (pool *FastPool[C]) closeConnection(conn *Pooled[C]) {
+	state := conn.state.Load().(ConnectionState)
+
+	if !conn.state.CompareAndSwap(state, ConnectionState{state: REMOVED, setting: state.setting}) {
+		return
+	}
+
+	// Remove this connection from our connections slice
+	pool.connectionsMu.Lock()
+	connections := pool.connections.Load().([]*Pooled[C])
+	for i, c := range connections {
+		if c == conn {
+			// Remove the connection from the slice
+			connections = append(connections[:i], connections[i+1:]...)
+			break
+		}
+	}
+	pool.connections.Store(connections)
+	pool.connectionsMu.Unlock()
+
+	conn.Conn.Close()
+	conn.pool = nil
+}
+
+func (pool *FastPool[C]) borrow(ctx context.Context, setting *Setting) (*Pooled[C], error) {
+	requestedState := ConnectionState{
+		state:   NOT_IN_USE,
+		setting: setting,
+	}
+
+	borrowedState := ConnectionState{
+		state:   IN_USE,
+		setting: setting,
+	}
+
+	pool.waiters.Add(1)
+	defer pool.waiters.Add(-1)
+
+	// See if we have any matching, unused connections in the pool
+	connections := pool.connections.Load().([]*Pooled[C])
+	for _, conn := range connections {
+		// fmt.Println("Checking connection:", conn, "State:", conn.state.Load())
+
+		if conn.state.CompareAndSwap(requestedState, borrowedState) {
+			// We successfully borrowed this connection, so we can return it
+			conn.timeUsed.set(monotonicNow())
+			return conn, nil
+		}
+	}
+
+	// fmt.Println("No available connections found in ", len(connections), " connections, waiting for one...")
+
+	// If we have more waiters than in-flight connection add requests,
+	// ask for another connection
+	if pool.waiters.Load() > int64(len(pool.addConnectionChan)) {
+		// fmt.Println("Requesting a new connection to be added to the pool...")
+		// Request a new connection to be added to the pool
+		select {
+		case pool.addConnectionChan <- struct{}{}:
+		default:
+			// We don't want to block if the channel is already full
+		}
+	}
+
+	start := time.Now()
+
+	for {
+		// Wait for a connection to become available
+		conn, err := pool.wait.waitForConn(ctx, setting, pool.closed.Load)
+		if err != nil {
+			return nil, err
+		}
+
+		state := conn.state.Load().(ConnectionState)
+		if state.state != NOT_IN_USE {
+			// Someone has taken this connection from us, so we need to try again
+			continue
+		}
+
+		// Verify that no one has stolen the connection from us
+		if conn.state.CompareAndSwap(state, borrowedState) {
+			// We successfully borrowed this connection, so we can return it
+			conn.timeUsed.set(monotonicNow())
+
+			// If the connection has a setting, we need to set it
+			if state.setting != borrowedState.setting {
+				pool.Metrics.diffSetting.Add(1)
+
+				err := conn.Conn.ApplySetting(ctx, borrowedState.setting)
+				if err != nil {
+					// If we couldn't apply the setting, we need to close the connection
+					pool.closeConnection(conn)
+
+					// Wait again
+					continue
+				}
+			}
+
+			pool.recordWait(start)
+
+			return conn, nil
+		}
+
+		// Otherwise, we need to wait for another connection to become available...
+	}
+}
+
+func (pool *FastPool[C]) recordWait(start time.Time) {
+	pool.Metrics.waitCount.Add(1)
+	pool.Metrics.waitTime.Add(time.Since(start).Nanoseconds())
+	if pool.config.logWait != nil {
+		pool.config.logWait(start)
+	}
+}
+
+func (pool *FastPool[C]) Get(ctx context.Context, setting *Setting) (*Pooled[C], error) {
+	if ctx.Err() != nil {
+		return nil, ErrCtxTimeout
+	}
+
+	if pool.closed.Load() {
+		return nil, ErrConnPoolClosed
+	}
+
+	return pool.borrow(ctx, setting)
+}

--- a/go/pools/smartconnpool/fast_pool_test.go
+++ b/go/pools/smartconnpool/fast_pool_test.go
@@ -7,7 +7,63 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/loov/hrtime"
 )
+
+type ConnStats struct {
+	Requests int
+	Reset    int
+	Apply    int
+}
+
+type BenchConn struct {
+	Stats ConnStats
+
+	setting *Setting
+	latency time.Duration
+	closed  bool
+}
+
+func (b *BenchConn) Expired(_ time.Duration) bool {
+	return false
+}
+
+func (b *BenchConn) IsSettingApplied() bool {
+	return b.setting != nil
+}
+
+func (b *BenchConn) IsSameSetting(setting string) bool {
+	return b.setting != nil && b.setting.ApplyQuery() == setting
+}
+
+var _ Connection = (*BenchConn)(nil)
+
+func (b *BenchConn) ApplySetting(ctx context.Context, setting *Setting) error {
+	time.Sleep(b.latency)
+	b.setting = setting
+	b.Stats.Apply++
+	return nil
+}
+
+func (b *BenchConn) ResetSetting(ctx context.Context) error {
+	time.Sleep(b.latency)
+	b.setting = nil
+	b.Stats.Reset++
+	return nil
+}
+
+func (b *BenchConn) Setting() *Setting {
+	return b.setting
+}
+
+func (b *BenchConn) IsClosed() bool {
+	return b.closed
+}
+
+func (b *BenchConn) Close() {
+	b.closed = true
+}
 
 func TestFastPoolGetAndPut(t *testing.T) {
 	var state TestState
@@ -77,6 +133,179 @@ func TestFastPoolGetAndPut(t *testing.T) {
 	// }
 
 	// require.EqualValues(t, 0, state.open.Load())
+}
+
+func BenchmarkPoolWithDifferentSettings(b *testing.B) {
+	var state TestState
+
+	latency := 500 * time.Microsecond
+	var mu sync.Mutex
+	connstats := make([]*ConnStats, 0, 64)
+
+	benchConnector := func(ctx context.Context) (*BenchConn, error) {
+		conn := &BenchConn{latency: latency}
+
+		mu.Lock()
+		connstats = append(connstats, &conn.Stats)
+		mu.Unlock()
+
+		return conn, nil
+	}
+
+	ctx := context.Background()
+	p := NewPool(&Config[*BenchConn]{
+		Capacity:     30,
+		MaxIdleCount: 5,
+		IdleTimeout:  time.Second,
+		LogWait:      state.LogWait,
+	}).Open(benchConnector, nil)
+
+	b.Cleanup(func() {
+		p.Close()
+	})
+
+	b.ReportAllocs()
+
+	b.SetParallelism(128)
+
+	var m sync.Map
+	var i atomic.Int64
+
+	b.RunParallel(func(pb *testing.PB) {
+		var setting *Setting
+
+		run := i.Add(1)
+		switch run % 3 {
+		case 0:
+			setting = sFoo
+		case 1:
+			setting = sBar
+		default:
+			setting = nil
+		}
+
+		var laps []time.Duration
+
+		for pb.Next() {
+			start := time.Now()
+			r, err := p.Get(ctx, setting)
+			laps = append(laps, time.Since(start))
+			if err != nil {
+				b.Fatalf("Failed to get connection: %v", err)
+			}
+
+			time.Sleep(2 * time.Millisecond) // Simulate some work
+			r.Recycle()
+		}
+
+		m.Store(run, laps)
+	})
+
+	b.ReportMetric(float64(state.open.Load()), "open_connections")
+	b.ReportMetric(float64(len(state.waits)), "waits")
+	b.ReportMetric(float64(p.Metrics.diffSetting.Load()), "setting_changes")
+
+	var durations []time.Duration
+	m.Range(func(key, value any) bool {
+		durations = append(durations, value.([]time.Duration)...)
+		return true
+	})
+
+	histogram := hrtime.NewDurationHistogram(durations, &hrtime.HistogramOptions{
+		BinCount:        20,
+		NiceRange:       true,
+		ClampMaximum:    0,
+		ClampPercentile: 0.999,
+	})
+
+	fmt.Println("Histogram:", histogram)
+}
+
+func BenchmarkFastPoolWithDifferentSettings(b *testing.B) {
+	var state TestState
+
+	latency := 500 * time.Microsecond
+	var mu sync.Mutex
+	connstats := make([]*ConnStats, 0, 64)
+
+	benchConnector := func(ctx context.Context) (*BenchConn, error) {
+		conn := &BenchConn{latency: latency}
+
+		mu.Lock()
+		connstats = append(connstats, &conn.Stats)
+		mu.Unlock()
+
+		return conn, nil
+	}
+
+	ctx := context.Background()
+	p := NewFastPool(&Config[*BenchConn]{
+		Capacity:     30,
+		MaxIdleCount: 5,
+		IdleTimeout:  time.Second,
+		LogWait:      state.LogWait,
+	}).Open(benchConnector, nil)
+
+	b.Cleanup(func() {
+		p.Close()
+	})
+
+	b.ReportAllocs()
+
+	b.SetParallelism(128)
+
+	var m sync.Map
+	var i atomic.Int64
+
+	b.RunParallel(func(pb *testing.PB) {
+		var setting *Setting
+
+		run := i.Add(1)
+		switch run % 3 {
+		case 0:
+			setting = sFoo
+		case 1:
+			setting = sBar
+		default:
+			setting = nil
+		}
+
+		var laps []time.Duration
+
+		for pb.Next() {
+			start := time.Now()
+			r, err := p.Get(ctx, setting)
+			laps = append(laps, time.Since(start))
+			if err != nil {
+				b.Fatalf("Failed to get connection: %v", err)
+			}
+
+			time.Sleep(2 * time.Millisecond) // Simulate some work
+
+			r.Recycle()
+		}
+
+		m.Store(run, laps)
+	})
+
+	b.ReportMetric(float64(state.open.Load()), "open_connections")
+	b.ReportMetric(float64(len(state.waits)), "waits")
+	b.ReportMetric(float64(p.Metrics.diffSetting.Load()), "setting_changes")
+
+	var durations []time.Duration
+	m.Range(func(key, value any) bool {
+		durations = append(durations, value.([]time.Duration)...)
+		return true
+	})
+
+	histogram := hrtime.NewDurationHistogram(durations, &hrtime.HistogramOptions{
+		BinCount:        20,
+		NiceRange:       true,
+		ClampMaximum:    0,
+		ClampPercentile: 0.999,
+	})
+
+	fmt.Println("Histogram:", histogram)
 }
 
 func TestFastPoolWithDifferentSettings(t *testing.T) {

--- a/go/pools/smartconnpool/fast_pool_test.go
+++ b/go/pools/smartconnpool/fast_pool_test.go
@@ -1,0 +1,152 @@
+package smartconnpool
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestFastPoolGetAndPut(t *testing.T) {
+	var state TestState
+
+	ctx := context.Background()
+	p := NewFastPool(&Config[*TestConn]{
+		Capacity:     1,
+		MaxIdleCount: 1,
+		IdleTimeout:  time.Second,
+		LogWait:      state.LogWait,
+	}).Open(newConnector(&state), nil)
+
+	var closed = atomic.Bool{}
+
+	wg := sync.WaitGroup{}
+
+	fmt.Println("Starting TestCloseDuringGetAndPut")
+	var count atomic.Int64
+
+	// Spawn multiple goroutines to perform Get and Put operations, but only
+	// allow connections to be checked out until `closed` has been set to true.
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			for !closed.Load() {
+				r, err := p.Get(ctx, nil)
+				if err != nil {
+					break
+				}
+
+				count.Add(1)
+
+				r.Recycle()
+			}
+
+			wg.Done()
+		}()
+	}
+
+	// Allow some time for goroutines to start and attempt to get connections.
+	time.Sleep(1000 * time.Millisecond)
+
+	// Close the pool, which should allow all goroutines to finish.
+	ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+	defer cancel()
+
+	// err := p.CloseWithContext(ctx)
+	// closed.Store(true)
+
+	// fmt.Println("Count of connections checked out:", count.Load())
+	// require.NoError(t, err, "Failed to close pool")
+
+	fmt.Println("Count of connections checked out:", count.Load())
+	fmt.Println("Number of waits", len(state.waits))
+
+	// // Wait for a short time to ensure all goroutines have completed.
+	wg.Wait()
+
+	// // time.Sleep(1000 * time.Millisecond)
+
+	// // Check that the pool is closed and no connections are available.
+	// assert.EqualValues(t, 0, p.Capacity())
+	// assert.EqualValues(t, 0, p.Available())
+
+	// if state.open.Load() != 0 {
+	// 	t.Errorf("Expected no open connections, but found %d", state.open.Load())
+	// }
+
+	// require.EqualValues(t, 0, state.open.Load())
+}
+
+func TestFastPoolWithDifferentSettings(t *testing.T) {
+	var state TestState
+
+	ctx := context.Background()
+	p := NewFastPool(&Config[*TestConn]{
+		Capacity:     30,
+		MaxIdleCount: 5,
+		IdleTimeout:  time.Second,
+		LogWait:      state.LogWait,
+	}).Open(newConnector(&state), nil)
+
+	var closed = atomic.Bool{}
+	wg := sync.WaitGroup{}
+
+	fmt.Println("Starting TestFastPoolWithDifferentSettings")
+	var count atomic.Int64
+	// Spawn multiple goroutines to perform Get and Put operations, but only
+	// allow connections to be checked out until `closed` has been set to true.
+	for i := 0; i < 40; i++ {
+		wg.Add(1)
+		go func() {
+			for !closed.Load() {
+				var setting *Setting
+				switch i % 3 {
+				case 0:
+					setting = sFoo
+				case 1:
+					setting = sBar
+				default:
+					setting = nil
+				}
+
+				r, err := p.Get(ctx, setting)
+				if err != nil {
+					break
+				}
+
+				count.Add(1)
+
+				r.Recycle()
+			}
+			wg.Done()
+		}()
+	}
+
+	// Allow some time for goroutines to start and attempt to get connections.
+	time.Sleep(1000 * time.Millisecond)
+
+	// Close the pool, which should allow all goroutines to finish.
+	ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+	defer cancel()
+
+	// err := p.CloseWithContext(ctx)
+	closed.Store(true)
+
+	fmt.Println("Count of connections checked out:", count.Load())
+	// require.NoError(t, err, "Failed to close pool")
+
+	fmt.Println("Number of waits", len(state.waits))
+
+	fmt.Println("Count of setting changes:", p.Metrics.diffSetting.Load())
+
+	fmt.Println("Count of connections opened:", state.open.Load())
+
+	// Wait for a short time to ensure all goroutines have completed.
+	wg.Wait()
+
+	// // Check that the pool is closed and no connections are available.
+	// assert.EqualValues(t, 0, p.Capacity())
+	// assert.EqualValues(t, 0, p.Available())
+}

--- a/go/pools/smartconnpool/fast_pool_test.go
+++ b/go/pools/smartconnpool/fast_pool_test.go
@@ -154,7 +154,7 @@ func BenchmarkPoolWithDifferentSettings(b *testing.B) {
 
 	ctx := context.Background()
 	p := NewPool(&Config[*BenchConn]{
-		Capacity:     30,
+		Capacity:     64,
 		MaxIdleCount: 5,
 		IdleTimeout:  time.Second,
 		LogWait:      state.LogWait,
@@ -166,7 +166,7 @@ func BenchmarkPoolWithDifferentSettings(b *testing.B) {
 
 	b.ReportAllocs()
 
-	b.SetParallelism(128)
+	//	b.SetParallelism(64)
 
 	var m sync.Map
 	var i atomic.Int64
@@ -240,7 +240,7 @@ func BenchmarkFastPoolWithDifferentSettings(b *testing.B) {
 
 	ctx := context.Background()
 	p := NewFastPool(&Config[*BenchConn]{
-		Capacity:     30,
+		Capacity:     64,
 		MaxIdleCount: 5,
 		IdleTimeout:  time.Second,
 		LogWait:      state.LogWait,
@@ -252,7 +252,7 @@ func BenchmarkFastPoolWithDifferentSettings(b *testing.B) {
 
 	b.ReportAllocs()
 
-	b.SetParallelism(128)
+	//	b.SetParallelism(64)
 
 	var m sync.Map
 	var i atomic.Int64

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -51,6 +51,7 @@ type Metrics struct {
 	waitTime             atomic.Int64
 	idleClosed           atomic.Int64
 	diffSetting          atomic.Int64
+	openCount            atomic.Int64
 	resetSetting         atomic.Int64
 }
 

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -1241,3 +1241,147 @@ func TestGetSpike(t *testing.T) {
 		close(errs)
 	}
 }
+
+func TestCloseDuringGetAndPut(t *testing.T) {
+	for z := 0; z < 1000; z++ {
+		var state TestState
+
+		ctx := context.Background()
+		p := NewPool(&Config[*TestConn]{
+			Capacity:     1,
+			MaxIdleCount: 1,
+			IdleTimeout:  time.Second,
+			LogWait:      state.LogWait,
+		}).Open(newConnector(&state), nil)
+
+		var closed = atomic.Bool{}
+
+		wg := sync.WaitGroup{}
+
+		fmt.Println("Starting TestCloseDuringGetAndPut")
+		var count atomic.Int64
+
+		// Spawn multiple goroutines to perform Get and Put operations, but only
+		// allow connections to be checked out until `closed` has been set to true.
+		for i := 0; i < 2; i++ {
+			wg.Add(1)
+			go func() {
+				for !closed.Load() {
+					r, err := p.Get(ctx, nil)
+					if err != nil {
+						continue
+					}
+
+					count.Add(1)
+
+					r.Recycle()
+				}
+
+				wg.Done()
+			}()
+		}
+
+		// Allow some time for goroutines to start and attempt to get connections.
+		time.Sleep(1000 * time.Millisecond)
+
+		// Close the pool, which should allow all goroutines to finish.
+		ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+		defer cancel()
+
+		err := p.CloseWithContext(ctx)
+		closed.Store(true)
+
+		fmt.Println("Count of connections checked out:", count.Load())
+		require.NoError(t, err, "Failed to close pool")
+
+		// Wait for a short time to ensure all goroutines have completed.
+		wg.Wait()
+
+		fmt.Println("Count of connections checked out:", count.Load())
+
+		// time.Sleep(1000 * time.Millisecond)
+
+		// Check that the pool is closed and no connections are available.
+		assert.EqualValues(t, 0, p.Capacity())
+		assert.EqualValues(t, 0, p.Available())
+
+		if state.open.Load() != 0 {
+			t.Errorf("Expected no open connections, but found %d", state.open.Load())
+		}
+
+		require.EqualValues(t, 0, state.open.Load())
+	}
+}
+
+func TestPoolWithDifferentSettings(t *testing.T) {
+	var state TestState
+
+	ctx := context.Background()
+	p := NewPool(&Config[*TestConn]{
+		Capacity:     30,
+		MaxIdleCount: 5,
+		IdleTimeout:  time.Second,
+		LogWait:      state.LogWait,
+	}).Open(newConnector(&state), nil)
+
+	var closed = atomic.Bool{}
+	wg := sync.WaitGroup{}
+
+	fmt.Println("Starting TestFastPoolWithDifferentSettings")
+	var count atomic.Int64
+	// Spawn multiple goroutines to perform Get and Put operations, but only
+	// allow connections to be checked out until `closed` has been set to true.
+	for i := 0; i < 40; i++ {
+		wg.Add(1)
+		go func() {
+			for !closed.Load() {
+				var setting *Setting
+				switch i % 3 {
+				case 0:
+					setting = sFoo
+				case 1:
+					setting = sBar
+				default:
+					setting = nil
+				}
+
+				r, err := p.Get(ctx, setting)
+				if err != nil {
+					break
+				}
+
+				count.Add(1)
+
+				r.Recycle()
+			}
+
+			wg.Done()
+		}()
+	}
+
+	// Allow some time for goroutines to start and attempt to get connections.
+	time.Sleep(1000 * time.Millisecond)
+
+	// Close the pool, which should allow all goroutines to finish.
+	ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+	defer cancel()
+
+	// err := p.CloseWithContext(ctx)
+	closed.Store(true)
+
+	fmt.Println("Count of connections checked out:", count.Load())
+	// require.NoError(t, err, "Failed to close pool")
+
+	fmt.Println("Number of waits", len(state.waits))
+
+	fmt.Println("Count of setting changes:", p.Metrics.diffSetting.Load())
+
+	fmt.Println("Count of connections opened:", state.open.Load())
+
+	// Wait for a short time to ensure all goroutines have completed.
+	wg.Wait()
+
+	// // Check that the pool is closed and no connections are available.
+	// assert.EqualValues(t, 0, p.Capacity())
+	// assert.EqualValues(t, 0, p.Available())
+}

--- a/go/pools/smartconnpool/waitlist.go
+++ b/go/pools/smartconnpool/waitlist.go
@@ -125,7 +125,7 @@ func (wl *waitlist[D]) tryReturnConn(conn *Pooled[D]) bool {
 }
 
 func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
-	const maxAge = 16
+	const maxAge = 8
 	var (
 		target      *list.Element[waiter[D]]
 		connSetting = conn.Conn.Setting()

--- a/go/pools/smartconnpool/waitlist.go
+++ b/go/pools/smartconnpool/waitlist.go
@@ -125,7 +125,7 @@ func (wl *waitlist[D]) tryReturnConn(conn *Pooled[D]) bool {
 }
 
 func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
-	const maxAge = 8
+	const maxAge = 16
 	var (
 		target      *list.Element[waiter[D]]
 		connSetting = conn.Conn.Setting()

--- a/go/pools/smartconnpool/waitlist_test.go
+++ b/go/pools/smartconnpool/waitlist_test.go
@@ -38,7 +38,11 @@ func TestWaitlistExpireWithMultipleWaiters(t *testing.T) {
 
 	for i := 0; i < waiterCount; i++ {
 		go func() {
-			_, err := wait.waitForConn(ctx, nil)
+			_, err := wait.waitForConn(ctx, nil, func() bool {
+				// This function is called to check if the pool is closed.
+				return ctx.Err() != nil
+			})
+
 			if err != nil {
 				expireCount.Add(1)
 			}


### PR DESCRIPTION
## Description

This is a work-in-progress implementation of an alternative connection pool implementation.

It takes a lot of inspiration from [HikariCP](https://github.com/brettwooldridge/HikariCP), with slight deviations to better support the specific requirements of Vitess (e.g. the tracking of the connection settings).

The main difference from the current pool is that instead of using various stacks to track connections of different setting types, it tracks all connections that are managed by the pool in a single slice, and uses atomics on the `Pooled[C]` struct to manage the state a connection is in (e.g. whether it's idle or in use).

It seems like just looping over the connections list is faster than managing the connection stacks.

When a connection is requested from the pool, we first try to find an idle connection with matching settings, then fall back to find any idle connection for which we can change the settings, or add the connection to the waitlist (which is reused from the current pool implementation).

When a connection is returned to the pool, we mark the connection as unused and try to hand it over to any of the waiting checkout requests, if there's any.

Another difference to the current pool implementation is that connections that are marked as idle and attempted to be handed over to waiting requests can be "stolen" by concurrent checkout calls. It also does not block on opening a new connection. If we haven't hit the connection limit yet, new connections are opened in the background and if a matching connection is returned to the pool in the meantime, the returned connection will be used instead of waiting on the `Open` operation to finish.

### TODOs

* `Close()` is not implemented correctly - it currently does not close any of the background workers, and I'd like it to be an intermediate operation (orphaning all the in-use connections instead of waiting for connections to be returned to the pool as is done by the current implementation).
* max connection lifetime is not implemented yet.

### Benchmark Results

I added two benchmarks in `fast_pool_test.go`:

```
Histogram:   avg 18.2µs;  min 41ns;  p50 125ns;  max 9.1ms;
  p90 542ns;  p99 2.08µs;  p999 6.58ms;  p9999 9.1ms;
       41ns [3360] ████████████████████████████████████████
      500µs [   0]
        1ms [   0]
      1.5ms [   7]
        2ms [   0]
      2.5ms [   0]
        3ms [   0]
      3.5ms [   0]
        4ms [   4]
      4.5ms [   0]
        5ms [   0]
      5.5ms [   0]
        6ms [   0]
      6.5ms [   2]
        7ms [   0]
      7.5ms [   0]
        8ms [   0]
      8.5ms [   0]
        9ms [   2]
      9.5ms [   0]

BenchmarkPoolWithDifferentSettings-10        	    3375	    350184 ns/op	         0 open_connections	         8.000 setting_changes	         0 waits	      84 B/op	       1 allocs/op
```

```
Histogram:   avg 1.94µs;  min 41ns;  p50 250ns;  max 656µs;
  p90 1µs;  p99 2.45µs;  p999 552µs;  p9999 656µs;
       41ns [3595] ████████████████████████████████████████
       50µs [   2]
      100µs [   1]
      150µs [   1]
      200µs [   1]
      250µs [   0]
      300µs [   1]
      350µs [   0]
      400µs [   0]
      450µs [   0]
      500µs [   3]
      550µs [   4]
      600µs [   0]
      650µs [   1]
      700µs [   0]
      750µs [   0]
      800µs [   0]
      850µs [   0]
      900µs [   0]
      950µs [   0]

BenchmarkFastPoolWithDifferentSettings-10    	    3609	    375357 ns/op	         0 open_connections	         7.000 setting_changes	        10.00 waits	      77 B/op	       0 allocs/op
```

In this benchmark, the new pool shows less variance and better timings.

I also updated the existing benchmark in `load_test.go` to run benchmarks against this new pool (labeled "Fast"):

```
BenchmarkGetPut
BenchmarkGetPut/Legacy/x1-cap64
BenchmarkGetPut/Legacy/x1-cap64-10         	 3959982	       288.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Smart/x1-cap64
BenchmarkGetPut/Smart/x1-cap64-10          	 3577706	       380.1 ns/op	      16 B/op	       1 allocs/op
BenchmarkGetPut/Fast/x1-cap64
BenchmarkGetPut/Fast/x1-cap64-10           	 8898646	       133.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Legacy/x8-cap64
BenchmarkGetPut/Legacy/x8-cap64-10         	 3983781	       286.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Smart/x8-cap64
BenchmarkGetPut/Smart/x8-cap64-10          	 3436444	       365.6 ns/op	      16 B/op	       0 allocs/op
BenchmarkGetPut/Fast/x8-cap64
BenchmarkGetPut/Fast/x8-cap64-10           	 8746041	       131.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Legacy/x32-cap64
BenchmarkGetPut/Legacy/x32-cap64-10        	 3940970	      1227 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Smart/x32-cap64
BenchmarkGetPut/Smart/x32-cap64-10         	 1950273	       684.4 ns/op	       8 B/op	       0 allocs/op
BenchmarkGetPut/Fast/x32-cap64
BenchmarkGetPut/Fast/x32-cap64-10          	 9152787	       128.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Legacy/x128-cap64
BenchmarkGetPut/Legacy/x128-cap64-10       	 2792596	      1240 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Smart/x128-cap64
BenchmarkGetPut/Smart/x128-cap64-10        	  922064	      1156 ns/op	       3 B/op	       0 allocs/op
BenchmarkGetPut/Fast/x128-cap64
BenchmarkGetPut/Fast/x128-cap64-10         	 9346239	       120.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Legacy/x1-cap128
BenchmarkGetPut/Legacy/x1-cap128-10        	 4491429	       282.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Smart/x1-cap128
BenchmarkGetPut/Smart/x1-cap128-10         	 3799872	       352.5 ns/op	      16 B/op	       1 allocs/op
BenchmarkGetPut/Fast/x1-cap128
BenchmarkGetPut/Fast/x1-cap128-10          	 8840346	       129.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Legacy/x8-cap128
BenchmarkGetPut/Legacy/x8-cap128-10        	 4286198	       296.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Smart/x8-cap128
BenchmarkGetPut/Smart/x8-cap128-10         	 3368329	       375.4 ns/op	      16 B/op	       1 allocs/op
BenchmarkGetPut/Fast/x8-cap128
BenchmarkGetPut/Fast/x8-cap128-10          	 9240909	       144.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Legacy/x32-cap128
BenchmarkGetPut/Legacy/x32-cap128-10       	 3802398	       284.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Smart/x32-cap128
BenchmarkGetPut/Smart/x32-cap128-10        	 2726973	       524.1 ns/op	      12 B/op	       0 allocs/op
BenchmarkGetPut/Fast/x32-cap128
BenchmarkGetPut/Fast/x32-cap128-10         	 9124257	       127.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Legacy/x128-cap128
BenchmarkGetPut/Legacy/x128-cap128-10      	 4293358	      1131 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Smart/x128-cap128
BenchmarkGetPut/Smart/x128-cap128-10       	 1572543	      1233 ns/op	       2 B/op	       0 allocs/op
BenchmarkGetPut/Fast/x128-cap128
BenchmarkGetPut/Fast/x128-cap128-10        	 8773396	       118.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Legacy/x1-cap512
BenchmarkGetPut/Legacy/x1-cap512-10        	 4434146	       277.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Smart/x1-cap512
BenchmarkGetPut/Smart/x1-cap512-10         	 3653973	       348.1 ns/op	      16 B/op	       1 allocs/op
BenchmarkGetPut/Fast/x1-cap512
BenchmarkGetPut/Fast/x1-cap512-10          	 9064929	       131.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Legacy/x8-cap512
BenchmarkGetPut/Legacy/x8-cap512-10        	 4377208	       270.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Smart/x8-cap512
BenchmarkGetPut/Smart/x8-cap512-10         	 3278119	       374.9 ns/op	      16 B/op	       1 allocs/op
BenchmarkGetPut/Fast/x8-cap512
BenchmarkGetPut/Fast/x8-cap512-10          	 8968564	       136.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Legacy/x32-cap512
BenchmarkGetPut/Legacy/x32-cap512-10       	 4042659	       279.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Smart/x32-cap512
BenchmarkGetPut/Smart/x32-cap512-10        	 3665810	       353.0 ns/op	      16 B/op	       1 allocs/op
BenchmarkGetPut/Fast/x32-cap512
BenchmarkGetPut/Fast/x32-cap512-10         	 9650190	       123.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Legacy/x128-cap512
BenchmarkGetPut/Legacy/x128-cap512-10      	 4571138	       296.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetPut/Smart/x128-cap512
BenchmarkGetPut/Smart/x128-cap512-10       	 2567998	       608.4 ns/op	      11 B/op	       0 allocs/op
BenchmarkGetPut/Fast/x128-cap512
BenchmarkGetPut/Fast/x128-cap512-10        	10234790	       122.2 ns/op	       0 B/op	       0 allocs/op
```

Across the board the new pool seems to perform better.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
