### PR TITLE
vtorc: use syscall.Dup3 instead of Dup2 in test

### DIFF
--- a/go/vt/vtorc/logic/topology_recovery_test.go
+++ b/go/vt/vtorc/logic/topology_recovery_test.go
@@ -680,7 +680,7 @@ func TestRecoverIncapacitatedPrimary(t *testing.T) {
 				require.NoError(t, err)
 				oldFD, err := syscall.Dup(int(os.Stderr.Fd()))
 				require.NoError(t, err)
-				require.NoError(t, syscall.Dup2(int(w.Fd()), int(os.Stderr.Fd())))
+				require.NoError(t, syscall.Dup3(int(w.Fd()), int(os.Stderr.Fd()), 0))
 				os.Stderr = w
 				done := make(chan struct{})
 				go func() {
@@ -692,7 +692,7 @@ func TestRecoverIncapacitatedPrimary(t *testing.T) {
 					log.Flush()
 					_ = w.Close()
 					os.Stderr = oldStderr
-					_ = syscall.Dup2(oldFD, int(os.Stderr.Fd()))
+					_ = syscall.Dup3(oldFD, int(os.Stderr.Fd()), 0)
 					_ = syscall.Close(oldFD)
 					<-done
 				}


### PR DESCRIPTION
## Description

Replaces `syscall.Dup2` with `syscall.Dup3` in `TestRecoverIncapacitatedPrimary`. `Dup2` isn't available on linux/arm64 since the kernel only exposes `dup3` on that architecture. `Dup3` with `flags=0` is equivalent and works on all Linux architectures.

## Related Issue(s)

N/A

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [ ] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

This PR was written primarily by Claude Code — I just provided direction.