### PR TITLE
Allow specifying the number of characters to use when generating shard ranges.

### DIFF
--- a/go/vt/key/key.go
+++ b/go/vt/key/key.go
@@ -448,3 +448,47 @@ func GenerateShardRanges(shards int) ([]string, error) {
 
 	return shardRanges, nil
 }
+
+func GenerateShardRangesWithGranularity(shards int, hexChars int) ([]string, error) {
+	maxShards := math.Pow(16, float64(hexChars))
+
+	if shards <= 0 {
+		return nil, errors.New("shards must be greater than zero")
+	}
+	if shards > int(maxShards) {
+		return nil, fmt.Errorf("the given number of shards %d is too high for the given number of characters to use %d", shards, hexChars)
+	}
+
+	format := fmt.Sprintf("%%0%dx", hexChars)
+
+	rangeFormatter := func(start, end int) string {
+		var (
+			startKid string
+			endKid   string
+		)
+
+		if start != 0 {
+			startKid = fmt.Sprintf(format, start)
+		}
+
+		if end != int(maxShards) {
+			endKid = fmt.Sprintf(format, end)
+		}
+
+		return fmt.Sprintf("%s-%s", startKid, endKid)
+	}
+
+	boundaries := make([]int, 0, shards+1)
+	for i := 0; i < shards; i++ {
+		boundaries = append(boundaries, int(float64(i)*maxShards/float64(shards)))
+	}
+
+	shardRanges := make([]string, 0, shards)
+	shardRanges = append(shardRanges, rangeFormatter(0, boundaries[1])) // first shard
+	for i := 1; i < shards-1; i++ {
+		shardRanges = append(shardRanges, rangeFormatter(boundaries[i], boundaries[i+1]))
+	}
+	shardRanges = append(shardRanges, rangeFormatter(boundaries[shards-1], int(maxShards))) // last shard
+
+	return shardRanges, nil
+}

--- a/go/vt/key/key_test.go
+++ b/go/vt/key/key_test.go
@@ -1554,6 +1554,35 @@ func TestShardCalculatorForShardsGreaterThan512(t *testing.T) {
 	assert.Equal(t, want, got[511], "Invalid mapping for a 512-shard keyspace. Expected %v, got %v", want, got[511])
 }
 
+func TestGenerateShardRangesWithGranularity(t *testing.T) {
+	{
+		ranges, err := GenerateShardRanges(7)
+
+		assert.NoError(t, err)
+
+		assert.EqualValues(t, 7, len(ranges))
+		assert.EqualValues(t, []string{"-24", "24-49", "49-6d", "6d-92", "92-b6", "b6-db", "db-"}, ranges)
+	}
+
+	{
+		ranges, err := GenerateShardRangesWithGranularity(7, 3)
+
+		assert.NoError(t, err)
+
+		assert.EqualValues(t, 7, len(ranges))
+		assert.EqualValues(t, []string{"-249", "249-492", "492-6db", "6db-924", "924-b6d", "b6d-db6", "db6-"}, ranges)
+	}
+
+	{
+		ranges, err := GenerateShardRangesWithGranularity(7, 4)
+
+		assert.NoError(t, err)
+
+		assert.EqualValues(t, 7, len(ranges))
+		assert.EqualValues(t, []string{"-2492", "2492-4924", "4924-6db6", "6db6-9249", "9249-b6db", "b6db-db6d", "db6d-"}, ranges)
+	}
+}
+
 func stringToKeyRange(spec string) *topodatapb.KeyRange {
 	if spec == "" {
 		return nil


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
