### PR TITLE
[Query Throttler] Add dry-run mode

### DIFF
--- a/go/vt/vttablet/tabletserver/querythrottler/config.go
+++ b/go/vt/vttablet/tabletserver/querythrottler/config.go
@@ -27,6 +27,11 @@ type Config struct {
 	// Enabled indicates whether the throttler should actively apply throttling logic.
 	Enabled bool `json:"enabled"`
 
+	// DryRun indicates whether throttling decisions should be logged but not enforced.
+	// When true, queries that would be throttled are allowed to proceed, but the
+	// throttling decision is logged for observability.
+	DryRun bool `json:"dry_run"`
+
 	// Strategy selects which throttling strategy should be used.
 	Strategy registry.ThrottlingStrategy `json:"strategy"`
 }

--- a/go/vt/vttablet/tabletserver/querythrottler/file_based_config_loader_test.go
+++ b/go/vt/vttablet/tabletserver/querythrottler/file_based_config_loader_test.go
@@ -91,6 +91,23 @@ func TestFileBasedConfigLoader_Load(t *testing.T) {
 			expectedErrorNotNil: true,
 		},
 		{
+			name:       "successful config load with dry run as enabled",
+			configPath: "/config/throttler-config.json",
+			mockReadFile: func(filename string) ([]byte, error) {
+				require.Equal(t, "/config/throttler-config.json", filename)
+				return []byte(`{"enabled": true, "strategy": "TabletThrottler", "dry_run": true}`), nil
+			},
+			mockJsonUnmarshal: func(data []byte, v interface{}) error {
+				return json.Unmarshal(data, v)
+			},
+			expectedConfig: Config{
+				Enabled:  true,
+				Strategy: registry.ThrottlingStrategyTabletThrottler,
+				DryRun:   true,
+			},
+			expectedErrorNotNil: false,
+		},
+		{
 			name:       "file read error - permission denied",
 			configPath: "/config/throttler-config.json",
 			mockReadFile: func(filename string) ([]byte, error) {

--- a/go/vt/vttablet/tabletserver/querythrottler/query_throttler.go
+++ b/go/vt/vttablet/tabletserver/querythrottler/query_throttler.go
@@ -103,6 +103,12 @@ func (qt *QueryThrottler) Throttle(ctx context.Context, tabletType topodatapb.Ta
 		return nil
 	}
 
+	// If dry-run mode is enabled, log the decision but don't throttle
+	if qt.cfg.DryRun {
+		log.Warningf("[DRY-RUN] %s", decision.Message)
+		return nil
+	}
+
 	// Normal throttling: return an error to reject the query
 	return vterrors.New(vtrpcpb.Code_RESOURCE_EXHAUSTED, decision.Message)
 }

--- a/go/vt/vttablet/tabletserver/querythrottler/query_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/querythrottler/query_throttler_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
 	"vitess.io/vitess/go/vt/log"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"


### PR DESCRIPTION
## Description
This PR introduces option for having a "Dry Run Mode" in the Query Throttler system for Vitess tablets outlined in RFC https://github.com/vitessio/vitess/issues/18412  , First PR :https://github.com/vitessio/vitess/pull/18449
In this PR we are Implements a dry-run mode for the Query Throttler that allows observing throttling decisions without actually blocking queries.

### Background:
- Query throttling is critical for database performance but can be risky when first deployed
- Operators need visibility into throttling behavior before enabling actual query blocking
- Testing throttling logic in production environments requires non-disruptive monitoring 

### Solution:
- Add DryRun boolean field to Config struct for controlling dry-runbehavior
- When dry-run is enabled, throttling decisions are logged as warnings but queries proceed normally
- Maintains full compatibility with existing throttling logic and strategies
- Added comprehensive test coverage for all dry-run scenarios including disabled throttler, normal mode, and dry-run mode combinations.

### Test Plan:
- Added unit tests covering all dry-run mode scenarios in TestIncomingQueryThrottler_DryRunMode
- Tests verify proper logging behavior and query execution flow
- Existing query throttler tests continue to pass ensuring no regression

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required