### PR TITLE
fix: emit QueryExecutionsByTable for success cases only

### DIFF
--- a/go/vt/vtgate/executor_stats_test.go
+++ b/go/vt/vtgate/executor_stats_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"vitess.io/vitess/go/sqltypes"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	econtext "vitess.io/vitess/go/vt/vtgate/executorcontext"
+)
+
+// TestQueryExecutionsByTable_OnError verifies that queryExecutionsByTable counters
+// are incremented on successful execution but NOT incremented on execution failure.
+func TestQueryExecutionsByTable_OnError(t *testing.T) {
+	executor, sbc1, _, _, ctx := createExecutorEnv(t)
+
+	// Set up successful result first
+	sbc1.SetResults([]*sqltypes.Result{sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1")})
+
+	// Get initial counter values
+	initialCounts := getCurrentQueryExecutionsByTableCounts()
+
+	// Execute a query successfully first
+	session := econtext.NewSafeSession(&vtgatepb.Session{TargetString: KsTestSharded})
+	result, err := executorExecSession(ctx, executor, session, "select id from user where id = 1", nil)
+
+	// Verify successful execution
+	assert.NoError(t, err, "Expected query execution to succeed")
+	assert.NotNil(t, result, "Expected valid result")
+
+	// Get counter values after successful execution
+	successCounts := getCurrentQueryExecutionsByTableCounts()
+
+	// Check the specific counter that should be incremented for SELECT on user table
+	selectUserKey := "SELECT.TestExecutor_user"
+	initialUserCount := initialCounts[selectUserKey]
+	successUserCount := successCounts[selectUserKey]
+
+	// Verify counter was incremented on successful execution
+	assert.Equal(t, initialUserCount+1, successUserCount,
+		"queryExecutionsByTable counter should be incremented on successful execution")
+
+	// Now set up the sandbox connection to return an error on next execution
+	sbc1.MustFailCodes[vtrpcpb.Code_INTERNAL] = 1
+
+	// Execute the same query again, but this time it should fail
+	_, err = executorExecSession(ctx, executor, session, "select id from user where id = 1", nil)
+
+	// Verify that the execution failed
+	assert.Error(t, err, "Expected query execution to fail")
+
+	// Get counter values after failed execution
+	finalCounts := getCurrentQueryExecutionsByTableCounts()
+
+	// Verify that queryExecutionsByTable counter was NOT incremented on execution error
+	// The counter should remain the same as after the successful execution
+	finalUserCount := finalCounts[selectUserKey]
+	assert.Equal(t, successUserCount, finalUserCount,
+		"queryExecutionsByTable counter should not be incremented on execution error")
+}
+
+// getCurrentQueryExecutionsByTableCounts returns the current values of all queryExecutionsByTable counters
+func getCurrentQueryExecutionsByTableCounts() map[string]int64 {
+	// queryExecutionsByTable is a global variable, so we can use its Counts() method
+	// to get all counter values. The keys are already formatted as "query.table"
+	return queryExecutionsByTable.Counts()
+}

--- a/go/vt/vtgate/plan_execute.go
+++ b/go/vt/vtgate/plan_execute.go
@@ -409,7 +409,6 @@ func (e *Executor) rollbackPartialExec(ctx context.Context, safeSession *econtex
 func (e *Executor) setLogStats(logStats *logstats.LogStats, plan *engine.Plan, vcursor *econtext.VCursorImpl, execStart time.Time, err error, qr *sqltypes.Result) {
 	logStats.StmtType = plan.QueryType.String()
 	logStats.ActiveKeyspace = vcursor.GetKeyspace()
-	logStats.TablesUsed = plan.TablesUsed
 	logStats.TabletType = vcursor.TabletType().String()
 	errCount := e.logExecutionEnd(logStats, execStart, plan, vcursor, err, qr)
 	plan.AddStats(1, time.Since(logStats.StartTime), logStats.ShardQueries, logStats.RowsAffected, logStats.RowsReturned, errCount)
@@ -418,8 +417,6 @@ func (e *Executor) setLogStats(logStats *logstats.LogStats, plan *engine.Plan, v
 func (e *Executor) logExecutionEnd(logStats *logstats.LogStats, execStart time.Time, plan *engine.Plan, vcursor *econtext.VCursorImpl, err error, qr *sqltypes.Result) uint64 {
 	logStats.ExecuteTime = time.Since(execStart)
 
-	e.updateQueryStats(plan.QueryType.String(), plan.Type.String(), vcursor.TabletType().String(), int64(logStats.ShardQueries), plan.TablesUsed)
-
 	var errCount uint64
 	if err != nil {
 		logStats.Error = err
@@ -427,7 +424,12 @@ func (e *Executor) logExecutionEnd(logStats *logstats.LogStats, execStart time.T
 	} else {
 		logStats.RowsAffected = qr.RowsAffected
 		logStats.RowsReturned = uint64(len(qr.Rows))
+		// log the tables used in the plan for successful query execution.
+		logStats.TablesUsed = plan.TablesUsed
 	}
+
+	e.updateQueryStats(plan.QueryType.String(), plan.Type.String(), vcursor.TabletType().String(), int64(logStats.ShardQueries), logStats.TablesUsed)
+
 	return errCount
 }
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR stops emitting QueryExecutionsByTable metrics on error cases.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
