### PR TITLE
Fix bug where query consolidator returns empty result without error when the waiter cap exceeded

### DIFF
--- a/go/sync2/fake_consolidator.go
+++ b/go/sync2/fake_consolidator.go
@@ -51,8 +51,12 @@ type FakePendingResult struct {
 	BroadcastCalls int
 	// WaitCalls can be used to inspect Wait calls.
 	WaitCalls int
-	err       error
-	result    *sqltypes.Result
+	// AddWaiterCounterCalls can be used to inspect AddWaiterCounter calls.
+	AddWaiterCounterCalls []int64
+	// WaiterCount simulates the current waiter count
+	WaiterCount int64
+	err         error
+	result      *sqltypes.Result
 }
 
 var (
@@ -113,7 +117,9 @@ func (fr *FakePendingResult) Wait() {
 	fr.WaitCalls++
 }
 
-// AddWaiterCounter is currently a no-op.
-func (fr *FakePendingResult) AddWaiterCounter(int64) *int64 {
-	return new(int64)
+// AddWaiterCounter records the call and simulates waiter count changes.
+func (fr *FakePendingResult) AddWaiterCounter(delta int64) *int64 {
+	fr.AddWaiterCounterCalls = append(fr.AddWaiterCounterCalls, delta)
+	fr.WaiterCount += delta
+	return &fr.WaiterCount
 }

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -744,6 +744,7 @@ func (qre *QueryExecutor) execSelect() (*sqltypes.Result, error) {
 	// Check tablet type.
 	if qre.shouldConsolidate() {
 		q, original := qre.tsv.qe.consolidator.Create(sqlWithoutComments)
+		waiterCapExceeded := false
 		if original {
 			defer q.Broadcast()
 			conn, err := qre.getConn()
@@ -763,13 +764,21 @@ func (qre *QueryExecutor) execSelect() (*sqltypes.Result, error) {
 				startTime := time.Now()
 				q.Wait()
 				qre.tsv.stats.WaitTimings.Record("Consolidations", startTime)
+			} else {
+				// Waiter cap exceeded, fall back to independent query execution
+				waiterCapExceeded = true
 			}
 			q.AddWaiterCounter(-1)
 		}
-		if q.Err() != nil {
-			return nil, q.Err()
+
+		// Return consolidation results unless waiter cap was exceeded
+		if !waiterCapExceeded {
+			if q.Err() != nil {
+				return nil, q.Err()
+			}
+			return q.Result(), nil
 		}
-		return q.Result(), nil
+		// If waiter cap exceeded, fall through to independent execution
 	}
 	conn, err := qre.getConn()
 	if err != nil {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Fix bug introduced by https://github.com/vitessio/vitess/pull/17244

When the consolidator waiter cap is reached, queries should fall back to independent execution instead of returning empty results.

Before this fix:

Queries exceeding waiter cap would skip waiting for consolidation
They would immediately try to access q.Result() before completion
This resulted in empty/incomplete results being returned

After this fix:

Queries exceeding waiter cap fall back to regular execution path
All queries return correct results regardless of consolidation status
Waiter cap configuration still controls resource usage as intended

Changes:

Modified execSelect() in query_executor.go to implement fallback logic
Enhanced FakePendingResult to properly simulate waiter count behavior
Added comprehensive test TestQueryExecutorConsolidatorWaiterCapFallback

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
  - Fixes: https://github.com/vitessio/vitess/issues/18783
## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
