### PR TITLE
Fix information schema queries not being merged correctly

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -42,6 +42,25 @@ type InfoSchemaRouting struct {
 	seenPredicates []sqlparser.Expr
 }
 
+func (isr *InfoSchemaRouting) extraInfo() string {
+	var parts []string
+	if len(isr.SysTableTableSchema) > 0 {
+		var exprs []string
+		for _, expr := range isr.SysTableTableSchema {
+			exprs = append(exprs, sqlparser.String(expr))
+		}
+		parts = append(parts, "SysTableTableSchema:["+strings.Join(exprs, ", ")+"]")
+	}
+	if len(isr.SysTableTableName) > 0 {
+		var exprs []string
+		for k, expr := range isr.SysTableTableName {
+			exprs = append(exprs, k+"="+sqlparser.String(expr))
+		}
+		parts = append(parts, "SysTableTableName:["+strings.Join(exprs, ", ")+"]")
+	}
+	return strings.Join(parts, " ")
+}
+
 func (isr *InfoSchemaRouting) UpdateRoutingParams(ctx *plancontext.PlanningContext, rp *engine.RoutingParameters) {
 	rp.SysTableTableSchema = nil
 	for _, expr := range isr.SysTableTableSchema {
@@ -224,15 +243,12 @@ func tryMergeInfoSchemaRoutings(ctx *plancontext.PlanningContext, routingA, rout
 }
 
 func equalExprs(a, b []sqlparser.Expr) bool {
-	if len(a) != len(b) {
-		return false
-	}
 	for i := range a {
-		if !sqlparser.Equals.Expr(a[i], b[i]) {
-			return false
+		if sqlparser.Equals.Expr(a[i], b[i]) {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 var (

--- a/go/vt/vtgate/planbuilder/operators/union.go
+++ b/go/vt/vtgate/planbuilder/operators/union.go
@@ -19,6 +19,7 @@ package operators
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"vitess.io/vitess/go/slice"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -101,7 +102,7 @@ func (u *Union) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Ex
 		if !ok {
 			panic(vterrors.VT12001("pushing predicates on UNION where the first SELECT contains * or NEXT"))
 		}
-		offsets[ae.ColumnName()] = i
+		offsets[strings.ToLower(ae.ColumnName())] = i
 	}
 
 	if jp, ok := expr.(*predicates.JoinPredicate); ok {

--- a/go/vt/vtgate/planbuilder/operators/union.go
+++ b/go/vt/vtgate/planbuilder/operators/union.go
@@ -130,7 +130,7 @@ func (u *Union) predicatePerSource(expr sqlparser.Expr, offsets map[string]int) 
 
 			idx, ok := offsets[col.Name.Lowered()]
 			if !ok {
-				panic(vterrors.VT13001(fmt.Sprintf("column '%s' not found in UNION output columns", col.Name.String())))
+				panic(vterrors.VT13001(fmt.Sprintf("could not find the column '%s' on the UNION", sqlparser.String(col))))
 			}
 
 			sel := u.GetSelectFor(i)

--- a/go/vt/vtgate/planbuilder/operators/union_merging.go
+++ b/go/vt/vtgate/planbuilder/operators/union_merging.go
@@ -199,6 +199,7 @@ func tryMergeUnionInfoSchemaRouting(
 
 	// if we have no schema predicates on either side, we can merge if the table info is compatible
 	case len(isrA.SysTableTableSchema) == 0 && len(isrB.SysTableTableSchema) == 0:
+		isrA.seenPredicates = append(isrA.seenPredicates, isrB.seenPredicates...)
 		for k, expr := range isrB.SysTableTableName {
 			if e, found := isrA.SysTableTableName[k]; found && !sqlparser.Equals.Expr(expr, e) {
 				// contradicting table names, give up
@@ -210,6 +211,7 @@ func tryMergeUnionInfoSchemaRouting(
 
 	// if both sides have the same schema predicate, we can safely merge them
 	case equalExprs(isrA.SysTableTableSchema, isrB.SysTableTableSchema):
+		isrA.seenPredicates = append(isrA.seenPredicates, isrB.seenPredicates...)
 		for k, expr := range isrB.SysTableTableName {
 			isrA.SysTableTableName[k] = expr
 		}

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -98,41 +98,18 @@
     "comment": "union of information_schema",
     "query": "select TABLE_NAME from information_schema.columns union select table_schema from information_schema.tables",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select TABLE_NAME from information_schema.columns union select table_schema from information_schema.tables",
       "Instructions": {
-        "OperatorType": "Distinct",
-        "Collations": [
-          "0: utf8mb3_general_ci"
-        ],
-        "Inputs": [
-          {
-            "OperatorType": "Concatenate",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select `TABLE_NAME` from information_schema.`columns` where 1 != 1",
-                "Query": "select distinct `TABLE_NAME` from information_schema.`columns`"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select table_schema from information_schema.`tables` where 1 != 1",
-                "Query": "select distinct table_schema from information_schema.`tables`"
-              }
-            ]
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `TABLE_NAME` from information_schema.`columns` where 1 != 1 union select table_schema from information_schema.`tables` where 1 != 1",
+        "Query": "select `TABLE_NAME` from information_schema.`columns` union select table_schema from information_schema.`tables`"
       }
     }
   },
@@ -774,42 +751,19 @@
     "comment": "select sum(found) from (select 1 as found from information_schema.`tables` where table_schema = 'music' union all (select 1 as found from information_schema.views where table_schema = 'music' limit 1)) as t",
     "query": "select sum(found) from (select 1 as found from information_schema.`tables` where table_schema = 'music' union all (select 1 as found from information_schema.views where table_schema = 'music' limit 1)) as t",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select sum(found) from (select 1 as found from information_schema.`tables` where table_schema = 'music' union all (select 1 as found from information_schema.views where table_schema = 'music' limit 1)) as t",
       "Instructions": {
-        "OperatorType": "Aggregate",
-        "Variant": "Scalar",
-        "Aggregates": "sum(0) AS sum(`found`)",
-        "Inputs": [
-          {
-            "OperatorType": "Concatenate",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1",
-                "Query": "select 1 as `found` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
-                "SysTableTableSchema": "['music']"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select 1 as `found` from information_schema.views where 1 != 1",
-                "Query": "select 1 as `found` from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ limit 1",
-                "SysTableTableSchema": "['music']"
-              }
-            ]
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select sum(`found`) from (select 1 as `found` from information_schema.`tables` where 1 != 1 union all (select 1 as `found` from information_schema.views where 1 != 1)) as t where 1 != 1",
+        "Query": "select sum(`found`) from (select 1 as `found` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ union all (select 1 as `found` from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ limit 1)) as t",
+        "SysTableTableSchema": "['music']"
       }
     }
   },
@@ -817,35 +771,19 @@
     "comment": "union as a derived table",
     "query": "select found from (select 1 as found from information_schema.`tables` where table_schema = 'music' union all (select 1 as found from information_schema.views where table_schema = 'music' limit 1)) as t",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select found from (select 1 as found from information_schema.`tables` where table_schema = 'music' union all (select 1 as found from information_schema.views where table_schema = 'music' limit 1)) as t",
       "Instructions": {
-        "OperatorType": "Concatenate",
-        "Inputs": [
-          {
-            "OperatorType": "Route",
-            "Variant": "DBA",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1",
-            "Query": "select 1 as `found` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
-            "SysTableTableSchema": "['music']"
-          },
-          {
-            "OperatorType": "Route",
-            "Variant": "DBA",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select 1 as `found` from information_schema.views where 1 != 1",
-            "Query": "select 1 as `found` from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ limit 1",
-            "SysTableTableSchema": "['music']"
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `found` from (select 1 as `found` from information_schema.`tables` where 1 != 1 union all (select 1 as `found` from information_schema.views where 1 != 1)) as t where 1 != 1",
+        "Query": "select `found` from (select 1 as `found` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ union all (select 1 as `found` from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ limit 1)) as t",
+        "SysTableTableSchema": "['music']"
       }
     }
   },
@@ -925,63 +863,19 @@
     "comment": "merge union subquery with outer query referencing the same system schemas",
     "query": "select 1 as found from information_schema.`tables` where table_name = 'music' and table_name = 'Music' and exists (select 1 as found from information_schema.`tables` where table_name = 'music' and table_name = 'Music' union all (select 1 as found from information_schema.views where table_name = 'music' and table_name = 'user' limit 1))",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select 1 as found from information_schema.`tables` where table_name = 'music' and table_name = 'Music' and exists (select 1 as found from information_schema.`tables` where table_name = 'music' and table_name = 'Music' union all (select 1 as found from information_schema.views where table_name = 'music' and table_name = 'user' limit 1))",
       "Instructions": {
-        "OperatorType": "UncorrelatedSubquery",
-        "Variant": "PulloutExists",
-        "PulloutVars": [
-          "__sq_has_values"
-        ],
-        "Inputs": [
-          {
-            "InputName": "SubQuery",
-            "OperatorType": "Limit",
-            "Count": "1",
-            "Inputs": [
-              {
-                "OperatorType": "Concatenate",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "DBA",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": false
-                    },
-                    "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1",
-                    "Query": "select 1 as `found` from information_schema.`tables` where `table_name` = :table_name1 /* VARCHAR */ and `table_name` = :table_name1 /* VARCHAR */ limit :__upper_limit",
-                    "SysTableTableName": "[table_name1:'Music']"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "DBA",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": false
-                    },
-                    "FieldQuery": "select 1 as `found` from information_schema.views where 1 != 1",
-                    "Query": "select 1 as `found` from information_schema.views where `table_name` = :table_name2 /* VARCHAR */ and `table_name` = :table_name2 /* VARCHAR */ limit :__upper_limit",
-                    "SysTableTableName": "[table_name2:'user']"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "InputName": "Outer",
-            "OperatorType": "Route",
-            "Variant": "DBA",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1",
-            "Query": "select 1 as `found` from information_schema.`tables` where `table_name` = :table_name /* VARCHAR */ and `table_name` = :table_name /* VARCHAR */ and :__sq_has_values",
-            "SysTableTableName": "[table_name:'Music']"
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1",
+        "Query": "select 1 as `found` from information_schema.`tables` where `table_name` = :table_name /* VARCHAR */ and `table_name` = :table_name /* VARCHAR */ and exists (select 1 as `found` from information_schema.`tables` where `table_name` = :table_name1 /* VARCHAR */ and `table_name` = :table_name1 /* VARCHAR */ union all (select 1 as `found` from information_schema.views where `table_name` = :table_name2 /* VARCHAR */ and `table_name` = :table_name2 /* VARCHAR */ limit 1))",
+        "SysTableTableName": "[table_name1:'Music', table_name2:'user', table_name:'Music']"
       }
     }
   },
@@ -989,42 +883,19 @@
     "comment": "merge even one side have schema name in derived table",
     "query": "select * from (select TABLE_NAME from information_schema.tables t where t.TABLE_SCHEMA = 'a' union select TABLE_NAME from information_schema.columns) dt",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select * from (select TABLE_NAME from information_schema.tables t where t.TABLE_SCHEMA = 'a' union select TABLE_NAME from information_schema.columns) dt",
       "Instructions": {
-        "OperatorType": "Distinct",
-        "Collations": [
-          "0: utf8mb3_general_ci"
-        ],
-        "Inputs": [
-          {
-            "OperatorType": "Concatenate",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select `TABLE_NAME` from information_schema.`tables` as t where 1 != 1",
-                "Query": "select distinct `TABLE_NAME` from information_schema.`tables` as t where t.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */",
-                "SysTableTableSchema": "['a']"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select `TABLE_NAME` from information_schema.`columns` where 1 != 1",
-                "Query": "select distinct `TABLE_NAME` from information_schema.`columns`"
-              }
-            ]
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `TABLE_NAME` from (select `TABLE_NAME` from information_schema.`tables` as t where 1 != 1 union select `TABLE_NAME` from information_schema.`columns` where 1 != 1) as dt where 1 != 1",
+        "Query": "select `TABLE_NAME` from (select `TABLE_NAME` from information_schema.`tables` as t where t.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ union select `TABLE_NAME` from information_schema.`columns`) as dt",
+        "SysTableTableSchema": "['a']"
       }
     }
   },
@@ -1032,64 +903,19 @@
     "comment": "merge even one side have schema name in subquery",
     "query": "select `COLLATION_NAME` from information_schema.`COLUMNS` t where `COLUMN_NAME` in (select `TABLE_NAME` from information_schema.tables t where t.TABLE_SCHEMA = 'a' union select `COLUMN_NAME` from information_schema.columns)",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select `COLLATION_NAME` from information_schema.`COLUMNS` t where `COLUMN_NAME` in (select `TABLE_NAME` from information_schema.tables t where t.TABLE_SCHEMA = 'a' union select `COLUMN_NAME` from information_schema.columns)",
       "Instructions": {
-        "OperatorType": "UncorrelatedSubquery",
-        "Variant": "PulloutIn",
-        "PulloutVars": [
-          "__sq_has_values",
-          "__sq1"
-        ],
-        "Inputs": [
-          {
-            "InputName": "SubQuery",
-            "OperatorType": "Distinct",
-            "Collations": [
-              "0: utf8mb3_general_ci"
-            ],
-            "Inputs": [
-              {
-                "OperatorType": "Concatenate",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "DBA",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": false
-                    },
-                    "FieldQuery": "select `TABLE_NAME` from information_schema.`tables` as t where 1 != 1",
-                    "Query": "select distinct `TABLE_NAME` from information_schema.`tables` as t where t.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */",
-                    "SysTableTableSchema": "['a']"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "DBA",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": false
-                    },
-                    "FieldQuery": "select `COLUMN_NAME` from information_schema.`columns` where 1 != 1",
-                    "Query": "select distinct `COLUMN_NAME` from information_schema.`columns`"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "InputName": "Outer",
-            "OperatorType": "Route",
-            "Variant": "DBA",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select COLLATION_NAME from information_schema.`COLUMNS` as t where 1 != 1",
-            "Query": "select COLLATION_NAME from information_schema.`COLUMNS` as t where :__sq_has_values and `COLUMN_NAME` in ::__sq1"
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select COLLATION_NAME from information_schema.`COLUMNS` as t where 1 != 1",
+        "Query": "select COLLATION_NAME from information_schema.`COLUMNS` as t where `COLUMN_NAME` in (select `TABLE_NAME` from information_schema.`tables` as t where t.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ union select `COLUMN_NAME` from information_schema.`columns`)",
+        "SysTableTableSchema": "['a']"
       }
     }
   },

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -791,35 +791,19 @@
     "comment": "merge system schema queries as long as they have any same table_schema",
     "query": "select 1 as found from information_schema.`tables` where table_schema = 'music' and table_schema = 'Music' union all (select 1 as found from information_schema.views where table_schema = 'music' and table_schema = 'user' limit 1)",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select 1 as found from information_schema.`tables` where table_schema = 'music' and table_schema = 'Music' union all (select 1 as found from information_schema.views where table_schema = 'music' and table_schema = 'user' limit 1)",
       "Instructions": {
-        "OperatorType": "Concatenate",
-        "Inputs": [
-          {
-            "OperatorType": "Route",
-            "Variant": "DBA",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1",
-            "Query": "select 1 as `found` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */",
-            "SysTableTableSchema": "['music', 'Music']"
-          },
-          {
-            "OperatorType": "Route",
-            "Variant": "DBA",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select 1 as `found` from information_schema.views where 1 != 1",
-            "Query": "select 1 as `found` from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */ limit 1",
-            "SysTableTableSchema": "['music', 'user']"
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1 union all (select 1 as `found` from information_schema.views where 1 != 1)",
+        "Query": "select 1 as `found` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */ union all (select 1 as `found` from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */ limit 1)",
+        "SysTableTableSchema": "['music', 'Music']"
       }
     }
   },
@@ -827,35 +811,19 @@
     "comment": "merge system schema queries as long as they have any same table_name",
     "query": "select 1 as found from information_schema.`tables` where table_schema = 'music' and table_schema = 'Music' union all (select 1 as found from information_schema.views where table_schema = 'music' and table_schema = 'user' limit 1)",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select 1 as found from information_schema.`tables` where table_schema = 'music' and table_schema = 'Music' union all (select 1 as found from information_schema.views where table_schema = 'music' and table_schema = 'user' limit 1)",
       "Instructions": {
-        "OperatorType": "Concatenate",
-        "Inputs": [
-          {
-            "OperatorType": "Route",
-            "Variant": "DBA",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1",
-            "Query": "select 1 as `found` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */",
-            "SysTableTableSchema": "['music', 'Music']"
-          },
-          {
-            "OperatorType": "Route",
-            "Variant": "DBA",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select 1 as `found` from information_schema.views where 1 != 1",
-            "Query": "select 1 as `found` from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */ limit 1",
-            "SysTableTableSchema": "['music', 'user']"
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1 union all (select 1 as `found` from information_schema.views where 1 != 1)",
+        "Query": "select 1 as `found` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */ union all (select 1 as `found` from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */ limit 1)",
+        "SysTableTableSchema": "['music', 'Music']"
       }
     }
   },

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -98,41 +98,18 @@
     "comment": "union of information_schema",
     "query": "select TABLE_NAME from information_schema.columns union select table_schema from information_schema.tables",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select TABLE_NAME from information_schema.columns union select table_schema from information_schema.tables",
       "Instructions": {
-        "OperatorType": "Distinct",
-        "Collations": [
-          "0: utf8mb3_general_ci"
-        ],
-        "Inputs": [
-          {
-            "OperatorType": "Concatenate",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select `TABLE_NAME` from information_schema.`columns` where 1 != 1",
-                "Query": "select distinct `TABLE_NAME` from information_schema.`columns`"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select table_schema from information_schema.`tables` where 1 != 1",
-                "Query": "select distinct table_schema from information_schema.`tables`"
-              }
-            ]
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `TABLE_NAME` from information_schema.`columns` where 1 != 1 union select table_schema from information_schema.`tables` where 1 != 1",
+        "Query": "select `TABLE_NAME` from information_schema.`columns` union select table_schema from information_schema.`tables`"
       }
     }
   },
@@ -837,42 +814,19 @@
     "comment": "select sum(found) from (select 1 as found from information_schema.`tables` where table_schema = 'music' union all (select 1 as found from information_schema.views where table_schema = 'music' limit 1)) as t",
     "query": "select sum(found) from (select 1 as found from information_schema.`tables` where table_schema = 'music' union all (select 1 as found from information_schema.views where table_schema = 'music' limit 1)) as t",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select sum(found) from (select 1 as found from information_schema.`tables` where table_schema = 'music' union all (select 1 as found from information_schema.views where table_schema = 'music' limit 1)) as t",
       "Instructions": {
-        "OperatorType": "Aggregate",
-        "Variant": "Scalar",
-        "Aggregates": "sum(0) AS sum(`found`)",
-        "Inputs": [
-          {
-            "OperatorType": "Concatenate",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1",
-                "Query": "select 1 as `found` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
-                "SysTableTableSchema": "['music']"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select 1 as `found` from information_schema.views where 1 != 1",
-                "Query": "select 1 as `found` from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ limit 1",
-                "SysTableTableSchema": "['music']"
-              }
-            ]
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select sum(`found`) from (select 1 as `found` from information_schema.`tables` where 1 != 1 union all (select 1 as `found` from information_schema.views where 1 != 1)) as t where 1 != 1",
+        "Query": "select sum(`found`) from (select 1 as `found` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ union all (select 1 as `found` from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ limit 1)) as t",
+        "SysTableTableSchema": "['music']"
       }
     }
   },
@@ -880,35 +834,19 @@
     "comment": "union as a derived table",
     "query": "select found from (select 1 as found from information_schema.`tables` where table_schema = 'music' union all (select 1 as found from information_schema.views where table_schema = 'music' limit 1)) as t",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select found from (select 1 as found from information_schema.`tables` where table_schema = 'music' union all (select 1 as found from information_schema.views where table_schema = 'music' limit 1)) as t",
       "Instructions": {
-        "OperatorType": "Concatenate",
-        "Inputs": [
-          {
-            "OperatorType": "Route",
-            "Variant": "DBA",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1",
-            "Query": "select 1 as `found` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
-            "SysTableTableSchema": "['music']"
-          },
-          {
-            "OperatorType": "Route",
-            "Variant": "DBA",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select 1 as `found` from information_schema.views where 1 != 1",
-            "Query": "select 1 as `found` from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ limit 1",
-            "SysTableTableSchema": "['music']"
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `found` from (select 1 as `found` from information_schema.`tables` where 1 != 1 union all (select 1 as `found` from information_schema.views where 1 != 1)) as t where 1 != 1",
+        "Query": "select `found` from (select 1 as `found` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ union all (select 1 as `found` from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ limit 1)) as t",
+        "SysTableTableSchema": "['music']"
       }
     }
   },
@@ -988,63 +926,19 @@
     "comment": "merge union subquery with outer query referencing the same system schemas",
     "query": "select 1 as found from information_schema.`tables` where table_name = 'music' and table_name = 'Music' and exists (select 1 as found from information_schema.`tables` where table_name = 'music' and table_name = 'Music' union all (select 1 as found from information_schema.views where table_name = 'music' and table_name = 'user' limit 1))",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select 1 as found from information_schema.`tables` where table_name = 'music' and table_name = 'Music' and exists (select 1 as found from information_schema.`tables` where table_name = 'music' and table_name = 'Music' union all (select 1 as found from information_schema.views where table_name = 'music' and table_name = 'user' limit 1))",
       "Instructions": {
-        "OperatorType": "UncorrelatedSubquery",
-        "Variant": "PulloutExists",
-        "PulloutVars": [
-          "__sq_has_values"
-        ],
-        "Inputs": [
-          {
-            "InputName": "SubQuery",
-            "OperatorType": "Limit",
-            "Count": "1",
-            "Inputs": [
-              {
-                "OperatorType": "Concatenate",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "DBA",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": false
-                    },
-                    "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1",
-                    "Query": "select 1 as `found` from information_schema.`tables` where `table_name` = :table_name1 /* VARCHAR */ and `table_name` = :table_name1 /* VARCHAR */ limit :__upper_limit",
-                    "SysTableTableName": "[table_name1:'Music']"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "DBA",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": false
-                    },
-                    "FieldQuery": "select 1 as `found` from information_schema.views where 1 != 1",
-                    "Query": "select 1 as `found` from information_schema.views where `table_name` = :table_name2 /* VARCHAR */ and `table_name` = :table_name2 /* VARCHAR */ limit :__upper_limit",
-                    "SysTableTableName": "[table_name2:'user']"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "InputName": "Outer",
-            "OperatorType": "Route",
-            "Variant": "DBA",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1",
-            "Query": "select 1 as `found` from information_schema.`tables` where `table_name` = :table_name /* VARCHAR */ and `table_name` = :table_name /* VARCHAR */ and :__sq_has_values",
-            "SysTableTableName": "[table_name:'Music']"
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1",
+        "Query": "select 1 as `found` from information_schema.`tables` where `table_name` = :table_name /* VARCHAR */ and `table_name` = :table_name /* VARCHAR */ and exists (select 1 as `found` from information_schema.`tables` where `table_name` = :table_name1 /* VARCHAR */ and `table_name` = :table_name1 /* VARCHAR */ union all (select 1 as `found` from information_schema.views where `table_name` = :table_name2 /* VARCHAR */ and `table_name` = :table_name2 /* VARCHAR */ limit 1))",
+        "SysTableTableName": "[table_name1:'Music', table_name2:'user', table_name:'Music']"
       }
     }
   },
@@ -1052,42 +946,19 @@
     "comment": "merge even one side have schema name in derived table",
     "query": "select * from (select TABLE_NAME from information_schema.tables t where t.TABLE_SCHEMA = 'a' union select TABLE_NAME from information_schema.columns) dt",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select * from (select TABLE_NAME from information_schema.tables t where t.TABLE_SCHEMA = 'a' union select TABLE_NAME from information_schema.columns) dt",
       "Instructions": {
-        "OperatorType": "Distinct",
-        "Collations": [
-          "0: utf8mb3_general_ci"
-        ],
-        "Inputs": [
-          {
-            "OperatorType": "Concatenate",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select `TABLE_NAME` from information_schema.`tables` as t where 1 != 1",
-                "Query": "select distinct `TABLE_NAME` from information_schema.`tables` as t where t.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */",
-                "SysTableTableSchema": "['a']"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select `TABLE_NAME` from information_schema.`columns` where 1 != 1",
-                "Query": "select distinct `TABLE_NAME` from information_schema.`columns`"
-              }
-            ]
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `TABLE_NAME` from (select `TABLE_NAME` from information_schema.`tables` as t where 1 != 1 union select `TABLE_NAME` from information_schema.`columns` where 1 != 1) as dt where 1 != 1",
+        "Query": "select `TABLE_NAME` from (select `TABLE_NAME` from information_schema.`tables` as t where t.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ union select `TABLE_NAME` from information_schema.`columns`) as dt",
+        "SysTableTableSchema": "['a']"
       }
     }
   },
