### PR TITLE
fix: update teardown script reference in examples README

### DIFF
--- a/examples/local/README.md
+++ b/examples/local/README.md
@@ -53,5 +53,5 @@ vtctldclient Reshard --workflow cust2cust --target-keyspace customer complete
 vtctldclient DeleteShards --force --recursive customer/0
 
 # Down cluster
-./401_teardown.sh
+./501_teardown.sh
 ```


### PR DESCRIPTION
## What's this?

`examples/local/README.md` still references `./401_teardown.sh`, which was renamed to `./501_teardown.sh` in #16893.

## Changes

One-line fix: `./401_teardown.sh` → `./501_teardown.sh` in the example commands.

Related: vitessio/website#2081 (same fix for the website docs)