### PR TITLE
`vtorc`: enable `read_uncommitted` when in sqlite shared-cache mode

### DIFF
--- a/go/vt/vtorc/config/config.go
+++ b/go/vt/vtorc/config/config.go
@@ -307,6 +307,11 @@ func GetSQLiteDataFile() string {
 	return sqliteDataFile.Get()
 }
 
+// SetSQLiteDataFile is a Setter function.
+func SetSQLiteDataFile(dataFile string) {
+	sqliteDataFile.Set(dataFile)
+}
+
 // GetReasonableReplicationLagSeconds gets the reasonable replication lag but in seconds.
 func GetReasonableReplicationLagSeconds() int64 {
 	return int64(reasonableReplicationLag.Get() / time.Second)

--- a/go/vt/vtorc/db/db_test.go
+++ b/go/vt/vtorc/db/db_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/vtorc/config"
+)
+
+func TestGetSqlitePragmaSQLs(t *testing.T) {
+	origSqliteDataPath := config.GetSQLiteDataFile()
+	defer config.SetSQLiteDataFile(origSqliteDataPath)
+
+	// no shared-cache mode
+	config.SetSQLiteDataFile("file::memory:?mode=memory")
+	require.Equal(t, []string{
+		"PRAGMA journal_mode = WAL",
+		"PRAGMA synchronous = NORMAL",
+	}, getSqlitePragmaSQLs())
+
+	// shared-cache mode
+	config.SetSQLiteDataFile("file::memory:?mode=memory&cache=shared")
+	require.Equal(t, []string{
+		"PRAGMA journal_mode = WAL",
+		"PRAGMA synchronous = NORMAL",
+		"PRAGMA read_uncommitted = 1",
+	}, getSqlitePragmaSQLs())
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR causes VTOrc to use a `READ-COMMITTED` transaction isolation when running in shared-cache mode, which is what VTOrc does by default

Why? The default isolation level of sqlite3 is `SERIALIZABLE`, which has a major impact on concurrency of both reads and writes. VTOrc reads and writes data from the same sqlite3 tables concurrently. After the VTOrc performance tunings for concurrency _(many-1000s of tablets per instance)_, the main bottleneck showing up in profiles is the sqlite3 golang library itself

A change to `READ-COMMITTED` should reduce some overhead in the sqlite3 library and allow reads to occur without blocking on writes. Aside from CI passing, I believe this change is safe because the only explicit `BEGIN`/`COMMIT` transaction in VTOrc [happens during init time](https://github.com/vitessio/vitess/blob/main/go/vt/vtorc/db/db.go#L79), before the isolation level is set and any data is read or written. There are cases where many instances are written at once, however this is always done in a single mulit-`INSERT`/`REPLACE INTO`, never explicit transactions that could introduce consistency risks when paired with `READ-COMMITTED`

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
