### PR TITLE
Add `timvaillancourt` to more `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,7 @@ go.sum @harshit-gangal @mattlord @rohit-nayak-ps @systay @frouioui @timvaillanco
 /go/internal/flag @rohit-nayak-ps
 /go/mysql @harshit-gangal @systay @mattlord
 /go/pools @harshit-gangal
-/go/protoutil @mattlord
+/go/protoutil @mattlord @timvaillancourt
 /go/sqltypes @harshit-gangal @shlomi-noach
 /go/test/endtoend/onlineddl @rohit-nayak-ps @shlomi-noach
 /go/test/endtoend/messaging @mattlord @rohit-nayak-ps @derekperkins
@@ -41,7 +41,7 @@ go.sum @harshit-gangal @mattlord @rohit-nayak-ps @systay @frouioui @timvaillanco
 /go/vt/proto @harshit-gangal @mattlord
 /go/vt/proto/vtadmin @beingnoble03
 /go/vt/schema @mattlord @shlomi-noach
-/go/vt/servenv @dbussink
+/go/vt/servenv @dbussink @timvaillancourt
 /go/vt/schemadiff @shlomi-noach @mattlord
 /go/vt/sqlparser @harshit-gangal @systay
 /go/vt/srvtopo @mattlord @timvaillancourt

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -55,7 +55,7 @@ beingnoble03, rohit-nayak-ps
 ### Messaging
 derekperkins, mattlord
 
-### High-availability
+### High Availability
 mattlord, timvaillancourt
 
 ## Past Maintainers


### PR DESCRIPTION
## Description

This PR adds @timvaillancourt to more `CODEOWNERS` paths that I would like to be notified-on for reviews

Also, @mattlord is added to the VTOrc codepaths we agreed previously

## Related Issue(s)

N/A

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
