### PR TITLE
ci: don't run codecov twice.

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,4 +1,5 @@
 name: Code Coverage
+on:
   push:
     branches:
       - "main"


### PR DESCRIPTION
## Description

When opening a pull request for a branch that exists in the `vitessio/vitess` repo, we'd end up running the "Code Coverage" workflow twice - once for the "push" event to the head branch, and once as a "pull_request" event for the pull request itself.

This is wasteful and doesn't really give us any additional information, so let's limit running workflows for "push" events for a limited set of branches (mainly `main`, `release-x.y` and for all tags).

<img width="866" height="92" alt="image" src="https://github.com/user-attachments/assets/8e7b2c24-0c7e-4cac-9167-0e929639eec5" />

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
