### PR TITLE
`release-23.0`: Add version conditional for tablet missing error message

### DIFF
--- a/go/test/endtoend/reparent/plannedreparent/reparent_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/reparent_test.go
@@ -120,10 +120,7 @@ func TestReparentReplicaOffline(t *testing.T) {
 	out, err := utils.PrsWithTimeout(t, clusterInstance, tablets[1], false, "", "31s")
 	require.Error(t, err)
 
-<<<<<<< HEAD
 	// Assert that PRS failed
-	assert.Contains(t, out, "rpc error: code = DeadlineExceeded desc")
-=======
 	vtctldVersion, err := cluster.GetMajorVersion("vtctld")
 	require.NoError(t, err)
 	errStr := "rpc error: code = DeadlineExceeded desc"
@@ -132,7 +129,6 @@ func TestReparentReplicaOffline(t *testing.T) {
 	}
 	assert.Contains(t, out, errStr)
 
->>>>>>> 18497c8654 ([latest-23.0](#8227): CherryPick(#19044): VDiff: Do not intentionally timeout query, and display diff sample binary columns as hex (#8228))
 	utils.CheckPrimaryTablet(t, clusterInstance, tablets[0])
 }
 


### PR DESCRIPTION
## Description

This PR makes `release-23.0` compatible with a forwards-incompatible change in v24, introduced in #19009

Really only e2e tests should notice the incompatibility, which is just a change in the error message text

## Related Issue(s)

#19009 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
