### PR TITLE
test: Add missing unit tests in `vtgate/cli`

### DIFF
--- a/go/cmd/vtgate/cli/cli_test.go
+++ b/go/cmd/vtgate/cli/cli_test.go
@@ -95,13 +95,13 @@ func TestMainCommandMetadata(t *testing.T) {
 // GetKnownCells, and memorytopo doesn't give us that.
 
 func TestCheckCellFlags_NilServer(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	err := CheckCellFlags(ctx, nil, "c1", "c1")
 	require.ErrorContains(t, err, "topo server cannot be nil") // nil server should be rejected
 }
 
 func TestCheckCellFlags_GetTopoServerError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	passthrough := srvtopotest.NewPassthroughSrvTopoServer()
 	passthrough.TopoServerError = errors.New("topo unreachable")
 
@@ -111,7 +111,7 @@ func TestCheckCellFlags_GetTopoServerError(t *testing.T) {
 }
 
 func TestCheckCellFlags_GetKnownCellsError(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ts := memorytopo.NewServer(ctx, "c1")
 	defer ts.Close()
 	fake := &fakesrvtopo.FakeSrvTopo{Ts: ts}
@@ -124,7 +124,7 @@ func TestCheckCellFlags_GetKnownCellsError(t *testing.T) {
 }
 
 func TestCheckCellFlags_EmptyCell(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ts := memorytopo.NewServer(ctx, "c1")
 	defer ts.Close()
 	fake := &fakesrvtopo.FakeSrvTopo{Ts: ts}
@@ -134,7 +134,7 @@ func TestCheckCellFlags_EmptyCell(t *testing.T) {
 }
 
 func TestCheckCellFlags_CellNotInTopo(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ts := memorytopo.NewServer(ctx, "c1")
 	defer ts.Close()
 	fake := &fakesrvtopo.FakeSrvTopo{Ts: ts}
@@ -145,7 +145,7 @@ func TestCheckCellFlags_CellNotInTopo(t *testing.T) {
 }
 
 func TestCheckCellFlags_CellsToWatchInvalidCell(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ts := memorytopo.NewServer(ctx, "c1")
 	defer ts.Close()
 	fake := &fakesrvtopo.FakeSrvTopo{Ts: ts}
@@ -156,7 +156,7 @@ func TestCheckCellFlags_CellsToWatchInvalidCell(t *testing.T) {
 }
 
 func TestCheckCellFlags_CellsToWatchEmpty(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ts := memorytopo.NewServer(ctx, "c1")
 	defer ts.Close()
 	fake := &fakesrvtopo.FakeSrvTopo{Ts: ts}
@@ -166,7 +166,7 @@ func TestCheckCellFlags_CellsToWatchEmpty(t *testing.T) {
 }
 
 func TestCheckCellFlags_CellsToWatchEmptyAfterSplit(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ts := memorytopo.NewServer(ctx, "c1")
 	defer ts.Close()
 	fake := &fakesrvtopo.FakeSrvTopo{Ts: ts}
@@ -176,7 +176,7 @@ func TestCheckCellFlags_CellsToWatchEmptyAfterSplit(t *testing.T) {
 }
 
 func TestCheckCellFlags_Success(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ts := memorytopo.NewServer(ctx, "c1", "c2")
 	defer ts.Close()
 	fake := &fakesrvtopo.FakeSrvTopo{Ts: ts}
@@ -186,7 +186,7 @@ func TestCheckCellFlags_Success(t *testing.T) {
 }
 
 func TestCheckCellFlags_SuccessMultipleCells(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ts := memorytopo.NewServer(ctx, "c1", "c2")
 	defer ts.Close()
 	fake := &fakesrvtopo.FakeSrvTopo{Ts: ts}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR adds the missing unit tests for vtgate CLI (`go/cmd/vtgate/cli`)

**Test command:**
```bash
cd go/cmd/vtgate/cli
go test ./... -race -count=1 -coverprofile=coverage.out -covermode=atomic
```
**Result:**
<img width="964" height="98" alt="Screenshot 2026-02-22 at 1 28 47 PM" src="https://github.com/user-attachments/assets/eb5dc2b5-2391-4536-a38b-41c3fcc20412" />


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes part of #14931

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->