### PR TITLE
servenv: support SHA256-hashed passwords in the static gRPC auth plugin

### DIFF
--- a/examples/local/grpc_static_auth.json
+++ b/examples/local/grpc_static_auth.json
@@ -2,5 +2,9 @@
   {
     "Username": "vitess",
     "Password": "vitess_password"
+  },
+  {
+    "Username": "vitess_hashed",
+    "SHA256HashedPassword": "415a6502923945972202c5ce270568103e037be716652bb5e940737a66625a41"
   }
 ]

--- a/examples/local/grpc_static_auth.json
+++ b/examples/local/grpc_static_auth.json
@@ -5,6 +5,6 @@
   },
   {
     "Username": "vitess_hashed",
-    "SHA256HashedPassword": "415a6502923945972202c5ce270568103e037be716652bb5e940737a66625a41"
+    "CachingSha2Password": "*6c68316a29c3fcf7431524722c1be6cb54f5471f2cca326114f9eed99f731faa"
   }
 ]

--- a/go/test/endtoend/vtgate/grpc_api/main_test.go
+++ b/go/test/endtoend/vtgate/grpc_api/main_test.go
@@ -41,12 +41,12 @@ var (
 `
 	// The config mixes plaintext and SHA256-hashed passwords so both
 	// authentication paths of the static auth plugin are exercised.
-	// SHA256 hash of "test_password": "10a6e6cc8311a3e2bcc09bf6c199adecd5dd59408c343e926b129c4914f3cb01"
+	// SHA256(SHA256("test_password")): "9a3932ac9cde99161f6fbe5fe6102391bef0c46f0f396f104dd22cfb7f1fd5d1"
 	grpcServerAuthStaticJSON = `
 		[
 		  {
 			"Username": "some_other_user",
-			"SHA256HashedPassword": "10a6e6cc8311a3e2bcc09bf6c199adecd5dd59408c343e926b129c4914f3cb01"
+			"CachingSha2Password": "*9a3932ac9cde99161f6fbe5fe6102391bef0c46f0f396f104dd22cfb7f1fd5d1"
 		  },
 		  {
 			"Username": "another_unrelated_user",
@@ -54,7 +54,7 @@ var (
 		  },
 		  {
 			"Username": "user_with_access",
-			"SHA256HashedPassword": "10a6e6cc8311a3e2bcc09bf6c199adecd5dd59408c343e926b129c4914f3cb01"
+			"CachingSha2Password": "9a3932ac9cde99161f6fbe5fe6102391bef0c46f0f396f104dd22cfb7f1fd5d1"
 		  },
 		  {
 			"Username": "user_no_access",

--- a/go/test/endtoend/vtgate/grpc_api/main_test.go
+++ b/go/test/endtoend/vtgate/grpc_api/main_test.go
@@ -39,11 +39,14 @@ var (
 			primary key(id)
 		) Engine=InnoDB;
 `
+	// The config mixes plaintext and SHA256-hashed passwords so both
+	// authentication paths of the static auth plugin are exercised.
+	// SHA256 hash of "test_password": "10a6e6cc8311a3e2bcc09bf6c199adecd5dd59408c343e926b129c4914f3cb01"
 	grpcServerAuthStaticJSON = `
 		[
 		  {
 			"Username": "some_other_user",
-			"Password": "test_password"
+			"SHA256HashedPassword": "10a6e6cc8311a3e2bcc09bf6c199adecd5dd59408c343e926b129c4914f3cb01"
 		  },
 		  {
 			"Username": "another_unrelated_user",
@@ -51,7 +54,7 @@ var (
 		  },
 		  {
 			"Username": "user_with_access",
-			"Password": "test_password"
+			"SHA256HashedPassword": "10a6e6cc8311a3e2bcc09bf6c199adecd5dd59408c343e926b129c4914f3cb01"
 		  },
 		  {
 			"Username": "user_no_access",

--- a/go/vt/servenv/grpc_server_auth_static.go
+++ b/go/vt/servenv/grpc_server_auth_static.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/subtle"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -31,6 +30,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/utils"
 )
@@ -59,20 +59,23 @@ func registerGRPCServerAuthStaticFlags(fs *pflag.FlagSet) {
 type StaticAuthConfigEntry struct {
 	Username string
 	Password string
-	// SHA256HashedPassword is the hex-encoded SHA256 hash of the user's password.
-	// It is used only when Password is empty, allowing plaintext and hashed
-	// credentials to be mixed in the same configuration file.
-	SHA256HashedPassword string
+	// CachingSha2Password is the hex-encoded SHA256(SHA256(password)) of the
+	// user's password, with an optional leading '*'. It is used only when
+	// Password is empty, allowing plaintext and hashed credentials to be mixed
+	// in the same configuration file. The value matches the CachingSha2Password
+	// field of the MySQL protocol's static auth server, so the same stored
+	// credential can be used to authenticate both MySQL and gRPC clients.
+	CachingSha2Password string
 	// TODO (@rafael) Add authorization parameters
 }
 
 // staticAuthEntry is the runtime representation of a StaticAuthConfigEntry,
-// with the SHA256HashedPassword hex-decoded once at initialization so that
+// with the CachingSha2Password hex-decoded once at initialization so that
 // Authenticate does not re-decode it on every request.
 type staticAuthEntry struct {
 	StaticAuthConfigEntry
 
-	sha256HashedPassword []byte
+	cachingSha2Password []byte
 }
 
 // StaticAuthPlugin  implements static username/password authentication for grpc. It contains an array of username/passwords
@@ -94,9 +97,10 @@ func (sa *StaticAuthPlugin) Authenticate(ctx context.Context, fullMethod string)
 			if username != authEntry.Username {
 				continue
 			}
-			if authEntry.Password == "" && len(authEntry.sha256HashedPassword) > 0 {
-				hashedPassword := sha256.Sum256([]byte(password))
-				if subtle.ConstantTimeCompare(hashedPassword[:], authEntry.sha256HashedPassword) == 1 {
+			if authEntry.Password == "" && len(authEntry.cachingSha2Password) > 0 {
+				stage1 := sha256.Sum256([]byte(password))
+				hashedPassword := sha256.Sum256(stage1[:])
+				if subtle.ConstantTimeCompare(hashedPassword[:], authEntry.cachingSha2Password) == 1 {
 					return newStaticAuthContext(ctx, username), nil
 				}
 			} else if subtle.ConstantTimeCompare([]byte(password), []byte(authEntry.Password)) == 1 {
@@ -142,15 +146,15 @@ func staticAuthPluginInitializer() (Authenticator, error) {
 	authEntries := make([]staticAuthEntry, 0, len(entries))
 	for i, entry := range entries {
 		authEntry := staticAuthEntry{StaticAuthConfigEntry: entry}
-		if entry.SHA256HashedPassword != "" {
-			hash, err := hex.DecodeString(entry.SHA256HashedPassword)
+		if entry.CachingSha2Password != "" {
+			hash, err := mysql.DecodePasswordHex(entry.CachingSha2Password)
 			if err != nil {
-				return nil, fmt.Errorf("fail to load static auth plugin: entry %d (user=%s) has an invalid hex-encoded SHA256HashedPassword: %v", i, entry.Username, err)
+				return nil, fmt.Errorf("fail to load static auth plugin: entry %d (user=%s) has an invalid hex-encoded CachingSha2Password: %v", i, entry.Username, err)
 			}
 			if len(hash) != sha256.Size {
-				return nil, fmt.Errorf("fail to load static auth plugin: entry %d (user=%s) has an invalid SHA256HashedPassword length: expected %d hex chars, got %d", i, entry.Username, sha256.Size*2, len(entry.SHA256HashedPassword))
+				return nil, fmt.Errorf("fail to load static auth plugin: entry %d (user=%s) has an invalid CachingSha2Password length: expected %d hex chars, got %d", i, entry.Username, sha256.Size*2, len(hash)*2)
 			}
-			authEntry.sha256HashedPassword = hash
+			authEntry.cachingSha2Password = hash
 		}
 		authEntries = append(authEntries, authEntry)
 	}

--- a/go/vt/servenv/grpc_server_auth_static.go
+++ b/go/vt/servenv/grpc_server_auth_static.go
@@ -18,7 +18,9 @@ package servenv
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -57,13 +59,26 @@ func registerGRPCServerAuthStaticFlags(fs *pflag.FlagSet) {
 type StaticAuthConfigEntry struct {
 	Username string
 	Password string
+	// SHA256HashedPassword is the hex-encoded SHA256 hash of the user's password.
+	// It is used only when Password is empty, allowing plaintext and hashed
+	// credentials to be mixed in the same configuration file.
+	SHA256HashedPassword string
 	// TODO (@rafael) Add authorization parameters
+}
+
+// staticAuthEntry is the runtime representation of a StaticAuthConfigEntry,
+// with the SHA256HashedPassword hex-decoded once at initialization so that
+// Authenticate does not re-decode it on every request.
+type staticAuthEntry struct {
+	StaticAuthConfigEntry
+
+	sha256HashedPassword []byte
 }
 
 // StaticAuthPlugin  implements static username/password authentication for grpc. It contains an array of username/passwords
 // that will be authorized to connect to the grpc server.
 type StaticAuthPlugin struct {
-	entries []StaticAuthConfigEntry
+	entries []staticAuthEntry
 }
 
 // Authenticate implements AuthPlugin interface. This method will be used inside a middleware in grpc_server to authenticate
@@ -76,7 +91,15 @@ func (sa *StaticAuthPlugin) Authenticate(ctx context.Context, fullMethod string)
 		username := md["username"][0]
 		password := md["password"][0]
 		for _, authEntry := range sa.entries {
-			if username == authEntry.Username && subtle.ConstantTimeCompare([]byte(password), []byte(authEntry.Password)) == 1 {
+			if username != authEntry.Username {
+				continue
+			}
+			if authEntry.Password == "" && len(authEntry.sha256HashedPassword) > 0 {
+				hashedPassword := sha256.Sum256([]byte(password))
+				if subtle.ConstantTimeCompare(hashedPassword[:], authEntry.sha256HashedPassword) == 1 {
+					return newStaticAuthContext(ctx, username), nil
+				}
+			} else if subtle.ConstantTimeCompare([]byte(password), []byte(authEntry.Password)) == 1 {
 				return newStaticAuthContext(ctx, username), nil
 			}
 		}
@@ -116,8 +139,23 @@ func staticAuthPluginInitializer() (Authenticator, error) {
 		err := fmt.Errorf("fail to load static auth plugin: %v", err)
 		return nil, err
 	}
+	authEntries := make([]staticAuthEntry, 0, len(entries))
+	for i, entry := range entries {
+		authEntry := staticAuthEntry{StaticAuthConfigEntry: entry}
+		if entry.SHA256HashedPassword != "" {
+			hash, err := hex.DecodeString(entry.SHA256HashedPassword)
+			if err != nil {
+				return nil, fmt.Errorf("fail to load static auth plugin: entry %d (user=%s) has an invalid hex-encoded SHA256HashedPassword: %v", i, entry.Username, err)
+			}
+			if len(hash) != sha256.Size {
+				return nil, fmt.Errorf("fail to load static auth plugin: entry %d (user=%s) has an invalid SHA256HashedPassword length: expected %d hex chars, got %d", i, entry.Username, sha256.Size*2, len(entry.SHA256HashedPassword))
+			}
+			authEntry.sha256HashedPassword = hash
+		}
+		authEntries = append(authEntries, authEntry)
+	}
 	staticAuthPlugin := &StaticAuthPlugin{
-		entries: entries,
+		entries: authEntries,
 	}
 	log.Info("static auth plugin have initialized successfully with config from grpc-auth-static-password-file")
 	return staticAuthPlugin, nil

--- a/go/vt/servenv/grpc_server_auth_static.go
+++ b/go/vt/servenv/grpc_server_auth_static.go
@@ -149,10 +149,10 @@ func staticAuthPluginInitializer() (Authenticator, error) {
 		if entry.CachingSha2Password != "" {
 			hash, err := mysql.DecodePasswordHex(entry.CachingSha2Password)
 			if err != nil {
-				return nil, fmt.Errorf("fail to load static auth plugin: entry %d (user=%s) has an invalid hex-encoded CachingSha2Password: %v", i, entry.Username, err)
+				return nil, fmt.Errorf("failed to load static auth plugin: entry %d (user=%s) has an invalid hex-encoded CachingSha2Password: %v", i, entry.Username, err)
 			}
 			if len(hash) != sha256.Size {
-				return nil, fmt.Errorf("fail to load static auth plugin: entry %d (user=%s) has an invalid CachingSha2Password length: expected %d hex chars, got %d", i, entry.Username, sha256.Size*2, len(hash)*2)
+				return nil, fmt.Errorf("failed to load static auth plugin: entry %d (user=%s) has an invalid CachingSha2Password length: expected %d hex chars, got %d", i, entry.Username, sha256.Size*2, len(hash)*2)
 			}
 			authEntry.cachingSha2Password = hash
 		}

--- a/go/vt/servenv/grpc_server_auth_static.go
+++ b/go/vt/servenv/grpc_server_auth_static.go
@@ -60,11 +60,10 @@ type StaticAuthConfigEntry struct {
 	Username string
 	Password string
 	// CachingSha2Password is the hex-encoded SHA256(SHA256(password)) of the
-	// user's password, with an optional leading '*'. It is used only when
-	// Password is empty, allowing plaintext and hashed credentials to be mixed
-	// in the same configuration file. The value matches the CachingSha2Password
-	// field of the MySQL protocol's static auth server, so the same stored
-	// credential can be used to authenticate both MySQL and gRPC clients.
+	// user's password, with an optional leading '*'. When set, it takes
+	// precedence over Password, matching the behavior of the MySQL protocol's
+	// static auth server so the same stored credential can be used to
+	// authenticate both MySQL and gRPC clients.
 	CachingSha2Password string
 	// TODO (@rafael) Add authorization parameters
 }
@@ -93,14 +92,20 @@ func (sa *StaticAuthPlugin) Authenticate(ctx context.Context, fullMethod string)
 		}
 		username := md["username"][0]
 		password := md["password"][0]
+		// SHA256(SHA256(password)), computed lazily on the first entry that
+		// needs it so plaintext-only configurations never pay for the hashing.
+		var hashedPassword []byte
 		for _, authEntry := range sa.entries {
 			if username != authEntry.Username {
 				continue
 			}
-			if authEntry.Password == "" && len(authEntry.cachingSha2Password) > 0 {
-				stage1 := sha256.Sum256([]byte(password))
-				hashedPassword := sha256.Sum256(stage1[:])
-				if subtle.ConstantTimeCompare(hashedPassword[:], authEntry.cachingSha2Password) == 1 {
+			if len(authEntry.cachingSha2Password) > 0 {
+				if hashedPassword == nil {
+					stage1 := sha256.Sum256([]byte(password))
+					stage2 := sha256.Sum256(stage1[:])
+					hashedPassword = stage2[:]
+				}
+				if subtle.ConstantTimeCompare(hashedPassword, authEntry.cachingSha2Password) == 1 {
 					return newStaticAuthContext(ctx, username), nil
 				}
 			} else if subtle.ConstantTimeCompare([]byte(password), []byte(authEntry.Password)) == 1 {

--- a/go/vt/servenv/grpc_server_auth_static_bench_test.go
+++ b/go/vt/servenv/grpc_server_auth_static_bench_test.go
@@ -27,7 +27,7 @@ import (
 
 // newBenchStaticAuthPlugin builds a plugin with numEntries entries; the target
 // user is the last entry (worst case for the linear scan). If hashed is true
-// the target entry uses SHA256HashedPassword, otherwise plaintext Password.
+// the target entry uses CachingSha2Password, otherwise plaintext Password.
 func newBenchStaticAuthPlugin(numEntries int, hashed bool, password string) *StaticAuthPlugin {
 	entries := make([]staticAuthEntry, 0, numEntries)
 	for i := 0; i < numEntries-1; i++ {
@@ -44,9 +44,10 @@ func newBenchStaticAuthPlugin(numEntries int, hashed bool, password string) *Sta
 		},
 	}
 	if hashed {
-		hash := sha256.Sum256([]byte(password))
-		target.SHA256HashedPassword = hex.EncodeToString(hash[:])
-		target.sha256HashedPassword = hash[:]
+		stage1 := sha256.Sum256([]byte(password))
+		hash := sha256.Sum256(stage1[:])
+		target.CachingSha2Password = hex.EncodeToString(hash[:])
+		target.cachingSha2Password = hash[:]
 	} else {
 		target.Password = password
 	}
@@ -78,7 +79,7 @@ func BenchmarkStaticAuthPlugin_AuthenticatePlaintext(b *testing.B) {
 }
 
 // BenchmarkStaticAuthPlugin_AuthenticateHashed measures per-RPC authentication
-// cost with a SHA256HashedPassword entry.
+// cost with a CachingSha2Password entry.
 func BenchmarkStaticAuthPlugin_AuthenticateHashed(b *testing.B) {
 	benchmarkStaticAuthPluginAuthenticate(b, true)
 }

--- a/go/vt/servenv/grpc_server_auth_static_bench_test.go
+++ b/go/vt/servenv/grpc_server_auth_static_bench_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servenv
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// newBenchStaticAuthPlugin builds a plugin with numEntries entries; the target
+// user is the last entry (worst case for the linear scan). If hashed is true
+// the target entry uses SHA256HashedPassword, otherwise plaintext Password.
+func newBenchStaticAuthPlugin(numEntries int, hashed bool, password string) *StaticAuthPlugin {
+	entries := make([]staticAuthEntry, 0, numEntries)
+	for i := 0; i < numEntries-1; i++ {
+		entries = append(entries, staticAuthEntry{
+			StaticAuthConfigEntry: StaticAuthConfigEntry{
+				Username: fmt.Sprintf("other_user_%d", i),
+				Password: "other_password",
+			},
+		})
+	}
+	target := staticAuthEntry{
+		StaticAuthConfigEntry: StaticAuthConfigEntry{
+			Username: "bench_user",
+		},
+	}
+	if hashed {
+		hash := sha256.Sum256([]byte(password))
+		target.SHA256HashedPassword = hex.EncodeToString(hash[:])
+		target.sha256HashedPassword = hash[:]
+	} else {
+		target.Password = password
+	}
+	entries = append(entries, target)
+	return &StaticAuthPlugin{entries: entries}
+}
+
+func benchmarkStaticAuthPluginAuthenticate(b *testing.B, hashed bool) {
+	plugin := newBenchStaticAuthPlugin(5, hashed, "bench_password")
+	md := metadata.New(map[string]string{
+		"username": "bench_user",
+		"password": "bench_password",
+	})
+	ctx := metadata.NewIncomingContext(b.Context(), md)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := plugin.Authenticate(ctx, "/test.Service/Method"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkStaticAuthPlugin_AuthenticatePlaintext measures per-RPC
+// authentication cost with a plaintext Password entry.
+func BenchmarkStaticAuthPlugin_AuthenticatePlaintext(b *testing.B) {
+	benchmarkStaticAuthPluginAuthenticate(b, false)
+}
+
+// BenchmarkStaticAuthPlugin_AuthenticateHashed measures per-RPC authentication
+// cost with a SHA256HashedPassword entry.
+func BenchmarkStaticAuthPlugin_AuthenticateHashed(b *testing.B) {
+	benchmarkStaticAuthPluginAuthenticate(b, true)
+}

--- a/go/vt/servenv/grpc_server_auth_static_test.go
+++ b/go/vt/servenv/grpc_server_auth_static_test.go
@@ -256,10 +256,10 @@ func TestStaticAuthPlugin_DuplicateUsernameEntries(t *testing.T) {
 	}
 }
 
-// TestStaticAuthPlugin_PlaintextTakesPrecedence tests that when an entry has
-// both Password and CachingSha2Password set, the plaintext Password is used
-// and the SHA256 hash is ignored.
-func TestStaticAuthPlugin_PlaintextTakesPrecedence(t *testing.T) {
+// TestStaticAuthPlugin_HashTakesPrecedence tests that when an entry has both
+// Password and CachingSha2Password set, the SHA256 hash is used and the
+// plaintext Password is ignored, matching the MySQL static auth server.
+func TestStaticAuthPlugin_HashTakesPrecedence(t *testing.T) {
 	plugin := newTestStaticAuthPlugin(t, []StaticAuthConfigEntry{
 		{
 			Username:            "user1",
@@ -268,14 +268,14 @@ func TestStaticAuthPlugin_PlaintextTakesPrecedence(t *testing.T) {
 		},
 	})
 
-	t.Run("plaintext password matches", func(t *testing.T) {
-		newCtx, err := authenticate(t, plugin, "user1", "plain_password")
+	t.Run("hashed password matches", func(t *testing.T) {
+		newCtx, err := authenticate(t, plugin, "user1", "hashed_password")
 		require.NoError(t, err)
 		require.Equal(t, "user1", StaticAuthUsernameFromContext(newCtx))
 	})
 
-	t.Run("hashed password is ignored", func(t *testing.T) {
-		_, err := authenticate(t, plugin, "user1", "hashed_password")
+	t.Run("plaintext password is ignored", func(t *testing.T) {
+		_, err := authenticate(t, plugin, "user1", "plain_password")
 		require.Error(t, err)
 		st, ok := status.FromError(err)
 		require.True(t, ok, "error should be a gRPC status error")

--- a/go/vt/servenv/grpc_server_auth_static_test.go
+++ b/go/vt/servenv/grpc_server_auth_static_test.go
@@ -1,0 +1,436 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servenv
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// newTestStaticAuthPlugin builds a StaticAuthPlugin from config entries by
+// going through the same initialization path as production code (a JSON
+// credentials file loaded by staticAuthPluginInitializer).
+func newTestStaticAuthPlugin(t *testing.T, entries []StaticAuthConfigEntry) *StaticAuthPlugin {
+	t.Helper()
+
+	data, err := json.Marshal(entries)
+	require.NoError(t, err)
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "static_auth_test_*.json")
+	require.NoError(t, err)
+	_, err = tmpFile.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	credsFile = tmpFile.Name()
+	t.Cleanup(func() { credsFile = "" })
+
+	plugin, err := staticAuthPluginInitializer()
+	require.NoError(t, err)
+
+	staticPlugin, ok := plugin.(*StaticAuthPlugin)
+	require.True(t, ok)
+	return staticPlugin
+}
+
+// authenticate runs plugin.Authenticate with the given credentials passed as
+// gRPC metadata, mirroring how the auth interceptors invoke it.
+func authenticate(t *testing.T, plugin *StaticAuthPlugin, username, password string) (context.Context, error) {
+	t.Helper()
+
+	md := metadata.New(map[string]string{
+		"username": username,
+		"password": password,
+	})
+	ctx := metadata.NewIncomingContext(t.Context(), md)
+	return plugin.Authenticate(ctx, "/test.Service/Method")
+}
+
+// TestStaticAuthPlugin_Authenticate tests authentication against a credentials
+// file mixing plaintext and SHA256-hashed passwords.
+func TestStaticAuthPlugin_Authenticate(t *testing.T) {
+	// SHA256 hash of "password" is "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
+	// SHA256 hash of "secret123" is "fcf730b6d95236ecd3c9fc2d92d7b6b2bb061514961aec041d6c7a7192f592e4"
+	plugin := newTestStaticAuthPlugin(t, []StaticAuthConfigEntry{
+		{
+			Username:             "user1",
+			SHA256HashedPassword: "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8", // "password" as SHA256 hash
+		},
+		{
+			Username:             "user2",
+			SHA256HashedPassword: "fcf730b6d95236ecd3c9fc2d92d7b6b2bb061514961aec041d6c7a7192f592e4", // "secret123" as SHA256 hash
+		},
+		{
+			Username: "user3",
+			Password: "plaintext_password", // plaintext password
+		},
+	})
+
+	tests := []struct {
+		name           string
+		username       string
+		password       string
+		expectError    bool
+		expectedCode   codes.Code
+		expectedErrMsg string
+	}{
+		{
+			name:        "valid credentials - user1 (SHA256)",
+			username:    "user1",
+			password:    "password",
+			expectError: false,
+		},
+		{
+			name:        "valid credentials - user2 (SHA256)",
+			username:    "user2",
+			password:    "secret123",
+			expectError: false,
+		},
+		{
+			name:        "valid credentials - user3 (plaintext)",
+			username:    "user3",
+			password:    "plaintext_password",
+			expectError: false,
+		},
+		{
+			name:           "invalid password - SHA256 user",
+			username:       "user1",
+			password:       "wrongpassword",
+			expectError:    true,
+			expectedCode:   codes.PermissionDenied,
+			expectedErrMsg: "auth failure: caller \"user1\" provided invalid credentials",
+		},
+		{
+			name:           "invalid password - plaintext user",
+			username:       "user3",
+			password:       "wrongpassword",
+			expectError:    true,
+			expectedCode:   codes.PermissionDenied,
+			expectedErrMsg: "auth failure: caller \"user3\" provided invalid credentials",
+		},
+		{
+			name:           "non-existent user",
+			username:       "nonexistent",
+			password:       "password",
+			expectError:    true,
+			expectedCode:   codes.PermissionDenied,
+			expectedErrMsg: "auth failure: caller \"nonexistent\" provided invalid credentials",
+		},
+		{
+			name:           "empty password",
+			username:       "user1",
+			password:       "",
+			expectError:    true,
+			expectedCode:   codes.PermissionDenied,
+			expectedErrMsg: "auth failure: caller \"user1\" provided invalid credentials",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			newCtx, err := authenticate(t, plugin, tt.username, tt.password)
+
+			if tt.expectError {
+				require.Error(t, err)
+				st, ok := status.FromError(err)
+				require.True(t, ok, "error should be a gRPC status error")
+				assert.Equal(t, tt.expectedCode, st.Code())
+				assert.Contains(t, st.Message(), tt.expectedErrMsg)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, newCtx)
+
+				// Verify username is stored in context
+				assert.Equal(t, tt.username, StaticAuthUsernameFromContext(newCtx))
+			}
+		})
+	}
+}
+
+// TestStaticAuthPlugin_UppercaseHash tests that a SHA256HashedPassword written
+// in uppercase (or mixed-case) hex still authenticates, since the hash is
+// hex-decoded at initialization rather than compared as a string.
+func TestStaticAuthPlugin_UppercaseHash(t *testing.T) {
+	plugin := newTestStaticAuthPlugin(t, []StaticAuthConfigEntry{
+		{
+			Username:             "user1",
+			SHA256HashedPassword: "5E884898DA28047151D0E56F8DC6292773603D0D6AABBDD62A11EF721D1542D8", // "password" as uppercase SHA256 hash
+		},
+	})
+
+	newCtx, err := authenticate(t, plugin, "user1", "password")
+	require.NoError(t, err)
+	assert.Equal(t, "user1", StaticAuthUsernameFromContext(newCtx))
+}
+
+// TestStaticAuthPlugin_DuplicateUsernameEntries tests that when multiple
+// entries share the same username, authentication keeps checking the remaining
+// entries after a password mismatch, so any of the configured passwords is
+// accepted.
+func TestStaticAuthPlugin_DuplicateUsernameEntries(t *testing.T) {
+	plugin := newTestStaticAuthPlugin(t, []StaticAuthConfigEntry{
+		{
+			Username:             "user1",
+			SHA256HashedPassword: "faa9ef1976a332ec21a17d4a88fb0cae8ce93743b3f8c69370161d6b38839898", // "first_password" as SHA256 hash
+		},
+		{
+			Username:             "user1",
+			SHA256HashedPassword: "900cc4a6adbb527ac2ef8ac8f4d92104a040befa1c46c21bb6bab09eb72fc565", // "second_password" as SHA256 hash
+		},
+	})
+
+	tests := []struct {
+		name        string
+		password    string
+		expectError bool
+	}{
+		{
+			name:        "first entry matches",
+			password:    "first_password",
+			expectError: false,
+		},
+		{
+			name:        "first entry fails but second entry matches",
+			password:    "second_password",
+			expectError: false,
+		},
+		{
+			name:        "no entry matches",
+			password:    "wrong_password",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			newCtx, err := authenticate(t, plugin, "user1", tt.password)
+
+			if tt.expectError {
+				require.Error(t, err)
+				st, ok := status.FromError(err)
+				require.True(t, ok, "error should be a gRPC status error")
+				assert.Equal(t, codes.PermissionDenied, st.Code())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, "user1", StaticAuthUsernameFromContext(newCtx))
+			}
+		})
+	}
+}
+
+// TestStaticAuthPlugin_PlaintextTakesPrecedence tests that when an entry has
+// both Password and SHA256HashedPassword set, the plaintext Password is used
+// and the SHA256 hash is ignored.
+func TestStaticAuthPlugin_PlaintextTakesPrecedence(t *testing.T) {
+	plugin := newTestStaticAuthPlugin(t, []StaticAuthConfigEntry{
+		{
+			Username:             "user1",
+			Password:             "plain_password",
+			SHA256HashedPassword: "b2867617492e26c338ab49f72afabc984d798b59755a27e312b953716ae964d7", // "hashed_password" as SHA256 hash
+		},
+	})
+
+	t.Run("plaintext password matches", func(t *testing.T) {
+		newCtx, err := authenticate(t, plugin, "user1", "plain_password")
+		require.NoError(t, err)
+		assert.Equal(t, "user1", StaticAuthUsernameFromContext(newCtx))
+	})
+
+	t.Run("hashed password is ignored", func(t *testing.T) {
+		_, err := authenticate(t, plugin, "user1", "hashed_password")
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok, "error should be a gRPC status error")
+		assert.Equal(t, codes.PermissionDenied, st.Code())
+	})
+}
+
+// TestStaticAuthPlugin_NoMetadata tests that authentication fails with
+// Unauthenticated when the incoming context carries no gRPC metadata.
+func TestStaticAuthPlugin_NoMetadata(t *testing.T) {
+	plugin := newTestStaticAuthPlugin(t, []StaticAuthConfigEntry{
+		{
+			Username: "user1",
+			Password: "password",
+		},
+	})
+
+	_, err := plugin.Authenticate(t.Context(), "/test.Service/Method")
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unauthenticated, st.Code())
+	assert.Contains(t, st.Message(), "username and password must be provided")
+}
+
+// TestStaticAuthPlugin_MissingCredentials tests that authentication fails with
+// Unauthenticated when the username or password metadata keys are absent.
+func TestStaticAuthPlugin_MissingCredentials(t *testing.T) {
+	plugin := newTestStaticAuthPlugin(t, []StaticAuthConfigEntry{
+		{
+			Username: "user1",
+			Password: "password",
+		},
+	})
+
+	tests := []struct {
+		name     string
+		metadata map[string]string
+	}{
+		{
+			name: "missing username",
+			metadata: map[string]string{
+				"password": "password",
+			},
+		},
+		{
+			name: "missing password",
+			metadata: map[string]string{
+				"username": "user1",
+			},
+		},
+		{
+			name:     "missing both",
+			metadata: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			md := metadata.New(tt.metadata)
+			ctx := metadata.NewIncomingContext(t.Context(), md)
+
+			_, err := plugin.Authenticate(ctx, "/test.Service/Method")
+
+			require.Error(t, err)
+			st, ok := status.FromError(err)
+			require.True(t, ok)
+			assert.Equal(t, codes.Unauthenticated, st.Code())
+			assert.Contains(t, st.Message(), "username and password must be provided")
+		})
+	}
+}
+
+// TestStaticAuthPluginInitializer tests the initialization and validation of
+// the static auth plugin credentials file, in particular the SHA256 hash
+// validation added for SHA256HashedPassword entries.
+func TestStaticAuthPluginInitializer(t *testing.T) {
+	writeConfig := func(t *testing.T, contents string) {
+		t.Helper()
+		tmpFile, err := os.CreateTemp(t.TempDir(), "static_auth_test_*.json")
+		require.NoError(t, err)
+		_, err = tmpFile.WriteString(contents)
+		require.NoError(t, err)
+		require.NoError(t, tmpFile.Close())
+
+		credsFile = tmpFile.Name()
+		t.Cleanup(func() { credsFile = "" })
+	}
+
+	marshal := func(t *testing.T, entries []StaticAuthConfigEntry) string {
+		t.Helper()
+		data, err := json.Marshal(entries)
+		require.NoError(t, err)
+		return string(data)
+	}
+
+	t.Run("valid config file", func(t *testing.T) {
+		writeConfig(t, marshal(t, []StaticAuthConfigEntry{
+			{
+				Username:             "testuser",
+				SHA256HashedPassword: "13d249f2cb4127b40cfa757866850278793f814ded3c587fe5889e889a7a9f6c", // "testpass" as SHA256 hash
+			},
+			{
+				Username: "plainuser",
+				Password: "plainpass",
+			},
+		}))
+
+		plugin, err := staticAuthPluginInitializer()
+		require.NoError(t, err)
+
+		staticPlugin, ok := plugin.(*StaticAuthPlugin)
+		require.True(t, ok)
+		require.Len(t, staticPlugin.entries, 2)
+		assert.Equal(t, "testuser", staticPlugin.entries[0].Username)
+		assert.Len(t, staticPlugin.entries[0].sha256HashedPassword, 32)
+		assert.Equal(t, "plainuser", staticPlugin.entries[1].Username)
+		assert.Empty(t, staticPlugin.entries[1].sha256HashedPassword)
+	})
+
+	t.Run("missing file path", func(t *testing.T) {
+		credsFile = ""
+		t.Cleanup(func() { credsFile = "" })
+
+		_, err := staticAuthPluginInitializer()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "grpc-auth-static-password-file not provided")
+	})
+
+	t.Run("non-existent file", func(t *testing.T) {
+		credsFile = "/nonexistent/path/to/file.json"
+		t.Cleanup(func() { credsFile = "" })
+
+		_, err := staticAuthPluginInitializer()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to load static auth plugin")
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		writeConfig(t, "{invalid json")
+
+		_, err := staticAuthPluginInitializer()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "fail to load static auth plugin")
+	})
+
+	t.Run("invalid hash length", func(t *testing.T) {
+		writeConfig(t, marshal(t, []StaticAuthConfigEntry{
+			{
+				Username:             "testuser",
+				SHA256HashedPassword: "abcdef", // valid hex but not a SHA256 digest
+			},
+		}))
+
+		_, err := staticAuthPluginInitializer()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid SHA256HashedPassword length")
+	})
+
+	t.Run("invalid hex encoding", func(t *testing.T) {
+		writeConfig(t, marshal(t, []StaticAuthConfigEntry{
+			{
+				Username:             "testuser",
+				SHA256HashedPassword: strings.Repeat("z", 64), // 64 chars but invalid hex
+			},
+		}))
+
+		_, err := staticAuthPluginInitializer()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid hex-encoded SHA256HashedPassword")
+	})
+}

--- a/go/vt/servenv/grpc_server_auth_static_test.go
+++ b/go/vt/servenv/grpc_server_auth_static_test.go
@@ -72,16 +72,16 @@ func authenticate(t *testing.T, plugin *StaticAuthPlugin, username, password str
 // TestStaticAuthPlugin_Authenticate tests authentication against a credentials
 // file mixing plaintext and SHA256-hashed passwords.
 func TestStaticAuthPlugin_Authenticate(t *testing.T) {
-	// SHA256 hash of "password" is "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
-	// SHA256 hash of "secret123" is "fcf730b6d95236ecd3c9fc2d92d7b6b2bb061514961aec041d6c7a7192f592e4"
+	// SHA256(SHA256("password")) is "73641c99f7719f57d8f4beb11a303afcd190243a51ced8782ca6d3dbe014d146"
+	// SHA256(SHA256("secret123")) is "49bbd275dd4bfb1170ced93e839a8ec1d5b86eab6acb0842502130a31702390d"
 	plugin := newTestStaticAuthPlugin(t, []StaticAuthConfigEntry{
 		{
-			Username:             "user1",
-			SHA256HashedPassword: "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8", // "password" as SHA256 hash
+			Username:            "user1",
+			CachingSha2Password: "73641c99f7719f57d8f4beb11a303afcd190243a51ced8782ca6d3dbe014d146", // SHA256(SHA256("password"))
 		},
 		{
-			Username:             "user2",
-			SHA256HashedPassword: "fcf730b6d95236ecd3c9fc2d92d7b6b2bb061514961aec041d6c7a7192f592e4", // "secret123" as SHA256 hash
+			Username:            "user2",
+			CachingSha2Password: "49bbd275dd4bfb1170ced93e839a8ec1d5b86eab6acb0842502130a31702390d", // SHA256(SHA256("secret123"))
 		},
 		{
 			Username: "user3",
@@ -170,14 +170,30 @@ func TestStaticAuthPlugin_Authenticate(t *testing.T) {
 	}
 }
 
-// TestStaticAuthPlugin_UppercaseHash tests that a SHA256HashedPassword written
+// TestStaticAuthPlugin_UppercaseHash tests that a CachingSha2Password written
 // in uppercase (or mixed-case) hex still authenticates, since the hash is
 // hex-decoded at initialization rather than compared as a string.
 func TestStaticAuthPlugin_UppercaseHash(t *testing.T) {
 	plugin := newTestStaticAuthPlugin(t, []StaticAuthConfigEntry{
 		{
-			Username:             "user1",
-			SHA256HashedPassword: "5E884898DA28047151D0E56F8DC6292773603D0D6AABBDD62A11EF721D1542D8", // "password" as uppercase SHA256 hash
+			Username:            "user1",
+			CachingSha2Password: "73641C99F7719F57D8F4BEB11A303AFCD190243A51CED8782CA6D3DBE014D146", // uppercase SHA256(SHA256("password"))
+		},
+	})
+
+	newCtx, err := authenticate(t, plugin, "user1", "password")
+	require.NoError(t, err)
+	assert.Equal(t, "user1", StaticAuthUsernameFromContext(newCtx))
+}
+
+// TestStaticAuthPlugin_StarPrefixedHash tests that a CachingSha2Password with
+// the MySQL-style leading '*' authenticates, so values can be copied verbatim
+// from a MySQL static auth configuration.
+func TestStaticAuthPlugin_StarPrefixedHash(t *testing.T) {
+	plugin := newTestStaticAuthPlugin(t, []StaticAuthConfigEntry{
+		{
+			Username:            "user1",
+			CachingSha2Password: "*73641c99f7719f57d8f4beb11a303afcd190243a51ced8782ca6d3dbe014d146", // SHA256(SHA256("password"))
 		},
 	})
 
@@ -193,12 +209,12 @@ func TestStaticAuthPlugin_UppercaseHash(t *testing.T) {
 func TestStaticAuthPlugin_DuplicateUsernameEntries(t *testing.T) {
 	plugin := newTestStaticAuthPlugin(t, []StaticAuthConfigEntry{
 		{
-			Username:             "user1",
-			SHA256HashedPassword: "faa9ef1976a332ec21a17d4a88fb0cae8ce93743b3f8c69370161d6b38839898", // "first_password" as SHA256 hash
+			Username:            "user1",
+			CachingSha2Password: "1cb0d8e6f8975f4993ac48974d03a903bba80ed3ea94997ffc4e339c0f1e8b3d", // SHA256(SHA256("first_password"))
 		},
 		{
-			Username:             "user1",
-			SHA256HashedPassword: "900cc4a6adbb527ac2ef8ac8f4d92104a040befa1c46c21bb6bab09eb72fc565", // "second_password" as SHA256 hash
+			Username:            "user1",
+			CachingSha2Password: "064fb3be00bc3bcf9df547e3be390829e45710fca25966fb068798ae4ea5ff76", // SHA256(SHA256("second_password"))
 		},
 	})
 
@@ -242,14 +258,14 @@ func TestStaticAuthPlugin_DuplicateUsernameEntries(t *testing.T) {
 }
 
 // TestStaticAuthPlugin_PlaintextTakesPrecedence tests that when an entry has
-// both Password and SHA256HashedPassword set, the plaintext Password is used
+// both Password and CachingSha2Password set, the plaintext Password is used
 // and the SHA256 hash is ignored.
 func TestStaticAuthPlugin_PlaintextTakesPrecedence(t *testing.T) {
 	plugin := newTestStaticAuthPlugin(t, []StaticAuthConfigEntry{
 		{
-			Username:             "user1",
-			Password:             "plain_password",
-			SHA256HashedPassword: "b2867617492e26c338ab49f72afabc984d798b59755a27e312b953716ae964d7", // "hashed_password" as SHA256 hash
+			Username:            "user1",
+			Password:            "plain_password",
+			CachingSha2Password: "79cc80902b3f156439204d9c08f77f59a918fbbd302309e0844993d7c21c6da5", // SHA256(SHA256("hashed_password"))
 		},
 	})
 
@@ -337,7 +353,7 @@ func TestStaticAuthPlugin_MissingCredentials(t *testing.T) {
 
 // TestStaticAuthPluginInitializer tests the initialization and validation of
 // the static auth plugin credentials file, in particular the SHA256 hash
-// validation added for SHA256HashedPassword entries.
+// validation added for CachingSha2Password entries.
 func TestStaticAuthPluginInitializer(t *testing.T) {
 	writeConfig := func(t *testing.T, contents string) {
 		t.Helper()
@@ -361,8 +377,8 @@ func TestStaticAuthPluginInitializer(t *testing.T) {
 	t.Run("valid config file", func(t *testing.T) {
 		writeConfig(t, marshal(t, []StaticAuthConfigEntry{
 			{
-				Username:             "testuser",
-				SHA256HashedPassword: "13d249f2cb4127b40cfa757866850278793f814ded3c587fe5889e889a7a9f6c", // "testpass" as SHA256 hash
+				Username:            "testuser",
+				CachingSha2Password: "6cbfe567592500d58fdcc0e0bbeca784fbc53bd6159869df6cbeac0b6604d4e9", // SHA256(SHA256("testpass"))
 			},
 			{
 				Username: "plainuser",
@@ -377,9 +393,9 @@ func TestStaticAuthPluginInitializer(t *testing.T) {
 		require.True(t, ok)
 		require.Len(t, staticPlugin.entries, 2)
 		assert.Equal(t, "testuser", staticPlugin.entries[0].Username)
-		assert.Len(t, staticPlugin.entries[0].sha256HashedPassword, 32)
+		assert.Len(t, staticPlugin.entries[0].cachingSha2Password, 32)
 		assert.Equal(t, "plainuser", staticPlugin.entries[1].Username)
-		assert.Empty(t, staticPlugin.entries[1].sha256HashedPassword)
+		assert.Empty(t, staticPlugin.entries[1].cachingSha2Password)
 	})
 
 	t.Run("missing file path", func(t *testing.T) {
@@ -411,26 +427,26 @@ func TestStaticAuthPluginInitializer(t *testing.T) {
 	t.Run("invalid hash length", func(t *testing.T) {
 		writeConfig(t, marshal(t, []StaticAuthConfigEntry{
 			{
-				Username:             "testuser",
-				SHA256HashedPassword: "abcdef", // valid hex but not a SHA256 digest
+				Username:            "testuser",
+				CachingSha2Password: "abcdef", // valid hex but not a SHA256 digest
 			},
 		}))
 
 		_, err := staticAuthPluginInitializer()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid SHA256HashedPassword length")
+		assert.Contains(t, err.Error(), "invalid CachingSha2Password length")
 	})
 
 	t.Run("invalid hex encoding", func(t *testing.T) {
 		writeConfig(t, marshal(t, []StaticAuthConfigEntry{
 			{
-				Username:             "testuser",
-				SHA256HashedPassword: strings.Repeat("z", 64), // 64 chars but invalid hex
+				Username:            "testuser",
+				CachingSha2Password: strings.Repeat("z", 64), // 64 chars but invalid hex
 			},
 		}))
 
 		_, err := staticAuthPluginInitializer()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid hex-encoded SHA256HashedPassword")
+		assert.Contains(t, err.Error(), "invalid hex-encoded CachingSha2Password")
 	})
 }

--- a/go/vt/servenv/grpc_server_auth_static_test.go
+++ b/go/vt/servenv/grpc_server_auth_static_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -157,14 +156,14 @@ func TestStaticAuthPlugin_Authenticate(t *testing.T) {
 				require.Error(t, err)
 				st, ok := status.FromError(err)
 				require.True(t, ok, "error should be a gRPC status error")
-				assert.Equal(t, tt.expectedCode, st.Code())
-				assert.Contains(t, st.Message(), tt.expectedErrMsg)
+				require.Equal(t, tt.expectedCode, st.Code())
+				require.Contains(t, st.Message(), tt.expectedErrMsg)
 			} else {
 				require.NoError(t, err)
-				assert.NotNil(t, newCtx)
+				require.NotNil(t, newCtx)
 
 				// Verify username is stored in context
-				assert.Equal(t, tt.username, StaticAuthUsernameFromContext(newCtx))
+				require.Equal(t, tt.username, StaticAuthUsernameFromContext(newCtx))
 			}
 		})
 	}
@@ -183,7 +182,7 @@ func TestStaticAuthPlugin_UppercaseHash(t *testing.T) {
 
 	newCtx, err := authenticate(t, plugin, "user1", "password")
 	require.NoError(t, err)
-	assert.Equal(t, "user1", StaticAuthUsernameFromContext(newCtx))
+	require.Equal(t, "user1", StaticAuthUsernameFromContext(newCtx))
 }
 
 // TestStaticAuthPlugin_StarPrefixedHash tests that a CachingSha2Password with
@@ -199,7 +198,7 @@ func TestStaticAuthPlugin_StarPrefixedHash(t *testing.T) {
 
 	newCtx, err := authenticate(t, plugin, "user1", "password")
 	require.NoError(t, err)
-	assert.Equal(t, "user1", StaticAuthUsernameFromContext(newCtx))
+	require.Equal(t, "user1", StaticAuthUsernameFromContext(newCtx))
 }
 
 // TestStaticAuthPlugin_DuplicateUsernameEntries tests that when multiple
@@ -248,10 +247,10 @@ func TestStaticAuthPlugin_DuplicateUsernameEntries(t *testing.T) {
 				require.Error(t, err)
 				st, ok := status.FromError(err)
 				require.True(t, ok, "error should be a gRPC status error")
-				assert.Equal(t, codes.PermissionDenied, st.Code())
+				require.Equal(t, codes.PermissionDenied, st.Code())
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, "user1", StaticAuthUsernameFromContext(newCtx))
+				require.Equal(t, "user1", StaticAuthUsernameFromContext(newCtx))
 			}
 		})
 	}
@@ -272,7 +271,7 @@ func TestStaticAuthPlugin_PlaintextTakesPrecedence(t *testing.T) {
 	t.Run("plaintext password matches", func(t *testing.T) {
 		newCtx, err := authenticate(t, plugin, "user1", "plain_password")
 		require.NoError(t, err)
-		assert.Equal(t, "user1", StaticAuthUsernameFromContext(newCtx))
+		require.Equal(t, "user1", StaticAuthUsernameFromContext(newCtx))
 	})
 
 	t.Run("hashed password is ignored", func(t *testing.T) {
@@ -280,7 +279,7 @@ func TestStaticAuthPlugin_PlaintextTakesPrecedence(t *testing.T) {
 		require.Error(t, err)
 		st, ok := status.FromError(err)
 		require.True(t, ok, "error should be a gRPC status error")
-		assert.Equal(t, codes.PermissionDenied, st.Code())
+		require.Equal(t, codes.PermissionDenied, st.Code())
 	})
 }
 
@@ -299,8 +298,8 @@ func TestStaticAuthPlugin_NoMetadata(t *testing.T) {
 	require.Error(t, err)
 	st, ok := status.FromError(err)
 	require.True(t, ok)
-	assert.Equal(t, codes.Unauthenticated, st.Code())
-	assert.Contains(t, st.Message(), "username and password must be provided")
+	require.Equal(t, codes.Unauthenticated, st.Code())
+	require.Contains(t, st.Message(), "username and password must be provided")
 }
 
 // TestStaticAuthPlugin_MissingCredentials tests that authentication fails with
@@ -345,8 +344,8 @@ func TestStaticAuthPlugin_MissingCredentials(t *testing.T) {
 			require.Error(t, err)
 			st, ok := status.FromError(err)
 			require.True(t, ok)
-			assert.Equal(t, codes.Unauthenticated, st.Code())
-			assert.Contains(t, st.Message(), "username and password must be provided")
+			require.Equal(t, codes.Unauthenticated, st.Code())
+			require.Contains(t, st.Message(), "username and password must be provided")
 		})
 	}
 }
@@ -392,10 +391,10 @@ func TestStaticAuthPluginInitializer(t *testing.T) {
 		staticPlugin, ok := plugin.(*StaticAuthPlugin)
 		require.True(t, ok)
 		require.Len(t, staticPlugin.entries, 2)
-		assert.Equal(t, "testuser", staticPlugin.entries[0].Username)
-		assert.Len(t, staticPlugin.entries[0].cachingSha2Password, 32)
-		assert.Equal(t, "plainuser", staticPlugin.entries[1].Username)
-		assert.Empty(t, staticPlugin.entries[1].cachingSha2Password)
+		require.Equal(t, "testuser", staticPlugin.entries[0].Username)
+		require.Len(t, staticPlugin.entries[0].cachingSha2Password, 32)
+		require.Equal(t, "plainuser", staticPlugin.entries[1].Username)
+		require.Empty(t, staticPlugin.entries[1].cachingSha2Password)
 	})
 
 	t.Run("missing file path", func(t *testing.T) {
@@ -404,7 +403,7 @@ func TestStaticAuthPluginInitializer(t *testing.T) {
 
 		_, err := staticAuthPluginInitializer()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "grpc-auth-static-password-file not provided")
+		require.Contains(t, err.Error(), "grpc-auth-static-password-file not provided")
 	})
 
 	t.Run("non-existent file", func(t *testing.T) {
@@ -413,7 +412,7 @@ func TestStaticAuthPluginInitializer(t *testing.T) {
 
 		_, err := staticAuthPluginInitializer()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to load static auth plugin")
+		require.Contains(t, err.Error(), "failed to load static auth plugin")
 	})
 
 	t.Run("invalid json", func(t *testing.T) {
@@ -421,7 +420,7 @@ func TestStaticAuthPluginInitializer(t *testing.T) {
 
 		_, err := staticAuthPluginInitializer()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "fail to load static auth plugin")
+		require.Contains(t, err.Error(), "fail to load static auth plugin")
 	})
 
 	t.Run("invalid hash length", func(t *testing.T) {
@@ -434,7 +433,7 @@ func TestStaticAuthPluginInitializer(t *testing.T) {
 
 		_, err := staticAuthPluginInitializer()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid CachingSha2Password length")
+		require.Contains(t, err.Error(), "invalid CachingSha2Password length")
 	})
 
 	t.Run("invalid hex encoding", func(t *testing.T) {
@@ -447,6 +446,6 @@ func TestStaticAuthPluginInitializer(t *testing.T) {
 
 		_, err := staticAuthPluginInitializer()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid hex-encoded CachingSha2Password")
+		require.Contains(t, err.Error(), "invalid hex-encoded CachingSha2Password")
 	})
 }


### PR DESCRIPTION
## Description

Fixes #20516

This PR started as a separate sha1 auth plugin, but following the feedback (thanks @dbussink, @timvaillancourt, SHA1 is a no-go for anything security-related), I reworked it entirely: instead of adding a new plugin, the existing `static` plugin now supports hashed passwords.

`StaticAuthConfigEntry` gets an optional `CachingSha2Password` field holding the hex-encoded `SHA256(SHA256(password))`, with an optional leading `*`, the exact same format as the `CachingSha2Password` field of the MySQL protocol's static auth server (`go/mysql/auth_server_static.go`). That's deliberate: it means the same stored credential value can authenticate a user on both the MySQL and gRPC endpoints, and operators who already manage `caching_sha2_password`-style hashes can copy them verbatim. The double hash is also the safer value to keep on disk: on the MySQL side it can verify a login but can't be replayed to produce one.

A credentials file can mix plaintext and hashed entries:

```json
[
  {"Username": "user1", "Password": "plaintext_password"},
  {"Username": "user2", "CachingSha2Password": "*49bbd275dd4bfb1170ced93e839a8ec1d5b86eab6acb0842502130a31702390d"}
]
```

The hash is validated and hex-decoded once at startup (reusing `mysql.DecodePasswordHex`), and compared in constant time against the double SHA256 of the incoming password. No new plugin, no new flags.

On the overhead question: the auth interceptor runs on every RPC (connection pooling doesn't amortize it), but hashing is cheap enough not to matter:

```
benchmark                                     old ns/op     new ns/op     delta
BenchmarkStaticAuthPlugin_Authenticate-14     215           309           +43.72%
```

~90ns and zero extra allocations per RPC, i.e. ~0.003% of a 3ms query.

The `grpc_api` e2e tests now use a mix of hashed and plaintext credentials, so both paths are exercised without a new test cluster.
