### PR TITLE
Add support for querylog-time-threshold duration flag for query logging

### DIFF
--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -272,6 +272,7 @@ Flags:
       --querylog-mode string                                             Mode for logging queries. "error" will only log queries that return an error. Otherwise all queries will be logged. (default "all")
       --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
       --querylog-sample-rate float                                       Sample rate for logging queries. Value must be between 0.0 (no logging) and 1.0 (all queries)
+      --querylog-time-threshold duration                                 Execution time duration a query needs to run over before being logged; time duration expressed in the form recognized by time.ParseDuration; not useful for streaming queries.
       --queryserver-config-acl-exempt-acl string                         an acl that exempt from table acl checking (this acl is free to access any vitess tables).
       --queryserver-config-annotate-queries                              prefix queries to MySQL backend with comment indicating vtgate principal (user) and target tablet type
       --queryserver-config-enable-table-acl-dry-run                      If this flag is enabled, tabletserver will emit monitoring metrics and let the request pass regardless of table acl check results

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -181,6 +181,7 @@ Flags:
       --querylog-mode string                                             Mode for logging queries. "error" will only log queries that return an error. Otherwise all queries will be logged. (default "all")
       --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
       --querylog-sample-rate float                                       Sample rate for logging queries. Value must be between 0.0 (no logging) and 1.0 (all queries)
+      --querylog-time-threshold duration                                 Execution time duration a query needs to run over before being logged; time duration expressed in the form recognized by time.ParseDuration; not useful for streaming queries.
       --redact-debug-ui-queries                                          redact full queries and bind variables from debug UI
       --remote-operation-timeout duration                                time to wait for a remote operation (default 15s)
       --retry-count int                                                  retry count (default 2)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -264,6 +264,7 @@ Flags:
       --querylog-mode string                                             Mode for logging queries. "error" will only log queries that return an error. Otherwise all queries will be logged. (default "all")
       --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
       --querylog-sample-rate float                                       Sample rate for logging queries. Value must be between 0.0 (no logging) and 1.0 (all queries)
+      --querylog-time-threshold duration                                 Execution time duration a query needs to run over before being logged; time duration expressed in the form recognized by time.ParseDuration; not useful for streaming queries.
       --queryserver-config-acl-exempt-acl string                         an acl that exempt from table acl checking (this acl is free to access any vitess tables).
       --queryserver-config-annotate-queries                              prefix queries to MySQL backend with comment indicating vtgate principal (user) and target tablet type
       --queryserver-config-enable-table-acl-dry-run                      If this flag is enabled, tabletserver will emit monitoring metrics and let the request pass regardless of table acl check results

