### PR TITLE
VReplication: Treat ER_BINLOG_CREATE_ROUTINE_NEED_SUPER as unrecoverable

### DIFF
--- a/go/mysql/sqlerror/constants.go
+++ b/go/mysql/sqlerror/constants.go
@@ -84,12 +84,12 @@ const (
 	ERKeyDoesNotExist       = ErrorCode(1176)
 
 	// permissions
-	ERDBAccessDenied                = ErrorCode(1044)
-	ERAccessDeniedError             = ErrorCode(1045)
-	ERKillDenied                    = ErrorCode(1095)
-	ERNoPermissionToCreateUsers     = ErrorCode(1211)
-	ERSpecifiedAccessDenied         = ErrorCode(1227)
-	ERBinlogCreateRoutineNeedsSuper = ErrorCode(1419)
+	ERDBAccessDenied               = ErrorCode(1044)
+	ERAccessDeniedError            = ErrorCode(1045)
+	ERKillDenied                   = ErrorCode(1095)
+	ERNoPermissionToCreateUsers    = ErrorCode(1211)
+	ERSpecifiedAccessDenied        = ErrorCode(1227)
+	ERBinlogCreateRoutineNeedSuper = ErrorCode(1419)
 
 	// failed precondition
 	ERNoDb                          = ErrorCode(1046)

--- a/go/vt/vttablet/tabletmanager/vreplication/utils.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils.go
@@ -214,7 +214,7 @@ func isUnrecoverableError(err error) bool {
 		sqlerror.ErrWrongValueForType,
 		sqlerror.ERSPDoesNotExist,
 		sqlerror.ERSpecifiedAccessDenied,
-		sqlerror.ERBinlogCreateRoutineNeedsSuper,
+		sqlerror.ERBinlogCreateRoutineNeedSuper,
 		sqlerror.ERSyntaxError,
 		sqlerror.ERTooBigRowSize,
 		sqlerror.ERTooBigSet,

--- a/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/utils_test.go
@@ -162,8 +162,8 @@ func TestIsUnrecoverableError(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "SQL error with ERBinlogCreateRoutineNeedsSuper",
-			err:      sqlerror.NewSQLError(sqlerror.ERBinlogCreateRoutineNeedsSuper, "unknown", "error applying event: You do not have the SUPER privilege and binary logging is enabled (you *might* want to use the less safe log_bin_trust_function_creators variable) (errno 1419) (sqlstate HY000) during query: CREATE DEFINER=`root`@`localhost` TRIGGER upd_customer BEFORE UPDATE ON customer FOR EACH ROW SET @email = NEW.email + \" (updated)\""),
+			name:     "SQL error with ERBinlogCreateRoutineNeedSuper",
+			err:      sqlerror.NewSQLError(sqlerror.ERBinlogCreateRoutineNeedSuper, "unknown", "error applying event: You do not have the SUPER privilege and binary logging is enabled (you *might* want to use the less safe log_bin_trust_function_creators variable) (errno 1419) (sqlstate HY000) during query: CREATE DEFINER=`root`@`localhost` TRIGGER upd_customer BEFORE UPDATE ON customer FOR EACH ROW SET @email = NEW.email + \" (updated)\""),
 			expected: true,
 		},
 	}


### PR DESCRIPTION
## Description

This adds handling for a specific MySQL error — [ER_BINLOG_CREATE_ROUTINE_NEED_SUPER](https://dev.mysql.com/doc/mysql-errors/en/server-error-reference.html#error_er_binlog_create_routine_need_super), which we were not previously handling — so that we treat it as fatal / unrecoverable in VReplication and do not continuously retry the workflow indefinitely. This is how it should work since this will not resolve itself and requires manual intervention from the operator (who can then restart the workflow afterwards using the workflow type's `start` sub-command). 

> [!NOTE]
> You can instruct VReplication to give up after encountering the same error repeatedly in the workflow for a given period of time, no matter if it's considered recoverable or not,  
using the [--vreplication-max-time-to-retry-on-error](https://vitess.io/docs/23.0/reference/vreplication/flags/#vreplication-max-time-to-retry-on-error) `vttablet` flag. Also note that you can override the process level flag value on a per-workflow basis as well in the given `create` sub-command using the `--config-overrides` flag (e.g. [for `MoveTables`](https://vitess.io/docs/reference/programs/vtctldclient/vtctldclient_movetables/vtctldclient_movetables_create/)) along with updating it for an existing workflow using the same flag with the [`workflow update`](https://vitess.io/docs/reference/programs/vtctldclient/vtctldclient_workflow/vtctldclient_workflow_update/) command.

> [!IMPORTANT]
> I think that we should backport this to v22 since it's such a small change.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/18781

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
