### PR TITLE
connpool: Fix handling of expired contexts

### DIFF
--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -134,7 +134,7 @@ func (cp *Pool) Get(ctx context.Context, setting *smartconnpool.Setting) (*Poole
 
 	if cp.timeout != 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, cp.timeout)
+		ctx, cancel = context.WithTimeoutCause(ctx, cp.timeout, smartconnpool.ErrTimeout)
 		defer cancel()
 	}
 


### PR DESCRIPTION
## Description

When a context expires, the function that received the context should either return the cause of the expiration (via `context.Cause`) or wrap the cause of the expiration with a different error (to enrich the error information).

`*ConnPool[C].Get` did not follow these guidelines. If it was called with an expired context, it would return `ErrCtxTimeout` instead of the cause of the context expiration, and if the context expired while waiting for a connection, it would return `ErrTimeout`.

## Related Issue(s)

N/A

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