--- a/go/streamlog/streamlog_test.go
+++ b/go/streamlog/streamlog_test.go
@@ -281,69 +281,105 @@ func TestShouldSampleQuery(t *testing.T) {
 
 func TestShouldEmitLog(t *testing.T) {
 	tests := []struct {
-		sql              string
-		qLogFilterTag    string
-		qLogRowThreshold uint64
-		qLogSampleRate   float64
-		qLogMode         string
-		rowsAffected     uint64
-		rowsReturned     uint64
-		errored          bool
-		ok               bool
+		sql               string
+		qLogFilterTag     string
+		qLogRowThreshold  uint64
+		qLogTimeThreshold time.Duration
+		qLogSampleRate    float64
+		qLogMode          string
+		rowsAffected      uint64
+		rowsReturned      uint64
+		totalTime         time.Duration
+		errored           bool
+		ok                bool
 	}{
 		{
-			sql:              "queryLogThreshold smaller than affected and returned",
-			qLogFilterTag:    "",
-			qLogRowThreshold: 2,
-			qLogSampleRate:   0.0,
-			rowsAffected:     7,
-			rowsReturned:     7,
-			ok:               true,
+			sql:               "queryLogRowThreshold smaller than affected and returned",
+			qLogFilterTag:     "",
+			qLogRowThreshold:  2,
+			qLogTimeThreshold: 0,
+			qLogSampleRate:    0.0,
+			rowsAffected:      7,
+			rowsReturned:      7,
+			totalTime:         1000,
+			ok:                true,
 		},
 		{
-			sql:              "queryLogThreshold greater than affected and returned",
-			qLogFilterTag:    "",
-			qLogRowThreshold: 27,
-			qLogSampleRate:   0.0,
-			rowsAffected:     7,
-			rowsReturned:     17,
-			ok:               false,
+			sql:               "queryLogRowThreshold greater than affected and returned",
+			qLogFilterTag:     "",
+			qLogRowThreshold:  27,
+			qLogTimeThreshold: 0,
+			qLogSampleRate:    0.0,
+			rowsAffected:      7,
+			rowsReturned:      17,
+			totalTime:         1000,
+			ok:                false,
 		},
 		{
-			sql:              "this doesn't contains queryFilterTag: TAG",
-			qLogFilterTag:    "special tag",
-			qLogRowThreshold: 10,
-			qLogSampleRate:   0.0,
-			rowsAffected:     7,
-			rowsReturned:     17,
-			ok:               false,
+			sql:               "queryLogTimeThreshold smaller than total time and returned",
+			qLogFilterTag:     "",
+			qLogRowThreshold:  0,
+			qLogTimeThreshold: 10,
+			qLogSampleRate:    0.0,
+			rowsAffected:      7,
+			rowsReturned:      7,
+			totalTime:         1000,
+			ok:                true,
 		},
 		{
-			sql:              "this contains queryFilterTag: TAG",
-			qLogFilterTag:    "TAG",
-			qLogRowThreshold: 0,
-			qLogSampleRate:   0.0,
-			rowsAffected:     7,
-			rowsReturned:     17,
-			ok:               true,
+			sql:               "queryLogTimeThreshold greater than total time and returned",
+			qLogFilterTag:     "",
+			qLogRowThreshold:  0,
+			qLogTimeThreshold: 10000,
+			qLogSampleRate:    0.0,
+			rowsAffected:      7,
+			rowsReturned:      17,
+			totalTime:         1000,
+			ok:                false,
 		},
 		{
-			sql:              "this contains querySampleRate: 1.0",
-			qLogFilterTag:    "",
-			qLogRowThreshold: 0,
-			qLogSampleRate:   1.0,
-			rowsAffected:     7,
-			rowsReturned:     17,
-			ok:               true,
+			sql:               "this doesn't contains queryFilterTag: TAG",
+			qLogFilterTag:     "special tag",
+			qLogRowThreshold:  10,
+			qLogTimeThreshold: 0,
+			qLogSampleRate:    0.0,
+			rowsAffected:      7,
+			rowsReturned:      17,
+			totalTime:         1000,
+			ok:                false,
 		},
 		{
-			sql:              "this contains querySampleRate: 1.0 without expected queryFilterTag",
-			qLogFilterTag:    "TAG",
-			qLogRowThreshold: 0,
-			qLogSampleRate:   1.0,
-			rowsAffected:     7,
-			rowsReturned:     17,
-			ok:               true,
+			sql:               "this contains queryFilterTag: TAG",
+			qLogFilterTag:     "TAG",
+			qLogRowThreshold:  0,
+			qLogTimeThreshold: 0,
+			qLogSampleRate:    0.0,
+			rowsAffected:      7,
+			rowsReturned:      17,
+			totalTime:         1000,
+			ok:                true,
+		},
+		{
+			sql:               "this contains querySampleRate: 1.0",
+			qLogFilterTag:     "",
+			qLogRowThreshold:  0,
+			qLogTimeThreshold: 0,
+			qLogSampleRate:    1.0,
+			rowsAffected:      7,
+			rowsReturned:      17,
+			totalTime:         1000,
+			ok:                true,
+		},
+		{
+			sql:               "this contains querySampleRate: 1.0 without expected queryFilterTag",
+			qLogFilterTag:     "TAG",
+			qLogRowThreshold:  0,
+			qLogTimeThreshold: 0,
+			qLogSampleRate:    1.0,
+			rowsAffected:      7,
+			rowsReturned:      17,
+			totalTime:         1000,
+			ok:                true,
 		},
 		{
 			sql:      "log only error - no error",
@@ -362,12 +398,13 @@ func TestShouldEmitLog(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.sql, func(t *testing.T) {
 			qlConfig := QueryLogConfig{
-				FilterTag:    tt.qLogFilterTag,
-				RowThreshold: tt.qLogRowThreshold,
-				sampleRate:   tt.qLogSampleRate,
-				Mode:         tt.qLogMode,
+				FilterTag:     tt.qLogFilterTag,
+				RowThreshold:  tt.qLogRowThreshold,
+				TimeThreshold: tt.qLogTimeThreshold,
+				sampleRate:    tt.qLogSampleRate,
+				Mode:          tt.qLogMode,
 			}
-			require.Equal(t, tt.ok, qlConfig.ShouldEmitLog(tt.sql, tt.rowsAffected, tt.rowsReturned, tt.errored))
+			require.Equal(t, tt.ok, qlConfig.ShouldEmitLog(tt.sql, tt.rowsAffected, tt.rowsReturned, tt.totalTime, tt.errored))
 		})
 	}
 }

--- a/go/vt/vtgate/logstats/logstats.go
+++ b/go/vt/vtgate/logstats/logstats.go
@@ -133,7 +133,7 @@ func (stats *LogStats) MirrorTargetErrorStr() string {
 // Logf formats the log record to the given writer, either as
 // tab-separated list of logged fields or as JSON.
 func (stats *LogStats) Logf(w io.Writer, params url.Values) error {
-	if !stats.Config.ShouldEmitLog(stats.SQL, stats.RowsAffected, stats.RowsReturned, stats.Error != nil) {
+	if !stats.Config.ShouldEmitLog(stats.SQL, stats.RowsAffected, stats.RowsReturned, stats.TotalTime(), stats.Error != nil) {
 		return nil
 	}
 

--- a/go/vt/vtgate/logstats/logstats_test.go
+++ b/go/vt/vtgate/logstats/logstats_test.go
@@ -185,6 +185,28 @@ func TestLogStatsRowThreshold(t *testing.T) {
 	assert.Empty(t, got)
 }
 
+func TestLogStatsTimeThreshold(t *testing.T) {
+	logStats := NewLogStats(context.Background(), "test", "sql1 /* LOG_THIS_QUERY */", "",
+		map[string]*querypb.BindVariable{"intVal": sqltypes.Int64BindVariable(1)}, streamlog.NewQueryLogConfigForTest())
+	// Query total time is 1 second and 1234 nanosecond
+	logStats.StartTime = time.Date(2017, time.January, 1, 1, 2, 3, 0, time.UTC)
+	logStats.EndTime = time.Date(2017, time.January, 1, 1, 2, 4, 1234, time.UTC)
+	params := map[string][]string{"full": {}}
+
+	got := testFormat(t, logStats, params)
+	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t\"\"\t0.000000\t0.000000\t\"\"\n"
+	assert.Equal(t, want, got)
+
+	got = testFormat(t, logStats, params)
+	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t\"\"\t0.000000\t0.000000\t\"\"\n"
+	assert.Equal(t, want, got)
+
+	// Set Query threshold more than query duration: 1 second and 1234 nanosecond
+	logStats.Config.TimeThreshold = 2 * 1024 * 1024 * 1024
+	got = testFormat(t, logStats, params)
+	assert.Empty(t, got)
+}
+
 func TestLogStatsContextHTML(t *testing.T) {
 	html := "HtmlContext"
 	callInfo := &fakecallinfo.FakeCallInfo{

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats.go
@@ -180,7 +180,7 @@ func (stats *LogStats) CallInfo() (string, string) {
 // Logf formats the log record to the given writer, either as
 // tab-separated list of logged fields or as JSON.
 func (stats *LogStats) Logf(w io.Writer, params url.Values) error {
-	if !stats.Config.ShouldEmitLog(stats.OriginalSQL, uint64(stats.RowsAffected), uint64(len(stats.Rows)), stats.Error != nil) {
+	if !stats.Config.ShouldEmitLog(stats.OriginalSQL, uint64(stats.RowsAffected), uint64(len(stats.Rows)), stats.TotalTime(), stats.Error != nil) {
 		return nil
 	}
 


### PR DESCRIPTION
## Description

    Currently vtgate/vttable query log supports flag --querylog-row-threshold uint to emit query log when the row count is over a threshold. This PR adds the flag --querylog-time-threshold time.duration to emit query log when the query execution time over the time threshold.
    
    On MySQL side, we have slow-query-log which emits slow query based on either execution time or affected rows, it would be good vtgate/tablet can issue the query log using the same criteria so we can correlate the log from both vitess and mysql sides.
    
    The implementation pretty much followed the code path for querylog-row-threshold, the new flag querylog-time-threshold takes in a duration argument.  The duration can be expressed in a form recognized by time.ParseDuration (e.g. 300ms, 100ns).

    Unit tests are added to cover the new querylog-time-threshold

    The fix can be back ported to releases v21 and v22 since those releases have the same issue and can be benefited from the same fix, the back port should be straightforward.

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/18456

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None