@@ -1095,64 +966,19 @@
     "comment": "merge even one side have schema name in subquery",
     "query": "select `COLLATION_NAME` from information_schema.`COLUMNS` t where `COLUMN_NAME` in (select `TABLE_NAME` from information_schema.tables t where t.TABLE_SCHEMA = 'a' union select `COLUMN_NAME` from information_schema.columns)",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select `COLLATION_NAME` from information_schema.`COLUMNS` t where `COLUMN_NAME` in (select `TABLE_NAME` from information_schema.tables t where t.TABLE_SCHEMA = 'a' union select `COLUMN_NAME` from information_schema.columns)",
       "Instructions": {
-        "OperatorType": "UncorrelatedSubquery",
-        "Variant": "PulloutIn",
-        "PulloutVars": [
-          "__sq_has_values",
-          "__sq1"
-        ],
-        "Inputs": [
-          {
-            "InputName": "SubQuery",
-            "OperatorType": "Distinct",
-            "Collations": [
-              "0: utf8mb3_general_ci"
-            ],
-            "Inputs": [
-              {
-                "OperatorType": "Concatenate",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "DBA",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": false
-                    },
-                    "FieldQuery": "select `TABLE_NAME` from information_schema.`tables` as t where 1 != 1",
-                    "Query": "select distinct `TABLE_NAME` from information_schema.`tables` as t where t.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */",
-                    "SysTableTableSchema": "['a']"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "DBA",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": false
-                    },
-                    "FieldQuery": "select `COLUMN_NAME` from information_schema.`columns` where 1 != 1",
-                    "Query": "select distinct `COLUMN_NAME` from information_schema.`columns`"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "InputName": "Outer",
-            "OperatorType": "Route",
-            "Variant": "DBA",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select COLLATION_NAME from information_schema.`COLUMNS` as t where 1 != 1",
-            "Query": "select COLLATION_NAME from information_schema.`COLUMNS` as t where :__sq_has_values and `COLUMN_NAME` in ::__sq1"
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select COLLATION_NAME from information_schema.`COLUMNS` as t where 1 != 1",
+        "Query": "select COLLATION_NAME from information_schema.`COLUMNS` as t where `COLUMN_NAME` in (select `TABLE_NAME` from information_schema.`tables` as t where t.TABLE_SCHEMA = :__vtschemaname /* VARCHAR */ union select `COLUMN_NAME` from information_schema.`columns`)",
+        "SysTableTableSchema": "['a']"
       }
     }
   },

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -854,35 +854,19 @@
     "comment": "merge system schema queries as long as they have any same table_schema",
     "query": "select 1 as found from information_schema.`tables` where table_schema = 'music' and table_schema = 'Music' union all (select 1 as found from information_schema.views where table_schema = 'music' and table_schema = 'user' limit 1)",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select 1 as found from information_schema.`tables` where table_schema = 'music' and table_schema = 'Music' union all (select 1 as found from information_schema.views where table_schema = 'music' and table_schema = 'user' limit 1)",
       "Instructions": {
-        "OperatorType": "Concatenate",
-        "Inputs": [
-          {
-            "OperatorType": "Route",
-            "Variant": "DBA",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1",
-            "Query": "select 1 as `found` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */",
-            "SysTableTableSchema": "['music', 'Music']"
-          },
-          {
-            "OperatorType": "Route",
-            "Variant": "DBA",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select 1 as `found` from information_schema.views where 1 != 1",
-            "Query": "select 1 as `found` from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */ limit 1",
-            "SysTableTableSchema": "['music', 'user']"
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1 union all (select 1 as `found` from information_schema.views where 1 != 1)",
+        "Query": "select 1 as `found` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */ union all (select 1 as `found` from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */ limit 1)",
+        "SysTableTableSchema": "['music', 'Music']"
       }
     }
   },
