### PR TITLE
Split error codes workflow

### DIFF
--- a/.github/workflows/error_code_docs_generate.yml
+++ b/.github/workflows/error_code_docs_generate.yml
@@ -1,0 +1,72 @@
+# Generates error code documentation when go/vt/vterrors/code.go is modified.
+name: Generate error code docs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "go/vt/vterrors/code.go"
+
+permissions:
+  contents: read
+
+jobs:
+  generate_error_codes:
+    name: Generate error codes
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout vitess
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+
+      - name: Generate error codes
+        run: |
+          go run ./go/vt/vterrors/vterrorsgen > /tmp/error_codes.txt
+          echo "Error codes generated successfully"
+
+      - name: Determine docs version
+        id: docs_version
+        run: |
+          BASE_REF="${{ github.base_ref }}"
+
+          if [[ "$BASE_REF" == "main" ]]; then
+            echo "target_branch=main" >> "$GITHUB_OUTPUT"
+            echo "Targeting main branch, version will be determined by update workflow"
+          elif [[ "$BASE_REF" =~ ^release-([0-9]+\.[0-9]+)$ ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "target_branch=$BASE_REF" >> "$GITHUB_OUTPUT"
+            echo "Docs version (from release branch): $VERSION"
+          else
+            echo "Unknown base ref: $BASE_REF, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Prepare artifact metadata
+        if: steps.docs_version.outputs.skip != 'true'
+        run: |
+          mkdir -p /tmp/artifact
+          cp /tmp/error_codes.txt /tmp/artifact/
+
+          cat > /tmp/artifact/metadata.json << EOF
+          {
+            "pr_number": ${{ github.event.pull_request.number }},
+            "base_ref": "${{ github.base_ref }}",
+            "version": "${{ steps.docs_version.outputs.version }}",
+            "target_branch": "${{ steps.docs_version.outputs.target_branch }}",
+            "head_sha": "${{ github.event.pull_request.head.sha }}"
+          }
+          EOF
+
+      - name: Upload artifact
+        if: steps.docs_version.outputs.skip != 'true'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: error-codes-${{ github.event.pull_request.number }}
+          path: /tmp/artifact/
+          retention-days: 1

--- a/.github/workflows/error_code_docs_update.yml
+++ b/.github/workflows/error_code_docs_update.yml
@@ -1,20 +1,46 @@
-# Updates error code documentation on the website repository when go/vt/vterrors/code.go is modified.
-# Creates a PR on vitessio/website with the updated query-serving error documentation.
+# Updates the website repository with generated error code documentation.
 name: Update error code docs
+
 on:
-  pull_request_target:
-    types: [opened, synchronize]
-    paths:
-      - 'go/vt/vterrors/code.go'
+  workflow_run:
+    workflows: ["Generate error code docs"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
 
 jobs:
   update_error_code_docs:
     name: Update error code docs
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
 
     steps:
+      - name: Download artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: error-codes-*
+          path: /tmp/artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          merge-multiple: true
+
+      - name: Read metadata
+        id: metadata
+        run: |
+          if [[ ! -f /tmp/artifact/metadata.json ]]; then
+            echo "No metadata found, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "pr_number=$(jq -r '.pr_number' /tmp/artifact/metadata.json)" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$(jq -r '.base_ref' /tmp/artifact/metadata.json)" >> "$GITHUB_OUTPUT"
+
       - name: Generate GitHub App token
-        uses: actions/create-github-app-token@v2
+        if: steps.metadata.outputs.skip != 'true'
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -25,37 +51,17 @@ jobs:
           permission-pull-requests: write
 
       - name: Set token in environment
+        if: steps.metadata.outputs.skip != 'true'
         run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
 
-      - name: Checkout vitess
-        uses: actions/checkout@v4
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
-          fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Generate error codes
-        id: generate
-        run: |
-          # Run vterrorsgen to generate the error code documentation
-          ERROR_CODES=$(go run ./go/vt/vterrors/vterrorsgen)
-          
-          # Save to file for later use
-          echo "$ERROR_CODES" > /tmp/error_codes.txt
-          
-          echo "Error codes generated successfully"
-
       - name: Determine docs version
+        if: steps.metadata.outputs.skip != 'true'
         id: docs_version
         run: |
-          BASE_REF="${{ github.event.pull_request.base.ref }}"
-          
+          BASE_REF="${{ steps.metadata.outputs.base_ref }}"
+
           if [[ "$BASE_REF" == "main" ]]; then
-            # Get the "next" version from website config.toml
+            # Get the "next" version from website config.toml.
             VERSION=$(gh api repos/${{ github.repository_owner }}/website/contents/config.toml \
               --jq '.content' | base64 -d | grep 'next = ' | sed 's/.*"\([0-9.]*\)".*/\1/')
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -70,36 +76,36 @@ jobs:
           fi
 
       - name: Clone website repository
-        if: steps.docs_version.outputs.skip != 'true'
+        if: steps.metadata.outputs.skip != 'true' && steps.docs_version.outputs.skip != 'true'
         run: |
           git clone --depth 1 https://github.com/${{ github.repository_owner }}/website.git /tmp/website
 
       - name: Update error documentation
-        if: steps.docs_version.outputs.skip != 'true'
+        if: steps.metadata.outputs.skip != 'true' && steps.docs_version.outputs.skip != 'true'
         id: update_docs
         run: |
           VERSION="${{ steps.docs_version.outputs.version }}"
           DOC_PATH="/tmp/website/content/en/docs/${VERSION}/reference/errors/query-serving.md"
-          
+
           if [[ ! -f "$DOC_PATH" ]]; then
             echo "Documentation file not found: $DOC_PATH"
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          
-          # Read the generated error codes
-          ERROR_CODES=$(cat /tmp/error_codes.txt)
-          
-          # Update the documentation between <!-- start --> and <!-- end --> markers
+
+          # Read the generated error codes.
+          ERROR_CODES=$(cat /tmp/artifact/error_codes.txt)
+
+          # Update the documentation between <!-- start --> and <!-- end --> markers.
           awk -v codes="$ERROR_CODES" '
             /<!-- start -->/ { print; print codes; skip=1; next }
             /<!-- end -->/ { skip=0 }
             !skip { print }
           ' "$DOC_PATH" > /tmp/query-serving-new.md
-          
+
           mv /tmp/query-serving-new.md "$DOC_PATH"
-          
-          # Check if there are actual changes
+
+          # Check if there are actual changes.
           cd /tmp/website
           if git diff --quiet; then
             echo "No changes detected in error code documentation"
@@ -110,28 +116,28 @@ jobs:
           fi
 
       - name: Get GitHub App user ID
-        if: steps.docs_version.outputs.skip != 'true' && steps.update_docs.outputs.skip != 'true'
+        if: steps.metadata.outputs.skip != 'true' && steps.docs_version.outputs.skip != 'true' && steps.update_docs.outputs.skip != 'true'
         id: get-user-id
         run: |
           echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
 
       - name: Configure Git
-        if: steps.docs_version.outputs.skip != 'true' && steps.update_docs.outputs.skip != 'true'
+        if: steps.metadata.outputs.skip != 'true' && steps.docs_version.outputs.skip != 'true' && steps.update_docs.outputs.skip != 'true'
         run: |
           git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
 
       - name: Create or update PR on website
-        if: steps.docs_version.outputs.skip != 'true' && steps.update_docs.outputs.skip != 'true'
+        if: steps.metadata.outputs.skip != 'true' && steps.docs_version.outputs.skip != 'true' && steps.update_docs.outputs.skip != 'true'
         run: |
-          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_NUMBER="${{ steps.metadata.outputs.pr_number }}"
           BRANCH_NAME="update-error-code-${PR_NUMBER}"
           DOC_PATH="${{ steps.update_docs.outputs.doc_path }}"
           REPO_OWNER="${{ github.repository_owner }}"
-          
+
           cd /tmp/website
-          
-          # Check if branch already exists
+
+          # Check if branch already exists.
           if gh api "repos/${REPO_OWNER}/website/branches/${BRANCH_NAME}" --silent 2>/dev/null; then
             echo "Branch ${BRANCH_NAME} already exists, updating..."
             git fetch origin "${BRANCH_NAME}"
@@ -141,22 +147,22 @@ jobs:
             echo "Creating new branch ${BRANCH_NAME}..."
             git checkout -b "${BRANCH_NAME}"
           fi
-          
-          # Stage and commit changes
+
+          # Stage and commit changes.
           git add "$DOC_PATH"
           git commit -m "Updated the query-serving error code"
-          
-          # Push changes
+
+          # Push changes.
           git push -f "https://x-access-token:${GH_TOKEN}@github.com/${REPO_OWNER}/website.git" "${BRANCH_NAME}"
-          
-          # Check if PR already exists
+
+          # Check if PR already exists.
           EXISTING_PR=$(gh pr list --repo "${REPO_OWNER}/website" --head "${BRANCH_NAME}" --json number --jq '.[0].number' 2>/dev/null || echo "")
-          
+
           if [[ -n "$EXISTING_PR" ]]; then
             echo "PR #${EXISTING_PR} already exists, updated branch"
             echo "https://github.com/${REPO_OWNER}/website/pull/${EXISTING_PR}"
           else
-            # Create new PR
+            # Create new PR.
             gh pr create \
               --repo "${REPO_OWNER}/website" \
               --title "Update error code documentation (#${PR_NUMBER})" \


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Split error code generation workflow into two: one uploads the generated code as an artifact, and a second to pull the artifact and create the website PR.

h/t to @AdnaneKhan for bringing the security issue to our attention. :heart:

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/security/code-scanning/4082

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
