### PR TITLE
ci: Disable man-db auto updates.

### DIFF
--- a/.github/workflows/check_make_vtadmin_authz_testgen.yml
+++ b/.github/workflows/check_make_vtadmin_authz_testgen.yml
@@ -54,6 +54,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get dependencies
       if: steps.changes.outputs.vtadmin_changes == 'true'
       run: |

--- a/.github/workflows/cluster_endtoend_12.yml
+++ b/.github/workflows/cluster_endtoend_12.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_13.yml
+++ b/.github/workflows/cluster_endtoend_13.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_15.yml
+++ b/.github/workflows/cluster_endtoend_15.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_18.yml
+++ b/.github/workflows/cluster_endtoend_18.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_21.yml
+++ b/.github/workflows/cluster_endtoend_21.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_backup_pitr.yml
+++ b/.github/workflows/cluster_endtoend_backup_pitr.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_backup_pitr_mysqlshell.yml
+++ b/.github/workflows/cluster_endtoend_backup_pitr_mysqlshell.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_backup_pitr_xtrabackup.yml
+++ b/.github/workflows/cluster_endtoend_backup_pitr_xtrabackup.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
+++ b/.github/workflows/cluster_endtoend_ers_prs_newfeatures_heavy.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_mysql84.yml
+++ b/.github/workflows/cluster_endtoend_mysql84.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_mysql_server_vault.yml
+++ b/.github/workflows/cluster_endtoend_mysql_server_vault.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_revert.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_revert.yml
@@ -78,9 +78,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_scheduler.yml
@@ -78,9 +78,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl.yml
@@ -78,9 +78,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress.yml
@@ -78,9 +78,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_stress_suite.yml
@@ -78,9 +78,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
+++ b/.github/workflows/cluster_endtoend_onlineddl_vrepl_suite.yml
@@ -78,9 +78,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
+++ b/.github/workflows/cluster_endtoend_schemadiff_vrepl.yml
@@ -78,9 +78,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_consul.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_tablegc.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_tabletmanager_throttler_topo.yml
+++ b/.github/workflows/cluster_endtoend_tabletmanager_throttler_topo.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_topo_connection_cache.yml
+++ b/.github/workflows/cluster_endtoend_topo_connection_cache.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_across_db_versions.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_basic.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_basic.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_cellalias.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_copy_parallel.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_copy_parallel.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_foreign_key_stress.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_foreign_key_stress.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_mariadb_to_mysql.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_mariadb_to_mysql.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_migrate.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_migrate.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_multi_tenant.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_multi_tenant.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_partial_movetables_and_materialize.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_partial_movetables_and_materialize.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_v2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_v2.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_vdiff2.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_vdiff2.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vreplication_vtctldclient_movetables_tz.yml
+++ b/.github/workflows/cluster_endtoend_vreplication_vtctldclient_movetables_tz.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vstream.yml
+++ b/.github/workflows/cluster_endtoend_vstream.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtbackup.yml
+++ b/.github/workflows/cluster_endtoend_vtbackup.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtctlbackup_sharded_clustertest_heavy.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_concurrentdml.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_foreignkey_stress.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_foreignkey_stress.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_gen4.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_gen4.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_general_heavy.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_godriver.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_godriver.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_partial_keyspace.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_plantests.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_plantests.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_queries.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_queries.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_readafterwrite.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_reservedconn.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_schema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_schema_tracker.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_tablet_healthcheck_cache.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_consul.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_topo_etcd.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_transaction.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_transaction.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_unsharded.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vindex_heavy.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtgate_vschema.yml
+++ b/.github/workflows/cluster_endtoend_vtgate_vschema.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vtorc.yml
+++ b/.github/workflows/cluster_endtoend_vtorc.yml
@@ -86,9 +86,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_vttablet_prscomplex.yml
+++ b/.github/workflows/cluster_endtoend_vttablet_prscomplex.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_xb_backup.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -77,9 +77,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -48,6 +48,10 @@ jobs:
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get dependencies
       if: steps.changes.outputs.changed_files == 'true'
       run: |

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -31,6 +31,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -56,6 +56,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -56,6 +56,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'
       run: |

--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -127,6 +127,10 @@ jobs:
         run: |
           sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+          # Don't waste a bunch of time processing man-db triggers
+          echo "set man-db/auto-update false" | sudo debconf-communicate
+          sudo dpkg-reconfigure man-db
+
       - name: Run go fmt
         if: steps.changes.outputs.go_files == 'true'
         run: |

--- a/.github/workflows/unit_race.yml
+++ b/.github/workflows/unit_race.yml
@@ -71,6 +71,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get dependencies
       if: steps.changes.outputs.unit_tests == 'true'
       run: |

--- a/.github/workflows/unit_race_evalengine.yml
+++ b/.github/workflows/unit_race_evalengine.yml
@@ -71,6 +71,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get dependencies
       if: steps.changes.outputs.unit_tests == 'true'
       run: |

