### PR TITLE
planbuilder: handle comparison of two subqueries in WHERE clause

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/ast_to_op.go
+++ b/go/vt/vtgate/planbuilder/operators/ast_to_op.go
@@ -87,6 +87,13 @@ func addWherePredsToSubQueryBuilder(ctx *plancontext.PlanningContext, in sqlpars
 	for _, expr := range sqlparser.SplitAndExpression(nil, in) {
 		sqlparser.RemoveKeyspaceInCol(expr)
 		expr = simplifyPredicates(ctx, expr)
+
+		if newExpr := sqc.pullOutBothSubqueriesComparison(ctx, expr, outerID); newExpr != nil {
+			op = op.AddPredicate(ctx, newExpr)
+			addColumnEquality(ctx, newExpr)
+			continue
+		}
+
 		subq := sqc.handleSubquery(ctx, expr, outerID)
 		if subq != nil {
 			continue

--- a/go/vt/vtgate/planbuilder/operators/subquery_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_builder.go
@@ -18,6 +18,7 @@ package operators
 
 import (
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine/opcode"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 	"vitess.io/vitess/go/vt/vtgate/semantics"
@@ -347,7 +348,7 @@ func createComparisonSubQuery(
 ) *SubQuery {
 	subq, outside := semantics.GetSubqueryAndOtherSide(parent)
 	if outside == nil || subq != subFromOutside {
-		panic("uh oh")
+		panic(vterrors.VT12001("comparison of two subqueries"))
 	}
 
 	filterType := opcode.PulloutValue

--- a/go/vt/vtgate/planbuilder/operators/subquery_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_builder.go
@@ -273,6 +273,12 @@ func (sqb *SubQueryBuilder) inspectWhere(
 	}
 	for _, predicate := range sqlparser.SplitAndExpression(nil, in.Expr) {
 		sqlparser.RemoveKeyspaceInCol(predicate)
+
+		if newExpr := sqb.pullOutBothSubqueriesComparison(ctx, predicate, sqb.totalID); newExpr != nil {
+			jpc.inspectPredicate(ctx, newExpr)
+			continue
+		}
+
 		subq := sqb.handleSubquery(ctx, predicate, sqb.totalID)
 		if subq != nil {
 			continue
@@ -365,6 +371,23 @@ func createComparisonSubQuery(
 	}
 
 	return subquery
+}
+
+// pullOutBothSubqueriesComparison handles comparisons where both sides are subqueries (e.g. subq1 <= subq2).
+// It pulls out each subquery as a separate argument and returns the rewritten expression, or nil if not applicable.
+// IN and NOT IN are excluded because they require different pullout opcodes for left and right sides.
+func (sqb *SubQueryBuilder) pullOutBothSubqueriesComparison(ctx *plancontext.PlanningContext, expr sqlparser.Expr, outerID semantics.TableSet) sqlparser.Expr {
+	cmp, ok := expr.(*sqlparser.ComparisonExpr)
+	if !ok {
+		return nil
+	}
+	_, leftIsSubq := cmp.Left.(*sqlparser.Subquery)
+	_, rightIsSubq := cmp.Right.(*sqlparser.Subquery)
+	if !leftIsSubq || !rightIsSubq || cmp.Operator == sqlparser.InOp || cmp.Operator == sqlparser.NotInOp {
+		return nil
+	}
+	newExpr, _ := sqb.pullOutValueSubqueries(ctx, expr, outerID, true)
+	return newExpr
 }
 
 // pullOutValueSubqueries extracts all subqueries from an expression and replaces them with arguments.

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -860,6 +860,87 @@
     "skip_e2e": true
   },
   {
+    "comment": "comparing subquery with subquery",
+    "query": "select (select count(*) from user_extra) > (select count(*) from user)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select (select count(*) from user_extra) > (select count(*) from user)",
+      "Instructions": {
+        "OperatorType": "UncorrelatedSubquery",
+        "Variant": "PulloutValue",
+        "PulloutVars": [
+          "__sq2"
+        ],
+        "Inputs": [
+          {
+            "InputName": "SubQuery",
+            "OperatorType": "Aggregate",
+            "Variant": "Scalar",
+            "Aggregates": "sum_count_star(0) AS count(*)",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select count(*) from `user` where 1 != 1",
+                "Query": "select count(*) from `user`"
+              }
+            ]
+          },
+          {
+            "InputName": "Outer",
+            "OperatorType": "UncorrelatedSubquery",
+            "Variant": "PulloutValue",
+            "PulloutVars": [
+              "__sq1"
+            ],
+            "Inputs": [
+              {
+                "InputName": "SubQuery",
+                "OperatorType": "Aggregate",
+                "Variant": "Scalar",
+                "Aggregates": "sum_count_star(0) AS count(*)",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select count(*) from user_extra where 1 != 1",
+                    "Query": "select count(*) from user_extra"
+                  }
+                ]
+              },
+              {
+                "InputName": "Outer",
+                "OperatorType": "Route",
+                "Variant": "Reference",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select :__sq1 /* INT64 */ > :__sq2 /* INT64 */ as `(select count(*) from user_extra) > (select count(*) from ``user``)` from dual where 1 != 1",
+                "Query": "select :__sq1 /* INT64 */ > :__sq2 /* INT64 */ as `(select count(*) from user_extra) > (select count(*) from ``user``)` from dual"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.dual",
+        "user.user",
+        "user.user_extra"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
     "comment": "Jumbled references",
     "query": "select user.col, user_extra.id, user.col2 from user join user_extra",
     "plan": {


### PR DESCRIPTION
## Description
Allow the planner to handle subqueries on both sides of a comparison.

## Related Issue(s)
Fixes #19540

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

### AI Disclosure

Opus 4.6 was here.