### PR TITLE
`vtorc`: add flag to set collection metric retention/ttl

### DIFF
--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -35,6 +35,7 @@ Flags:
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --consul-auth-static-file string                              JSON File to read the topos/tokens from.
+      --discovery-collection-metrics-ttl duration                   The time-to-live for discovery collection metrics (default 2m0s)
       --discovery-workers int                                       Number of workers used for tablet discovery (default 300)
       --emit-stats                                                  If set, emit stats to push-based monitoring and stats backends
       --enable-primary-disk-stalled-recovery                        Whether VTOrc should detect a stalled disk on the primary and failover

--- a/go/vt/vtorc/collection/collection.go
+++ b/go/vt/vtorc/collection/collection.go
@@ -45,7 +45,7 @@ data which is suitable for easy collection by monitoring systems.
 
 Expiry is triggered by default if the collection is created via
 CreateOrReturnCollection() and uses an expiry period of
-DiscoveryCollectionRetentionSeconds. It can also be enabled by
+config.GetDiscoveryCollectionMetricsTTL(). It can also be enabled by
 calling StartAutoExpiration() after setting the required expire
 period with SetExpirePeriod().
 
@@ -54,7 +54,7 @@ of metrics which have passed the time specified. Not enabling expiry
 will mean data is collected but never freed which will make
 vtorc run out of memory eventually.
 
-Current code uses DiscoveryCollectionRetentionSeconds as the
+Current code uses config.GetDiscoveryCollectionMetricsTTL() as the
 time to keep metric data.
 */
 package collection
@@ -111,7 +111,7 @@ func CreateOrReturnCollection(name string) *Collection {
 		collection: nil,
 		done:       make(chan struct{}),
 		// WARNING: use a different configuration name
-		expirePeriod: time.Duration(config.DiscoveryCollectionRetentionSeconds) * time.Second,
+		expirePeriod: config.GetDiscoveryCollectionMetricsTTL(),
 	}
 	go qmc.StartAutoExpiration()
 

--- a/go/vt/vtorc/config/config.go
+++ b/go/vt/vtorc/config/config.go
@@ -34,7 +34,6 @@ const (
 	StaleInstanceCoordinatesExpireSeconds = 60
 	DiscoveryQueueCapacity                = 100000
 	DiscoveryQueueMaxStatisticsSize       = 120
-	DiscoveryCollectionRetentionSeconds   = 120
 	UnseenInstanceForgetHours             = 240 // Number of hours after which an unseen instance is forgotten
 )
 
@@ -218,6 +217,15 @@ var (
 			Dynamic:  true,
 		},
 	)
+
+	discoveryCollectionMetricsTTL = viperutil.Configure(
+		"discovery-collection-metrics-ttl",
+		viperutil.Options[time.Duration]{
+			FlagName: "discovery-collection-metrics-ttl",
+			Default:  120 * time.Second,
+			Dynamic:  true,
+		},
+	)
 )
 
 func init() {
@@ -246,6 +254,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.Bool("allow-recovery", allowRecovery.Default(), "Whether VTOrc should be allowed to run recovery actions")
 	fs.Bool("change-tablets-with-errant-gtid-to-drained", convertTabletsWithErrantGTIDs.Default(), "Whether VTOrc should be changing the type of tablets with errant GTIDs to DRAINED")
 	fs.Bool("enable-primary-disk-stalled-recovery", enablePrimaryDiskStalledRecovery.Default(), "Whether VTOrc should detect a stalled disk on the primary and failover")
+	fs.Duration("discovery-collection-metrics-ttl", discoveryCollectionMetricsTTL.Default(), "The time-to-live for discovery collection metrics")
 
 	viperutil.BindFlags(fs,
 		instancePollTime,
@@ -268,6 +277,7 @@ func registerFlags(fs *pflag.FlagSet) {
 		allowRecovery,
 		convertTabletsWithErrantGTIDs,
 		enablePrimaryDiskStalledRecovery,
+		discoveryCollectionMetricsTTL,
 	)
 }
 
@@ -379,6 +389,11 @@ func GetTopoInformationRefreshDuration() time.Duration {
 // GetRecoveryPollDuration is a getter function.
 func GetRecoveryPollDuration() time.Duration {
 	return recoveryPollDuration.Get()
+}
+
+// GetDiscoveryCollectionMetricsTTL is a getter function.
+func GetDiscoveryCollectionMetricsTTL() time.Duration {
+	return discoveryCollectionMetricsTTL.Get()
 }
 
 // ERSEnabled reports whether VTOrc is allowed to run ERS or not.


### PR DESCRIPTION
## Description

This PR adds the flag `--discovery-collection-metrics-ttl duration` for setting the time-to-live for discovery collection metrics _(default 2m0s)_. This data seems to be used for the aggregated metrics HTTP API only.

This replaces the hardcoded `120` seconds that exists today. In some situations this can lead to a lot of metrics being stored, for example a host monitoring 3000 tablets every 2s will store 180,000 metrics at the `120` second expiry

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
