### PR TITLE
VReplication: Fix bug while reading _vt.vreplication record

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_vreplication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication.go
@@ -59,7 +59,7 @@ const (
 	sqlHasVReplicationWorkflows   = "select if(count(*) > 0, 1, 0) as has_workflows from %s.vreplication where db_name = %a"
 	// Read all VReplication workflows. The final format specifier is used to
 	// optionally add any additional predicates to the query.
-	sqlReadVReplicationWorkflows = "select workflow, id, source, pos, stop_pos, max_tps, max_replication_lag, cell, tablet_types, time_updated, transaction_timestamp, state, message, db_name, rows_copied, tags, time_heartbeat, workflow_type, time_throttled, component_throttled, workflow_sub_type, defer_secondary_keys, options from %s.vreplication where db_name = %a%s group by workflow, id order by workflow, id"
+	sqlReadVReplicationWorkflows = "select workflow, id, source, pos, stop_pos, max_tps, max_replication_lag, cell, tablet_types, time_updated, transaction_timestamp, state, message, db_name, rows_copied, tags, time_heartbeat, workflow_type, time_throttled, component_throttled, workflow_sub_type, defer_secondary_keys, options from %s.vreplication where db_name = %a%s order by workflow, id"
 	// Read a VReplication workflow.
 	sqlReadVReplicationWorkflow = "select id, source, pos, stop_pos, max_tps, max_replication_lag, cell, tablet_types, time_updated, transaction_timestamp, state, message, db_name, rows_copied, tags, time_heartbeat, workflow_type, time_throttled, component_throttled, workflow_sub_type, defer_secondary_keys, options from %s.vreplication where workflow = %a and db_name = %a"
 	// Delete VReplication records for the given workflow.


### PR DESCRIPTION


## Description

Removes the unnecessary `group by` in `sqlReadVReplicationWorkflows` which fails on an import from MariaDB in the reverse workflow. It was 

```
select workflow, id, source, pos, stop_pos, max_tps, max_replication_lag, cell, tablet_types, time_updated,
transaction_timestamp, state, message, db_name, rows_copied, tags, time_heartbeat, workflow_type, time_throttled, 
component_throttled, workflow_sub_type, defer_secondary_keys, options from %s.vreplication 
where db_name = %a%s order by workflow, id
```

In standard SQL, a  `GROUP BY` clause is only meaningful when you’re aggregating rows. Every column in the SELECT list must either
* appear in the GROUP BY
* or be wrapped in an aggregate function.

MySQL historically (when sql_mode did not include `ONLY_FULL_GROUP_BY`) relaxed that rule and implicitly picked “some” value for the non‑grouped columns. MariaDB appears to enforce the stricter SQL modes and rejects the query because columns like `source`, `pos`, `stop_pos`, ... in the `GROUP BY`.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
