### PR TITLE
vstreamer: improve error message when table not found due to keyspace…

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/local_vschema.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/local_vschema.go
@@ -75,6 +75,9 @@ func (lvs *localVSchema) findTable(tablename string) (*vindexes.BaseTable, error
 		if schema.IsInternalOperationTableName(tablename) {
 			log.Infof("found internal table %s, ignoring in local vschema search", tablename)
 		} else {
+			if ks.Error != nil {
+				return nil, fmt.Errorf("table %s not found in keyspace %s (keyspace has error: %v)", tablename, lvs.keyspace, ks.Error)
+			}
 			return nil, fmt.Errorf("table %s not found", tablename)
 		}
 	}


### PR DESCRIPTION
## Description

Improves error message when VReplication fails to find a table due to keyspace vindex errors. Previously, if a `region_json` vindex failed to load its config file (not mounted on vttablet), users saw only "table customer not found". Now the underlying error is included: `table customer not found in keyspace main (keyspace has error: open /path/to/file: no such file or directory)`.

## Related Issue(s)

Fixes #18247

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

None - error message improvement only.

### AI Disclosure

Tests were written by Claude