### PR TITLE
Backport to v23: Support Go 1.26 and later with Swiss maps always enabled (#19088)

### DIFF
--- a/go/hack/ensure_swiss_map.go
+++ b/go/hack/ensure_swiss_map.go
@@ -1,4 +1,4 @@
-//go:build !goexperiment.swissmap
+//go:build !goexperiment.swissmap && !go1.26
 
 /*
 Copyright (c) 2009 The Go Authors. All rights reserved.
@@ -32,7 +32,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // This is invalid Go code, and it will fail to compile if you disable
 // Swiss maps when building Vitess. Our runtime memory accounting system
-// expects the map implementation in Go 1.24 to be Swiss.
+// expects the map implementation in Go 1.24 and 1.25 to be Swiss.
+// In Go 1.26 and later, Swiss maps are always enabled.
 
 package hack
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Backport changes from https://github.com/vitessio/vitess/pull/19088/changes so consumers of vitess.io/vitess/go/vt/vitessdriver can update their applications to Go 1.26.

## Related Issue(s)

- Related: https://github.com/vitessio/vitess/pull/19088/changes
- Fixes: https://github.com/vitessio/vitess/issues/19087#issuecomment-3888896699

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

No AI was used, it's just a simple cherry-pick of an existing commit

```
git cherry-pick 28105fd7ba9defbda6f5827734f1cfa1b5c2b1c4
```
