### PR TITLE
Add rerun failed jobs workflow

### DIFF
--- a/.github/workflows/rerun_failed_jobs.yml
+++ b/.github/workflows/rerun_failed_jobs.yml
@@ -17,6 +17,9 @@ concurrency:
   group: rerun-failed-jobs
   cancel-in-progress: false
 
+env:
+  BASE_BRANCHES: "main, release-*"
+
 jobs:
   rerun:
     runs-on: ubuntu-latest
@@ -45,6 +48,17 @@ jobs:
             const MAX_PR_AGE_DAYS = 5;
             const MAX_ALLOWED_FAILURES = 10;
             const MAX_PRS = 20;
+
+            // Parse base branch patterns from env. Supports exact names
+            // and trailing wildcards (e.g. "release-*").
+            const baseBranchPatterns = (process.env.BASE_BRANCHES || 'main')
+              .split(',')
+              .map(s => s.trim())
+              .filter(Boolean)
+              .map(p => p.endsWith('*')
+                ? new RegExp(`^${p.slice(0, -1)}`)
+                : new RegExp(`^${p}$`)
+              );
 
             const ignoreWorkflows = (process.env.IGNORE_WORKFLOWS || '')
               .split(',')
@@ -94,6 +108,7 @@ jobs:
             rule();
             console.log('');
             info(`Repository:           ${BOLD}${owner}/${repo}${RESET}`);
+            info(`Base branches:        ${BOLD}${process.env.BASE_BRANCHES}${RESET}`);
             info(`Max retries:          ${BOLD}${MAX_RETRIES}${RESET}`);
             info(`Max PR age:           ${BOLD}${MAX_PR_AGE_DAYS} days${RESET}`);
             info(`Max allowed failures: ${BOLD}${MAX_ALLOWED_FAILURES}${RESET}`);
@@ -116,12 +131,16 @@ jobs:
               per_page: 100,
             });
 
+            debug(`${allPRs.length} open PR(s) fetched`);
+
             const prs = allPRs
+              .filter(pr => baseBranchPatterns.some(p => p.test(pr.base.ref)))
               .filter(pr => new Date(pr.updated_at) >= cutoff)
               .slice(0, MAX_PRS);
 
             info(`Found ${BOLD}${prs.length}${RESET} eligible open PR(s)`);
             debug(`PR numbers: ${prs.map(pr => pr.number).join(', ')}`);
+            debug(`Skipped ${allPRs.length - prs.length} PR(s) (wrong base branch or too old)`);
             console.log('');
 
             // -----------------------------------------------------------


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Adds a rerun failed jobs workflow, instead of relying on the old method of a cron job running somewhere with someone's personal token. The thought behind this is so that it's easier to maintain and validate when it's working, and importantly, when it's not working.

This currently ports the functionality 1-to-1, which is that it runs on a 10-minute schedule. There is room for improvement here, which is to rely on the GitHub actions `workflow_run` trigger, which is triggered on workflow run completion, which can be quicker but might be less flexible.

The only way to really test this is to merge it first, then run `workflow_dispatch` runs and iterate on it that way.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->

Help from Claude Opus 4.6.
