### PR TITLE
Fix sporadic TestServingKeyspaces panic on context cancellation

### DIFF
--- a/go/vt/vtgate/sandbox_test.go
+++ b/go/vt/vtgate/sandbox_test.go
@@ -298,6 +298,11 @@ func (sct *sandboxTopo) WatchSrvVSchema(ctx context.Context, cell string, callba
 		return
 	}
 
+	// Context may already be canceled during test cleanup - exit gracefully.
+	if ctx.Err() != nil {
+		return
+	}
+
 	// Update the backing topo server with the current sandbox vschemas.
 	for ks := range ksToSandbox {
 		ksvs := &topo.KeyspaceVSchemaInfo{
@@ -305,12 +310,23 @@ func (sct *sandboxTopo) WatchSrvVSchema(ctx context.Context, cell string, callba
 			Keyspace: srvVSchema.Keyspaces[ks],
 		}
 		if err := sct.topoServer.SaveVSchema(ctx, ksvs); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
 			panic(fmt.Sprintf("sandboxTopo SaveVSchema returned an error: %v", err))
 		}
 	}
-	sct.topoServer.UpdateSrvVSchema(ctx, cell, srvVSchema)
+	if err := sct.topoServer.UpdateSrvVSchema(ctx, cell, srvVSchema); err != nil {
+		if ctx.Err() != nil {
+			return
+		}
+		panic(fmt.Sprintf("sandboxTopo UpdateSrvVSchema returned an error: %v", err))
+	}
 	current, updateChan, err := sct.topoServer.WatchSrvVSchema(ctx, cell)
 	if err != nil {
+		if ctx.Err() != nil {
+			return
+		}
 		panic(fmt.Sprintf("sandboxTopo WatchSrvVSchema returned an error: %v", err))
 	}
 	if !callback(current.Value, nil) {


### PR DESCRIPTION
## Description

I recently noticed quite a few CI failures on unit test runs with `sandboxTopo SaveVSchema returned an error: context canceled` errors.

Claude was able to track these down to the `sandboxTopo.WatchSrvVSchema` function:

```
Location: go/vt/discovery/keyspace_events.go:244-254

The KeyspaceEventWatcher.run() spawns goroutines that:
1. Call getKeyspaceStatus() → newKeyspaceState() → WatchSrvVSchema()
2. Use the test context directly
3. Have no explicit shutdown mechanism

When the test ends:
1. executor.Close() is called (but doesn't wait for KEW goroutines)
2. cancel() is called, canceling the context
3. A goroutine may be mid-call to SaveVSchema() when context cancels
4. SaveVSchema() returns context.Canceled
5. The panic fires
```

The error was reproducible quiet quickly via:

```bash
go test -v -count=50 -run TestServingKeyspaces ./go/vt/vtgate/
```

Tests are cleaned up in `createExecutorEnvCallback` like this:

```
	t.Cleanup(func() {
		defer utils.EnsureNoLeaks(t)
		executor.Close()
		cancel()
	})
```

Claude (and I) believe that inside `sandboxTopo.WatchSrvVSchema`, an expiration of `ctx` should be treated as a signal for a "graceful" exit, without leading to a panic.

```
  Context Flow Diagram

  Test Setup (executor_framework_test.go:130)
  │
  │   ctx, cancel = context.WithCancel(context.Background())
  │
  ├──► newSandboxForCells(ctx, ...)           (line 143)
  │
  ├──► newTestResolver(ctx, hc, serv, cell)   (line 162)
  │    │
  │    └──► newTestScatterConn(ctx, ...)      (legacy_scatter_conn_test.go:621)
  │         │
  │         └──► NewTabletGateway(ctx, ...)   (tabletgateway.go:126)
  │              │
  │              └──► setupBuffering(ctx)     (tabletgateway.go:146)
  │                   │
  │                   └──► NewKeyspaceEventWatcher(ctx, ...)  (line 160)
  │                        │
  │                        └──► kew.run(ctx)  (keyspace_events.go:100)
  │                             │
  │                             ├──► goroutine 1: health check listener (line 228)
  │                             │
  │                             └──► goroutine 2: keyspace seeder (line 244)
  │                                  │
  │                                  └──► kew.getKeyspaceStatus(ctx, ks)  (line 252)
  │                                       │
  │                                       └──► newKeyspaceState(ctx, ...)
  │                                            │
  │                                            └──► kew.ts.WatchSrvVSchema(ctx, ...)  ← PANIC HERE
  │
  └──► NewExecutor(ctx, ...)                  (line 181)
       │
       └──► serv.WatchSrvVSchema(ctx, ...)    (executor.go:219)

  The Race Condition

  During test cleanup (lines 186-190):

  t.Cleanup(func() {
      executor.Close()   // ① Closes executor, but goroutines keep running
      cancel()           // ② Cancels context
  })

  The problem:

  1. executor.Close() doesn't wait for KeyspaceEventWatcher goroutines to finish
  2. The goroutine at keyspace_events.go:244 (goroutine 2) is still running with the same ctx
  3. This goroutine calls getKeyspaceStatus(ctx, ks) → newKeyspaceState(ctx, ...) → WatchSrvVSchema(ctx, ...)
  4. cancel() is called, marking ctx as canceled
  5. If the goroutine is mid-call to SaveVSchema(ctx, ...) when cancel() fires, SaveVSchema returns context.Canceled
  6. The old code panicked on this error instead of handling it gracefully

  The fix adds if ctx.Err() != nil { return } checks so that context cancellation is treated as a normal shutdown signal rather than a fatal error.
```

## Related Issue(s)

N/A

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
