### PR TITLE
update java packages to use central instead of ossrh

### DIFF
--- a/java/client/pom.xml
+++ b/java/client/pom.xml
@@ -8,6 +8,7 @@
     <version>24.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>vitess-client</artifactId>
+  <name>Vitess Java Client</name>
 
   <dependencies>
     <dependency>

--- a/java/example/pom.xml
+++ b/java/example/pom.xml
@@ -8,6 +8,7 @@
     <version>24.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>vitess-example</artifactId>
+  <name>Vitess Java Client Example</name>
 
   <dependencies>
     <dependency>

--- a/java/grpc-client/pom.xml
+++ b/java/grpc-client/pom.xml
@@ -8,6 +8,7 @@
     <version>24.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>vitess-grpc-client</artifactId>
+  <name>Vitess gRPC Client</name>
 
   <dependencies>
     <dependency>

--- a/java/jdbc/pom.xml
+++ b/java/jdbc/pom.xml
@@ -8,6 +8,7 @@
     <version>24.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>vitess-jdbc</artifactId>
+  <name>Vitess JDBC Driver</name>
 
   <dependencies>
     <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -222,8 +222,8 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <id>central</id>
+      <url>https://central.sonatype.com</url>
     </snapshotRepository>
   </distributionManagement>
 
@@ -291,14 +291,13 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.7.0</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.6.0</version>
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
             </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
Updates the Java package to publish artifacts to central instead of ossrh. Ossrh has reached end of life earlier this year and is no longer supported.

Backporting this to 23 and 22 as we may need to make more patch releases on these branches.