### PR TITLE
[release-22.0] Fix vtgate upgrade downgrade tests

### DIFF
--- a/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
@@ -82,9 +82,15 @@ func TestMain(m *testing.M) {
 			VSchema:       VSchema,
 			SidecarDBName: sidecarDBName,
 		}
-		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,
-			"--schema_change_signal",
-			"--vschema_ddl_authorized_users", "%")
+		if vtgateVer >= 22 {
+			clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,
+				"--schema-change-signal",
+				"--vschema-ddl-authorized-users", "%")
+		} else {
+			clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,
+				"--schema_change_signal",
+				"--vschema_ddl_authorized_users", "%")
+		}
 		clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-config-schema-change-signal")
 
 		if vtgateVer >= 16 && vttabletVer >= 16 {

--- a/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
@@ -82,9 +82,9 @@ func TestMain(m *testing.M) {
 			VSchema:       VSchema,
 			SidecarDBName: sidecarDBName,
 		}
-		if vtgateVer >= 22 {
+		if vtgateVer > 22 {
 			clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,
-				"--schema_change_signal",
+				"--schema-change-signal",
 				"--vschema-ddl-authorized-users", "%")
 		} else {
 			clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,

--- a/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
+++ b/go/test/endtoend/vtgate/schematracker/sharded/st_sharded_test.go
@@ -84,7 +84,7 @@ func TestMain(m *testing.M) {
 		}
 		if vtgateVer >= 22 {
 			clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,
-				"--schema-change-signal",
+				"--schema_change_signal",
 				"--vschema-ddl-authorized-users", "%")
 		} else {
 			clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,


### PR DESCRIPTION
## Description

This fixes a failing end to end test case on the `release-22.0` branch, that's caused by recent CLI argument changes (`_` being changed to `-`) in `main`.

I didn't bother pulling in the `GetFlagVariantForTestsByVersion` helper from `main`, because just using an `if`/`else` seemed simple enough here.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
