### PR TITLE
Fix expired MySQL GPG keys in Docker builds

### DIFF
--- a/docker/utils/install_dependencies.sh
+++ b/docker/utils/install_dependencies.sh
@@ -193,3 +193,4 @@ fi
 rm -rf /var/lib/apt/lists/*
 rm -rf /var/lib/mysql/
 rm -rf /tmp/*.deb
+rm -rf /etc/apt/sources.list.d/mysql.list /etc/apt/sources.list.d/percona*.list


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Expired GPG keys may be still cached by apt, then dependent docker images e.g., [debezium](https://github.com/debezium/debezium-connector-vitess/blob/main/src/test/docker/Dockerfile#L5) when calling apt-get update will fail. So as a best practice we should remove those dependencies similar to previous lines that are no longer needed. This presents the build failure we saw here 
```
[INFO] DOCKER> Reading package lists...
[INFO] DOCKER> 
[INFO] DOCKER> [91mW: GPG error: http://repo.mysql.com/apt/debian bullseye InRelease: The following signatures were invalid: EXPKEYSIG B7B3B788A8D3785C MySQL Release Engineering <mysql-build@oss.oracle.com>
E: The repository 'http://repo.mysql.com/apt/debian bullseye InRelease' is not signed.

[INFO] DOCKER> ---> Removed intermediate container 411bee189546
Error:  DOCKER> Unable to build image [vitess/test-database] : "The command '/bin/sh -c apt-get update' returned a non-zero code: 100"  ["The command '/bin/sh -c apt-get update' returned a non-zero code: 100" ]
```

I also considered a workaround like this if we want to drop the keys, but even when expired the old key didn't cause the build to fail so I opted to leave it. Let me know if this is desired and I could add it back
```diff
diff --git a/docker/utils/install_dependencies.sh b/docker/utils/install_dependencies.sh
index be2cf4f2a0..1e694a30dc 100755
--- a/docker/utils/install_dependencies.sh
+++ b/docker/utils/install_dependencies.sh
@@ -56,6 +56,7 @@ BASE_PACKAGES=(
     libev4
     libjemalloc2
     libtcmalloc-minimal4
+    lsb-release
     procps
     rsync
     strace
(1/3) Stash this hunk [y,n,q,a,d,j,J,g,/,e,p,?]? y
@@ -140,20 +141,27 @@ percona80)
 esac

 # Get GPG keys for extra apt repositories.
-# repo.mysql.com
-add_apt_key 8C718D3B5072E1F5
-add_apt_key A8D3785C
-
 # All flavors include Percona XtraBackup (from repo.percona.com).
 add_apt_key 9334A25F8507EFA5

-# Add extra apt repositories for MySQL.
+# Add MySQL apt repository using mysql-apt-config package (includes updated GPG keys).
 case "${FLAVOR}" in
-mysql80)
-    echo 'deb http://repo.mysql.com/apt/debian/ bookworm mysql-8.0' > /etc/apt/sources.list.d/mysql.list
-    ;;
-mysql84)
-    echo 'deb http://repo.mysql.com/apt/debian/ bookworm mysql-8.4-lts' > /etc/apt/sources.list.d/mysql.list
+mysql80|mysql84)
+    do_fetch https://dev.mysql.com/get/mysql-apt-config_0.8.34-1_all.deb /tmp/mysql-apt-config.deb
+
+    # Pre-configure mysql-apt-config to select the appropriate version
+    if [ "${FLAVOR}" = "mysql80" ]; then
+        debconf-set-selections <<EOF
+mysql-apt-config mysql-apt-config/select-server select mysql-8.0
+EOF
+    else
+        debconf-set-selections <<EOF
+mysql-apt-config mysql-apt-config/select-server select mysql-8.4-lts
+EOF
+    fi
+
+    dpkg -i /tmp/mysql-apt-config.deb
+    rm /tmp/mysql-apt-config.deb
     ;;
 esac
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
