### PR TITLE
Update list of maintainers.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,13 +3,13 @@ This page lists all active maintainers and their areas of expertise. This can be
 The following is the full list, alphabetically ordered.
 
 * Andres Taylor ([systay](https://github.com/systay)) andres@planetscale.com
-* Arthur Schreiber ([arthurschreiber](https://github.com/arthurschreiber)) arthurschreiber@github.com
+* Arthur Schreiber ([arthurschreiber](https://github.com/arthurschreiber)) schreiber.arthur@gmail.com
 * Derek Perkins ([derekperkins](https://github.com/derekperkins)) derek@nozzle.io
 * Dirkjan Bussink ([dbussink](https://github.com/dbussink)) dbussink@planetscale.com
 * Florent Poinsard ([frouioui](https://github.com/frouioui)) florent@planetscale.com
-* Frances Thai ([notfelineit](https://github.com/notfelineit)) notfelineit@gmail.com
 * Harshit Gangal ([harshit-gangal](https://github.com/harshit-gangal)) harshit.gangal@gmail.com
 * Matt Lord ([mattlord](https://github.com/mattlord)) mattalord@gmail.com
+* Noble Mittal ([beingnoble03](https://github.com/beingnoble03)) noble@planetscale.com
 * Rohit Nayak ([rohit-nayak-ps](https://github.com/rohit-nayak-ps)) rohit@planetscale.com
 * Shlomi Noach ([shlomi-noach](https://github.com/shlomi-noach)) shlomi@planetscale.com
 * Tim Vaillancourt ([timvaillancourt](https://github.com/timvaillancourt)) tim@timvaillancourt.com
@@ -26,7 +26,7 @@ shlomi-noach, frouioui
 rohit-nayak-ps, mattlord
 
 ### Parser
-systay, harshit-gangal, vmg, dbussink
+systay, harshit-gangal, dbussink
 
 ### Evaluation Engine
 dbussink, systay
@@ -50,7 +50,7 @@ harshit-gangal
 derekperkins, frouioui
 
 ### VTAdmin
-notfelineit, rohit-nayak-ps
+beingnoble03, rohit-nayak-ps
 
 ### Messaging
 derekperkins, mattlord
@@ -65,6 +65,7 @@ We thank the following past maintainers for their contributions.
 * Dan Kozlowski ([dkhenry](https://github.com/dkhenry))
 * David Weitzman ([dweitzman](https://github.com/dweitzman))
 * Deepthi Sigireddi ([deepthi](https://github.com/deepthi))
+* Frances Thai ([notfelineit](https://github.com/notfelineit))
 * Jon Tirsen ([tirsen](https://github.com/tirsen))
 * Leo X. Lin ([leoxlin](https://github.com/leoxlin))
 * Mali Akmanalp ([makmanalp](https://github.com/makmanalp)


### PR DESCRIPTION
## Description

This moves @notfelineit to the list of past maintainers, and adds @beingnoble03. Also removes leftover mention of @vmg.

## Related Issue(s)

N/A

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
