### PR TITLE
Fix scalar aggregation with literals in empty result sets

### DIFF
--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -80,6 +80,7 @@ func TestAggrWithLimit(t *testing.T) {
 		mcmp.Exec(fmt.Sprintf("insert into aggr_test(id, val1, val2) values(%d, 'a', %d)", i, r))
 	}
 	mcmp.Exec("select val2, count(*) from aggr_test group by val2 order by count(*), val2 limit 10")
+	mcmp.Exec("SELECT 1 AS `id`, COUNT(*) FROM (SELECT `id` FROM aggr_test WHERE val1 = 1 LIMIT 100) `t`")
 }
 
 func TestAggregateTypes(t *testing.T) {

--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -80,7 +80,9 @@ func TestAggrWithLimit(t *testing.T) {
 		mcmp.Exec(fmt.Sprintf("insert into aggr_test(id, val1, val2) values(%d, 'a', %d)", i, r))
 	}
 	mcmp.Exec("select val2, count(*) from aggr_test group by val2 order by count(*), val2 limit 10")
-	mcmp.Exec("SELECT 1 AS `id`, COUNT(*) FROM (SELECT `id` FROM aggr_test WHERE val1 = 1 LIMIT 100) `t`")
+	if utils.BinaryIsAtLeastAtVersion(23, "vtgate") {
+		mcmp.Exec("SELECT 1 AS `id`, COUNT(*) FROM (SELECT `id` FROM aggr_test WHERE val1 = 1 LIMIT 100) `t`")
+	}
 }
 
 func TestAggregateTypes(t *testing.T) {

--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -19,6 +19,7 @@ package sqlparser
 // analyzer.go contains utility analysis functions.
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"unicode"
@@ -379,7 +380,7 @@ func IsColName(node Expr) bool {
 	return ok
 }
 
-var errNotStatic = fmt.Errorf("not static")
+var errNotStatic = errors.New("not static")
 
 // IsConstant returns true if the Expr can be evaluated without input or access to tables.
 func IsConstant(node Expr) bool {

--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -379,6 +379,20 @@ func IsColName(node Expr) bool {
 	return ok
 }
 
+var errNotStatic = fmt.Errorf("not static")
+
+// IsConstant returns true if the Expr can be evaluated without input or access to tables.
+func IsConstant(node Expr) bool {
+	err := Walk(func(node SQLNode) (kontinue bool, err error) {
+		switch node.(type) {
+		case *ColName, *Subquery:
+			return false, errNotStatic
+		}
+		return true, nil
+	}, node)
+	return err == nil
+}
+
 // IsValue returns true if the Expr is a string, integral or value arg.
 // NULL is not considered to be a value.
 func IsValue(node Expr) bool {

--- a/go/vt/vtgate/engine/aggregations.go
+++ b/go/vt/vtgate/engine/aggregations.go
@@ -412,7 +412,10 @@ func newAggregation(fields []*querypb.Field, aggregates []*AggregateParams, env 
 
 	agstate := make([]aggregator, len(fields))
 	for _, aggr := range aggregates {
-		sourceType := fields[aggr.Col].Type
+		var sourceType querypb.Type
+		if aggr.Col < len(fields) {
+			sourceType = fields[aggr.Col].Type
+		}
 		targetType := aggr.typ(sourceType, env)
 
 		var ag aggregator

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -29,7 +29,11 @@ func (cached *AggregateParams) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(112)
+		size += int64(128)
+	}
+	// field EExpr vitess.io/vitess/go/vt/vtgate/evalengine.Expr
+	if cc, ok := cached.EExpr.(cachedObject); ok {
+		size += cc.CachedSize(true)
 	}
 	// field Type vitess.io/vitess/go/vt/vtgate/evalengine.Type
 	size += cached.Type.CachedSize(false)

--- a/go/vt/vtgate/engine/opcode/constants.go
+++ b/go/vt/vtgate/engine/opcode/constants.go
@@ -77,8 +77,9 @@ const (
 	AggregateCountStar
 	AggregateGroupConcat
 	AggregateAvg
-	AggregateUDF  // This is an opcode used to represent UDFs
-	_NumOfOpCodes // This line must be last of the opcodes!
+	AggregateUDF      // This is an opcode used to represent UDFs
+	AggregateConstant // This is an opcode used to represent constants that are not grouped
+	_NumOfOpCodes     // This line must be last of the opcodes!
 )
 
 // SupportedAggregates maps the list of supported aggregate
@@ -97,6 +98,7 @@ var SupportedAggregates = map[string]AggregateOpcode{
 	"count_star":     AggregateCountStar,
 	"any_value":      AggregateAnyValue,
 	"group_concat":   AggregateGroupConcat,
+	"constant_aggr":  AggregateGroupConcat,
 }
 
 var AggregateName = map[AggregateOpcode]string{
@@ -111,6 +113,7 @@ var AggregateName = map[AggregateOpcode]string{
 	AggregateGroupConcat:   "group_concat",
 	AggregateAnyValue:      "any_value",
 	AggregateAvg:           "avg",
+	AggregateConstant:      "constant_aggr",
 }
 
 func (code AggregateOpcode) String() string {
@@ -127,7 +130,7 @@ func (code AggregateOpcode) MarshalJSON() ([]byte, error) {
 	return ([]byte)(fmt.Sprintf("\"%s\"", code.String())), nil
 }
 
-// Type returns the opcode return sql type, and a bool telling is we are sure about this type or not
+// SQLType returns the opcode return sql type, and a bool telling is we are sure about this type or not
 func (code AggregateOpcode) SQLType(typ querypb.Type) querypb.Type {
 	switch code {
 	case AggregateUnassigned:
@@ -154,7 +157,7 @@ func (code AggregateOpcode) SQLType(typ querypb.Type) querypb.Type {
 		return sqltypes.Int64
 	case AggregateGtid:
 		return sqltypes.VarChar
-	case AggregateUDF:
+	case AggregateUDF, AggregateConstant: // TODO: we can probably figure out the type here
 		return sqltypes.Unknown
 	default:
 		panic(code.String()) // we have a unit test checking we never reach here

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -132,7 +132,7 @@ func (oa *OrderedAggregate) execute(ctx context.Context, vcursor VCursor, bindVa
 		return oa.executeGroupBy(result)
 	}
 
-	agg, fields, err := newAggregation(result.Fields, oa.Aggregates, env, 0)
+	agg, fields, err := newAggregation(result.Fields, oa.Aggregates, env, vcursor.ConnCollation())
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +309,7 @@ func (oa *OrderedAggregate) GetFields(ctx context.Context, vcursor VCursor, bind
 		return nil, err
 	}
 	env := evalengine.NewExpressionEnv(ctx, bindVars, vcursor)
-	_, fields, err := newAggregation(qr.Fields, oa.Aggregates, env, 0)
+	_, fields, err := newAggregation(qr.Fields, oa.Aggregates, env, vcursor.ConnCollation())
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/engine/ordered_aggregate_test.go
+++ b/go/vt/vtgate/engine/ordered_aggregate_test.go
@@ -53,7 +53,7 @@ func TestOrderedAggregateExecute(t *testing.T) {
 	}
 
 	oa := &OrderedAggregate{
-		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, "", collations.MySQL8())},
+		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, nil, "", collations.MySQL8())},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0}},
 		Input:       fp,
 	}
@@ -85,7 +85,7 @@ func TestOrderedAggregateExecuteTruncate(t *testing.T) {
 		)},
 	}
 
-	aggr := NewAggregateParam(AggregateSum, 1, "", collations.MySQL8())
+	aggr := NewAggregateParam(AggregateSum, 1, nil, "", collations.MySQL8())
 	aggr.OrigOpcode = AggregateCountStar
 
 	oa := &OrderedAggregate{
@@ -125,7 +125,7 @@ func TestMinMaxFailsCorrectly(t *testing.T) {
 		)},
 	}
 
