### PR TITLE
vtctl: fix nil pointer dereference in SNAPSHOT keyspace creation

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -1903,9 +1903,10 @@ func commandCreateKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 			} else {
 				return err
 			}
+		} else {
+			// Copy the vschema from the base keyspace to the new one.
+			ksvs.Keyspace = bksvs.Keyspace.CloneVT()
 		}
-		// Copy the vschema from the base keyspace to the new one.
-		ksvs.Keyspace = bksvs.Keyspace.CloneVT()
 		// SNAPSHOT keyspaces are excluded from global routing.
 		ksvs.RequireExplicitRouting = true
 		if err := wr.TopoServer().SaveVSchema(ctx, ksvs); err != nil {


### PR DESCRIPTION
## Description

When creating a SNAPSHOT keyspace, if the base keyspace has no VSchema (NoNode error), the code would set ksvs.Keyspace to an empty vschema, but then unconditionally try to clone from bksvs.Keyspace. Since bksvs is nil when GetVSchema returns an error, this causes a panic.

Fix by moving the clone into an else block so it only runs when GetVSchema succeeds. This matches the correct pattern already used in grpcvtctldserver/server.go.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/19134

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

This was discovered by doing some thorough analyses with AI and then validating the findings. 
