### PR TITLE
`golangci-lint`: fix `QF1008` stragglers from PR #18929

### DIFF
--- a/go/vt/vtgate/planbuilder/window.go
+++ b/go/vt/vtgate/planbuilder/window.go
@@ -57,7 +57,7 @@ func isSingleShardPrimitive(route *engine.Route) bool {
 	if route == nil || route.RoutingParameters == nil {
 		return false
 	}
-	return route.RoutingParameters.Opcode.IsSingleShard()
+	return route.Opcode.IsSingleShard()
 }
 
 type windowTableInfo struct {

--- a/go/vt/vttablet/tabletmanager/vdiff/table_differ.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/table_differ.go
@@ -951,7 +951,7 @@ func (td *tableDiffer) getSourcePKCols() error {
 		// The table no longer exists on the source. Any rows that exist on the target will be
 		// reported as extra rows.
 		log.Warningf("The %s table was not found on source tablet %s during VDiff for the %s workflow; any rows on the target will be reported as extra",
-			td.table.Name, topoproto.TabletAliasString(sourceTablet.Tablet.Alias), td.wd.ct.workflow)
+			td.table.Name, topoproto.TabletAliasString(sourceTablet.Alias), td.wd.ct.workflow)
 		return nil
 	}
 	sourceTable := sourceSchema.TableDefinitions[0]


### PR DESCRIPTION
## Description

This PR fixes 2 x linter violations that must have been created between the creation and merge of https://github.com/vitessio/vitess/pull/18929. Bad timing!

Example annotation from failures:
<img width="750" alt="Screenshot 2025-12-17 at 22 11 42" src="https://github.com/user-attachments/assets/692143db-f99a-4138-aeb0-36bf4add5223" />

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
