### PR TITLE
vtgateconn minor enhancements

### DIFF
--- a/go/flags/endtoend/vtbench.txt
+++ b/go/flags/endtoend/vtbench.txt
@@ -95,6 +95,6 @@ Flags:
       --vtgate-grpc-ca string                                       the server ca to use to validate servers when connecting
       --vtgate-grpc-cert string                                     the cert to use to connect
       --vtgate-grpc-crl string                                      the server crl to use to validate server certificates when connecting
-      --vtgate-grpc-fail-fast                                       whether to enable grpc fail fast when communicating with vtgate
+      --vtgate-grpc-fail-fast                                       whether to enable grpc fail fast when connecting
       --vtgate-grpc-key string                                      the key to use to connect
       --vtgate-grpc-server-name string                              the server name to use to validate server certificate

--- a/go/flags/endtoend/vtbench.txt
+++ b/go/flags/endtoend/vtbench.txt
@@ -95,5 +95,6 @@ Flags:
       --vtgate-grpc-ca string                                       the server ca to use to validate servers when connecting
       --vtgate-grpc-cert string                                     the cert to use to connect
       --vtgate-grpc-crl string                                      the server crl to use to validate server certificates when connecting
+      --vtgate-grpc-fail-fast                                       whether to enable grpc fail fast when communicating with vtgate
       --vtgate-grpc-key string                                      the key to use to connect
       --vtgate-grpc-server-name string                              the server name to use to validate server certificate

--- a/go/flags/endtoend/vtclient.txt
+++ b/go/flags/endtoend/vtclient.txt
@@ -68,7 +68,7 @@ Flags:
       --vtgate-grpc-ca string                                       the server ca to use to validate servers when connecting
       --vtgate-grpc-cert string                                     the cert to use to connect
       --vtgate-grpc-crl string                                      the server crl to use to validate server certificates when connecting
-      --vtgate-grpc-fail-fast                                       whether to enable grpc fail fast when communicating with vtgate
+      --vtgate-grpc-fail-fast                                       whether to enable grpc fail fast when connecting
       --vtgate-grpc-key string                                      the key to use to connect
       --vtgate-grpc-server-name string                              the server name to use to validate server certificate
       --vtgate_protocol string                                      how to talk to vtgate (default "grpc")

--- a/go/flags/endtoend/vtclient.txt
+++ b/go/flags/endtoend/vtclient.txt
@@ -68,6 +68,7 @@ Flags:
       --vtgate-grpc-ca string                                       the server ca to use to validate servers when connecting
       --vtgate-grpc-cert string                                     the cert to use to connect
       --vtgate-grpc-crl string                                      the server crl to use to validate server certificates when connecting
+      --vtgate-grpc-fail-fast                                       whether to enable grpc fail fast when communicating with vtgate
       --vtgate-grpc-key string                                      the key to use to connect
       --vtgate-grpc-server-name string                              the server name to use to validate server certificate
       --vtgate_protocol string                                      how to talk to vtgate (default "grpc")

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -430,6 +430,7 @@ Flags:
       --vtgate-grpc-ca string                                            the server ca to use to validate servers when connecting
       --vtgate-grpc-cert string                                          the cert to use to connect
       --vtgate-grpc-crl string                                           the server crl to use to validate server certificates when connecting
+      --vtgate-grpc-fail-fast                                            whether to enable grpc fail fast when communicating with vtgate
       --vtgate-grpc-key string                                           the key to use to connect
       --vtgate-grpc-server-name string                                   the server name to use to validate server certificate
       --vttablet-skip-buildinfo-tags string                              comma-separated list of buildinfo tags to skip from merging with --init-tags. each tag is either an exact match or a regular expression of the form '/regexp/'. (default "/.*/")

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -430,7 +430,7 @@ Flags:
       --vtgate-grpc-ca string                                            the server ca to use to validate servers when connecting
       --vtgate-grpc-cert string                                          the cert to use to connect
       --vtgate-grpc-crl string                                           the server crl to use to validate server certificates when connecting
