### PR TITLE
fix: handle aliases in UNIONs better

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/union.go
+++ b/go/vt/vtgate/planbuilder/operators/union.go
@@ -179,8 +179,11 @@ func (u *Union) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool,
 	case *sqlparser.ColName:
 		cols := u.GetColumns(ctx)
 		// here we deal with pure column access on top of the union
-		offset := slices.IndexFunc(cols, func(expr *sqlparser.AliasedExpr) bool {
-			return e.Name.EqualString(expr.ColumnName())
+		offset := slices.IndexFunc(cols, func(column *sqlparser.AliasedExpr) bool {
+			if column.ColumnName() == expr.ColumnName() {
+				return true
+			}
+			return e.Name.EqualString(column.ColumnName())
 		})
 		if offset == -1 {
 			panic(vterrors.VT13001(fmt.Sprintf("could not find the column '%s' on the UNION", sqlparser.String(e))))

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -2007,5 +2007,66 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "UNION with column aliases ",
+    "query": "(SELECT `team_id` AS `foo` FROM user WHERE `team_id` = 1 ORDER BY `id` DESC LIMIT 1) UNION ALL (SELECT `team_id` AS `foo` FROM user WHERE `team_id` = 2 ORDER BY `id` DESC LIMIT 1)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "(SELECT `team_id` AS `foo` FROM user WHERE `team_id` = 1 ORDER BY `id` DESC LIMIT 1) UNION ALL (SELECT `team_id` AS `foo` FROM user WHERE `team_id` = 2 ORDER BY `id` DESC LIMIT 1)",
+      "Instructions": {
+        "OperatorType": "SimpleProjection",
+        "ColumnNames": [
+          "0:foo"
+        ],
+        "Columns": "0",
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Limit",
+                "Count": "1",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select team_id as foo, id, weight_string(id) from `user` where 1 != 1",
+                    "OrderBy": "(1|2) DESC",
+                    "Query": "select team_id as foo, id, weight_string(id) from `user` where team_id = 1 order by id desc limit 1"
+                  }
+                ]
+              },
+              {
+                "OperatorType": "Limit",
+                "Count": "1",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select team_id as foo, id, weight_string(id) from `user` where 1 != 1",
+                    "OrderBy": "(1|2) DESC",
+                    "Query": "select team_id as foo, id, weight_string(id) from `user` where team_id = 2 order by id desc limit 1"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
+
 ]


### PR DESCRIPTION
## Description
When planning UNIONs, Vitess was having a hard time handling column aliases correctly.

## Related Issue(s)
Fixes #18469


## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
