### PR TITLE
Fix golangci-lint changed package arg 

### DIFF
--- a/misc/git/hooks/lint-fmt
+++ b/misc/git/hooks/lint-fmt
@@ -68,4 +68,4 @@ if [ -z "$changed_pkgs" ]; then
 fi
 
 echo "Linting staged changes..."
-golangci-lint run --new-from-rev=HEAD "$changed_pkgs"
+golangci-lint run --new-from-rev=HEAD $changed_pkgs


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Quoting the changed packages would pass the package list as one single string (separated by newlines), which would break golangci-lint. Leaving it unquoted now passes each package as a separate argument. I tested the initial PR with only one package so this issue did not reveal itself initially 😞 .

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
