### PR TITLE
`vttest`: reduce flakiness from `randomPort()`

### DIFF
--- a/go/vt/vttest/environment.go
+++ b/go/vt/vttest/environment.go
@@ -21,13 +21,23 @@ import (
 	"net"
 	"os"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
+	"sync"
 
 	"vitess.io/vitess/go/vt/proto/vttest"
 
 	// we use gRPC everywhere, so import the vtgate client.
 	_ "vitess.io/vitess/go/vt/vtgate/grpcvtgateconn"
+)
+
+var (
+	// randomPortsMu provides synchronization for randomPorts().
+	randomPortsMu sync.Mutex
+
+	// usedRandomPorts stores ports that have been used by remotePort().
+	usedRandomPorts []int
 )
 
 // Environment is the interface that customizes the global settings for
@@ -235,21 +245,31 @@ func tmpdir(dataroot string) (dir string, err error) {
 // randomPort gets a random port that is available for a TCP connection.
 // After we generate a random port, we try to establish tcp connections on it and the next 5 values.
 // If any of them fail, then we try a different port.
-func randomPort() int {
+func randomPort() (port int) {
+	randomPortsMu.Lock()
+	defer randomPortsMu.Unlock()
 	for {
-		port := int(rand.Int32N(20000) + 10000)
+		portBase := int(rand.Int32N(20000) + 10000)
 		portInUse := false
+		portRange := make([]int, 0, 6)
 		for i := 0; i < 6; i++ {
-			ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port+i)))
+			port = portBase + i
+			if slices.Contains(usedRandomPorts, port) {
+				portInUse = true
+				break
+			}
+			ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
 			if err != nil {
 				portInUse = true
 				break
 			}
+			portRange = append(portRange, port)
 			ln.Close()
 		}
 		if portInUse {
 			continue
 		}
+		usedRandomPorts = append(usedRandomPorts, portRange...)
 		return port
 	}
 }

--- a/go/vt/vttest/environment_test.go
+++ b/go/vt/vttest/environment_test.go
@@ -44,3 +44,15 @@ func TestVtcomboArguments(t *testing.T) {
 		assert.ElementsMatch(t, expectedServiceList, serviceMapList, "--service-map list does not contain expected vtcombo services")
 	})
 }
+
+func TestVtcomboRandomPort(t *testing.T) {
+	require.Empty(t, usedRandomPorts)
+	port := randomPort()
+	// 10000-30000 is the range the rand call in randomPorts() can return
+	require.GreaterOrEqual(t, port, 10000)
+	require.LessOrEqual(t, port, 30000)
+	require.Len(t, usedRandomPorts, 6)
+	require.Contains(t, usedRandomPorts, port)
+	require.NotEqual(t, port, randomPort())
+	require.Len(t, usedRandomPorts, 12)
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR addresses flakiness in some tests that rely on `go/vt/vttest`, specifically where a random port is generated

The `bind: address already in use` error:
```bash
2025-11-12T08:09:29.7133344Z I1112 08:06:11.681655   26881 grpc_server.go:325] Listening for gRPC calls on port 23180
2025-11-12T08:09:29.7133697Z F1112 08:06:11.681747   26881 grpc_server.go:328] Cannot listen on port 23180 for gRPC: listen tcp :23180: bind: address already in use
2025-11-12T08:09:29.7133823Z     main_test.go:314: 
2025-11-12T08:09:29.7134297Z         	Error Trace:	/home/runner/work/vitess/vitess/go/cmd/vttestserver/cli/main_test.go:314
2025-11-12T08:09:29.7134500Z         	Error:      	Received unexpected error:
2025-11-12T08:09:29.7134988Z         	            	process 'vtcombo' exited prematurely (err: exit status 1)
2025-11-12T08:09:29.7135136Z         	Test:       	TestMtlsAuth
2025-11-12T08:09:29.7135230Z --- FAIL: TestMtlsAuth (7.71s)
```

The cause of this is mainly that we test if `port + 1` is in use, but we return `port` without the increment. So we're not returning what we are testing 😕 

While I was there I added a mutex and tracking of already-used ports. Tracking used ports may be overkill, but it won't hurt. I don't expect duplicate ports here anymore

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
