### PR TITLE
ci: revert to using the oracle apt repo for mysql-8.0 builds

### DIFF
--- a/.github/workflows/unit_test_evalengine_mysql80.yml
+++ b/.github/workflows/unit_test_evalengine_mysql80.yml
@@ -100,6 +100,8 @@ jobs:
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A8D3785C
         wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.35-1_all.deb
 
+        echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+        sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
         sudo apt-get update
         sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
         

--- a/.github/workflows/unit_test_mysql80.yml
+++ b/.github/workflows/unit_test_mysql80.yml
@@ -100,6 +100,8 @@ jobs:
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A8D3785C
         wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.35-1_all.deb
 
+        echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+        sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
         sudo apt-get update
         sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
         

--- a/test/templates/unit_test.tpl
+++ b/test/templates/unit_test.tpl
@@ -124,6 +124,8 @@ jobs:
         {{end}}
 
         {{if (eq .Platform "mysql80")}}
+        echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+        sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
         sudo apt-get update
         sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
         {{end}}


### PR DESCRIPTION
## Description

This reverts the unit test builds to use the oracle apt repo again for mysql-8.0 builds, now that the repo has been fixed.

The change that this PR is reverting was not included in backports of https://github.com/vitessio/vitess/pull/18790, so it does not need to be backported either.

## Related Issue(s)

https://github.com/vitessio/vitess/pull/18790

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
