### PR TITLE
`CLAUDE.md`: required code is formatted by `goimports`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,7 +259,7 @@ func TestProcessor_ImprovedBehavior(t *testing.T) {
 - You may read git state: `git status`, `git log`, `git diff`, `git branch --show-current`
 - You may NOT: `git commit`, `git add`, `git reset`, `git checkout`, `git restore`, `git rebase`, `git push`, etc.
 - **ONLY commit when explicitly asked to commit**
-- Always sign git commits with the --signoff flag
+- Always sign git commits with the `git commit --signoff` flag
 - When asked to commit, do it once and stop
 - Only I can modify git state unless you've been given explicit permission to commit
 
@@ -334,7 +334,8 @@ Me: "Now let's optimize without breaking functionality"
 Before considering any work "done":
 - [ ] Tests pass and cover the feature
 - [ ] Code is clean and readable
-    - [ ] Code passes the `gofumpt` formatter
+    - [ ] Golang code passes the `gofumpt` formatter
+    - [ ] Golang code passes the `goimports -local "vitess.io/vitess" -w ...` formatter
 - [ ] Edge cases are handled
 - [ ] Performance is acceptable
 - [ ] Documentation is updated if needed


### PR DESCRIPTION
## Description

This PR ensures `CLAUDE.md` reflects the requirement for code to pass the `goimports` formatter, with our project-specific flags/config

Claude can currently generate code that fails this formatter. It manages to fix this but it wastes cycles 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
