### PR TITLE
Set up better dependency checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,60 @@ linters:
           deny:
             - pkg: math/rand$
               desc: Please use math/rand/v2
+        mysql_package_restrictions:
+          list-mode: lax
+          files:
+            - "**/go/mysql/**"
+            - "!**/go/mysql/collations/integration/**"
+            - "!**/go/mysql/collations/tools/**"
+          deny:
+            - pkg: vitess.io/vitess/go/vt/servenv
+              desc: "mysql package should not depend on servenv - this component should be usable as a library without server infrastructure dependencies"
+            - pkg: github.com/spf13/pflag
+              desc: "mysql package should not depend on pflag - this component should be usable as a library with explicit configuration, not global flags"
+            - pkg: vitess.io/vitess/go/vt/dbconfigs
+              desc: "mysql package should not depend on dbconfigs - creates servenv dependency"
+        sqlparser_package_restrictions:
+          list-mode: lax
+          files:
+            - "**/go/vt/sqlparser/**"
+            - "!**/go/vt/sqlparser/goyacc/**"
+          deny:
+            - pkg: github.com/spf13/pflag
+              desc: "sqlparser package should not depend on pflag except in goyacc subpackage - this component should be usable as a library with explicit configuration, not global flags"
+            - pkg: vitess.io/vitess/go/vt/servenv
+              desc: "sqlparser should not depend on servenv - this component should be usable as a library without server infrastructure dependencies"
+        schemadiff_package_restrictions:
+          list-mode: lax
+          files:
+            - "**/go/vt/schemadiff/**"
+          deny:
+            - pkg: github.com/spf13/pflag
+              desc: "schemadiff package should not depend on pflag - this component should be usable as a library with explicit configuration, not global flags"
+            - pkg: vitess.io/vitess/go/vt/servenv
+              desc: "schemadiff should not depend on servenv - this component should be usable as a library without server infrastructure dependencies"
+        collations_package_restrictions:
+          list-mode: lax
+          files:
+            - "**/go/mysql/collations/**"
+            - "!**/go/mysql/collations/integration/**"
+            - "!**/go/mysql/collations/tools/**"
+          deny:
+            - pkg: vitess.io/vitess/go/vt/servenv
+              desc: "collations package should not depend on servenv - this component should be usable as a library without server infrastructure dependencies"
+            - pkg: github.com/spf13/pflag
+              desc: "collations package should not depend on pflag - this component should be usable as a library with explicit configuration, not global flags"
+        vindexes_package_restrictions:
+          list-mode: lax
+          files:
+            - "**/go/vt/vtgate/vindexes/**"
+          deny:
+            - pkg: vitess.io/vitess/go/vt/topotools
+              desc: "vindexes package should not depend on topotools - creates unnecessary dependency tree"
+            - pkg: github.com/spf13/pflag
+              desc: "vindexes package should not depend on pflag - this component should be usable as a library with explicit configuration, not global flags"
+            - pkg: vitess.io/vitess/go/vt/servenv
+              desc: "vindexes should not depend on servenv - this component should be usable as a library without server infrastructure dependencies"
     errcheck:
       exclude-functions:
         - flag.Set

--- a/go/cmd/vtgate/cli/plugin_auth_clientcert.go
+++ b/go/cmd/vtgate/cli/plugin_auth_clientcert.go
@@ -28,5 +28,7 @@ var clientcertAuthMethod string
 func init() {
 	Main.Flags().StringVar(&clientcertAuthMethod, "mysql_clientcert_auth_method", string(mysql.MysqlClearPassword), "client-side authentication method to use. Supported values: mysql_clear_password, dialog.")
 
-	vtgate.RegisterPluginInitializer(func() { mysql.InitAuthServerClientCert(clientcertAuthMethod) })
+	vtgate.RegisterPluginInitializer(func() {
+		mysql.InitAuthServerClientCert(clientcertAuthMethod, vtgate.GetMysqlServerSSLCA())
+	})
 }

--- a/go/mysql/auth_server_clientcert.go
+++ b/go/mysql/auth_server_clientcert.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/spf13/pflag"
-
 	"vitess.io/vitess/go/vt/log"
 )
 
@@ -32,12 +30,7 @@ type AuthServerClientCert struct {
 }
 
 // InitAuthServerClientCert is public so it can be called from plugin_auth_clientcert.go (go/cmd/vtgate)
-func InitAuthServerClientCert(clientcertAuthMethod string) {
-	caValue := pflag.CommandLine.Lookup("mysql-server-ssl-ca").Value.String()
-	//TODO: This block can be removed in v25 when "mysql_server_ssl_ca" will be deprecated.
-	if caValue == "" {
-		caValue = pflag.CommandLine.Lookup("mysql_server_ssl_ca").Value.String()
-	}
+func InitAuthServerClientCert(clientcertAuthMethod string, caValue string) {
 	if caValue == "" {
 		log.Info("Not configuring AuthServerClientCert because mysql-server-ssl-ca is empty")
 		return

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -809,6 +809,11 @@ func mysqlSocketPath() string {
 	return mysqlServerSocketPath
 }
 
+// GetMysqlServerSSLCA returns the current value of the mysql-server-ssl-ca flag
+func GetMysqlServerSSLCA() string {
+	return mysqlSslCa
+}
+
 func init() {
 	servenv.OnParseFor("vtgate", registerPluginFlags)
 	servenv.OnParseFor("vtcombo", registerPluginFlags)


### PR DESCRIPTION
In order to avoid future regressions around some key areas used as libraries, let's make sure we have some depguard checks in place that block some regularly occuring cases.

This is not green until we merge the regression from v22 in #18507 

It also fixes one violation which is not as problematic as #18507 and has existed for longer already, so it's ok to only fix that on `main` moving forward. 

## Related Issue(s)

Part of fixing #18506 and important for #14717 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
