### PR TITLE
Add lite image build CI job

### DIFF
--- a/.github/workflows/docker_lite_build_check.yml
+++ b/.github/workflows/docker_lite_build_check.yml
@@ -1,0 +1,68 @@
+name: Docker Lite Build Check
+
+on:
+  pull_request:
+    branches: '**'
+  push:
+    branches:
+      - "main"
+      - "release-[0-9]+.[0-9]"
+
+permissions: read-all
+
+jobs:
+  generate-matrix:
+    name: Generate matrix
+    runs-on: ubuntu-24.04
+    outputs:
+      dockerfiles: ${{ steps.generate-matrix.outputs.dockerfiles }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: 'false'
+
+      - name: Generate matrix
+        id: generate-matrix
+        run: |
+          dockerfiles=$(ls docker/lite/Dockerfile* | jq -Rnc '[inputs]')
+          echo "dockerfiles=${dockerfiles}" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.dockerfile }}
+    runs-on: ubuntu-24.04
+    needs: generate-matrix
+
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile: ${{ fromJson(needs.generate-matrix.outputs.dockerfiles) }}
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1
+        with:
+          egress-policy: audit
+
+      - name: Skip CI
+        run: |
+          if [[ "${{contains( github.event.pull_request.labels.*.name, 'Skip CI')}}" == "true" ]]; then
+            echo "skipping CI due to the 'Skip CI' label"
+            exit 1
+          fi
+
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: 'false'
+
+      - name: Build lite image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: false
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.dockerfile }}
+      cancel-in-progress: true


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Adds a job that builds all the lite Docker images. This should be added as a required check on PRs so that merging is blocked until the build is successful.

This should be backported to release branches and added as a required check as well, to prevent broken images there as well (as we've seen before).
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
