### PR TITLE
MoveTables: Verify that source & target keyspaces are distinct

### DIFF
--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1049,8 +1049,8 @@ func (s *Server) moveTablesCreate(ctx context.Context, req *vtctldatapb.MoveTabl
 	targetKeyspace := req.TargetKeyspace
 	// FIXME validate tableSpecs, allTables, excludeTables
 
-	if sourceKeyspace == targetKeyspace {
-		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "source and target keyspace must be different")
+	if workflowType == binlogdatapb.VReplicationWorkflowType_MoveTables && sourceKeyspace == targetKeyspace {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "source and target keyspace must be different for MoveTables workflows")
 	}
 
 	var (

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -2889,7 +2889,7 @@ func TestMaterializeAddTables(t *testing.T) {
 	}
 }
 
-func TestMoveTablesCreateSourceEqualsTarget(t *testing.T) {
+func TestMoveTablesPreventsSourceEqualsTarget(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
@@ -2901,5 +2901,20 @@ func TestMoveTablesCreateSourceEqualsTarget(t *testing.T) {
 		Workflow:       "wf1",
 	})
 
-	require.ErrorContains(t, err, "source and target keyspace must be different")
+	require.ErrorContains(t, err, "source and target keyspace must be different for MoveTables workflows")
+}
+
+func TestMigrateAllowsSourceEqualsTarget(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	ts := memorytopo.NewServer(ctx, "cell1")
+
+	_, err := NewServer(vtenv.NewTestEnv(), ts, nil).MigrateCreate(ctx, &vtctldatapb.MigrateCreateRequest{
+		SourceKeyspace: "ks1",
+		TargetKeyspace: "ks1",
+		Workflow:       "wf1",
+		MountName:      "ext1",
+	})
+	require.NotContains(t, err.Error(), "source and target keyspace must be different for MoveTables workflows")
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

It is possible to submit a MoveTables workflow with the same source & target keyspaces. This should be safeguarded and throw an error.

Otherwise the user is able to create hanging MoveTables workflows that will attempt to copy rows to itself, but does not progress.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/19011

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
