### PR TITLE
Fix GC table regex for lower case compatibility

### DIFF
--- a/go/vt/schema/tablegc.go
+++ b/go/vt/schema/tablegc.go
@@ -52,7 +52,7 @@ func (s TableGCState) TableHint() InternalTableHint {
 }
 
 const (
-	OldGCTableNameExpression string = `^_vt_(HOLD|PURGE|EVAC|DROP)_([0-f]{32})_([0-9]{14})$`
+	OldGCTableNameExpression string = `^_vt_(HOLD|PURGE|EVAC|DROP|hold|purge|evac|drop)_([0-f]{32})_([0-9]{14})$`
 	// GCTableNameExpression parses new internal table name format, e.g. _vt_hld_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_
 	GCTableNameExpression string = `^_vt_(hld|prg|evc|drp)_([0-f]{32})_([0-9]{14})_$`
 )
@@ -72,6 +72,7 @@ func init() {
 	gcStatesTableHints[DropTableGCState] = InternalTableGCDropHint
 	for _, gcState := range []TableGCState{HoldTableGCState, PurgeTableGCState, EvacTableGCState, DropTableGCState} {
 		gcStates[string(gcState)] = gcState
+		gcStates[strings.ToLower(string(gcState))] = gcState
 		gcStates[gcState.TableHint().String()] = gcState
 	}
 }

--- a/go/vt/schema/tablegc_test.go
+++ b/go/vt/schema/tablegc_test.go
@@ -65,6 +65,11 @@ func TestIsGCTableName(t *testing.T) {
 			"_vt_DROP_6ace8bcef73211ea87e9f875a4d24e90_20200915120410",
 			"_vt_HOLD_6ace8bcef73211ea87e9f875a4d24e90_20200915120410",
 			"_vt_drp_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_",
+			// Test lowercase variants for lower_case_table_names=1 compatibility
+			"_vt_drop_6ace8bcef73211ea87e9f875a4d24e90_20200915120410",
+			"_vt_hold_6ace8bcef73211ea87e9f875a4d24e90_20200915120410",
+			"_vt_purge_6ace8bcef73211ea87e9f875a4d24e90_20200915120410",
+			"_vt_evac_6ace8bcef73211ea87e9f875a4d24e90_20200915120410",
 		}
 		for _, tableName := range names {
 			t.Run(tableName, func(t *testing.T) {
@@ -182,6 +187,31 @@ func TestAnalyzeGCTableName(t *testing.T) {
 		{
 			tableName: "_vt_xyz_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_",
 			isGC:      false,
+		},
+		// Test lowercase variants for lower_case_table_names=1 compatibility
+		{
+			tableName: "_vt_drop_6ace8bcef73211ea87e9f875a4d24e90_20200915120410",
+			state:     DropTableGCState,
+			t:         baseTime,
+			isGC:      true,
+		},
+		{
+			tableName: "_vt_hold_6ace8bcef73211ea87e9f875a4d24e90_20200915120410",
+			state:     HoldTableGCState,
+			t:         baseTime,
+			isGC:      true,
+		},
+		{
+			tableName: "_vt_purge_6ace8bcef73211ea87e9f875a4d24e90_20200915120410",
+			state:     PurgeTableGCState,
+			t:         baseTime,
+			isGC:      true,
+		},
+		{
+			tableName: "_vt_evac_6ace8bcef73211ea87e9f875a4d24e90_20200915120410",
+			state:     EvacTableGCState,
+			t:         baseTime,
+			isGC:      true,
 		},
 	}
 	for _, ts := range tt {


### PR DESCRIPTION
Problem: When MySQL is configured with lower_case_table_names=1, all table names are stored in lowercase. Vitess generates GC table names like vt_HOLD, but MySQL stores them as vt_hold. The old regex only matched uppercase state names, causing TableGC to fail to recognize.

Solution: The fix makes the GC table recognition case-insensitive while maintaining backward compatibility with existing uppercase table names.


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
https://github.com/vitessio/vitess/issues/18939

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
