### PR TITLE
CI: Improve reliability of codecov workflow with larger runner

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,7 +16,7 @@ permissions: read-all
 jobs:
   test:
     name: Code Coverage
-    runs-on: ubuntu-24.04
+    runs-on: oracle-vm-8cpu-32gb-x86-64
 
     steps:
     - name: Check out code


### PR DESCRIPTION
## Description

The `codecov` workflow has been VERY flaky lately. Typically taking 3+ attempts before it succeeds. This workflow runs *every* unit test with code coverage enabled — so it's heavier than our other unit test workflows which have split off the evalengine tests into a separate workflow — and the failures I kept seeing made no sense, unless we were resource starved. So to test that theory I used a larger runner (up until 9 months ago, we were using a larger one). You can see the results here from 10 runs: https://github.com/vitessio/vitess/actions/runs/19942952837?pr=18992

We went from having to run it 2-5 times to get it to pass once, so let's say it was passing ~ 30% of the time. Whereas on this branch it passed 7 out of 10 times, so 70%. That is pretty good, considering that we DO have a number of flaky individual unit tests.

> [!NOTE]
> Backporting to v22 so that we have an improved CI for all supported release branches.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
