### PR TITLE
`vtbench`: add `--db-credentials-*` flags

### DIFF
--- a/go/flags/endtoend/vtbench.txt
+++ b/go/flags/endtoend/vtbench.txt
@@ -50,6 +50,17 @@ Flags:
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --count int                                                   Number of queries per thread (default 1000)
       --db string                                                   Database name to use when connecting / running the queries (e.g. @replica, keyspace, keyspace/shard etc)
+      --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file
+      --db-credentials-server string                                db credentials server type ('file' - file implementation; 'vault' - HashiCorp Vault implementation) (default "file")
+      --db-credentials-vault-addr string                            URL to Vault server
+      --db-credentials-vault-path string                            Vault path to credentials JSON blob, e.g.: secret/data/prod/dbcreds
+      --db-credentials-vault-role-mountpoint string                 Vault AppRole mountpoint; can also be passed using VAULT_MOUNTPOINT environment variable (default "approle")
+      --db-credentials-vault-role-secretidfile string               Path to file containing Vault AppRole secret_id; can also be passed using VAULT_SECRETID environment variable
+      --db-credentials-vault-roleid string                          Vault AppRole id; can also be passed using VAULT_ROLEID environment variable
+      --db-credentials-vault-timeout duration                       Timeout for vault API operations (default 10s)
+      --db-credentials-vault-tls-ca string                          Path to CA PEM for validating Vault server certificate
+      --db-credentials-vault-tokenfile string                       Path to file containing Vault auth token; token can also be passed using VAULT_TOKEN environment variable
+      --db-credentials-vault-ttl duration                           How long to cache DB credentials from the Vault server (default 30m0s)
       --deadline duration                                           Maximum duration for the test run (default 5 minutes) (default 5m0s)
       --grpc-auth-static-client-creds string                        When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc-compression string                                     Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy

--- a/go/vt/dbconfigs/credentials.go
+++ b/go/vt/dbconfigs/credentials.go
@@ -60,6 +60,7 @@ var (
 		"mysqlctl",
 		"mysqlctld",
 		"vtbackup",
+		"vtbench",
 		"vtcombo",
 		"vttablet",
 	}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR adds missing DB credential flags to `vtbench`. These flags are mentioned in comments/docs but somehow were missed in some refactoring

## Related Issue(s)

  - Fixes: #18553

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
