### PR TITLE
docker: add trixie and rm bullseye from build matrix

### DIFF
--- a/.github/workflows/docker_build_images.yml
+++ b/.github/workflows/docker_build_images.yml
@@ -144,7 +144,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        debian: [ bullseye, bookworm ]
+        debian: [ bookworm, trixie ]
         component: [ vtadmin, vtorc, vtgate, vttablet, mysqlctld, mysqlctl, vtctl, vtctlclient, vtctld, vtctldclient, logrotate, logtail, vtbackup, vtexplain ]
 
     steps:


### PR DESCRIPTION
## Description

[Bullseye was EOL 1 year ago](https://www.debian.org/releases/), so it seems reasonable to stop doing that build. Open to keeping it if we see Docker Hub stats showing that it's active.

Trixie was just released on August 9, so it seems reasonable to start doing builds for it. This PR explicitly does not change the default debian tag to trixie, as it's worth letting it soak for a bit, and doesn't change the bootstrap builds for the same reason.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
