### PR TITLE
`ci`: allow `make unit_test_cover` to run in parallel

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -87,6 +87,7 @@ jobs:
         export VTDATAROOT="/tmp/"
 
         export NOVTADMINBUILD=1
+        export VT_GO_PARALLEL_VALUE=$(nproc)
 
         # Exclude endtoend tests from the coverage report.
         # TODO: figure out how best to include our endtoend tests in the coverage report.


### PR DESCRIPTION
## Description

This PR allows `make unit_test_cover` to run in parallel, similar to other CI that rely on heavy `go` processing, example here: https://github.com/vitessio/vitess/blob/main/test/templates/unit_test.tpl#L137

<img width="700" alt="Screenshot 2025-12-15 at 16 58 09" src="https://github.com/user-attachments/assets/625b612b-5b79-4e96-aa75-dedb25e52529" />

It appears this override was never added to the code coverage CI. Let's see how it goes! This might address the bad flakiness we see

TIL: `$(nproc)` in GitHub Actions magically gives you the # of CPUs. We are already using this in other CI 👍 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
