### PR TITLE
Docker: Add percona84 to the docker build images workflow

### DIFF
--- a/.github/workflows/docker_build_images.yml
+++ b/.github/workflows/docker_build_images.yml
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        branch: [ latest, mysql80, mysql84, percona80 ]
+        branch: [ latest, mysql80, mysql84, percona80, percona84 ]
 
     steps:
       - name: Check out code


### PR DESCRIPTION
## Description

This is a follow-up to https://github.com/vitessio/vitess/pull/18950

We now leverage that Dockerfile to build and publish Percona Server for MySQL 8.4 container images.

## Related Issue(s)

  - https://github.com/vitessio/vitess/pull/18950
 
## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required