### PR TITLE
[release-21.0] Update codeowners and maintainers.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,88 +1,92 @@
-* @deepthi
-bootstrap.sh @ajm188 @deepthi @frouioui @vmg
-go.mod @ajm188 @deepthi @harshit-gangal @mattlord @rohit-nayak-ps @systay @frouioui
-go.sum @ajm188 @deepthi @harshit-gangal @mattlord @rohit-nayak-ps @systay @frouioui
-/.github/ @deepthi @mattlord @rohit-nayak-ps @frouioui
-/.github/ISSUE_TEMPLATE/ @deepthi @frouioui @mattlord
-/.github/workflows/ @deepthi @frouioui @mattlord @rohit-nayak-ps
-/config/mycnf/ @deepthi @shlomi-noach @mattlord
-/doc/ @deepthi @frouioui @GuptaManan100
-/docker/ @deepthi @derekperkins @mattlord @GuptaManan100 @frouioui
-/examples/compose @shlomi-noach @GuptaManan100 @frouioui
+bootstrap.sh @frouioui
+go.mod @harshit-gangal @mattlord @rohit-nayak-ps @systay @frouioui
+go.sum @harshit-gangal @mattlord @rohit-nayak-ps @systay @frouioui
+/.github/ @mattlord @rohit-nayak-ps @frouioui
+/.github/ISSUE_TEMPLATE/ @frouioui @mattlord
+/.github/workflows/ @frouioui @mattlord @rohit-nayak-ps
+/config/mycnf/ @shlomi-noach @mattlord
+/doc/ @frouioui
+/docker/ @derekperkins @mattlord @frouioui
+/examples/compose @shlomi-noach @frouioui
 /examples/demo @mattlord @rohit-nayak-ps
-/examples/local @rohit-nayak-ps @frouioui @mattlord @GuptaManan100
-/examples/operator @GuptaManan100 @frouioui @mattlord
-/examples/region_sharding @deepthi @mattlord
+/examples/local @rohit-nayak-ps @frouioui @mattlord
+/examples/operator @frouioui @mattlord
+/examples/region_sharding @mattlord
 /java/ @harshit-gangal
-/go/cache @vmg
-/go/cmd @ajm188 @deepthi @mattlord
-/go/cmd/vtadmin @ajm188 @notfelineit
-/go/cmd/vtctldclient @ajm188 @mattlord
+/go/cmd @mattlord
+/go/cmd/vtadmin @notfelineit
+/go/cmd/vtctldclient @mattlord @notfelineit
 /go/cmd/vtctldclient/command/throttler.go @shlomi-noach @mattlord
-/go/cmd/vtctldclient/command/vreplication @mattlord @rohit-nayak-ps
-/go/internal/flag @ajm188 @rohit-nayak-ps
+/go/cmd/vtctldclient/command/vreplication @mattlord @rohit-nayak-ps @shlomi-noach @notfelineit
+/go/cmd/vtctldclient/command/backups.go @frouioui @mattlord
+/go/cmd/vtbackup @frouioui
+/go/internal/flag @rohit-nayak-ps
 /go/mysql @harshit-gangal @systay @mattlord
-/go/pools @deepthi @harshit-gangal
-/go/protoutil @ajm188 @deepthi @mattlord
-/go/sqltypes @harshit-gangal @shlomi-noach @vmg
+/go/pools @harshit-gangal
+/go/protoutil @mattlord
+/go/sqltypes @harshit-gangal @shlomi-noach
 /go/test/endtoend/onlineddl @rohit-nayak-ps @shlomi-noach
 /go/test/endtoend/messaging @mattlord @rohit-nayak-ps @derekperkins
 /go/test/endtoend/schemadiff @shlomi-noach @mattlord
