### PR TITLE
Replace the pool when reopening.

### DIFF
--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -311,7 +311,7 @@ func (pool *ConnPool[C]) CloseWithContext(ctx context.Context) error {
 	// wait for connections to be returned to the pool if we're reducing the capacity.
 	defer pool.setIdleCount()
 
-	// close connections until we're under capacity
+	// Close idle connections currently in the stack
 	for {
 		// make sure there's no clients waiting for connections because they won't be returned in the future
 		pool.wait.expire(true)

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -328,10 +328,6 @@ func (pool *ConnPool[C]) CloseWithContext(ctx context.Context) error {
 		pool.closedConn()
 	}
 
-	if pool.active.Load() == 0 {
-		close(pool.close)
-	}
-
 	return nil
 }
 

--- a/go/vt/dbconnpool/connection_pool.go
+++ b/go/vt/dbconnpool/connection_pool.go
@@ -93,7 +93,9 @@ func (cp *ConnectionPool) Open(info dbconfigs.Connector) {
 	}
 
 	cp.ConnPool.Open(connect, refresh)
-	cp.statsExporter.SetPool(cp.ConnPool)
+	if cp.statsExporter != nil {
+		cp.statsExporter.SetPool(cp.ConnPool)
+	}
 }
 
 func (cp *ConnectionPool) Close() {

--- a/go/vt/dbconnpool/connection_pool.go
+++ b/go/vt/dbconnpool/connection_pool.go
@@ -72,7 +72,6 @@ func NewConnectionPool(name string, stats *servenv.Exporter, capacity int, idleT
 
 	cp.statsExporter = smartconnpool.NewStatsExporter[*DBConnection](stats, name)
 
-	//	cp.connPool.Load().RegisterStats(stats, name)
 	return cp
 }
 

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"net"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"vitess.io/vitess/go/netutil"
@@ -48,7 +49,7 @@ type PooledConn = smartconnpool.Pooled[*Conn]
 // Other than the connection type, ConnPool maintains an additional
 // pool of dba connections that are used to kill connections.
 type Pool struct {
-	*smartconnpool.ConnPool[*Conn]
+	connPool atomic.Pointer[smartconnpool.ConnPool[*Conn]]
 
 	config        smartconnpool.Config[*Conn]
 	statsExporter *smartconnpool.StatsExporter[*Conn]
@@ -88,7 +89,7 @@ func NewPool(env tabletenv.Env, name string, cfg tabletenv.ConnPoolConfig) *Pool
 
 	cp.config = config
 
-	cp.ConnPool = smartconnpool.NewPool(&config)
+	cp.connPool.Store(smartconnpool.NewPool(&config))
 	cp.statsExporter = smartconnpool.NewStatsExporter[*Conn](env.Exporter(), name)
 
 	cp.dbaPool = dbconnpool.NewConnectionPool("", env.Exporter(), 1, config.IdleTimeout, config.MaxLifetime, 0)
@@ -109,8 +110,9 @@ func (cp *Pool) Open(appParams, dbaParams, appDebugParams dbconfigs.Connector) {
 		return newPooledConn(ctx, cp, appParams)
 	}
 
-	cp.ConnPool.Open(connect, refresh)
-	cp.statsExporter.SetPool(cp.ConnPool)
+	pool := cp.connPool.Load()
+	pool.Open(connect, refresh)
+	cp.statsExporter.SetPool(pool)
 
 	cp.dbaPool.Open(dbaParams)
 }
@@ -118,8 +120,9 @@ func (cp *Pool) Open(appParams, dbaParams, appDebugParams dbconfigs.Connector) {
 // Close will close the pool and wait for connections to be returned before
 // exiting.
 func (cp *Pool) Close() {
-	cp.ConnPool.Close()
-	cp.ConnPool = smartconnpool.NewPool(&cp.config)
+	pool := cp.connPool.Load()
+	pool.Close()
+	cp.connPool.Store(smartconnpool.NewPool(&cp.config))
 
 	cp.dbaPool.Close()
 }
@@ -137,10 +140,11 @@ func (cp *Pool) Get(ctx context.Context, setting *smartconnpool.Setting) (*Poole
 		}
 		return &smartconnpool.Pooled[*Conn]{Conn: conn}, nil
 	}
-	span.Annotate("capacity", cp.Capacity())
-	span.Annotate("in_use", cp.InUse())
-	span.Annotate("available", cp.Available())
-	span.Annotate("active", cp.Active())
+	pool := cp.connPool.Load()
+	span.Annotate("capacity", pool.Capacity())
+	span.Annotate("in_use", pool.InUse())
+	span.Annotate("available", pool.Available())
+	span.Annotate("active", pool.Active())
 
 	if cp.timeout != 0 {
 		var cancel context.CancelFunc
@@ -149,7 +153,7 @@ func (cp *Pool) Get(ctx context.Context, setting *smartconnpool.Setting) (*Poole
 	}
 
 	start := time.Now()
-	conn, err := cp.ConnPool.Get(ctx, setting)
+	conn, err := pool.Get(ctx, setting)
 	if err != nil {
 		return nil, err
 	}
@@ -165,20 +169,67 @@ func (cp *Pool) Get(ctx context.Context, setting *smartconnpool.Setting) (*Poole
 
 // SetIdleTimeout sets the idleTimeout on the pool.
 func (cp *Pool) SetIdleTimeout(idleTimeout time.Duration) {
-	cp.ConnPool.SetIdleTimeout(idleTimeout)
+	pool := cp.connPool.Load()
+	pool.SetIdleTimeout(idleTimeout)
 	cp.dbaPool.SetIdleTimeout(idleTimeout)
 }
 
 // StatsJSON returns the pool stats as a JSON object.
 func (cp *Pool) StatsJSON() string {
-	if !cp.ConnPool.IsOpen() {
+	pool := cp.connPool.Load()
+	if !pool.IsOpen() {
 		return "{}"
 	}
 
 	var buf strings.Builder
 	enc := json.NewEncoder(&buf)
-	_ = enc.Encode(cp.ConnPool.StatsJSON())
+	_ = enc.Encode(pool.StatsJSON())
 	return buf.String()
+}
+
+func (cp *Pool) Capacity() int64 {
+	pool := cp.connPool.Load()
+	return pool.Capacity()
+}
+
+func (cp *Pool) SetCapacity(ctx context.Context, newcap int64) error {
+	pool := cp.connPool.Load()
+	return pool.SetCapacity(ctx, newcap)
+}
+
+func (cp *Pool) Available() int64 {
+	pool := cp.connPool.Load()
+	return pool.Available()
+}
+
+func (cp *Pool) Active() int64 {
+	pool := cp.connPool.Load()
+	return pool.Active()
+}
+
+func (cp *Pool) InUse() int64 {
+	pool := cp.connPool.Load()
+	return pool.InUse()
+}
+
+func (cp *Pool) IdleCount() int64 {
+	pool := cp.connPool.Load()
+	return pool.IdleCount()
+}
+
+func (cp *Pool) IdleTimeout() time.Duration {
+	pool := cp.connPool.Load()
+	return pool.IdleTimeout()
+}
+
+func (cp *Pool) IsOpen() bool {
+	pool := cp.connPool.Load()
+	return pool.IsOpen()
+}
+
+func (cp *Pool) Metrics() *smartconnpool.Metrics {
+	pool := cp.connPool.Load()
+	return &pool.Metrics
 }
 
 func (cp *Pool) isCallerIDAppDebug(ctx context.Context) bool {

--- a/go/vt/vttablet/tabletserver/connpool/pool_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool_test.go
@@ -163,15 +163,15 @@ func TestConnPoolMaxIdleCount(t *testing.T) {
 
 	// after recycle - 1 idle connection
 	conns[0].Recycle()
-	assert.Zero(t, connPool.Metrics.IdleClosed(), "pool idle closed should be 0")
+	assert.Zero(t, connPool.Metrics().IdleClosed(), "pool idle closed should be 0")
 
 	// after recycle - 2 idle connection
 	conns[1].Recycle()
-	assert.Zero(t, connPool.Metrics.IdleClosed(), "pool idle closed should be 0")
+	assert.Zero(t, connPool.Metrics().IdleClosed(), "pool idle closed should be 0")
 
 	// after recycle - 3 idle connection, 1 will be closed
 	conns[2].Recycle()
-	assert.EqualValues(t, 1, connPool.Metrics.IdleClosed(), "pool idle closed should be 1")
+	assert.EqualValues(t, 1, connPool.Metrics().IdleClosed(), "pool idle closed should be 1")
 
 	// changing the pool capacity will affect the idle count allowed for that pool.
 	// If setting the capacity to lower value than max idle count.
@@ -218,8 +218,8 @@ func TestConnPoolStateWhilePoolIsOpen(t *testing.T) {
 	connPool.Open(params, params, params)
 	defer connPool.Close()
 	assert.EqualValues(t, 100, connPool.Capacity(), "pool capacity should be 100")
-	assert.EqualValues(t, 0, connPool.Metrics.WaitTime(), "pool wait time should be 0")
-	assert.EqualValues(t, 0, connPool.Metrics.WaitCount(), "pool wait count should be 0")
+	assert.EqualValues(t, 0, connPool.Metrics().WaitTime(), "pool wait time should be 0")
+	assert.EqualValues(t, 0, connPool.Metrics().WaitCount(), "pool wait count should be 0")
 	assert.EqualValues(t, idleTimeout, connPool.IdleTimeout(), "pool idle timeout should be 0")
 	assert.EqualValues(t, 100, connPool.Available(), "pool available connections should be 100")
 	assert.EqualValues(t, 0, connPool.Active(), "pool active connections should be 0")
@@ -247,29 +247,29 @@ func TestConnPoolStateWithSettings(t *testing.T) {
 	assert.EqualValues(t, 5, connPool.Available(), "pool available connections should be 5")
 	assert.EqualValues(t, 0, connPool.Active(), "pool active connections should be 0")
 	assert.EqualValues(t, 0, connPool.InUse(), "pool inUse connections should be 0")
-	assert.EqualValues(t, 0, connPool.Metrics.GetCount(), "pool get count should be 0")
-	assert.EqualValues(t, 0, connPool.Metrics.GetSettingCount(), "pool get with settings should be 0")
-	assert.EqualValues(t, 0, connPool.Metrics.DiffSettingCount(), "pool different settings count should be 0")
-	assert.EqualValues(t, 0, connPool.Metrics.ResetSettingCount(), "pool reset settings count should be 0")
+	assert.EqualValues(t, 0, connPool.Metrics().GetCount(), "pool get count should be 0")
+	assert.EqualValues(t, 0, connPool.Metrics().GetSettingCount(), "pool get with settings should be 0")
+	assert.EqualValues(t, 0, connPool.Metrics().DiffSettingCount(), "pool different settings count should be 0")
+	assert.EqualValues(t, 0, connPool.Metrics().ResetSettingCount(), "pool reset settings count should be 0")
 
 	dbConn, err := connPool.Get(context.Background(), nil)
 	require.NoError(t, err)
 	assert.EqualValues(t, 4, connPool.Available(), "pool available connections should be 4")
 	assert.EqualValues(t, 1, connPool.Active(), "pool active connections should be 1")
 	assert.EqualValues(t, 1, connPool.InUse(), "pool inUse connections should be 1")
-	assert.EqualValues(t, 1, connPool.Metrics.GetCount(), "pool get count should be 1")
-	assert.EqualValues(t, 0, connPool.Metrics.GetSettingCount(), "pool get with settings should be 0")
-	assert.EqualValues(t, 0, connPool.Metrics.DiffSettingCount(), "pool different settings count should be 0")
-	assert.EqualValues(t, 0, connPool.Metrics.ResetSettingCount(), "pool reset settings count should be 0")
+	assert.EqualValues(t, 1, connPool.Metrics().GetCount(), "pool get count should be 1")
+	assert.EqualValues(t, 0, connPool.Metrics().GetSettingCount(), "pool get with settings should be 0")
+	assert.EqualValues(t, 0, connPool.Metrics().DiffSettingCount(), "pool different settings count should be 0")
+	assert.EqualValues(t, 0, connPool.Metrics().ResetSettingCount(), "pool reset settings count should be 0")
 
 	dbConn.Recycle()
 	assert.EqualValues(t, 5, connPool.Available(), "pool available connections should be 5")
 	assert.EqualValues(t, 1, connPool.Active(), "pool active connections should be 1")
 	assert.EqualValues(t, 0, connPool.InUse(), "pool inUse connections should be 0")
-	assert.EqualValues(t, 1, connPool.Metrics.GetCount(), "pool get count should be 0")
-	assert.EqualValues(t, 0, connPool.Metrics.GetSettingCount(), "pool get with settings should be 0")
-	assert.EqualValues(t, 0, connPool.Metrics.DiffSettingCount(), "pool different settings count should be 0")
-	assert.EqualValues(t, 0, connPool.Metrics.ResetSettingCount(), "pool reset settings count should be 0")
+	assert.EqualValues(t, 1, connPool.Metrics().GetCount(), "pool get count should be 0")
+	assert.EqualValues(t, 0, connPool.Metrics().GetSettingCount(), "pool get with settings should be 0")
+	assert.EqualValues(t, 0, connPool.Metrics().DiffSettingCount(), "pool different settings count should be 0")
+	assert.EqualValues(t, 0, connPool.Metrics().ResetSettingCount(), "pool reset settings count should be 0")
 
 	db.AddQuery("a", &sqltypes.Result{})
 	sa := smartconnpool.NewSetting("a", "")
@@ -278,19 +278,19 @@ func TestConnPoolStateWithSettings(t *testing.T) {
 	assert.EqualValues(t, 4, connPool.Available(), "pool available connections should be 4")
 	assert.EqualValues(t, 1, connPool.Active(), "pool active connections should be 1")
 	assert.EqualValues(t, 1, connPool.InUse(), "pool inUse connections should be 1")
-	assert.EqualValues(t, 1, connPool.Metrics.GetCount(), "pool get count should be 1")
-	assert.EqualValues(t, 1, connPool.Metrics.GetSettingCount(), "pool get with settings should be 1")
-	assert.EqualValues(t, 0, connPool.Metrics.DiffSettingCount(), "pool different settings count should be 0")
-	assert.EqualValues(t, 0, connPool.Metrics.ResetSettingCount(), "pool reset settings count should be 0")
+	assert.EqualValues(t, 1, connPool.Metrics().GetCount(), "pool get count should be 1")
+	assert.EqualValues(t, 1, connPool.Metrics().GetSettingCount(), "pool get with settings should be 1")
+	assert.EqualValues(t, 0, connPool.Metrics().DiffSettingCount(), "pool different settings count should be 0")
+	assert.EqualValues(t, 0, connPool.Metrics().ResetSettingCount(), "pool reset settings count should be 0")
 
 	dbConn.Recycle()
 	assert.EqualValues(t, 5, connPool.Available(), "pool available connections should be 5")
 	assert.EqualValues(t, 1, connPool.Active(), "pool active connections should be 1")
 	assert.EqualValues(t, 0, connPool.InUse(), "pool inUse connections should be 0")
-	assert.EqualValues(t, 1, connPool.Metrics.GetCount(), "pool get count should be 1")
-	assert.EqualValues(t, 1, connPool.Metrics.GetSettingCount(), "pool get with settings should be 1")
-	assert.EqualValues(t, 0, connPool.Metrics.DiffSettingCount(), "pool different settings count should be 0")
-	assert.EqualValues(t, 0, connPool.Metrics.ResetSettingCount(), "pool reset settings count should be 0")
+	assert.EqualValues(t, 1, connPool.Metrics().GetCount(), "pool get count should be 1")
+	assert.EqualValues(t, 1, connPool.Metrics().GetSettingCount(), "pool get with settings should be 1")
+	assert.EqualValues(t, 0, connPool.Metrics().DiffSettingCount(), "pool different settings count should be 0")
+	assert.EqualValues(t, 0, connPool.Metrics().ResetSettingCount(), "pool reset settings count should be 0")
 
 	// now showcasing diff and reset setting.
 	// Steps 1: acquire all connection with same setting
@@ -308,10 +308,10 @@ func TestConnPoolStateWithSettings(t *testing.T) {
 	assert.EqualValues(t, 0, connPool.Available(), "pool available connections should be 0")
 	assert.EqualValues(t, 5, connPool.Active(), "pool active connections should be 5")
 	assert.EqualValues(t, 5, connPool.InUse(), "pool inUse connections should be 5")
-	assert.EqualValues(t, 1, connPool.Metrics.GetCount(), "pool get count should be 1")
-	assert.EqualValues(t, 6, connPool.Metrics.GetSettingCount(), "pool get with settings should be 6")
-	assert.EqualValues(t, 0, connPool.Metrics.DiffSettingCount(), "pool different settings count should be 0")
-	assert.EqualValues(t, 0, connPool.Metrics.ResetSettingCount(), "pool reset settings count should be 0")
+	assert.EqualValues(t, 1, connPool.Metrics().GetCount(), "pool get count should be 1")
+	assert.EqualValues(t, 6, connPool.Metrics().GetSettingCount(), "pool get with settings should be 6")
+	assert.EqualValues(t, 0, connPool.Metrics().DiffSettingCount(), "pool different settings count should be 0")
+	assert.EqualValues(t, 0, connPool.Metrics().ResetSettingCount(), "pool reset settings count should be 0")
 
 	// Step 2
 	for _, conn := range conns {
@@ -320,10 +320,10 @@ func TestConnPoolStateWithSettings(t *testing.T) {
 	assert.EqualValues(t, 5, connPool.Available(), "pool available connections should be 5")
 	assert.EqualValues(t, 5, connPool.Active(), "pool active connections should be 5")
 	assert.EqualValues(t, 0, connPool.InUse(), "pool inUse connections should be 0")
-	assert.EqualValues(t, 1, connPool.Metrics.GetCount(), "pool get count should be 1")
-	assert.EqualValues(t, 6, connPool.Metrics.GetSettingCount(), "pool get with settings should be 6")
-	assert.EqualValues(t, 0, connPool.Metrics.DiffSettingCount(), "pool different settings count should be 0")
-	assert.EqualValues(t, 0, connPool.Metrics.ResetSettingCount(), "pool reset settings count should be 0")
+	assert.EqualValues(t, 1, connPool.Metrics().GetCount(), "pool get count should be 1")
+	assert.EqualValues(t, 6, connPool.Metrics().GetSettingCount(), "pool get with settings should be 6")
+	assert.EqualValues(t, 0, connPool.Metrics().DiffSettingCount(), "pool different settings count should be 0")
+	assert.EqualValues(t, 0, connPool.Metrics().ResetSettingCount(), "pool reset settings count should be 0")
 
 	// Step 3
 	dbConn, err = connPool.Get(context.Background(), nil)
@@ -331,10 +331,10 @@ func TestConnPoolStateWithSettings(t *testing.T) {
 	assert.EqualValues(t, 4, connPool.Available(), "pool available connections should be 4")
 	assert.EqualValues(t, 5, connPool.Active(), "pool active connections should be 5")
 	assert.EqualValues(t, 1, connPool.InUse(), "pool inUse connections should be 1")
-	assert.EqualValues(t, 2, connPool.Metrics.GetCount(), "pool get count should be 2")
-	assert.EqualValues(t, 6, connPool.Metrics.GetSettingCount(), "pool get with settings should be 6")
-	assert.EqualValues(t, 0, connPool.Metrics.DiffSettingCount(), "pool different settings count should be 0")
-	assert.EqualValues(t, 1, connPool.Metrics.ResetSettingCount(), "pool reset settings count should be 1")
+	assert.EqualValues(t, 2, connPool.Metrics().GetCount(), "pool get count should be 2")
+	assert.EqualValues(t, 6, connPool.Metrics().GetSettingCount(), "pool get with settings should be 6")
+	assert.EqualValues(t, 0, connPool.Metrics().DiffSettingCount(), "pool different settings count should be 0")
+	assert.EqualValues(t, 1, connPool.Metrics().ResetSettingCount(), "pool reset settings count should be 1")
 	dbConn.Recycle()
 
 	// Step 4
@@ -345,10 +345,10 @@ func TestConnPoolStateWithSettings(t *testing.T) {
 	assert.EqualValues(t, 4, connPool.Available(), "pool available connections should be 4")
 	assert.EqualValues(t, 5, connPool.Active(), "pool active connections should be 5")
 	assert.EqualValues(t, 1, connPool.InUse(), "pool inUse connections should be 1")
-	assert.EqualValues(t, 2, connPool.Metrics.GetCount(), "pool get count should be 2")
-	assert.EqualValues(t, 7, connPool.Metrics.GetSettingCount(), "pool get with settings should be 7")
-	assert.EqualValues(t, 0, connPool.Metrics.DiffSettingCount(), "pool different settings count should be 0")
-	assert.EqualValues(t, 1, connPool.Metrics.ResetSettingCount(), "pool reset settings count should be 1")
+	assert.EqualValues(t, 2, connPool.Metrics().GetCount(), "pool get count should be 2")
+	assert.EqualValues(t, 7, connPool.Metrics().GetSettingCount(), "pool get with settings should be 7")
+	assert.EqualValues(t, 0, connPool.Metrics().DiffSettingCount(), "pool different settings count should be 0")
+	assert.EqualValues(t, 1, connPool.Metrics().ResetSettingCount(), "pool reset settings count should be 1")
 	dbConn.Recycle()
 }
 


### PR DESCRIPTION
## Description

It's proven quite difficult to fix some shortcomings in the connection pool like the blocking `Close()` call (which is quite problematic as this call happens during `PlannedReparentShard` and makes the operation take longer than required) and race conditions around concurrent `Get()`/`put()`/`Close()` operations.

Instead, I want to pick a previous idea that we disallow reopening a pool after `Close()` has been called and replace the whole pool object.

The `Close()` function becomes non-blocking - we close any connections that have been returned to the pool before the `Close()` call was made, and return. Any in-flight connections will be closed once `Recycle()` gets called on the connection.

`SetCapacity()` probably should also be changed in a followup PR to disallow setting the capacity to 0 or lower, and to be non-blocking as well (we can just start closing connections once they get returned to the pool).

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
