### PR TITLE
fix: replace deprecated maven-badges.herokuapp.com with maven-badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.vitess/vitess-jdbc/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.vitess/vitess-jdbc)
+[![Maven Central](https://maven-badges.sml.io/maven-central/io.vitess/vitess-jdbc/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.vitess/vitess-jdbc)
 [![Coverage Status](https://codecov.io/gh/vitessio/vitess/branch/main/graph/badge.svg)](https://app.codecov.io/gh/vitessio/vitess/tree/main)
 [![Go Report Card](https://goreportcard.com/badge/vitess.io/vitess)](https://goreportcard.com/report/vitess.io/vitess)
 [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B162%2Fvitess.svg?type=shield&issueType=license)](https://app.fossa.com/projects/custom%2B162%2Fvitess?ref=badge_shield&issueType=license)


### PR DESCRIPTION
## Description

The Maven Central badge in the README was broken because `maven-badges.herokuapp.com` has been officially deprecated and migrated to `maven-badges.sml.io` by the maintainers ([[softwaremill/maven-badges](https://github.com/softwaremill/maven-badges)](https://github.com/softwaremill/maven-badges)). The old Heroku instance is defunct, causing the badge to fail to render.

**Before:**
<img width="600" alt="Before fix - Maven Central badge broken" src="https://github.com/user-attachments/assets/f2499d97-c0b4-4907-8490-2266384b8a31" />

**After:**
<img width="600" alt="After fix - Maven Central badge rendering correctly" src="https://github.com/user-attachments/assets/7d618a27-fcde-450e-b69a-8fe8b096dd70" />

## Related Issue(s)

No related issue — minor README badge fix.

## Checklist
- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [ ] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

No deployment impact. README-only change.

### AI Disclosure

This PR was not written by AI.