### PR TITLE
Fire vttablet_restore_done hook from RestoreFromBackup RPC path

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_backup.go
+++ b/go/vt/vttablet/tabletmanager/rpc_backup.go
@@ -207,7 +207,9 @@ func (tm *TabletManager) RestoreFromBackup(ctx context.Context, logger logutil.L
 	l := logutil.NewTeeLogger(logutil.NewConsoleLogger(), logger)
 
 	// Now we can run restore.
-	_, err = tm.restoreBackupLocked(ctx, l, 0 /* waitForBackupInterval */, true /* deleteBeforeRestore */, request, mysqlShutdownTimeout)
+	startTime := time.Now()
+	backupEngine, err := tm.restoreBackupLocked(ctx, l, 0 /* waitForBackupInterval */, true /* deleteBeforeRestore */, request, mysqlShutdownTimeout)
+	tm.invokeRestoreDoneHook(startTime, err, backupEngine)
 
 	// Re-run health check to be sure to capture any replication delay.
 	tm.QueryServiceControl.BroadcastHealth()


### PR DESCRIPTION
## Description

  The `vttablet_restore_done` hook is currently only invoked from the `RestoreBackup` (startup) and `restoreFromClone` paths, but not from the
  `RestoreFromBackup` RPC handler. This means restores triggered via `vtctldclient RestoreFromBackup` never fire the hook.

  This is a follow-up to #19405 which added backup engine information to the hook.

  ### Changes

  Add `invokeRestoreDoneHook` call to `RestoreFromBackup` in `rpc_backup.go`, matching the pattern already used in `RestoreBackup` and
  `restoreFromClone`.

  ### Test plan

  - Trigger a restore via `vtctldclient RestoreFromBackup` and verify the `vttablet_restore_done` hook is executed (visible in vttablet logs)
  - Verify the hook receives correct env vars: `TM_RESTORE_DATA_START_TS`, `TM_RESTORE_DATA_STOP_TS`, `TM_RESTORE_DATA_DURATION`,
  `TM_RESTORE_DATA_BACKUP_ENGINE`
<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes #19593, follow-up from #19416

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
This PR was written primarily by Claude Code