### PR TITLE
copy_state: use a mediumblob instead of a smaller varbinary for lastpk

### DIFF
--- a/go/vt/sidecardb/schema/vreplication/copy_state.sql
+++ b/go/vt/sidecardb/schema/vreplication/copy_state.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS copy_state
     `id` bigint unsigned NOT NULL AUTO_INCREMENT,
     `vrepl_id`   int            NOT NULL,
     `table_name` varbinary(128) NOT NULL,
-    `lastpk`     varbinary(2000) DEFAULT NULL,
+    `lastpk`     mediumblob     DEFAULT NULL,
     PRIMARY KEY (`id`),
     KEY `vrepl_id` (`vrepl_id`,`table_name`)
 ) ENGINE = InnoDB CHARSET = utf8mb4


### PR DESCRIPTION
## Description

If you do OnlineDDL with a particularly huge PK, we won't be able to save the `lastpk` in `copy_state`, which will cause the OnlineDDL to not be able to proceed. This makes it reasonably large, which should make this much less likely. 

Backporting this because it can break OnlineDDL in some cases. 

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/18851

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

N/A

### AI Disclosure

I did this all by my lonesome