### PR TITLE
Add pool generation numbers to allow a pool to be closed instantly.

### DIFF
--- a/go/pools/smartconnpool/connection.go
+++ b/go/pools/smartconnpool/connection.go
@@ -36,6 +36,8 @@ type Pooled[C Connection] struct {
 	timeUsed    timestamp
 	pool        *ConnPool[C]
 
+	generation int64 // generation of the pool when this connection was created
+
 	Conn C
 }
 
@@ -48,9 +50,9 @@ func (dbc *Pooled[C]) Recycle() {
 	case dbc.pool == nil:
 		dbc.Conn.Close()
 	case dbc.Conn.IsClosed():
-		dbc.pool.put(nil)
+		dbc.pool.put(nil, dbc.generation)
 	default:
-		dbc.pool.put(dbc)
+		dbc.pool.put(dbc, dbc.generation)
 	}
 }
 
@@ -58,6 +60,6 @@ func (dbc *Pooled[C]) Taint() {
 	if dbc.pool == nil {
 		return
 	}
-	dbc.pool.put(nil)
+	dbc.pool.put(nil, dbc.generation)
 	dbc.pool = nil
 }

--- a/go/pools/smartconnpool/waitlist.go
+++ b/go/pools/smartconnpool/waitlist.go
@@ -153,6 +153,11 @@ func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
 		return false
 	}
 
+	// if the pool's generation has changed, it means that the pool has been closed.
+	if conn.generation != conn.pool.generation.Load() {
+		return false
+	}
+
 	// if we have a target to return the connection to, simply write the connection
 	// into the waiter and signal their semaphore. they'll wake up to pick up the
 	// connection.


### PR DESCRIPTION
## Description

Every connection that is opened by the pool is tracked with the pool's generation number. This number is incremented whenever a pool is closed and allows us to close the pool immediately when `.Close()` is called.

* For connections that are idle, we close them directly when lowering the capacity.
* For connections that are returned to the pool, we check whether the generation numbers match and if they don't, we close the returned connection directly.

Effectively, this means connections are unlinked from the pool once `.Close()` is called, allowing `.Close()` to be non-blocking when connections are still in use.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