@@ -890,35 +874,19 @@
     "comment": "merge system schema queries as long as they have any same table_name",
     "query": "select 1 as found from information_schema.`tables` where table_schema = 'music' and table_schema = 'Music' union all (select 1 as found from information_schema.views where table_schema = 'music' and table_schema = 'user' limit 1)",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select 1 as found from information_schema.`tables` where table_schema = 'music' and table_schema = 'Music' union all (select 1 as found from information_schema.views where table_schema = 'music' and table_schema = 'user' limit 1)",
       "Instructions": {
-        "OperatorType": "Concatenate",
-        "Inputs": [
-          {
-            "OperatorType": "Route",
-            "Variant": "DBA",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1",
-            "Query": "select 1 as `found` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */",
-            "SysTableTableSchema": "['music', 'Music']"
-          },
-          {
-            "OperatorType": "Route",
-            "Variant": "DBA",
-            "Keyspace": {
-              "Name": "main",
-              "Sharded": false
-            },
-            "FieldQuery": "select 1 as `found` from information_schema.views where 1 != 1",
-            "Query": "select 1 as `found` from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */ limit 1",
-            "SysTableTableSchema": "['music', 'user']"
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1 union all (select 1 as `found` from information_schema.views where 1 != 1)",
+        "Query": "select 1 as `found` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */ union all (select 1 as `found` from information_schema.views where table_schema = :__vtschemaname /* VARCHAR */ and table_schema = :__vtschemaname /* VARCHAR */ limit 1)",
+        "SysTableTableSchema": "['music', 'Music']"
       }
     }
   },

