### PR TITLE
Remove examples directory from dependabot config and add one missing SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,7 +44,6 @@ updates:
       - "/docker/lite"
       - "/docker/mini"
       - "/docker/vttestserver"
-      - "/examples/compose/external_db/mysql"
       - "/go/mysql/collations/tools/colldump"
     schedule:
       interval: "weekly"

--- a/docker/binaries/vtadmin/Dockerfile
+++ b/docker/binaries/vtadmin/Dockerfile
@@ -29,7 +29,7 @@ COPY --from=lite /vt/web/vtadmin /vt/web/vtadmin
 RUN npm --prefix /vt/web/vtadmin ci && \
     npm run --prefix /vt/web/vtadmin build
 
-FROM nginxinc/nginx-unprivileged:1.22 AS nginx
+FROM nginxinc/nginx-unprivileged:1.22@sha256:b711a5cfcea280bc8b2ad04a2c58a65d3589bc1679d38cbde17b22c08d4ddcc2 AS nginx
 
 ENV VTADMIN_WEB_PORT=14201
 


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Removes the examples directory from the dependabot config since it's trying to update a MySQL image to 9.0. In addition, add a SHA to an image that was missing it from the previous PR.
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->

Help from GPT 5.2 Codex
