### PR TITLE
OnlineDDL: always close lock connection

### DIFF
--- a/go/vt/vttablet/onlineddl/executor.go
+++ b/go/vt/vttablet/onlineddl/executor.go
@@ -894,7 +894,11 @@ func (e *Executor) cutOverVReplMigration(ctx context.Context, s *VReplStream, sh
 		// Always attempt UNLOCK TABLES first, as it releases locks immediately on this
 		// connection. Then kill the connection as a fallback to guarantee any held locks
 		// are released, even if UNLOCK TABLES were to fail.
-		lockConn.Conn.Exec(ctx, sqlUnlockTables, 1, false)
+		unlockCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, err := lockConn.Conn.Exec(unlockCtx, sqlUnlockTables, 1, false); err != nil {
+			log.Warn(fmt.Sprintf("Failed to UNLOCK TABLES in OnlineDDL migration %s: %v", onlineDDL.UUID, err))
+		}
 		if err := lockConn.Conn.Kill("closing lock tables connection", 0); err != nil {
 			log.Warn(fmt.Sprintf("Failed to kill lock tables connection in OnlineDDL migration %s: %v", onlineDDL.UUID, err))
 		}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR causes the OnlineDDL executor to close the lock-connection on unsuccessful cut-over, the same way the rename-connection handless this: by calling `.Conn.Kill(...)`. This leads to a connection close.

Currently, if `UNLOCK TABLES` is unsuccessful the lock connection can be returned to the pool, holding the `LOCK TABLES` open for the `wait_timeout` _(default 8 hours)_ while blocking traffic

~~To add defence in depth, a `wait_timeout` is set on the session, similar to `github/gh-ost`. This is reverted to the global default after. `initConnectionLockWaitTimeout(...)` was generalised into `initConnectionSessionTimeout(...)` so both wait-timeout vars can reuse the same logic~~

Finally the `defer` block of `renameConn` was consolidated to make the ordering more clear, and to be more consistent with `lockConn`

### Backport Reason

Orphaned `LOCK TABLES` is a production risk

## Related Issue(s)

Resolves: https://github.com/vitessio/vitess/issues/19588

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->