### PR TITLE
Fix `ReloadSchema` incorrectly using `DisableBinlogs` value in `grpctmclient`

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_backup.go
+++ b/go/vt/vttablet/tabletmanager/rpc_backup.go
@@ -102,12 +102,6 @@ func (tm *TabletManager) Backup(ctx context.Context, logger logutil.Logger, req 
 		return vterrors.Wrap(err, "failed to execute backup init SQL queries")
 	}
 
-	// Reload the schema so that backup takes most up-to-date snapshot of the sidecar database (for example,
-	// to capture a new table that has been created since the last schema reload).
-	if err := tm.QueryServiceControl.ReloadSchema(ctx); err != nil {
-		return vterrors.Wrap(err, "failed to reload schema before backup")
-	}
-
 	// Prevent concurrent backups, and record stats
 	backupMode := backupModeOnline
 	if engine.ShouldDrainForBackup(req) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Fixes a small bug where `ReloadSchema` was incorrectly set to `req.DisableBinlogs` instead of `req.ReloadSchema` in `ExecuteFetchAsDba` and `ExecuteMultiFetchAsDba`.

Some backup test cases broke as a result of this fix, since they silently relied on the fact `ExecuteFetchAsDba` wasn't properly reloading the schema cache. Fixed by resetting test state in between runs.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
