### PR TITLE
Restore `/vthook` to dot-ignore files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,6 @@
 /dist/
 /bin/
 /vtdataroot/
+/vthook/
 /web/vtadmin/node_modules
 /web/vtadmin/build

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ _test/
 /dist/
 /bin/
 /vtdataroot/
+/vthook/
 venv
 
 .scannerwork


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

It seems PR #19071 caused this new failure in the Static Code Checks CI, that can only be noticed post-`main` merge:

```bash
We wish to maintain a tidy state for go mod. Please run `go mod tidy` on your branch, commit and push again.
Running `go mod tidy` on this CI test yields with the following changes:
?? vthook/
```

I don't know what's making `vthook/`,  but this means it still needs to be ignored. It is restored to the ignore files

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
