### PR TITLE
VReplication: Fix some switch writes related issues and logging

### DIFF
--- a/go/vt/sidecardb/schema/vreplication/resharding_journal.sql
+++ b/go/vt/sidecardb/schema/vreplication/resharding_journal.sql
@@ -18,6 +18,6 @@ CREATE TABLE IF NOT EXISTS resharding_journal
 (
     `id`      bigint NOT NULL,
     `db_name` varbinary(255) DEFAULT NULL,
-    `val`     mediumblob,
+    `val`     longblob,
     PRIMARY KEY (`id`)
 ) ENGINE = InnoDB CHARSET = utf8mb4

--- a/go/vt/vterrors/vterrors.go
+++ b/go/vt/vterrors/vterrors.go
@@ -290,7 +290,8 @@ func (w *wrapping) Cause() error  { return w.cause }
 
 func (w *wrapping) Format(s fmt.State, verb rune) {
 	if rune('v') == verb {
-		panicIfError(fmt.Fprintf(s, "%v :: %v\n", w.msg, w.Cause()))
+		panicIfError(fmt.Fprintf(s, "%v\n", w.Cause()))
+		panicIfError(io.WriteString(s, w.msg))
 		if getLogErrStacks() {
 			w.stack.Format(s, verb)
 		}


### PR DESCRIPTION
## Description

* Increase size of `val` column in `_vt.resharding_journal` to `longblob` since GTID sets can quickly go over 64K causing SwitchWrites to fail
* Improved logging to provide better visibility of progress and errors.

## Related Issue(s)


## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
