### PR TITLE
fix(vtexplain): case-sensitive COMMENT check for sequence tables

### DIFF
--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -437,7 +437,7 @@ func newTabletEnvironment(ddls []sqlparser.DDLStatement, opts *Options, collatio
 		spec := ddl.GetTableSpec()
 		if spec != nil {
 			for _, option := range spec.Options {
-				if option.Name == "comment" && string(option.Value.Val) == "vitess_sequence" {
+				if strings.EqualFold(option.Name, "comment") && string(option.Value.Val) == "vitess_sequence" {
 					options = "vitess_sequence"
 				}
 			}

--- a/go/vt/vtexplain/vtexplain_vttablet_test.go
+++ b/go/vt/vtexplain/vtexplain_vttablet_test.go
@@ -117,6 +117,13 @@ create table t1_seq(
   primary key(id)
 ) comment 'vitess_sequence';
 
+create table t2_seq(
+  id int,
+  next_id bigint,
+  cache bigint,
+  primary key(id)
+) COMMENT 'vitess_sequence';
+
 create table test_partitioned (
 	id bigint,
 	date_create int,
@@ -191,6 +198,10 @@ create table test_partitioned (
 	seq := tables["t1_seq"]
 	require.NotNil(t, seq)
 	assert.Equal(t, schema.Sequence, seq.Type)
+
+	seq2 := tables["t2_seq"]
+	require.NotNil(t, seq2)
+	assert.Equal(t, schema.Sequence, seq2.Type)
 }
 
 func TestErrParseSchema(t *testing.T) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Fixes a bug where vtexplain fails to recognize `vitess_sequence` tables when the DDL uses uppercase `COMMENT` (e.g., `COMMENT 'vitess_sequence'`).

The AST parser preserves the original casing of table options, but the check in vtexplain used a case-sensitive comparison (`option.Name == "comment"`). Changed to `strings.EqualFold` so any casing works.

## Changes
- Use `strings.EqualFold` for the comment option name check in `vtexplain_vttablet.go`
- Added a test case with uppercase `COMMENT` to verify the fix


## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes #14941

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->




Tests written by Claude.