### PR TITLE
`backupengine`: disallow path traversals via backup `MANIFEST` on restore

### DIFF
--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -30,13 +30,13 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/spf13/pflag"
 	"golang.org/x/sync/errgroup"
 
+	"vitess.io/vitess/go/fileutil"
 	"vitess.io/vitess/go/ioutil"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/replication"
@@ -200,14 +200,7 @@ func (fe *FileEntry) fullPath(cnf *Mycnf) (string, error) {
 		return "", vterrors.Errorf(vtrpcpb.Code_UNKNOWN, "unknown base: %v", fe.Base)
 	}
 
-	baseDir := filepath.Clean(path.Join(fe.ParentPath, root))
-	resolved := filepath.Clean(path.Join(baseDir, fe.Name))
-
-	if !strings.HasPrefix(resolved, baseDir+string(filepath.Separator)) && resolved != baseDir {
-		return "", vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "path traversal not allowed: name %q escapes base directory %q", fe.Name, baseDir)
-	}
-
-	return resolved, nil
+	return fileutil.SafePathJoin(path.Join(fe.ParentPath, root), fe.Name)
 }
 
 // open attempts to open the file


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR addresses a [GHSA-8g8j-r87h-p36x](https://github.com/vitessio/vitess/security/advisories/GHSA-8g8j-r87h-p36x) where it is possible for an attacker with access to the backup storage to cause files to be restored outside of the intended backup path(s), via a directory traversal

How? In the backup `MANIFEST` there is a `FileEntries` array/list/slice representing files to restore. In this structure is a `Name` string field we trust to be the place to restore the files. If a user adds `../..`s to these paths, the backup engine will trust this on restore and construct a path that traverses the intended base path

This PR updates this code to validate that the paths we build from the `Name` field do not escape the parent/base directory they are meant to restore to. These 4 x base paths are known and on a typical install are:
1. `$VTDATAROOT/vt_0000000100/data`
2. `$VTDATAROOT/vt_0000000100/innodb/data`
3. `$VTDATAROOT/vt_0000000100/innodb/logs`
4. `$VTDATAROOT/vt_0000000100/bin-logs`

## Related Issue(s)

https://github.com/vitessio/vitess/security/advisories/GHSA-8g8j-r87h-p36x

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

Claude w/Opus 4.6 wrote the tests and reviewed the changes I made
