### PR TITLE
Fix vexplain trace row count deserialization in OLAP mode

### DIFF
--- a/go/vt/vtgate/engine/plan_description.go
+++ b/go/vt/vtgate/engine/plan_description.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 
@@ -165,9 +166,12 @@ func PrimitiveDescriptionFromMap(data map[string]any) (pd PrimitiveDescription, 
 		pd.InputName = inpName.(string)
 	}
 	if avgRows, isPresent := data["AvgNumberOfRows"]; isPresent {
-		pd.RowsReceived = RowsReceived{
-			int(avgRows.(float64)),
+		noOfCalls := 1
+		if n, ok := data["NoOfCalls"]; ok {
+			noOfCalls = int(n.(float64))
 		}
+		totalRows := int(math.Round(avgRows.(float64) * float64(noOfCalls)))
+		pd.RowsReceived = RowsReceived{totalRows}
 	}
 	if sq, isPresent := data["ShardsQueried"]; isPresent {
 		sq := int(sq.(float64))

--- a/go/vt/vtgate/engine/plan_description_test.go
+++ b/go/vt/vtgate/engine/plan_description_test.go
@@ -19,6 +19,9 @@ package engine
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 
@@ -86,6 +89,63 @@ func TestPlanDescriptionWithInputs(t *testing.T) {
 	}
 
 	utils.MustMatch(t, expected, planDescription, "descriptions did not match")
+}
+
+// TestPrimitiveDescriptionFromMapRowsReceived verifies that RowsReceived is
+// reconstructed from the lossy JSON form (NoOfCalls + AvgNumberOfRows) without
+// truncating the total row count, including the streaming-mode case where the
+// average is fractional (e.g. RowsReceived [0, 1] -> AvgNumberOfRows 0.5).
+func TestPrimitiveDescriptionFromMapRowsReceived(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]any
+		want RowsReceived
+	}{
+		{
+			name: "streaming fractional average rounds to total",
+			in: map[string]any{
+				"NoOfCalls":       float64(2),
+				"AvgNumberOfRows": float64(0.5),
+			},
+			want: RowsReceived{1},
+		},
+		{
+			name: "single call preserves count",
+			in: map[string]any{
+				"NoOfCalls":       float64(1),
+				"AvgNumberOfRows": float64(5),
+			},
+			want: RowsReceived{5},
+		},
+		{
+			name: "missing NoOfCalls falls back to single call",
+			in: map[string]any{
+				"AvgNumberOfRows": float64(7),
+			},
+			want: RowsReceived{7},
+		},
+		{
+			name: "missing AvgNumberOfRows leaves RowsReceived unset",
+			in:   map[string]any{},
+			want: nil,
+		},
+		{
+			name: "non-trivial average across multiple calls",
+			in: map[string]any{
+				"NoOfCalls":       float64(3),
+				"AvgNumberOfRows": float64(2.6666666666666665), // (3+2+3)/3
+			},
+			want: RowsReceived{8},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pd, err := PrimitiveDescriptionFromMap(tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, pd.RowsReceived)
+		})
+	}
 }
 
 func getDescriptionFor(route *Route) PrimitiveDescription {


### PR DESCRIPTION
## Description

Fixes incorrect `RowsReceived` deserialization in `PrimitiveDescriptionFromMap` that caused `TestE2ECases` plan test failures when the default workload is OLAP (streaming).

The initial assessment in the linked issue suggested the test assertions themselves were wrong, but the actual root cause is a lossy deserialization in the `vexplain trace` output parsing.

In streaming mode, the trace callback is invoked multiple times (e.g. fields with 0 rows, then data rows), producing `RowsReceived` like `[0, 1]`. The JSON serialization stores this as `AvgNumberOfRows: 0.5`, but `PrimitiveDescriptionFromMap` reconstructed it as `int(0.5) = 0`, truncating the fractional part and losing the row count entirely. The fix computes `totalRows = round(AvgNumberOfRows * NoOfCalls)` to correctly recover the total.

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/19567

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [ ] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

This PR was authored by Claude Code with direction from @z-bhoy.