### PR TITLE
`vtorc`: remove snapshot topologies feature (wait for v24)

### DIFF
--- a/go/vt/vtorc/config/config.go
+++ b/go/vt/vtorc/config/config.go
@@ -79,15 +79,6 @@ var (
 		},
 	)
 
-	snapshotTopologyInterval = viperutil.Configure(
-		"snapshot-topology-interval",
-		viperutil.Options[time.Duration]{
-			FlagName: "snapshot-topology-interval",
-			Default:  0 * time.Hour,
-			Dynamic:  true,
-		},
-	)
-
 	reasonableReplicationLag = viperutil.Configure(
 		"reasonable-replication-lag",
 		viperutil.Options[time.Duration]{
@@ -233,7 +224,6 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.Int("discovery-workers", discoveryWorkers.Default(), "Number of workers used for tablet discovery")
 	fs.String("sqlite-data-file", sqliteDataFile.Default(), "SQLite Datafile to use as VTOrc's database")
 	fs.Duration("instance-poll-time", instancePollTime.Default(), "Timer duration on which VTOrc refreshes MySQL information")
-	fs.Duration("snapshot-topology-interval", snapshotTopologyInterval.Default(), "Timer duration on which VTOrc takes a snapshot of the current MySQL information it has in the database. Should be in multiple of hours")
 	fs.Duration("reasonable-replication-lag", reasonableReplicationLag.Default(), "Maximum replication lag on replicas which is deemed to be acceptable")
 	fs.String("audit-file-location", auditFileLocation.Default(), "File location where the audit logs are to be stored")
 	fs.Bool("audit-to-backend", auditToBackend.Default(), "Whether to store the audit log in the VTOrc database")
@@ -256,7 +246,6 @@ func registerFlags(fs *pflag.FlagSet) {
 		preventCrossCellFailover,
 		discoveryWorkers,
 		sqliteDataFile,
-		snapshotTopologyInterval,
 		reasonableReplicationLag,
 		auditFileLocation,
 		auditToBackend,
@@ -308,11 +297,6 @@ func GetSQLiteDataFile() string {
 // GetReasonableReplicationLagSeconds gets the reasonable replication lag but in seconds.
 func GetReasonableReplicationLagSeconds() int64 {
 	return int64(reasonableReplicationLag.Get() / time.Second)
-}
-
-// GetSnapshotTopologyInterval is a getter function.
-func GetSnapshotTopologyInterval() time.Duration {
-	return snapshotTopologyInterval.Get()
 }
 
 // GetAuditFileLocation is a getter function.

--- a/go/vt/vtorc/db/generate_base.go
+++ b/go/vt/vtorc/db/generate_base.go
@@ -21,7 +21,6 @@ var TableNames = []string{
 	"audit",
 	"node_health",
 	"topology_recovery",
-	"database_instance_topology_history",
 	"recovery_detection",
 	"database_instance_last_analysis",
 	"database_instance_analysis_changelog",
@@ -164,25 +163,6 @@ CREATE TABLE topology_recovery (
 )`,
 	`
 CREATE INDEX start_recovery_idx_topology_recovery ON topology_recovery (start_recovery)
-	`,
-	`
-DROP TABLE IF EXISTS database_instance_topology_history
-`,
-	`
-CREATE TABLE database_instance_topology_history (
-	snapshot_unix_timestamp int NOT NULL,
-	alias varchar(256) NOT NULL,
-	hostname varchar(128) NOT NULL,
-	port smallint NOT NULL,
-	source_host varchar(128) NOT NULL,
-	source_port smallint NOT NULL,
-	keyspace varchar(128) NOT NULL,
-	shard varchar(128) NOT NULL,
-	version varchar(128) not null default '',
-	PRIMARY KEY (snapshot_unix_timestamp, alias)
-)`,
-	`
-CREATE INDEX keyspace_shard_idx_database_instance_topology_history ON database_instance_topology_history (snapshot_unix_timestamp, keyspace, shard)
 	`,
 	`
 DROP TABLE IF EXISTS recovery_detection

--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -1127,40 +1127,6 @@ func ForgetLongUnseenInstances() error {
 	return err
 }
 
-// SnapshotTopologies records topology graph for all existing topologies
-func SnapshotTopologies() error {
-	writeFunc := func() error {
-		_, err := db.ExecVTOrc(`INSERT OR IGNORE
-			INTO database_instance_topology_history (
-				snapshot_unix_timestamp,
-				alias,
-				hostname,
-				port,
-				source_host,
-				source_port,
-				keyspace,
-				shard,
-				version
-			)
-			SELECT
-				STRFTIME('%s', 'now'),
-				vitess_tablet.alias, vitess_tablet.hostname, vitess_tablet.port,
-				database_instance.source_host, database_instance.source_port,
-				vitess_tablet.keyspace, vitess_tablet.shard, database_instance.version
-			FROM
-				vitess_tablet LEFT JOIN database_instance USING (alias, hostname, port)
-			`,
-		)
-		if err != nil {
-			log.Error(err)
-			return err
-		}
-
-		return nil
-	}
-	return ExecDBWriteFunc(writeFunc)
-}
-
 func ExpireStaleInstanceBinlogCoordinates() error {
 	expireSeconds := config.GetReasonableReplicationLagSeconds() * 2
 	if expireSeconds < config.StaleInstanceCoordinatesExpireSeconds {

--- a/go/vt/vtorc/inst/instance_dao_test.go
+++ b/go/vt/vtorc/inst/instance_dao_test.go
@@ -781,31 +781,6 @@ func TestForgetInstanceAndInstanceIsForgotten(t *testing.T) {
 	}
 }
 
-func TestSnapshotTopologies(t *testing.T) {
-	// Clear the database after the test. The easiest way to do that is to run all the initialization commands again.
-	defer func() {
-		db.ClearVTOrcDatabase()
-	}()
-
-	for _, query := range initialSQL {
-		_, err := db.ExecVTOrc(query)
-		require.NoError(t, err)
-	}
-
-	err := SnapshotTopologies()
-	require.NoError(t, err)
-
-	query := "select alias from database_instance_topology_history"
-	var tabletAliases []string
-	err = db.QueryVTOrc(query, nil, func(rowMap sqlutils.RowMap) error {
-		tabletAliases = append(tabletAliases, rowMap.GetString("alias"))
-		return nil
-	})
-	require.NoError(t, err)
-
-	require.Equal(t, []string{"zone1-0000000100", "zone1-0000000101", "zone1-0000000112", "zone2-0000000200"}, tabletAliases)
-}
-
 // waitForCacheInitialization waits for the cache to be initialized to prevent data race in tests
 // that alter the cache or depend on its behaviour.
 func waitForCacheInitialization() {


### PR DESCRIPTION
## Description

This PR removes the snapshot topologies feature of VTOrc

This feature, if enabled, causes snapshots of instances (on a schedule) to be written to a new sqlite table. This table is never directly read, however. It can be dumped via the diagnostics/debug `/api/database-state` endpoint, but only because this dumps every row of every table

Seeing this data isn't used I suggest we drop this code in v24 to make the VTOrc codebase smaller

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
