### PR TITLE
experimental: mutex protection for AppendGTIDInPlace

### DIFF
--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -413,6 +413,12 @@ func (se *Engine) ReloadAtEx(ctx context.Context, pos replication.Position, incl
 	return nil
 }
 
+func (se *Engine) MutexProtected(f func()) {
+	se.mu.Lock()
+	defer se.mu.Unlock()
+	f()
+}
+
 func populateInnoDBStats(ctx context.Context, conn *connpool.Conn) (map[string]*Table, error) {
 	innodbTableSizesQuery := conn.BaseShowInnodbTableSizes()
 	if innodbTableSizesQuery == "" {

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -413,12 +413,6 @@ func (se *Engine) ReloadAtEx(ctx context.Context, pos replication.Position, incl
 	return nil
 }
 
-func (se *Engine) MutexProtected(f func()) {
-	se.mu.Lock()
-	defer se.mu.Unlock()
-	f()
-}
-
 func populateInnoDBStats(ctx context.Context, conn *connpool.Conn) (map[string]*Table, error) {
 	innodbTableSizesQuery := conn.BaseShowInnodbTableSizes()
 	if innodbTableSizesQuery == "" {

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -491,9 +491,7 @@ func (vs *vstreamer) parseEvent(ev mysql.BinlogEvent, bufferAndTransmit func(vev
 				SequenceNumber: sequenceNumber,
 			})
 		}
-		vs.se.MutexProtected(func() {
-			vs.pos = replication.AppendGTIDInPlace(vs.pos, gtid)
-		})
+		vs.pos = replication.AppendGTID(vs.pos, gtid)
 		vs.commitParent = commitParent
 		vs.sequenceNumber = sequenceNumber
 		vs.eventGTID = gtid

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -491,7 +491,9 @@ func (vs *vstreamer) parseEvent(ev mysql.BinlogEvent, bufferAndTransmit func(vev
 				SequenceNumber: sequenceNumber,
 			})
 		}
-		vs.pos = replication.AppendGTIDInPlace(vs.pos, gtid)
+		vs.se.MutexProtected(func() {
+			vs.pos = replication.AppendGTIDInPlace(vs.pos, gtid)
+		})
 		vs.commitParent = commitParent
 		vs.sequenceNumber = sequenceNumber
 		vs.eventGTID = gtid


### PR DESCRIPTION

## Description

https://github.com/vitessio/vitess/pull/18196 seemed to have introduces a recurring CI failure in `onlineddl_vrepl_suite` where vttablet panics as follows:

```log
fatal error: concurrent map read and map write

goroutine 364949 gp=0x1400034dc00 m=17 mp=0x140008d4808 [running]:
runtime.fatal({0x1021f9923, 0x21})
	runtime/panic.go:1116 +0x48 fp=0x1400481adc0 sp=0x1400481ad90 pc=0x1000e5c58
internal/runtime/maps.fatal({0x1021f9923?, 0x1000ad1d0?})
	runtime/panic.go:1046 +0x20 fp=0x1400481ade0 sp=0x1400481adc0 pc=0x10011eb50
runtime.mapaccess2(0x1031abf00, 0x14000d81770, 0x1400481ae78)
	internal/runtime/maps/runtime_swiss.go:136 +0x48 fp=0x1400481ae50 sp=0x1400481ade0 pc=0x1000b04b8
vitess.io/vitess/go/mysql/replication.Mysql56GTIDSet.Contains(0x14000d81770, {0x1032e6b40?, 0x14002e9e750?})
	vitess.io/vitess/go/mysql/replication/mysql56_gtid_set.go:248 +0xc8 fp=0x1400481af00 sp=0x1400481ae50 pc=0x100bfd1f8
vitess.io/vitess/go/mysql/replication.Position.AtLeast(...)
	vitess.io/vitess/go/mysql/replication/replication_position.go:83
vitess.io/vitess/go/vt/vttablet/tabletserver/schema.(*Engine).ReloadAtEx(0x140006b3e10, {0x1032c7df8, 0x1053a98e0}, {{}, {0x1032e6b40?, 0x14002e9e750?}}, 0x0)
	vitess.io/vitess/go/vt/vttablet/tabletserver/schema/engine.go:405 +0x148 fp=0x1400481af90 sp=0x1400481af00 pc=0x1012d6ec8
vitess.io/vitess/go/vt/vttablet/tabletserver/schema.(*Engine).ReloadAt(...)
	vitess.io/vitess/go/vt/vttablet/tabletserver/schema/engine.go:389
vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer.(*vstreamer).parseEvent(0x14001dd8360, {0x1032fb590, 0x140020783a0}, 0x14004fa3630)
	vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go:572 +0xbcc fp=0x1400481b330 sp=0x1400481af90 pc=0x1014b2f3c
vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer.(*vstreamer).parseEvents(0x14001dd8360, {0x1032c7f70, 0x140018759a0}, 0x14002088e00, 0x14002088e70)
	vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go:389 +0x5a8 fp=0x1400481b660 sp=0x1400481b330 pc=0x1014b1168
vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer.(*vstreamer).replicate(0x14001dd8360, {0x33?, 0x140018726d0?})
	vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go:214 +0xdc fp=0x1400481b6e0 sp=0x1400481b660 pc=0x1014b0aac
vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer.(*vstreamer).Stream(0x14001dd8360)
	vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go:193 +0x160 fp=0x1400481b780 sp=0x1400481b6e0 pc=0x1014b0840
vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer.(*uvstreamer).Stream(0x1400013ec80)
	vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/uvstreamer.go:460 +0x240 fp=0x1400481b850 sp=0x1400481b780 pc=0x1014af2f0
vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer.(*Engine).Stream(0x14000548580, {0x1032c7f38, 0x14002455170}, {0x14002d0b000, 0x33}, {0x0, 0x0, 0x0}, 0x14001c13560, {0x1021a330d, ...}, ...)
	vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/engine.go:280 +0x114 fp=0x1400481b910 sp=0x1400481b850 pc=0x10149d8c4
vitess.io/vitess/go/vt/vttablet/tabletserver.(*TabletServer).VStream(0x14000044870, {0x1032c7f38, 0x14002455170}, 0x14001b28300, 0x14002b13638)
	vitess.io/vitess/go/vt/vttablet/tabletserver/tabletserver.go:1285 +0x80 fp=0x1400481b990 sp=0x1400481b910 pc=0x10155f450
vitess.io/vitess/go/vt/vttablet/grpcqueryservice.(*query).VStream(0x14000d05ba0, 0x14001b28300, {0x1032debf0, 0x14001504f60})
	vitess.io/vitess/go/vt/vttablet/grpcqueryservice/server.go:348 +0x100 fp=0x1400481ba30 sp=0x1400481b990 pc=0x101d49620
```

This is the reading code. The writing code must be `AppendGTIDInPlace()`.
I'm not entire sure yet how come there's concurrency specifically in `ReloadEx`, since `parseEvent` runs `Reload()` and `AppendGTIDInPlace()` sequentially. In this PR I will try to resolve the matter.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
