### PR TITLE
Online DDL: set migration's progress to 100% once it's `ready_to_complete`

### DIFF
--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -569,6 +569,7 @@ func testScheduler(t *testing.T) {
 			require.NotNil(t, rs)
 			for _, row := range rs.Named().Rows {
 				assert.True(t, row["shadow_analyzed_timestamp"].IsNull())
+				assert.Equal(t, 100.0, row.AsFloat64("progress", 0))
 			}
 		})
 
@@ -619,6 +620,7 @@ func testScheduler(t *testing.T) {
 			require.NotNil(t, rs)
 			for _, row := range rs.Named().Rows {
 				assert.True(t, row["shadow_analyzed_timestamp"].IsNull())
+				assert.Equal(t, 100.0, row.AsFloat64("progress", 0))
 			}
 		})
 

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -4041,6 +4041,15 @@ func (e *Executor) updateMigrationReadyToComplete(ctx context.Context, uuid stri
 			atomic.StoreInt64(&runningMigration.ReadyToComplete, storeValue)
 		}
 	}
+
+	if isReady {
+		// We set progress to 100%. Remember that progress is based on table rows estimation. We can get here
+		// with progress 87% or anyother value that is way off. But once we realize the migration is ready to complete,
+		// we know row copy is fully complete _and_ that vplayer is not far behind. So it's a better DX to report 100%.
+		if err = e.updateMigrationProgress(ctx, uuid, progressPctFull); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -4044,7 +4044,7 @@ func (e *Executor) updateMigrationReadyToComplete(ctx context.Context, uuid stri
 
 	if isReady {
 		// We set progress to 100%. Remember that progress is based on table rows estimation. We can get here
-		// with progress 87% or anyother value that is way off. But once we realize the migration is ready to complete,
+		// with progress 87% or another value that is way off. But once we realize the migration is ready to complete,
 		// we know row copy is fully complete _and_ that vplayer is not far behind. So it's a better DX to report 100%.
 		if err = e.updateMigrationProgress(ctx, uuid, progressPctFull); err != nil {
 			return err


### PR DESCRIPTION

## Description

Migration progress is based on table rows estimation. We can get to a `ready_to_complete=1` state
with progress 87% or another value that is way off. But once we realize the migration is ready to complete,
we know row copy is fully complete _and_ that vplayer is not far behind. So it's a better DX to report 100%.

## Related Issue(s)

- general: https://github.com/vitessio/vitess/issues/6926

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