-      --vtgate-grpc-fail-fast                                            whether to enable grpc fail fast when communicating with vtgate
+      --vtgate-grpc-fail-fast                                            whether to enable grpc fail fast when connecting
       --vtgate-grpc-key string                                           the key to use to connect
       --vtgate-grpc-server-name string                                   the server name to use to validate server certificate
       --vttablet-skip-buildinfo-tags string                              comma-separated list of buildinfo tags to skip from merging with --init-tags. each tag is either an exact match or a regular expression of the form '/regexp/'. (default "/.*/")

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -163,7 +163,7 @@ Flags:
       --vtgate-grpc-ca string                                            the server ca to use to validate servers when connecting
       --vtgate-grpc-cert string                                          the cert to use to connect
       --vtgate-grpc-crl string                                           the server crl to use to validate server certificates when connecting
-      --vtgate-grpc-fail-fast                                            whether to enable grpc fail fast when communicating with vtgate
+      --vtgate-grpc-fail-fast                                            whether to enable grpc fail fast when connecting
       --vtgate-grpc-key string                                           the key to use to connect
       --vtgate-grpc-server-name string                                   the server name to use to validate server certificate
       --xbstream-restore-flags string                                    Flags to pass to xbstream command during restore. These should be space separated and will be added to the end of the command. These need to match the ones used for backup e.g. --compress / --decompress, --encrypt / --decrypt

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -163,6 +163,7 @@ Flags:
       --vtgate-grpc-ca string                                            the server ca to use to validate servers when connecting
       --vtgate-grpc-cert string                                          the cert to use to connect
       --vtgate-grpc-crl string                                           the server crl to use to validate server certificates when connecting
+      --vtgate-grpc-fail-fast                                            whether to enable grpc fail fast when communicating with vtgate
       --vtgate-grpc-key string                                           the key to use to connect
       --vtgate-grpc-server-name string                                   the server name to use to validate server certificate
       --xbstream-restore-flags string                                    Flags to pass to xbstream command during restore. These should be space separated and will be added to the end of the command. These need to match the ones used for backup e.g. --compress / --decompress, --encrypt / --decrypt

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -67,7 +67,7 @@ func RegisterFlags(fs *pflag.FlagSet) {
 	utils.SetFlagStringVar(fs, &ca, "vtgate-grpc-ca", "", "the server ca to use to validate servers when connecting")
 	utils.SetFlagStringVar(fs, &crl, "vtgate-grpc-crl", "", "the server crl to use to validate server certificates when connecting")
 	utils.SetFlagStringVar(fs, &name, "vtgate-grpc-server-name", "", "the server name to use to validate server certificate")
-	utils.SetFlagBoolVar(fs, &failFast, "vtgate-grpc-fail-fast", false, "whether to enable grpc fail fast when communicating with vtgate")
+	utils.SetFlagBoolVar(fs, &failFast, "vtgate-grpc-fail-fast", false, "whether to enable grpc fail fast when connecting")
 }
 
 type vtgateConn struct {

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -57,11 +57,11 @@ func init() {
 		"vtctl",
 		"vttestserver",
 	} {
-		servenv.OnParseFor(cmd, registerFlags)
+		servenv.OnParseFor(cmd, RegisterFlags)
 	}
 }
 
