### PR TITLE
discovery: clarify use of TabletFilter in NewHealthCheck

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -359,9 +359,10 @@ func NewVTGateHealthCheckFilters() (filters TabletFilters, err error) {
 //
 // filters.
 //
-//	Is one or more filters to apply when determining what tablets we want to stream healthchecks from.
+//	Is an optional filter (implementing the TabletFilter interface) to apply when determining
+//	what tablets we want to stream healthchecks from. If nil, no filtering is performed.
 func NewHealthCheck(
-	ctx context.Context, retryDelay, healthCheckTimeout time.Duration, topoServer *topo.Server, localCell, cellsToWatch string, filters TabletFilter, opts ...Option,
+	ctx context.Context, retryDelay, healthCheckTimeout time.Duration, topoServer *topo.Server, localCell, cellsToWatch string, filter TabletFilter, opts ...Option,
 ) *HealthCheckImpl {
 	hc := &HealthCheckImpl{
 		ts:                 topoServer,
@@ -390,7 +391,7 @@ func NewHealthCheck(
 		if c == "" {
 			continue
 		}
-		topoWatchers = append(topoWatchers, NewTopologyWatcher(ctx, topoServer, hc, filters, c, refreshInterval, refreshKnownTablets, opts...))
+		topoWatchers = append(topoWatchers, NewTopologyWatcher(ctx, topoServer, hc, filter, c, refreshInterval, refreshKnownTablets, opts...))
 	}
 
 	hc.topoWatchers = topoWatchers

--- a/go/vt/discovery/topology_watcher.go
+++ b/go/vt/discovery/topology_watcher.go
@@ -92,12 +92,12 @@ type TopologyWatcher struct {
 // NewTopologyWatcher returns a TopologyWatcher that monitors all
 // the tablets in a cell, and reloads them as needed.
 func NewTopologyWatcher(
-	ctx context.Context, topoServer *topo.Server, hc HealthCheck, f TabletFilter, cell string, refreshInterval time.Duration, refreshKnownTablets bool, opts ...Option,
+	ctx context.Context, topoServer *topo.Server, hc HealthCheck, filter TabletFilter, cell string, refreshInterval time.Duration, refreshKnownTablets bool, opts ...Option,
 ) *TopologyWatcher {
 	tw := &TopologyWatcher{
 		topoServer:          topoServer,
 		healthcheck:         hc,
-		tabletFilter:        f,
+		tabletFilter:        filter,
 		cell:                cell,
 		refreshInterval:     refreshInterval,
 		refreshKnownTablets: refreshKnownTablets,


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

While updating calling code that uses this function, I noticed that the TabletFilter argument is implied to both be a slice and a required argument with one or more values.

Since TabletFilter is an interface but the TabletFilters slice type implements that interface, I believe the confusion stems from there.

Document that passing a type implementing TabletFilter is entirely optional given that all internal callers also guard against nil with a nil check. Rename the argument to the singular version to reinforce the notion that it is an interface type.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

n/a, documentation and tidying.

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
