### PR TITLE
workflow: rebuild SrvVSchema after cancel with keepData=false

### DIFF
--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -2701,6 +2701,9 @@ func (s *Server) finalizeMigrateWorkflow(ctx context.Context, ts *trafficSwitche
 		if err := sw.removeTargetTables(ctx); err != nil {
 			return nil, err
 		}
+		if err := ts.TopoServer().RebuildSrvVSchema(ctx, nil); err != nil {
+			return nil, err
+		}
 	}
 	return sw.logs(), nil
 }


### PR DESCRIPTION
## Description

`finalizeMigrateWorkflow` skipped `RebuildSrvVSchema` when canceling with `keepData=false`, leaving stale `SrvVSchema` entries that routed `vtgate` to dropped target tables until a manual rebuild occurred.

Call `RebuildSrvVSchema` after `removeTargetTables` so the serving graph reflects the removed tables immediately.

## Related Issue(s)

Fixes: #19127 
Similar ish to: https://github.com/vitessio/vitess/issues/19115

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

### AI Disclosure

This bug was found with the help of Opus 4.5 and GPT 5.2, and both reviewed by AI and a human reviewer.