+/go/test/endtoend/transaction @harshit-gangal @systay @frouioui
 /go/test/endtoend/*throttler* @shlomi-noach @mattlord @timvaillancourt
 /go/test/endtoend/vtgate @harshit-gangal @systay @frouioui
-/go/test/endtoend/vtorc @deepthi @shlomi-noach @GuptaManan100 @timvaillancourt
+/go/test/endtoend/vtorc @shlomi-noach @timvaillancourt
 /go/tools/ @frouioui @systay
 /go/vt/dbconnpool @harshit-gangal @mattlord
-/go/vt/discovery @deepthi @frouioui
+/go/vt/discovery @frouioui
 /go/vt/discovery/*tablet_picker* @rohit-nayak-ps @mattlord
-/go/vt/mysqlctl @deepthi @mattlord
-/go/vt/proto @deepthi @harshit-gangal @mattlord
-/go/vt/proto/vtadmin @ajm188 @notfelineit
+/go/vt/mysqlctl @mattlord @frouioui
+/go/vt/proto @harshit-gangal @mattlord
+/go/vt/proto/vtadmin @notfelineit
 /go/vt/schema @mattlord @shlomi-noach
-/go/vt/servenv @deepthi @ajm188
+/go/vt/servenv @dbussink
 /go/vt/schemadiff @shlomi-noach @mattlord
-/go/vt/sqlparser @harshit-gangal @systay @GuptaManan100
-/go/vt/srvtopo @deepthi @mattlord
+/go/vt/sqlparser @harshit-gangal @systay
+/go/vt/srvtopo @mattlord
 /go/vt/sysvars @harshit-gangal @systay
-/go/vt/topo @deepthi @mattlord
-/go/vt/topotools @deepthi @mattlord
+/go/vt/topo @mattlord
+/go/vt/topotools @mattlord
 /go/vt/vitessdriver @harshit-gangal
-/go/vt/vtadmin @ajm188 @notfelineit @rohit-nayak-ps
-/go/vt/vtctl @ajm188 @deepthi @rohit-nayak-ps
+/go/vt/vtadmin @notfelineit @rohit-nayak-ps
+/go/vt/vtctl @rohit-nayak-ps
 /go/vt/vtctl/vtctl.go @notfelineit @rohit-nayak-ps
-/go/vt/vtctl/grpcvtctldclient @ajm188 @notfelineit @mattlord
-/go/vt/vtctl/grpcvtctldserver @ajm188 @notfelineit @mattlord
-/go/vt/vtctl/reparentutil @ajm188 @GuptaManan100 @deepthi
-/go/vt/vtctl/vtctldclient @ajm188 @notfelineit @mattlord
-/go/vt/vtctld @ajm188 @deepthi @notfelineit @rohit-nayak-ps @mattlord
-/go/vt/vterrors @harshit-gangal @systay
+/go/vt/vtctl/grpcvtctldclient @notfelineit @mattlord
+/go/vt/vtctl/grpcvtctldserver @notfelineit @mattlord
+/go/vt/vtctl/reparentutil
+/go/vt/vtctl/vtctldclient @notfelineit @mattlord
+/go/vt/vtctld @notfelineit @rohit-nayak-ps @mattlord
+/go/vt/vterrors @harshit-gangal @systay @frouioui
 /go/vt/vtexplain @systay @harshit-gangal
-/go/vt/vtgate @harshit-gangal @systay @frouioui @GuptaManan100
-/go/vt/vtgate/endtoend/*vstream* @rohit-nayak-ps @mattlord
-/go/vt/vtgate/planbuilder @harshit-gangal @systay @frouioui @GuptaManan100 @arthurschreiber
-/go/vt/vtgate/*vstream* @rohit-nayak-ps @mattlord
-/go/vt/vtorc @deepthi @shlomi-noach @GuptaManan100 @timvaillancourt
+/go/vt/vtgate @harshit-gangal @systay @frouioui
+/go/vt/vtgate/endtoend/*vstream* @rohit-nayak-ps @mattlord @shlomi-noach @notfelineit
+/go/vt/vtgate/planbuilder @harshit-gangal @systay @frouioui @arthurschreiber
+/go/vt/vtgate/*vstream* @rohit-nayak-ps @mattlord @shlomi-noach @notfelineit
+/go/vt/vtgate/evalengine @dbussink @systay
+/go/vt/vtorc @shlomi-noach @timvaillancourt
 /go/vt/vttablet/*conn* @harshit-gangal @systay
 /go/vt/vttablet/endtoend @harshit-gangal @mattlord @rohit-nayak-ps @systay
-/go/vt/vttablet/grpc* @ajm188 @rohit-nayak-ps @shlomi-noach @harshit-gangal
-/go/vt/vttablet/onlineddl @mattlord @rohit-nayak-ps @shlomi-noach
+/go/vt/vttablet/grpc* @rohit-nayak-ps @shlomi-noach @harshit-gangal
+/go/vt/vttablet/onlineddl @mattlord @rohit-nayak-ps @shlomi-noach @notfelineit
 /go/vt/vttablet/queryservice @harshit-gangal @systay
-/go/vt/vttablet/tabletmanager @deepthi @GuptaManan100 @rohit-nayak-ps @shlomi-noach
+/go/vt/vttablet/tabletmanager @rohit-nayak-ps @shlomi-noach
+/go/vt/vttablet/tabletmanager/rpc_backup.go @rohit-nayak-ps @shlomi-noach @frouioui
 /go/vt/vttablet/tabletmanager/rpc_throttler.go @shlomi-noach @mattlord @timvaillancourt
 /go/vt/vttablet/tabletserver/throttle @shlomi-noach @mattlord @timvaillancourt
-/go/vt/vttablet/tabletmanager/vreplication @rohit-nayak-ps @mattlord
-/go/vt/vttablet/tabletmanager/vstreamer @rohit-nayak-ps @mattlord
+/go/vt/vttablet/tabletmanager/vreplication @rohit-nayak-ps @mattlord @shlomi-noach @notfelineit
+/go/vt/vttablet/tabletmanager/vdiff @rohit-nayak-ps @mattlord @shlomi-noach @notfelineit
+/go/vt/vttablet/tabletmanager/vstreamer @rohit-nayak-ps @mattlord @shlomi-noach @notfelineit
 /go/vt/vttablet/tabletserver* @harshit-gangal @systay @shlomi-noach @rohit-nayak-ps @timvaillancourt
 /go/vt/vttablet/tabletserver/messager @mattlord @rohit-nayak-ps @derekperkins
-/go/vt/vttablet/*tmclient* @ajm188 @GuptaManan100 @rohit-nayak-ps @shlomi-noach
+/go/vt/vttablet/*tmclient* @rohit-nayak-ps @shlomi-noach
 /go/vt/vttablet/vexec @mattlord @rohit-nayak-ps @shlomi-noach
-/go/vt/wrangler @deepthi @mattlord @rohit-nayak-ps
-/go/vt/workflow @mattlord @rohit-nayak-ps
-/proto/ @deepthi @harshit-gangal
-/proto/vtadmin.proto @ajm188 @notfelineit @mattlord
-/proto/vtctldata.proto @ajm188 @notfelineit @mattlord
-/proto/vtctlservice.proto @ajm188 @notfelineit @mattlord
-/test/ @GuptaManan100 @frouioui @rohit-nayak-ps @deepthi @mattlord @harshit-gangal
+/go/vt/wrangler @mattlord @rohit-nayak-ps
+/go/vt/vtctl/workflow @mattlord @rohit-nayak-ps @shlomi-noach @notfelineit
+/proto/ @harshit-gangal
+/proto/vtadmin.proto @notfelineit @mattlord
+/proto/vtctldata.proto @notfelineit @mattlord
+/proto/vtctlservice.proto @notfelineit @mattlord
+/test/ @frouioui @rohit-nayak-ps @mattlord @harshit-gangal
 /tools/ @frouioui @rohit-nayak-ps
-/web/vtadmin @ajm188 @notfelineit
-/web/vtadmin/src/proto @deepthi @harshit-gangal @mattlord
+/web/vtadmin @notfelineit
+/web/vtadmin/src/proto @harshit-gangal @mattlord @notfelineit

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,61 +3,54 @@ This page lists all active maintainers and their areas of expertise. This can be
 The following is the full list, alphabetically ordered.
 
 * Andres Taylor ([systay](https://github.com/systay)) andres@planetscale.com
-* Andrew Mason ([amason](https://github.com/ajm188)) amason@hey.com
-* Arthur Schreiber ([arthurschreiber](https://github.com/arthurschreiber)) arthurschreiber@github.com
-* Deepthi Sigireddi ([deepthi](https://github.com/deepthi)) deepthi@planetscale.com
+* Arthur Schreiber ([arthurschreiber](https://github.com/arthurschreiber)) schreiber.arthur@gmail.com
 * Derek Perkins ([derekperkins](https://github.com/derekperkins)) derek@nozzle.io
 * Dirkjan Bussink ([dbussink](https://github.com/dbussink)) dbussink@planetscale.com
 * Florent Poinsard ([frouioui](https://github.com/frouioui)) florent@planetscale.com
-* Frances Thai ([notfelineit](https://github.com/notfelineit)) frances@planetscale.com
 * Harshit Gangal ([harshit-gangal](https://github.com/harshit-gangal)) harshit.gangal@gmail.com
-* Manan Gupta ([GuptaManan100](https://github.com/GuptaManan100)) manan@planetscale.com
-* Matt Lord ([mattlord](https://github.com/mattlord)) mlord@planetscale.com
+* Matt Lord ([mattlord](https://github.com/mattlord)) mattalord@gmail.com
+* Noble Mittal ([beingnoble03](https://github.com/beingnoble03)) noble@planetscale.com
 * Rohit Nayak ([rohit-nayak-ps](https://github.com/rohit-nayak-ps)) rohit@planetscale.com
 * Shlomi Noach ([shlomi-noach](https://github.com/shlomi-noach)) shlomi@planetscale.com
 * Tim Vaillancourt ([timvaillancourt](https://github.com/timvaillancourt)) tim@timvaillancourt.com
-* Vicent Marti ([vmg](https://github.com/vmg)) vmg@planetscale.com
 
 ## Areas of expertise
 
 ### General Vitess
-deepthi, mattlord, derekperkins
+mattlord, derekperkins
 
 ### Builds
-shlomi-noach, ajm188, vmg, GuptaManan100, frouioui
+shlomi-noach, frouioui
 
 ### Resharding
-rohit-nayak-ps, deepthi, mattlord
+rohit-nayak-ps, mattlord
 
 ### Parser
-systay, harshit-gangal, vmg, GuptaManan100, dbussink
+systay, harshit-gangal, dbussink
 
 ### Evaluation Engine
-vmg
+dbussink, systay
 
 ### Planner
-systay, harshit-gangal, GuptaManan100, frouioui 
+systay, harshit-gangal, frouioui 
 
 ### Query Serving
-systay, harshit-gangal, GuptaManan100, frouioui, vmg, dbussink
+systay, harshit-gangal, frouioui, dbussink
 
 ### Online DDL
 shlomi-noach, dbussink
 
-### Performance
-vmg
-
 ### Cluster Management
-deepthi, ajm188, GuptaManan100, dbussink
+dbussink
 
 ### Java
 harshit-gangal
 
 ### Kubernetes
-derekperkins, GuptaManan100, frouioui
+derekperkins, frouioui
 
 ### VTAdmin
-ajm188, notfelineit
+beingnoble03, rohit-nayak-ps
 
 ### Messaging
 derekperkins, mattlord
@@ -67,12 +60,16 @@ We thank the following past maintainers for their contributions.
 
 * Alain Jobart ([alainjobart](https://github.com/alainjobart))
 * Alkin Tezuysal ([askdba](https://github.com/askdba))
+* Andrew Mason ([ajm188](https://github.com/ajm188))
 * Anthony Yeh ([enisoc](https://github.com/enisoc))
 * Dan Kozlowski ([dkhenry](https://github.com/dkhenry))
 * David Weitzman ([dweitzman](https://github.com/dweitzman))
+* Deepthi Sigireddi ([deepthi](https://github.com/deepthi))
+* Frances Thai ([notfelineit](https://github.com/notfelineit))
 * Jon Tirsen ([tirsen](https://github.com/tirsen))
 * Leo X. Lin ([leoxlin](https://github.com/leoxlin))
 * Mali Akmanalp ([makmanalp](https://github.com/makmanalp)
+* Manan Gupta ([GuptaManan100](https://github.com/GuptaManan100))
 * Michael Berlin ([michael-berlin](https://github.com/michael-berlin))
 * Michael Demmer ([demmer](https://github.com/demmer))
 * Michael Pawliszyn ([mpawliszyn](https://github.com/mpawliszyn))
@@ -81,3 +78,4 @@ We thank the following past maintainers for their contributions.
 * Rafael Chacon ([rafael](https://github.com/rafael))
 * Sara Bee ([doeg](https://github.com/doeg))
 * Sugu Sougoumarane ([sougou](https://github.com/sougou))
+* Vicent Marti ([vmg](https://github.com/vmg))


### PR DESCRIPTION
## Description

This pull request updates code owners and maintainers on the `release-21.0`.

This should stop the auto-review requests for no-longer active maintainers on back port PRs.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
