### PR TITLE
`e2e`: disable gRPC `GOAWAY`/`too_many_pings` keepalive errors in e2e CI

### DIFF
--- a/test.go
+++ b/test.go
@@ -222,10 +222,10 @@ func (t *Test) run(dir, dataDir string) ([]byte, error) {
 		// Disable gRPC server GOAWAY/"too_many_pings" errors. Context:
 		// https://github.com/grpc/grpc/blob/master/doc/keepalive.md
 		"GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA": "0",
-		"VTROOT":      "/vt/src/vitess.io/vitess",
-		"VTDATAROOT":  dataDir,
-		"VTPORTSTART": strconv.FormatInt(int64(getPortStart(100)), 10),
-		"TOPO":        os.Getenv("TOPO"),
+		"VTROOT":                                "/vt/src/vitess.io/vitess",
+		"VTDATAROOT":                            dataDir,
+		"VTPORTSTART":                           strconv.FormatInt(int64(getPortStart(100)), 10),
+		"TOPO":                                  os.Getenv("TOPO"),
 	})
 
 	// Capture test output.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR disables too-many-ping protection in gRPC when running e2e tests with `test.go`. This is achieved by setting `GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA` to `0`

Context from docs:

> GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA
This channel argument controls the maximum number of pings that can be sent when there is no data/header frame to be sent. gRPC Core will not continue sending pings if we run over the limit. Setting it to 0 allows sending pings without such a restriction. (Note that this is an unfortunate setting that does not agree with [A8-client-side-keepalive.md](https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md). There should ideally be no such restriction on the keepalive ping and we plan to deprecate it in the future.)

and

> Why am I receiving a GOAWAY with error code ENHANCE_YOUR_CALM?
A server sends a GOAWAY with ENHANCE_YOUR_CALM if the client sends too many misbehaving pings as described in [A8-client-side-keepalive.md](https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md). Some scenarios where this can happen are -
if a server has GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS set to false while the client has set this to true resulting in keepalive pings being sent even when there is no call in flight.
if the client's GRPC_ARG_KEEPALIVE_TIME_MS setting is lower than the server's GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS.

Today, many e2e tests connect/reconnect to the gRPC server too quickly and hit the `GOAWAY`/`too_many_pings` error. When this occurs, the victim test has to wait the `GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS` default of 300000 milliseconds _(5 minutes)_ doing nothing 😱. This protection makes sense in a normal world, but in an e2e test all running on localhost we don't really care

When tests hit this, we see this error and pause for 5min:
```bash
E1218 18:18:06.674435  32993 component.go:44] [transport] Client received GoAway with error code ENHANCE_YOUR_CALM and debug data equal to ASCII "too_many_pings".
```

Docs: https://github.com/grpc/grpc/blob/master/doc/keepalive.md

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
