### PR TITLE
`vtorc`: improve logging in `DiscoverInstance`, remove old metric

### DIFF
--- a/go/vt/vtorc/logic/vtorc.go
+++ b/go/vt/vtorc/logic/vtorc.go
@@ -187,12 +187,10 @@ func DiscoverInstance(tabletAlias string, forceDiscovery bool) {
 	discoveryInstanceTimings.Add("Instance", instanceLatency)
 	discoveryInstanceTimings.Add("Other", otherLatency)
 
-	if forceDiscovery && err == nil {
-		log.Infof("Force discovered %s - %+v", tabletAlias, instance)
-	} else if forceDiscovery && err != nil {
-		log.Errorf("Force discovered %s - %+v, err - %v", tabletAlias, instance, err)
-	} else if err != nil {
-		log.Errorf("Failed to discover %s: %v", tabletAlias, err)
+	if err != nil {
+		log.Errorf("Failed to discover %s (force: %t), err: %v", tabletAlias, forceDiscovery, err)
+	} else {
+		log.Infof("Discovered %s (force: %t): %+v", tabletAlias, forceDiscovery, instance)
 	}
 
 	if instance == nil {


### PR DESCRIPTION
## Description

This PR improves VTOrc observability by including the tablet alias in errors when `DiscoveryInstance` fails. Also, when an error occurs the correct `ERROR` loglevel is used

Today, VTOrc logs this when it fails to discover a tablet:
```bash
[vtorc.go:205] Force discovered - <nil>, err - tablet alias is nil
```
Which tablet threw this error? It's anyone's guess 😅 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
