### PR TITLE
VDiff: Prevent division by 0 when reconciling mismatches for reference tables

### DIFF
--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ.go
@@ -82,7 +82,7 @@ func (wd *workflowDiffer) reconcileExtraRows(dr *DiffReport, maxExtraRowsToCompa
 }
 
 func (wd *workflowDiffer) reconcileReferenceTables(dr *DiffReport) error {
-	if dr.MismatchedRows == 0 {
+	if dr.MismatchedRows == 0 && dr.MatchingRows > 0 {
 		// Get the VSchema on the target and source keyspaces. We can then use this
 		// for handling additional edge cases, such as adjusting results for reference
 		// tables when the shard count is different between the source and target as
@@ -97,16 +97,14 @@ func (wd *workflowDiffer) reconcileReferenceTables(dr *DiffReport) error {
 		}
 		svt, sok := srcvschema.Tables[dr.TableName]
 		tvt, tok := tgtvschema.Tables[dr.TableName]
-		if dr.ExtraRowsSource > 0 && sok && svt.Type == vindexes.TypeReference &&
-			(dr.MatchingRows > 0 && dr.ExtraRowsSource%dr.MatchingRows == 0) {
+		if dr.ExtraRowsSource > 0 && sok && svt.Type == vindexes.TypeReference && dr.ExtraRowsSource%dr.MatchingRows == 0 {
 			// We have a reference table with no mismatched rows and the number of
 			// extra rows on the source is a multiple of the matching rows. This
 			// means that there's no actual diff.
 			dr.ExtraRowsSource = 0
 			dr.ExtraRowsSourceDiffs = nil
 		}
-		if dr.ExtraRowsTarget > 0 && tok && tvt.Type == vindexes.TypeReference &&
-			(dr.MatchingRows > 0 && dr.ExtraRowsTarget%dr.MatchingRows == 0) {
+		if dr.ExtraRowsTarget > 0 && tok && tvt.Type == vindexes.TypeReference && dr.ExtraRowsTarget%dr.MatchingRows == 0 {
 			// We have a reference table with no mismatched rows and the number of
 			// extra rows on the target is a multiple of the matching rows. This
 			// means that there's no actual diff.

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -323,11 +323,10 @@ func TestReconcileReferenceTables(t *testing.T) {
 	wd, err := newWorkflowDiffer(ct, vdiffenv.opts, collations.MySQL8())
 	require.NoError(t, err)
 
-	// Create VSchema for source keyspace with a reference table.
+	// Create VSchema for the source keyspace with a reference table.
 	err = tstenv.TopoServ.EnsureVSchema(ctx, tstenv.KeyspaceName)
 	require.NoError(t, err)
 	sourceVS := &vschemapb.Keyspace{
-		Sharded: true,
 		Tables: map[string]*vschemapb.Table{
 			"ref_table": {
 				Type: "reference",
@@ -373,7 +372,7 @@ func TestReconcileReferenceTables(t *testing.T) {
 		err := wd.reconcileReferenceTables(dr)
 		require.NoError(t, err)
 
-		// Values should remain unchanged since MatchingRows is 0
+		// Values should remain unchanged since MatchingRows is 0.
 		require.Equal(t, int64(0), dr.ExtraRowsSource)
 		require.Equal(t, int64(10), dr.ExtraRowsTarget)
 	})


### PR DESCRIPTION
## Description

This PR adds a check to prevent a division by 0 in the specific scenario mentioned in the bug report (https://github.com/vitessio/vitess/issues/19140) where the reference table is emptied on the target (or on the source) before the VDiff is done so that there are 0 matching rows.

The new test fails on `main` as expected:
```
❯ go test -timeout 30s -run ^TestReconcileReferenceTables$ vitess.io/vitess/go/vt/vttablet/tabletmanager/vdiff
E0116 03:15:53.824466   24807 controller.go:130] Encountered an error getting vdiff record for ccbdbf03-b3f2-4a69-af1f-8d2d7eacbfac: no vdiff found for id 1 on tablet cell:"cell1" uid:100
--- FAIL: TestReconcileReferenceTables (0.00s)
    engine.go:295: DBClient query: select * from _vt.vdiff where state in ('started','pending')
    engine.go:321: DBClient query: select * from _vt.vdiff where id = 1
    --- FAIL: TestReconcileReferenceTables/division_by_zero_with_zero_matching_rows_-_source_side (0.00s)
panic: runtime error: integer divide by zero [recovered, repanicked]

goroutine 198 gp=0x14000458540 m=5 mp=0x14000100008 [running]:
panic({0x105f694c0?, 0x10794bed0?})
        /usr/local/go/src/runtime/panic.go:802 +0x150 fp=0x140008759a0 sp=0x140008758f0 pc=0x1041de410
testing.tRunner.func1.2({0x105f694c0, 0x10794bed0})
        /usr/local/go/src/testing/testing.go:1872 +0x190 fp=0x14000875a50 sp=0x140008759a0 pc=0x1042af3a0
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1875 +0x31c fp=0x14000875bf0 sp=0x14000875a50 pc=0x1042aeeac
panic({0x105f694c0?, 0x10794bed0?})
        /usr/local/go/src/runtime/panic.go:783 +0x120 fp=0x14000875ca0 sp=0x14000875bf0 pc=0x1041de3e0
runtime.panicdivide()
        /usr/local/go/src/runtime/panic.go:241 +0x44 fp=0x14000875cc0 sp=0x14000875ca0 pc=0x1041a4314
vitess.io/vitess/go/vt/vttablet/tabletmanager/vdiff.(*workflowDiffer).reconcileReferenceTables(0x14000b18b10, 0x14000700da0)
        /Users/matt/git/vitess/go/vt/vttablet/tabletmanager/vdiff/workflow_differ.go:100 +0x200 fp=0x14000875d20 sp=0x14000875cc0 pc=0x1056f8bf0
vitess.io/vitess/go/vt/vttablet/tabletmanager/vdiff.TestReconcileReferenceTables.func1(0x1400049fdc0)
```

> [!NOTE]
> We should backport this to v22 as it's a very small and contained fix that prevents a serious potential problem when performing a VDiff on a workflow that includes reference tables.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/19140

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

My man Claude helped with the unit test.