-	aggr := NewAggregateParam(AggregateMax, 0, "", collations.MySQL8())
+	aggr := NewAggregateParam(AggregateMax, 0, nil, "", collations.MySQL8())
 	aggr.WCol = 1
 	oa := &ScalarAggregate{
 		Aggregates:          []*AggregateParams{aggr},
@@ -154,7 +154,7 @@ func TestOrderedAggregateStreamExecute(t *testing.T) {
 	}
 
 	oa := &OrderedAggregate{
-		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, "", collations.MySQL8())},
+		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, nil, "", collations.MySQL8())},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0}},
 		Input:       fp,
 	}
@@ -193,7 +193,7 @@ func TestOrderedAggregateStreamExecuteTruncate(t *testing.T) {
 	}
 
 	oa := &OrderedAggregate{
-		Aggregates:          []*AggregateParams{NewAggregateParam(AggregateSum, 1, "", collations.MySQL8())},
+		Aggregates:          []*AggregateParams{NewAggregateParam(AggregateSum, 1, nil, "", collations.MySQL8())},
 		GroupByKeys:         []*GroupByParams{{KeyCol: 2}},
 		TruncateColumnCount: 2,
 		Input:               fp,
@@ -296,8 +296,8 @@ func TestOrderedAggregateExecuteCountDistinct(t *testing.T) {
 		)},
 	}
 
-	aggr1 := NewAggregateParam(AggregateCountDistinct, 1, "count(distinct col2)", collations.MySQL8())
-	aggr2 := NewAggregateParam(AggregateSum, 2, "", collations.MySQL8())
+	aggr1 := NewAggregateParam(AggregateCountDistinct, 1, nil, "count(distinct col2)", collations.MySQL8())
+	aggr2 := NewAggregateParam(AggregateSum, 2, nil, "", collations.MySQL8())
 	aggr2.OrigOpcode = AggregateCountStar
 	oa := &OrderedAggregate{
 		Aggregates:  []*AggregateParams{aggr1, aggr2},
@@ -365,12 +365,12 @@ func TestOrderedAggregateStreamCountDistinct(t *testing.T) {
 		)},
 	}
 
-	aggr2 := NewAggregateParam(AggregateSum, 2, "", collations.MySQL8())
+	aggr2 := NewAggregateParam(AggregateSum, 2, nil, "", collations.MySQL8())
 	aggr2.OrigOpcode = AggregateCountDistinct
 
 	oa := &OrderedAggregate{
 		Aggregates: []*AggregateParams{
-			NewAggregateParam(AggregateCountDistinct, 1, "count(distinct col2)", collations.MySQL8()),
+			NewAggregateParam(AggregateCountDistinct, 1, nil, "count(distinct col2)", collations.MySQL8()),
 			aggr2},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0}},
 		Input:       fp,
@@ -451,8 +451,8 @@ func TestOrderedAggregateSumDistinctGood(t *testing.T) {
 
 	oa := &OrderedAggregate{
 		Aggregates: []*AggregateParams{
-			NewAggregateParam(AggregateSumDistinct, 1, "sum(distinct col2)", collations.MySQL8()),
-			NewAggregateParam(AggregateSum, 2, "", collations.MySQL8()),
+			NewAggregateParam(AggregateSumDistinct, 1, nil, "sum(distinct col2)", collations.MySQL8()),
+			NewAggregateParam(AggregateSum, 2, nil, "", collations.MySQL8()),
 		},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0}},
 		Input:       fp,
@@ -495,7 +495,7 @@ func TestOrderedAggregateSumDistinctTolerateError(t *testing.T) {
 	}
 
 	oa := &OrderedAggregate{
-		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSumDistinct, 1, "sum(distinct col2)", collations.MySQL8())},
+		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSumDistinct, 1, nil, "sum(distinct col2)", collations.MySQL8())},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0}},
 		Input:       fp,
 	}
@@ -527,7 +527,7 @@ func TestOrderedAggregateKeysFail(t *testing.T) {
 	}
 
 	oa := &OrderedAggregate{
-		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, "", collations.MySQL8())},
+		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, nil, "", collations.MySQL8())},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0}},
 		Input:       fp,
 	}
@@ -557,7 +557,7 @@ func TestOrderedAggregateMergeFail(t *testing.T) {
 	}
 
 	oa := &OrderedAggregate{
-		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, "", collations.MySQL8())},
+		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, nil, "", collations.MySQL8())},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0}},
 		Input:       fp,
 	}
@@ -618,7 +618,7 @@ func TestOrderedAggregateExecuteGtid(t *testing.T) {
 	}
 
 	oa := &OrderedAggregate{
-		Aggregates:          []*AggregateParams{NewAggregateParam(AggregateGtid, 1, "vgtid", collations.MySQL8())},
+		Aggregates:          []*AggregateParams{NewAggregateParam(AggregateGtid, 1, nil, "vgtid", collations.MySQL8())},
 		TruncateColumnCount: 2,
 		Input:               fp,
 	}
@@ -651,7 +651,7 @@ func TestCountDistinctOnVarchar(t *testing.T) {
 		)},
 	}
 
-	aggr := NewAggregateParam(AggregateCountDistinct, 1, "count(distinct c2)", collations.MySQL8())
+	aggr := NewAggregateParam(AggregateCountDistinct, 1, nil, "count(distinct c2)", collations.MySQL8())
 	aggr.WCol = 2
 	oa := &OrderedAggregate{
 		Aggregates:          []*AggregateParams{aggr},
@@ -711,7 +711,7 @@ func TestCountDistinctOnVarcharWithNulls(t *testing.T) {
 		)},
 	}
 
-	aggr := NewAggregateParam(AggregateCountDistinct, 1, "count(distinct c2)", collations.MySQL8())
+	aggr := NewAggregateParam(AggregateCountDistinct, 1, nil, "count(distinct c2)", collations.MySQL8())
 	aggr.WCol = 2
 	oa := &OrderedAggregate{
 		Aggregates:          []*AggregateParams{aggr},
@@ -773,7 +773,7 @@ func TestSumDistinctOnVarcharWithNulls(t *testing.T) {
 		)},
 	}
 
-	aggr := NewAggregateParam(AggregateSumDistinct, 1, "sum(distinct c2)", collations.MySQL8())
+	aggr := NewAggregateParam(AggregateSumDistinct, 1, nil, "sum(distinct c2)", collations.MySQL8())
 	aggr.WCol = 2
 	oa := &OrderedAggregate{
 		Aggregates:          []*AggregateParams{aggr},
@@ -839,8 +839,8 @@ func TestMultiDistinct(t *testing.T) {
 
 	oa := &OrderedAggregate{
 		Aggregates: []*AggregateParams{
-			NewAggregateParam(AggregateCountDistinct, 1, "count(distinct c2)", collations.MySQL8()),
-			NewAggregateParam(AggregateSumDistinct, 2, "sum(distinct c3)", collations.MySQL8()),
+			NewAggregateParam(AggregateCountDistinct, 1, nil, "count(distinct c2)", collations.MySQL8()),
+			NewAggregateParam(AggregateSumDistinct, 2, nil, "sum(distinct c3)", collations.MySQL8()),
 		},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0}},
 		Input:       fp,
@@ -898,7 +898,7 @@ func TestOrderedAggregateCollate(t *testing.T) {
 	collationEnv := collations.MySQL8()
 	collationID, _ := collationEnv.LookupID("utf8mb4_0900_ai_ci")
 	oa := &OrderedAggregate{
-		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, "", collationEnv)},
+		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, nil, "", collationEnv)},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0, Type: evalengine.NewType(sqltypes.Unknown, collationID)}},
 		Input:       fp,
 	}
@@ -937,7 +937,7 @@ func TestOrderedAggregateCollateAS(t *testing.T) {
 	collationEnv := collations.MySQL8()
 	collationID, _ := collationEnv.LookupID("utf8mb4_0900_as_ci")
 	oa := &OrderedAggregate{
-		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, "", collationEnv)},
+		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, nil, "", collationEnv)},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0, Type: evalengine.NewType(sqltypes.Unknown, collationID)}},
 		Input:       fp,
 	}
