### PR TITLE
Fix a panic in VDiff when reconciling extra rows.

### DIFF
--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ.go
@@ -119,8 +119,8 @@ func (wd *workflowDiffer) doReconcileExtraRows(dr *DiffReport, maxExtraRowsToCom
 	if dr.ExtraRowsSource == 0 || dr.ExtraRowsTarget == 0 {
 		return nil
 	}
-	matchedSourceDiffs := make([]bool, int(dr.ExtraRowsSource))
-	matchedTargetDiffs := make([]bool, int(dr.ExtraRowsTarget))
+	matchedSourceDiffs := make([]bool, len(dr.ExtraRowsSourceDiffs))
+	matchedTargetDiffs := make([]bool, len(dr.ExtraRowsTargetDiffs))
 	matchedDiffs := int64(0)
 
 	maxRows := int(dr.ExtraRowsSource)
@@ -131,8 +131,8 @@ func (wd *workflowDiffer) doReconcileExtraRows(dr *DiffReport, maxExtraRowsToCom
 		dr.TableName, wd.ct.uuid, dr.ExtraRowsSource, dr.ExtraRowsTarget, maxRows)
 
 	// Find the matching extra rows
-	for i := 0; i < maxRows; i++ {
-		for j := 0; j < int(dr.ExtraRowsTarget); j++ {
+	for i := 0; i < len(dr.ExtraRowsSourceDiffs); i++ {
+		for j := 0; j < len(dr.ExtraRowsTargetDiffs); j++ {
 			if matchedTargetDiffs[j] {
 				// previously matched
 				continue
@@ -151,9 +151,8 @@ func (wd *workflowDiffer) doReconcileExtraRows(dr *DiffReport, maxExtraRowsToCom
 			dr.TableName, maxRows, wd.ct.uuid)
 	} else {
 		// Now remove the matching extra rows
-		newExtraRowsSourceDiffs := make([]*RowDiff, 0, dr.ExtraRowsSource-matchedDiffs)
-		newExtraRowsTargetDiffs := make([]*RowDiff, 0, dr.ExtraRowsTarget-matchedDiffs)
-		for i := 0; i < int(dr.ExtraRowsSource); i++ {
+		newExtraRowsSourceDiffs := make([]*RowDiff, 0, int64(len(dr.ExtraRowsSourceDiffs))-matchedDiffs)
+		for i := 0; i < len(dr.ExtraRowsSourceDiffs); i++ {
 			if !matchedSourceDiffs[i] {
 				newExtraRowsSourceDiffs = append(newExtraRowsSourceDiffs, dr.ExtraRowsSourceDiffs[i])
 			}
@@ -161,7 +160,9 @@ func (wd *workflowDiffer) doReconcileExtraRows(dr *DiffReport, maxExtraRowsToCom
 				break
 			}
 		}
-		for i := 0; i < int(dr.ExtraRowsTarget); i++ {
+
+		newExtraRowsTargetDiffs := make([]*RowDiff, 0, int64(len(dr.ExtraRowsTargetDiffs))-matchedDiffs)
+		for i := 0; i < len(dr.ExtraRowsTargetDiffs); i++ {
 			if !matchedTargetDiffs[i] {
 				newExtraRowsTargetDiffs = append(newExtraRowsTargetDiffs, dr.ExtraRowsTargetDiffs[i])
 			}
@@ -173,8 +174,8 @@ func (wd *workflowDiffer) doReconcileExtraRows(dr *DiffReport, maxExtraRowsToCom
 		dr.ExtraRowsTargetDiffs = newExtraRowsTargetDiffs
 
 		// Update the counts
-		dr.ExtraRowsSource = int64(len(dr.ExtraRowsSourceDiffs))
-		dr.ExtraRowsTarget = int64(len(dr.ExtraRowsTargetDiffs))
+		dr.ExtraRowsSource -= matchedDiffs
+		dr.ExtraRowsTarget -= matchedDiffs
 		dr.MatchingRows += matchedDiffs
 		dr.MismatchedRows -= matchedDiffs
 		dr.ProcessedRows += matchedDiffs


### PR DESCRIPTION
## Description

An out of bounds slice access could happen if the number of extra source or target rows exceeded the `max_extra_rows_to_compare` vdiff option.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
