### PR TITLE
Properly Strip Keyspace Table Qualifiers in FK Constraints

### DIFF
--- a/go/vt/vtgate/planbuilder/ddl.go
+++ b/go/vt/vtgate/planbuilder/ddl.go
@@ -109,6 +109,8 @@ func buildDDLPlans(ctx context.Context, sql string, ddlStatement sqlparser.DDLSt
 		if err != nil {
 			return nil, nil, err
 		}
+		// Remove keyspace qualifiers from all table references (including foreign key references).
+		sqlparser.RemoveSpecificKeyspace(ddlStatement, keyspace.Name)
 		err = checkFKError(vschema, ddlStatement, keyspace)
 	case *sqlparser.CreateView:
 		destination, keyspace, err = buildCreateViewCommon(ctx, vschema, reservedVars, cfg, ddl.Select, ddl)

--- a/go/vt/vtgate/planbuilder/testdata/ddl_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/ddl_cases.json
@@ -683,5 +683,105 @@
         "main.function_default"
       ]
     }
+  },
+  {
+    "comment": "create table with foreign key reference without keyspace qualifier",
+    "query": "create table t1(id bigint, t2_id bigint, primary key(id), foreign key (t2_id) references t2(id))",
+    "plan": {
+      "Type": "DirectDDL",
+      "QueryType": "DDL",
+      "Original": "create table t1(id bigint, t2_id bigint, primary key(id), foreign key (t2_id) references t2(id))",
+      "Instructions": {
+        "OperatorType": "DDL",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "Query": "create table t1 (\n\tid bigint,\n\tt2_id bigint,\n\tprimary key (id),\n\tforeign key (t2_id) references t2 (id)\n)"
+      },
+      "TablesUsed": [
+        "main.t1"
+      ]
+    }
+  },
+  {
+    "comment": "create table with foreign key reference with keyspace qualifier",
+    "query": "create table user.t1(id bigint, t2_id bigint, primary key(id), foreign key (t2_id) references user.t2(id))",
+    "plan": {
+      "Type": "DirectDDL",
+      "QueryType": "DDL",
+      "Original": "create table user.t1(id bigint, t2_id bigint, primary key(id), foreign key (t2_id) references user.t2(id))",
+      "Instructions": {
+        "OperatorType": "DDL",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "create table t1 (\n\tid bigint,\n\tt2_id bigint,\n\tprimary key (id),\n\tforeign key (t2_id) references t2 (id)\n)"
+      },
+      "TablesUsed": [
+        "user.t1"
+      ]
+    }
+  },
+  {
+    "comment": "create table with multiple foreign keys with keyspace qualifiers",
+    "query": "create table user.orders(order_id bigint, customer_id bigint, product_id bigint, primary key(order_id), foreign key (customer_id) references user.customers(id), foreign key (product_id) references user.products(id))",
+    "plan": {
+      "Type": "DirectDDL",
+      "QueryType": "DDL",
+      "Original": "create table user.orders(order_id bigint, customer_id bigint, product_id bigint, primary key(order_id), foreign key (customer_id) references user.customers(id), foreign key (product_id) references user.products(id))",
+      "Instructions": {
+        "OperatorType": "DDL",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "create table orders (\n\torder_id bigint,\n\tcustomer_id bigint,\n\tproduct_id bigint,\n\tprimary key (order_id),\n\tforeign key (customer_id) references customers (id),\n\tforeign key (product_id) references products (id)\n)"
+      },
+      "TablesUsed": [
+        "user.orders"
+      ]
+    }
+  },
+  {
+    "comment": "alter table add foreign key with keyspace qualifier",
+    "query": "alter table user.t1 add foreign key (t2_id) references user.t2(id)",
+    "plan": {
+      "Type": "DirectDDL",
+      "QueryType": "DDL",
+      "Original": "alter table user.t1 add foreign key (t2_id) references user.t2(id)",
+      "Instructions": {
+        "OperatorType": "DDL",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "alter table t1 add foreign key (t2_id) references t2 (id)"
+      },
+      "TablesUsed": [
+        "user.t1"
+      ]
+    }
+  },
+  {
+    "comment": "create table with foreign key with ON DELETE and ON UPDATE clauses and keyspace qualifier",
+    "query": "create table user.employees(emp_id bigint, dept_id bigint, primary key(emp_id), foreign key (dept_id) references user.departments(dept_id) on delete set null on update cascade)",
+    "plan": {
+      "Type": "DirectDDL",
+      "QueryType": "DDL",
+      "Original": "create table user.employees(emp_id bigint, dept_id bigint, primary key(emp_id), foreign key (dept_id) references user.departments(dept_id) on delete set null on update cascade)",
+      "Instructions": {
+        "OperatorType": "DDL",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "create table employees (\n\temp_id bigint,\n\tdept_id bigint,\n\tprimary key (emp_id),\n\tforeign key (dept_id) references departments (dept_id) on delete set null on update cascade\n)"
+      },
+      "TablesUsed": [
+        "user.employees"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Description

Here we follow the existing pattern — used for [`CREATE PROCEDURE`](https://github.com/vitessio/vitess/blob/a5865903f7d12dc39b3156d8f67d1a07dcc79e87/go/vt/vtgate/planbuilder/ddl.go#L177) and [`CREATE VIEW`](https://github.com/vitessio/vitess/blob/a5865903f7d12dc39b3156d8f67d1a07dcc79e87/go/vt/vtgate/planbuilder/ddl.go#L329) statements — for [`CREATE/ALTER/TRUNCATE TABLE`](https://github.com/vitessio/vitess/pull/18926/files#diff-0905caaa118bcc2973468315adb67479198f3c185637aa8b240d32829b27edddR113) when it contains foreign key constraint definitions (`REFERENCES` clauses). That is, we strip all keyspace qualifiers (you cannot have FK constraints across keyspaces).

This ensures that when a `CREATE TABLE` statement like `CREATE TABLE user.employees (..., FOREIGN KEY (dept_id) REFERENCES user.departments(dept_id))` gets sent down to MySQL, it becomes `CREATE TABLE employees (..., FOREIGN KEY (dept_id) REFERENCES departments(dept_id))`. This is important because by default the keyspace name will e.g. be `customer` but in MySQL the database/schema name will be `vt_customer`. So without stripping the keyspace table qualifier, the DDL fails in MySQL due to the database not being found.

> [!NOTE]
> I think that it's worth backporting this to v23 and v22 as it's a small change and improves our MySQL compatibility.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/18889

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

I paired with my man Claude on the work.