### PR TITLE
Skip flaky `TestRedial` test

### DIFF
--- a/go/vt/vtadmin/vtctldclient/proxy_test.go
+++ b/go/vt/vtadmin/vtctldclient/proxy_test.go
@@ -126,6 +126,8 @@ func (d *testdisco) DiscoverVtctldAddrs(ctx context.Context, tags []string) ([]s
 // TestRedial tests that vtadmin-api is able to recover from a lost connection to
 // a vtctld by rediscovering and redialing a new one.
 func TestRedial(t *testing.T) {
+	t.Skip("flaky test, gRPC reconnection timing is unreliable")
+
 	// Initialize vtctld #1
 	listener1, server1, err := initVtctldServer()
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Test rarely succeeds in CI and hangs for the full test timeout interval (default 10 minutes).

Backporting to v22 and v23 to fix their CI as well.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