--- a/go/vt/vtgate/planbuilder/testdata/onecase.json
+++ b/go/vt/vtgate/planbuilder/testdata/onecase.json
@@ -1,8 +1,9 @@
 [
   {
-    "comment": "Add your test case here for debugging and run go test -run=One.",
-    "query": "",
+    "comment": "systable union query in derived tables with join",
+    "query": "SELECT 1 FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu  INNER JOIN (SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS cols WHERE cols.TABLE_SCHEMA = 'ks' AND cols.TABLE_NAME = 't1' UNION SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS cols WHERE cols.TABLE_SCHEMA = 'ks' AND cols.TABLE_NAME = 't7_xxhash') cols ON kcu.TABLE_SCHEMA = cols.TABLE_SCHEMA AND kcu.TABLE_NAME = cols.TABLE_NAME AND kcu.COLUMN_NAME = cols.COLUMN_NAME WHERE kcu.TABLE_SCHEMA = 'ks' AND kcu.TABLE_NAME = 't1'",
     "plan": {
+
     }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -982,41 +982,18 @@
     "comment": "test handling of TEXT column type handling",
     "query": "select table_comment from information_schema.tables union select table_comment from information_schema.tables",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select table_comment from information_schema.tables union select table_comment from information_schema.tables",
       "Instructions": {
-        "OperatorType": "Distinct",
-        "Collations": [
-          "0"
-        ],
-        "Inputs": [
-          {
-            "OperatorType": "Concatenate",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select table_comment from information_schema.`tables` where 1 != 1",
-                "Query": "select distinct table_comment from information_schema.`tables`"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select table_comment from information_schema.`tables` where 1 != 1",
-                "Query": "select distinct table_comment from information_schema.`tables`"
-              }
-            ]
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select table_comment from information_schema.`tables` where 1 != 1 union select table_comment from information_schema.`tables` where 1 != 1",
+        "Query": "select table_comment from information_schema.`tables` union select table_comment from information_schema.`tables`"
       }
     }
   },
