### PR TITLE
docker: add trixie and rm bullseye from build matrix

### DIFF
--- a/.github/workflows/docker_build_images.yml
+++ b/.github/workflows/docker_build_images.yml
@@ -144,7 +144,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        debian: [ bullseye, bookworm ]
+        debian: [ bookworm, trixie ]
         component: [ vtadmin, vtorc, vtgate, vttablet, mysqlctld, mysqlctl, vtctl, vtctlclient, vtctld, vtctldclient, logrotate, logtail, vtbackup, vtexplain ]
 
     steps:

--- a/changelog/23.0/23.0.0/summary.md
+++ b/changelog/23.0/23.0.0/summary.md
@@ -18,6 +18,7 @@
         - [CLI Flags](#flags-vttablet)
         - [Managed MySQL configuration defaults to caching-sha2-password](#mysql-caching-sha2-password) 
         - [MySQL timezone environment propagation](#mysql-timezone-env)
+    - **[Docker](#docker)**
 
 ## <a id="major-changes"/>Major Changes</a>
 
@@ -105,3 +106,9 @@ In future Vitess versions, the `mysql_native_password` authentication plugin wil
 Fixed a bug where environment variables like `TZ` were not propagated from mysqlctl to the mysqld process.
 As a result, timezone settings from the environment were previously ignored. Now mysqld correctly inherits environment variables.
 ⚠️ Deployments that relied on the old behavior and explicitly set a non-UTC timezone may see changes in how DATETIME values are interpreted. To preserve compatibility, set `TZ=UTC` explicitly in MySQL pods.
+
+### <a id="docker"/>Docker</a>
+
+[Bullseye went EOL 1 year ago](https://www.debian.org/releases/), so starting from v23, we will no longer build or publish images based on debian:bullseye.
+
+Builds will continue for Debian Bookworm, and add the recently released Debian Trixie. v23 explicitly does not change the default Debian tag to Trixie.


### PR DESCRIPTION
I couldn't edit the branch in the original PR (https://github.com/vitessio/vitess/pull/18543), so this is the same code, plus an addition to release notes.

## Description

[Bullseye was EOL 1 year ago](https://www.debian.org/releases/), so it seems reasonable to stop doing that build. Open to keeping it if we see Docker Hub stats showing that it's active.

Trixie was just released on August 9, so it seems reasonable to start doing builds for it. This PR explicitly does not change the default debian tag to trixie, as it's worth letting it soak for a bit, and doesn't change the bootstrap builds for the same reason.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
