### PR TITLE
bugfix: Rewriter not visiting new operators

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/rewriters.go
+++ b/go/vt/vtgate/planbuilder/operators/rewriters.go
@@ -342,6 +342,13 @@ func topDown(
 		return newOp, anythingChanged
 	}
 
+	// If the rewriter replaced the operator with a different one, we need to re-visit
+	// the new operator to give it a chance to be processed
+	if anythingChanged.Changed() && newOp != root {
+		revisitedOp, revisitChanged := topDown(newOp, rootID, resolveID, rewriter, shouldVisit, isRoot)
+		return revisitedOp, anythingChanged.Merge(revisitChanged)
+	}
+
 	if anythingChanged.Changed() {
 		root = newOp
 	}

--- a/go/vt/vtgate/planbuilder/operators/rewriters_test.go
+++ b/go/vt/vtgate/planbuilder/operators/rewriters_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operators
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"vitess.io/vitess/go/vt/vtgate/semantics"
+)
+
+// TestTopDown_RevisitsReplacedOperators verifies that when an operator is replaced
+// during TopDown traversal, the new operator gets re-visited.
+//
+// This test demonstrates the bug fix where TopDown now re-visits operators that are returned
+// as replacements. Without the fix, if a visitor returns a different operator, that new
+// operator would be inserted into the tree but never visited itself.
+//
+// Test scenario:
+//  1. Create a simple operator
+//  2. First visit returns a different operator (simulating what happens in offset planning)
+//  3. Verify that the replacement operator is also visited
+//
+// Without the fix, the second operator would never be visited because TopDown would just
+// replace the first with the second and descend into the second's inputs without visiting
+// the second itself.
+func TestTopDown_RevisitsReplacedOperators(t *testing.T) {
+	visited := map[semantics.TableSet]bool{}
+
+	// Create two simple operators to track visits
+	id0 := semantics.SingleTableSet(0)
+	id1 := semantics.SingleTableSet(1)
+	op1 := &fakeOp{id: id0}
+	op2 := &fakeOp{id: id1}
+
+	// Create visitor that replaces op1 with op2 and marks each operator as visited
+
+	visitor := func(in Operator, _ semantics.TableSet, _ bool) (Operator, *ApplyResult) {
+		visited[TableID(in)] = true
+		if in == op1 {
+			return op2, Rewrote("replaced operator")
+		}
+		return in, NoRewrite
+	}
+
+	// Run TopDown traversal
+	result := TopDown(op1, func(op Operator) semantics.TableSet {
+		return semantics.EmptyTableSet()
+	}, visitor, func(Operator) VisitRule {
+		return VisitChildren
+	})
+
+	// Verify both operators were visited
+	assert.True(t, visited[id0], "first operator should have been visited")
+	assert.True(t, visited[id1], "second operator (replacement) should have been visited")
+	assert.Equal(t, op2, result, "result should be the second operator")
+}

--- a/go/vt/vtgate/planbuilder/operators/utils_test.go
+++ b/go/vt/vtgate/planbuilder/operators/utils_test.go
@@ -41,8 +41,7 @@ func (f *fakeOp) Inputs() []Operator {
 }
 
 func (f *fakeOp) SetInputs(operators []Operator) {
-	// TODO implement me
-	panic("implement me")
+	f.inputs = operators
 }
 
 func (f *fakeOp) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) Operator {


### PR DESCRIPTION
## Description

Found this bug while working on Neki, where we have the same operator infrastructure. It's not really affecting any plans in Vitess, but since the code is there, we might as well fix this issue so it doesn't affect us in the future.

## Related Issue(s)


## Checklist
-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
