### PR TITLE
planner: Stop searching for alternatives once we found a merge opportunity

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -250,6 +250,10 @@ func findBestJoin(
 				continue
 			}
 			plan := getJoinFor(ctx, planCache, lhs, rhs, joinPredicates)
+			if _, ok := plan.(*Route); ok {
+				// we were able to merge the two inputs - we're done for now
+				return plan, i, j
+			}
 			if bestPlan == nil || CostOf(plan) < CostOf(bestPlan) {
 				bestPlan = plan
 				// remember which plans we based on, so we can remove them later

--- a/go/vt/vtgate/planbuilder/testdata/reference_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/reference_cases.json
@@ -753,7 +753,7 @@
           "Sharded": true
         },
         "FieldQuery": "select 1 from `user` as u, user_extra as ue, ref_with_source as sr, ref as rr where 1 != 1",
-        "Query": "select 1 from `user` as u, user_extra as ue, ref_with_source as sr, ref as rr where rr.bar = sr.bar and u.id = ue.user_id and sr.foo = ue.foo"
+        "Query": "select 1 from `user` as u, user_extra as ue, ref_with_source as sr, ref as rr where u.id = ue.user_id and rr.bar = sr.bar and sr.foo = ue.foo"
       },
       "TablesUsed": [
         "user.ref",


### PR DESCRIPTION
## Description

This change introduces a minor optimization to the greedy join selection loop.
The Vitess planner’s primary heuristic is to maximize pushdown by merging subplans into the largest possible MySQL-executable fragments. Once a fully pushable join is identified, further exploration of join alternatives becomes redundant.

This early-termination criterion does not alter the produced plans but reduces planning effort for complex queries. Empirically, it yields a measurable improvement in planning time for large join graphs, with no observed regressions.

```
                                           │    main     │             abort-early              │
                                           │   sec/op    │    sec/op     vs base                │
OLTP-4                                       148.2µ ± 1%    145.7µ ± 4%        ~ (p=0.063 n=10)
TPCC-4                                       1.076m ± 1%    1.034m ± 3%   -3.87% (p=0.000 n=10)
TPCH-4                                       6.279m ± 3%    6.260m ± 3%        ~ (p=0.218 n=10)
Planner/from_cases.json-gen4-4               4.627m ± 2%    4.602m ± 4%        ~ (p=0.315 n=10)
Planner/filter_cases.json-gen4-4             112.5m ± 1%    113.0m ± 3%        ~ (p=0.089 n=10)
Planner/large_cases.json-gen4-4              243.6µ ± 0%    149.6µ ± 1%  -38.61% (p=0.000 n=10)
Planner/aggr_cases.json-gen4-4               8.104m ± 2%    8.120m ± 1%        ~ (p=0.971 n=10)
Planner/select_cases.json-gen4-4             6.703m ± 2%    6.586m ± 2%   -1.75% (p=0.002 n=10)
Planner/union_cases.json-gen4-4              2.454m ± 2%    2.468m ± 1%        ~ (p=0.280 n=10)

                                           │     main      │              abort-early              │
                                           │     B/op      │     B/op       vs base                │
OLTP-4                                        156.4Ki ± 0%    156.4Ki ± 0%        ~ (p=0.725 n=10)
TPCC-4                                       1007.6Ki ± 0%    997.9Ki ± 0%   -0.96% (p=0.000 n=10)
TPCH-4                                        4.702Mi ± 0%    4.699Mi ± 0%   -0.06% (p=0.000 n=10)
Planner/from_cases.json-gen4-4                4.426Mi ± 0%    4.356Mi ± 0%   -1.59% (p=0.000 n=10)
Planner/filter_cases.json-gen4-4              19.10Mi ± 0%    19.08Mi ± 0%   -0.06% (p=0.000 n=10)
Planner/large_cases.json-gen4-4               207.7Ki ± 0%    143.2Ki ± 0%  -31.08% (p=0.000 n=10)
Planner/aggr_cases.json-gen4-4                6.948Mi ± 0%    6.930Mi ± 0%   -0.26% (p=0.000 n=10)
Planner/select_cases.json-gen4-4              6.258Mi ± 0%    6.196Mi ± 0%   -0.99% (p=0.000 n=10)
Planner/union_cases.json-gen4-4               2.297Mi ± 0%    2.297Mi ± 0%        ~ (p=0.739 n=10)

                                           │    main     │              abort-early              │
                                           │  allocs/op  │  allocs/op   vs base                  │
OLTP-4                                       3.814k ± 0%   3.814k ± 0%        ~ (p=1.000 n=10) ¹
TPCC-4                                       24.18k ± 0%   24.02k ± 0%   -0.67% (p=0.000 n=10)
TPCH-4                                       116.3k ± 0%   116.3k ± 0%   -0.05% (p=0.000 n=10)
Planner/from_cases.json-gen4-4               98.38k ± 0%   96.76k ± 0%   -1.64% (p=0.000 n=10)
Planner/filter_cases.json-gen4-4             481.7k ± 0%   481.4k ± 0%   -0.06% (p=0.000 n=10)
Planner/large_cases.json-gen4-4              7.334k ± 0%   4.355k ± 0%  -40.62% (p=0.000 n=10)
Planner/aggr_cases.json-gen4-4               155.0k ± 0%   154.7k ± 0%   -0.24% (p=0.000 n=10)
Planner/select_cases.json-gen4-4             141.0k ± 0%   139.6k ± 0%   -0.97% (p=0.000 n=10)
Planner/union_cases.json-gen4-4              50.93k ± 0%   50.93k ± 0%        ~ (p=1.000 n=10) ¹
```
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
