### PR TITLE
Normalize the --on-ddl param for MoveTables

### DIFF
--- a/go/cmd/vtctldclient/command/vreplication/common/utils.go
+++ b/go/cmd/vtctldclient/command/vreplication/common/utils.go
@@ -192,9 +192,11 @@ func ParseTableMaterializeSettings(tableSettings string, parser *sqlparser.Parse
 }
 
 func validateOnDDL(cmd *cobra.Command) error {
-	if _, ok := binlogdatapb.OnDDLAction_value[strings.ToUpper(CreateOptions.OnDDL)]; !ok {
+	normalized := strings.ToUpper(CreateOptions.OnDDL)
+	if _, ok := binlogdatapb.OnDDLAction_value[normalized]; !ok {
 		return fmt.Errorf("invalid on-ddl value: %s", CreateOptions.OnDDL)
 	}
+	CreateOptions.OnDDL = normalized
 	return nil
 }
 

--- a/go/cmd/vtctldclient/command/vreplication/common/utils_test.go
+++ b/go/cmd/vtctldclient/command/vreplication/common/utils_test.go
@@ -116,6 +116,48 @@ func TestParseAndValidateCreateOptions(t *testing.T) {
 				require.Equal(t, cells, common.CreateOptions.Cells)
 			},
 		},
+		{
+			name: "invalid on-ddl value",
+			setFunc: func(cmd *cobra.Command) error {
+				onDDLFlag := cmd.Flags().Lookup("on-ddl")
+				if err := onDDLFlag.Value.Set("INVALID"); err != nil {
+					return err
+				}
+				onDDLFlag.Changed = true
+				return nil
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid on-ddl normalizes to uppercase",
+			setFunc: func(cmd *cobra.Command) error {
+				onDDLFlag := cmd.Flags().Lookup("on-ddl")
+				if err := onDDLFlag.Value.Set("exec"); err != nil {
+					return err
+				}
+				onDDLFlag.Changed = true
+				return nil
+			},
+			wantErr: false,
+			checkFunc: func() {
+				require.Equal(t, "EXEC", common.CreateOptions.OnDDL)
+			},
+		},
+		{
+			name: "valid on-ddl EXEC_IGNORE",
+			setFunc: func(cmd *cobra.Command) error {
+				onDDLFlag := cmd.Flags().Lookup("on-ddl")
+				if err := onDDLFlag.Value.Set("exec_ignore"); err != nil {
+					return err
+				}
+				onDDLFlag.Changed = true
+				return nil
+			},
+			wantErr: false,
+			checkFunc: func() {
+				require.Equal(t, "EXEC_IGNORE", common.CreateOptions.OnDDL)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Currently, for the  `MoveTables` command, the `--on-ddl` param takes only uppercase option names like `EXEC_IGNORE`. The command doesn't throw errors on lowercase names, nor does it actually apply the option. Option names like `exec_ignore` will fail silently.

e.g. `MoveTables create --workflow myworkflow --source-keyspace src --target-keyspae tgt --tables mytable --on-ddl exec`
For this command, no error will be thrown and the `--on-ddl` param is ignored silently

This PR converts lowercase option names to uppercase after they are validated

>[!NOTE]
> We should backport this as it's a bug with a very small and safe change.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

 - Fixes: https://github.com/vitessio/vitess/issues/19446

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
