### PR TITLE
CI: Use new Percona Server repo name

### DIFF
--- a/.github/workflows/cluster_endtoend_backup_pitr_xtrabackup.yml
+++ b/.github/workflows/cluster_endtoend_backup_pitr_xtrabackup.yml
@@ -90,7 +90,7 @@ jobs:
         sudo apt-get -qq install -y lsb-release gnupg2
         wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
         sudo DEBIAN_FRONTEND="noninteractive" dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo percona-release setup ps80
+        sudo percona-release setup pdps8.0
         sudo apt-get -qq update
 
         sudo apt-get -qq install -y percona-server-server percona-server-client

--- a/.github/workflows/cluster_endtoend_xb_backup.yml
+++ b/.github/workflows/cluster_endtoend_xb_backup.yml
@@ -90,7 +90,7 @@ jobs:
         sudo apt-get -qq install -y lsb-release gnupg2
         wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
         sudo DEBIAN_FRONTEND="noninteractive" dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo percona-release setup ps80
+        sudo percona-release setup pdps8.0
         sudo apt-get -qq update
 
         sudo apt-get -qq install -y percona-server-server percona-server-client

--- a/.github/workflows/cluster_endtoend_xb_recovery.yml
+++ b/.github/workflows/cluster_endtoend_xb_recovery.yml
@@ -90,7 +90,7 @@ jobs:
         sudo apt-get -qq install -y lsb-release gnupg2
         wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
         sudo DEBIAN_FRONTEND="noninteractive" dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo percona-release setup ps80
+        sudo percona-release setup pdps8.0
         sudo apt-get -qq update
 
         sudo apt-get -qq install -y percona-server-server percona-server-client

--- a/test/templates/cluster_endtoend_test.tpl
+++ b/test/templates/cluster_endtoend_test.tpl
@@ -120,7 +120,7 @@ jobs:
         sudo apt-get -qq install -y lsb-release gnupg2
         wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
         sudo DEBIAN_FRONTEND="noninteractive" dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
-        sudo percona-release setup ps80
+        sudo percona-release setup pdps8.0
         sudo apt-get -qq update
 
         sudo apt-get -qq install -y percona-server-server percona-server-client


### PR DESCRIPTION
## Description

Percona apparently changed the repo name in their `percona-release` script from `ps80`: https://github.com/vitessio/vitess/blob/4c881ff69bd47da44476963b769aef609f3a071a/.github/workflows/cluster_endtoend_xb_backup.yml#L93

To `pdps8.0` as you can see in the failures here: https://github.com/vitessio/vitess/actions/runs/21319915216/job/61369826966?pr=19201

>[!NOTE]
> We should backport this to v22. v23 already has it via this PR: https://github.com/vitessio/vitess/pull/19201

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required