### PR TITLE
Delete invalid comments.

### DIFF
--- a/examples/common/backup-scripts/vttablet-up.sh
+++ b/examples/common/backup-scripts/vttablet-up.sh
@@ -35,8 +35,6 @@ fi
 
 # Additional logging and explicit topology flags for vttablet for the backup local example
 # to ensure it uses the underscored topology flags that are required for older vttablet versions.
-// TODO: in v25 we can start using the local example env.sh and common scripts and delete the extra
-// ones created for backup upgrade/downgrade tests to work.
 echo "Starting backup vttablet for $alias..."
 echo "Topology flags inherited at start of backup vttablet: $TOPOLOGY_FLAGS"
 export TOPOLOGY_FLAGS="--topo_implementation etcd2 --topo_global_server_address $ETCD_SERVER --topo_global_root /vitess/global"


### PR DESCRIPTION
## Description

In `examples/common/backup-scripts/vttablet-up.sh`, which was added recently, we have two commented out lines which are using `//` to start the comment. Unfortunately, that's not how comments can be started in bash, leading to error messages (but is not sever enough to stop the script execution).

<img width="848" height="151" alt="image" src="https://github.com/user-attachments/assets/ed681d7d-0666-4e9e-a984-af7bbd79f9e7" />

Let's just remove those two lines.

## Related Issue(s)

N/A

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
