### PR TITLE
vtgate: Add bounds check in `visitUnion` for mismatched column counts

### DIFF
--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -941,6 +941,9 @@ func TestInvalidQueries(t *testing.T) {
 		err:  &UnionWithSQLCalcFoundRowsError{},
 		serr: "VT12001: unsupported: SQL_CALC_FOUND_ROWS not supported with union",
 	}, {
+		sql: "select 1 union select *, m from t1",
+		err: &UnionColumnsDoNotMatchError{FirstProj: 1, SecondProj: 2},
+	}, {
 		sql:  "select * from (select sql_calc_found_rows id from a) as t",
 		serr: "Incorrect usage/placement of 'SQL_CALC_FOUND_ROWS'",
 	}, {

--- a/go/vt/vtgate/semantics/table_collector.go
+++ b/go/vt/vtgate/semantics/table_collector.go
@@ -175,6 +175,9 @@ func (tc *tableCollector) visitUnion(union *sqlparser.Union) error {
 
 	err = sqlparser.VisitAllSelects(union, func(s *sqlparser.Select, idx int) error {
 		for i, expr := range s.GetColumns() {
+			if i >= size {
+				return &UnionColumnsDoNotMatchError{FirstProj: size, SecondProj: len(s.GetColumns())}
+			}
 			ae, ok := expr.(*sqlparser.AliasedExpr)
 			if !ok {
 				continue


### PR DESCRIPTION
## Description

When a `UNION` has `SELECT`s with different column counts after star expansion (e.g. `SELECT 1 UNION SELECT *, m FROM t1`), `visitUnion` in `table_collector.go` allocates arrays sized to the first `SELECT`'s column count, then iterates all `SELECT`s including ones with more columns, causing an out-of-bounds slice access.

This adds a bounds check that returns a `UnionColumnsDoNotMatchError` instead.

## Related Issue(s)

N/A

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [ ] Documentation was added or is not required

## Deployment Notes

N/A

### AI Disclosure

Most of this PR was written by Claude Code.