### PR TITLE
VStream: before and after filters should return raw values regardless

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -1054,7 +1054,9 @@ func (vs *vstreamer) processRowEvent(vevents []*binlogdatapb.VEvent, plan *strea
 		}
 
 		rowChange := &binlogdatapb.RowChange{}
-		if beforeOK {
+
+		// if either the before or after values were ok we'll forward the values
+		if beforeOK || afterOK {
 			if len(beforeRawValues) > 0 {
 				beforeValues, err := plan.mapValues(beforeRawValues)
 				if err != nil {
@@ -1082,17 +1084,6 @@ func (vs *vstreamer) processRowEvent(vevents []*binlogdatapb.VEvent, plan *strea
 						Count: int64(row.JSONPartialValues.Count()),
 						Cols:  row.JSONPartialValues.Bits(),
 					}
-				}
-			}
-
-			// Add raw before values if only afterOK succeeded
-			if !beforeOK {
-				if len(beforeRawValues) > 0 {
-					beforeValues, err := plan.mapValues(beforeRawValues)
-					if err != nil {
-						return nil, err
-					}
-					rowChange.Before = sqltypes.RowToProto3(beforeValues)
 				}
 			}
 		}


### PR DESCRIPTION
## Description

`processRowEvent` now returns before value if either after or before image check passes, this makes sure that the event doesn't end up as a new record but rather should be treated as `UPDATE`

## Related Issue(s)

Fixes: #18426

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

