### PR TITLE
Fix go upgrade tool

### DIFF
--- a/go/tools/go-upgrade/go-upgrade.go
+++ b/go/tools/go-upgrade/go-upgrade.go
@@ -358,7 +358,6 @@ func replaceGoVersionInCodebase(old, new *version.Version) error {
 		return nil
 	}
 	explore := []string{
-		"./test/templates",
 		"./build.env",
 		"./docker/bootstrap/Dockerfile.common",
 		"./docker/lite/Dockerfile",
@@ -439,7 +438,6 @@ func updateBootstrapVersionInCodebase(old, new string, newGoVersion *version.Ver
 	}
 	files, err := getListOfFilesInPaths([]string{
 		"./Makefile",
-		"./test/templates",
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Fixes the go upgrade tool by removing the `test/templates` directory from the list of directories/files to update. Those test templates were removed when the workflows were consolidated into one in https://github.com/vitessio/vitess/pull/19259.

Backporting as the previous PR is in the process of being backported as well.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
