### PR TITLE
mysqlctl: improve error handling in buildLdPaths function

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -1266,11 +1266,17 @@ func (mysqld *Mysqld) OnTerm(f func()) {
 func buildLdPaths() ([]string, error) {
 	vtMysqlRoot, err := vtenv.VtMysqlRoot()
 	if err != nil {
-		return []string{}, err
+		return nil, fmt.Errorf("failed to get VtMysqlRoot: %w", err)
+	}
+
+	// Validate that the MySQL lib directory exists
+	libPath := fmt.Sprintf("%s/lib/mysql", vtMysqlRoot)
+	if _, err := os.Stat(libPath); err != nil {
+		return nil, fmt.Errorf("MySQL library path does not exist: %s", libPath)
 	}
 
 	ldPaths := []string{
-		fmt.Sprintf("LD_LIBRARY_PATH=%s/lib/mysql", vtMysqlRoot),
+		fmt.Sprintf("LD_LIBRARY_PATH=%s", libPath),
 		os.ExpandEnv("LD_PRELOAD=$LD_PRELOAD"),
 	}
 


### PR DESCRIPTION
This change enhances the buildLdPaths function with better error handling:
- Return proper nil instead of empty slice on VtMysqlRoot error
- Add validation to ensure MySQL library directory exists
- Use error wrapping for more informative error messages
- Extract libPath variable for better code readability

These improvements help provide clearer diagnostics when MySQL library paths are misconfigured or missing.

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