@@ -1302,45 +1279,20 @@
     "comment": "systable union query in derived table with constraint on outside (without star projection)",
     "query": "select * from (select kcu.`COLUMN_NAME` from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select kcu.`COLUMN_NAME` from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `COLUMN_NAME` = 'primary'",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select * from (select kcu.`COLUMN_NAME` from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select kcu.`COLUMN_NAME` from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `COLUMN_NAME` = 'primary'",
       "Instructions": {
-        "OperatorType": "Distinct",
-        "Collations": [
-          "0: utf8mb3_general_ci"
-        ],
-        "Inputs": [
-          {
-            "OperatorType": "Concatenate",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where 1 != 1",
-                "Query": "select distinct kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name /* VARCHAR */ and `COLUMN_NAME` = 'primary'",
-                "SysTableTableName": "[kcu_table_name:'user_extra']",
-                "SysTableTableSchema": "['user']"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where 1 != 1",
-                "Query": "select distinct kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name1 /* VARCHAR */ and `COLUMN_NAME` = 'primary'",
-                "SysTableTableName": "[kcu_table_name1:'music']",
-                "SysTableTableSchema": "['user']"
-              }
-            ]
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `COLUMN_NAME` from (select kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where 1 != 1 union select kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where 1 != 1) as kcu where 1 != 1",
+        "Query": "select `COLUMN_NAME` from (select kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name /* VARCHAR */ and `COLUMN_NAME` = 'primary' union select kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name1 /* VARCHAR */ and `COLUMN_NAME` = 'primary') as kcu",
+        "SysTableTableName": "[kcu_table_name1:'music', kcu_table_name:'user_extra']",
+        "SysTableTableSchema": "['user']"
       }
     }
   },
