### PR TITLE
Lint only changed packages

### DIFF
--- a/misc/git/hooks/lint-fmt
+++ b/misc/git/hooks/lint-fmt
@@ -24,15 +24,15 @@ version_greater_or_equal() {
   local ver2=($2)
 
   # Fill empty fields in ver1 with zeros
-  for ((i=${#ver1[@]}; i<${#ver2[@]}; i++)); do
+  for ((i = ${#ver1[@]}; i < ${#ver2[@]}; i++)); do
     ver1[i]=0
   done
   # Fill empty fields in ver2 with zeros
-  for ((i=${#ver2[@]}; i<${#ver1[@]}; i++)); do
+  for ((i = ${#ver2[@]}; i < ${#ver1[@]}; i++)); do
     ver2[i]=0
   done
 
-  for ((i=0; i<${#ver1[@]}; i++)); do
+  for ((i = 0; i < ${#ver1[@]}; i++)); do
     if ((10#${ver1[i]} > 10#${ver2[i]})); then
       return 0
     elif ((10#${ver1[i]} < 10#${ver2[i]})); then
@@ -56,6 +56,16 @@ else
   fi
 fi
 
-# Lint only new issues in staged changes
+# Lint only changed packages.
+changed_pkgs=$(git diff --cached --name-only --diff-filter=ACM -- '*.go' \
+  | xargs -n1 dirname \
+  | sort -u \
+  | sed 's|$|/...|')
+
+if [ -z "$changed_pkgs" ]; then
+  echo "No staged .go files, skipping lint."
+  exit 0
+fi
+
 echo "Linting staged changes..."
-golangci-lint run --new-from-rev=HEAD
+golangci-lint run --new-from-rev=HEAD "$changed_pkgs"


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
When I added `golangci-lint --new-from-rev=HEAD`, I had misunderstood that it would only build/type-check packages that have changed since `HEAD`. I don't believe that's the case; it'll check _everything_, but only _output_ those from new changes. That's why we've seen excruciatingly long linting times since.

This adds back the logic that finds only the Go packages that have changed, and runs linting only on those.

Apologies for the wasted time!
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
