### PR TITLE
VStream: Try new tablet on purged binlog error

### DIFF
--- a/go/mysql/sqlerror/constants.go
+++ b/go/mysql/sqlerror/constants.go
@@ -124,6 +124,7 @@ const (
 	ErSPNotVarArg                   = ErrorCode(1414)
 	ERRowIsReferenced2              = ErrorCode(1451)
 	ErNoReferencedRow2              = ErrorCode(1452)
+	ERSourceHasPurgedRequiredGtids  = ErrorCode(1789)
 	ERInnodbIndexCorrupt            = ErrorCode(1817)
 	ERDupIndex                      = ErrorCode(1831)
 	ERInnodbReadOnly                = ErrorCode(1874)

--- a/go/vt/vtgate/vstream_manager_test.go
+++ b/go/vt/vtgate/vstream_manager_test.go
@@ -836,7 +836,14 @@ func TestVStreamRetriableErrors(t *testing.T) {
 		{
 			name:         "binary log purged",
 			code:         vtrpcpb.Code_UNKNOWN,
-			msg:          "vttablet: rpc error: code = Unknown desc = stream (at source tablet) error @ <GTID>: Cannot replicate because the source purged required binary logs. Replicate the missing transactions from elsewhere",
+			msg:          "vttablet: rpc error: code = Unknown desc = stream (at source tablet) error @ 013c5ddc-dd89-11ed-b3a1-125a006436b9:1-305627274,fe50e15a-0213-11ee-bfbe-0a048e8090b5:1-340389717: Cannot replicate because the source purged required binary logs. Replicate the missing transactions from elsewhere, or provision a new replica from backup. Consider increasing the source's binary log expiration period. The GTID sets and the missing purged transactions are too long to print in this message. For more information, please see the source's error log or the manual for GTID_SUBTRACT (errno 1236) (sqlstate HY000)",
+			shouldRetry:  true,
+			ignoreTablet: true,
+		},
+		{
+			name:         "source purged required gtids",
+			code:         vtrpcpb.Code_UNKNOWN,
+			msg:          "vttablet: rpc error: code = Unknown desc = Cannot replicate because the source purged required binary logs. Replicate the missing transactions from elsewhere, or provision a new replica from backup. Consider increasing the source's binary log expiration period. Missing transactions are: 013c5ddc-dd89-11ed-b3a1-125a006436b9:305627275-305627280 (errno 1789) (sqlstate HY000)",
 			shouldRetry:  true,
 			ignoreTablet: true,
 		},


### PR DESCRIPTION
## Description

Before these changes, if we get a "purged binlogs" error we do not add the tablet to the ignore list. There could be other tablets with the binlog history, so we should add this tablet to the ignore list (similar to what we do for the GTID set mismatch error).

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/18696

## Checklist

-   [X] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [X] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [X] Tests were added or are not required
-   [X] Did the new or modified tests pass consistently locally and on CI?
-   [X] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
