### PR TITLE
Stop using Equinix Metal self hosted runners

### DIFF
--- a/test/vtop_example.sh
+++ b/test/vtop_example.sh
@@ -24,7 +24,7 @@
 source build.env
 
 # Use this to debug issues. It will print the commands as they run
-set -x
+# set -x
 shopt -s expand_aliases
 alias vtctlclient="vtctlclient --server=localhost:15999"
 alias vtctldclient="vtctldclient --server=localhost:15999"


### PR DESCRIPTION
## Description

Equinix Metal (CNCF account) is going away next year and we need to migrate and/or eliminate all usage of the machines there. 

This PR removes the one remaining usage of the self hosted GH runners there so that we can decommission them. We instead use one of the larger instances provided in OCI via CNCF.

We need to backport this to the other supported releases/branches: v22 and v23. 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
