### PR TITLE
Backups: Cap the number of backups to list

### DIFF
--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"path/filepath"
 	"runtime/debug"


### PR DESCRIPTION
Fixes: https://github.com/vitessio/vitess/security/code-scanning/788

In general, to fix this class of problem, you must bound any user-controlled value used in `make` (length or capacity) by a reasonable maximum and reject or clamp values that exceed that limit. This prevents excessively large allocations even if the user sends very large numbers.

For this specific case, the best fix is to validate `req.Limit` and `req.DetailedLimit` in `VtctldServer.GetBackups` before using them to override `len(bhs)`. We should:
- Define a maximum allowed value for the number of backups and detailed backups (e.g., a `const maxBackupLimit = 10000` or similar) or at least ensure the chosen limit does not exceed `len(bhs)` and does not overflow `int`.
- Replace the existing, ineffective negative checks (`if int(req.Limit) < 0`) with checks that:  
  * ensure the requested limit does not exceed some configured/compiled-in maximum, and  
  * cap `totalBackups`/`totalDetailedBackups` at both that maximum and `len(bhs)`.
- Keep behavior compatible: a limit of 0 should still mean “no explicit limit” (use all backups), and positive values less than or equal to the maximum should behave as before, except that they will not be allowed to exceed the actual available backups.

All necessary imports (`math`) are already present in `go/vt/vtctl/grpcvtctldserver/server.go`, so we only need to add new constants and adjust logic in the `GetBackups` method in that file, in the region around lines 1531–1545.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