--- a/.github/workflows/unit_test_evalengine_mysql57.yml
+++ b/.github/workflows/unit_test_evalengine_mysql57.yml
@@ -72,9 +72,14 @@ jobs:
       if: steps.changes.outputs.unit_tests == 'true'
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_evalengine_mysql80.yml
+++ b/.github/workflows/unit_test_evalengine_mysql80.yml
@@ -72,9 +72,14 @@ jobs:
       if: steps.changes.outputs.unit_tests == 'true'
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_evalengine_mysql84.yml
+++ b/.github/workflows/unit_test_evalengine_mysql84.yml
@@ -72,9 +72,14 @@ jobs:
       if: steps.changes.outputs.unit_tests == 'true'
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_mysql57.yml
+++ b/.github/workflows/unit_test_mysql57.yml
@@ -72,9 +72,14 @@ jobs:
       if: steps.changes.outputs.unit_tests == 'true'
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -72,9 +72,14 @@ jobs:
       if: steps.changes.outputs.unit_tests == 'true'
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test_mysql84.yml
+++ b/.github/workflows/unit_test_mysql84.yml
@@ -72,9 +72,14 @@ jobs:
       if: steps.changes.outputs.unit_tests == 'true'
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -77,6 +77,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get base dependencies
       timeout-minutes: 10
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -79,6 +79,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get base dependencies
       timeout-minutes: 10
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -81,6 +81,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get base dependencies
       timeout-minutes: 10
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -82,6 +82,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get base dependencies
       timeout-minutes: 10
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
+++ b/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
@@ -88,6 +88,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get base dependencies
       timeout-minutes: 10
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -81,6 +81,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get base dependencies
       timeout-minutes: 10
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
@@ -81,6 +81,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get base dependencies
       timeout-minutes: 10
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
@@ -82,6 +82,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get base dependencies
       timeout-minutes: 10
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -82,6 +82,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get base dependencies
       timeout-minutes: 10
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -81,6 +81,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get base dependencies
       timeout-minutes: 10
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -82,6 +82,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get base dependencies
       timeout-minutes: 10
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -82,6 +82,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get base dependencies
       timeout-minutes: 10
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -82,6 +82,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get base dependencies
       timeout-minutes: 10
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -81,6 +81,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get base dependencies
       timeout-minutes: 10
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -81,6 +81,10 @@ jobs:
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
     - name: Get base dependencies
       timeout-minutes: 10
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_semi_sync.yml
+++ b/.github/workflows/upgrade_downgrade_test_semi_sync.yml
@@ -77,6 +77,10 @@ jobs:
         run: |
           sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
 
+          # Don't waste a bunch of time processing man-db triggers
+          echo "set man-db/auto-update false" | sudo debconf-communicate
+          sudo dpkg-reconfigure man-db
+
       - name: Get base dependencies
         timeout-minutes: 10
         if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/vitess_tester_vtgate.yml
+++ b/.github/workflows/vitess_tester_vtgate.yml
@@ -76,9 +76,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/vtop_example.yml
+++ b/.github/workflows/vtop_example.yml
@@ -61,6 +61,10 @@ jobs:
         run: |
           echo '1024 65535' | sudo tee -a /proc/sys/net/ipv4/ip_local_port_range
 
+          # Don't waste a bunch of time processing man-db triggers
+          echo "set man-db/auto-update false" | sudo debconf-communicate
+          sudo dpkg-reconfigure man-db
+
       - name: Get dependencies
         if: steps.changes.outputs.end_to_end == 'true'
         run: |

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -98,9 +98,15 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_endtoend_test_mysql57.tpl
+++ b/test/templates/cluster_endtoend_test_mysql57.tpl
@@ -100,9 +100,15 @@ jobs:
       if: steps.changes.outputs.end_to_end == 'true'
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/cluster_vitess_tester.tpl
+++ b/test/templates/cluster_vitess_tester.tpl
@@ -81,9 +81,14 @@ jobs:
         # Limit local port range to not use ports that overlap with server side
         # ports that we listen on.
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -77,9 +77,15 @@ jobs:
       if: steps.changes.outputs.unit_tests == 'true'
       run: |
         sudo sysctl -w net.ipv4.ip_local_port_range="22768 65535"
+
         # Increase the asynchronous non-blocking I/O. More information at https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_use_native_aio
         echo "fs.aio-max-nr = 1048576" | sudo tee -a /etc/sysctl.conf
         sudo sysctl -p /etc/sysctl.conf
+
+        # Don't waste a bunch of time processing man-db triggers
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
+
 
     - name: Get dependencies
       if: steps.changes.outputs.unit_tests == 'true'


### PR DESCRIPTION
## Description

This change reduces the time spent in GitHub Actions installing dependencies by skipping man db updates during the installation.

Thanks to @nickvanw for the idea!

#### Before

<img width="1276" height="840" alt="image" src="https://github.com/user-attachments/assets/9c7ef824-4417-4e9c-b1fe-c1337924f990" />

#### After

<img width="1266" height="839" alt="image" src="https://github.com/user-attachments/assets/a3346963-b0ef-4863-bfc6-71f224548a45" />

## Related Issue(s)

N/A

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
