### PR TITLE
Unify PKE selection semantics across schemadiff consumers

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -19,6 +19,7 @@
 - **[Minor Changes](#minor-changes)**
     - **[VReplication](#minor-changes-vreplication)**
         - [Default data protection for `_reverse` workflow cancel/complete](#vreplication-reverse-workflow-data-protection)
+        - [Unified Primary Key Equivalent (PKE) selection](#vreplication-unified-pke-selection)
     - **[VTGate](#minor-changes-vtgate)**
         - [Ingress bytes in query LogStats](#vtgate-logstats-ingress-bytes)
         - [New controls for cross-keyspace reads](#vtgate-cross-keyspace-reads)
@@ -152,6 +153,8 @@ Both compatibility behaviors will be removed in v26, along with the `SelectStrea
 
 ## <a id="minor-changes"/>Minor Changes</a>
 
+### <a id="minor-changes-vreplication"/>VReplication</a>
+
 #### <a id="vreplication-reverse-workflow-data-protection"/>Default data protection for `_reverse` workflow cancel/complete</a>
 
 When calling `cancel` or `complete` on an auto-generated `_reverse` workflow without explicitly providing `--keep-data=false`, the system now defaults to keeping data and returns a warning. This prevents accidental deletion of production tables on the original source side, where the `_reverse` workflow's target is actually your production keyspace.
@@ -167,6 +170,20 @@ When calling `cancel` or `complete` on an auto-generated `_reverse` workflow wit
 The `--keep-data` flag help text has been updated to note this default explicitly. This change applies to MoveTables, Reshard, and other VReplication workflow types that use the shared cancel/complete paths.
 
 See [#19906](https://github.com/vitessio/vitess/pull/19906) for details.
+
+#### <a id="vreplication-unified-pke-selection"/>Unified Primary Key Equivalent (PKE) selection</a>
+
+VReplication workflows (MoveTables, Reshard, Materialize, VDiff) and Online DDL now share a single implementation for selecting a Primary Key Equivalent (PKE) — the unique, non-NULLable key used to iterate and identify rows in tables that have no defined PRIMARY KEY. The PKE is now determined by parsing the table's `CREATE TABLE` statement (via the `schemadiff` package) instead of querying `information_schema`, and both code paths rank candidate keys using the same data-type cost model. Exact cost ties are broken deterministically by the lexicographically smallest index name.
+
+**Behavior changes:**
+
+- Online DDL's unique key prioritization now ranks candidate keys by the total storage cost of all columns in the key, rather than by properties of the key's first column only. For some tables this changes which unique key an Online DDL migration iterates over. The selected key is still a valid unique, non-NULLable key in all cases; only the preference order among multiple candidates has changed.
+- Unique keys containing functional (expression) key parts are no longer PKE candidates. Previously, the `information_schema`-based selection could pick such a key and produce a broken column list that could make VReplication identify rows by a non-unique set of columns; such keys are now skipped in favor of the next valid candidate, or all columns when no valid candidate exists.
+- If a no-PK table's `CREATE TABLE` statement cannot be parsed (for example, it uses table options unknown to the Vitess SQL parser, such as `SECONDARY_ENGINE`), VReplication and VDiff now log a warning and use all columns as the substitute PK instead of failing the workflow.
+
+**Upgrading with in-flight workflows:** the PKE is re-derived whenever a workflow (re)starts, so the key selected for a no-PK table can change across an upgrade while that table's copy phase is in progress. The source tablet now validates that a resumed copy's `lastpk` value was generated using the currently selected key columns and fails with a clear error rather than resuming from the wrong position. If you hit this error, restart the copy for the affected table (for example, by recreating the workflow) and run VDiff afterwards. Where possible, let the copy phase of tables without a primary key complete before upgrading.
+
+See [#10259](https://github.com/vitessio/vitess/issues/10259) for details.
 
 ### <a id="minor-changes-vtgate"/>VTGate</a>
 

--- a/go/cmd/vttablet/cli/cli.go
+++ b/go/cmd/vttablet/cli/cli.go
@@ -172,7 +172,7 @@ func run(cmd *cobra.Command, args []string) error {
 		UpdateStream:        binlog.NewUpdateStream(ts, tablet.Keyspace, tabletAlias.Cell, qsc.SchemaEngine(), env.Parser()),
 		VREngine:            vreplication.NewEngine(env, config, ts, tabletAlias.Cell, mysqld, qsc.LagThrottler()),
 		SemiSyncMonitor:     semisyncmonitor.NewMonitor(config, qsc.Exporter()),
-		VDiffEngine:         vdiff.NewEngine(ts, tablet, env.CollationEnv(), env.Parser()),
+		VDiffEngine:         vdiff.NewEngine(ts, tablet, env),
 	}
 	if err := tm.Start(tablet, config); err != nil {
 		return fmt.Errorf("failed to parse --tablet-path or initialize DB credentials: %w", err)

--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -578,21 +578,14 @@ func (mysqld *Mysqld) ApplySchemaChange(ctx context.Context, dbName string, chan
 	return &tabletmanagerdatapb.SchemaChangeResult{BeforeSchema: beforeSchema, AfterSchema: afterSchema}, nil
 }
 
-// GetPrimaryKeyEquivalentColumns can be used if the table has
-// no defined PRIMARY KEY. It will return the columns in a
-// viable PRIMARY KEY equivalent (PKE) -- a NON-NULL UNIQUE
-// KEY -- along with that index's name in the specified table.
-// When multiple PKE indexes are available it will attempt to
-// choose the most efficient one based on the column data types
-// and the number of columns in the index. See here for the data
-// type storage sizes:
-//
-//	https://dev.mysql.com/doc/refman/en/storage-requirements.html
-//
-// If this function is used on a table that DOES have a
-// defined PRIMARY KEY then it may return the columns for
-// that index if it is likely the most efficient one amongst
-// the available PKE indexes on the table.
+// GetPrimaryKeyEquivalentColumns returns the columns and name of the
+// best Primary Key Equivalent (PKE) index -- a unique key with no
+// NULLable columns and no functional (expression) key parts -- using an
+// information_schema query. Prefer
+// schemadiff.GetPrimaryKeyEquivalent, which implements the same
+// selection at the SQL parser level; this database-backed variant is
+// retained as the fallback for CREATE TABLE statements the parser
+// cannot handle (e.g. ones using unsupported table options).
 func GetPrimaryKeyEquivalentColumns(ctx context.Context, exec func(string, int, bool) (*sqltypes.Result, error), dbName, table string) ([]string, string, error) {
 	// We use column name aliases to guarantee lower case for our named results.
 	sql := `
@@ -628,7 +621,7 @@ func GetPrimaryKeyEquivalentColumns(ctx context.Context, exec func(string, int, 
                 WHERE stats.TABLE_SCHEMA = %s AND stats.TABLE_NAME = %s AND stats.INDEX_NAME NOT IN
                 (
                     SELECT DISTINCT INDEX_NAME FROM information_schema.STATISTICS
-                    WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s AND (NON_UNIQUE = 1 OR NULLABLE = 'YES')
+                    WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s AND (NON_UNIQUE = 1 OR NULLABLE = 'YES' OR COLUMN_NAME IS NULL)
                 )
                 GROUP BY INDEX_NAME ORDER BY type_cost ASC, col_count ASC LIMIT 1
             ) AS pke ON index_cols.INDEX_NAME = pke.INDEX_NAME

--- a/go/vt/schemadiff/column.go
+++ b/go/vt/schemadiff/column.go
@@ -347,6 +347,11 @@ func (c *ColumnDefinitionEntity) HasBlobTypeStorage() bool {
 	return BlobTypeStorage(c.Type()) != 0
 }
 
+// TypeCost returns the relative type cost of this column for PKE ranking.
+func (c *ColumnDefinitionEntity) TypeCost() int {
+	return TypeCost(c.Type())
+}
+
 // Charset returns the column's charset
 func (c *ColumnDefinitionEntity) Charset() string {
 	return c.ColumnDefinition.Type.Charset.Name

--- a/go/vt/schemadiff/env.go
+++ b/go/vt/schemadiff/env.go
@@ -39,3 +39,9 @@ func NewEnv(env *vtenv.Environment, defaultColl collations.ID) *Environment {
 		DefaultColl: defaultColl,
 	}
 }
+
+// NewEnvWithDefaults creates a new Environment using the default connection
+// charset from the given vtenv.Environment.
+func NewEnvWithDefaults(env *vtenv.Environment) *Environment {
+	return NewEnv(env, env.CollationEnv().DefaultConnectionCharset())
+}

--- a/go/vt/schemadiff/key.go
+++ b/go/vt/schemadiff/key.go
@@ -108,6 +108,16 @@ func (i *IndexDefinitionEntity) HasColumnPrefix() bool {
 	return false
 }
 
+// TypeCost returns the sum of type costs for all columns in the index,
+// used for ranking PKE indexes.
+func (i *IndexDefinitionEntity) TypeCost() int {
+	cost := 0
+	for _, col := range i.ColumnList.Entities {
+		cost += col.TypeCost()
+	}
+	return cost
+}
+
 // ColumnNames returns the names of the columns in the index.
 func (i *IndexDefinitionEntity) ColumnNames() []string {
 	names := make([]string, 0, len(i.IndexDefinition.Columns))

--- a/go/vt/schemadiff/mysql.go
+++ b/go/vt/schemadiff/mysql.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package schemadiff
 
+import "strings"
+
 var engineCasing = map[string]string{
 	"INNODB": "InnoDB",
 	"MYISAM": "MyISAM",
@@ -115,4 +117,44 @@ var expandedDataTypes = map[string]bool{
 func IsExpandingDataType(sourceType string, targetType string) bool {
 	_, ok := expandedDataTypes[sourceType+":"+targetType]
 	return ok
+}
+
+const defaultTypeCost = 1000
+
+// typeCost maps MySQL data types to a relative cost for ranking Primary
+// Key Equivalent (PKE) candidate keys; lower is preferred. It matches the
+// ranking in mysqlctl.GetPrimaryKeyEquivalentColumns.
+var typeCost = map[string]int{
+	"enum":      0,
+	"tinyint":   1,
+	"year":      2,
+	"smallint":  3,
+	"date":      4,
+	"mediumint": 5,
+	"time":      6,
+	"int":       7,
+	"set":       8,
+	"timestamp": 9,
+	"bigint":    10,
+	"float":     11,
+	"double":    12,
+	"decimal":   13,
+	"datetime":  14,
+	"binary":    30,
+	"char":      31,
+	"varbinary": 60,
+	"varchar":   61,
+	"tinyblob":  80,
+	"tinytext":  81,
+}
+
+// TypeCost returns the relative cost of a MySQL column type for PKE
+// ranking. columnType must be a bare MySQL-canonical type name as emitted
+// by SHOW CREATE TABLE (e.g. "varchar", not "varchar(255)"); unknown
+// types get a high cost so they rank last.
+func TypeCost(columnType string) int {
+	if cost, ok := typeCost[strings.ToLower(columnType)]; ok {
+		return cost
+	}
+	return defaultTypeCost
 }

--- a/go/vt/schemadiff/onlineddl.go
+++ b/go/vt/schemadiff/onlineddl.go
@@ -192,30 +192,8 @@ func PrioritizedUniqueKeys(createTableEntity *CreateTableEntity) *IndexDefinitio
 			// Prefix comes last
 			return false
 		}
-		iFirstColEntity := uniqueKeys[i].ColumnList.Entities[0]
-		jFirstColEntity := uniqueKeys[j].ColumnList.Entities[0]
-		if iFirstColEntity.IsIntegralType() && !jFirstColEntity.IsIntegralType() {
-			// Prioritize integers
-			return true
-		}
-		if !iFirstColEntity.IsIntegralType() && jFirstColEntity.IsIntegralType() {
-			// Prioritize integers
-			return false
-		}
-		if !iFirstColEntity.HasBlobTypeStorage() && jFirstColEntity.HasBlobTypeStorage() {
-			return true
-		}
-		if iFirstColEntity.HasBlobTypeStorage() && !jFirstColEntity.HasBlobTypeStorage() {
-			return false
-		}
-		if !iFirstColEntity.IsTextual() && jFirstColEntity.IsTextual() {
-			return true
-		}
-		if iFirstColEntity.IsTextual() && !jFirstColEntity.IsTextual() {
-			return false
-		}
-		if storageDiff := IntegralTypeStorage(iFirstColEntity.Type()) - IntegralTypeStorage(jFirstColEntity.Type()); storageDiff != 0 {
-			return storageDiff < 0
+		if costDiff := uniqueKeys[i].TypeCost() - uniqueKeys[j].TypeCost(); costDiff != 0 {
+			return costDiff < 0
 		}
 		if lenDiff := len(uniqueKeys[i].ColumnList.Entities) - len(uniqueKeys[j].ColumnList.Entities); lenDiff != 0 {
 			return lenDiff < 0
@@ -223,6 +201,60 @@ func PrioritizedUniqueKeys(createTableEntity *CreateTableEntity) *IndexDefinitio
 		return false
 	})
 	return NewIndexDefinitionEntityList(uniqueKeys)
+}
+
+// IsValidPKEquivalent returns true if the key is a valid Primary Key Equivalent:
+// a unique, non-nullable key. Unlike IsValidIterationKey, this does not exclude
+// floating point types or prefix keys.
+func IsValidPKEquivalent(key *IndexDefinitionEntity) bool {
+	if key == nil {
+		return false
+	}
+	if !key.IsUnique() {
+		return false
+	}
+	if key.HasNullable() {
+		return false
+	}
+	return true
+}
+
+// GetPrimaryKeyEquivalent returns the lowest-cost valid PKE in a CREATE TABLE statement.
+// Exact (type cost, column count) ties are broken by the lexicographically smallest
+// index name so that the selection is deterministic across restarts and upgrades.
+func GetPrimaryKeyEquivalent(createTableEntity *CreateTableEntity) (columns []string, indexName string) {
+	var bestKey *IndexDefinitionEntity
+	for _, key := range createTableEntity.IndexDefinitionEntities() {
+		if key.HasExpression() {
+			continue
+		}
+		if !IsValidPKEquivalent(key) {
+			continue
+		}
+		if bestKey == nil {
+			bestKey = key
+			continue
+		}
+		if costDiff := key.TypeCost() - bestKey.TypeCost(); costDiff != 0 {
+			if costDiff < 0 {
+				bestKey = key
+			}
+			continue
+		}
+		if lenDiff := len(key.ColumnList.Entities) - len(bestKey.ColumnList.Entities); lenDiff != 0 {
+			if lenDiff < 0 {
+				bestKey = key
+			}
+			continue
+		}
+		if key.Name() < bestKey.Name() {
+			bestKey = key
+		}
+	}
+	if bestKey != nil {
+		return bestKey.ColumnNames(), bestKey.Name()
+	}
+	return nil, ""
 }
 
 // RemovedForeignKeyNames returns the names of removed foreign keys, ignoring mere name changes

--- a/go/vt/schemadiff/onlineddl_test.go
+++ b/go/vt/schemadiff/onlineddl_test.go
@@ -80,18 +80,159 @@ func TestPrioritizedUniqueKeys(t *testing.T) {
 	}
 	expect := []string{
 		"PRIMARY",
-		"uk42",
 		"uk2",
 		"uk3",
+		"uk42",
 		"ukidsha",
 		"ukv",
-		"uk2vprefix",
 		"ukvprefix",
-		"uk41",
+		"uk2vprefix",
 		"uk1",
+		"uk41",
 		"uk1f",
 	}
 	assert.Equal(t, expect, names)
+}
+
+func TestGetPrimaryKeyEquivalent(t *testing.T) {
+	env := NewTestEnv()
+	tests := []struct {
+		name      string
+		ddl       string
+		wantCols  []string
+		wantIndex string
+	}{
+		{
+			name: "WITHPK",
+			ddl: `CREATE TABLE withpk_t (pkid INT NOT NULL AUTO_INCREMENT, col1 VARCHAR(25),
+				PRIMARY KEY (pkid))`,
+			wantCols:  []string{"pkid"},
+			wantIndex: "PRIMARY",
+		},
+		{
+			name: "PRIMARYVSSECONDARYUNIQUE",
+			ddl: `CREATE TABLE primary_vs_secondary_unique_t (
+				bigint_id BIGINT NOT NULL,
+				tinyint_col TINYINT NOT NULL,
+				PRIMARY KEY (bigint_id),
+				UNIQUE KEY tiny_uid (tinyint_col)
+			)`,
+			wantCols:  []string{"tinyint_col"},
+			wantIndex: "tiny_uid",
+		},
+		{
+			name:      "0PKE",
+			ddl:       `CREATE TABLE zeropke_t (id INT NULL, col1 VARCHAR(25), UNIQUE KEY (id))`,
+			wantCols:  nil,
+			wantIndex: "",
+		},
+		{
+			name:      "1PKE",
+			ddl:       `CREATE TABLE onepke_t (id INT NOT NULL, col1 VARCHAR(25), UNIQUE KEY (id))`,
+			wantCols:  []string{"id"},
+			wantIndex: "id",
+		},
+		{
+			name: "3MULTICOL1PKE",
+			ddl: `CREATE TABLE onemcpke_t (col1 VARCHAR(25) NOT NULL, col2 VARCHAR(25) NOT NULL,
+					col3 VARCHAR(25) NOT NULL, col4 VARCHAR(25), UNIQUE KEY c4_c2_c1 (col4, col2, col1),
+					UNIQUE KEY c1_c2 (col1, col2), UNIQUE KEY c1_c2_c4 (col1, col2, col4),
+					KEY nc1_nc2 (col1, col2))`,
+			wantCols:  []string{"col1", "col2"},
+			wantIndex: "c1_c2",
+		},
+		{
+			name: "3MULTICOL2PKE",
+			ddl: `CREATE TABLE twomcpke_t (col1 VARCHAR(25) NOT NULL, col2 VARCHAR(25) NOT NULL,
+					col3 VARCHAR(25) NOT NULL, col4 VARCHAR(25), UNIQUE KEY (col4), UNIQUE KEY c4_c2_c1 (col4, col2, col1),
+					UNIQUE KEY c1_c2_c3 (col1, col2, col3), UNIQUE KEY c1_c2 (col1, col2))`,
+			wantCols:  []string{"col1", "col2"},
+			wantIndex: "c1_c2",
+		},
+		{
+			name: "1INTPKE1CHARPKE",
+			ddl: `CREATE TABLE oneintpke1charpke_t (col1 VARCHAR(25) NOT NULL, col2 VARCHAR(25) NOT NULL,
+					col3 VARCHAR(25) NOT NULL, id1 INT NOT NULL, id2 INT NOT NULL,
+					UNIQUE KEY c1_c2 (col1, col2), UNIQUE KEY id1_id2 (id1, id2))`,
+			wantCols:  []string{"id1", "id2"},
+			wantIndex: "id1_id2",
+		},
+		{
+			name: "INTINTVSVCHAR",
+			ddl: `CREATE TABLE twointvsvcharpke_t (col1 VARCHAR(25) NOT NULL, id1 INT NOT NULL, id2 INT NOT NULL,
+					UNIQUE KEY c1 (col1), UNIQUE KEY id1_id2 (id1, id2))`,
+			wantCols:  []string{"id1", "id2"},
+			wantIndex: "id1_id2",
+		},
+		{
+			name: "TINYINTVSBIGINT",
+			ddl: `CREATE TABLE tinyintvsbigint_t (tid1 TINYINT NOT NULL, id1 INT NOT NULL,
+					UNIQUE KEY tid1 (tid1), UNIQUE KEY id1 (id1))`,
+			wantCols:  []string{"tid1"},
+			wantIndex: "tid1",
+		},
+		{
+			name: "VCHARINTVSINT2VARCHAR",
+			ddl: `CREATE TABLE vcharintvsinttwovchar_t (id1 INT NOT NULL, col1 VARCHAR(25) NOT NULL, col2 VARCHAR(25) NOT NULL,
+					UNIQUE KEY col1_id1 (col1, id1), UNIQUE KEY id1_col1_col2 (id1, col1, col2))`,
+			wantCols:  []string{"col1", "id1"},
+			wantIndex: "col1_id1",
+		},
+		{
+			name: "VCHARVSINT3",
+			ddl: `CREATE TABLE vcharvsintthree_t (id1 INT NOT NULL, id2 INT NOT NULL, id3 INT NOT NULL, col1 VARCHAR(50) NOT NULL,
+					UNIQUE KEY col1 (col1), UNIQUE KEY id1_id2_id3 (id1, id2, id3))`,
+			wantCols:  []string{"id1", "id2", "id3"},
+			wantIndex: "id1_id2_id3",
+		},
+		{
+			name: "TYPEMODIFIERS",
+			ddl: `CREATE TABLE modifiers_t (
+				id1 BIGINT UNSIGNED NOT NULL,
+				id2 INT(11) NOT NULL,
+				ts TIMESTAMP(6) NOT NULL,
+				UNIQUE KEY uk1 (id1),
+				UNIQUE KEY uk2 (id2),
+				UNIQUE KEY uk_ts (ts)
+			)`,
+			wantCols:  []string{"id2"},
+			wantIndex: "uk2",
+		},
+		{
+			name: "PREFIXVSMOREEXPENSIVENONPREFIX",
+			ddl: `CREATE TABLE prefix_vs_nonprefix_t (
+				char_col CHAR(32) NOT NULL,
+				varchar_col VARCHAR(64) NOT NULL,
+				UNIQUE KEY char_prefix (char_col(8)),
+				UNIQUE KEY varchar_full (varchar_col)
+			)`,
+			wantCols:  []string{"char_col"},
+			wantIndex: "char_prefix",
+		},
+		{
+			name: "TIEBREAKBYNAME",
+			ddl: `CREATE TABLE tiebyname_t (id1 INT NOT NULL, id2 INT NOT NULL,
+					UNIQUE KEY uk_b (id1), UNIQUE KEY uk_a (id2))`,
+			wantCols:  []string{"id2"},
+			wantIndex: "uk_a",
+		},
+		{
+			name: "TIEBREAKLENGTHBLINDVARCHAR",
+			ddl: `CREATE TABLE tievarchar_t (col1 VARCHAR(10) NOT NULL, col2 VARCHAR(100) NOT NULL,
+					UNIQUE KEY uk_z (col1), UNIQUE KEY uk_y (col2))`,
+			wantCols:  []string{"col2"},
+			wantIndex: "uk_y",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			createTableEntity, err := NewCreateTableEntityFromSQL(env, tt.ddl)
+			require.NoError(t, err)
+			cols, indexName := GetPrimaryKeyEquivalent(createTableEntity)
+			assert.Equal(t, tt.wantCols, cols)
+			assert.Equal(t, tt.wantIndex, indexName)
+		})
+	}
 }
 
 func TestRemovedForeignKeyNames(t *testing.T) {
@@ -644,7 +785,7 @@ func TestIntroducedUniqueConstraints(t *testing.T) {
 					unique key ukv3 (v(3)),
 					key k2 (c2)
 				)`,
-			expectIntroduced: []string{"uk1v2", "ukv3"},
+			expectIntroduced: []string{"ukv3", "uk1v2"},
 			expectRemoved:    []string{"uk12"},
 		},
 	}
@@ -732,11 +873,11 @@ func TestUniqueKeysCoveredByColumns(t *testing.T) {
 		},
 		{
 			columns: []string{"v", "c2", "c3"},
-			expect:  []string{"uk3", "uk23", "uk3v", "ukv"},
+			expect:  []string{"uk3", "uk23", "ukv", "uk3v"},
 		},
 		{
 			columns: []string{"id", "c1", "c2", "c3", "v"},
-			expect:  []string{"PRIMARY", "uk1", "uk3", "uk12", "uk13", "uk23", "uk21", "uk3v", "uk123", "ukv"},
+			expect:  []string{"PRIMARY", "uk1", "uk3", "uk12", "uk13", "uk23", "uk21", "uk123", "ukv", "uk3v"},
 		},
 	}
 
@@ -754,11 +895,11 @@ func TestUniqueKeysCoveredByColumns(t *testing.T) {
 		"uk13",
 		"uk23",
 		"uk21",
-		"uk3v",
 		"uk123",
 		"ukv",
-		"uk2v5",
+		"uk3v",
 		"ukv3",
+		"uk2v5",
 		"uk9",
 	}, tableKeys.Names())
 

--- a/go/vt/vttablet/tabletmanager/vdiff/engine.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/engine.go
@@ -34,6 +34,7 @@ import (
 	"vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/vtenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication"
 	"vitess.io/vitess/go/vt/vttablet/tmclient"
 )
@@ -71,16 +72,18 @@ type Engine struct {
 
 	collationEnv *collations.Environment
 	parser       *sqlparser.Parser
+	env          *vtenv.Environment
 }
 
-func NewEngine(ts *topo.Server, tablet *topodata.Tablet, collationEnv *collations.Environment, parser *sqlparser.Parser) *Engine {
+func NewEngine(ts *topo.Server, tablet *topodata.Tablet, env *vtenv.Environment) *Engine {
 	vde := &Engine{
 		controllers:     make(map[int64]*controller),
 		ts:              ts,
 		thisTablet:      tablet,
 		tmClientFactory: func() tmclient.TabletManagerClient { return tmclient.NewTabletManagerClient() },
-		collationEnv:    collationEnv,
-		parser:          parser,
+		collationEnv:    env.CollationEnv(),
+		parser:          env.Parser(),
+		env:             env,
 	}
 	return vde
 }
@@ -89,6 +92,7 @@ func NewEngine(ts *topo.Server, tablet *topodata.Tablet, collationEnv *collation
 // tablet manager client factory, while setting the fortests field to true to modify any engine
 // behavior when used in tests (e.g. not starting the retry goroutine).
 func NewTestEngine(ts *topo.Server, tablet *topodata.Tablet, dbn string, dbcf func() binlogplayer.DBClient, tmcf func() tmclient.TabletManagerClient) *Engine {
+	testEnv := vtenv.NewTestEnv()
 	vde := &Engine{
 		controllers:             make(map[int64]*controller),
 		ts:                      ts,
@@ -98,8 +102,9 @@ func NewTestEngine(ts *topo.Server, tablet *topodata.Tablet, dbn string, dbcf fu
 		dbClientFactoryDba:      dbcf,
 		tmClientFactory:         tmcf,
 		fortests:                true,
-		collationEnv:            collations.MySQL8(),
-		parser:                  sqlparser.NewTestParser(),
+		collationEnv:            testEnv.CollationEnv(),
+		parser:                  testEnv.Parser(),
+		env:                     testEnv,
 	}
 	return vde
 }

--- a/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/framework_test.go
@@ -262,15 +262,14 @@ func (ftc *fakeTabletConn) VStreamRows(ctx context.Context, request *binlogdatap
 	if vstreamRowsHook != nil {
 		vstreamRowsHook(ctx)
 	}
-	var row []sqltypes.Value
+	var lastpk *sqltypes.Result
 	if request.Lastpk != nil {
-		r := sqltypes.Proto3ToResult(request.Lastpk)
-		if len(r.Rows) != 1 {
+		lastpk = sqltypes.Proto3ToResult(request.Lastpk)
+		if len(lastpk.Rows) != 1 {
 			return fmt.Errorf("unexpected lastpk input: %v", request.Lastpk)
 		}
-		row = r.Rows[0]
 	}
-	return vdiffenv.vse.StreamRows(ctx, request.Query, row, func(rows *binlogdatapb.VStreamRowsResponse) error {
+	return vdiffenv.vse.StreamRows(ctx, request.Query, lastpk, func(rows *binlogdatapb.VStreamRowsResponse) error {
 		if vstreamRowsSendHook != nil {
 			vstreamRowsSendHook(ctx)
 		}
@@ -435,11 +434,12 @@ func (dbc *realDBClient) SupportsCapability(capability capabilities.FlavorCapabi
 
 type fakeTMClient struct {
 	tmclient.TabletManagerClient
-	schema    *tabletmanagerdatapb.SchemaDefinition
-	vrQueries map[int]map[string]*querypb.QueryResult
-	waitpos   map[int]string
-	vrpos     map[int]string
-	pos       map[int]string
+	schema         *tabletmanagerdatapb.SchemaDefinition
+	vrQueries      map[int]map[string]*querypb.QueryResult
+	waitpos        map[int]string
+	vrpos          map[int]string
+	pos            map[int]string
+	execFetchAsApp func(query string) (*querypb.QueryResult, error)
 }
 
 func newFakeTMClient() *fakeTMClient {
@@ -453,6 +453,13 @@ func newFakeTMClient() *fakeTMClient {
 
 // Close satisfies the TabletManagerClient interface.
 func (tmc *fakeTMClient) Close() {}
+
+func (tmc *fakeTMClient) ExecuteFetchAsApp(ctx context.Context, tablet *topodatapb.Tablet, usePool bool, req *tabletmanagerdatapb.ExecuteFetchAsAppRequest) (*querypb.QueryResult, error) {
+	if tmc.execFetchAsApp == nil {
+		return nil, fmt.Errorf("unexpected ExecuteFetchAsApp call: %s", req.Query)
+	}
+	return tmc.execFetchAsApp(string(req.Query))
+}
 
 func (tmc *fakeTMClient) GetSchema(ctx context.Context, tablet *topodatapb.Tablet, request *tabletmanagerdatapb.GetSchemaRequest) (*tabletmanagerdatapb.SchemaDefinition, error) {
 	return tmc.schema, nil

--- a/go/vt/vttablet/tabletmanager/vdiff/table_differ.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/table_differ.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/rand/v2"
 	"slices"
 	"strings"
@@ -39,6 +40,7 @@ import (
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl"
+	"vitess.io/vitess/go/vt/schemadiff"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
@@ -986,26 +988,51 @@ func (td *tableDiffer) getSourcePKCols() error {
 	sourceTable := sourceSchema.TableDefinitions[0]
 	if len(sourceTable.PrimaryKeyColumns) == 0 {
 		// We use the columns from a PKE if there is one.
-		executeFetch := func(query string, maxrows int, wantfields bool) (*sqltypes.Result, error) {
-			res, err := td.wd.ct.tmc.ExecuteFetchAsApp(ctx, sourceTablet.Tablet, false, &tabletmanagerdatapb.ExecuteFetchAsAppRequest{
-				Query:   []byte(query),
-				MaxRows: uint64(maxrows),
-			})
+		if sourceTable.Schema != "" {
+			senv := schemadiff.NewEnvWithDefaults(td.wd.ct.vde.env)
+			createTableEntity, err := schemadiff.NewCreateTableEntityFromSQL(senv, sourceTable.Schema)
 			if err != nil {
-				return nil, vterrors.Wrapf(err, "failed to query the %s source tablet in order to get a primary key equivalent for the %s table",
-					topoproto.TabletAliasString(sourceTablet.Alias), td.table.Name)
+				// An unparseable schema is not the same as one with no PKE: fall back
+				// to the information_schema-based lookup rather than keying on all columns.
+				log.Warn("Failed to parse the CREATE TABLE schema to determine a primary key equivalent; falling back to the information_schema lookup",
+					slog.String("table", td.table.Name),
+					slog.String("source_tablet", topoproto.TabletAliasString(sourceTablet.Alias)),
+					slog.String("vdiff", td.wd.ct.uuid),
+					slog.Any("error", err))
+				executeFetch := func(query string, maxrows int, wantfields bool) (*sqltypes.Result, error) {
+					res, err := td.wd.ct.tmc.ExecuteFetchAsApp(ctx, sourceTablet.Tablet, false, &tabletmanagerdatapb.ExecuteFetchAsAppRequest{
+						Query:   []byte(query),
+						MaxRows: uint64(maxrows),
+					})
+					if err != nil {
+						return nil, vterrors.Wrapf(err, "failed to query the %s source tablet in order to get a primary key equivalent for the %s table",
+							topoproto.TabletAliasString(sourceTablet.Alias), td.table.Name)
+					}
+					return sqltypes.Proto3ToResult(res), nil
+				}
+				pkeCols, _, err := mysqlctl.GetPrimaryKeyEquivalentColumns(ctx, executeFetch, sourceTablet.DbName(), td.table.Name)
+				if err != nil {
+					return vterrors.Wrapf(err, "failed to get a primary key equivalent for the %s table from source tablet %s",
+						td.table.Name, topoproto.TabletAliasString(sourceTablet.Alias))
+				}
+				if len(pkeCols) > 0 {
+					log.Info(fmt.Sprintf("Using primary key equivalent columns %+v for table %s in vdiff %s", pkeCols, td.table.Name, td.wd.ct.uuid))
+					sourceTable.PrimaryKeyColumns = pkeCols
+				}
+			} else {
+				pkeCols, _ := schemadiff.GetPrimaryKeyEquivalent(createTableEntity)
+				if len(pkeCols) > 0 {
+					log.Info(fmt.Sprintf("Using primary key equivalent columns %+v for table %s in vdiff %s", pkeCols, td.table.Name, td.wd.ct.uuid))
+					sourceTable.PrimaryKeyColumns = pkeCols
+				}
 			}
-			return sqltypes.Proto3ToResult(res), nil
-		}
-		pkeCols, _, err := mysqlctl.GetPrimaryKeyEquivalentColumns(ctx, executeFetch, sourceTablet.DbName(), td.table.Name)
-		if err != nil {
-			return vterrors.Wrapf(err, "failed to get a primary key equivalent for the %s table from source tablet %s",
-				td.table.Name, topoproto.TabletAliasString(sourceTablet.Alias))
-		}
-		if len(pkeCols) > 0 {
-			log.Info(fmt.Sprintf("Using primary key equivalent columns %+v for table %s in vdiff %s", pkeCols, td.table.Name, td.wd.ct.uuid))
-			sourceTable.PrimaryKeyColumns = pkeCols
 		} else {
+			log.Warn("No CREATE TABLE schema available to determine a primary key equivalent",
+				slog.String("table", td.table.Name),
+				slog.String("source_tablet", topoproto.TabletAliasString(sourceTablet.Alias)),
+				slog.String("vdiff", td.wd.ct.uuid))
+		}
+		if len(sourceTable.PrimaryKeyColumns) == 0 {
 			// We use every column together as a substitute PK.
 			log.Info(fmt.Sprintf("Using all columns as a substitute primary key for table %s in vdiff %s", td.table.Name, td.wd.ct.uuid))
 			sourceTable.PrimaryKeyColumns = append(sourceTable.PrimaryKeyColumns, td.table.Columns...)

--- a/go/vt/vttablet/tabletmanager/vdiff/table_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/table_differ_test.go
@@ -161,3 +161,53 @@ func TestGetSourcePKCols_TableDroppedOnSource(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, td.tablePlan.sourcePkCols)
 }
+
+// TestGetSourcePKCols_UnparseableSourceSchema confirms that a source
+// CREATE TABLE the SQL parser cannot parse (e.g. one using the unknown
+// SECONDARY_ENGINE option) does not fail the diff and does not degrade to
+// the all-columns substitute PK: we warn and fall back to the
+// information_schema-based PKE lookup on the source tablet.
+func TestGetSourcePKCols_UnparseableSourceSchema(t *testing.T) {
+	tvde := newTestVDiffEnv(t)
+	defer tvde.close()
+
+	ct := tvde.createController(t, 1)
+
+	table := &tabletmanagerdatapb.TableDefinition{
+		Name:    "no_pk_table",
+		Columns: []string{"c1", "c2"},
+		Fields:  sqltypes.MakeTestFields("c1|c2", "int64|varchar"),
+	}
+
+	tvde.tmc.schema = &tabletmanagerdatapb.SchemaDefinition{
+		TableDefinitions: []*tabletmanagerdatapb.TableDefinition{{
+			Name:    "no_pk_table",
+			Columns: []string{"c1", "c2"},
+			Schema:  "CREATE TABLE no_pk_table (c1 int NOT NULL, c2 varchar(10), UNIQUE KEY uk1 (c1)) SECONDARY_ENGINE=RAPID",
+		}},
+	}
+	tvde.tmc.execFetchAsApp = func(query string) (*querypb.QueryResult, error) {
+		require.Contains(t, query, "information_schema.STATISTICS")
+		return sqltypes.ResultToProto3(sqltypes.MakeTestResult(
+			sqltypes.MakeTestFields(
+				"column_name|index_name",
+				"varchar|varchar",
+			),
+			"c1|uk1",
+		)), nil
+	}
+
+	td := &tableDiffer{
+		wd: &workflowDiffer{
+			ct: ct,
+		},
+		table: table,
+		tablePlan: &tablePlan{
+			table: table,
+		},
+	}
+
+	err := td.getSourcePKCols()
+	require.NoError(t, err)
+	require.Equal(t, []int{0}, td.tablePlan.sourcePkCols)
+}

--- a/go/vt/vttablet/tabletmanager/vdiff/table_plan.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/table_plan.go
@@ -19,13 +19,16 @@ package vdiff
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl"
+	"vitess.io/vitess/go/vt/schemadiff"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/engine"
@@ -166,7 +169,8 @@ func (td *tableDiffer) buildTablePlan(dbClient binlogplayer.DBClient, dbName str
 
 	if len(tp.table.PrimaryKeyColumns) == 0 {
 		// We use the columns from a PKE if there is one.
-		pkeCols, err := tp.getPKEquivalentColumns(dbClient)
+		senv := schemadiff.NewEnvWithDefaults(td.wd.ct.vde.env)
+		pkeCols, err := tp.getPKEquivalentColumns(dbClient, senv)
 		if err != nil {
 			return nil, vterrors.Wrapf(err, "error getting PK equivalent columns for table %s", tp.table.Name)
 		}
@@ -298,16 +302,36 @@ func (tp *tablePlan) getPKColumnCollations(dbClient binlogplayer.DBClient, colla
 	return nil
 }
 
-func (tp *tablePlan) getPKEquivalentColumns(dbClient binlogplayer.DBClient) ([]string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), BackgroundOperationTimeout/2)
-	defer cancel()
-	executeFetch := func(query string, maxrows int, wantfields bool) (*sqltypes.Result, error) {
-		// This sets wantfields to true.
-		return dbClient.ExecuteFetch(query, maxrows)
-	}
-	pkeCols, _, err := mysqlctl.GetPrimaryKeyEquivalentColumns(ctx, executeFetch, tp.dbName, tp.table.Name)
+func (tp *tablePlan) getPKEquivalentColumns(dbClient binlogplayer.DBClient, env *schemadiff.Environment) ([]string, error) {
+	query := fmt.Sprintf("SHOW CREATE TABLE %s.%s", sqlescape.EscapeID(tp.dbName), sqlescape.EscapeID(tp.table.Name))
+	qr, err := dbClient.ExecuteFetch(query, 1)
 	if err != nil {
 		return nil, err
 	}
+	if len(qr.Rows) == 0 || len(qr.Rows[0]) < 2 {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "unexpected result for SHOW CREATE TABLE query for table %s.%s: %d rows",
+			tp.dbName, tp.table.Name, len(qr.Rows))
+	}
+	createTableSQL := qr.Rows[0][1].ToString()
+	createTableEntity, err := schemadiff.NewCreateTableEntityFromSQL(env, createTableSQL)
+	if err != nil {
+		// An unparseable schema is not the same as one with no PKE: fall back
+		// to the information_schema-based lookup rather than keying on all columns.
+		log.Warn("Failed to parse the CREATE TABLE schema to determine a primary key equivalent; falling back to the information_schema lookup",
+			slog.String("table", tp.table.Name),
+			slog.Any("error", err))
+		ctx, cancel := context.WithTimeout(context.Background(), BackgroundOperationTimeout/2)
+		defer cancel()
+		executeFetch := func(query string, maxrows int, wantfields bool) (*sqltypes.Result, error) {
+			// This sets wantfields to true.
+			return dbClient.ExecuteFetch(query, maxrows)
+		}
+		pkeCols, _, err := mysqlctl.GetPrimaryKeyEquivalentColumns(ctx, executeFetch, tp.dbName, tp.table.Name)
+		if err != nil {
+			return nil, err
+		}
+		return pkeCols, nil
+	}
+	pkeCols, _ := schemadiff.GetPrimaryKeyEquivalent(createTableEntity)
 	return pkeCols, nil
 }

--- a/go/vt/vttablet/tabletmanager/vdiff/table_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/table_plan_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vdiff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/binlog/binlogplayer"
+	"vitess.io/vitess/go/vt/schemadiff"
+
+	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
+)
+
+// TestGetPKEquivalentColumnsUnparseableSchema ensures an unparseable SHOW
+// CREATE TABLE result (e.g. one using the unknown SECONDARY_ENGINE option)
+// falls back to the information_schema-based PKE lookup instead of being
+// treated as having no PKE.
+func TestGetPKEquivalentColumnsUnparseableSchema(t *testing.T) {
+	vdenv := newTestVDiffEnv(t)
+	defer vdenv.close()
+
+	dbc := binlogplayer.NewMockDBClient(t)
+	tp := &tablePlan{
+		dbName: vdiffDBName,
+		table:  &tabletmanagerdatapb.TableDefinition{Name: "nopk"},
+	}
+	dbc.ExpectRequestRE("SHOW CREATE TABLE", sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"Table|Create Table",
+			"varchar|varchar",
+		),
+		"nopk|CREATE TABLE `nopk` (`c1` int NOT NULL, UNIQUE KEY `uk1` (`c1`)) ENGINE=InnoDB SECONDARY_ENGINE=RAPID",
+	), nil)
+	dbc.ExpectRequestRE("SELECT index_cols.COLUMN_NAME AS column_name", sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"column_name|index_name",
+			"varchar|varchar",
+		),
+		"c1|uk1",
+	), nil)
+
+	pkeCols, err := tp.getPKEquivalentColumns(dbc, schemadiff.NewEnvWithDefaults(vdenv.vde.env))
+	require.NoError(t, err)
+	require.Equal(t, []string{"c1"}, pkeCols)
+	dbc.Wait()
+}

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -935,17 +935,21 @@ func TestBuildPlanSuccess(t *testing.T) {
 			require.NoError(t, err)
 			dbc.ExpectRequestRE("select vdt.lastpk as lastpk, vdt.mismatch as mismatch, vdt.report as report", noResults, nil)
 			if len(tcase.tablePlan.table.PrimaryKeyColumns) == 0 {
-				result := noResults
-				if tcase.table == "nopkwithpke" { // This has a PKE column: c3
-					result = sqltypes.MakeTestResult(
-						sqltypes.MakeTestFields(
-							"column_name|index_name",
-							"varchar|varchar",
-						),
-						"c3|c3",
-					)
+				var createTableSQL string
+				switch tcase.table {
+				case "nopkwithpke":
+					createTableSQL = "CREATE TABLE `nopkwithpke` (`c1` int DEFAULT NULL, `c2` int DEFAULT NULL, `c3` int NOT NULL, UNIQUE KEY `c3` (`c3`)) ENGINE=InnoDB"
+				case "nopk":
+					createTableSQL = "CREATE TABLE `nopk` (`c1` int DEFAULT NULL, `c2` int DEFAULT NULL, `c3` int DEFAULT NULL) ENGINE=InnoDB"
 				}
-				dbc.ExpectRequestRE("SELECT index_cols.COLUMN_NAME AS column_name, index_cols.INDEX_NAME as index_name FROM information_schema.STATISTICS", result, nil)
+				result := sqltypes.MakeTestResult(
+					sqltypes.MakeTestFields(
+						"Table|Create Table",
+						"varchar|varchar",
+					),
+					fmt.Sprintf("%s|%s", tcase.table, createTableSQL),
+				)
+				dbc.ExpectRequestRE("SHOW CREATE TABLE", result, nil)
 			}
 			if len(tcase.tablePlan.comparePKs) > 0 {
 				columnList := make([]string, len(tcase.tablePlan.comparePKs))

--- a/go/vt/vttablet/tabletmanager/vreplication/external_connector.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/external_connector.go
@@ -143,15 +143,14 @@ func (c *mysqlConnector) VStream(ctx context.Context, startPos string, tablePKs 
 func (c *mysqlConnector) VStreamRows(ctx context.Context, query string, lastpk *querypb.QueryResult,
 	send func(*binlogdatapb.VStreamRowsResponse) error, options *binlogdatapb.VStreamOptions,
 ) error {
-	var row []sqltypes.Value
+	var lastpkResult *sqltypes.Result
 	if lastpk != nil {
-		r := sqltypes.Proto3ToResult(lastpk)
-		if len(r.Rows) != 1 {
+		lastpkResult = sqltypes.Proto3ToResult(lastpk)
+		if len(lastpkResult.Rows) != 1 {
 			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unexpected lastpk input: %v", lastpk)
 		}
-		row = r.Rows[0]
 	}
-	return c.vstreamer.StreamRows(ctx, query, row, send, options)
+	return c.vstreamer.StreamRows(ctx, query, lastpkResult, send, options)
 }
 
 func (c *mysqlConnector) VStreamTables(ctx context.Context,

--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -381,18 +381,17 @@ func (ftc *fakeTabletConn) VStreamRows(ctx context.Context, request *binlogdatap
 	if vstreamRowsHook != nil {
 		vstreamRowsHook(ctx)
 	}
-	var row []sqltypes.Value
+	var lastpk *sqltypes.Result
 	if request.Lastpk != nil {
-		r := sqltypes.Proto3ToResult(request.Lastpk)
-		if len(r.Rows) != 1 {
+		lastpk = sqltypes.Proto3ToResult(request.Lastpk)
+		if len(lastpk.Rows) != 1 {
 			return fmt.Errorf("unexpected lastpk input: %v", request.Lastpk)
 		}
-		row = r.Rows[0]
 	}
 	vstreamOptions := &binlogdatapb.VStreamOptions{
 		ConfigOverrides: vttablet.GetVReplicationConfigDefaults(false).Map(),
 	}
-	return streamerEngine.StreamRows(ctx, request.Query, row, func(rows *binlogdatapb.VStreamRowsResponse) error {
+	return streamerEngine.StreamRows(ctx, request.Query, lastpk, func(rows *binlogdatapb.VStreamRowsResponse) error {
 		if vstreamRowsSendHook != nil {
 			vstreamRowsSendHook(ctx)
 		}

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"sort"
 	"strconv"
@@ -36,6 +37,7 @@ import (
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/schema"
+	"vitess.io/vitess/go/vt/schemadiff"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	vttablet "vitess.io/vitess/go/vt/vttablet/common"
@@ -396,12 +398,29 @@ func (vr *vreplicator) buildColInfoMap(ctx context.Context) (map[string][]*Colum
 			pks = td.PrimaryKeyColumns
 		} else {
 			// Use a PK equivalent if one exists.
-			executeFetch := func(query string, maxrows int, wantfields bool) (*sqltypes.Result, error) {
-				// This sets wantfields to true.
-				return vr.dbClient.ExecuteFetch(query, maxrows)
-			}
-			if pks, _, err = mysqlctl.GetPrimaryKeyEquivalentColumns(ctx, executeFetch, vr.dbClient.DBName(), td.Name); err != nil {
-				return nil, err
+			if td.Schema != "" {
+				senv := schemadiff.NewEnvWithDefaults(vr.vre.env)
+				createTableEntity, err := schemadiff.NewCreateTableEntityFromSQL(senv, td.Schema)
+				if err != nil {
+					// An unparseable schema is not the same as one with no PKE: fall back
+					// to the information_schema-based lookup rather than keying on all columns.
+					log.Warn("Failed to parse the CREATE TABLE schema to determine a primary key equivalent; falling back to the information_schema lookup",
+						slog.String("table", td.Name),
+						slog.String("workflow", vr.WorkflowName),
+						slog.Any("error", err))
+					executeFetch := func(query string, maxrows int, wantfields bool) (*sqltypes.Result, error) {
+						// This sets wantfields to true.
+						return vr.dbClient.ExecuteFetch(query, maxrows)
+					}
+					if pks, _, err = mysqlctl.GetPrimaryKeyEquivalentColumns(ctx, executeFetch, vr.dbClient.DBName(), td.Name); err != nil {
+						return nil, err
+					}
+				} else {
+					pks, _ = schemadiff.GetPrimaryKeyEquivalent(createTableEntity)
+				}
+			} else {
+				log.Warn("No CREATE TABLE schema available to determine a primary key equivalent",
+					slog.String("table", td.Name))
 			}
 			// Fall back to using every column in the table if there's no PK or PKE.
 			if len(pks) == 0 {

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
@@ -40,6 +40,7 @@ import (
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/schemadiff"
+	"vitess.io/vitess/go/vt/vtenv"
 	vttablet "vitess.io/vitess/go/vt/vttablet/common"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -85,15 +86,76 @@ func TestMaxQuerySize(t *testing.T) {
 }
 
 // fakeFetchSuperQueryMysqld is a minimal MysqlDaemon test double that delegates
-// FetchSuperQuery to a callback. Only the methods exercised by tests are valid;
-// any other call will panic on the embedded nil interface.
+// FetchSuperQuery and GetSchema to callbacks. Only the methods exercised by
+// tests are valid; any other call will panic on the embedded nil interface.
 type fakeFetchSuperQueryMysqld struct {
 	mysqlctl.MysqlDaemon
-	callback func(query string) (*sqltypes.Result, error)
+	callback       func(query string) (*sqltypes.Result, error)
+	schemaCallback func(dbName string, request *tabletmanagerdatapb.GetSchemaRequest) (*tabletmanagerdatapb.SchemaDefinition, error)
 }
 
 func (f *fakeFetchSuperQueryMysqld) FetchSuperQuery(ctx context.Context, query string) (*sqltypes.Result, error) {
 	return f.callback(query)
+}
+
+func (f *fakeFetchSuperQueryMysqld) GetSchema(ctx context.Context, dbName string, request *tabletmanagerdatapb.GetSchemaRequest) (*tabletmanagerdatapb.SchemaDefinition, error) {
+	return f.schemaCallback(dbName, request)
+}
+
+// TestBuildColInfoMapUnparseableSchemaFallback confirms that a no-PK table
+// whose CREATE TABLE cannot be parsed (e.g. unknown SECONDARY_ENGINE
+// option) does not fail the stream and does not degrade to the all-columns
+// substitute PK: buildColInfoMap warns and falls back to the
+// information_schema-based PKE lookup.
+func TestBuildColInfoMapUnparseableSchemaFallback(t *testing.T) {
+	infoSchemaCols := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"character_set_name|collation_name|column_name|data_type|column_type|extra",
+			"varchar|varchar|varchar|varchar|varchar|varchar",
+		),
+		"utf8mb4|utf8mb4_general_ci|c1|int|int|",
+		"utf8mb4|utf8mb4_general_ci|c2|varchar|varchar(10)|",
+	)
+	fmd := &fakeFetchSuperQueryMysqld{
+		callback: func(query string) (*sqltypes.Result, error) {
+			return infoSchemaCols, nil
+		},
+		schemaCallback: func(dbName string, request *tabletmanagerdatapb.GetSchemaRequest) (*tabletmanagerdatapb.SchemaDefinition, error) {
+			return &tabletmanagerdatapb.SchemaDefinition{
+				TableDefinitions: []*tabletmanagerdatapb.TableDefinition{{
+					Name:    "t1",
+					Columns: []string{"c1", "c2"},
+					Fields:  sqltypes.MakeTestFields("c1|c2", "int64|varchar"),
+					Schema:  "CREATE TABLE t1 (c1 int NOT NULL, c2 varchar(10), UNIQUE KEY uk1 (c1)) SECONDARY_ENGINE=RAPID",
+				}},
+			}, nil
+		},
+	}
+	dbc := binlogplayer.NewMockDBClient(t)
+	dbc.ExpectRequestRE("SELECT index_cols.COLUMN_NAME AS column_name", sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"column_name|index_name",
+			"varchar|varchar",
+		),
+		"c1|uk1",
+	), nil)
+	stats := binlogplayer.NewStats()
+	defer stats.Stop()
+	vr := &vreplicator{
+		mysqld:       fmd,
+		dbClient:     newVDBClient(dbc, stats, vttablet.DefaultVReplicationConfig.RelayLogMaxItems),
+		vre:          &Engine{env: vtenv.NewTestEnv()},
+		WorkflowName: "wf1",
+	}
+
+	colInfo, err := vr.buildColInfoMap(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, colInfo, "t1")
+	require.Len(t, colInfo["t1"], 2)
+	for _, ci := range colInfo["t1"] {
+		assert.Equal(t, ci.Name == "c1", ci.IsPK, "only the c1 PKE column should be a PK, got IsPK=%v for %s", ci.IsPK, ci.Name)
+	}
+	dbc.Wait()
 }
 
 func TestFetchInfoSchemaColumnsRetry(t *testing.T) {
@@ -224,6 +286,18 @@ func TestPrimaryKeyEquivalentColumns(t *testing.T) {
 			wantIndex: "PRIMARY",
 		},
 		{
+			name:  "PRIMARYVSSECONDARYUNIQUE",
+			table: "primary_vs_secondary_unique_t",
+			ddl: `CREATE TABLE primary_vs_secondary_unique_t (
+					bigint_id BIGINT NOT NULL,
+					tinyint_col TINYINT NOT NULL,
+					PRIMARY KEY (bigint_id),
+					UNIQUE KEY tiny_uid (tinyint_col)
+				)`,
+			wantCols:  []string{"tinyint_col"},
+			wantIndex: "tiny_uid",
+		},
+		{
 			name:      "0PKE",
 			table:     "zeropke_t",
 			ddl:       `CREATE TABLE zeropke_t (id INT NULL, col1 VARCHAR(25), UNIQUE KEY (id))`,
@@ -297,6 +371,33 @@ func TestPrimaryKeyEquivalentColumns(t *testing.T) {
 			wantCols:  []string{"id1", "id2", "id3"},
 			wantIndex: "id1_id2_id3",
 		},
+		{
+			name:  "FUNCTIONALINDEXSKIPPED",
+			table: "functional_skipped_t",
+			ddl: `CREATE TABLE functional_skipped_t (c1 INT NOT NULL, c2 INT NOT NULL, c3 VARCHAR(10) NOT NULL,
+					UNIQUE KEY ufunc ((c1+1), c2), UNIQUE KEY uc3 (c3))`,
+			wantCols:  []string{"c3"},
+			wantIndex: "uc3",
+		},
+		{
+			name:      "ONLYFUNCTIONALINDEX",
+			table:     "functional_only_t",
+			ddl:       `CREATE TABLE functional_only_t (c1 INT NOT NULL, c2 INT NOT NULL, UNIQUE KEY ufunc ((c1+1), c2))`,
+			wantCols:  []string{},
+			wantIndex: "",
+		},
+		{
+			name:  "PREFIXVSMOREEXPENSIVENONPREFIX",
+			table: "prefix_vs_nonprefix_t",
+			ddl: `CREATE TABLE prefix_vs_nonprefix_t (
+					char_col CHAR(32) NOT NULL,
+					varchar_col VARCHAR(64) NOT NULL,
+					UNIQUE KEY char_prefix (char_col(8)),
+					UNIQUE KEY varchar_full (varchar_col)
+				)`,
+			wantCols:  []string{"char_col"},
+			wantIndex: "char_prefix",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -308,6 +409,17 @@ func TestPrimaryKeyEquivalentColumns(t *testing.T) {
 			require.NoError(t, err)
 			require.Equalf(t, tt.wantCols, cols, "Mysqld.GetPrimaryKeyEquivalentColumns() columns = %v, want %v", cols, tt.wantCols)
 			require.Equalf(t, tt.wantIndex, indexName, "Mysqld.GetPrimaryKeyEquivalentColumns() index = %v, want %v", indexName, tt.wantIndex)
+
+			senv := schemadiff.NewTestEnv()
+			createTableEntity, err := schemadiff.NewCreateTableEntityFromSQL(senv, tt.ddl)
+			require.NoError(t, err)
+			sdCols, sdIndex := schemadiff.GetPrimaryKeyEquivalent(createTableEntity)
+			if len(tt.wantCols) == 0 {
+				assert.Empty(t, sdCols, "schemadiff columns should be empty")
+			} else {
+				assert.Equalf(t, tt.wantCols, sdCols, "schemadiff.GetPrimaryKeyEquivalent() columns = %v, want %v", sdCols, tt.wantCols)
+			}
+			assert.Equalf(t, tt.wantIndex, sdIndex, "schemadiff.GetPrimaryKeyEquivalent() index = %v, want %v", sdIndex, tt.wantIndex)
 		})
 	}
 }

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1322,15 +1322,14 @@ func (tsv *TabletServer) VStreamRows(ctx context.Context, request *binlogdatapb.
 	if err := tsv.sm.VerifyTarget(ctx, request.Target); err != nil {
 		return err
 	}
-	var row []sqltypes.Value
+	var lastpk *sqltypes.Result
 	if request.Lastpk != nil {
-		r := sqltypes.Proto3ToResult(request.Lastpk)
-		if len(r.Rows) != 1 {
+		lastpk = sqltypes.Proto3ToResult(request.Lastpk)
+		if len(lastpk.Rows) != 1 {
 			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unexpected lastpk input: %v", request.Lastpk)
 		}
-		row = r.Rows[0]
 	}
-	return tsv.vstreamer.StreamRows(ctx, request.Query, row, send, request.Options)
+	return tsv.vstreamer.StreamRows(ctx, request.Query, lastpk, send, request.Options)
 }
 
 // VStreamTables streams all tables.

--- a/go/vt/vttablet/tabletserver/vstreamer/copy.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/copy.go
@@ -176,19 +176,17 @@ func (uvs *uvstreamer) sendEventsForRows(ctx context.Context, tableName string, 
 	return nil
 }
 
-// converts lastpk from proto to value
-func getLastPKFromQR(qr *querypb.QueryResult) []sqltypes.Value {
+// converts lastpk from proto to result
+func getLastPKFromQR(qr *querypb.QueryResult) *sqltypes.Result {
 	if qr == nil {
 		return nil
 	}
-	var lastPK []sqltypes.Value
 	r := sqltypes.Proto3ToResult(qr)
 	if len(r.Rows) != 1 {
 		log.Error(fmt.Sprintf("unexpected lastpk input: %v", qr))
 		return nil
 	}
-	lastPK = r.Rows[0]
-	return lastPK
+	return r
 }
 
 // converts lastpk from value to proto

--- a/go/vt/vttablet/tabletserver/vstreamer/engine.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
@@ -29,11 +30,13 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/acl"
+	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl"
+	"vitess.io/vitess/go/vt/schemadiff"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/topo"
@@ -284,14 +287,17 @@ func (vse *Engine) Stream(ctx context.Context, startPos string, tablePKs []*binl
 
 // StreamRows streams rows.
 // This streams the table data rows (so we can copy the table data snapshot)
-func (vse *Engine) StreamRows(ctx context.Context, query string, lastpk []sqltypes.Value,
+// The lastpk result, when provided, carries both the values and the fields of
+// the last PK from a previous copy phase cycle, so that the row streamer can
+// verify the values still bind to the same key columns before resuming.
+func (vse *Engine) StreamRows(ctx context.Context, query string, lastpk *sqltypes.Result,
 	send func(*binlogdatapb.VStreamRowsResponse) error, options *binlogdatapb.VStreamOptions,
 ) error {
 	// Ensure vschema is initialized and the watcher is started.
 	// Starting of the watcher has to be delayed till the first call to Stream
 	// because this overhead should be incurred only if someone uses this feature.
 	vse.watcherOnce.Do(vse.setWatch)
-	log.Info(fmt.Sprintf("Streaming rows for query %s, lastpk: %s", query, lastpk))
+	log.Info(fmt.Sprintf("Streaming rows for query %s, lastpk: %v", query, lastpk))
 
 	// Create stream and add it to the map.
 	rowStreamer, idx, err := func() (*rowStreamer, int, error) {
@@ -601,20 +607,40 @@ func (vse *Engine) getMySQLEndpoint(ctx context.Context, db dbconfigs.Connector)
 	return fmt.Sprintf("%s:%d", host, port), nil
 }
 
-// mapPKEquivalentCols gets a PK equivalent from mysqld for the table
-// and maps the column names to field indexes in the MinimalTable struct.
+// mapPKEquivalentCols gets a PK equivalent for the table and maps the
+// column names to field indexes in the MinimalTable struct.
 func (vse *Engine) mapPKEquivalentCols(ctx context.Context, db dbconfigs.Connector, table *binlogdatapb.MinimalTable) ([]int, error) {
 	conn, err := db.Connect(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer conn.Close()
-	pkeColNames, indexName, err := mysqlctl.GetPrimaryKeyEquivalentColumns(ctx, conn.ExecuteFetch, vse.env.Config().DB.DBName, table.Name)
+	query := fmt.Sprintf("SHOW CREATE TABLE %s.%s", sqlescape.EscapeID(vse.env.Config().DB.DBName), sqlescape.EscapeID(table.Name))
+	qr, err := conn.ExecuteFetch(query, 1, true)
 	if err != nil {
 		return nil, err
 	}
-	if len(pkeColNames) > 0 && indexName != "" {
-		table.PKIndexName = indexName
+	if len(qr.Rows) == 0 || len(qr.Rows[0]) < 2 {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "unexpected result for SHOW CREATE TABLE query for table %s.%s: %d rows",
+			vse.env.Config().DB.DBName, table.Name, len(qr.Rows))
+	}
+	createTableSQL := qr.Rows[0][1].ToString()
+	senv := schemadiff.NewEnvWithDefaults(vse.env.Environment())
+	var pkeColNames []string
+	var indexName string
+	createTableEntity, err := schemadiff.NewCreateTableEntityFromSQL(senv, createTableSQL)
+	if err != nil {
+		// An unparseable schema is not the same as one with no PKE: fall back
+		// to the information_schema-based lookup rather than keying on all columns.
+		log.Warn("Failed to parse the CREATE TABLE schema to determine a primary key equivalent; falling back to the information_schema lookup",
+			slog.String("table", table.Name),
+			slog.Any("error", err))
+		pkeColNames, indexName, err = mysqlctl.GetPrimaryKeyEquivalentColumns(ctx, conn.ExecuteFetch, vse.env.Config().DB.DBName, table.Name)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		pkeColNames, indexName = schemadiff.GetPrimaryKeyEquivalent(createTableEntity)
 	}
 	pkeCols := make([]int, len(pkeColNames))
 	matches := 0
@@ -629,6 +655,19 @@ func (vse *Engine) mapPKEquivalentCols(ctx context.Context, db dbconfigs.Connect
 		if matches == len(pkeColNames) {
 			break
 		}
+	}
+	if matches != len(pkeColNames) {
+		// The fields can be stale, e.g. when a DDL landed after the table
+		// snapshot was taken; a partially mapped slice would silently key
+		// on the wrong columns.
+		log.Warn("Not all primary key equivalent columns were found in the table fields; falling back to using all columns",
+			slog.String("table", table.Name),
+			slog.String("index", indexName),
+			slog.Any("pke_columns", pkeColNames))
+		return nil, nil
+	}
+	if len(pkeColNames) > 0 && indexName != "" {
+		table.PKIndexName = indexName
 	}
 	return pkeCols, nil
 }

--- a/go/vt/vttablet/tabletserver/vstreamer/engine_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
+	"vitess.io/vitess/go/sqlescape"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -162,6 +163,99 @@ func expectUpdateCount(t *testing.T, wantCount int64) int64 {
 		time.Sleep(10 * time.Millisecond)
 	}
 	panic("unreachable")
+}
+
+func TestMapPKEquivalentCols(t *testing.T) {
+	testDB := fakesqldb.New(t)
+	defer testDB.Close()
+
+	dbName := engine.env.Config().DB.DBName
+	query := "SHOW CREATE TABLE " + sqlescape.EscapeID(dbName) + "." + sqlescape.EscapeID("t1")
+	showCreateResult := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields("Table|Create Table", "varchar|varchar"),
+		"t1|CREATE TABLE `t1` (\n"+
+			"  `bigint_id` bigint NOT NULL,\n"+
+			"  `tinyint_col` tinyint NOT NULL,\n"+
+			"  PRIMARY KEY (`bigint_id`),\n"+
+			"  UNIQUE KEY `tiny_uid` (`tinyint_col`)\n"+
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+	)
+	testDB.AddQuery(query, showCreateResult)
+
+	table := &binlogdatapb.MinimalTable{
+		Name:   "t1",
+		Fields: sqltypes.MakeTestFields("bigint_id|tinyint_col", "int64|int64"),
+	}
+	pkeCols, err := engine.mapPKEquivalentCols(t.Context(), dbconfigs.New(testDB.ConnParams()), table)
+	require.NoError(t, err)
+	require.Equal(t, []int{1}, pkeCols)
+	require.Equal(t, "tiny_uid", table.PKIndexName)
+}
+
+// TestMapPKEquivalentColsUnparseableSchemaFallsBack ensures a CREATE TABLE
+// statement the SQL parser cannot handle (e.g. one using the unknown
+// SECONDARY_ENGINE option) falls back to the information_schema-based PKE
+// lookup instead of being treated as having no PKE.
+func TestMapPKEquivalentColsUnparseableSchemaFallsBack(t *testing.T) {
+	testDB := fakesqldb.New(t)
+	defer testDB.Close()
+
+	dbName := engine.env.Config().DB.DBName
+	query := "SHOW CREATE TABLE " + sqlescape.EscapeID(dbName) + "." + sqlescape.EscapeID("t1")
+	showCreateResult := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields("Table|Create Table", "varchar|varchar"),
+		"t1|CREATE TABLE `t1` (\n"+
+			"  `payload` text,\n"+
+			"  `id` bigint NOT NULL,\n"+
+			"  UNIQUE KEY `uk_id` (`id`)\n"+
+			") ENGINE=InnoDB SECONDARY_ENGINE=RAPID",
+	)
+	testDB.AddQuery(query, showCreateResult)
+	testDB.AddQueryPattern("(?s).*information_schema.STATISTICS.*", sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields("column_name|index_name", "varchar|varchar"),
+		"id|uk_id",
+	))
+
+	table := &binlogdatapb.MinimalTable{
+		Name:   "t1",
+		Fields: sqltypes.MakeTestFields("payload|id", "text|int64"),
+	}
+	pkeCols, err := engine.mapPKEquivalentCols(t.Context(), dbconfigs.New(testDB.ConnParams()), table)
+	require.NoError(t, err)
+	require.Equal(t, []int{1}, pkeCols)
+	require.Equal(t, "uk_id", table.PKIndexName)
+}
+
+// TestMapPKEquivalentColsStaleFields ensures that a PKE column missing from
+// the (possibly stale) MinimalTable fields yields no PKE, rather than a
+// column-index slice whose unmatched entries silently point at field 0.
+func TestMapPKEquivalentColsStaleFields(t *testing.T) {
+	testDB := fakesqldb.New(t)
+	defer testDB.Close()
+
+	dbName := engine.env.Config().DB.DBName
+	query := "SHOW CREATE TABLE " + sqlescape.EscapeID(dbName) + "." + sqlescape.EscapeID("t1")
+	showCreateResult := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields("Table|Create Table", "varchar|varchar"),
+		"t1|CREATE TABLE `t1` (\n"+
+			"  `bigint_id` bigint NOT NULL,\n"+
+			"  `tinyint_col` tinyint NOT NULL,\n"+
+			"  PRIMARY KEY (`bigint_id`),\n"+
+			"  UNIQUE KEY `tiny_uid` (`tinyint_col`)\n"+
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+	)
+	testDB.AddQuery(query, showCreateResult)
+
+	// The fields snapshot predates the DDL that added tinyint_col, the
+	// column the selected PKE (tiny_uid) is defined on.
+	table := &binlogdatapb.MinimalTable{
+		Name:   "t1",
+		Fields: sqltypes.MakeTestFields("bigint_id", "int64"),
+	}
+	pkeCols, err := engine.mapPKEquivalentCols(t.Context(), dbconfigs.New(testDB.ConnParams()), table)
+	require.NoError(t, err)
+	require.Empty(t, pkeCols)
+	require.Empty(t, table.PKIndexName)
 }
 
 // TestVStreamerWaitForMySQL tests the wait for MySQL to catch-up

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/url"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -64,12 +65,13 @@ type rowStreamer struct {
 	ctx    context.Context
 	cancel func()
 
-	cp      dbconfigs.Connector
-	se      *schema.Engine
-	query   string
-	lastpk  []sqltypes.Value
-	send    func(*binlogdatapb.VStreamRowsResponse) error
-	vschema *localVSchema
+	cp           dbconfigs.Connector
+	se           *schema.Engine
+	query        string
+	lastpk       []sqltypes.Value
+	lastpkFields []*querypb.Field
+	send         func(*binlogdatapb.VStreamRowsResponse) error
+	vschema      *localVSchema
 
 	plan          *Plan
 	pkColumns     []int
@@ -85,29 +87,38 @@ type rowStreamer struct {
 }
 
 func newRowStreamer(ctx context.Context, cp dbconfigs.Connector, se *schema.Engine, query string,
-	lastpk []sqltypes.Value, vschema *localVSchema, send func(*binlogdatapb.VStreamRowsResponse) error, vse *Engine,
+	lastpk *sqltypes.Result, vschema *localVSchema, send func(*binlogdatapb.VStreamRowsResponse) error, vse *Engine,
 	mode RowStreamerMode, conn *snapshotConn, options *binlogdatapb.VStreamOptions,
 ) *rowStreamer {
 	config, err := GetVReplicationConfig(options)
 	if err != nil {
 		return nil
 	}
+	var lastpkRow []sqltypes.Value
+	var lastpkFields []*querypb.Field
+	if lastpk != nil {
+		lastpkFields = lastpk.Fields
+		if len(lastpk.Rows) == 1 {
+			lastpkRow = lastpk.Rows[0]
+		}
+	}
 	ctx, cancel := context.WithCancel(ctx)
 	return &rowStreamer{
-		ctx:     ctx,
-		cancel:  cancel,
-		cp:      cp,
-		se:      se,
-		query:   query,
-		lastpk:  lastpk,
-		send:    send,
-		vschema: vschema,
-		vse:     vse,
-		pktsize: DefaultPacketSizer(config.VStreamDynamicPacketSize, config.VStreamPacketSize),
-		mode:    mode,
-		conn:    conn,
-		options: options,
-		config:  config,
+		ctx:          ctx,
+		cancel:       cancel,
+		cp:           cp,
+		se:           se,
+		query:        query,
+		lastpk:       lastpkRow,
+		lastpkFields: lastpkFields,
+		send:         send,
+		vschema:      vschema,
+		vse:          vse,
+		pktsize:      DefaultPacketSizer(config.VStreamDynamicPacketSize, config.VStreamPacketSize),
+		mode:         mode,
+		conn:         conn,
+		options:      options,
+		config:       config,
 	}
 }
 
@@ -244,6 +255,38 @@ func (rs *rowStreamer) buildPKColumns(st *binlogdatapb.MinimalTable) ([]int, err
 	return pkColumns, nil
 }
 
+// validateLastPKFields verifies that a resumed lastpk value was generated
+// using the same key columns the plan has selected now. The selected key can
+// change while a copy phase is paused, e.g. when the PK equivalent ranking
+// changes across an upgrade; binding the stored values to different columns
+// would silently skip rows. Older clients may not send the lastpk fields, in
+// which case there is nothing to validate.
+func (rs *rowStreamer) validateLastPKFields(st *binlogdatapb.MinimalTable) error {
+	if len(rs.lastpkFields) == 0 {
+		return nil
+	}
+	if len(rs.lastpkFields) != len(rs.lastpk) {
+		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unexpected lastpk input for the %s table: %d fields provided for %d values",
+			st.Name, len(rs.lastpkFields), len(rs.lastpk))
+	}
+	currentNames := make([]string, len(rs.pkColumns))
+	for i, pk := range rs.pkColumns {
+		currentNames[i] = rs.plan.Table.Fields[pk].Name
+	}
+	storedNames := make([]string, len(rs.lastpkFields))
+	for i, field := range rs.lastpkFields {
+		storedNames[i] = field.Name
+	}
+	for i := range currentNames {
+		if !strings.EqualFold(storedNames[i], currentNames[i]) {
+			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
+				"cannot resume the copy phase of the %s table: the lastpk value (%v) was generated using the (%s) key columns, but the table's current key columns are (%s); the table copy must be restarted",
+				st.Name, rs.lastpk, strings.Join(storedNames, ", "), strings.Join(currentNames, ", "))
+		}
+	}
+	return nil
+}
+
 func (rs *rowStreamer) buildSelect(st *binlogdatapb.MinimalTable) (string, error) {
 	buf := sqlparser.NewTrackedBuffer(nil)
 	// We could have used select *, but being explicit is more predictable.
@@ -292,6 +335,9 @@ func (rs *rowStreamer) buildSelect(st *binlogdatapb.MinimalTable) (string, error
 		if len(rs.lastpk) != len(rs.pkColumns) {
 			return "", fmt.Errorf("cannot build a row streamer plan for the %s table as a lastpk value was provided and the number of primary key values within it (%v) does not match the number of primary key columns in the table (%d)",
 				st.Name, rs.lastpk, rs.pkColumns)
+		}
+		if err := rs.validateLastPKFields(st); err != nil {
+			return "", err
 		}
 		buf.WriteString(" where ")
 		// First we add any predicates that should be pushed down.

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
@@ -36,6 +36,7 @@ import (
 	vttablet "vitess.io/vitess/go/vt/vttablet/common"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
 // TestRowStreamerQuery validates that the correct force index hint and order by is added to the rowstreamer query.
@@ -670,9 +671,94 @@ func TestStreamRowsHeartbeat(t *testing.T) {
 	}, 50*time.Millisecond, time.Millisecond, "expected context cancellation to stop row and heartbeat callbacks")
 }
 
+// TestStreamRowsLastPKStaleKeyColumns confirms that resuming a copy with a
+// lastpk whose field names no longer match the currently selected key
+// columns fails with a clear error instead of silently binding the values
+// to the wrong columns and skipping rows. Key selection can change, e.g.
+// when the PKE ranking changes across an upgrade.
+func TestStreamRowsLastPKStaleKeyColumns(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	execStatements(t, []string{
+		"create table t6(id1 int not null, id2 int not null, val varbinary(128), unique key uk_b (id1), unique key uk_a (id2))",
+		"insert into t6 values (1, 2, 'aaa'), (2, 3, 'bbb')",
+	})
+	defer execStatements(t, []string{
+		"drop table t6",
+	})
+
+	// The table's PK equivalent is uk_a (id2): uk_a and uk_b tie on cost and
+	// the tie is broken by index name. A lastpk stored from the uk_b (id1)
+	// key must be rejected.
+	stalePK := &sqltypes.Result{
+		Fields: []*querypb.Field{{Name: "id1", Type: querypb.Type_INT32}},
+		Rows:   [][]sqltypes.Value{{sqltypes.NewInt32(1)}},
+	}
+	err := engine.StreamRows(t.Context(), "select * from t6", stalePK, func(rows *binlogdatapb.VStreamRowsResponse) error {
+		return nil
+	}, nil)
+	require.ErrorContains(t, err, "was generated using the (id1) key columns")
+	require.ErrorContains(t, err, "current key columns are (id2)")
+
+	// A lastpk from the currently selected key resumes the stream.
+	currentPK := &sqltypes.Result{
+		Fields: []*querypb.Field{{Name: "id2", Type: querypb.Type_INT32}},
+		Rows:   [][]sqltypes.Value{{sqltypes.NewInt32(2)}},
+	}
+	var rowsReceived int
+	err = engine.StreamRows(t.Context(), "select * from t6", currentPK, func(rows *binlogdatapb.VStreamRowsResponse) error {
+		rowsReceived += len(rows.Rows)
+		return nil
+	}, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, rowsReceived, "expected only the row with id2 > 2")
+}
+
+// TestStreamRowsPKEFallbackOnUnparseableSchema confirms that a table whose
+// CREATE TABLE statement the SQL parser cannot handle (e.g. one using the
+// SECONDARY_ENGINE option) still gets its PK equivalent via the
+// information_schema fallback. Without the fallback the stream would key on
+// every column, and resuming from a checkpoint that contains a NULL value
+// would silently skip the remaining rows.
+func TestStreamRowsPKEFallbackOnUnparseableSchema(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	// The composite functional unique key must not be selected by the
+	// information_schema fallback, even though its visible column ranks
+	// cheaper than uk_id: its column list would be incomplete and non-unique.
+	execStatements(t, []string{
+		"create table t7(payload text, id bigint not null, tiny tinyint not null, unique key uk_id (id), unique key uk_func ((tiny+1), tiny)) engine=innodb secondary_engine=RAPID",
+		"insert into t7 values (null, 1, 1), ('a', 2, 2), (null, 3, 3), ('b', 4, 4)",
+	})
+	defer execStatements(t, []string{
+		"drop table t7",
+	})
+
+	// Resume from a checkpoint keyed on the uk_id (id) PK equivalent.
+	lastpk := &sqltypes.Result{
+		Fields: []*querypb.Field{{Name: "id", Type: querypb.Type_INT64}},
+		Rows:   [][]sqltypes.Value{{sqltypes.NewInt64(2)}},
+	}
+	var rowsReceived int
+	err := engine.StreamRows(t.Context(), "select * from t7", lastpk, func(rows *binlogdatapb.VStreamRowsResponse) error {
+		rowsReceived += len(rows.Rows)
+		return nil
+	}, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, rowsReceived, "expected the rows with id > 2")
+}
+
 func checkStream(t *testing.T, query string, lastpk []sqltypes.Value, wantQuery string, wantStream []string, options *binlogdatapb.VStreamOptions) {
 	t.Helper()
 
+	var lastpkResult *sqltypes.Result
+	if lastpk != nil {
+		lastpkResult = &sqltypes.Result{Rows: [][]sqltypes.Value{lastpk}}
+	}
 	i := 0
 	ch := make(chan error)
 	// We don't want to report errors inside callback functions because
@@ -689,7 +775,7 @@ func checkStream(t *testing.T, query string, lastpk []sqltypes.Value, wantQuery 
 		options.ConfigOverrides["vstream-dynamic-packet-size"] = strconv.FormatBool(vttablet.VStreamerUseDynamicPacketSize)
 		options.ConfigOverrides["vstream-packet-size"] = strconv.Itoa(vttablet.VStreamerDefaultPacketSize)
 
-		err := engine.StreamRows(t.Context(), query, lastpk, func(rows *binlogdatapb.VStreamRowsResponse) error {
+		err := engine.StreamRows(t.Context(), query, lastpkResult, func(rows *binlogdatapb.VStreamRowsResponse) error {
 			if first {
 				if rows.Gtid == "" {
 					ch <- errors.New("stream gtid is empty")

--- a/go/vt/vttablet/tabletserver/vstreamer/tablestreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/tablestreamer.go
@@ -149,7 +149,7 @@ func (ts *tableStreamer) Stream() error {
 	return nil
 }
 
-func (ts *tableStreamer) newRowStreamer(ctx context.Context, query string, lastpk []sqltypes.Value,
+func (ts *tableStreamer) newRowStreamer(ctx context.Context, query string, lastpk *sqltypes.Result,
 	send func(*binlogdatapb.VStreamRowsResponse) error,
 ) (*rowStreamer, func(), error) {
 	vse := ts.vse

--- a/go/vt/wrangler/fake_tablet_test.go
+++ b/go/vt/wrangler/fake_tablet_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
-	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/mysql/fakesqldb"
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/vt/dbconfigs"
@@ -34,7 +33,6 @@ import (
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/servenv"
-	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vtenv"
 	"vitess.io/vitess/go/vt/vttablet/grpctmserver"
@@ -185,15 +183,16 @@ func (ft *fakeTablet) StartActionLoop(t *testing.T, wr *Wrangler) {
 	ft.Tablet.Hostname = "127.0.0.1"
 	// Create a test tm on that port, and re-read the record
 	// (it has new ports and IP).
+	testEnv := vtenv.NewTestEnv()
 	ft.TM = &tabletmanager.TabletManager{
 		BatchCtx:            t.Context(),
 		TopoServer:          wr.TopoServer(),
 		MysqlDaemon:         ft.FakeMysqlDaemon,
 		DBConfigs:           &dbconfigs.DBConfigs{},
 		QueryServiceControl: tabletservermock.NewController(),
-		VDiffEngine:         vdiff2.NewEngine(wr.TopoServer(), ft.Tablet, collations.MySQL8(), sqlparser.NewTestParser()),
+		VDiffEngine:         vdiff2.NewEngine(wr.TopoServer(), ft.Tablet, testEnv),
 		SemiSyncMonitor:     semisyncmonitor.CreateTestSemiSyncMonitor(ft.FakeMysqlDaemon.DB(), exporter),
-		Env:                 vtenv.NewTestEnv(),
+		Env:                 testEnv,
 	}
 	require.NoError(t, ft.TM.Start(ft.Tablet, nil))
 	ft.Tablet = ft.TM.Tablet()


### PR DESCRIPTION
## Description

Unifies Primary Key Equivalent (PKE) selection for OnlineDDL and VReplication on a single `schemadiff` implementation, replacing the legacy `information_schema` query in `mysqlctl`.

- New `schemadiff.GetPrimaryKeyEquivalent()` parses `CREATE TABLE` and ranks keys by total type cost, then column count — same semantics as the legacy SQL. Ties broken by index name.
- vdiff, vreplicator, and vstreamer now use it; `mysqlctl.GetPrimaryKeyEquivalentColumns` is deprecated. A parity test runs both against a real MySQL.
- OnlineDDL's `PrioritizedUniqueKeys` now uses the same whole-key cost ranking (behavior change, see release notes). VReplication selection unchanged.
- Source tablet now rejects a resumed copy `lastpk` generated with different key columns instead of resuming from the wrong position.

## Related Issue(s)

- Fixes #10259

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

Behavior change; not intended for backporting.

## Deployment Notes

See v25 release notes (`changelog/25.0/25.0.0/summary.md`): OnlineDDL may pick a different (still valid) unique key; expression keys are no longer PKE candidates; unparseable no-PK schemas fall back to all columns with a warning; in-flight no-PK copies may need a restart across the upgrade.

### AI Disclosure
Took help of opus 4.8