### PR TITLE
Update golang version CI: remove deprecated `--workflow-update` flag and v20

### DIFF
--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        branch: [ main, release-23.0, release-22.0, release-21.0, release-20.0 ]
+        branch: [ main, release-23.0, release-22.0 ]
     name: Update Golang Version
     runs-on: ubuntu-24.04
     steps:
@@ -39,10 +39,8 @@ jobs:
 
           if [[ "${{ matrix.branch }}" == "main" ]]; then
             go run ./go/tools/go-upgrade/go-upgrade.go upgrade --main --allow-major-upgrade
-          elif [[ ("${{ matrix.branch }}" == "release-21.0") || ("${{ matrix.branch }}" == "release-22.0") ]]; then
-            go run ./go/tools/go-upgrade/go-upgrade.go upgrade
           else
-            go run ./go/tools/go-upgrade/go-upgrade.go upgrade --workflow-update=false
+            go run ./go/tools/go-upgrade/go-upgrade.go upgrade
           fi
 
           output=$(git status -s)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

To address the failure of the "Upgrade golang version" CI on `release-23.0`, this PR removes the non-existent flag `--workflow-update` that we pass to `go-upgrade.go` when the branch is not `main` or a specified list

Failure:
```bash
Run old_go_version=$(go run ./go/tools/go-upgrade/go-upgrade.go get go-version)
go: downloading github.com/hashicorp/go-version v1.7.0
go: downloading github.com/spf13/cobra v1.10.1
go: downloading github.com/spf13/pflag v1.0.10
Error: unknown flag: --workflow-update
Usage:
  go-upgrade upgrade [flags]

Flags:
      --allow-major-upgrade   Defines if Golang major version upgrade are allowed.
  -h, --help                  help for upgrade
      --main                  Defines if the current branch is the main branch.

Error: unknown flag: --workflow-update
exit status 1
Error: Process completed with exit code 1.
```

Also, `release-20.0` and `release-21.0` were removed as it is now EOL

cc @frouioui 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
