### PR TITLE
OnlineDDL: log changes to `ready_to_complete`

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -4041,6 +4041,7 @@ func (e *Executor) updateMigrationReadyToComplete(ctx context.Context, uuid stri
 			atomic.StoreInt64(&runningMigration.ReadyToComplete, storeValue)
 		}
 	}
+	log.Infof("updateMigrationReadyToComplete: uuid=%s, isReady=%t", uuid, isReady)
 
 	if isReady {
 		// We set progress to 100%. Remember that progress is based on table rows estimation. We can get here


### PR DESCRIPTION

## Description

Adding a log entry any time `ready_to_complete` changes (both when set as well as when cleared). This is useful for debugging why a migration was delayed to complete.

## Related Issue(s)

- #6926 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
