### PR TITLE
fix: remove database qualifier after building query in operator to sql

### DIFF
--- a/go/test/endtoend/vtgate/queries/orderby/orderby_test.go
+++ b/go/test/endtoend/vtgate/queries/orderby/orderby_test.go
@@ -53,6 +53,15 @@ func TestSimpleOrderBy(t *testing.T) {
 	mcmp.AssertMatches(`SELECT id2 FROM t1 ORDER BY id2 ASC`, `[[INT64(5)] [INT64(6)] [INT64(7)] [INT64(8)] [INT64(9)] [INT64(10)]]`)
 }
 
+// TestQueryWithDBQualifier tests that we remove the db qualifier in the plan output that is sent down to the database.
+func TestQueryWithDBQualifier(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	mcmp.Exec("insert into t1(id1, id2) values (0,10),(1,9),(2,8),(3,7),(4,6),(5,5)")
+	mcmp.Exec(`SELECT ks_orderby.t1.id1, ks_orderby.t1.id2 FROM ks_orderby.t1 ORDER BY ks_orderby.t1.id2 ASC, ks_orderby.t1.id1 desc`)
+}
+
 func TestOrderBy(t *testing.T) {
 	mcmp, closer := start(t)
 	defer closer()

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -572,8 +572,6 @@ func createProjection(ctx *plancontext.PlanningContext, src Operator, derivedNam
 }
 
 func (r *Route) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, expr *sqlparser.AliasedExpr) int {
-	// removeKeyspaceFromSelectExpr(expr)
-
 	if reuse {
 		offset := r.FindCol(ctx, expr.Expr, true)
 		if offset != -1 {

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -572,7 +572,7 @@ func createProjection(ctx *plancontext.PlanningContext, src Operator, derivedNam
 }
 
 func (r *Route) AddColumn(ctx *plancontext.PlanningContext, reuse bool, gb bool, expr *sqlparser.AliasedExpr) int {
-	removeKeyspaceFromSelectExpr(expr)
+	// removeKeyspaceFromSelectExpr(expr)
 
 	if reuse {
 		offset := r.FindCol(ctx, expr.Expr, true)

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -4803,5 +4803,48 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "order by and project pushed under route having database qualifier - it should be removed in final query",
+    "query": "select user.user.col from user.user order by user.user.id",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select user.user.col from user.user order by user.user.id",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select `user`.col, `user`.id, weight_string(`user`.id) from `user` where 1 != 1",
+        "OrderBy": "(1|2) ASC",
+        "Query": "select `user`.col, `user`.id, weight_string(`user`.id) from `user` order by `user`.id asc",
+        "ResultColumns": 1
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "order by and project pushed under route having information_schema database qualifier - it should not be removed in final query",
+    "query": "select information_schema.table.col from information_schema.table order by information_schema.table.name",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select information_schema.table.col from information_schema.table order by information_schema.table.name",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select information_schema.`table`.col from information_schema.`table` where 1 != 1",
+        "Query": "select information_schema.`table`.col from information_schema.`table` order by information_schema.`table`.`name` asc"
+      }
+    }
   }
 ]


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

This PR fixes the issue in the column name having the database qualifier being sent down to the tablet.
During planning it should be removed as the keyspace qualifier and database name can be different, for example when we switch writes and the application still targets the source keyspace before completing the workflow.

Earlier the removal of database qualifier was spread out for sharded query.
This PR now does is after the full query is built.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes https://github.com/vitessio/vitess/issues/18603

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
