### PR TITLE
Fix running foreign key end-to-end tests on MySQL 8.0

### DIFF
--- a/go/test/endtoend/vtgate/foreignkey/extra_my.cnf
+++ b/go/test/endtoend/vtgate/foreignkey/extra_my.cnf
@@ -1,2 +1,3 @@
+[mysqld-8.4]
 # Foreign key test configuration
 restrict_fk_on_non_standard_key = OFF


### PR DESCRIPTION
## Description

When CI was switched to run against MySQL 8.4, the foreign key tests were updated to set `restrict_fk_on_non_standard_key`, which is a MySQL 8.4 specific option. This option is now set unconditionally, so running the foreign key end-to-end tests now fails when running them against MySQL 8.0.

This updates the way we set the option to only be set on MySQL 8.4. Once we drop support for MySQL 8.0, we can remove this change again.

## Related Issue(s)

N/A

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
