### PR TITLE
support mysql protocol connection attributes

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -127,6 +127,10 @@ type Conn struct {
 	// It is set during the initial handshake.
 	UserData Getter
 
+	// ConnectionAttributes stores arbitrary client-supplied attributes sent in the
+	// connection handshake.
+	Attributes ConnectionAttributes
+
 	bufferedReader *bufio.Reader
 	flushTimer     *time.Timer
 	flushDelay     time.Duration

--- a/go/mysql/conn_params.go
+++ b/go/mysql/conn_params.go
@@ -67,6 +67,8 @@ type ConnParams struct {
 	TruncateErrLen int
 
 	MultiQuery bool
+
+	Attributes ConnectionAttributes
 }
 
 // EnableSSL will set the right flag on the parameters.

--- a/go/mysql/constants.go
+++ b/go/mysql/constants.go
@@ -37,6 +37,10 @@ const (
 // implemented authentication methods.
 type AuthMethodDescription string
 
+// ConnectionAttributes is a map of key/value pairs sent by the client during
+// the connection phase.
+type ConnectionAttributes map[string]string
+
 // Supported auth forms.
 const (
 	// MysqlNativePassword uses a salt and transmits a hash on the wire.

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -488,6 +488,79 @@ func TestClientFoundRows(t *testing.T) {
 	c.Close()
 }
 
+func TestConnAttrs(t *testing.T) {
+	ctx := utils.LeakCheckContext(t)
+	th := &testHandler{}
+
+	authServer := NewAuthServerStatic("", "", 0)
+	authServer.entries["user1"] = []*AuthServerStaticEntry{{
+		Password: "password1",
+		UserData: "userData1",
+	}}
+	defer authServer.close()
+
+	l, err := NewListener("tcp", "127.0.0.1:", authServer, th, 0, 0, false, false, 0, 0, false)
+	require.NoError(t, err, "NewListener failed")
+	host, port := getHostPort(t, l.Addr())
+
+	// Test with attrs.
+	params := &ConnParams{
+		Host:  host,
+		Port:  port,
+		Uname: "user1",
+		Pass:  "password1",
+		Attributes: map[string]string{
+			"key1": "value1",
+			"k2":   "v2",
+		},
+	}
+	go l.Accept()
+	defer cleanupListener(ctx, l, params)
+
+	clientConn, err := Connect(ctx, params)
+	require.NoError(t, err, "Connect failed")
+
+	serverConn := th.LastConn()
+	assert.Equal(t, uint32(CapabilityClientConnAttr), clientConn.Capabilities&CapabilityClientConnAttr, "ConnAttr flag: %x, bit must be set", th.LastConn().Capabilities)
+	assert.Equal(t, serverConn.Attributes, params.Attributes, "attributes should be sent and parsed")
+
+	clientConn.Close()
+	assert.True(t, clientConn.IsClosed(), "IsClosed should be true on Close-d connection.")
+
+	// Empty attrs do not even set the capability flag
+	params = &ConnParams{
+		Host:  host,
+		Port:  port,
+		Uname: "user1",
+		Pass:  "password1",
+	}
+
+	clientConn, err = Connect(ctx, params)
+	require.NoError(t, err, "Connect failed")
+
+	serverConn = th.LastConn()
+	assert.Equal(t, uint32(0), clientConn.Capabilities&CapabilityClientConnAttr, "ConnAttr flag: %x, bit must not be set", th.LastConn().Capabilities)
+	assert.Equal(t, 0, len(serverConn.Attributes), "attributes should be empty")
+
+	clientConn.Close()
+	assert.True(t, clientConn.IsClosed(), "IsClosed should be true on Close-d connection.")
+
+	// Attributes more than 255 bytes are not supported
+	params = &ConnParams{
+		Host:  host,
+		Port:  port,
+		Uname: "user1",
+		Pass:  "password1",
+		Attributes: map[string]string{
+			"tooLongKey": strings.Repeat("a", 256),
+		},
+	}
+
+	_, err = Connect(ctx, params)
+	require.Error(t, err, "writeHandshakeResponse41: attribute key or value is too long")
+
+}
+
 func TestConnCounts(t *testing.T) {
 	ctx := utils.LeakCheckContext(t)
 	th := &testHandler{}


### PR DESCRIPTION
## Description
Add mysql protocol support to handle attributes in the connection handshake.

The server-side already supported parsing these, so just stash the resulting parsed values in the Connection for use by the server process. Also add support to the client to pass these along if requested, and use that for testing.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
