### PR TITLE
`filebackupstorage`: use `fileutil.SafePathJoin` for all path building

### DIFF
--- a/go/vt/mysqlctl/filebackupstorage/file.go
+++ b/go/vt/mysqlctl/filebackupstorage/file.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 
 	"github.com/spf13/pflag"
 
@@ -98,7 +97,10 @@ func (fbh *FileBackupHandle) AddFile(ctx context.Context, filename string, files
 	if fbh.readOnly {
 		return nil, errors.New("AddFile cannot be called on read-only backup")
 	}
-	p := path.Join(FileBackupStorageRoot, fbh.dir, fbh.name, filename)
+	p, err := fileutil.SafePathJoin(FileBackupStorageRoot, fbh.dir, fbh.name, filename)
+	if err != nil {
+		return nil, err
+	}
 	f, err := os2.Create(p)
 	if err != nil {
 		return nil, err
@@ -190,7 +192,10 @@ func (fbs *FileBackupStorage) StartBackup(ctx context.Context, dir, name string)
 	}
 
 	// Create the subdirectory for this named backup.
-	p = path.Join(p, name)
+	p, err = fileutil.SafePathJoin(p, name)
+	if err != nil {
+		return nil, err
+	}
 	if err = os2.Mkdir(p); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

This PR ensures all file-path construction in `filebackupstorage` uses `fileutil.SafePathJoin` that prevents path traversal

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
