### PR TITLE
ci: remove code patching for error differences between versions

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -142,15 +142,6 @@ jobs:
       run: |
         find ./go/test/endtoend -name '*.go' -exec sed -i 's/ErrorContains/Error/g' {} +
         find ./go/test/endtoend -name '*.go' -exec sed -i 's/EqualError/Error/g' {} +
-        # Relax TestSpecializedPlan for < v24 due to window functions error message change.
-        # <= v23: "VT12001: unsupported: OVER CLAUSE with sharded keyspace"
-        # >= v24: "VT12001: unsupported: window functions are only supported for single-shard queries"
-        # Use Contains check to accept both versions.
-        ref="${{ steps.output-previous-release-ref.outputs.previous_release_ref }}"
-        version=$(echo "$ref" | sed 's/release-//' | cut -d. -f1)
-        if [ "$version" -lt 24 ]; then
-          sed -i 's/require\.EqualValues(t, "VT12001: unsupported: OVER CLAUSE with sharded keyspace", pm\["BaselineErr"\])/require.Contains(t, pm["BaselineErr"].(string), "VT12001: unsupported:")/' go/test/endtoend/preparestmt/stmt_methods_test.go
-        fi
 
     # Swap the binaries in the bin. Use vtgate version n-1 and keep vttablet at version n
     - name: Use last release's VTGate


### PR DESCRIPTION
## Description

This was introduced as part of https://github.com/vitessio/vitess/pull/18903, but it's no longer required now that https://github.com/vitessio/vitess/pull/18989/commits/cf3f338c4742e6e397b2c9add6e34c37d0ef896e has landed on the `release-23.0` branch. So let's⚡it.

## Related Issue(s)

https://github.com/vitessio/vitess/pull/18903

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
