### PR TITLE
`vtadmin`: remove `graphql` and `rest` imports

### DIFF
--- a/web/vtadmin/tests/handlers.ts
+++ b/web/vtadmin/tests/handlers.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { graphql, rest } from 'msw'
 
 // Add handlers here as needed for mocking the test server
 export const handlers = [


### PR DESCRIPTION
## Description

This PR removes the unused `graphql` and `rest` dependencies of VTAdmin, which are causing this complaint to show up on every PR, seemingly since v23 where VTAdmin and vite were upgraded:

<img width="892" height="503" alt="Screenshot 2025-11-18 at 18 30 19" src="https://github.com/user-attachments/assets/0c861966-5721-4f1b-94de-3a7b1c6164b8" />

This kind of makes sense, because as far as I know, Vitess doesn't use GraphQL (❤️). REST **could** make sense because the lag throttler and VTOrc both have/had legacy REST APIs _(`freno` and a partial version of `orchestator`'s API specifically)_

I tried to get AI to tell me at what point GraphQL ever made sense, and it couldn't find a reason 🤔. My theory on the `rest` import is VTAdmin used the lag throttler REST endpoints _(which have a gRPC equivalent now)_, but it's a guess - perhaps @shlomi-noach can confirm?

Following this change I don't see any problems clicking around the VTAdmin UI:
<img width="840" height="704" alt="Screenshot 2025-11-18 at 18 48 46" src="https://github.com/user-attachments/assets/2bce2724-a64e-4575-98f8-a4d25214c95a" />

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
