### PR TITLE
Add flag for cells to watch to VTOrc

### DIFF
--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -26,6 +26,7 @@ Flags:
       --bind-address string                                         Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --catch-sigpipe                                               catch and ignore SIGPIPE on stdout and stderr if specified
       --cell string                                                 cell to use (required in v25+)
+      --cells-to-watch strings                                      Comma-separated list of cells that this instance will monitor and repair. Defaults to all cells in the topology. Example: "cell1,cell2"
       --change-tablets-with-errant-gtid-to-drained                  Whether VTOrc should be changing the type of tablets with errant GTIDs to DRAINED
       --clusters-to-watch strings                                   Comma-separated list of keyspaces or keyspace/keyranges that this instance will monitor and repair. Defaults to all clusters in the topology. Example: "ks1,ks2/-80"
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Add a `--cells-to-watch` flag to VTOrc that allows operators to restrict tablet discovery to a specified set of cells. When set, VTOrc will only fetch and monitor tablets in the listed cells. When unset, existing behavior of watching all cells is preserved. Works in combination with `--clusters-to-watch` — when both flags are set, a tablet must match both the cell and keyspace/shard filters to be monitored.

  Cell filtering is applied at three levels for defense in depth:
  1. `refreshTabletsUsing` — filters the cell list before fetching tablets from topo, avoiding unnecessary topo calls entirely
  2. `refreshTabletsInKeyspaceShard` — applies `shouldWatchTablet` filter before passing tablets to `refreshTablets`
  3. `shouldWatchTablet` — checks cell membership in addition to the existing keyspace/shard checks, so both entry points share the same filtering logic

We tested this change at HubSpot on Vitess v22 and request a backport to that version for us to use

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes https://github.com/vitessio/vitess/issues/19353

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

New optional flag `--cells-to-watch` added to VTOrc. No migration needed. No behavior change when flag is unset.

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->

This PR was primarily written by Claude Code and reviewed by humans.  
