### PR TITLE
vttest: add gateway-initial-tablet-timeout flag to enable faster startup

### DIFF
--- a/go/cmd/vttestserver/cli/main.go
+++ b/go/cmd/vttestserver/cli/main.go
@@ -224,6 +224,8 @@ func New() (cmd *cobra.Command) {
 
 	utils.SetFlagDurationVar(cmd.Flags(), &config.VtgateTabletRefreshInterval, "tablet-refresh-interval", 10*time.Second, "Interval at which vtgate refreshes tablet information from topology server.")
 
+	utils.SetFlagDurationVar(cmd.Flags(), &config.VtgateGatewayInitialTabletTimeout, "gateway-initial-tablet-timeout", 30*time.Second, "At startup, the tabletGateway will wait up to this duration to get at least one tablet per keyspace/shard/tablet type")
+
 	cmd.Flags().BoolVar(&doCreateTCPUser, "initialize-with-vt-dba-tcp", false, "If this flag is enabled, MySQL will be initialized with an additional user named vt_dba_tcp, who will have access via TCP/IP connection.")
 
 	utils.SetFlagBoolVar(cmd.Flags(), &config.NoScatter, "no-scatter", false, "when set to true, the planner will fail instead of producing a plan that includes scatter queries")

--- a/go/cmd/vttestserver/cli/main_test.go
+++ b/go/cmd/vttestserver/cli/main_test.go
@@ -254,6 +254,21 @@ func TestCanGetKeyspaces(t *testing.T) {
 	assertGetKeyspaces(ctx, t, clusterInstance)
 }
 
+func TestGatewayInitialTabletTimeout(t *testing.T) {
+	conf := config
+	defer resetConfig(conf)
+
+	// Start cluster with custom gateway tablet timeout and verify it starts successfully
+	cluster, err := startCluster("--gateway-initial-tablet-timeout=1s")
+	require.NoError(t, err)
+	defer cluster.TearDown()
+
+	// Verify the cluster is functional by getting keyspaces
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	assertGetKeyspaces(ctx, t, cluster)
+}
+
 func TestExternalTopoServerConsul(t *testing.T) {
 	conf := config
 	defer resetConfig(conf)

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -132,6 +132,7 @@ Flags:
       --external-topo-server                                             Should vtcombo use an external topology server instead of starting its own in-memory topology server. If true, vtcombo will use the flags defined in topo/server.go to open topo server
       --foreign-key-mode string                                          This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow, disallow (default "allow")
       --gate-query-cache-memory int                                      gate server query cache size in bytes, maximum amount of memory to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 33554432)
+      --gateway-initial-tablet-timeout duration                          At startup, the tabletGateway will wait up to this duration to get at least one tablet per keyspace/shard/tablet type (default 30s)
       --gc-check-interval duration                                       Interval between garbage collection checks (default 1h0m0s)
       --gc-purge-check-interval duration                                 Interval between purge discovery checks (default 1m0s)
       --grpc-auth-mode string                                            Which auth plugin implementation to use (eg: static)

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -43,6 +43,7 @@ Flags:
       --external-topo-implementation string                              the topology implementation to use for vtcombo process
       --extra-my-cnf string                                              extra files to add to the config, separated by ':'
       --foreign-key-mode string                                          This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow, disallow (default "allow")
+      --gateway-initial-tablet-timeout duration                          At startup, the tabletGateway will wait up to this duration to get at least one tablet per keyspace/shard/tablet type (default 30s)
       --grpc-auth-mode string                                            Which auth plugin implementation to use (eg: static)
       --grpc-auth-mtls-allowed-substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc-auth-static-client-creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.

--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -68,16 +68,23 @@ var (
 	logCollations = logutil.NewThrottledLogger("CollationInconsistent", 1*time.Minute)
 )
 
+func registerTabletGatewayFlags(fs *pflag.FlagSet) {
+	utils.SetFlagStringVar(fs, &CellsToWatch, "cells-to-watch", "", "comma-separated list of cells for watching tablets")
+	utils.SetFlagDurationVar(fs, &initialTabletTimeout, "gateway-initial-tablet-timeout", 30*time.Second, "At startup, the tabletGateway will wait up to this duration to get at least one tablet per keyspace/shard/tablet type")
+	fs.IntVar(&retryCount, "retry-count", 2, "retry count")
+	fs.BoolVar(&balancerEnabled, "enable-balancer", false, "(DEPRECATED: use --vtgate-balancer-mode instead) Enable the tablet balancer to evenly spread query load for a given tablet type")
+	fs.StringVar(&balancerModeFlag, "vtgate-balancer-mode", "", fmt.Sprintf("Tablet balancer mode (options: %s). Defaults to 'cell' which shuffles tablets in the local cell.", strings.Join(balancer.GetAvailableModeNames(), ", ")))
+	fs.StringSliceVar(&balancerVtgateCells, "balancer-vtgate-cells", []string{}, "Comma-separated list of cells that contain vttablets. For 'prefer-cell' mode, this is required. For 'random' mode, this is optional and filters tablets to those cells.")
+	fs.StringSliceVar(&balancerKeyspaces, "balancer-keyspaces", []string{}, "Comma-separated list of keyspaces for which to use the balancer (optional). If empty, applies to all keyspaces.")
+}
+
+func registerVtcomboTabletGatewayFlags(fs *pflag.FlagSet) {
+	utils.SetFlagDurationVar(fs, &initialTabletTimeout, "gateway-initial-tablet-timeout", 30*time.Second, "At startup, the tabletGateway will wait up to this duration to get at least one tablet per keyspace/shard/tablet type")
+}
+
 func init() {
-	servenv.OnParseFor("vtgate", func(fs *pflag.FlagSet) {
-		utils.SetFlagStringVar(fs, &CellsToWatch, "cells-to-watch", "", "comma-separated list of cells for watching tablets")
-		utils.SetFlagDurationVar(fs, &initialTabletTimeout, "gateway-initial-tablet-timeout", 30*time.Second, "At startup, the tabletGateway will wait up to this duration to get at least one tablet per keyspace/shard/tablet type")
-		fs.IntVar(&retryCount, "retry-count", 2, "retry count")
-		fs.BoolVar(&balancerEnabled, "enable-balancer", false, "(DEPRECATED: use --vtgate-balancer-mode instead) Enable the tablet balancer to evenly spread query load for a given tablet type")
-		fs.StringVar(&balancerModeFlag, "vtgate-balancer-mode", "", fmt.Sprintf("Tablet balancer mode (options: %s). Defaults to 'cell' which shuffles tablets in the local cell.", strings.Join(balancer.GetAvailableModeNames(), ", ")))
-		fs.StringSliceVar(&balancerVtgateCells, "balancer-vtgate-cells", []string{}, "Comma-separated list of cells that contain vttablets. For 'prefer-cell' mode, this is required. For 'random' mode, this is optional and filters tablets to those cells.")
-		fs.StringSliceVar(&balancerKeyspaces, "balancer-keyspaces", []string{}, "Comma-separated list of keyspaces for which to use the balancer (optional). If empty, applies to all keyspaces.")
-	})
+	servenv.OnParseFor("vtgate", registerTabletGatewayFlags)
+	servenv.OnParseFor("vtcombo", registerVtcomboTabletGatewayFlags)
 }
 
 // TabletGateway implements the Gateway interface.

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -158,6 +158,9 @@ type Config struct {
 
 	VtgateTabletRefreshInterval time.Duration
 
+	// Gateway initial tablet timeout - how long VTGate waits for tablets at startup
+	VtgateGatewayInitialTabletTimeout time.Duration
+
 	// Set the planner to fail on scatter queries
 	NoScatter bool
 }

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -279,6 +279,14 @@ func VtcomboProcess(environment Environment, args *Config, mysql MySQLManager) (
 		vt.ExtraArgs = append(vt.ExtraArgs, fmt.Sprintf("--tablet-refresh-interval=%v", args.VtgateTabletRefreshInterval))
 	}
 
+	// If gateway initial tablet timeout is not defined then we will give it value of 30s (vtcombo default).
+	// Setting it to a lower value will reduce the time VTGate waits for tablets at startup.
+	if args.VtgateGatewayInitialTabletTimeout <= 0 {
+		vt.ExtraArgs = append(vt.ExtraArgs, fmt.Sprintf("--gateway-initial-tablet-timeout=%v", 30*time.Second))
+	} else {
+		vt.ExtraArgs = append(vt.ExtraArgs, fmt.Sprintf("--gateway-initial-tablet-timeout=%v", args.VtgateGatewayInitialTabletTimeout))
+	}
+
 	vt.ExtraArgs = append(vt.ExtraArgs, QueryServerArgs...)
 	vt.ExtraArgs = append(vt.ExtraArgs, environment.VtcomboArguments()...)
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

This PR adds support for the `gateway-initial-tablet-timeout` flag in `vtcombo` and `vttestserver`. From local experiments, setting a low `gateway-initial-tablet-timeout` value (e.g. `1s`) appears to massively reduce `vttestserver` start-up time (by ~30s). This seems to work well because in a `vttestserver` environment, keyspaces and tablets are typically quick to start up. 

### Testing

- Added a test  in `go/cmd/vttestserver/cli/main_test.go` that validates `vttestserver` can start up using the `gateway-initial-tablet-timeout` flag  
- Built a custom `vttestserver` Docker image from this branch, and tested it locally in Block's Vitess test suite in [Misk](https://github.com/cashapp/misk/tree/master). Initial usage of `gateway-initial-tablet-timeout` with a low threshold appears to reduce start up time by ~30s (from ~55 seconds to ~25 seconds).

### Backport

If this is an acceptable change that can be merged, we'd love to get this backported to v22 and v23, since Block's CI follows the Vitess version used by PlanetScale for consistency; we're currently on [v21.0.5](https://github.com/cashapp/misk/blob/c3f957c47bcc8b8f60479a1a9279903de1d0a8a9/misk-vitess/src/testFixtures/kotlin/misk/vitess/testing/VitessTestDbSettings.kt#L30) and we'd be looking at moving to v22 next as our PS clusters move to v22.

<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Fixes https://github.com/vitessio/vitess/issues/18888

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
