### PR TITLE
[release-23.0] Bump to `v23.0.2-SNAPSHOT` after the `v23.0.1` release

### DIFF
--- a/go/vt/servenv/version.go
+++ b/go/vt/servenv/version.go
@@ -19,4 +19,4 @@ package servenv
 // DO NOT EDIT
 // THIS FILE IS AUTO-GENERATED DURING NEW RELEASES BY THE VITESS-RELEASER
 
-const versionName = "23.0.1"
+const versionName = "23.0.2-SNAPSHOT"

--- a/java/client/pom.xml
+++ b/java/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>23.0.1</version>
+    <version>23.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>vitess-client</artifactId>
   <name>Vitess Java Client</name>

--- a/java/example/pom.xml
+++ b/java/example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>23.0.1</version>
+    <version>23.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>vitess-example</artifactId>
   <name>Vitess Java Client Example</name>

--- a/java/grpc-client/pom.xml
+++ b/java/grpc-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>23.0.1</version>
+    <version>23.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>vitess-grpc-client</artifactId>
   <name>Vitess gRPC Client</name>

--- a/java/jdbc/pom.xml
+++ b/java/jdbc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>23.0.1</version>
+    <version>23.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>vitess-jdbc</artifactId>
   <name>Vitess JDBC Driver</name>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>io.vitess</groupId>
   <artifactId>vitess-parent</artifactId>
-  <version>23.0.1</version>
+  <version>23.0.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Vitess Java Client libraries [Parent]</name>


### PR DESCRIPTION
Includes the changes required to go back into dev mode (v23.0.2-SNAPSHOT) after the release of v23.0.1.