### PR TITLE
Fix: Add context support to Consolidator. Wait to prevent goroutine leaks (#18272)

### DIFF
--- a/go/sync2/fake_consolidator.go
+++ b/go/sync2/fake_consolidator.go
@@ -109,8 +109,9 @@ func (fr *FakePendingResult) SetResult(result *sqltypes.Result) {
 }
 
 // Wait records the Wait call for later verification.
-func (fr *FakePendingResult) Wait() {
+func (fr *FakePendingResult) Wait(ctx context.Context) error {
 	fr.WaitCalls++
+	return nil
 }
 
 // AddWaiterCounter is currently a no-op.


### PR DESCRIPTION
## Description

This pull request updates the `PendingResult.Wait()` method in the query consolidator to support `context.Context`, allowing waiting goroutines to respect cancellation or timeout.

Previously, if the original query being consolidated did not return (e.g. due to a hang or mismanaged timeout), duplicate queries would block indefinitely on `sync.RWMutex.RLock()`. This led to goroutine buildup, memory pressure, and excessive GC cycles, as reported in [Issue #18272](https://github.com/vitessio/vitess/issues/18272).

### What this PR changes:
- Updated the `PendingResult` interface in `consolidator.go` to change `Wait()` → `Wait(ctx context.Context) error`
- Wrapped the `.RLock()` call in a goroutine, and used a `select` to allow returning early if the context is done
- Safely releases the lock if the context is cancelled before `.RLock()` is acquired
- Updated the `FakePendingResult` mock in `fake_consolidator.go` to match the new method signature

This is a safe and minimal fix that improves consolidator robustness and prevents goroutine leaks in edge cases.

## Related Issue(s)

- Fixes [#18272](https://github.com/vitessio/vitess/issues/18272)

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description *(not required in this case)*
- [x] Tests were added or are not required *(interface is not currently called externally; mock updated)*
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required *(this is an internal concurrency fix)*

## Deployment Notes

No deployment action required. This change affects internal consolidator logic and interface only.

