### PR TITLE
examples/operator: Remove duplicate operator service account definition

### DIFF
--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -7722,6 +7722,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: vitess-operator
+    namespace: default
 ---
 apiVersion: scheduling.k8s.io/v1
 description: Vitess components (vttablet, vtgate, vtctld, etcd)


### PR DESCRIPTION
## Description

Kustomize fails to install the operator resources in a custom namespace (i.e `vitess` namespace):
```
kustomize build failed: namespace transformation produces ID conflict: [{"apiVersion":"v1","kind":"ServiceAccount","metadata":{"annotations":{"internal.config.kubernetes.io/previousKinds":"ServiceAccount","internal.config.kubernetes.io/previousNames":"vitess-operator","internal.config.kubernetes.io/previousNamespaces":"example"},"name":"vitess-operator","namespace":"vitess"}} {"apiVersion":"v1","kind":"ServiceAccount","metadata":{"annotations":{"internal.config.kubernetes.io/previousKinds":"ServiceAccount","internal.config.kubernetes.io/previousNames":"vitess-operator","internal.config.kubernetes.io/previousNamespaces":"default"},"name":"vitess-operator","namespace":"vitess"}}]
```

## Related Issue(s)

  - Fixes: [Bug Report: Kustomize operator service account duplicate definition conflict #19054](https://github.com/vitessio/vitess/issues/19054)

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

No deployment notes.

### AI Disclosure

No AI was used for this change.
