### PR TITLE
`e2e`: fix race in `TestFailingReplication`

### DIFF
--- a/go/test/endtoend/backup/vtbackup/backup_only_test.go
+++ b/go/test/endtoend/backup/vtbackup/backup_only_test.go
@@ -132,6 +132,11 @@ func prepareCluster(t *testing.T) {
 
 	// Restore the Tablet
 	restore(t, primary, "replica", "NOT_SERVING")
+	// restore() returns as soon as the vttablet's HTTP endpoint is responsive,
+	// but RestoreData runs in the background and holds the actionSema for the
+	// entire duration of the restore. We need to wait for it to finish before
+	// issuing RPCs like SetWritable that also need the actionSema.
+	waitForRestoreComplete(t, primary.VttabletProcess, 180*time.Second)
 	// Vitess expects that the user has set the database into ReadWrite mode before calling
 	// TabletExternallyReparented
 	err = localCluster.VtctldClientProcess.ExecuteCommand(
@@ -345,6 +350,28 @@ func restore(t *testing.T, tablet *cluster.Vttablet, tabletType string, waitForS
 	tablet.VttabletProcess.SupportsBackup = true
 	err := tablet.VttabletProcess.Setup()
 	require.NoError(t, err)
+}
+
+// waitForRestoreComplete waits for a vttablet's background restore to finish.
+// The tablet type transitions replica -> restore -> replica during a restore.
+// This function polls until it observes "restore" and then sees "replica" again.
+// If the restore completes faster than the polling interval and "restore" is
+// never observed, the function returns since the restore is already done.
+func waitForRestoreComplete(t *testing.T, vttablet *cluster.VttabletProcess, timeout time.Duration) {
+	t.Helper()
+	sawRestore := false
+	assert.Eventually(t, func() bool {
+		tabletType := vttablet.GetTabletType()
+		if tabletType == "restore" {
+			sawRestore = true
+		}
+		return sawRestore && tabletType == "replica"
+	}, timeout, 300*time.Millisecond)
+	if sawRestore {
+		require.Equal(t, "replica", vttablet.GetTabletType(), "timed out waiting for tablet restore to complete")
+	}
+	// If we never observed "restore" type, the restore likely completed
+	// before we started polling. Nothing to wait for.
 }
 
 func resetTabletDirectory(t *testing.T, tablet cluster.Vttablet, initMysql bool) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR fixes a race condition in the `vtbackup` e2e test that causes `TestFailingReplication` (and other tests using `prepareCluster()`) to hang in CI.

## The problem

`prepareCluster()` calls `restore()`, which returns as soon as the vttablet HTTP endpoint responds. But `RestoreData` continues running in the background holding the `actionSema` — a weight-1 semaphore. The next call, `SetWritable`, also needs the `actionSema`, so it blocks waiting for the restore to finish.

This race has always existed on all branches, but became a consistent failure on `main` and `release-23.0` because MySQL 8.4 restores take longer than MySQL 8.0, widening the race window enough that `SetWritable` fires before `RestoreData` completes. In CI this causes a 19+ minute hang followed by a timeout.

## The fix

Adds a `waitForRestoreComplete()` helper between `restore()` and `SetWritable` that polls the tablet type via `/debug/vars`, waiting for the `replica → restore → replica` transition that signals `RestoreData` has finished and released the semaphore.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

Fix found by Claude while debugging flakiness on PR https://github.com/vitessio/vitess/pull/19472