### PR TITLE
Fix column offset tracking for `UNION`s to be case insensitive.

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -1306,43 +1306,37 @@
       "QueryType": "SELECT",
       "Original": "select * from (select kcu.`COLUMN_NAME` from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select kcu.`COLUMN_NAME` from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `COLUMN_NAME` = 'primary'",
       "Instructions": {
-        "OperatorType": "Filter",
-        "Predicate": "`COLUMN_NAME` = 'primary'",
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0: utf8mb3_general_ci"
+        ],
         "Inputs": [
           {
-            "OperatorType": "Distinct",
-            "Collations": [
-              "0: utf8mb3_general_ci"
-            ],
+            "OperatorType": "Concatenate",
             "Inputs": [
               {
-                "OperatorType": "Concatenate",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "DBA",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": false
-                    },
-                    "FieldQuery": "select kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where 1 != 1",
-                    "Query": "select distinct kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name /* VARCHAR */",
-                    "SysTableTableName": "[kcu_table_name:'user_extra']",
-                    "SysTableTableSchema": "['user']"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "DBA",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": false
-                    },
-                    "FieldQuery": "select kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where 1 != 1",
-                    "Query": "select distinct kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name1 /* VARCHAR */",
-                    "SysTableTableName": "[kcu_table_name1:'music']",
-                    "SysTableTableSchema": "['user']"
-                  }
-                ]
+                "OperatorType": "Route",
+                "Variant": "DBA",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where 1 != 1",
+                "Query": "select distinct kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name /* VARCHAR */ and `COLUMN_NAME` = 'primary'",
+                "SysTableTableName": "[kcu_table_name:'user_extra']",
+                "SysTableTableSchema": "['user']"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "DBA",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where 1 != 1",
+                "Query": "select distinct kcu.`COLUMN_NAME` from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name1 /* VARCHAR */ and `COLUMN_NAME` = 'primary'",
+                "SysTableTableName": "[kcu_table_name1:'music']",
+                "SysTableTableSchema": "['user']"
               }
             ]
           }
@@ -1385,54 +1379,48 @@
       "QueryType": "SELECT",
       "Original": "select * from (select * from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'user_extra' union select * from `information_schema`.`key_column_usage` `kcu` where `kcu`.`table_schema` = 'user' and `kcu`.`table_name` = 'music') `kcu` where `constraint_name` = 'primary'",
       "Instructions": {
-        "OperatorType": "Filter",
-        "Predicate": "`constraint_name` = 'primary'",
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0: utf8mb3_general_ci",
+          "1: utf8mb3_general_ci",
+          "2: utf8mb3_general_ci",
+          "3: utf8mb3_general_ci",
+          "4: utf8mb3_general_ci",
+          "5: utf8mb3_general_ci",
+          "6: utf8mb3_general_ci",
+          "7",
+          "8",
+          "9: utf8mb3_general_ci",
+          "10: utf8mb3_general_ci",
+          "11: utf8mb3_general_ci"
+        ],
         "Inputs": [
           {
-            "OperatorType": "Distinct",
-            "Collations": [
-              "0: utf8mb3_general_ci",
-              "1: utf8mb3_general_ci",
-              "2: utf8mb3_general_ci",
-              "3: utf8mb3_general_ci",
-              "4: utf8mb3_general_ci",
-              "5: utf8mb3_general_ci",
-              "6: utf8mb3_general_ci",
-              "7",
-              "8",
-              "9: utf8mb3_general_ci",
-              "10: utf8mb3_general_ci",
-              "11: utf8mb3_general_ci"
-            ],
+            "OperatorType": "Concatenate",
             "Inputs": [
               {
-                "OperatorType": "Concatenate",
-                "Inputs": [
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "DBA",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": false
-                    },
-                    "FieldQuery": "select `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where 1 != 1",
-                    "Query": "select distinct `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name /* VARCHAR */",
-                    "SysTableTableName": "[kcu_table_name:'user_extra']",
-                    "SysTableTableSchema": "['user']"
-                  },
-                  {
-                    "OperatorType": "Route",
-                    "Variant": "DBA",
-                    "Keyspace": {
-                      "Name": "main",
-                      "Sharded": false
-                    },
-                    "FieldQuery": "select `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where 1 != 1",
-                    "Query": "select distinct `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name1 /* VARCHAR */",
-                    "SysTableTableName": "[kcu_table_name1:'music']",
-                    "SysTableTableSchema": "['user']"
-                  }
-                ]
+                "OperatorType": "Route",
+                "Variant": "DBA",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where 1 != 1",
+                "Query": "select distinct `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name /* VARCHAR */ and `CONSTRAINT_NAME` = 'primary'",
+                "SysTableTableName": "[kcu_table_name:'user_extra']",
+                "SysTableTableSchema": "['user']"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "DBA",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where 1 != 1",
+                "Query": "select distinct `CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, `COLUMN_NAME`, ORDINAL_POSITION, POSITION_IN_UNIQUE_CONSTRAINT, REFERENCED_TABLE_SCHEMA, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME from information_schema.key_column_usage as kcu where kcu.table_schema = :__vtschemaname /* VARCHAR */ and kcu.`table_name` = :kcu_table_name1 /* VARCHAR */ and `CONSTRAINT_NAME` = 'primary'",
+                "SysTableTableName": "[kcu_table_name1:'music']",
+                "SysTableTableSchema": "['user']"
               }
             ]
           }
@@ -2138,5 +2126,4 @@
       ]
     }
   }
-
 ]


### PR DESCRIPTION
## Description

This is a followup to https://github.com/vitessio/vitess/pull/19046.

It fixes an issue where `UNION` queries couldn't push down predicates correctly when a column name in the first `SELECT` of the union was using upper case characters while the predicate used lower case names. This caused an additional `FILTER` operation to be added to queries, which in turn could prevent route merging.

This pull request fixes this issue by ensuring that both building the offset map and lookups into the offset map use lowercase column names.

This also fixes an issue introduced via https://github.com/vitessio/vitess/pull/19046, where we added the join predicate unwrapping. This seemingly fixed the issue that pull request attempted to fix, but the fix broke down with the changes added in this PR - it caused all sorts of issues with `information_schema` queries.

Instead of unwrapping the `JoinPredicate`, we create new `JoinPredicate` objects for every source of the `UNION`. This allows the existing code to modify/restore the `JoinPredicate`s pushed down into the `UNION`s correctly in cases where those modifications need to be reverted (which can happen if LHS and RHS of an `ApplyJoin` get merged).

## Related Issue(s)

Related to https://github.com/vitessio/vitess/issues/19113

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
