### PR TITLE
Add TLS support to vtadmin GRPC

### DIFF
--- a/go/cmd/vtadmin/main.go
+++ b/go/cmd/vtadmin/main.go
@@ -36,6 +36,7 @@ import (
 	vtadminhttp "vitess.io/vitess/go/vt/vtadmin/http"
 	"vitess.io/vitess/go/vt/vtadmin/http/debug"
 	"vitess.io/vitess/go/vt/vtadmin/rbac"
+	"vitess.io/vitess/go/vt/vtctl/grpcclientcommon"
 	"vitess.io/vitess/go/vt/vtenv"
 )
 
@@ -217,6 +218,9 @@ func main() {
 	rootCmd.Flags().AddGoFlag(flag.Lookup("log_dir"))
 
 	servenv.RegisterMySQLServerFlags(rootCmd.Flags())
+
+	// Register TLS flags for gRPC connections to vtctld
+	grpcclientcommon.RegisterFlags(rootCmd.Flags())
 
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal(err)

--- a/go/vt/vtctl/grpcclientcommon/dial_option.go
+++ b/go/vt/vtctl/grpcclientcommon/dial_option.go
@@ -34,6 +34,7 @@ func init() {
 	servenv.OnParseFor("vttestserver", RegisterFlags)
 	servenv.OnParseFor("vtctlclient", RegisterFlags)
 	servenv.OnParseFor("vtctldclient", RegisterFlags)
+	servenv.OnParseFor("vtadmin", RegisterFlags)
 }
 
 func RegisterFlags(fs *pflag.FlagSet) {


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
### Why
- At HubSpot we use TLS GRPC for all our communications
- We are in the process of upgrading to Vitess 23+ and were unable to bringup `vtadmin` without TLS
- This change adds this functionallity

### What
- Reused same utilities from vtctlclient
- Registers vtadmin to use `grpcclientcommon`
- Updates vtadmin proxy dial options to use grpc secure dial options when possible
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
[Feature Request: expose TLS related flags for vtadmin config](https://github.com/vitessio/vitess/issues/14434#top)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [X] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on CI?
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
