### PR TITLE
binlog_json: fix opaque value parsing to read variable-length

### DIFF
--- a/go/mysql/binlog/binlog_json.go
+++ b/go/mysql/binlog/binlog_json.go
@@ -450,16 +450,18 @@ func binparserLiteral(_ jsonDataType, data []byte, pos int) (node *json.Value, e
 // we currently know about (and support) date/time/datetime/decimal.
 func binparserOpaque(_ jsonDataType, data []byte, pos int) (node *json.Value, err error) {
 	if pos >= len(data) {
-		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "opaque value missing type at position %d", pos)
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "opaque JSON field value missing type at position %d", pos)
 	}
-	dataType := data[pos]
-	if pos+1 >= len(data) {
-		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "opaque value missing length at position %d", pos)
+	typePos := pos
+	dataType := data[typePos]
+	pos = typePos + 1
+	if pos >= len(data) {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "opaque JSON field value missing length at position %d", typePos)
 	}
-	length, start := readVariableLength(data, pos+1)
+	length, start := readVariableLength(data, pos)
 	end := start + length
 	if start > len(data) || end > len(data) {
-		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "opaque value length %d exceeds available bytes", length)
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "opaque JSON field value length %d exceeds available bytes", length)
 	}
 	switch dataType {
 	case TypeDate:

--- a/go/mysql/binlog/binlog_json_test.go
+++ b/go/mysql/binlog/binlog_json_test.go
@@ -263,26 +263,30 @@ func TestBinaryJSON(t *testing.T) {
 
 func TestBinaryJSONOpaqueErrors(t *testing.T) {
 	testcases := []struct {
-		name string
-		data []byte
+		name        string
+		data        []byte
+		expectedErr string
 	}{
 		{
-			name: "opaque length exceeds payload",
-			data: []byte{15, 252, 2, 202},
+			name:        "opaque length exceeds payload",
+			data:        []byte{15, 252, 2, 202},
+			expectedErr: "opaque JSON field value length 2 exceeds available bytes",
 		},
 		{
-			name: "opaque date too short",
-			data: []byte{15, 10, 4, 0, 0, 0, 0},
+			name:        "opaque date too short",
+			data:        []byte{15, 10, 4, 0, 0, 0, 0},
+			expectedErr: "opaque date length 4 is too short",
 		},
 		{
-			name: "opaque decimal too short",
-			data: []byte{15, 246, 1, 0x01},
+			name:        "opaque decimal too short",
+			data:        []byte{15, 246, 1, 0x01},
+			expectedErr: "opaque decimal length 1 is too short",
 		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := ParseBinaryJSON(tc.data)
-			require.Error(t, err)
+			require.ErrorContains(t, err, tc.expectedErr)
 		})
 	}
 }


### PR DESCRIPTION
## Description

We have seen a few instances of this code `panic`ing, looking further it appears it's assuming some fixed-length values when they can actually be variable length.

In investigating, I also found that we were reading some very specific JSON objects incorrectly. 

This should be backported to all supported versions, as this is a correctness and stability issue.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/19103

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

### AI Disclosure

This bug was found with the help of Claude and Codex working together. 
