### PR TITLE
Create e2e tests AI skill

### DIFF
--- a/.claude/skills/e2e-tests/SKILL.md
+++ b/.claude/skills/e2e-tests/SKILL.md
@@ -26,7 +26,7 @@ Always rebuild after code changes so tests run against up-to-date binaries.
 
 ```bash
 source build.env
-go test -run TestName -v -count=1 -timeout 10m ./go/test/endtoend/<test-dir>/...
+go test -count=1 -timeout 10m -run ^TestName$ vitess.io/vitess/go/test/endtoend/<pkg>
 ```
 
 Use `-timeout` generously. End-to-end tests start entire clusters (etcd, MySQL, vttablet, vtgate) and can take minutes. Default 10m is safe for most tests. `-count=1` disables caching, which is essential since these tests have side effects.
@@ -34,7 +34,7 @@ Use `-timeout` generously. End-to-end tests start entire clusters (etcd, MySQL, 
 To run a specific subtest:
 
 ```bash
-go test -run TestParent/SubTest -v -count=1 -timeout 10m ./go/test/endtoend/<test-dir>/...
+go test -count=1 -timeout 10m -run ^TestParent/SubTest$ vitess.io/vitess/go/test/endtoend/<pkg>
 ```
 
 ## VTDATAROOT
@@ -75,7 +75,7 @@ Look for `*-stderr.txt` files and glog files (`*.INFO`, `*.WARNING`, `*.ERROR`).
 Stale data in `VTDATAROOT` causes test failures: port conflicts, leftover MySQL data, stale socket files. Clear it between runs:
 
 ```bash
-rm -rf $VTDATAROOT/*
+rm -rf $VTDATAROOT/vtroot_*
 ```
 
 Do this before re-running tests that failed, especially if the previous run did not tear down cleanly (crash, timeout, ctrl-c).
@@ -86,7 +86,7 @@ Each end-to-end test package starts a `cluster.LocalProcessCluster` (topo, vtctl
 
 ## Debugging failures
 
-1. Clear VTDATAROOT: `rm -rf $VTDATAROOT/*`
+1. Clear VTDATAROOT: `rm -rf $VTDATAROOT/vtroot_*`
 2. Rebuild binaries: `make build`
 3. Run the failing test with `-v`
 4. On failure, read logs from `$VTDATAROOT/vtroot_*/tmp_*/`


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Creates an [AI skill](https://agentskills.io/home) for running and debugging end-to-end tests. In my experience, AI struggles knowing how to run them, not realizing it needs to rebuild binaries, or not knowing where it should look for logs (it's just like me!). This creates a skill under `.claude/skills`, which most CLIs should support (`.agents` is the agent-agnostic directory, but Claude Code (annoyingly) does not support it).
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
