### PR TITLE
[QueryThrottler]Add query attributes extraction

### DIFF
--- a/go/vt/vttablet/tabletserver/querythrottler/query_throttler.go
+++ b/go/vt/vttablet/tabletserver/querythrottler/query_throttler.go
@@ -18,6 +18,7 @@ package querythrottler
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"time"
 
@@ -33,6 +34,11 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/throttle"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/throttle/base"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/throttle/throttlerapp"
+)
+
+const (
+	// defaultPriority is the default priority value when none is specified
+	defaultPriority = 100 // sqlparser.MaxPriorityValue
 )
 
 type QueryThrottler struct {
@@ -95,8 +101,14 @@ func (qt *QueryThrottler) Throttle(ctx context.Context, tabletType topodatapb.Ta
 		return nil
 	}
 
+	// Extract query attributes once to avoid re computation in strategies
+	attrs := registry.QueryAttributes{
+		WorkloadName: extractWorkloadName(options),
+		Priority:     extractPriority(options),
+	}
+
 	// Evaluate the throttling decision
-	decision := qt.strategy.Evaluate(ctx, tabletType, parsedQuery, transactionID, options)
+	decision := qt.strategy.Evaluate(ctx, tabletType, parsedQuery, transactionID, attrs)
 
 	// If no throttling is needed, allow the query
 	if !decision.Throttle {
@@ -111,6 +123,43 @@ func (qt *QueryThrottler) Throttle(ctx context.Context, tabletType topodatapb.Ta
 
 	// Normal throttling: return an error to reject the query
 	return vterrors.New(vtrpcpb.Code_RESOURCE_EXHAUSTED, decision.Message)
+}
+
+// extractWorkloadName extracts the workload name from ExecuteOptions.
+// If no workload name is provided, returns a default value.
+func extractWorkloadName(options *querypb.ExecuteOptions) string {
+	if options == nil {
+		return "unknown"
+	}
+
+	if options.WorkloadName != "" {
+		return options.WorkloadName
+	}
+
+	return "default"
+}
+
+// extractPriority extracts the priority from ExecuteOptions.
+// Priority is stored as a string but represents an integer value (0-100).
+// If no priority is provided, returns the default priority.
+func extractPriority(options *querypb.ExecuteOptions) int {
+	if options == nil {
+		return defaultPriority
+	}
+
+	if options.Priority == "" {
+		return defaultPriority
+	}
+
+	optionsPriority, err := strconv.Atoi(options.Priority)
+	// This should never error out, as the value for Priority has been validated in the vtgate already.
+	// Still, handle it just to make sure.
+	if err != nil || optionsPriority < 0 || optionsPriority > 100 {
+		log.Warningf("Invalid priority value '%s' in ExecuteOptions, expected integer 0-100, using default priority %d", options.Priority, defaultPriority)
+		return defaultPriority
+	}
+
+	return optionsPriority
 }
 
 // selectThrottlingStrategy returns the appropriate strategy implementation based on the config.

--- a/go/vt/vttablet/tabletserver/querythrottler/registry/noop_strategy.go
+++ b/go/vt/vttablet/tabletserver/querythrottler/registry/noop_strategy.go
@@ -23,7 +23,6 @@ import (
 
 	"vitess.io/vitess/go/vt/sqlparser"
 
-	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
@@ -36,7 +35,7 @@ var _ ThrottlingStrategyHandler = (*NoOpStrategy)(nil)
 type NoOpStrategy struct{}
 
 // Evaluate always returns a decision to not throttle since this is a no-op strategy.
-func (s *NoOpStrategy) Evaluate(ctx context.Context, targetTabletType topodatapb.TabletType, fullQuery *sqlparser.ParsedQuery, transactionID int64, options *querypb.ExecuteOptions) ThrottleDecision {
+func (s *NoOpStrategy) Evaluate(ctx context.Context, targetTabletType topodatapb.TabletType, fullQuery *sqlparser.ParsedQuery, transactionID int64, attrs QueryAttributes) ThrottleDecision {
 	return ThrottleDecision{
 		Throttle: false,
 		Message:  "NoOpStrategy: no throttling applied",

--- a/go/vt/vttablet/tabletserver/querythrottler/registry/noop_strategy_test.go
+++ b/go/vt/vttablet/tabletserver/querythrottler/registry/noop_strategy_test.go
@@ -43,7 +43,7 @@ func TestNoOpStrategy_Lifecycle(t *testing.T) {
 	strategy.Stop()
 
 	// Verify Evaluate still works after Start/Stop
-	decision := strategy.Evaluate(context.Background(), topodatapb.TabletType_PRIMARY, &sqlparser.ParsedQuery{Query: "SELECT 1"}, 0, nil)
+	decision := strategy.Evaluate(context.Background(), topodatapb.TabletType_PRIMARY, &sqlparser.ParsedQuery{Query: "SELECT 1"}, 0, QueryAttributes{WorkloadName: "test", Priority: 100})
 	require.False(t, decision.Throttle, "NoOpStrategy should never throttle")
 }
 
@@ -86,7 +86,7 @@ func TestNoOpStrategy_Evaluate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			strategy := &NoOpStrategy{}
 
-			result := strategy.Evaluate(context.Background(), tt.giveTabletType, &sqlparser.ParsedQuery{Query: tt.giveSQL}, 0, nil)
+			result := strategy.Evaluate(context.Background(), tt.giveTabletType, &sqlparser.ParsedQuery{Query: tt.giveSQL}, 0, QueryAttributes{WorkloadName: "test", Priority: 100})
 			require.Equal(t, tt.expectedResult, result)
 		})
 	}

--- a/go/vt/vttablet/tabletserver/querythrottler/registry/throttling_handler.go
+++ b/go/vt/vttablet/tabletserver/querythrottler/registry/throttling_handler.go
@@ -21,7 +21,6 @@ import (
 
 	"vitess.io/vitess/go/vt/sqlparser"
 
-	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
@@ -46,8 +45,9 @@ type ThrottlingStrategy string
 type ThrottlingStrategyHandler interface {
 	// Evaluate determines whether a query should be throttled and returns detailed information about the decision.
 	// This method separates the decision-making logic from the enforcement action, enabling features like dry-run mode.
+	// QueryAttributes contains pre-computed workload and priority information to avoid re computation.
 	// It returns a ThrottleDecision struct containing all relevant information about the throttling decision.
-	Evaluate(ctx context.Context, targetTabletType topodatapb.TabletType, parsedQuery *sqlparser.ParsedQuery, transactionID int64, options *querypb.ExecuteOptions) ThrottleDecision
+	Evaluate(ctx context.Context, targetTabletType topodatapb.TabletType, parsedQuery *sqlparser.ParsedQuery, transactionID int64, attrs QueryAttributes) ThrottleDecision
 
 	// Start initializes and starts the throttling strategy.
 	// This method should be called when the strategy becomes active.

--- a/go/vt/vttablet/tabletserver/querythrottler/registry/types.go
+++ b/go/vt/vttablet/tabletserver/querythrottler/registry/types.go
@@ -21,6 +21,16 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/throttle"
 )
 
+// QueryAttributes contains query-level metadata used by throttling strategies.
+// This centralizes extraction of workload and priority information.
+type QueryAttributes struct {
+	// WorkloadName contains the name of the workload for the query.
+	WorkloadName string
+
+	// Priority contains the priority of the query (0-100, where 0 is highest priority).
+	Priority int
+}
+
 // ThrottleDecision represents the result of evaluating whether a query should be throttled.
 // It separates the decision-making logic from the enforcement action.
 type ThrottleDecision struct {


### PR DESCRIPTION
## Description

This PR introduces "query attributes" like WorkloadName,Priority in the Query Throttler system for Vitess tablets outlined in RFC https://github.com/vitessio/vitess/issues/18412


## Background:
- The query throttler previously passed raw ExecuteOptions to strategy handlers, requiring each strategy to extract workload and priority information independently
- This led to potential code duplication and inconsistent parsing logic across different throttling strategies
- Query attributes like workload name and priority are fundamental to throttling decisions and should be consistently extracted

## Solution:
- Added QueryAttributes struct to centralize workload name and priority extraction
- Modified ThrottlingStrategyHandler interface to accept QueryAttributes instead of raw ExecuteOptions
- Implemented extractWorkloadName() and extractPriority() helper functions with proper validation
- Updated all strategy implementations to use the new QueryAttributes parameter
- Added comprehensive unit tests for the extraction functions with edge case validation

### Test Plan:
- Added unit tests for extractWorkloadName() covering nil options, empty workload, and custom workload scenarios
- Added unit tests for extractPriority() covering nil options, empty priority, valid integers (0-100), and invalid values
- Updated existing strategy tests to use QueryAttributes instead of ExecuteOptions
- All existing query throttler tests continue to pass with the new interface

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
