### PR TITLE
`vtorc`: address CodeQL scanning alerts

### DIFF
--- a/go/vt/vtorc/inst/analysis_dao.go
+++ b/go/vt/vtorc/inst/analysis_dao.go
@@ -305,7 +305,7 @@ func GetDetectionAnalysis(keyspace string, shard string, hints *DetectionAnalysi
 		}
 
 		a.TabletType = tablet.Type
-		a.CurrentTabletType = topodatapb.TabletType(m.GetInt("current_tablet_type"))
+		a.CurrentTabletType = topodatapb.TabletType(m.GetInt32("current_tablet_type"))
 		a.AnalyzedKeyspace = m.GetString("keyspace")
 		a.AnalyzedShard = m.GetString("shard")
 		a.AnalyzedKeyspaceEmergencyReparentDisabled = m.GetBool("keyspace_disable_emergency_reparent")

--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -518,7 +518,7 @@ func readInstanceRow(m sqlutils.RowMap) *Instance {
 
 	instance.Hostname = m.GetString("hostname")
 	instance.Port = m.GetInt("port")
-	instance.TabletType = topodatapb.TabletType(m.GetInt("tablet_type"))
+	instance.TabletType = topodatapb.TabletType(m.GetInt32("tablet_type"))
 	instance.Cell = m.GetString("cell")
 	instance.ServerID = m.GetUint("server_id")
 	instance.ServerUUID = m.GetString("server_uuid")


### PR DESCRIPTION
## Description

This PR addresses 2 x CodeQL code scanning alerts for bad string-integer conversions

> Incorrect conversion between integer types
Incorrect conversion of an integer with architecture-dependent bit size from  to a lower bit size type int32 without an upper bound check.
>
> If a string is parsed into an int using strconv.Atoi, and subsequently that int is converted into another integer type of a smaller size, the result can produce unexpected values.

TL;DR we are using `strconv.Atoi` to do a string-integer conversion that is passed to `topodatapb.TabletType`, which is `int32`-backed _(not `int`)_

## Related Issue(s)

- Closes: https://github.com/vitessio/vitess/security/code-scanning/3553
- Closes: https://github.com/vitessio/vitess/security/code-scanning/3289

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
