### PR TITLE
Pass SSL config when checking connection to external mysql instance

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -954,6 +954,11 @@ func (c *TabletConfig) checkConnectionForExternalMysql() error {
 		Uname:      c.DB.App.User,
 		Pass:       c.DB.App.Password,
 		UnixSocket: c.DB.Socket,
+		SslMode:    c.DB.SslMode,
+		SslCa:      c.DB.SslCa,
+		SslCaPath:  c.DB.SslCaPath,
+		SslCert:    c.DB.SslCert,
+		SslKey:     c.DB.SslKey,
 	}
 
 	conn, err := mysql.Connect(context.Background(), &params)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
When connecting to an external mysql instance, vttablet performs a connectivity check. That connectivity check doesn't pass through any SSL configuration to the connect logic so if the external mysql instance requires secure connections, then an error is thrown from mysql, preventing the vttablet from starting.

This PR addresses the issue by passing through the SSL configuration to the connect logic.


## Related Issue(s)
Fixes: https://github.com/vitessio/vitess/issues/18480
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