-func registerFlags(fs *pflag.FlagSet) {
+func RegisterFlags(fs *pflag.FlagSet) {
 	utils.SetFlagStringVar(fs, &cert, "vtgate-grpc-cert", "", "the cert to use to connect")
 	utils.SetFlagStringVar(fs, &key, "vtgate-grpc-key", "", "the key to use to connect")
 	utils.SetFlagStringVar(fs, &ca, "vtgate-grpc-ca", "", "the server ca to use to validate servers when connecting")

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -39,11 +39,12 @@ import (
 )
 
 var (
-	cert string
-	key  string
-	ca   string
-	crl  string
-	name string
+	cert     string
+	key      string
+	ca       string
+	crl      string
+	name     string
+	failFast bool
 )
 
 func init() {
@@ -66,6 +67,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	utils.SetFlagStringVar(fs, &ca, "vtgate-grpc-ca", "", "the server ca to use to validate servers when connecting")
 	utils.SetFlagStringVar(fs, &crl, "vtgate-grpc-crl", "", "the server crl to use to validate server certificates when connecting")
 	utils.SetFlagStringVar(fs, &name, "vtgate-grpc-server-name", "", "the server name to use to validate server certificate")
+	utils.SetFlagBoolVar(fs, &failFast, "vtgate-grpc-fail-fast", false, "whether to enable grpc fail fast when communicating with vtgate")
 }
 
 type vtgateConn struct {
@@ -87,7 +89,7 @@ func Dial(opts ...grpc.DialOption) vtgateconn.DialerFunc {
 
 		opts = append(opts, opt)
 
-		cc, err := grpcclient.DialContext(ctx, address, grpcclient.FailFast(false), opts...)
+		cc, err := grpcclient.DialContext(ctx, address, grpcclient.FailFast(failFast), opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
@@ -57,6 +57,7 @@ func TestGRPCVTGateConn(t *testing.T) {
 	// run the test suite
 	RunTests(t, client, service)
 	RunErrorTests(t, service)
+	RunSessionTests(t, client, service)
 
 	// and clean up
 	client.Close()

--- a/go/vt/vtgate/grpcvtgateconn/suite_test.go
+++ b/go/vt/vtgate/grpcvtgateconn/suite_test.go
@@ -51,6 +51,8 @@ type fakeVTGateService struct {
 	panics   bool
 	hasError bool
 
+	ActiveTxns int
+
 	errorWait chan struct{}
 }
 
@@ -121,10 +123,19 @@ func (f *fakeVTGateService) Execute(
 		f.t.Errorf("Execute:\n%+v, want\n%+v", query, execCase.execQuery)
 		return session, nil, nil
 	}
+
 	if execCase.outSession != nil {
+		if !session.InTransaction && execCase.outSession.InTransaction {
+			f.ActiveTxns++
+		}
+		if session.InTransaction && !execCase.outSession.InTransaction {
+			f.ActiveTxns--
+		}
+
 		proto.Reset(session)
 		proto.Merge(session, execCase.outSession)
 	}
+
 	return session, execCase.result, nil
 }
 
@@ -276,7 +287,10 @@ func (f *fakeVTGateService) Prepare(ctx context.Context, session *vtgatepb.Sessi
 
 // CloseSession is part of the VTGateService interface
 func (f *fakeVTGateService) CloseSession(ctx context.Context, session *vtgatepb.Session) error {
-	panic("unimplemented")
+	if session.InTransaction {
+		f.ActiveTxns--
+	}
+	return nil
 }
 
 func (f *fakeVTGateService) VStream(ctx context.Context, tabletType topodatapb.TabletType, vgtid *binlogdatapb.VGtid, filter *binlogdatapb.Filter, flags *vtgatepb.VStreamFlags, send func([]*binlogdatapb.VEvent) error) error {
@@ -321,7 +335,7 @@ func RunTests(t *testing.T, impl vtgateconn.Impl, fakeServer vtgateservice.VTGat
 
 	fs := fakeServer.(*fakeVTGateService)
 
-	testExecute(t, session)
+	testExecute(t, session, "request1")
 	testExecuteMulti(t, session)
 	testStreamExecute(t, session)
 	testStreamExecuteMulti(t, session)
@@ -391,9 +405,9 @@ func verifyErrorString(t *testing.T, err error, method string) {
 	}
 }
 
-func testExecute(t *testing.T, session *vtgateconn.VTGateSession) {
+func testExecute(t *testing.T, session *vtgateconn.VTGateSession, request string) {
 	ctx := newContext()
-	execCase := execMap["request1"]
+	execCase := execMap[request]
 	qr, err := session.Execute(ctx, execCase.execQuery.SQL, execCase.execQuery.BindVariables, false)
 	require.NoError(t, err)
 	if !qr.Equal(execCase.result) {
@@ -708,6 +722,66 @@ var execMap = map[string]struct {
 			},
 		},
 	},
+	"begin": {
+		execQuery: &queryExecute{
+			SQL: "begin",
+			Session: &vtgatepb.Session{
+				TargetString:  "connection_ks",
+				InTransaction: false,
+			},
+		},
+		result: &sqltypes.Result{},
+		outSession: &vtgatepb.Session{
+			TargetString:  "connection_ks",
+			Autocommit:    false,
+			InTransaction: true,
+		},
+	},
+	"commit": {
+		execQuery: &queryExecute{
+			SQL: "commit",
+			Session: &vtgatepb.Session{
+				TargetString:  "connection_ks",
+				InTransaction: true,
+			},
+		},
+		result: &sqltypes.Result{},
+		outSession: &vtgatepb.Session{
+			TargetString:  "connection_ks",
+			Autocommit:    false,
+			InTransaction: false,
+		},
+	},
+	"txnRequest": {
+		execQuery: &queryExecute{
+			SQL: "txnRequest",
+			Session: &vtgatepb.Session{
+				TargetString:  "connection_ks",
+				InTransaction: true,
+			},
+		},
+		result: &sqltypes.Result{},
+		outSession: &vtgatepb.Session{
+			TargetString:  "connection_ks",
+			Autocommit:    false,
+			InTransaction: true,
+		},
+	},
+	"nontxnRequest": {
+		execQuery: &queryExecute{
+			SQL: "nontxnRequest",
+			Session: &vtgatepb.Session{
+				TargetString:  "connection_ks",
+				InTransaction: false,
+			},
+		},
+		result: &sqltypes.Result{},
+		outSession: &vtgatepb.Session{
+			TargetString:  "connection_ks",
+			Autocommit:    false,
+			InTransaction: false,
+		},
+	},
 }
 
 var result1 = sqltypes.Result{
@@ -740,4 +814,42 @@ var result1 = sqltypes.Result{
 var streamResultFields = sqltypes.Result{
 	Fields: result1.Fields,
 	Rows:   [][]sqltypes.Value{},
+}
+
+func RunSessionTests(t *testing.T, impl vtgateconn.Impl, fakeServer vtgateservice.VTGateService) {
+	vtgateconn.RegisterDialer("test", func(ctx context.Context, address string) (vtgateconn.Impl, error) {
+		return impl, nil
+	})
+	conn, err := vtgateconn.DialProtocol(context.Background(), "test", "")
+	if err != nil {
+		t.Fatalf("Got err: %v from vtgateconn.DialProtocol", err)
+	}
+	session := conn.Session("connection_ks", nil)
+	session.SessionPb().Autocommit = false
+
+	fs := fakeServer.(*fakeVTGateService)
+
+	require.Equal(t, fs.ActiveTxns, 0)
+
+	testExecute(t, session, "begin")
+	require.Equal(t, fs.ActiveTxns, 1)
+	testExecute(t, session, "txnRequest")
+	require.Equal(t, fs.ActiveTxns, 1)
+	testExecute(t, session, "commit")
+	require.Equal(t, fs.ActiveTxns, 0)
+
+	session = conn.Session("connection_ks", nil)
+	session.SessionPb().Autocommit = false
+
+	testExecute(t, session, "begin")
+	require.Equal(t, fs.ActiveTxns, 1)
+
+	session.CloseSession(newContext())
+	require.Equal(t, fs.ActiveTxns, 0)
+
+	session = conn.Session("connection_ks", nil)
+	session.SessionPb().Autocommit = false
+
+	testExecute(t, session, "nontxnRequest")
+	require.Equal(t, fs.ActiveTxns, 0)
 }

--- a/go/vt/vtgate/vtgateconn/vtgateconn.go
+++ b/go/vt/vtgate/vtgateconn/vtgateconn.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Vitess Authors.
+Copyright 2024 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -169,6 +169,11 @@ func (sn *VTGateSession) Prepare(ctx context.Context, query string) ([]*querypb.
 	session, fields, paramsCount, err := sn.impl.Prepare(ctx, sn.session, query)
 	sn.session = session
 	return fields, paramsCount, err
+}
+
+// CloseSession closes the session provided by rolling back any active transaction.
+func (sn *VTGateSession) CloseSession(ctx context.Context) error {
+	return sn.impl.CloseSession(ctx, sn.session)
 }
 
 //

--- a/go/vt/vtgate/vtgateconn/vtgateconn.go
+++ b/go/vt/vtgate/vtgateconn/vtgateconn.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Vitess Authors.
+Copyright 2019 The Vitess Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Minor enhancements to the vtgateconn grpc interface:

1. Expose the CloseSession method so callers can shut down a connection if not needed.
2. Add a flag to enable the grpc fail fast option as opposed to hard coding to false.
3. Expose RegisterFlags to be called outside the module

## Related Issue(s)

#18550

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
