### PR TITLE
`vtorc`: add `Reason` and missing cases to `SkippedRecoveries` metric

### DIFF
--- a/changelog/23.0/23.0.0/summary.md
+++ b/changelog/23.0/23.0.0/summary.md
@@ -70,9 +70,9 @@ VTGate also advertises MySQL version `8.4.6` by default instead of `8.0.40`. If 
 
 #### <a id="new-vtorc-metrics"/>VTOrc
 
-|          Name       |   Dimensions                        |                   Description                        |                           PR                            |
-|:-------------------:|:-----------------------------------:|:----------------------------------------------------:|:-------------------------------------------------------:|
-| `SkippedRecoveries` | `RecoveryName`, `Keyspace`, `Shard` | Count of the different skipped recoveries performed. | [#17985](https://github.com/vitessio/vitess/pull/17985) |
+|          Name       |   Dimensions                                  |                   Description                        |                           PR                            |
+|:-------------------:|:---------------------------------------------:|:----------------------------------------------------:|:-------------------------------------------------------:|
+| `SkippedRecoveries` | `RecoveryName`, `Keyspace`, `Shard`, `Reason` | Count of the different skipped recoveries processed. | [#17985](https://github.com/vitessio/vitess/pull/17985) |
 
 ### <a id="minor-changes-topo"/>Topology</a>
 

--- a/go/test/endtoend/vtorc/primaryfailure/primary_failure_test.go
+++ b/go/test/endtoend/vtorc/primaryfailure/primary_failure_test.go
@@ -166,7 +166,7 @@ func TestDownPrimary_KeyspaceEmergencyReparentDisabled(t *testing.T) {
 	}()
 
 	// check ERS did not occur. For the RecoverDeadPrimary recovery, expect 1 skipped recovery, 0 successful recoveries and 0 ERS operations.
-	utils.WaitForSkippedRecoveryCount(t, vtOrcProcess, logic.RecoverDeadPrimaryRecoveryName, keyspace.Name, shard0.Name, 1)
+	utils.WaitForSkippedRecoveryCount(t, vtOrcProcess, logic.RecoverDeadPrimaryRecoveryName, keyspace.Name, shard0.Name, inst.RecoverySkippedReasonERSDisabled, 1)
 	utils.WaitForSuccessfulRecoveryCount(t, vtOrcProcess, logic.RecoverDeadPrimaryRecoveryName, keyspace.Name, shard0.Name, 0)
 	utils.WaitForSuccessfulERSCount(t, vtOrcProcess, keyspace.Name, shard0.Name, 0)
 

--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -1002,10 +1002,10 @@ func WaitForSuccessfulRecoveryCount(t *testing.T, vtorcInstance *cluster.VTOrcPr
 }
 
 // WaitForSkippedRecoveryCount waits until the given recovery name's count of skipped runs matches the count expected
-func WaitForSkippedRecoveryCount(t *testing.T, vtorcInstance *cluster.VTOrcProcess, recoveryName, keyspace, shard string, countExpected int) {
+func WaitForSkippedRecoveryCount(t *testing.T, vtorcInstance *cluster.VTOrcProcess, recoveryName, keyspace, shard, reason string, countExpected int) {
 	t.Helper()
 	timeout := 15 * time.Second
-	mapKey := fmt.Sprintf("%s.%s.%s", recoveryName, keyspace, shard)
+	mapKey := fmt.Sprintf("%s.%s.%s.%s", recoveryName, keyspace, shard, reason)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		vars := vtorcInstance.GetVars()
 		skippedRecoveriesMap := vars["SkippedRecoveries"].(map[string]interface{})


### PR DESCRIPTION
## Description

This PR extends the VTOrc `SkippedRecoveries` counter-metric by adding a `Reason` field and some missing cases

This metric was recently introduced in https://github.com/vitessio/vitess/pull/17985 and no releases have occurred since

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