@@ -1375,56 +1327,20 @@
     "comment": "systable union query in derived table with constraint on outside (star projection)",
     "query": "select * from (select * from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select * from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `constraint_name` = 'primary'",
     "plan": {
-      "Type": "Complex",
+      "Type": "Passthrough",
       "QueryType": "SELECT",
       "Original": "select * from (select * from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select * from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `constraint_name` = 'primary'",
       "Instructions": {
-        "OperatorType": "Distinct",
-        "Collations": [
-          "0: utf8mb3_general_ci",
-          "1: utf8mb3_general_ci",
-          "2: utf8mb3_general_ci",
-          "3: utf8mb3_general_ci",
-          "4: utf8mb3_general_ci",
-          "5: utf8mb3_general_ci",
-          "6: utf8mb3_general_ci",
-          "7",
-          "8",
-          "9: utf8mb3_general_ci",
-          "10: utf8mb3_general_ci",
-          "11: utf8mb3_general_ci"
-        ],
-        "Inputs": [
-          {
-            "OperatorType": "Concatenate",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where 1 != 1",
-                "Query": "select distinct `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name /* VARCHAR */ and `CONSTRAINT_NAME` = 'primary'",
-                "SysTableTableName": "[kcu_table_name:'user_extra']",
-                "SysTableTableSchema": "['user']"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "DBA",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where 1 != 1",
-                "Query": "select distinct `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name1 /* VARCHAR */ and `CONSTRAINT_NAME` = 'primary'",
-                "SysTableTableName": "[kcu_table_name1:'music']",
-                "SysTableTableSchema": "['user']"
-              }
-            ]
-          }
-        ]
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from (select `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where 1 != 1 union select `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where 1 != 1) as kcu where 1 != 1",
+        "Query": "select `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from (select `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name /* VARCHAR */ and `CONSTRAINT_NAME` = 'primary' union select `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name1 /* VARCHAR */ and `CONSTRAINT_NAME` = 'primary') as kcu",
+        "SysTableTableName": "[kcu_table_name1:'music', kcu_table_name:'user_extra']",
+        "SysTableTableSchema": "['user']"
       }
     }
   },

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -1306,43 +1306,37 @@
       "QueryType": "SELECT",
       "Original": "select * from (select kcu.`COLUMN_NAME` from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select kcu.`COLUMN_NAME` from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `COLUMN_NAME` = 'primary'",
       "Instructions": {
-        "OperatorType": "Filter",
-        "Predicate": "`COLUMN_NAME` = 'primary'",
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0: utf8mb3_general_ci"
+        ],
         "Inputs": [
           {
-            "OperatorType": "Distinct",
-            "Collations": [
-              "0: utf8mb3_general_ci"
-            ],
+            "OperatorType": "Concatenate",
             "Inputs": [
               {
-                "OperatorType": "Concatenate",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "DBA",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": false
-                    },
-                    "FieldQuery": "select kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where 1 != 1",
-                    "Query": "select distinct kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name /* VARCHAR */",
-                    "SysTableTableName": "[kcu_table_name:'user_extra']",
-                    "SysTableTableSchema": "['user']"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "DBA",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": false
-                    },
-                    "FieldQuery": "select kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where 1 != 1",
-                    "Query": "select distinct kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name1 /* VARCHAR */",
-                    "SysTableTableName": "[kcu_table_name1:'music']",
-                    "SysTableTableSchema": "['user']"
-                  }
-                ]
+                "OperatorType": "Route",
+                "Variant": "DBA",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where 1 != 1",
+                "Query": "select distinct kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name /* VARCHAR */ and `COLUMN_NAME` = 'primary'",
+                "SysTableTableName": "[kcu_table_name:'user_extra']",
+                "SysTableTableSchema": "['user']"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "DBA",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where 1 != 1",
+                "Query": "select distinct kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name1 /* VARCHAR */ and `COLUMN_NAME` = 'primary'",
+                "SysTableTableName": "[kcu_table_name1:'music']",
+                "SysTableTableSchema": "['user']"
               }
             ]
           }
