### PR TITLE
`ci`: stop installing `etcd` twice in some workflows, skip `protoc`

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -68,19 +68,15 @@ jobs:
         export DEBIAN_FRONTEND="noninteractive"
         sudo apt-get update
 
-        sudo apt-get install -y make unzip g++ curl git wget ant openjdk-11-jdk
-
-        mkdir -p dist bin
-        curl --max-time 10 --retry 3 --retry-max-time 45 -s -L https://github.com/coreos/etcd/releases/download/v3.5.25/etcd-v3.5.25-linux-amd64.tar.gz | tar -zxC dist
-        mv dist/etcd-v3.5.25-linux-amd64/{etcd,etcdctl} bin/
+        sudo apt-get install -y make unzip g++ curl git wget
 
         go mod download
         go install golang.org/x/tools/cmd/goimports@034e59c473362f8f2be47694d98fd3f12a1ad497 # v0.39.0
-        
+
     - name: Run make tools
       if: steps.changes.outputs.changed_files == 'true'
       run: |
-        make tools
+        make BUILD_PROTOC=0 tools
 
     - name: Run unit tests and generate code coverage reports
       if: steps.changes.outputs.changed_files == 'true'

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -132,17 +132,13 @@ jobs:
           export DEBIAN_FRONTEND="noninteractive"
           sudo apt-get install -y make unzip g++ curl git wget ant openjdk-11-jdk
 
-          mkdir -p dist bin
-          curl --max-time 10 --retry 3 --retry-max-time 45 -s -L https://github.com/coreos/etcd/releases/download/v3.5.25/etcd-v3.5.25-linux-amd64.tar.gz | tar -zxC dist
-          mv dist/etcd-v3.5.25-linux-amd64/{etcd,etcdctl} bin/
-
           go mod download
           go install golang.org/x/tools/cmd/goimports@v0.39.0
 
       - name: Run make tools
         if: steps.changes.outputs.unit_tests == 'true'
         run: |
-          make tools
+          make BUILD_PROTOC=0 tools
 
       - name: Setup launchable dependencies
         if: |

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,6 +25,7 @@ source ./dev.env
 
 BUILD_JAVA=${BUILD_JAVA:-1}
 BUILD_CONSUL=${BUILD_CONSUL:-1}
+BUILD_PROTOC=${BUILD_PROTOC:-1}
 
 VITESS_RESOURCES_DOWNLOAD_BASE_URL="https://github.com/vitessio/vitess-resources/releases/download"
 VITESS_RESOURCES_RELEASE="v4.0"
@@ -308,7 +309,9 @@ install_all() {
 	echo "##local system details..."
 	echo "##platform: $(uname) target:$(get_arch) OS: $OSTYPE"
 	# protoc
-	install_dep "protoc" "$PROTOC_VER" "$VTROOT/dist/vt-protoc-$PROTOC_VER" install_protoc
+	if [ "$BUILD_PROTOC" == 1 ]; then
+		install_dep "protoc" "$PROTOC_VER" "$VTROOT/dist/vt-protoc-$PROTOC_VER" install_protoc
+	fi
 
 	# zk
 	if [ "$BUILD_JAVA" == 1 ]; then


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR moves `etcd` stops installing `etcd` twice in some workflows. If a workflow uses `make tools`, it's already installing `etcd`. The 2 x workflows updated in this PR run `make tools` 👍 

Example:
```bash
Run make tools
Sun Feb 8 23:52:57 UTC 2026: Installing dependencies
##local system details...
##platform: Linux target:x86_64 OS: linux-gnu
<<< Installing protoc 21.3 >>>
OK: SHA256 checksum verified for protoc-21.3-linux-x86_64.zip
Archive:  protoc-21.3-linux-x86_64.zip
  inflating: bin/protoc              
  inflating: include/google/protobuf/any.proto  
  inflating: include/google/protobuf/api.proto  
  inflating: include/google/protobuf/compiler/plugin.proto  
  inflating: include/google/protobuf/descriptor.proto  
  inflating: include/google/protobuf/duration.proto  
  inflating: include/google/protobuf/empty.proto  
  inflating: include/google/protobuf/field_mask.proto  
  inflating: include/google/protobuf/source_context.proto  
  inflating: include/google/protobuf/struct.proto  
  inflating: include/google/protobuf/timestamp.proto  
  inflating: include/google/protobuf/type.proto  
  inflating: include/google/protobuf/wrappers.proto  
  inflating: readme.txt              
<<< Installing Zookeeper 3.9.4 >>>
OK: SHA512 checksum verified for /home/ubuntu/_work/vitess/vitess/dist/vt-zookeeper-3.9.4/apache-zookeeper-3.9.4-bin.tar.gz
<<< Installing etcd v3.6.7 >>>
OK: SHA256 checksum verified for etcd-v3.6.7-linux-amd64.tar.gz
<<< Installing Consul 1.11.4 >>>
OK: SHA256 checksum verified for consul_1.11.4_linux_amd64.zip
Archive:  consul_1.11.4_linux_amd64.zip
  inflating: consul                  
bootstrap finished - run 'make build' to compile
```

As a side effect, the version of etcd is synchronised _(we use 3.6.x now)_

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
