### PR TITLE
Build mysql80 Dockerfile with go1.25.1

### DIFF
--- a/docker/lite/Dockerfile.mysql80
+++ b/docker/lite/Dockerfile.mysql80
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 golang:1.24.4-bookworm AS builder
+FROM --platform=linux/amd64 golang:1.25.1-bookworm AS builder
 
 # Allows docker builds to set the BUILD_NUMBER
 ARG BUILD_NUMBER


### PR DESCRIPTION
Needed to properly build MySQL 8.0 containers. Follow-on to https://github.com/vitessio/vitess/pull/18692