@@ -1385,54 +1379,48 @@
       "QueryType": "SELECT",
       "Original": "select * from (select * from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select * from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `constraint_name` = 'primary'",
       "Instructions": {
-        "OperatorType": "Filter",
-        "Predicate": "`constraint_name` = 'primary'",
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0: utf8mb3_general_ci",
+          "1: utf8mb3_general_ci",
+          "2: utf8mb3_general_ci",
+          "3: utf8mb3_general_ci",
+          "4: utf8mb3_general_ci",
+          "5: utf8mb3_general_ci",
+          "6: utf8mb3_general_ci",
+          "7",
+          "8",
+          "9: utf8mb3_general_ci",
+          "10: utf8mb3_general_ci",
+          "11: utf8mb3_general_ci"
+        ],
         "Inputs": [
           {
-            "OperatorType": "Distinct",
-            "Collations": [
-              "0: utf8mb3_general_ci",
-              "1: utf8mb3_general_ci",
-              "2: utf8mb3_general_ci",
-              "3: utf8mb3_general_ci",
-              "4: utf8mb3_general_ci",
-              "5: utf8mb3_general_ci",
-              "6: utf8mb3_general_ci",
-              "7",
-              "8",
-              "9: utf8mb3_general_ci",
-              "10: utf8mb3_general_ci",
-              "11: utf8mb3_general_ci"
-            ],
+            "OperatorType": "Concatenate",
             "Inputs": [
               {
-                "OperatorType": "Concatenate",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "DBA",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": false
-                    },
-                    "FieldQuery": "select `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where 1 != 1",
-                    "Query": "select distinct `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name /* VARCHAR */",
-                    "SysTableTableName": "[kcu_table_name:'user_extra']",
-                    "SysTableTableSchema": "['user']"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "DBA",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": false
-                    },
-                    "FieldQuery": "select `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where 1 != 1",
-                    "Query": "select distinct `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name1 /* VARCHAR */",
-                    "SysTableTableName": "[kcu_table_name1:'music']",
-                    "SysTableTableSchema": "['user']"
-                  }
-                ]
+                "OperatorType": "Route",
+                "Variant": "DBA",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where 1 != 1",
+                "Query": "select distinct `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name /* VARCHAR */ and `CONSTRAINT_NAME` = 'primary'",
+                "SysTableTableName": "[kcu_table_name:'user_extra']",
+                "SysTableTableSchema": "['user']"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "DBA",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where 1 != 1",
+                "Query": "select distinct `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name1 /* VARCHAR */ and `CONSTRAINT_NAME` = 'primary'",
+                "SysTableTableName": "[kcu_table_name1:'music']",
+                "SysTableTableSchema": "['user']"
               }
             ]
           }
