### PR TITLE
Address `Moderate` dependabot vulns in VTAdmin

### DIFF
--- a/java/jdbc/pom.xml
+++ b/java/jdbc/pom.xml
@@ -34,9 +34,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.8.10</version>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Description

This PR updates VTAdmin dependencies that are triggering Dependabot alerts

This was a achieved by running `npm audit fix` in the `web/vtadmin` dir
    - This fixed https://github.com/vitessio/vitess/security/dependabot/403 but also updated other packages
    - I don't know how we validate this (@harshit-gangal any thoughts? 🙇)

I believe this should be done before we release v23, so I have added the backport label for 23.0. cc @systay for thoughts

## Related Issue(s)

1. Resolves https://github.com/vitessio/vitess/security/dependabot/403
2. Resolves https://github.com/vitessio/vitess/security/dependabot/418

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
