### PR TITLE
fix: ensure callbacks are not called after `VStream` returns

### DIFF
--- a/go/vt/vtgate/vstream_manager.go
+++ b/go/vt/vtgate/vstream_manager.go
@@ -319,11 +319,17 @@ func (vsm *vstreamManager) GetTotalStreamDelay() int64 {
 
 func (vs *vstream) stream(ctx context.Context) error {
 	ctx, vs.cancel = context.WithCancel(ctx)
-	defer vs.cancel()
 
 	vs.wg.Add(1)
 	go func() {
 		defer vs.wg.Done()
+
+		// sendEvents returns either if the given context has been canceled or if
+		// an error is returned from the callback. If the callback returns an error,
+		// we need to cancel the context to stop the other stream goroutines
+		// and to unblock the VStream call.
+		defer vs.cancel()
+
 		vs.sendEvents(ctx)
 	}()
 


### PR DESCRIPTION
## Description

While trying to debug the flaky test failures in the race detector unit test job after https://github.com/vitessio/vitess/pull/18679 was merged, I noticed there's an issue with the implementation of `*vstreamManager.VStream`. Namely, the passed in callback can end up being called _after_ `*vstreamManager.VStream` has already returned.

This pull request fixes that problem and ensures the callback does not get called anymore once `*vstreamManager.VStream` returns.

I also noticed that a lot of the test cases for `*vstreamManager.VStream` are written in a very convoluted fashion. They involved channels, timers, and goroutines. This made the tests harder to read and understand, so I spent some time cleaning all of them up.

A second problem that this fixes too is that `*vstreamManager.VStream` does not immediately return if an error is returned from the callback.

## Related Issue(s)

N/A

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