@@ -2138,5 +2126,4 @@
       ]
     }
   }
-
 ]


### PR DESCRIPTION
## Description

Various queries against `information_schema` tables were not being merged correctly.

This pull request contains multiple interlinked fixes:

### Column offset map for `UNION` queries

The column offset map used for `UNION` queries was doing column name comparisons incorrectly. The offset map was built using the user provided column names, but lowercased column names were used during lookups into the map. Column names in MySQL are case insensitive, so we now lowercase both the values used for creating the map as well as looking up the offsets.

This affects not just `information_schema` `UNION` queries, but was noticed there because the schema for `information_schema` tables that ships with Vitess uses upper cased column names.

### Add support for merging `UNION` queries targeting `information_schema` tables

`JOIN` operations against `information_schema` tables supported being merged if the LHS and RHS targeted the same data sources (e.g. if the same schemas or tables were queried). This logic was missing from the `UNION` merging implementation.

### Fix `information_schema` merge ability rules (affects both `JOIN` and `UNION` merging)

Merging of `information_schema` routes was only possible if the table schema list of the LHS and the RHS of the merge matched fully (exact match of all values). This was artificially limiting the routes that could be merged, as the actual requirement is that the table schema lists only need to intersect (share one common value).

---

This also updated the planner debug output for DBA routes (used for `information_schema` queries) to include the `SysTableTableSchema` and `SysTableTableName` information to make it a bit easier to understand what's going on.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
