### PR TITLE
Fix for simple projection showing no fields

### DIFF
--- a/go/test/endtoend/vtgate/grpc_api/prepare_test.go
+++ b/go/test/endtoend/vtgate/grpc_api/prepare_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc_api
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/endtoend/cluster"
+)
+
+// TestTransactionsWithGRPCAPI test the transaction queries through vtgate grpc apis.
+// It is done through both streaming api and non-streaming api.
+func TestPrepareWithGRPCAPI(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	vtgateConn, err := cluster.DialVTGate(ctx, t.Name(), vtgateGrpcAddress, "user_with_access", "test_password")
+	require.NoError(t, err)
+	defer vtgateConn.Close()
+
+	query := `SELECT DISTINCT
+                BINARY table_info.table_name AS table_name,
+                table_info.create_options AS create_options,
+                table_info.table_comment AS table_comment
+              FROM information_schema.tables AS table_info
+              JOIN information_schema.columns AS column_info
+                  ON BINARY column_info.table_name = BINARY table_info.table_name
+              WHERE
+                  table_info.table_schema = ?
+                  AND column_info.table_schema = ?
+                  -- Exclude views.
+                  AND table_info.table_type = 'BASE TABLE'
+              ORDER BY BINARY table_info.table_name`
+
+	vtSession := vtgateConn.Session(keyspaceName, nil)
+	fields, paramsCount, err := vtSession.Prepare(t.Context(), query)
+	require.NoError(t, err)
+	assert.Equal(t, `[name:"table_name" type:VARBINARY name:"create_options" type:VARCHAR name:"table_comment" type:VARCHAR]`, fmt.Sprintf("%v", fields))
+	assert.EqualValues(t, 2, paramsCount)
+
+}

--- a/go/vt/vtgate/engine/simple_projection.go
+++ b/go/vt/vtgate/engine/simple_projection.go
@@ -104,7 +104,17 @@ func (sc *SimpleProjection) buildFields(inner *sqltypes.Result) []*querypb.Field
 	if len(inner.Fields) == 0 {
 		return nil
 	}
-	fields := make([]*querypb.Field, 0, len(sc.Cols))
+	fields := make([]*querypb.Field, 0, len(sc.ColNames))
+	if sc.namesOnly() {
+		for idx, field := range inner.Fields {
+			if sc.ColNames[idx] != "" {
+				field = proto.Clone(field).(*querypb.Field)
+				field.Name = sc.ColNames[idx]
+			}
+			fields = append(fields, field)
+		}
+		return fields
+	}
 	for idx, col := range sc.Cols {
 		field := inner.Fields[col]
 		if sc.ColNames[idx] != "" {

--- a/go/vt/vtgate/engine/simple_projection_test.go
+++ b/go/vt/vtgate/engine/simple_projection_test.go
@@ -175,3 +175,50 @@ func TestSubqueryGetFields(t *testing.T) {
 	_, err = sq.GetFields(context.Background(), nil, bv)
 	require.EqualError(t, err, `err`)
 }
+
+func TestSubqueryGetFieldsNamesOnly(t *testing.T) {
+	prim := &fakePrimitive{
+		results: []*sqltypes.Result{
+			sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields(
+					"col1|col2|col3",
+					"int64|varchar|varchar",
+				),
+				"1|a|aa",
+				"2|b|bb",
+				"3|c|cc",
+			),
+		},
+	}
+
+	sq := &SimpleProjection{
+		ColNames: []string{"col1alias", "", "col3alias"},
+		Input:    prim,
+	}
+
+	bv := map[string]*querypb.BindVariable{
+		"a": sqltypes.Int64BindVariable(1),
+	}
+
+	r, err := sq.GetFields(context.Background(), nil, bv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prim.ExpectLog(t, []string{
+		`GetFields a: type:INT64 value:"1"`,
+		`Execute a: type:INT64 value:"1" true`,
+	})
+	expectResult(t, r, sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"col1alias|col2|col3alias",
+			"int64|varchar|varchar",
+		),
+	))
+
+	// Error case.
+	sq.Input = &fakePrimitive{
+		sendErr: errors.New("err"),
+	}
+	_, err = sq.GetFields(context.Background(), nil, bv)
+	require.EqualError(t, err, `err`)
+}


### PR DESCRIPTION
When a simple projection ends up in a statement that is prepared, we end up directly calling `buildFields` from `GetFields`.

When we do that, we don't do the same check we do on results, which is that we have a names only optimization where `sc.Cols` is nil. This leads to building an empty fields list.

@systay @harshit-gangal I'd love to know if this investigation makes sense or if this bug is something else. Also I'm not really sure how we should best test this? Is the test I added enough here? 

## Related Issue(s)

Fixes #18488 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
