### PR TITLE
`release-23.0`: add e2e compatibility for v24 PR #19009

### DIFF
--- a/go/test/endtoend/reparent/plannedreparent/reparent_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/reparent_test.go
@@ -120,8 +120,15 @@ func TestReparentReplicaOffline(t *testing.T) {
 	out, err := utils.PrsWithTimeout(t, clusterInstance, tablets[1], false, "", "31s")
 	require.Error(t, err)
 
+	vtctldclientVersion, err := cluster.GetMajorVersion("vtctldclient")
+	require.NoError(t, err)
+
 	// Assert that PRS failed
-	assert.Contains(t, out, "rpc error: code = DeadlineExceeded desc")
+	if vtctldclientVersion >= 24 {
+		assert.Contains(t, out, "rpc error: code = Unknown desc = tablet is shutdown")
+	} else {
+		assert.Contains(t, out, "rpc error: code = DeadlineExceeded desc")
+	}
 	utils.CheckPrimaryTablet(t, clusterInstance, tablets[0])
 }
 


### PR DESCRIPTION
## Description

This PR fixes a bug in `release-23.0` upgrade e2e testing, which is incompatible with the v24 PR #19009

The problem is "upgrade" e2e CI uses an `N + 1` version of `vtctldclient`, and in v24 this client was updated to return new error messaging. TL;DR: v24 returns `rpc error: code = Unknown desc = tablet is shutdown` when a tablet is down

## Related Issue(s)

#19009

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