@@ -978,7 +978,7 @@ func TestOrderedAggregateCollateKS(t *testing.T) {
 	collationEnv := collations.MySQL8()
 	collationID, _ := collationEnv.LookupID("utf8mb4_ja_0900_as_cs_ks")
 	oa := &OrderedAggregate{
-		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, "", collationEnv)},
+		Aggregates:  []*AggregateParams{NewAggregateParam(AggregateSum, 1, nil, "", collationEnv)},
 		GroupByKeys: []*GroupByParams{{KeyCol: 0, Type: evalengine.NewType(sqltypes.Unknown, collationID)}},
 		Input:       fp,
 	}
@@ -1059,7 +1059,7 @@ func TestGroupConcatWithAggrOnEngine(t *testing.T) {
 	for _, tcase := range tcases {
 		t.Run(tcase.name, func(t *testing.T) {
 			fp := &fakePrimitive{results: []*sqltypes.Result{tcase.inputResult}}
-			agp := NewAggregateParam(AggregateGroupConcat, 1, "group_concat(c2)", collations.MySQL8())
+			agp := NewAggregateParam(AggregateGroupConcat, 1, nil, "group_concat(c2)", collations.MySQL8())
 			agp.Func = &sqlparser.GroupConcatExpr{Separator: ","}
 			oa := &OrderedAggregate{
 				Aggregates:  []*AggregateParams{agp},
@@ -1140,7 +1140,7 @@ func TestGroupConcat(t *testing.T) {
 	for _, tcase := range tcases {
 		t.Run(tcase.name, func(t *testing.T) {
 			fp := &fakePrimitive{results: []*sqltypes.Result{tcase.inputResult}}
-			agp := NewAggregateParam(AggregateGroupConcat, 1, "", collations.MySQL8())
+			agp := NewAggregateParam(AggregateGroupConcat, 1, nil, "", collations.MySQL8())
 			agp.Func = &sqlparser.GroupConcatExpr{Separator: ","}
 			oa := &OrderedAggregate{
 				Aggregates:  []*AggregateParams{agp},

--- a/go/vt/vtgate/engine/ordered_aggregate_test.go
+++ b/go/vt/vtgate/engine/ordered_aggregate_test.go
@@ -231,7 +231,7 @@ func TestOrderedAggregateGetFields(t *testing.T) {
 
 	oa := &OrderedAggregate{Input: fp}
 
-	got, err := oa.GetFields(context.Background(), nil, nil)
+	got, err := oa.GetFields(context.Background(), &noopVCursor{}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, got, input)
 }

--- a/go/vt/vtgate/engine/scalar_aggregation.go
+++ b/go/vt/vtgate/engine/scalar_aggregation.go
@@ -51,7 +51,7 @@ func (sa *ScalarAggregate) GetFields(ctx context.Context, vcursor VCursor, bindV
 	}
 	env := evalengine.NewExpressionEnv(ctx, bindVars, vcursor)
 
-	_, fields, err := newAggregation(qr.Fields, sa.Aggregates, env, 0)
+	_, fields, err := newAggregation(qr.Fields, sa.Aggregates, env, vcursor.ConnCollation())
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func (sa *ScalarAggregate) TryExecute(ctx context.Context, vcursor VCursor, bind
 	}
 	env := evalengine.NewExpressionEnv(ctx, bindVars, vcursor)
 
-	agg, fields, err := newAggregation(result.Fields, sa.Aggregates, env, 0)
+	agg, fields, err := newAggregation(result.Fields, sa.Aggregates, env, vcursor.ConnCollation())
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (sa *ScalarAggregate) TryStreamExecute(ctx context.Context, vcursor VCursor
 
 		if agg == nil && len(result.Fields) != 0 {
 			var err error
-			agg, fields, err = newAggregation(result.Fields, sa.Aggregates, env, 0)
+			agg, fields, err = newAggregation(result.Fields, sa.Aggregates, env, vcursor.ConnCollation())
 			if err != nil {
 				return err
 			}

--- a/go/vt/vtgate/engine/scalar_aggregation.go
+++ b/go/vt/vtgate/engine/scalar_aggregation.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"sync"
 
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
+
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
@@ -47,8 +49,9 @@ func (sa *ScalarAggregate) GetFields(ctx context.Context, vcursor VCursor, bindV
 	if err != nil {
 		return nil, err
 	}
+	env := evalengine.NewExpressionEnv(ctx, bindVars, vcursor)
 
-	_, fields, err := newAggregation(qr.Fields, sa.Aggregates)
+	_, fields, err := newAggregation(qr.Fields, sa.Aggregates, env)
 	if err != nil {
 		return nil, err
 	}
@@ -68,21 +71,26 @@ func (sa *ScalarAggregate) TryExecute(ctx context.Context, vcursor VCursor, bind
 	if err != nil {
 		return nil, err
 	}
+	env := evalengine.NewExpressionEnv(ctx, bindVars, vcursor)
 
-	agg, fields, err := newAggregation(result.Fields, sa.Aggregates)
+	agg, fields, err := newAggregation(result.Fields, sa.Aggregates, env)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, row := range result.Rows {
-		if err := agg.add(row); err != nil {
+		if err := agg.add(row, env); err != nil {
 			return nil, err
 		}
 	}
 
+	values, err := agg.finish(env)
+	if err != nil {
+		return nil, err
+	}
 	out := &sqltypes.Result{
 		Fields: fields,
-		Rows:   [][]sqltypes.Value{agg.finish()},
+		Rows:   [][]sqltypes.Value{values},
 	}
 	return out.Truncate(sa.TruncateColumnCount), nil
 }
@@ -92,6 +100,7 @@ func (sa *ScalarAggregate) TryStreamExecute(ctx context.Context, vcursor VCursor
 	cb := func(qr *sqltypes.Result) error {
 		return callback(qr.Truncate(sa.TruncateColumnCount))
 	}
+	env := evalengine.NewExpressionEnv(ctx, bindVars, vcursor)
 
 	var mu sync.Mutex
 	var agg aggregationState
@@ -107,7 +116,7 @@ func (sa *ScalarAggregate) TryStreamExecute(ctx context.Context, vcursor VCursor
 
 		if agg == nil && len(result.Fields) != 0 {
 			var err error
-			agg, fields, err = newAggregation(result.Fields, sa.Aggregates)
+			agg, fields, err = newAggregation(result.Fields, sa.Aggregates, env)
 			if err != nil {
 				return err
 			}
@@ -120,7 +129,7 @@ func (sa *ScalarAggregate) TryStreamExecute(ctx context.Context, vcursor VCursor
 		}
 
 		for _, row := range result.Rows {
-			if err := agg.add(row); err != nil {
+			if err := agg.add(row, env); err != nil {
 				return err
 			}
 		}
@@ -130,7 +139,11 @@ func (sa *ScalarAggregate) TryStreamExecute(ctx context.Context, vcursor VCursor
 		return err
 	}
 
-	return cb(&sqltypes.Result{Rows: [][]sqltypes.Value{agg.finish()}})
+	values, err := agg.finish(env)
+	if err != nil {
+		return err
+	}
+	return cb(&sqltypes.Result{Rows: [][]sqltypes.Value{values}})
 }
 
 // Inputs implements the Primitive interface

--- a/go/vt/vtgate/engine/scalar_aggregation_test.go
+++ b/go/vt/vtgate/engine/scalar_aggregation_test.go
@@ -276,8 +276,8 @@ func TestScalarDistinctAggrOnEngine(t *testing.T) {
 
 	oa := &ScalarAggregate{
 		Aggregates: []*AggregateParams{
-			NewAggregateParam(AggregateCountDistinct, 0, "count(distinct value)", collations.MySQL8()),
-			NewAggregateParam(AggregateSumDistinct, 1, "sum(distinct value)", collations.MySQL8()),
+			NewAggregateParam(AggregateCountDistinct, 0, nil, "count(distinct value)", collations.MySQL8()),
+			NewAggregateParam(AggregateSumDistinct, 1, nil, "sum(distinct value)", collations.MySQL8()),
 		},
 		Input: fp,
 	}
@@ -314,9 +314,9 @@ func TestScalarDistinctPushedDown(t *testing.T) {
 		"8|90",
 	)}}
 
-	countAggr := NewAggregateParam(AggregateSum, 0, "count(distinct value)", collations.MySQL8())
+	countAggr := NewAggregateParam(AggregateSum, 0, nil, "count(distinct value)", collations.MySQL8())
 	countAggr.OrigOpcode = AggregateCountDistinct
-	sumAggr := NewAggregateParam(AggregateSum, 1, "sum(distinct value)", collations.MySQL8())
+	sumAggr := NewAggregateParam(AggregateSum, 1, nil, "sum(distinct value)", collations.MySQL8())
 	sumAggr.OrigOpcode = AggregateSumDistinct
 	oa := &ScalarAggregate{
 		Aggregates: []*AggregateParams{

--- a/go/vt/vtgate/evalengine/eval_result.go
+++ b/go/vt/vtgate/evalengine/eval_result.go
@@ -41,8 +41,13 @@ func (er EvalResult) Value(id collations.ID) sqltypes.Value {
 		return evalToSQLValue(er.v)
 	}
 
-	dst, err := charset.Convert(nil, colldata.Lookup(id).Charset(), str.bytes, colldata.Lookup(str.col.Collation).Charset())
-	if err != nil {
+	lookup := colldata.Lookup(id)
+	var err error
+	var dst []byte
+	if lookup != nil {
+		dst, err = charset.Convert(nil, lookup.Charset(), str.bytes, colldata.Lookup(str.col.Collation).Charset())
+	}
+	if lookup == nil || err != nil {
 		// If we can't convert, we just return what we have, but it's going
 		// to be invalidly encoded. Should normally never happen as only utf8mb4
 		// is really supported for the connection character set anyway and all

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -342,9 +342,23 @@ func transformAggregator(ctx *plancontext.PlanningContext, op *operators.Aggrega
 		case opcode.AggregateUDF:
 			message := fmt.Sprintf("Aggregate UDF '%s' must be pushed down to MySQL", sqlparser.String(aggr.Original.Expr))
 			return nil, vterrors.VT12001(message)
+		case opcode.AggregateConstant:
+			// For AnyValue aggregations (literals, parameters), translate to evalengine
+			// This allows evaluation even when no input rows are present (empty result sets)
+			cfg := &evalengine.Config{
+				Collation:     ctx.VSchema.ConnCollation(),
+				Environment:   ctx.VSchema.Environment(),
+				ResolveColumn: func(name *sqlparser.ColName) (int, error) { return aggr.ColOffset, nil },
+			}
+			expr, err := evalengine.Translate(aggr.Original.Expr, cfg)
+			if err != nil {
+				return nil, err
+			}
+			aggregates = append(aggregates, engine.NewAggregateParam(aggr.OpCode, aggr.ColOffset, expr, aggr.Alias, ctx.VSchema.Environment().CollationEnv()))
+			continue
 		}
 
-		aggrParam := engine.NewAggregateParam(aggr.OpCode, aggr.ColOffset, aggr.Alias, ctx.VSchema.Environment().CollationEnv())
+		aggrParam := engine.NewAggregateParam(aggr.OpCode, aggr.ColOffset, nil, aggr.Alias, ctx.VSchema.Environment().CollationEnv())
 		aggrParam.Func = aggr.Func
 		if gcFunc, isGc := aggrParam.Func.(*sqlparser.GroupConcatExpr); isGc && gcFunc.Separator == "" {
 			gcFunc.Separator = sqlparser.GroupConcatDefaultSeparator

--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing_helper.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing_helper.go
@@ -130,11 +130,8 @@ func (ab *aggBuilder) handleAggr(ctx *plancontext.PlanningContext, aggr Aggr) er
 		return nil
 	case opcode.AggregateCount, opcode.AggregateSum:
 		return ab.handleAggrWithCountStarMultiplier(ctx, aggr)
-	case opcode.AggregateMax, opcode.AggregateMin, opcode.AggregateAnyValue:
+	case opcode.AggregateMax, opcode.AggregateMin, opcode.AggregateAnyValue, opcode.AggregateConstant:
 		return ab.handlePushThroughAggregation(ctx, aggr)
-	case opcode.AggregateConstant:
-		ab.pushThroughLeft(aggr)
-		return nil
 	case opcode.AggregateGroupConcat:
 		f := aggr.Func.(*sqlparser.GroupConcatExpr)
 		if f.Distinct || len(f.OrderBy) > 0 {

--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing_helper.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing_helper.go
@@ -132,6 +132,9 @@ func (ab *aggBuilder) handleAggr(ctx *plancontext.PlanningContext, aggr Aggr) er
 		return ab.handleAggrWithCountStarMultiplier(ctx, aggr)
 	case opcode.AggregateMax, opcode.AggregateMin, opcode.AggregateAnyValue:
 		return ab.handlePushThroughAggregation(ctx, aggr)
+	case opcode.AggregateConstant:
+		ab.pushThroughLeft(aggr)
+		return nil
 	case opcode.AggregateGroupConcat:
 		f := aggr.Func.(*sqlparser.GroupConcatExpr)
 		if f.Distinct || len(f.OrderBy) > 0 {

--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -79,6 +79,16 @@ func (a *Aggregator) AddPredicate(_ *plancontext.PlanningContext, expr sqlparser
 	return newFilter(a, expr)
 }
 
+// createNonGroupingAggr creates the appropriate aggregation for a non-grouping, non-aggregation column
+// If the expression is constant, it returns AggregateConstant, otherwise AggregateAnyValue
+func createNonGroupingAggr(expr *sqlparser.AliasedExpr) Aggr {
+	if sqlparser.IsConstant(expr.Expr) {
+		return NewAggr(opcode.AggregateConstant, nil, expr, expr.ColumnName())
+	} else {
+		return NewAggr(opcode.AggregateAnyValue, nil, expr, expr.ColumnName())
+	}
+}
+
 func (a *Aggregator) addColumnWithoutPushing(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, addToGroupBy bool) int {
 	offset := len(a.Columns)
 	a.Columns = append(a.Columns, expr)
@@ -94,12 +104,12 @@ func (a *Aggregator) addColumnWithoutPushing(ctx *plancontext.PlanningContext, e
 			aggr = createAggrFromAggrFunc(e, expr)
 		case *sqlparser.FuncExpr:
 			if ctx.IsAggr(e) {
-				aggr = NewAggr(opcode.AggregateUDF, nil, expr, expr.As.String())
-			} else {
-				aggr = NewAggr(opcode.AggregateAnyValue, nil, expr, expr.As.String())
+				aggr = NewAggr(opcode.AggregateUDF, nil, expr, expr.ColumnName())
 			}
-		default:
-			aggr = NewAggr(opcode.AggregateAnyValue, nil, expr, expr.As.String())
+		}
+
+		if aggr.Alias == "" {
+			aggr = createNonGroupingAggr(expr)
 		}
 		aggr.ColOffset = offset
 		a.Aggregations = append(a.Aggregations, aggr)
@@ -176,7 +186,7 @@ func (a *Aggregator) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gro
 	}
 
 	if !groupBy {
-		aggr := NewAggr(opcode.AggregateAnyValue, nil, ae, ae.As.String())
+		aggr := createNonGroupingAggr(ae)
 		aggr.ColOffset = len(a.Columns)
 		a.Aggregations = append(a.Aggregations, aggr)
 	}
@@ -417,7 +427,7 @@ func (aggr Aggr) setPushColumn(exprs []sqlparser.Expr) {
 
 func (aggr Aggr) getPushColumn() sqlparser.Expr {
 	switch aggr.OpCode {
-	case opcode.AggregateAnyValue:
+	case opcode.AggregateAnyValue, opcode.AggregateConstant:
 		return aggr.Original.Expr
 	case opcode.AggregateCountStar:
 		return sqlparser.NewIntLiteral("1")
@@ -440,10 +450,10 @@ func (aggr Aggr) getPushColumnExprs() []sqlparser.Expr {
 		return []sqlparser.Expr{aggr.Original.Expr}
 	case opcode.AggregateCountStar:
 		return []sqlparser.Expr{sqlparser.NewIntLiteral("1")}
-	case opcode.AggregateUDF:
-		// AggregateUDFs can't be evaluated on the vtgate. So either we are able to push everything down, or we will have to fail the query.
-		return nil
 	default:
+		if aggr.Func == nil {
+			return nil
+		}
 		return aggr.Func.GetArgs()
 	}
 }

--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -446,7 +446,7 @@ func (aggr Aggr) getPushColumn() sqlparser.Expr {
 
 func (aggr Aggr) getPushColumnExprs() []sqlparser.Expr {
 	switch aggr.OpCode {
-	case opcode.AggregateAnyValue:
+	case opcode.AggregateAnyValue, opcode.AggregateConstant:
 		return []sqlparser.Expr{aggr.Original.Expr}
 	case opcode.AggregateCountStar:
 		return []sqlparser.Expr{sqlparser.NewIntLiteral("1")}

--- a/go/vt/vtgate/planbuilder/operators/queryprojection.go
+++ b/go/vt/vtgate/planbuilder/operators/queryprojection.go
@@ -404,19 +404,19 @@ func (qp *QueryProjection) AggregationExpressions(ctx *plancontext.PlanningConte
 	// Here we go over the expressions we are returning. Since we know we are aggregating,
 	// all expressions have to be either grouping expressions or aggregate expressions.
 	// If we find an expression that is neither, we treat is as a special aggregation function AggrRandom
-	for _, expr := range qp.SelectExprs {
-		aliasedExpr, err := expr.GetAliasedExpr()
+	for _, selectExpr := range qp.SelectExprs {
+		aliasedExpr, err := selectExpr.GetAliasedExpr()
 		if err != nil {
 			panic(err)
 		}
 
-		if !ctx.ContainsAggr(expr.Col) {
-			getExpr, err := expr.GetExpr()
+		if !ctx.ContainsAggr(selectExpr.Col) {
+			getExpr, err := selectExpr.GetExpr()
 			if err != nil {
 				panic(err)
 			}
 			if !qp.isExprInGroupByExprs(ctx, getExpr) {
-				aggr := NewAggr(opcode.AggregateAnyValue, nil, aliasedExpr, aliasedExpr.ColumnName())
+				aggr := createNonGroupingAggr(aliasedExpr)
 				out = append(out, aggr)
 			}
 			continue
@@ -462,7 +462,7 @@ func (qp *QueryProjection) extractAggr(
 			return true
 		}
 		if !qp.isExprInGroupByExprs(ctx, ex) {
-			aggr := NewAggr(opcode.AggregateAnyValue, nil, aeWrap(ex), "")
+			aggr := createNonGroupingAggr(aeWrap(ex))
 			addAggr(aggr)
 		}
 		return false

--- a/go/vt/vtgate/planbuilder/show.go
+++ b/go/vt/vtgate/planbuilder/show.go
@@ -571,7 +571,7 @@ func buildShowVGtidPlan(show *sqlparser.ShowBasic, vschema plancontext.VSchema) 
 	}
 	return &engine.OrderedAggregate{
 		Aggregates: []*engine.AggregateParams{
-			engine.NewAggregateParam(popcode.AggregateGtid, 1, "global vgtid_executed", vschema.Environment().CollationEnv()),
+			engine.NewAggregateParam(popcode.AggregateGtid, 1, nil, "global vgtid_executed", vschema.Environment().CollationEnv()),
 		},
 		TruncateColumnCount: 2,
 		Input:               send,

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -2345,7 +2345,7 @@
           {
             "OperatorType": "Aggregate",
             "Variant": "Scalar",
-            "Aggregates": "any_value(0) AS 1, sum_count(1) AS count(id)",
+            "Aggregates": "constant_aggr(1) AS 1, sum_count(1) AS count(id)",
             "Inputs": [
               {
                 "OperatorType": "VindexLookup",
@@ -2464,7 +2464,7 @@
           {
             "OperatorType": "Aggregate",
             "Variant": "Scalar",
-            "Aggregates": "any_value(0) AS 1, sum_count(1) AS count(id)",
+            "Aggregates": "constant_aggr(1) AS 1, sum_count(1) AS count(id)",
             "Inputs": [
               {
                 "OperatorType": "Route",
@@ -3825,7 +3825,7 @@
                   {
                     "OperatorType": "Aggregate",
                     "Variant": "Scalar",
-                    "Aggregates": "any_value(0) AS id, sum_count_star(1) AS count(*), any_value(2)",
+                    "Aggregates": "any_value(0) AS id, sum_count_star(1) AS count(*), constant_aggr(1) AS 1",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
@@ -5464,7 +5464,7 @@
           {
             "OperatorType": "Aggregate",
             "Variant": "Scalar",
-            "Aggregates": "any_value(0), sum_count_star(1) AS count(*)",
+            "Aggregates": "constant_aggr(1) AS 1, sum_count_star(1) AS count(*)",
             "Inputs": [
               {
                 "OperatorType": "Route",

--- a/go/vt/vtgate/planbuilder/testdata/cte_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/cte_cases.json
@@ -396,7 +396,7 @@
                   {
                     "OperatorType": "Aggregate",
                     "Variant": "Scalar",
-                    "Aggregates": "any_value(0) AS id, sum_count_star(1) AS count(*), any_value(2)",
+                    "Aggregates": "any_value(0) AS id, sum_count_star(1) AS count(*), constant_aggr(1) AS 1",
                     "Inputs": [
                       {
                         "OperatorType": "Route",
@@ -1977,7 +1977,7 @@
                   {
                     "OperatorType": "Aggregate",
                     "Variant": "Scalar",
-                    "Aggregates": "any_value(0), sum(1) AS sum(num)",
+                    "Aggregates": "constant_aggr(1000) AS 1000, sum(1) AS sum(num)",
                     "Inputs": [
                       {
                         "OperatorType": "Projection",

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -724,84 +724,72 @@
             "OrderBy": "1 ASC, 4 ASC",
             "Inputs": [
               {
-                "OperatorType": "Projection",
-                "Expressions": [
-                  "1 as 1",
-                  "user_extra.col as col",
-                  "um.col as col",
-                  "user_extra.col as col",
-                  "music.intcol as intcol"
-                ],
+                "OperatorType": "Join",
+                "Variant": "HashLeftJoin",
+                "Collation": "binary",
+                "ComparisonType": "FLOAT64",
+                "JoinColumnIndexes": "-1,-2,1,-2,-4,-1",
+                "Predicate": "user_extra.col = um.col",
                 "Inputs": [
                   {
                     "OperatorType": "Join",
-                    "Variant": "HashLeftJoin",
-                    "Collation": "binary",
-                    "ComparisonType": "FLOAT64",
-                    "JoinColumnIndexes": "-1,1,-1,-3",
-                    "Predicate": "user_extra.col = um.col",
+                    "Variant": "Join",
+                    "JoinColumnIndexes": "L:0,R:0,R:0,L:1",
+                    "JoinVars": {
+                      "music_intcol": 1
+                    },
                     "Inputs": [
                       {
-                        "OperatorType": "Join",
-                        "Variant": "Join",
-                        "JoinColumnIndexes": "R:0,R:0,L:1",
-                        "JoinVars": {
-                          "music_intcol": 1
+                        "OperatorType": "Route",
+                        "Variant": "Scatter",
+                        "Keyspace": {
+                          "Name": "user",
+                          "Sharded": true
                         },
-                        "Inputs": [
-                          {
-                            "OperatorType": "Route",
-                            "Variant": "Scatter",
-                            "Keyspace": {
-                              "Name": "user",
-                              "Sharded": true
-                            },
-                            "FieldQuery": "select 1, music.intcol from music where 1 != 1 group by music.intcol",
-                            "Query": "select 1, music.intcol from music group by music.intcol"
-                          },
-                          {
-                            "OperatorType": "Route",
-                            "Variant": "EqualUnique",
-                            "Keyspace": {
-                              "Name": "user",
-                              "Sharded": true
-                            },
-                            "FieldQuery": "select user_extra.col, user_extra.col from `user`, user_extra where 1 != 1 group by user_extra.col",
-                            "Query": "select user_extra.col, user_extra.col from `user`, user_extra where `user`.id in (103) and user_extra.col = :music_intcol /* INT16 */ and `user`.id = user_extra.user_id group by user_extra.col",
-                            "Values": [
-                              "103"
-                            ],
-                            "Vindex": "user_index"
-                          }
-                        ]
+                        "FieldQuery": "select 1, music.intcol from music where 1 != 1 group by music.intcol",
+                        "Query": "select 1, music.intcol from music group by music.intcol"
                       },
                       {
-                        "OperatorType": "Aggregate",
-                        "Variant": "Ordered",
-                        "GroupBy": "(0|1)",
+                        "OperatorType": "Route",
+                        "Variant": "EqualUnique",
+                        "Keyspace": {
+                          "Name": "user",
+                          "Sharded": true
+                        },
+                        "FieldQuery": "select user_extra.col, user_extra.col from `user`, user_extra where 1 != 1 group by user_extra.col",
+                        "Query": "select user_extra.col, user_extra.col from `user`, user_extra where `user`.id in (103) and user_extra.col = :music_intcol /* INT16 */ and `user`.id = user_extra.user_id group by user_extra.col",
+                        "Values": [
+                          "103"
+                        ],
+                        "Vindex": "user_index"
+                      }
+                    ]
+                  },
+                  {
+                    "OperatorType": "Aggregate",
+                    "Variant": "Ordered",
+                    "GroupBy": "(0|1)",
+                    "Inputs": [
+                      {
+                        "OperatorType": "SimpleProjection",
+                        "Columns": "0,2",
                         "Inputs": [
                           {
-                            "OperatorType": "SimpleProjection",
-                            "Columns": "0,2",
+                            "OperatorType": "Aggregate",
+                            "Variant": "Ordered",
+                            "Aggregates": "sum_count_star(1) AS count",
+                            "GroupBy": "(0|2)",
                             "Inputs": [
                               {
-                                "OperatorType": "Aggregate",
-                                "Variant": "Ordered",
-                                "Aggregates": "sum_count_star(1) AS count",
-                                "GroupBy": "(0|2)",
-                                "Inputs": [
-                                  {
-                                    "OperatorType": "Route",
-                                    "Variant": "Scatter",
-                                    "Keyspace": {
-                                      "Name": "user",
-                                      "Sharded": true
-                                    },
-                                    "FieldQuery": "select user_metadata.col, count(*) as `count`, weight_string(user_metadata.col) from user_metadata where 1 != 1 group by user_metadata.col, weight_string(user_metadata.col)",
-                                    "OrderBy": "(0|2) ASC",
-                                    "Query": "select user_metadata.col, count(*) as `count`, weight_string(user_metadata.col) from user_metadata group by user_metadata.col, weight_string(user_metadata.col) order by user_metadata.col asc"
-                                  }
-                                ]
+                                "OperatorType": "Route",
+                                "Variant": "Scatter",
+                                "Keyspace": {
+                                  "Name": "user",
+                                  "Sharded": true
+                                },
+                                "FieldQuery": "select user_metadata.col, count(*) as `count`, weight_string(user_metadata.col) from user_metadata where 1 != 1 group by user_metadata.col, weight_string(user_metadata.col)",
+                                "OrderBy": "(0|2) ASC",
+                                "Query": "select user_metadata.col, count(*) as `count`, weight_string(user_metadata.col) from user_metadata group by user_metadata.col, weight_string(user_metadata.col) order by user_metadata.col asc"
                               }
                             ]
                           }

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -714,7 +714,7 @@
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Ordered",
-        "Aggregates": "any_value(0) AS 1",
+        "Aggregates": "constant_aggr(1) AS 1",
         "GroupBy": "1, 4",
         "ResultColumns": 1,
         "Inputs": [
@@ -724,72 +724,84 @@
             "OrderBy": "1 ASC, 4 ASC",
             "Inputs": [
               {
-                "OperatorType": "Join",
-                "Variant": "HashLeftJoin",
-                "Collation": "binary",
-                "ComparisonType": "FLOAT64",
-                "JoinColumnIndexes": "-1,-2,1,-2,-4,-1",
-                "Predicate": "user_extra.col = um.col",
+                "OperatorType": "Projection",
+                "Expressions": [
+                  "1 as 1",
+                  "user_extra.col as col",
+                  "um.col as col",
+                  "user_extra.col as col",
+                  "music.intcol as intcol"
+                ],
                 "Inputs": [
                   {
                     "OperatorType": "Join",
-                    "Variant": "Join",
-                    "JoinColumnIndexes": "L:0,R:0,R:0,L:1",
-                    "JoinVars": {
-                      "music_intcol": 1
-                    },
+                    "Variant": "HashLeftJoin",
+                    "Collation": "binary",
+                    "ComparisonType": "FLOAT64",
+                    "JoinColumnIndexes": "-1,1,-1,-3",
+                    "Predicate": "user_extra.col = um.col",
                     "Inputs": [
                       {
-                        "OperatorType": "Route",
-                        "Variant": "Scatter",
-                        "Keyspace": {
-                          "Name": "user",
-                          "Sharded": true
+                        "OperatorType": "Join",
+                        "Variant": "Join",
+                        "JoinColumnIndexes": "R:0,R:0,L:1",
+                        "JoinVars": {
+                          "music_intcol": 1
                         },
-                        "FieldQuery": "select 1, music.intcol from music where 1 != 1 group by music.intcol",
-                        "Query": "select 1, music.intcol from music group by music.intcol"
-                      },
-                      {
-                        "OperatorType": "Route",
-                        "Variant": "EqualUnique",
-                        "Keyspace": {
-                          "Name": "user",
-                          "Sharded": true
-                        },
-                        "FieldQuery": "select user_extra.col, user_extra.col from `user`, user_extra where 1 != 1 group by user_extra.col",
-                        "Query": "select user_extra.col, user_extra.col from `user`, user_extra where `user`.id in (103) and user_extra.col = :music_intcol /* INT16 */ and `user`.id = user_extra.user_id group by user_extra.col",
-                        "Values": [
-                          "103"
-                        ],
-                        "Vindex": "user_index"
-                      }
-                    ]
-                  },
-                  {
-                    "OperatorType": "Aggregate",
-                    "Variant": "Ordered",
-                    "GroupBy": "(0|1)",
-                    "Inputs": [
-                      {
-                        "OperatorType": "SimpleProjection",
-                        "Columns": "0,2",
                         "Inputs": [
                           {
-                            "OperatorType": "Aggregate",
-                            "Variant": "Ordered",
-                            "Aggregates": "sum_count_star(1) AS count",
-                            "GroupBy": "(0|2)",
+                            "OperatorType": "Route",
+                            "Variant": "Scatter",
+                            "Keyspace": {
+                              "Name": "user",
+                              "Sharded": true
+                            },
+                            "FieldQuery": "select 1, music.intcol from music where 1 != 1 group by music.intcol",
+                            "Query": "select 1, music.intcol from music group by music.intcol"
+                          },
+                          {
+                            "OperatorType": "Route",
+                            "Variant": "EqualUnique",
+                            "Keyspace": {
+                              "Name": "user",
+                              "Sharded": true
+                            },
+                            "FieldQuery": "select user_extra.col, user_extra.col from `user`, user_extra where 1 != 1 group by user_extra.col",
+                            "Query": "select user_extra.col, user_extra.col from `user`, user_extra where `user`.id in (103) and user_extra.col = :music_intcol /* INT16 */ and `user`.id = user_extra.user_id group by user_extra.col",
+                            "Values": [
+                              "103"
+                            ],
+                            "Vindex": "user_index"
+                          }
+                        ]
+                      },
+                      {
+                        "OperatorType": "Aggregate",
+                        "Variant": "Ordered",
+                        "GroupBy": "(0|1)",
+                        "Inputs": [
+                          {
+                            "OperatorType": "SimpleProjection",
+                            "Columns": "0,2",
                             "Inputs": [
                               {
-                                "OperatorType": "Route",
-                                "Variant": "Scatter",
-                                "Keyspace": {
-                                  "Name": "user",
-                                  "Sharded": true
-                                },
-                                "FieldQuery": "select user_metadata.col, count(*) as `count`, weight_string(user_metadata.col) from user_metadata where 1 != 1 group by user_metadata.col, weight_string(user_metadata.col)",
-                                "OrderBy": "(0|2) ASC",
-                                "Query": "select user_metadata.col, count(*) as `count`, weight_string(user_metadata.col) from user_metadata group by user_metadata.col, weight_string(user_metadata.col) order by user_metadata.col asc"
+                                "OperatorType": "Aggregate",
+                                "Variant": "Ordered",
+                                "Aggregates": "sum_count_star(1) AS count",
+                                "GroupBy": "(0|2)",
+                                "Inputs": [
+                                  {
+                                    "OperatorType": "Route",
+                                    "Variant": "Scatter",
+                                    "Keyspace": {
+                                      "Name": "user",
+                                      "Sharded": true
+                                    },
+                                    "FieldQuery": "select user_metadata.col, count(*) as `count`, weight_string(user_metadata.col) from user_metadata where 1 != 1 group by user_metadata.col, weight_string(user_metadata.col)",
+                                    "OrderBy": "(0|2) ASC",
+                                    "Query": "select user_metadata.col, count(*) as `count`, weight_string(user_metadata.col) from user_metadata group by user_metadata.col, weight_string(user_metadata.col) order by user_metadata.col asc"
+                                  }
+                                ]
                               }
                             ]
                           }

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -1508,23 +1508,24 @@
                   {
                     "OperatorType": "Projection",
                     "Expressions": [
-                      "sum(ps_supplycost * ps_availqty) * count(*) as sum(ps_supplycost * ps_availqty)"
+                      "sum(ps_supplycost * ps_availqty) * count(*) as sum(ps_supplycost * ps_availqty)",
+                      ":2 as 0.00001000000"
                     ],
                     "Inputs": [
                       {
                         "OperatorType": "Join",
                         "Variant": "Join",
-                        "JoinColumnIndexes": "L:0,R:0,L:2",
+                        "JoinColumnIndexes": "L:0,R:0,L:1",
                         "JoinVars": {
-                          "s_nationkey1": 1
+                          "s_nationkey1": 2
                         },
                         "Inputs": [
                           {
                             "OperatorType": "Projection",
                             "Expressions": [
                               "sum(ps_supplycost * ps_availqty) * count(*) as sum(ps_supplycost * ps_availqty)",
-                              ":3 as s_nationkey",
-                              ":2 as 0.00001000000"
+                              ":2 as 0.00001000000",
+                              ":3 as s_nationkey"
                             ],
                             "Inputs": [
                               {

--- a/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/tpch_cases.json
@@ -1503,29 +1503,28 @@
               {
                 "OperatorType": "Aggregate",
                 "Variant": "Scalar",
-                "Aggregates": "sum(0) AS sum(ps_supplycost * ps_availqty), any_value(1)",
+                "Aggregates": "sum(0) AS sum(ps_supplycost * ps_availqty), constant_aggr(0.00001000000) AS 0.00001000000",
                 "Inputs": [
                   {
                     "OperatorType": "Projection",
                     "Expressions": [
-                      "sum(ps_supplycost * ps_availqty) * count(*) as sum(ps_supplycost * ps_availqty)",
-                      ":2 as 0.00001000000"
+                      "sum(ps_supplycost * ps_availqty) * count(*) as sum(ps_supplycost * ps_availqty)"
                     ],
                     "Inputs": [
                       {
                         "OperatorType": "Join",
                         "Variant": "Join",
-                        "JoinColumnIndexes": "L:0,R:0,L:1",
+                        "JoinColumnIndexes": "L:0,R:0,L:2",
                         "JoinVars": {
-                          "s_nationkey1": 2
+                          "s_nationkey1": 1
                         },
                         "Inputs": [
                           {
                             "OperatorType": "Projection",
                             "Expressions": [
                               "sum(ps_supplycost * ps_availqty) * count(*) as sum(ps_supplycost * ps_availqty)",
-                              ":2 as 0.00001000000",
-                              ":3 as s_nationkey"
+                              ":3 as s_nationkey",
+                              ":2 as 0.00001000000"
                             ],
                             "Inputs": [
                               {
@@ -1905,7 +1904,7 @@
           {
             "OperatorType": "Aggregate",
             "Variant": "Scalar",
-            "Aggregates": "any_value(0), sum(1) AS sum(case when p_type like 'PROMO%' then l_extendedprice * (1 - l_discount) else 0 end), sum(2) AS sum(l_extendedprice * (1 - l_discount))",
+            "Aggregates": "constant_aggr(100.00) AS 100.00, sum(1) AS sum(case when p_type like 'PROMO%' then l_extendedprice * (1 - l_discount) else 0 end), sum(2) AS sum(l_extendedprice * (1 - l_discount))",
             "Inputs": [
               {
                 "OperatorType": "Projection",

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -1895,7 +1895,7 @@
           {
             "OperatorType": "Aggregate",
             "Variant": "Ordered",
-            "Aggregates": "any_value(0) AS type, any_value(1) AS id",
+            "Aggregates": "constant_aggr('a') AS type, constant_aggr(0) AS id",
             "GroupBy": "2 COLLATE utf8mb4_0900_ai_ci",
             "ResultColumns": 2,
             "Inputs": [

--- a/go/vt/vttablet/tabletmanager/vdiff/table_plan.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/table_plan.go
@@ -122,6 +122,7 @@ func (td *tableDiffer) buildTablePlan(dbClient binlogplayer.DBClient, dbName str
 					aggregates = append(aggregates, engine.NewAggregateParam(
 						/*opcode*/ opcode.AggregateSum,
 						/*offset*/ sourceSelect.GetColumnCount()-1,
+						nil,
 						/*alias*/ "", collationEnv),
 					)
 				}

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -686,8 +686,8 @@ func TestBuildPlanSuccess(t *testing.T) {
 				Direction: sqlparser.AscOrder,
 			}},
 			aggregates: []*engine.AggregateParams{
-				engine.NewAggregateParam(opcode.AggregateSum, 2, "", collations.MySQL8()),
-				engine.NewAggregateParam(opcode.AggregateSum, 3, "", collations.MySQL8()),
+				engine.NewAggregateParam(opcode.AggregateSum, 2, nil, "", collations.MySQL8()),
+				engine.NewAggregateParam(opcode.AggregateSum, 3, nil, "", collations.MySQL8()),
 			},
 		},
 	}, {

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -710,6 +710,7 @@ func (df *vdiff) buildTablePlan(table *tabletmanagerdatapb.TableDefinition, quer
 					aggregates = append(aggregates, engine.NewAggregateParam(
 						/*opcode*/ opcode.AggregateSum,
 						/*offset*/ sourceSelect.GetColumnCount()-1,
+						nil,
 						/*alias*/ "", df.env.CollationEnv()))
 				}
 			}

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -27,6 +27,8 @@ import (
 	"sync"
 	"time"
 
+	"vitess.io/vitess/go/mysql/config"
+
 	"google.golang.org/protobuf/encoding/prototext"
 
 	"vitess.io/vitess/go/mysql/replication"
@@ -1417,6 +1419,18 @@ func (vc *contextVCursor) ExecutePrimitive(ctx context.Context, primitive engine
 
 func (vc *contextVCursor) StreamExecutePrimitive(ctx context.Context, primitive engine.Primitive, bindVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
 	return primitive.TryStreamExecute(ctx, vc, bindVars, wantfields, callback)
+}
+
+func (vc *contextVCursor) TimeZone() *time.Location {
+	return time.Local
+}
+
+func (vc *contextVCursor) SQLMode() string {
+	return config.DefaultSQLMode
+}
+
+func (vc *contextVCursor) Environment() *vtenv.Environment {
+	return vtenv.NewTestEnv()
 }
 
 // -----------------------------------------------------------------

--- a/go/vt/wrangler/vdiff_test.go
+++ b/go/vt/wrangler/vdiff_test.go
@@ -38,8 +38,8 @@ import (
 )
 
 func TestVDiffPlanSuccess(t *testing.T) {
+	env := vtenv.NewTestEnv()
 	collationEnv := collations.MySQL8()
-	parser := sqlparser.NewTestParser()
 	schm := &tabletmanagerdatapb.SchemaDefinition{
 		TableDefinitions: []*tabletmanagerdatapb.TableDefinition{{
 			Name:              "t1",
@@ -100,8 +100,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{0},
 			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
 			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
-			collationEnv:     collationEnv,
-			parser:           parser,
+			env:              env,
 		},
 	}, {
 		input: &binlogdatapb.Rule{
@@ -119,8 +118,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{0},
 			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
 			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
-			collationEnv:     collationEnv,
-			parser:           parser,
+			env:              env,
 		},
 	}, {
 		input: &binlogdatapb.Rule{
@@ -138,8 +136,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{0},
 			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
 			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
-			collationEnv:     collationEnv,
-			parser:           parser,
+			env:              env,
 		},
 	}, {
 		input: &binlogdatapb.Rule{
@@ -157,8 +154,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{1},
 			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{1, collations.Unknown, nil, true}}, collationEnv),
 			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{1, collations.Unknown, nil, true}}, collationEnv),
-			collationEnv:     collationEnv,
-			parser:           parser,
+			env:              env,
 		},
 	}, {
 		input: &binlogdatapb.Rule{
@@ -176,8 +172,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{0},
 			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
 			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
-			collationEnv:     collationEnv,
-			parser:           parser,
+			env:              env,
 		},
 	}, {
 		// non-pk text column.
@@ -196,8 +191,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{0},
 			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
 			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
-			collationEnv:     collationEnv,
-			parser:           parser,
+			env:              env,
 		},
 	}, {
 		// non-pk text column, different order.
@@ -216,8 +210,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{1},
 			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{1, collations.Unknown, nil, true}}, collationEnv),
 			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{1, collations.Unknown, nil, true}}, collationEnv),
-			collationEnv:     collationEnv,
-			parser:           parser,
+			env:              env,
 		},
 	}, {
 		// pk text column.
@@ -236,8 +229,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{0},
 			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, collationEnv.DefaultConnectionCharset(), nil, false}}, collationEnv),
 			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, collationEnv.DefaultConnectionCharset(), nil, false}}, collationEnv),
-			collationEnv:     collationEnv,
-			parser:           parser,
+			env:              env,
 		},
 	}, {
 		// pk text column, different order.
@@ -256,8 +248,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{1},
 			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{1, collationEnv.DefaultConnectionCharset(), nil, false}}, collationEnv),
 			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{1, collationEnv.DefaultConnectionCharset(), nil, false}}, collationEnv),
-			collationEnv:     collationEnv,
-			parser:           parser,
+			env:              env,
 		},
 	}, {
 		// text column as expression.
@@ -276,8 +267,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{1},
 			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{1, collationEnv.DefaultConnectionCharset(), nil, false}}, collationEnv),
 			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{1, collationEnv.DefaultConnectionCharset(), nil, false}}, collationEnv),
-			collationEnv:     collationEnv,
-			parser:           parser,
+			env:              env,
 		},
 	}, {
 		input: &binlogdatapb.Rule{
@@ -294,8 +284,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{0, 1},
 			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}, {1, collations.Unknown, nil, true}}, collationEnv),
 			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}, {1, collations.Unknown, nil, true}}, collationEnv),
-			collationEnv:     collationEnv,
-			parser:           parser,
+			env:              env,
 		},
 	}, {
 		// in_keyrange
@@ -314,8 +303,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{0},
 			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
 			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
-			collationEnv:     collationEnv,
-			parser:           parser,
+			env:              env,
 		},
 	}, {
 		// in_keyrange on RHS of AND.
@@ -335,8 +323,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{0},
 			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
 			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
-			collationEnv:     collationEnv,
-			parser:           parser,
+			env:              env,
 		},
 	}, {
 		// in_keyrange on LHS of AND.
@@ -356,8 +343,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{0},
 			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
 			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
-			collationEnv:     collationEnv,
-			parser:           parser,
+			env:              env,
 		},
 	}, {
 		// in_keyrange on cascaded AND expression
@@ -377,8 +363,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{0},
 			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
 			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
-			collationEnv:     collationEnv,
-			parser:           parser,
+			env:              env,
 		},
 	}, {
 		// in_keyrange parenthesized
@@ -398,8 +383,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{0},
 			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
 			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
-			collationEnv:     collationEnv,
-			parser:           parser,
+			env:              env,
 		},
 	}, {
 		// group by
@@ -418,8 +402,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{0},
 			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
 			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
-			collationEnv:     collationEnv,
-			parser:           parser,
+			env:              env,
 		},
 	}, {
 		// aggregations
@@ -445,8 +428,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 				Input:       newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
 			},
 			targetPrimitive: newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
-			collationEnv:    collationEnv,
-			parser:          parser,
+			env:             env,
 		},
 	}, {
 		input: &binlogdatapb.Rule{
@@ -464,8 +446,7 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{0},
 			sourcePrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
 			targetPrimitive:  newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),
-			collationEnv:     collationEnv,
-			parser:           parser,
+			env:              env,
 		},
 	}}
 

--- a/go/vt/wrangler/vdiff_test.go
+++ b/go/vt/wrangler/vdiff_test.go
@@ -438,8 +438,8 @@ func TestVDiffPlanSuccess(t *testing.T) {
 			selectPks:        []int{0},
 			sourcePrimitive: &engine.OrderedAggregate{
 				Aggregates: []*engine.AggregateParams{
-					engine.NewAggregateParam(opcode.AggregateSum, 2, "", collationEnv),
-					engine.NewAggregateParam(opcode.AggregateSum, 3, "", collationEnv),
+					engine.NewAggregateParam(opcode.AggregateSum, 2, nil, "", collationEnv),
+					engine.NewAggregateParam(opcode.AggregateSum, 3, nil, "", collationEnv),
 				},
 				GroupByKeys: []*engine.GroupByParams{{KeyCol: 0, WeightStringCol: -1, CollationEnv: collations.MySQL8()}},
 				Input:       newMergeSorter(nil, []compareColInfo{{0, collations.Unknown, nil, true}}, collationEnv),


### PR DESCRIPTION
## Description

Fixes an issue where scalar aggregations with literal values incorrectly returned NULL when the input result set was empty, instead of evaluating the literal expression.

### Problem

When executing queries like:
```sql
SELECT 1 AS `id`, COUNT(*) FROM (SELECT `id` FROM table WHERE condition LIMIT 100) `t`
```

If the subquery returns no rows due to the WHERE condition, Vitess incorrectly returned:
```
(NULL, 0)
```

Instead of the expected MySQL-compatible result:
```
(1, 0)  
```

The issue occurred because the aggregation engine primitives depended on incoming rows to provide values. When no rows were present, literal expressions (like `1`) were treated the same as column references and returned NULL.


### Solution

Allow the engine primitives to handle evaluating evalengine expressions to handle literals and parameters given empty inputs.

## Related Issue(s)
Fixes #18468

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
