### PR TITLE
Add info schema regression test case

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -1269,5 +1269,25 @@
         "Query": "select c.`column_name` from (select `table_name` from information_schema.`tables` where table_schema != 'information_schema' limit 1) as `tables`, information_schema.`columns` as c where `tables`.`table_name` = c.`table_name`"
       }
     }
+  },
+  {
+    "comment": "equality predicate on table_schema with LIMIT inside derived table",
+    "query": "SELECT c.column_name, c.data_type, c.table_name, c.table_schema, c.is_nullable FROM information_schema.columns c JOIN ( SELECT table_name FROM information_schema.tables WHERE table_schema = 'ks' LIMIT 1000 ) tables ON tables.table_name = c.table_name ORDER BY c.table_name",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "SELECT c.column_name, c.data_type, c.table_name, c.table_schema, c.is_nullable FROM information_schema.columns c JOIN ( SELECT table_name FROM information_schema.tables WHERE table_schema = 'ks' LIMIT 1000 ) tables ON tables.table_name = c.table_name ORDER BY c.table_name",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select c.`column_name`, c.data_type, c.`table_name`, c.table_schema, c.is_nullable from (select `table_name` from information_schema.`tables` where 1 != 1) as `tables`, information_schema.`columns` as c where 1 != 1",
+        "Query": "select c.`column_name`, c.data_type, c.`table_name`, c.table_schema, c.is_nullable from (select `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ limit 1000) as `tables`, information_schema.`columns` as c where `tables`.`table_name` = c.`table_name` order by c.`table_name` asc",
+        "SysTableTableSchema": "['ks']"
+      }
+    }
   }
 ]


### PR DESCRIPTION

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
From https://github.com/vitessio/vitess/pull/17877 through until https://github.com/vitessio/vitess/pull/18974 inadvertently fixed it, a query like this:

```sql
select c.column_name, c.data_type, c.table_name, c.table_schema, c.is_nullable
from information_schema.columns c
join (
  select table_name
  from information_schema.tables
  where table_schema = ?
  limit ?
) tables on tables.table_name = c.table_name
order by c.table_name
```

Would fail with:

```
vttablet: rpc error: code = InvalidArgument desc = missing bind var __vtschemaname
```

This adds a test case for it so that any future regressions are caught earlier.
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
