### PR TITLE
Fix TestSelectScatterPartialOLAP data race

### DIFF
--- a/go/vt/vtgate/tx_conn.go
+++ b/go/vt/vtgate/tx_conn.go
@@ -415,7 +415,7 @@ func (txc *TxConn) Rollback(ctx context.Context, session *econtext.SafeSession) 
 	}
 	defer session.ResetTx()
 
-	allsessions := session.GetShardSessionsForCleanup()
+	allsessions := session.ShardSessionsForCleanup()
 
 	err := txc.runSessions(ctx, allsessions, session.GetLogger(), func(ctx context.Context, s *vtgatepb.Session_ShardSession, logging *econtext.ExecuteLogger) error {
 		if s.TransactionId == 0 {
@@ -450,7 +450,7 @@ func (txc *TxConn) Release(ctx context.Context, session *econtext.SafeSession) e
 	}
 	defer session.Reset()
 
-	allsessions := session.GetShardSessionsForCleanup()
+	allsessions := session.ShardSessionsForCleanup()
 
 	return txc.runSessions(ctx, allsessions, session.GetLogger(), func(ctx context.Context, s *vtgatepb.Session_ShardSession, logging *econtext.ExecuteLogger) error {
 		if s.ReservedId == 0 && s.TransactionId == 0 {
@@ -496,7 +496,7 @@ func (txc *TxConn) ReleaseAll(ctx context.Context, session *econtext.SafeSession
 	}
 	defer session.ResetAll()
 
-	allsessions := session.GetShardSessionsForReleaseAll()
+	allsessions := session.ShardSessionsForReleaseAll()
 
 	return txc.runSessions(ctx, allsessions, session.GetLogger(), func(ctx context.Context, s *vtgatepb.Session_ShardSession, loggging *econtext.ExecuteLogger) error {
 		if s.ReservedId == 0 && s.TransactionId == 0 {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
-->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR fixes a potential race condition in vtgate where multiple goroutines may access or mutate `PreSessions`, `ShardSessions`, and `PostSessions` concurrently during `Rollback`, `Release`, or `ReleaseAll`.  

Previously, these flows directly iterated over session slice fields without taking a stable snapshot. If another goroutine modified those slices at the same time, it could lead to a data race.  

This change introduces safe snapshot helpers on `SafeSession` and updates the relevant call sites to use them, ensuring that Rollback, Release, and ReleaseAll work on a stable copy of the session slices.  

The race was detected in the unit test `TestSelectScatterPartialOLAP`, which would occasionally fail with `-race` enabled.

## Related Issue(s)

Fixes #18996

## BEFORE

<img width="1982" height="784" alt="image" src="https://github.com/user-attachments/assets/c790a1f2-b2bc-4a7b-9025-4d08f85bc114" />

## AFTER 

<img width="580" height="665" alt="Screenshot 2026-02-15 at 4 00 11 PM" src="https://github.com/user-attachments/assets/110898dd-b920-47c2-a584-45efc5eed358" />

## To Reproduce
### Reproduction Steps

To reproduce the race condition in `TestSelectScatterPartialOLAP`, run the test multiple times with the race detector enabled:

```bash
source dev.env
go clean -testcache
cnt=0
while [[ $cnt -lt 200 ]]; do
  echo "Run $cnt"
  go test -count=1 -race -timeout 30s \
    -run ^TestSelectScatterPartialOLAP$ \
    vitess.io/vitess/go/vt/vtgate || break
  cnt=$((cnt+1))
done
```



## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
Used grep command to trace the function calls and map out the flow, then manually patched the logic (kept it simple since it's a small change.) 
