### PR TITLE
connpool: Bump the hang detection timeout to fix flakiness

### DIFF
--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -1247,7 +1247,7 @@ func TestGetSpike(t *testing.T) {
 func TestCloseDuringWaitForConn(t *testing.T) {
 	ctx := context.Background()
 	goRoutineCnt := 50
-	getTimeout := 1000 * time.Millisecond
+	getTimeout := 2000 * time.Millisecond
 
 	for range 50 {
 		hung := make(chan (struct{}), goRoutineCnt)


### PR DESCRIPTION
## Description

This fixes a tiny bit of flakiness that was introduced via https://github.com/vitessio/vitess/pull/18713. On slower machines, the hang detection timeout might be hit while the test was actually still running and not hanging, leading to flakiness in CI.

## Related Issue(s)

See https://github.com/vitessio/vitess/pull/18713.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
