### PR TITLE
Vstreamer: idempotent gtid set (bugfix)

### DIFF
--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -413,6 +413,12 @@ func (se *Engine) ReloadAtEx(ctx context.Context, pos replication.Position, incl
 	return nil
 }
 
+func (se *Engine) MutexProtected(f func()) {
+	se.mu.Lock()
+	defer se.mu.Unlock()
+	f()
+}
+
 func populateInnoDBStats(ctx context.Context, conn *connpool.Conn) (map[string]*Table, error) {
 	innodbTableSizesQuery := conn.BaseShowInnodbTableSizes()
 	if innodbTableSizesQuery == "" {

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -413,12 +413,6 @@ func (se *Engine) ReloadAtEx(ctx context.Context, pos replication.Position, incl
 	return nil
 }
 
-func (se *Engine) MutexProtected(f func()) {
-	se.mu.Lock()
-	defer se.mu.Unlock()
-	f()
-}
-
 func populateInnoDBStats(ctx context.Context, conn *connpool.Conn) (map[string]*Table, error) {
 	innodbTableSizesQuery := conn.BaseShowInnodbTableSizes()
 	if innodbTableSizesQuery == "" {

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -491,9 +491,7 @@ func (vs *vstreamer) parseEvent(ev mysql.BinlogEvent, bufferAndTransmit func(vev
 				SequenceNumber: sequenceNumber,
 			})
 		}
-		vs.se.MutexProtected(func() {
-			vs.pos = replication.AppendGTIDInPlace(vs.pos, gtid)
-		})
+		vs.pos = replication.AppendGTID(vs.pos, gtid)
 		vs.commitParent = commitParent
 		vs.sequenceNumber = sequenceNumber
 		vs.eventGTID = gtid

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -491,7 +491,9 @@ func (vs *vstreamer) parseEvent(ev mysql.BinlogEvent, bufferAndTransmit func(vev
 				SequenceNumber: sequenceNumber,
 			})
 		}
-		vs.pos = replication.AppendGTIDInPlace(vs.pos, gtid)
+		vs.se.MutexProtected(func() {
+			vs.pos = replication.AppendGTIDInPlace(vs.pos, gtid)
+		})
 		vs.commitParent = commitParent
 		vs.sequenceNumber = sequenceNumber
 		vs.eventGTID = gtid


### PR DESCRIPTION

## Description

https://github.com/vitessio/vitess/pull/18196 introduced a test flakiness that indicates a more serious problem: crashing vttablet due to 
```
fatal error: concurrent map read and map write

goroutine 364949 gp=0x1400034dc00 m=17 mp=0x140008d4808 [running]:
runtime.fatal({0x1021f9923, 0x21})
	runtime/panic.go:1116 +0x48 fp=0x1400481adc0 sp=0x1400481ad90 pc=0x1000e5c58
internal/runtime/maps.fatal({0x1021f9923?, 0x1000ad1d0?})
	runtime/panic.go:1046 +0x20 fp=0x1400481ade0 sp=0x1400481adc0 pc=0x10011eb50
runtime.mapaccess2(0x1031abf00, 0x14000d81770, 0x1400481ae78)
	internal/runtime/maps/runtime_swiss.go:136 +0x48 fp=0x1400481ae50 sp=0x1400481ade0 pc=0x1000b04b8
vitess.io/vitess/go/mysql/replication.Mysql56GTIDSet.Contains(0x14000d81770, {0x1032e6b40?, 0x14002e9e750?})
	vitess.io/vitess/go/mysql/replication/mysql56_gtid_set.go:248 +0xc8 fp=0x1400481af00 sp=0x1400481ae50 pc=0x100bfd1f8
vitess.io/vitess/go/mysql/replication.Position.AtLeast(...)
	vitess.io/vitess/go/mysql/replication/replication_position.go:83
vitess.io/vitess/go/vt/vttablet/tabletserver/schema.(*Engine).ReloadAtEx(0x140006b3e10, {0x1032c7df8, 0x1053a98e0}, {{}, {0x1032e6b40?, 0x14002e9e750?}}, 0x0)
	vitess.io/vitess/go/vt/vttablet/tabletserver/schema/engine.go:405 +0x148 fp=0x1400481af90 sp=0x1400481af00 pc=0x1012d6ec8
vitess.io/vitess/go/vt/vttablet/tabletserver/schema.(*Engine).ReloadAt(...)
	vitess.io/vitess/go/vt/vttablet/tabletserver/schema/engine.go:389
vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer.(*vstreamer).parseEvent(0x14001dd8360, {0x1032fb590, 0x140020783a0}, 0x14004fa3630)
	vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go:572 +0xbcc fp=0x1400481b330 sp=0x1400481af90 pc=0x1014b2f3c
```

After some investigation, it seems there's more concurrency at play than we'd like. For the time being, `main` is broken and we want to unbreak it. We thus revert the in-place GTID computation for now.


## Related Issue(s)

https://github.com/vitessio/vitess/pull/18196

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
