### PR TITLE
Support configurable 'slow query' detection for vtgate

### DIFF
--- a/examples/common/scripts/vtgate-up.sh
+++ b/examples/common/scripts/vtgate-up.sh
@@ -23,6 +23,7 @@ web_port=15001
 grpc_port=15991
 mysql_server_port=15306
 mysql_server_socket_path="/tmp/mysql.sock"
+slow_query_threshold=${VTGATE_SLOW_QUERY_THRESHOLD:-10ms}
 
 echo "Starting vtgate..."
 # shellcheck disable=SC2086
@@ -40,6 +41,7 @@ vtgate \
    --pid-file $VTDATAROOT/tmp/vtgate.pid \
    --enable-buffer \
    --mysql-auth-server-impl none \
+   --slow-query-threshold $slow_query_threshold \
    --pprof-http \
    --log-format text \
    >$VTDATAROOT/tmp/vtgate.out 2>&1 &

--- a/examples/local/README.md
+++ b/examples/local/README.md
@@ -55,3 +55,122 @@ vtctldclient DeleteShards --force --recursive customer/0
 # Down cluster
 ./501_teardown.sh
 ```
+
+## vtgate slow query observability
+
+The local example enables vtgate-level slow-query detection and writes vtgate
+query logs to `$VTDATAROOT/tmp/vtgate_querylog.txt`.
+
+```
+--slow-query-threshold 10ms
+```
+
+Override the threshold before starting the cluster:
+
+```
+export VTGATE_SLOW_QUERY_THRESHOLD=250ms
+./101_initial_cluster.sh
+```
+
+### Generate slow query traffic
+
+Start the cluster and insert sample data. Any query whose vtgate execution time
+meets or exceeds the threshold is marked slow. The following command uses an
+`UPDATE` with `sleep()` only to make the behavior easy to reproduce locally:
+
+```
+source ../common/env.sh
+./101_initial_cluster.sh
+mysql < ../common/insert_commerce_data.sql
+
+mysql commerce <<'SQL'
+set workload = olap;
+update /* slow_docs */ customer set email = email where customer_id = 1 and sleep(0.05) = 0;
+SQL
+```
+
+The `slow_docs` comment makes the query easy to find in logs.
+
+### Check counters
+
+`SlowQueries` is keyed by query type, plan type, and tablet type. The query
+above increments `UPDATE.Passthrough.PRIMARY`:
+
+```
+curl -s http://localhost:15001/debug/vars | grep -o '"UPDATE.Passthrough.PRIMARY":[0-9]*'
+```
+
+Example output:
+
+```
+"UPDATE.Passthrough.PRIMARY":1
+```
+
+The same counter is exported to Prometheus as `vtgate_slow_queries`:
+
+```
+curl -s http://localhost:15001/metrics \
+  | grep 'vtgate_slow_queries' \
+  | grep 'query="UPDATE"' \
+  | grep 'plan="Passthrough"' \
+  | grep 'tablet="PRIMARY"'
+```
+
+Example output:
+
+```
+vtgate_slow_queries{plan="Passthrough",query="UPDATE",tablet="PRIMARY"} 1
+```
+
+### Alert on slow writes
+
+For an application-facing signal, alert when more than 1% of primary writes are
+slow over five minutes:
+
+```
+100 *
+sum(rate(vtgate_slow_queries{query=~"INSERT|UPDATE|DELETE",tablet="PRIMARY"}[5m]))
+/
+sum(rate(vtgate_query_executions{query=~"INSERT|UPDATE|DELETE",tablet="PRIMARY"}[5m]))
+> 1
+```
+
+This answers: "What percentage of writes routed through vtgate to PRIMARY were
+slow from the client/vtgate point of view?"
+
+For drilldown, group by query and plan:
+
+```
+sum by (query, plan, tablet) (
+  rate(vtgate_slow_queries{tablet="PRIMARY"}[5m])
+)
+```
+
+### Inspect slow queries
+
+The vtgate query log includes `SlowQuery=true`:
+
+```
+grep 'slow_docs' "$VTDATAROOT/tmp/vtgate_querylog.txt" | grep $'\ttrue\t'
+```
+
+`/debug/querylogz` shows the same signal in the debug UI. Start the request in
+one terminal:
+
+```
+curl 'http://localhost:15001/debug/querylogz?timeout=30&limit=1'
+```
+
+Then, in another terminal, run:
+
+```
+mysql commerce <<'SQL'
+set workload = olap;
+update /* slow_querylogz */ customer set email = email where customer_id = 1 and sleep(0.05) = 0;
+SQL
+```
+
+The rendered table includes a `SlowQuery` column with `true`.
+
+Clients that inspect MySQL protocol status flags should also see
+`SERVER_QUERY_WAS_SLOW` set on the OK packet returned by the slow `UPDATE`.

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -344,11 +344,11 @@ Flags:
       --security-policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --semi-sync-monitor-interval duration                              How frequently the semi-sync monitor checks if the primary is blocked on semi-sync ACKs (default 10s)
       --service-map strings                                              comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
-      --slow-query-threshold duration                                    Mark vtgate queries as slow when their total execution time meets or exceeds this duration. 0 disables slow-query detection.
       --serving-state-grace-period duration                              how long to pause after broadcasting health to vtgate, before enforcing a new serving state
       --shard-sync-retry-delay duration                                  delay between retries of updates to keep the tablet and its shard record in sync (default 30s)
       --shutdown-grace-period duration                                   how long to wait for queries and transactions to complete during graceful shutdown. (default 3s)
       --skip-user-metrics                                                If true, user based stats are not recorded.
+      --slow-query-threshold duration                                    Mark vtgate queries as slow when their total execution time meets or exceeds this duration. 0 disables slow-query detection.
       --sql-max-length-errors int                                        truncate queries in error logs to the given length (default unlimited)
       --sql-max-length-ui int                                            truncate queries in debug UIs to the given length (default 512) (default 512)
       --srv-topo-cache-refresh duration                                  how frequently to refresh the topology for cached entries (default 1s)

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -344,6 +344,7 @@ Flags:
       --security-policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --semi-sync-monitor-interval duration                              How frequently the semi-sync monitor checks if the primary is blocked on semi-sync ACKs (default 10s)
       --service-map strings                                              comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
+      --slow-query-threshold duration                                    Mark vtgate queries as slow when their total execution time meets or exceeds this duration. 0 disables slow-query detection.
       --serving-state-grace-period duration                              how long to pause after broadcasting health to vtgate, before enforcing a new serving state
       --shard-sync-retry-delay duration                                  delay between retries of updates to keep the tablet and its shard record in sync (default 30s)
       --shutdown-grace-period duration                                   how long to wait for queries and transactions to complete during graceful shutdown. (default 3s)

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -192,6 +192,7 @@ Flags:
       --schema-change-signal                                             Enable the schema tracker; requires queryserver-config-schema-change-signal to be enabled on the underlying vttablets for this to work (default true)
       --security-policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --service-map strings                                              comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
+      --slow-query-threshold duration                                    Mark vtgate queries as slow when their total execution time meets or exceeds this duration. 0 disables slow-query detection.
       --sql-max-length-errors int                                        truncate queries in error logs to the given length (default unlimited)
       --sql-max-length-ui int                                            truncate queries in debug UIs to the given length (default 512) (default 512)
       --srv-topo-cache-refresh duration                                  how frequently to refresh the topology for cached entries (default 1s)

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -185,6 +185,9 @@ type Conn struct {
 	// by Handler methods.
 	StatusFlags uint16
 
+	pendingMultiResultStatusFlags    uint16
+	hasPendingMultiResultStatusFlags bool
+
 	// CharacterSet is the charset for this connection, as negotiated
 	// in our handshake with the server. Note that although the MySQL protocol lists this
 	// as a "character set", the returned byte value is actually a Collation ID,
@@ -245,6 +248,20 @@ const (
 	execErr
 	connErr
 )
+
+func (c *Conn) SetPendingMultiResultStatusFlags(flags uint16) {
+	c.pendingMultiResultStatusFlags = flags
+	c.hasPendingMultiResultStatusFlags = true
+}
+
+func (c *Conn) consumePendingMultiResultStatusFlags() (uint16, bool) {
+	if !c.hasPendingMultiResultStatusFlags {
+		return 0, false
+	}
+	flags := c.pendingMultiResultStatusFlags
+	c.hasPendingMultiResultStatusFlags = false
+	return flags, true
+}
 
 // bufPool is used to allocate and free buffers in an efficient way.
 var bufPool = bucketpool.New(connBufferSize, MaxPacketSize)
@@ -1492,6 +1509,7 @@ func (c *Conn) execQueryMulti(query string, handler Handler) execResult {
 	callbackCalled := false
 	res := execSuccess
 	previousStatusFlags := c.StatusFlags
+	c.hasPendingMultiResultStatusFlags = false
 	defer func() {
 		c.StatusFlags &^= ServerQueryWasSlow
 	}()
@@ -1499,15 +1517,16 @@ func (c *Conn) execQueryMulti(query string, handler Handler) execResult {
 	err := handler.ComQueryMulti(c, query, func(qr sqltypes.QueryResponse, more bool, firstPacket bool) error {
 		currentStatusFlags := c.StatusFlags
 		callbackCalled = true
-		flag := currentStatusFlags
-		if more {
-			flag |= ServerMoreResultsExists
-		}
 
 		// firstPacket tells us that this is the start of a new query result.
 		// If we haven't sent a last packet yet, we should send the end result packet.
 		if firstPacket && needsEndPacket {
-			if err := c.writeEndResultWithFlags(previousStatusFlags, true, 0, 0, handler.WarningCount(c)); err != nil {
+			if flags, ok := c.consumePendingMultiResultStatusFlags(); ok {
+				if err := c.writeEndResultWithFlags(flags, true, 0, 0, handler.WarningCount(c)); err != nil {
+					log.Error(fmt.Sprintf("Error writing result to %s: %v", c, err))
+					return err
+				}
+			} else if err := c.writeEndResultWithFlags(previousStatusFlags, true, 0, 0, handler.WarningCount(c)); err != nil {
 				log.Error(fmt.Sprintf("Error writing result to %s: %v", c, err))
 				return err
 			}
@@ -1531,6 +1550,10 @@ func (c *Conn) execQueryMulti(query string, handler Handler) execResult {
 			needsEndPacket = true
 			previousStatusFlags = currentStatusFlags
 			if len(qr.QueryResult.Fields) == 0 {
+				flags := currentStatusFlags
+				if more {
+					flags |= ServerMoreResultsExists
+				}
 				// A successful callback with no fields means that this was a
 				// DML or other write-only operation.
 				//
@@ -1540,7 +1563,7 @@ func (c *Conn) execQueryMulti(query string, handler Handler) execResult {
 				ok := PacketOK{
 					affectedRows:     qr.QueryResult.RowsAffected,
 					lastInsertID:     qr.QueryResult.InsertID,
-					statusFlags:      flag,
+					statusFlags:      flags,
 					warnings:         handler.WarningCount(c),
 					info:             "",
 					sessionStateData: qr.QueryResult.SessionStateChanges,

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1278,6 +1278,9 @@ func (c *Conn) handleComStmtExecute(handler Handler, data []byte) (kontinue bool
 			kontinue = false
 		}
 	}()
+	defer func() {
+		c.StatusFlags &^= ServerQueryWasSlow
+	}()
 	queryStart := time.Now()
 	stmtID, _, err := c.parseComStmtExecute(c.PrepareData, data)
 	c.recycleReadPacket()
@@ -1488,10 +1491,15 @@ func (c *Conn) execQueryMulti(query string, handler Handler) execResult {
 	needsEndPacket := false
 	callbackCalled := false
 	res := execSuccess
+	previousStatusFlags := c.StatusFlags
+	defer func() {
+		c.StatusFlags &^= ServerQueryWasSlow
+	}()
 
 	err := handler.ComQueryMulti(c, query, func(qr sqltypes.QueryResponse, more bool, firstPacket bool) error {
+		currentStatusFlags := c.StatusFlags
 		callbackCalled = true
-		flag := c.StatusFlags
+		flag := currentStatusFlags
 		if more {
 			flag |= ServerMoreResultsExists
 		}
@@ -1499,7 +1507,7 @@ func (c *Conn) execQueryMulti(query string, handler Handler) execResult {
 		// firstPacket tells us that this is the start of a new query result.
 		// If we haven't sent a last packet yet, we should send the end result packet.
 		if firstPacket && needsEndPacket {
-			if err := c.writeEndResult(true, 0, 0, handler.WarningCount(c)); err != nil {
+			if err := c.writeEndResultWithFlags(previousStatusFlags, true, 0, 0, handler.WarningCount(c)); err != nil {
 				log.Error(fmt.Sprintf("Error writing result to %s: %v", c, err))
 				return err
 			}
@@ -1521,6 +1529,7 @@ func (c *Conn) execQueryMulti(query string, handler Handler) execResult {
 			// So we reset the needsEndPacket variable to signify we haven't sent the last
 			// packet for this query.
 			needsEndPacket = true
+			previousStatusFlags = currentStatusFlags
 			if len(qr.QueryResult.Fields) == 0 {
 				// A successful callback with no fields means that this was a
 				// DML or other write-only operation.
@@ -1636,6 +1645,9 @@ func (c *Conn) execQuery(query string, handler Handler, more bool) execResult {
 	callbackCalled := false
 	// sendFinished is set if the response should just be an OK packet.
 	sendFinished := false
+	defer func() {
+		c.StatusFlags &^= ServerQueryWasSlow
+	}()
 
 	err := handler.ComQuery(c, query, func(qr *sqltypes.Result) error {
 		flag := c.StatusFlags

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"strings"
 	"sync"
@@ -1523,11 +1524,11 @@ func (c *Conn) execQueryMulti(query string, handler Handler) execResult {
 		if firstPacket && needsEndPacket {
 			if flags, ok := c.consumePendingMultiResultStatusFlags(); ok {
 				if err := c.writeEndResultWithFlags(flags, true, 0, 0, handler.WarningCount(c)); err != nil {
-					log.Error(fmt.Sprintf("Error writing result to %s: %v", c, err))
+					log.Error("Error writing result", slog.String("connection", c.String()), slog.Any("error", err))
 					return err
 				}
 			} else if err := c.writeEndResultWithFlags(previousStatusFlags, true, 0, 0, handler.WarningCount(c)); err != nil {
-				log.Error(fmt.Sprintf("Error writing result to %s: %v", c, err))
+				log.Error("Error writing result", slog.String("connection", c.String()), slog.Any("error", err))
 				return err
 			}
 		}

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -946,6 +946,47 @@ func TestMultiStatement(t *testing.T) {
 	}
 }
 
+type slowQueryMultiHandler struct {
+	testRun
+}
+
+func (h slowQueryMultiHandler) ComQueryMulti(c *Conn, sql string, callback func(qr sqltypes.QueryResponse, more bool, firstPacket bool) error) error {
+	if err := callback(sqltypes.QueryResponse{QueryResult: selectRowsResult}, true, true); err != nil {
+		return err
+	}
+	c.StatusFlags |= ServerQueryWasSlow
+	c.SetPendingMultiResultStatusFlags(c.StatusFlags)
+	c.StatusFlags &^= ServerQueryWasSlow
+	return callback(sqltypes.QueryResponse{QueryResult: &sqltypes.Result{}}, false, true)
+}
+
+func TestMultiStatementUsesCurrentStatusFlagsForOKOnlyResults(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	sConn.multiQuery = true
+	sConn.Capabilities |= CapabilityClientMultiStatements
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	err := cConn.WriteComQuery("select 1; set autocommit = 1")
+	require.NoError(t, err)
+
+	res := sConn.handleNextCommand(slowQueryMultiHandler{})
+	require.True(t, res)
+
+	data, more, _, err := cConn.ReadQueryResult(100, true)
+	require.NoError(t, err)
+	require.True(t, more)
+	assert.NotZero(t, data.StatusFlags&ServerQueryWasSlow)
+
+	data, more, _, err = cConn.ReadQueryResult(100, true)
+	require.NoError(t, err)
+	require.False(t, more)
+	assert.Zero(t, data.StatusFlags&ServerQueryWasSlow)
+}
+
 func TestMultiStatementOnSplitError(t *testing.T) {
 	for _, b := range []bool{true, false} {
 		t.Run(fmt.Sprintf("MultiQueryProtocol: %v", b), func(t *testing.T) {

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -1284,6 +1284,64 @@ func createSendLongDataPacket(stmtID uint32, paramID uint16, data []byte) []byte
 	return packet
 }
 
+func createComStmtResetPacket(stmtID uint32) []byte {
+	packet := []byte{0, 0, 0, 0, ComStmtReset, 0, 0, 0, 0}
+	binary.LittleEndian.PutUint32(packet[5:], stmtID)
+	return packet
+}
+
+type slowQueryTestHandler struct {
+	testRun
+	queryResults map[string]*sqltypes.Result
+	slowQueries  map[string]bool
+}
+
+func (h slowQueryTestHandler) ComQuery(c *Conn, query string, callback func(*sqltypes.Result) error) error {
+	query = strings.TrimSpace(query)
+	query = strings.TrimSuffix(query, ";")
+	query = strings.TrimSpace(query)
+	result, ok := h.queryResults[query]
+	if !ok {
+		return fmt.Errorf("unexpected query: %s", query)
+	}
+	if h.slowQueries[query] {
+		c.StatusFlags |= ServerQueryWasSlow
+	} else {
+		c.StatusFlags &^= ServerQueryWasSlow
+	}
+	return callback(result)
+}
+
+func (h slowQueryTestHandler) ComQueryMulti(c *Conn, sql string, callback func(qr sqltypes.QueryResponse, more bool, firstPacket bool) error) error {
+	queries, err := h.Env().Parser().SplitStatementToPieces(sql)
+	if err != nil {
+		return err
+	}
+	if len(queries) == 0 {
+		return sqlerror.NewSQLErrorFromError(sqlparser.ErrEmpty)
+	}
+	for i, query := range queries {
+		firstPacket := true
+		err = h.ComQuery(c, query, func(result *sqltypes.Result) error {
+			err = callback(sqltypes.QueryResponse{QueryResult: result}, i < len(queries)-1, firstPacket)
+			firstPacket = false
+			return err
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h slowQueryTestHandler) WarningCount(*Conn) uint16 {
+	return 0
+}
+
+func (h slowQueryTestHandler) Env() *vtenv.Environment {
+	return vtenv.NewTestEnv()
+}
+
 type testRun struct {
 	UnimplementedHandler
 	paramCounts uint16
@@ -1453,4 +1511,128 @@ func TestWritePacketHeader(t *testing.T) {
 
 		assert.Equal(t, uint8(3), sConn.sequence)
 	})
+}
+
+func TestMultiQueryProtocolUsesCurrentSlowFlagForOKOnlyStatements(t *testing.T) {
+	testCases := []struct {
+		name       string
+		firstSlow  bool
+		secondSlow bool
+	}{
+		{name: "slow-then-fast", firstSlow: true, secondSlow: false},
+		{name: "fast-then-slow", firstSlow: false, secondSlow: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			listener, sConn, cConn := createSocketPair(t)
+			sConn.multiQuery = true
+			sConn.Capabilities |= CapabilityClientMultiStatements
+			defer func() {
+				listener.Close()
+				sConn.Close()
+				cConn.Close()
+			}()
+
+			handler := slowQueryTestHandler{
+				queryResults: map[string]*sqltypes.Result{
+					"select 1":            selectRowsResult,
+					"update t set id = 2": {RowsAffected: 1},
+				},
+				slowQueries: map[string]bool{
+					"select 1":            tc.firstSlow,
+					"update t set id = 2": tc.secondSlow,
+				},
+			}
+
+			err := cConn.WriteComQuery("select 1; update t set id = 2")
+			require.NoError(t, err)
+			require.True(t, sConn.handleNextCommand(handler))
+
+			result, more, _, err := cConn.ReadQueryResult(100, true)
+			require.NoError(t, err)
+			require.True(t, more)
+			assert.Equal(t, tc.firstSlow, result.StatusFlags&ServerQueryWasSlow != 0)
+
+			result, more, _, err = cConn.ReadQueryResult(100, true)
+			require.NoError(t, err)
+			require.False(t, more)
+			assert.Equal(t, tc.secondSlow, result.StatusFlags&ServerQueryWasSlow != 0)
+			assert.Zero(t, sConn.StatusFlags&ServerQueryWasSlow)
+		})
+	}
+}
+
+func TestQueryWasSlowFlagDoesNotLeakToLaterCommands(t *testing.T) {
+	testCases := []struct {
+		name          string
+		prepareServer func(*Conn)
+		writeCommand  func(*Conn) error
+	}{
+		{
+			name: "com_ping",
+			prepareServer: func(sConn *Conn) {
+				sConn.listener = &Listener{}
+			},
+			writeCommand: func(cConn *Conn) error {
+				cConn.sequence = 0
+				return cConn.writePacket([]byte{0, 0, 0, 0, ComPing})
+			},
+		},
+		{
+			name: "com_stmt_reset",
+			prepareServer: func(sConn *Conn) {
+				sConn.PrepareData[1] = &PrepareData{
+					StatementID: 1,
+					ParamsCount: 1,
+					BindVars:    map[string]*querypb.BindVariable{"v1": nil},
+				}
+			},
+			writeCommand: func(cConn *Conn) error {
+				cConn.sequence = 0
+				return cConn.writePacket(createComStmtResetPacket(1))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			listener, sConn, cConn := createSocketPair(t)
+			defer func() {
+				listener.Close()
+				sConn.Close()
+				cConn.Close()
+			}()
+
+			handler := slowQueryTestHandler{
+				queryResults: map[string]*sqltypes.Result{
+					"select 1": selectRowsResult,
+				},
+				slowQueries: map[string]bool{
+					"select 1": true,
+				},
+			}
+
+			err := cConn.WriteComQuery("select 1")
+			require.NoError(t, err)
+			require.True(t, sConn.handleNextCommand(handler))
+
+			result, more, _, err := cConn.ReadQueryResult(100, true)
+			require.NoError(t, err)
+			require.False(t, more)
+			assert.NotZero(t, result.StatusFlags&ServerQueryWasSlow)
+			assert.Zero(t, sConn.StatusFlags&ServerQueryWasSlow)
+
+			tc.prepareServer(sConn)
+			err = tc.writeCommand(cConn)
+			require.NoError(t, err)
+			require.True(t, sConn.handleNextCommand(handler))
+
+			data, err := cConn.ReadPacket()
+			require.NoError(t, err)
+			var ok PacketOK
+			require.NoError(t, cConn.parseOKPacket(&ok, data))
+			assert.Zero(t, ok.statusFlags&ServerQueryWasSlow)
+		})
+	}
 }

--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -1072,9 +1072,12 @@ func (c *Conn) writeRows(result *sqltypes.Result) error {
 // writeEndResult concludes the sending of a Result.
 // if more is set to true, then it means there are more results afterwords
 func (c *Conn) writeEndResult(more bool, affectedRows, lastInsertID uint64, warnings uint16) error {
+	return c.writeEndResultWithFlags(c.StatusFlags, more, affectedRows, lastInsertID, warnings)
+}
+
+func (c *Conn) writeEndResultWithFlags(flags uint16, more bool, affectedRows, lastInsertID uint64, warnings uint16) error {
 	// Send either an EOF, or an OK packet.
 	// See doc.go.
-	flags := c.StatusFlags
 	if more {
 		flags |= ServerMoreResultsExists
 	}

--- a/go/test/endtoend/vtgate/queries/misc/main_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/main_test.go
@@ -73,7 +73,10 @@ func TestMain(m *testing.M) {
 			return 1
 		}
 
-		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs, "--enable-views")
+		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,
+			"--enable-views",
+			"--slow-query-threshold", "10ms",
+		)
 		clusterInstance.VtTabletExtraArgs = append(clusterInstance.VtTabletExtraArgs, "--queryserver-enable-views")
 
 		// Start keyspace

--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -465,7 +465,7 @@ func assertQueryLogLineContains(t *testing.T, queryMarker string, substrings ...
 		if err != nil {
 			return false
 		}
-		for _, line := range strings.Split(string(data), "\n") {
+		for line := range strings.SplitSeq(string(data), "\n") {
 			if !strings.Contains(line, queryMarker) {
 				continue
 			}
@@ -489,7 +489,7 @@ func assertVtgateMetricsLineContains(t *testing.T, metric string, substrings ...
 	require.Equal(t, http.StatusOK, status)
 	assert.Contains(t, metrics, metric)
 
-	for _, line := range strings.Split(metrics, "\n") {
+	for line := range strings.SplitSeq(metrics, "\n") {
 		if !strings.Contains(line, metric) {
 			continue
 		}

--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -417,6 +417,21 @@ func TestPreparedStatementInOLAP(t *testing.T) {
 	require.Equal(t, int64(1), c7)
 }
 
+func TestSlowQueryStatusFlagsComQueryOKOnlyOLAPEndToEnd(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	mcmp.Exec("insert into t1(id1, id2) values (1, 2)")
+
+	_, err := mcmp.VtConn.ExecuteFetch("set workload = olap", 1000, false)
+	require.NoError(t, err)
+
+	result, err := mcmp.VtConn.ExecuteFetch("update t1 set id2 = id2 + sleep(0.05) where id1 = 1", 1000, true)
+	require.NoError(t, err)
+	assert.Empty(t, result.Fields)
+	assert.NotZero(t, result.StatusFlags&mysql.ServerQueryWasSlow)
+}
+
 func TestPrepareStatements(t *testing.T) {
 	mcmp, closer := start(t)
 	defer closer()

--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -20,6 +20,8 @@ import (
 	"database/sql"
 	_ "embed"
 	"fmt"
+	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -426,10 +428,80 @@ func TestSlowQueryStatusFlagsComQueryOKOnlyOLAPEndToEnd(t *testing.T) {
 	_, err := mcmp.VtConn.ExecuteFetch("set workload = olap", 1000, false)
 	require.NoError(t, err)
 
-	result, err := mcmp.VtConn.ExecuteFetch("update t1 set id2 = id2 + sleep(0.05) where id1 = 1", 1000, true)
+	slowQueryMetric := "UPDATE.Passthrough.PRIMARY"
+	initialSlowQueries := vtgateMetricValue(t, "SlowQueries", slowQueryMetric)
+	query := "update /* slow_e2e */ t1 set id2 = id2 + sleep(0.05) where id1 = 1"
+	result, err := mcmp.VtConn.ExecuteFetch(query, 1000, true)
 	require.NoError(t, err)
 	assert.Empty(t, result.Fields)
 	assert.NotZero(t, result.StatusFlags&mysql.ServerQueryWasSlow)
+	assert.Greater(t, vtgateMetricValue(t, "SlowQueries", slowQueryMetric), initialSlowQueries)
+	assertVtgateMetricsLineContains(t, "vtgate_slow_queries", `query="UPDATE"`, `plan="Passthrough"`, `tablet="PRIMARY"`)
+	assertQueryLogLineContains(t, "slow_e2e", "\ttrue\t")
+}
+
+func vtgateMetricValue(t *testing.T, metric, key string) float64 {
+	t.Helper()
+
+	vars := clusterInstance.VtgateProcess.GetVars()
+	require.NotNil(t, vars)
+
+	values, ok := vars[metric].(map[string]any)
+	require.True(t, ok, "%s is not a map", metric)
+
+	if raw, ok := values[key]; ok {
+		value, ok := raw.(float64)
+		require.True(t, ok, "%s value is not a number", metric)
+		return value
+	}
+	return 0
+}
+
+func assertQueryLogLineContains(t *testing.T, queryMarker string, substrings ...string) {
+	t.Helper()
+
+	assert.Eventually(t, func() bool {
+		data, err := os.ReadFile(clusterInstance.VtgateProcess.FileToLogQueries)
+		if err != nil {
+			return false
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			if !strings.Contains(line, queryMarker) {
+				continue
+			}
+			matched := true
+			for _, substring := range substrings {
+				matched = matched && strings.Contains(line, substring)
+			}
+			if matched {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 100*time.Millisecond)
+}
+
+func assertVtgateMetricsLineContains(t *testing.T, metric string, substrings ...string) {
+	t.Helper()
+
+	status, metrics, err := clusterInstance.VtgateProcess.MakeAPICall("metrics")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+	assert.Contains(t, metrics, metric)
+
+	for _, line := range strings.Split(metrics, "\n") {
+		if !strings.Contains(line, metric) {
+			continue
+		}
+		matched := true
+		for _, substring := range substrings {
+			matched = matched && strings.Contains(line, substring)
+		}
+		if matched {
+			return
+		}
+	}
+	assert.Failf(t, "missing vtgate metric line", "%s did not include labels %v", metric, substrings)
 }
 
 func TestPrepareStatements(t *testing.T) {

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -80,6 +80,7 @@ var (
 	queryExecutions        = stats.NewCountersWithMultiLabels("QueryExecutions", "Counts queries executed at VTGate by query type, plan type, and tablet type.", []string{"Query", "Plan", "Tablet"})
 	queryRoutes            = stats.NewCountersWithMultiLabels("QueryRoutes", "Counts queries routed from VTGate to VTTablet by query type, plan type, and tablet type.", []string{"Query", "Plan", "Tablet"})
 	queryExecutionsByTable = stats.NewCountersWithMultiLabels("QueryExecutionsByTable", "Counts queries executed at VTGate per table by query type and table.", []string{"Query", "Table"})
+	slowQueries            = stats.NewCountersWithMultiLabels("SlowQueries", "Counts vtgate queries classified as slow by query type, plan type, and tablet type.", []string{"Query", "Plan", "Tablet"})
 	txProcessed            = stats.NewCountersWithMultiLabels("TransactionsProcessed", "Counts transactions processed at VTGate by shard distribution (single or cross), transaction type (read write or read only)", []string{"Shard", "Type"})
 
 	// commitMode records the timing of the commit phase of a transaction.
@@ -286,8 +287,7 @@ func (e *Executor) Execute(
 		})
 	}
 
-	logStats.SaveEndTime()
-	e.queryLogger.Send(logStats)
+	e.finalizeLogStats(logStats, mysqlCtx)
 
 	err = errorTransform.TransformError(err)
 	err = vterrors.TruncateError(err, truncateErrorLen)
@@ -432,8 +432,7 @@ func (e *Executor) StreamExecute(
 		})
 	}
 
-	logStats.SaveEndTime()
-	e.queryLogger.Send(logStats)
+	e.finalizeLogStats(logStats, mysqlCtx)
 
 	err = errorTransform.TransformError(err)
 	err = vterrors.TruncateError(err, truncateErrorLen)
@@ -464,6 +463,18 @@ func saveSessionStats(safeSession *econtext.SafeSession, stmtType sqlparser.Stat
 	case sqlparser.StmtDDL, sqlparser.StmtSet, sqlparser.StmtBegin, sqlparser.StmtCommit, sqlparser.StmtRollback, sqlparser.StmtFlush:
 		safeSession.RowCount = 0
 	}
+}
+
+func (e *Executor) finalizeLogStats(logStats *logstats.LogStats, mysqlCtx vtgateservice.MySQLConnection) {
+	logStats.SaveEndTime()
+	logStats.MarkSlowQuery(slowQueryThreshold)
+	if mysqlCtx != nil {
+		mysqlCtx.SetQueryWasSlow(logStats.SlowQuery)
+	}
+	if logStats.SlowQuery && logStats.StmtType != "" && logStats.PlanType != "" && logStats.TabletType != "" {
+		slowQueries.Add([]string{logStats.StmtType, logStats.PlanType, logStats.TabletType}, 1)
+	}
+	e.queryLogger.Send(logStats)
 }
 
 func (e *Executor) execute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, safeSession *econtext.SafeSession, sql string, bindVars map[string]*querypb.BindVariable, prepared bool, logStats *logstats.LogStats) (sqlparser.StatementType, *sqltypes.Result, error) {
@@ -631,6 +642,10 @@ func ifReadAfterWriteExist(session *econtext.SafeSession, f func(*vtgatepb.ReadA
 func (e *Executor) handleBegin(ctx context.Context, vcursor *econtext.VCursorImpl, safeSession *econtext.SafeSession, logStats *logstats.LogStats, stmt sqlparser.Statement) (*sqltypes.Result, error) {
 	execStart := time.Now()
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
+	logStats.StmtType = sqlparser.StmtBegin.String()
+	logStats.PlanType = engine.PlanTransaction.String()
+	logStats.TabletType = vcursor.TabletType().String()
+	logStats.ActiveKeyspace = vcursor.GetKeyspace()
 	e.updateQueryStats(sqlparser.StmtBegin.String(), engine.PlanTransaction.String(), vcursor.TabletType().String(), 0, nil)
 
 	begin := stmt.(*sqlparser.Begin)
@@ -642,6 +657,10 @@ func (e *Executor) handleBegin(ctx context.Context, vcursor *econtext.VCursorImp
 func (e *Executor) handleCommit(ctx context.Context, vcursor *econtext.VCursorImpl, safeSession *econtext.SafeSession, logStats *logstats.LogStats) (*sqltypes.Result, error) {
 	execStart := time.Now()
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
+	logStats.StmtType = sqlparser.StmtCommit.String()
+	logStats.PlanType = engine.PlanTransaction.String()
+	logStats.TabletType = vcursor.TabletType().String()
+	logStats.ActiveKeyspace = vcursor.GetKeyspace()
 	logStats.ShardQueries = uint64(len(safeSession.ShardSessions))
 	e.updateQueryStats(sqlparser.StmtCommit.String(), engine.PlanTransaction.String(), vcursor.TabletType().String(), int64(logStats.ShardQueries), nil)
 
@@ -658,6 +677,10 @@ func (e *Executor) Commit(ctx context.Context, safeSession *econtext.SafeSession
 func (e *Executor) handleRollback(ctx context.Context, vcursor *econtext.VCursorImpl, safeSession *econtext.SafeSession, logStats *logstats.LogStats) (*sqltypes.Result, error) {
 	execStart := time.Now()
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
+	logStats.StmtType = sqlparser.StmtRollback.String()
+	logStats.PlanType = engine.PlanTransaction.String()
+	logStats.TabletType = vcursor.TabletType().String()
+	logStats.ActiveKeyspace = vcursor.GetKeyspace()
 	logStats.ShardQueries = uint64(len(safeSession.ShardSessions))
 	e.updateQueryStats(sqlparser.StmtRollback.String(), engine.PlanTransaction.String(), vcursor.TabletType().String(), int64(logStats.ShardQueries), nil)
 
@@ -669,6 +692,10 @@ func (e *Executor) handleRollback(ctx context.Context, vcursor *econtext.VCursor
 func (e *Executor) handleSavepoint(ctx context.Context, vcursor *econtext.VCursorImpl, safeSession *econtext.SafeSession, sql string, queryType string, logStats *logstats.LogStats, nonTxResponse func(query string) (*sqltypes.Result, error), ignoreMaxMemoryRows bool) (*sqltypes.Result, error) {
 	execStart := time.Now()
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
+	logStats.StmtType = queryType
+	logStats.PlanType = engine.PlanTransaction.String()
+	logStats.TabletType = vcursor.TabletType().String()
+	logStats.ActiveKeyspace = vcursor.GetKeyspace()
 	logStats.ShardQueries = uint64(len(safeSession.ShardSessions))
 	e.updateQueryStats(queryType, engine.PlanTransaction.String(), vcursor.TabletType().String(), int64(logStats.ShardQueries), nil)
 
@@ -732,6 +759,10 @@ func (e *Executor) executeSPInAllSessions(ctx context.Context, safeSession *econ
 func (e *Executor) handleKill(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, vcursor *econtext.VCursorImpl, stmt sqlparser.Statement, logStats *logstats.LogStats) (result *sqltypes.Result, err error) {
 	execStart := time.Now()
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
+	logStats.StmtType = "Kill"
+	logStats.PlanType = engine.PlanLocal.String()
+	logStats.TabletType = vcursor.TabletType().String()
+	logStats.ActiveKeyspace = vcursor.GetKeyspace()
 	e.updateQueryStats("Kill", engine.PlanLocal.String(), vcursor.TabletType().String(), 0, nil)
 
 	defer func() {
@@ -1507,8 +1538,7 @@ func (e *Executor) Prepare(ctx context.Context, method string, safeSession *econ
 	// To avoid spamming the log with no-op rollback records, ignore it if
 	// it was a no-op record (i.e. didn't issue any queries)
 	if logStats.StmtType != "ROLLBACK" || logStats.ShardQueries != 0 {
-		logStats.SaveEndTime()
-		e.queryLogger.Send(logStats)
+		e.finalizeLogStats(logStats, nil)
 	}
 
 	err = errorTransform.TransformError(err)

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -376,6 +376,23 @@ func (e *Executor) StreamExecute(
 		err := vc.StreamExecutePrimitive(ctx, plan.Instructions, bindVars, true, func(qr *sqltypes.Result) error {
 			return srr.storeResultStats(plan.QueryType, qr)
 		})
+
+		updateLogStats := func() {
+			logStats.StmtType = plan.QueryType.String()
+			logStats.PlanType = plan.Type.String()
+			logStats.TablesUsed = plan.TablesUsed
+			executedRoot := vc.ExecutedPrimitive()
+			if executedRoot == nil {
+				executedRoot = plan.Instructions
+			}
+			logStats.RoutingIndexesUsed = engine.GetRoutingIndexes(executedRoot)
+			logStats.TabletType = vc.TabletType().String()
+			logStats.ExecuteTime = time.Since(execStart)
+			logStats.ActiveKeyspace = vc.GetKeyspace()
+
+			e.updateQueryStats(plan.QueryType.String(), plan.Type.String(), vc.TabletType().String(), int64(logStats.ShardQueries), plan.TablesUsed)
+		}
+
 		// Check if there was partial DML execution. If so, rollback the effect of the partially executed query.
 		if err != nil {
 			if safeSession.InTransaction() && e.rollbackOnFatalTxError(ctx, safeSession, err) {
@@ -388,6 +405,7 @@ func (e *Executor) StreamExecute(
 		}
 
 		if !canReturnRows(plan.QueryType) {
+			updateLogStats()
 			return nil
 		}
 
@@ -399,17 +417,7 @@ func (e *Executor) StreamExecute(
 		}
 
 		// 5: Log and add statistics
-		logStats.TablesUsed = plan.TablesUsed
-		executedRoot := vc.ExecutedPrimitive()
-		if executedRoot == nil {
-			executedRoot = plan.Instructions
-		}
-		logStats.RoutingIndexesUsed = engine.GetRoutingIndexes(executedRoot)
-		logStats.TabletType = vc.TabletType().String()
-		logStats.ExecuteTime = time.Since(execStart)
-		logStats.ActiveKeyspace = vc.GetKeyspace()
-
-		e.updateQueryStats(plan.QueryType.String(), plan.Type.String(), vc.TabletType().String(), int64(logStats.ShardQueries), plan.TablesUsed)
+		updateLogStats()
 
 		return err
 	}

--- a/go/vt/vtgate/executor_stats_test.go
+++ b/go/vt/vtgate/executor_stats_test.go
@@ -18,8 +18,10 @@ package vtgate
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
@@ -77,9 +79,52 @@ func TestQueryExecutionsByTable_OnError(t *testing.T) {
 		"queryExecutionsByTable counter should not be incremented on execution error")
 }
 
+func TestSlowQueriesCounter(t *testing.T) {
+	executor, sbc1, _, _, ctx := createExecutorEnv(t)
+
+	oldThreshold := slowQueryThreshold
+	slowQueryThreshold = 5 * time.Millisecond
+	t.Cleanup(func() {
+		slowQueryThreshold = oldThreshold
+		sbc1.ExecDelayResponse = 0
+	})
+
+	sbc1.SetResults([]*sqltypes.Result{
+		sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1"),
+		sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1"),
+		sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1"),
+	})
+
+	session := econtext.NewSafeSession(&vtgatepb.Session{TargetString: KsTestSharded})
+	initialCount := getTotalSlowQueryCount()
+
+	_, err := executorExecSession(ctx, executor, session, "select id from user where id = 1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, initialCount, getTotalSlowQueryCount(), "fast query should not increment slow query count")
+
+	sbc1.ExecDelayResponse = 20 * time.Millisecond
+	_, err = executorExecSession(ctx, executor, session, "select id from user where id = 1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, initialCount+1, getTotalSlowQueryCount(), "slow query should increment slow query count")
+
+	sbc1.ExecDelayResponse = 20 * time.Millisecond
+	slowQueryThreshold = 0
+	_, err = executorExecSession(ctx, executor, session, "select id from user where id = 1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, initialCount+1, getTotalSlowQueryCount(), "disabled slow query threshold should not increment slow query count")
+}
+
 // getCurrentQueryExecutionsByTableCounts returns the current values of all queryExecutionsByTable counters
 func getCurrentQueryExecutionsByTableCounts() map[string]int64 {
 	// queryExecutionsByTable is a global variable, so we can use its Counts() method
 	// to get all counter values. The keys are already formatted as "query.table"
 	return queryExecutionsByTable.Counts()
+}
+
+func getTotalSlowQueryCount() int64 {
+	var total int64
+	for _, count := range slowQueries.Counts() {
+		total += count
+	}
+	return total
 }

--- a/go/vt/vtgate/executor_stats_test.go
+++ b/go/vt/vtgate/executor_stats_test.go
@@ -83,7 +83,7 @@ func TestSlowQueriesCounter(t *testing.T) {
 	executor, sbc1, _, _, ctx := createExecutorEnv(t)
 
 	oldThreshold := slowQueryThreshold
-	slowQueryThreshold = 5 * time.Millisecond
+	slowQueryThreshold = time.Hour
 	t.Cleanup(func() {
 		slowQueryThreshold = oldThreshold
 		sbc1.ExecDelayResponse = 0
@@ -103,6 +103,7 @@ func TestSlowQueriesCounter(t *testing.T) {
 	assert.Equal(t, initialCount, getTotalSlowQueryCount(), "fast query should not increment slow query count")
 
 	sbc1.ExecDelayResponse = 20 * time.Millisecond
+	slowQueryThreshold = 5 * time.Millisecond
 	_, err = executorExecSession(ctx, executor, session, "select id from user where id = 1", nil)
 	require.NoError(t, err)
 	assert.Equal(t, initialCount+1, getTotalSlowQueryCount(), "slow query should increment slow query count")

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -3010,6 +3010,10 @@ func (f *fakeMysqlConnection) KillConnection(ctx context.Context, connID uint32)
 	return nil
 }
 
+func (f *fakeMysqlConnection) SetQueryWasSlow(slow bool) {
+	f.Log = append(f.Log, fmt.Sprintf("slow query: %t", slow))
+}
+
 var _ vtgateservice.MySQLConnection = (*fakeMysqlConnection)(nil)
 
 func exec(executor *Executor, session *econtext.SafeSession, sql string) (*sqltypes.Result, error) {

--- a/go/vt/vtgate/logstats/logstats.go
+++ b/go/vt/vtgate/logstats/logstats.go
@@ -37,6 +37,7 @@ type LogStats struct {
 
 	Ctx                     context.Context
 	Method                  string
+	PlanType                string
 	TabletType              string
 	StmtType                string
 	SQL                     string
@@ -58,6 +59,7 @@ type LogStats struct {
 	MirrorSourceExecuteTime time.Duration
 	MirrorTargetExecuteTime time.Duration
 	MirrorTargetError       error
+	SlowQuery               bool
 }
 
 // NewLogStats constructs a new LogStats with supplied Method and ctx
@@ -77,6 +79,12 @@ func NewLogStats(ctx context.Context, methodName, sql, sessionUUID string, bindV
 // SaveEndTime sets the end time of this request to now
 func (stats *LogStats) SaveEndTime() {
 	stats.EndTime = time.Now()
+}
+
+// MarkSlowQuery updates the slow-query marker using the configured threshold.
+// A non-positive threshold disables slow-query detection.
+func (stats *LogStats) MarkSlowQuery(threshold time.Duration) {
+	stats.SlowQuery = threshold > 0 && stats.TotalTime() >= threshold
 }
 
 // ImmediateCaller returns the immediate caller stored in LogStats.Ctx
@@ -213,6 +221,8 @@ func (stats *LogStats) Logf(w io.Writer, params url.Values) error {
 	log.Duration(stats.MirrorTargetExecuteTime)
 	log.Key("MirrorTargetError")
 	log.String(stats.MirrorTargetErrorStr())
+	log.Key("SlowQuery")
+	log.Bool(stats.SlowQuery)
 	log.Key("EmitReason")
 	log.String(emitReason)
 

--- a/go/vt/vtgate/logstats/logstats_test.go
+++ b/go/vt/vtgate/logstats/logstats_test.go
@@ -72,42 +72,42 @@ func TestLogStatsFormat(t *testing.T) {
 		{ // 0
 			redact:   false,
 			format:   "text",
-			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t[]\t\"db\"\t0.000000\t0.000000\t\"\"\t\"\"\n",
+			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t[]\t\"db\"\t0.000000\t0.000000\t\"\"\tfalse\t\"\"\n",
 			bindVars: intBindVar,
 		}, { // 1
 			redact:   true,
 			format:   "text",
-			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t\"[REDACTED]\"\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t[]\t\"db\"\t0.000000\t0.000000\t\"\"\t\"\"\n",
+			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t\"[REDACTED]\"\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t[]\t\"db\"\t0.000000\t0.000000\t\"\"\tfalse\t\"\"\n",
 			bindVars: intBindVar,
 		}, { // 2
 			redact:   false,
 			format:   "json",
-			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":{\"intVal\":{\"type\":\"INT64\",\"value\":1}},\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"EmitReason\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"MirrorSourceExecuteTime\":0,\"MirrorTargetError\":\"\",\"MirrorTargetExecuteTime\":0,\"PlanTime\":0,\"RemoteAddr\":\"\",\"RoutingIndexesUsed\":[],\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
+			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":{\"intVal\":{\"type\":\"INT64\",\"value\":1}},\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"EmitReason\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"MirrorSourceExecuteTime\":0,\"MirrorTargetError\":\"\",\"MirrorTargetExecuteTime\":0,\"PlanTime\":0,\"RemoteAddr\":\"\",\"RoutingIndexesUsed\":[],\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"SlowQuery\":false,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
 			bindVars: intBindVar,
 		}, { // 3
 			redact:   true,
 			format:   "json",
-			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":\"[REDACTED]\",\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"EmitReason\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"MirrorSourceExecuteTime\":0,\"MirrorTargetError\":\"\",\"MirrorTargetExecuteTime\":0,\"PlanTime\":0,\"RemoteAddr\":\"\",\"RoutingIndexesUsed\":[],\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
+			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":\"[REDACTED]\",\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"EmitReason\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"MirrorSourceExecuteTime\":0,\"MirrorTargetError\":\"\",\"MirrorTargetExecuteTime\":0,\"PlanTime\":0,\"RemoteAddr\":\"\",\"RoutingIndexesUsed\":[],\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"SlowQuery\":false,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
 			bindVars: intBindVar,
 		}, { // 4
 			redact:   false,
 			format:   "text",
-			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t{\"strVal\": {\"type\": \"VARCHAR\", \"value\": \"abc\"}}\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t[]\t\"db\"\t0.000000\t0.000000\t\"\"\t\"\"\n",
+			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t{\"strVal\": {\"type\": \"VARCHAR\", \"value\": \"abc\"}}\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t[]\t\"db\"\t0.000000\t0.000000\t\"\"\tfalse\t\"\"\n",
 			bindVars: stringBindVar,
 		}, { // 5
 			redact:   true,
 			format:   "text",
-			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t\"[REDACTED]\"\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t[]\t\"db\"\t0.000000\t0.000000\t\"\"\t\"\"\n",
+			expected: "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t\"[REDACTED]\"\t0\t0\t\"\"\t\"PRIMARY\"\t\"suuid\"\tfalse\t[\"ks1.tbl1\",\"ks2.tbl2\"]\t[]\t\"db\"\t0.000000\t0.000000\t\"\"\tfalse\t\"\"\n",
 			bindVars: stringBindVar,
 		}, { // 6
 			redact:   false,
 			format:   "json",
-			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":{\"strVal\":{\"type\":\"VARCHAR\",\"value\":\"abc\"}},\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"EmitReason\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"MirrorSourceExecuteTime\":0,\"MirrorTargetError\":\"\",\"MirrorTargetExecuteTime\":0,\"PlanTime\":0,\"RemoteAddr\":\"\",\"RoutingIndexesUsed\":[],\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
+			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":{\"strVal\":{\"type\":\"VARCHAR\",\"value\":\"abc\"}},\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"EmitReason\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"MirrorSourceExecuteTime\":0,\"MirrorTargetError\":\"\",\"MirrorTargetExecuteTime\":0,\"PlanTime\":0,\"RemoteAddr\":\"\",\"RoutingIndexesUsed\":[],\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"SlowQuery\":false,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
 			bindVars: stringBindVar,
 		}, { // 7
 			redact:   true,
 			format:   "json",
-			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":\"[REDACTED]\",\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"EmitReason\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"MirrorSourceExecuteTime\":0,\"MirrorTargetError\":\"\",\"MirrorTargetExecuteTime\":0,\"PlanTime\":0,\"RemoteAddr\":\"\",\"RoutingIndexesUsed\":[],\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
+			expected: "{\"ActiveKeyspace\":\"db\",\"BindVars\":\"[REDACTED]\",\"Cached Plan\":false,\"CommitTime\":0,\"Effective Caller\":\"\",\"EmitReason\":\"\",\"End\":\"2017-01-01 01:02:04.000001\",\"Error\":\"\",\"ExecuteTime\":0,\"ImmediateCaller\":\"\",\"Method\":\"test\",\"MirrorSourceExecuteTime\":0,\"MirrorTargetError\":\"\",\"MirrorTargetExecuteTime\":0,\"PlanTime\":0,\"RemoteAddr\":\"\",\"RoutingIndexesUsed\":[],\"RowsAffected\":0,\"SQL\":\"sql1\",\"SessionUUID\":\"suuid\",\"ShardQueries\":0,\"SlowQuery\":false,\"Start\":\"2017-01-01 01:02:03.000000\",\"StmtType\":\"\",\"TablesUsed\":[\"ks1.tbl1\",\"ks2.tbl2\"],\"TabletType\":\"PRIMARY\",\"TotalTime\":1.000001,\"Username\":\"\"}",
 			bindVars: stringBindVar,
 		},
 	}
@@ -169,12 +169,12 @@ func TestLogStatsFilter(t *testing.T) {
 	params := map[string][]string{"full": {}}
 
 	got := testFormat(t, logStats, params)
-	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t[]\t\"\"\t0.000000\t0.000000\t\"\"\t\"\"\n"
+	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t[]\t\"\"\t0.000000\t0.000000\t\"\"\tfalse\t\"\"\n"
 	assert.Equal(t, want, got)
 
 	logStats.Config.FilterTag = "LOG_THIS_QUERY"
 	got = testFormat(t, logStats, params)
-	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t[]\t\"\"\t0.000000\t0.000000\t\"\"\t\"filtertag\"\n"
+	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t[]\t\"\"\t0.000000\t0.000000\t\"\"\tfalse\t\"filtertag\"\n"
 	assert.Equal(t, want, got)
 
 	logStats.Config.FilterTag = "NOT_THIS_QUERY"
@@ -191,11 +191,11 @@ func TestLogStatsRowThreshold(t *testing.T) {
 	params := map[string][]string{"full": {}}
 
 	got := testFormat(t, logStats, params)
-	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t[]\t\"\"\t0.000000\t0.000000\t\"\"\t\"\"\n"
+	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t[]\t\"\"\t0.000000\t0.000000\t\"\"\tfalse\t\"\"\n"
 	assert.Equal(t, want, got)
 
 	got = testFormat(t, logStats, params)
-	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t[]\t\"\"\t0.000000\t0.000000\t\"\"\t\"\"\n"
+	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t[]\t\"\"\t0.000000\t0.000000\t\"\"\tfalse\t\"\"\n"
 	assert.Equal(t, want, got)
 
 	logStats.Config.RowThreshold = 1
@@ -213,11 +213,11 @@ func TestLogStatsTimeThreshold(t *testing.T) {
 	params := map[string][]string{"full": {}}
 
 	got := testFormat(t, logStats, params)
-	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t[]\t\"\"\t0.000000\t0.000000\t\"\"\t\"time\"\n"
+	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t[]\t\"\"\t0.000000\t0.000000\t\"\"\tfalse\t\"time\"\n"
 	assert.Equal(t, want, got)
 
 	got = testFormat(t, logStats, params)
-	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t[]\t\"\"\t0.000000\t0.000000\t\"\"\t\"time\"\n"
+	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t[]\t\"\"\t0.000000\t0.000000\t\"\"\tfalse\t\"time\"\n"
 	assert.Equal(t, want, got)
 
 	// Set Query threshold more than query duration: 1 second and 1234 nanosecond
@@ -238,11 +238,11 @@ func TestLogStatsEmimtOnAnyConditionMet(t *testing.T) {
 	params := map[string][]string{"full": {}}
 
 	got := testFormat(t, logStats, params)
-	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t[]\t\"\"\t0.000000\t0.000000\t\"\"\t\"filtertag,time\"\n"
+	want := "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t[]\t\"\"\t0.000000\t0.000000\t\"\"\tfalse\t\"filtertag,time\"\n"
 	assert.Equal(t, want, got)
 
 	got = testFormat(t, logStats, params)
-	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t[]\t\"\"\t0.000000\t0.000000\t\"\"\t\"filtertag,time\"\n"
+	want = "test\t\t\t''\t''\t2017-01-01 01:02:03.000000\t2017-01-01 01:02:04.000001\t1.000001\t0.000000\t0.000000\t0.000000\t\t\"sql1 /* LOG_THIS_QUERY */\"\t{\"intVal\": {\"type\": \"INT64\", \"value\": 1}}\t0\t0\t\"\"\t\"\"\t\"\"\tfalse\t[]\t[]\t\"\"\t0.000000\t0.000000\t\"\"\tfalse\t\"filtertag,time\"\n"
 	assert.Equal(t, want, got)
 
 	// Set Query threshold more than query duration: 1 second and 1234 nanosecond
@@ -251,6 +251,23 @@ func TestLogStatsEmimtOnAnyConditionMet(t *testing.T) {
 	logStats.Config.RowThreshold = 1
 	got = testFormat(t, logStats, params)
 	assert.Empty(t, got)
+}
+
+func TestMarkSlowQuery(t *testing.T) {
+	logStats := NewLogStats(context.Background(), "test", "sql1", "", nil, streamlog.NewQueryLogConfigForTest())
+	logStats.StartTime = time.Date(2017, time.January, 1, 1, 2, 3, 0, time.UTC)
+
+	logStats.EndTime = logStats.StartTime.Add(time.Second)
+	logStats.MarkSlowQuery(time.Second)
+	assert.True(t, logStats.SlowQuery)
+
+	logStats.EndTime = logStats.StartTime.Add(999 * time.Millisecond)
+	logStats.MarkSlowQuery(time.Second)
+	assert.False(t, logStats.SlowQuery)
+
+	logStats.EndTime = logStats.StartTime.Add(2 * time.Second)
+	logStats.MarkSlowQuery(0)
+	assert.False(t, logStats.SlowQuery)
 }
 
 func TestLogStatsContextHTML(t *testing.T) {

--- a/go/vt/vtgate/logstats/logstats_test.go
+++ b/go/vt/vtgate/logstats/logstats_test.go
@@ -254,7 +254,7 @@ func TestLogStatsEmimtOnAnyConditionMet(t *testing.T) {
 }
 
 func TestMarkSlowQuery(t *testing.T) {
-	logStats := NewLogStats(context.Background(), "test", "sql1", "", nil, streamlog.NewQueryLogConfigForTest())
+	logStats := NewLogStats(t.Context(), "test", "sql1", "", nil, streamlog.NewQueryLogConfigForTest())
 	logStats.StartTime = time.Date(2017, time.January, 1, 1, 2, 3, 0, time.UTC)
 
 	logStats.EndTime = logStats.StartTime.Add(time.Second)

--- a/go/vt/vtgate/plan_execute.go
+++ b/go/vt/vtgate/plan_execute.go
@@ -482,6 +482,7 @@ func (e *Executor) rollbackPartialExec(ctx context.Context, safeSession *econtex
 
 func (e *Executor) setLogStats(logStats *logstats.LogStats, plan *engine.Plan, vcursor *econtext.VCursorImpl, execStart time.Time, err error, qr *sqltypes.Result) {
 	logStats.StmtType = plan.QueryType.String()
+	logStats.PlanType = plan.Type.String()
 	logStats.ActiveKeyspace = vcursor.GetKeyspace()
 	logStats.TabletType = vcursor.TabletType().String()
 	errCount := e.logExecutionEnd(logStats, execStart, plan, vcursor, err, qr)
@@ -516,6 +517,7 @@ func (e *Executor) logPlanningFinished(logStats *logstats.LogStats, plan *engine
 	execStart := time.Now()
 	if plan != nil {
 		logStats.StmtType = plan.QueryType.String()
+		logStats.PlanType = plan.Type.String()
 	}
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
 	return execStart

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -423,21 +423,9 @@ func (vh *vtgateHandler) ComQueryMulti(c *mysql.Conn, sql string, callback func(
 
 	fillInTxStatusFlags(c, session)
 	for idx, res := range queryResults {
-		if idx == 0 {
-			if len(mysqlCtx.slowQueryStates) > 0 {
-				setSlowQueryStatus(c, mysqlCtx.slowQueryStates[0])
-			}
-		} else if idx-1 < len(mysqlCtx.slowQueryStates) {
-			// The mysql server emits the previous result's EOF packet when the
-			// next result starts, so keep the previous statement's slow status in
-			// place until the next callback begins.
-			setSlowQueryStatus(c, mysqlCtx.slowQueryStates[idx-1])
-		}
+		setSlowQueryStatus(c, idx < len(mysqlCtx.slowQueryStates) && mysqlCtx.slowQueryStates[idx])
 		if callbackErr := callback(res, idx < len(queryResults)-1, true); callbackErr != nil {
 			return callbackErr
-		}
-		if idx < len(mysqlCtx.slowQueryStates) {
-			setSlowQueryStatus(c, mysqlCtx.slowQueryStates[idx])
 		}
 	}
 	return nil

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -487,7 +487,9 @@ func (vh *vtgateHandler) streamExecuteMultiQuery(ctx context.Context, c *mysql.C
 			return session, err
 		}
 		if deferredResult != nil {
-			applyMultiQueryStatusFlags(c, mysqlCtx.slowQueryStates, idx)
+			previousStatusFlags := c.StatusFlags
+			fillInTxStatusFlags(c, session)
+			applyMultiQueryStatusFlagsWithPrevious(c, mysqlCtx.slowQueryStates, idx, previousStatusFlags)
 			if err := callback(sqltypes.QueryResponse{QueryResult: deferredResult}, more, true); err != nil {
 				return session, err
 			}
@@ -514,8 +516,12 @@ func setSlowQueryStatus(c *mysql.Conn, slow bool) {
 }
 
 func applyMultiQueryStatusFlags(c *mysql.Conn, slowQueryStates []bool, idx int) {
+	applyMultiQueryStatusFlagsWithPrevious(c, slowQueryStates, idx, c.StatusFlags)
+}
+
+func applyMultiQueryStatusFlagsWithPrevious(c *mysql.Conn, slowQueryStates []bool, idx int, previousStatusFlags uint16) {
 	if idx > 0 && idx-1 < len(slowQueryStates) {
-		c.SetPendingMultiResultStatusFlags(slowQueryStatusFlags(c.StatusFlags, slowQueryStates[idx-1]))
+		c.SetPendingMultiResultStatusFlags(slowQueryStatusFlags(previousStatusFlags, slowQueryStates[idx-1]))
 	}
 	if idx < len(slowQueryStates) {
 		setSlowQueryStatus(c, slowQueryStates[idx])

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -396,12 +396,22 @@ func (vh *vtgateHandler) ComQueryMulti(c *mysql.Conn, sql string, callback func(
 			session, err = vh.streamExecuteMultiQuery(ctx, c, mysqlCtx, session, sql, callback)
 		} else {
 			firstPacket := true
+			var deferredResult *sqltypes.Result
 			session, err = vh.vtg.StreamExecute(ctx, mysqlCtx, session, sql, make(map[string]*querypb.BindVariable), func(result *sqltypes.Result) error {
+				if firstPacket && len(result.Fields) == 0 {
+					deferredResult = result
+					firstPacket = false
+					return nil
+				}
 				defer func() {
 					firstPacket = false
 				}()
 				return callback(sqltypes.QueryResponse{QueryResult: result}, false, firstPacket)
 			})
+			if err == nil && deferredResult != nil {
+				fillInTxStatusFlags(c, session)
+				return callback(sqltypes.QueryResponse{QueryResult: deferredResult}, false, true)
+			}
 		}
 		if err != nil {
 			return sqlerror.NewSQLErrorFromError(err)
@@ -471,6 +481,7 @@ func (vh *vtgateHandler) streamExecuteMultiQuery(ctx context.Context, c *mysql.C
 		}()
 		if err != nil {
 			if firstPacket {
+				applyMultiQueryStatusFlags(c, mysqlCtx.slowQueryStates, idx)
 				return session, callback(sqltypes.QueryResponse{QueryError: sqlerror.NewSQLErrorFromError(err)}, false, true)
 			}
 			return session, err

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -389,7 +389,7 @@ func (vh *vtgateHandler) ComQueryMulti(c *mysql.Conn, sql string, callback func(
 
 	if session.Options.Workload == querypb.ExecuteOptions_OLAP {
 		if c.Capabilities&mysql.CapabilityClientMultiStatements != 0 {
-			session, err = vh.vtg.StreamExecuteMulti(ctx, mysqlCtx, session, sql, callback)
+			session, err = vh.streamExecuteMultiQuery(ctx, c, mysqlCtx, session, sql, callback)
 		} else {
 			firstPacket := true
 			session, err = vh.vtg.StreamExecute(ctx, mysqlCtx, session, sql, make(map[string]*querypb.BindVariable), func(result *sqltypes.Result) error {
@@ -423,12 +423,61 @@ func (vh *vtgateHandler) ComQueryMulti(c *mysql.Conn, sql string, callback func(
 
 	fillInTxStatusFlags(c, session)
 	for idx, res := range queryResults {
-		setSlowQueryStatus(c, idx < len(mysqlCtx.slowQueryStates) && mysqlCtx.slowQueryStates[idx])
+		applyMultiQueryStatusFlags(c, mysqlCtx.slowQueryStates, idx)
 		if callbackErr := callback(res, idx < len(queryResults)-1, true); callbackErr != nil {
 			return callbackErr
 		}
 	}
 	return nil
+}
+
+func (vh *vtgateHandler) streamExecuteMultiQuery(ctx context.Context, c *mysql.Conn, mysqlCtx *vtgateMySQLConnection, session *vtgatepb.Session, sql string, callback func(qr sqltypes.QueryResponse, more bool, firstPacket bool) error) (*vtgatepb.Session, error) {
+	queries, err := vh.vtg.executor.Environment().Parser().SplitStatementToPieces(sql)
+	if err != nil {
+		return session, err
+	}
+	if len(queries) == 0 {
+		return session, sqlparser.ErrEmpty
+	}
+	var cancel context.CancelFunc
+	for idx, query := range queries {
+		firstPacket := true
+		more := idx < len(queries)-1
+		var deferredResult *sqltypes.Result
+		func() {
+			if mysqlQueryTimeout != 0 {
+				ctx, cancel = context.WithTimeout(ctx, mysqlQueryTimeout)
+				defer cancel()
+			}
+			session, err = vh.vtg.StreamExecute(ctx, mysqlCtx, session, query, make(map[string]*querypb.BindVariable), func(result *sqltypes.Result) error {
+				if firstPacket && len(result.Fields) == 0 {
+					deferredResult = result
+					firstPacket = false
+					return nil
+				}
+				if firstPacket {
+					applyMultiQueryStatusFlags(c, mysqlCtx.slowQueryStates, idx)
+				}
+				defer func() {
+					firstPacket = false
+				}()
+				return callback(sqltypes.QueryResponse{QueryResult: result}, more, firstPacket)
+			})
+		}()
+		if err != nil {
+			if firstPacket {
+				return session, callback(sqltypes.QueryResponse{QueryError: sqlerror.NewSQLErrorFromError(err)}, false, true)
+			}
+			return session, err
+		}
+		if deferredResult != nil {
+			applyMultiQueryStatusFlags(c, mysqlCtx.slowQueryStates, idx)
+			if err := callback(sqltypes.QueryResponse{QueryResult: deferredResult}, more, true); err != nil {
+				return session, err
+			}
+		}
+	}
+	return session, nil
 }
 
 func fillInTxStatusFlags(c *mysql.Conn, session *vtgatepb.Session) {
@@ -445,11 +494,23 @@ func fillInTxStatusFlags(c *mysql.Conn, session *vtgatepb.Session) {
 }
 
 func setSlowQueryStatus(c *mysql.Conn, slow bool) {
-	if slow {
-		c.StatusFlags |= mysql.ServerQueryWasSlow
-		return
+	c.StatusFlags = slowQueryStatusFlags(c.StatusFlags, slow)
+}
+
+func applyMultiQueryStatusFlags(c *mysql.Conn, slowQueryStates []bool, idx int) {
+	if idx > 0 && idx-1 < len(slowQueryStates) {
+		c.SetPendingMultiResultStatusFlags(slowQueryStatusFlags(c.StatusFlags, slowQueryStates[idx-1]))
 	}
-	c.StatusFlags &^= mysql.ServerQueryWasSlow
+	if idx < len(slowQueryStates) {
+		setSlowQueryStatus(c, slowQueryStates[idx])
+	}
+}
+
+func slowQueryStatusFlags(statusFlags uint16, slow bool) uint16 {
+	if slow {
+		return statusFlags | mysql.ServerQueryWasSlow
+	}
+	return statusFlags &^ mysql.ServerQueryWasSlow
 }
 
 // ComPrepare is the handler for command prepare.

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -330,20 +330,14 @@ func (vh *vtgateHandler) ComQuery(c *mysql.Conn, query string, callback func(*sq
 	}()
 
 	if session.Options.Workload == querypb.ExecuteOptions_OLAP {
-		var deferredResult *sqltypes.Result
-		session, err := vh.vtg.StreamExecute(ctx, mysqlCtx, session, query, make(map[string]*querypb.BindVariable), func(result *sqltypes.Result) error {
-			if len(result.Fields) == 0 {
-				deferredResult = result
-				return nil
-			}
-			return callback(result)
-		})
+		streamCallback, deferredResult := deferFirstOKOnlyResult(callback)
+		session, err := vh.vtg.StreamExecute(ctx, mysqlCtx, session, query, make(map[string]*querypb.BindVariable), streamCallback)
 		if err != nil {
 			return sqlerror.NewSQLErrorFromError(err)
 		}
 		fillInTxStatusFlags(c, session)
-		if deferredResult != nil {
-			return callback(deferredResult)
+		if result := deferredResult(); result != nil {
+			return callback(result)
 		}
 		return nil
 	}
@@ -449,17 +443,18 @@ func (vh *vtgateHandler) streamExecuteMultiQuery(ctx context.Context, c *mysql.C
 	if len(queries) == 0 {
 		return session, sqlparser.ErrEmpty
 	}
-	var cancel context.CancelFunc
 	for idx, query := range queries {
 		firstPacket := true
 		more := idx < len(queries)-1
 		var deferredResult *sqltypes.Result
 		func() {
+			queryCtx := ctx
+			var cancel context.CancelFunc
 			if mysqlQueryTimeout != 0 {
-				ctx, cancel = context.WithTimeout(ctx, mysqlQueryTimeout)
+				queryCtx, cancel = context.WithTimeout(ctx, mysqlQueryTimeout)
 				defer cancel()
 			}
-			session, err = vh.vtg.StreamExecute(ctx, mysqlCtx, session, query, make(map[string]*querypb.BindVariable), func(result *sqltypes.Result) error {
+			session, err = vh.vtg.StreamExecute(queryCtx, mysqlCtx, session, query, make(map[string]*querypb.BindVariable), func(result *sqltypes.Result) error {
 				if firstPacket && len(result.Fields) == 0 {
 					deferredResult = result
 					firstPacket = false
@@ -607,20 +602,14 @@ func (vh *vtgateHandler) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareDat
 	}()
 
 	if session.Options.Workload == querypb.ExecuteOptions_OLAP {
-		var deferredResult *sqltypes.Result
-		_, err := vh.vtg.StreamExecute(ctx, mysqlCtx, session, prepare.PrepareStmt, prepare.BindVars, func(result *sqltypes.Result) error {
-			if len(result.Fields) == 0 {
-				deferredResult = result
-				return nil
-			}
-			return callback(result)
-		})
+		streamCallback, deferredResult := deferFirstOKOnlyResult(callback)
+		_, err := vh.vtg.StreamExecute(ctx, mysqlCtx, session, prepare.PrepareStmt, prepare.BindVars, streamCallback)
 		if err != nil {
 			return sqlerror.NewSQLErrorFromError(err)
 		}
 		fillInTxStatusFlags(c, session)
-		if deferredResult != nil {
-			return callback(deferredResult)
+		if result := deferredResult(); result != nil {
+			return callback(result)
 		}
 		return nil
 	}
@@ -631,6 +620,25 @@ func (vh *vtgateHandler) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareDat
 	fillInTxStatusFlags(c, session)
 
 	return callback(qr)
+}
+
+func deferFirstOKOnlyResult(callback func(*sqltypes.Result) error) (func(*sqltypes.Result) error, func() *sqltypes.Result) {
+	firstPacket := true
+	var deferredResult *sqltypes.Result
+
+	streamCallback := func(result *sqltypes.Result) error {
+		if firstPacket {
+			firstPacket = false
+			if len(result.Fields) == 0 {
+				deferredResult = result
+				return nil
+			}
+		}
+		return callback(result)
+	}
+	return streamCallback, func() *sqltypes.Result {
+		return deferredResult
+	}
 }
 
 func (vh *vtgateHandler) WarningCount(c *mysql.Conn) uint16 {

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -128,6 +128,25 @@ type vtgateHandler struct {
 	busyConnections atomic.Int32
 }
 
+type vtgateMySQLConnection struct {
+	handler         *vtgateHandler
+	conn            *mysql.Conn
+	slowQueryStates []bool
+}
+
+func (vmc *vtgateMySQLConnection) KillQuery(connectionID uint32) error {
+	return vmc.handler.KillQuery(connectionID)
+}
+
+func (vmc *vtgateMySQLConnection) KillConnection(ctx context.Context, connectionID uint32) error {
+	return vmc.handler.KillConnection(ctx, connectionID)
+}
+
+func (vmc *vtgateMySQLConnection) SetQueryWasSlow(slow bool) {
+	setSlowQueryStatus(vmc.conn, slow)
+	vmc.slowQueryStates = append(vmc.slowQueryStates, slow)
+}
+
 func newVtgateHandler(vtg *VTGate) *vtgateHandler {
 	return &vtgateHandler{
 		vtg:         vtg,
@@ -299,6 +318,7 @@ func (vh *vtgateHandler) ComQuery(c *mysql.Conn, query string, callback func(*sq
 		c.RemoteAddr().String(), /* component: running client process */
 		"VTGate MySQL Connector" /* subcomponent: part of the client */)
 	ctx = callerid.NewContext(ctx, ef, im)
+	mysqlCtx := &vtgateMySQLConnection{handler: vh, conn: c}
 
 	if !session.InTransaction {
 		vh.busyConnections.Add(1)
@@ -310,14 +330,14 @@ func (vh *vtgateHandler) ComQuery(c *mysql.Conn, query string, callback func(*sq
 	}()
 
 	if session.Options.Workload == querypb.ExecuteOptions_OLAP {
-		session, err := vh.vtg.StreamExecute(ctx, vh, session, query, make(map[string]*querypb.BindVariable), callback)
+		session, err := vh.vtg.StreamExecute(ctx, mysqlCtx, session, query, make(map[string]*querypb.BindVariable), callback)
 		if err != nil {
 			return sqlerror.NewSQLErrorFromError(err)
 		}
 		fillInTxStatusFlags(c, session)
 		return nil
 	}
-	session, result, err := vh.vtg.Execute(ctx, vh, session, query, make(map[string]*querypb.BindVariable), false)
+	session, result, err := vh.vtg.Execute(ctx, mysqlCtx, session, query, make(map[string]*querypb.BindVariable), false)
 
 	if err := sqlerror.NewSQLErrorFromError(err); err != nil {
 		return err
@@ -356,6 +376,7 @@ func (vh *vtgateHandler) ComQueryMulti(c *mysql.Conn, sql string, callback func(
 		c.RemoteAddr().String(), /* component: running client process */
 		"VTGate MySQL Connector" /* subcomponent: part of the client */)
 	ctx = callerid.NewContext(ctx, ef, im)
+	mysqlCtx := &vtgateMySQLConnection{handler: vh, conn: c}
 
 	if !session.InTransaction {
 		vh.busyConnections.Add(1)
@@ -368,10 +389,10 @@ func (vh *vtgateHandler) ComQueryMulti(c *mysql.Conn, sql string, callback func(
 
 	if session.Options.Workload == querypb.ExecuteOptions_OLAP {
 		if c.Capabilities&mysql.CapabilityClientMultiStatements != 0 {
-			session, err = vh.vtg.StreamExecuteMulti(ctx, vh, session, sql, callback)
+			session, err = vh.vtg.StreamExecuteMulti(ctx, mysqlCtx, session, sql, callback)
 		} else {
 			firstPacket := true
-			session, err = vh.vtg.StreamExecute(ctx, vh, session, sql, make(map[string]*querypb.BindVariable), func(result *sqltypes.Result) error {
+			session, err = vh.vtg.StreamExecute(ctx, mysqlCtx, session, sql, make(map[string]*querypb.BindVariable), func(result *sqltypes.Result) error {
 				defer func() {
 					firstPacket = false
 				}()
@@ -388,7 +409,7 @@ func (vh *vtgateHandler) ComQueryMulti(c *mysql.Conn, sql string, callback func(
 	var result *sqltypes.Result
 	var queryResults []sqltypes.QueryResponse
 	if c.Capabilities&mysql.CapabilityClientMultiStatements != 0 {
-		session, results, err = vh.vtg.ExecuteMulti(ctx, vh, session, sql)
+		session, results, err = vh.vtg.ExecuteMulti(ctx, mysqlCtx, session, sql)
 		for _, res := range results {
 			queryResults = append(queryResults, sqltypes.QueryResponse{QueryResult: res})
 		}
@@ -396,14 +417,27 @@ func (vh *vtgateHandler) ComQueryMulti(c *mysql.Conn, sql string, callback func(
 			queryResults = append(queryResults, sqltypes.QueryResponse{QueryError: sqlerror.NewSQLErrorFromError(err)})
 		}
 	} else {
-		session, result, err = vh.vtg.Execute(ctx, vh, session, sql, make(map[string]*querypb.BindVariable), false)
+		session, result, err = vh.vtg.Execute(ctx, mysqlCtx, session, sql, make(map[string]*querypb.BindVariable), false)
 		queryResults = append(queryResults, sqltypes.QueryResponse{QueryResult: result, QueryError: sqlerror.NewSQLErrorFromError(err)})
 	}
 
 	fillInTxStatusFlags(c, session)
 	for idx, res := range queryResults {
+		if idx == 0 {
+			if len(mysqlCtx.slowQueryStates) > 0 {
+				setSlowQueryStatus(c, mysqlCtx.slowQueryStates[0])
+			}
+		} else if idx-1 < len(mysqlCtx.slowQueryStates) {
+			// The mysql server emits the previous result's EOF packet when the
+			// next result starts, so keep the previous statement's slow status in
+			// place until the next callback begins.
+			setSlowQueryStatus(c, mysqlCtx.slowQueryStates[idx-1])
+		}
 		if callbackErr := callback(res, idx < len(queryResults)-1, true); callbackErr != nil {
 			return callbackErr
+		}
+		if idx < len(mysqlCtx.slowQueryStates) {
+			setSlowQueryStatus(c, mysqlCtx.slowQueryStates[idx])
 		}
 	}
 	return nil
@@ -420,6 +454,14 @@ func fillInTxStatusFlags(c *mysql.Conn, session *vtgatepb.Session) {
 	} else {
 		c.StatusFlags &= mysql.NoServerStatusAutocommit
 	}
+}
+
+func setSlowQueryStatus(c *mysql.Conn, slow bool) {
+	if slow {
+		c.StatusFlags |= mysql.ServerQueryWasSlow
+		return
+	}
+	c.StatusFlags &^= mysql.ServerQueryWasSlow
 }
 
 // ComPrepare is the handler for command prepare.
@@ -493,6 +535,7 @@ func (vh *vtgateHandler) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareDat
 		c.RemoteAddr().String(), /* component: running client process */
 		"VTGate MySQL Connector" /* subcomponent: part of the client */)
 	ctx = callerid.NewContext(ctx, ef, im)
+	mysqlCtx := &vtgateMySQLConnection{handler: vh, conn: c}
 
 	session := vh.session(c)
 	if !session.InTransaction {
@@ -505,14 +548,14 @@ func (vh *vtgateHandler) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareDat
 	}()
 
 	if session.Options.Workload == querypb.ExecuteOptions_OLAP {
-		_, err := vh.vtg.StreamExecute(ctx, vh, session, prepare.PrepareStmt, prepare.BindVars, callback)
+		_, err := vh.vtg.StreamExecute(ctx, mysqlCtx, session, prepare.PrepareStmt, prepare.BindVars, callback)
 		if err != nil {
 			return sqlerror.NewSQLErrorFromError(err)
 		}
 		fillInTxStatusFlags(c, session)
 		return nil
 	}
-	_, qr, err := vh.vtg.Execute(ctx, vh, session, prepare.PrepareStmt, prepare.BindVars, true)
+	_, qr, err := vh.vtg.Execute(ctx, mysqlCtx, session, prepare.PrepareStmt, prepare.BindVars, true)
 	if err != nil {
 		return sqlerror.NewSQLErrorFromError(err)
 	}

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -330,11 +330,21 @@ func (vh *vtgateHandler) ComQuery(c *mysql.Conn, query string, callback func(*sq
 	}()
 
 	if session.Options.Workload == querypb.ExecuteOptions_OLAP {
-		session, err := vh.vtg.StreamExecute(ctx, mysqlCtx, session, query, make(map[string]*querypb.BindVariable), callback)
+		var deferredResult *sqltypes.Result
+		session, err := vh.vtg.StreamExecute(ctx, mysqlCtx, session, query, make(map[string]*querypb.BindVariable), func(result *sqltypes.Result) error {
+			if len(result.Fields) == 0 {
+				deferredResult = result
+				return nil
+			}
+			return callback(result)
+		})
 		if err != nil {
 			return sqlerror.NewSQLErrorFromError(err)
 		}
 		fillInTxStatusFlags(c, session)
+		if deferredResult != nil {
+			return callback(deferredResult)
+		}
 		return nil
 	}
 	session, result, err := vh.vtg.Execute(ctx, mysqlCtx, session, query, make(map[string]*querypb.BindVariable), false)
@@ -597,11 +607,21 @@ func (vh *vtgateHandler) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareDat
 	}()
 
 	if session.Options.Workload == querypb.ExecuteOptions_OLAP {
-		_, err := vh.vtg.StreamExecute(ctx, mysqlCtx, session, prepare.PrepareStmt, prepare.BindVars, callback)
+		var deferredResult *sqltypes.Result
+		_, err := vh.vtg.StreamExecute(ctx, mysqlCtx, session, prepare.PrepareStmt, prepare.BindVars, func(result *sqltypes.Result) error {
+			if len(result.Fields) == 0 {
+				deferredResult = result
+				return nil
+			}
+			return callback(result)
+		})
 		if err != nil {
 			return sqlerror.NewSQLErrorFromError(err)
 		}
 		fillInTxStatusFlags(c, session)
+		if deferredResult != nil {
+			return callback(deferredResult)
+		}
 		return nil
 	}
 	_, qr, err := vh.vtg.Execute(ctx, mysqlCtx, session, prepare.PrepareStmt, prepare.BindVars, true)

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -1069,6 +1069,48 @@ func TestSlowQueryStatusFlagsComQueryMultiOKOnlyOLAPFallbackWire(t *testing.T) {
 	assert.NotZero(t, result.StatusFlags&mysql.ServerQueryWasSlow)
 }
 
+func TestComQueryMultiOLAPDeferredOKRefreshesTransactionStatusWire(t *testing.T) {
+	executor, _, _, _, _ := createExecutorEnv(t)
+
+	oldDefaultWorkload := mysqlDefaultWorkload
+	mysqlDefaultWorkload = int32(querypb.ExecuteOptions_OLAP)
+	t.Cleanup(func() {
+		mysqlDefaultWorkload = oldDefaultWorkload
+	})
+
+	vh := newVtgateHandler(newVTGate(executor, nil, nil, nil, nil))
+	listener, err := mysql.NewListener("tcp", "127.0.0.1:", mysql.NewAuthServerNone(), vh, 0, 0, false, false, 0, 0, true)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	go listener.Accept()
+
+	addr := listener.Addr().(*net.TCPAddr)
+	params := &mysql.ConnParams{
+		Host:  addr.IP.String(),
+		Port:  addr.Port,
+		Uname: "user1",
+		Pass:  "password1",
+		Flags: mysql.CapabilityClientMultiStatements,
+	}
+
+	conn, err := mysql.Connect(t.Context(), params)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	result, more, err := conn.ExecuteFetchMulti("select 1; begin", 100, true)
+	require.NoError(t, err)
+	require.True(t, more)
+	assert.NotEmpty(t, result.Fields)
+	assert.Zero(t, result.StatusFlags&mysql.ServerStatusInTrans)
+
+	result, more, _, err = conn.ReadQueryResult(100, true)
+	require.NoError(t, err)
+	require.False(t, more)
+	assert.Empty(t, result.Fields)
+	assert.NotZero(t, result.StatusFlags&mysql.ServerStatusInTrans)
+}
+
 func TestSlowQueryStatusFlagsComStmtExecute(t *testing.T) {
 	executor, sbc1, _, _, _ := createExecutorEnv(t)
 

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -1028,6 +1028,47 @@ func TestSlowQueryStatusFlagsComQueryOKOnlyOLAPWire(t *testing.T) {
 	assert.NotZero(t, result.StatusFlags&mysql.ServerQueryWasSlow)
 }
 
+func TestSlowQueryStatusFlagsComQueryMultiOKOnlyOLAPFallbackWire(t *testing.T) {
+	executor, sbc1, _, _, _ := createExecutorEnv(t)
+
+	oldThreshold := slowQueryThreshold
+	oldDefaultWorkload := mysqlDefaultWorkload
+	slowQueryThreshold = 5 * time.Millisecond
+	mysqlDefaultWorkload = int32(querypb.ExecuteOptions_OLAP)
+	t.Cleanup(func() {
+		slowQueryThreshold = oldThreshold
+		mysqlDefaultWorkload = oldDefaultWorkload
+		sbc1.ExecDelayResponse = 0
+	})
+
+	sbc1.SetResults([]*sqltypes.Result{{RowsAffected: 1}})
+	sbc1.ExecDelayResponse = 20 * time.Millisecond
+
+	vh := newVtgateHandler(newVTGate(executor, nil, nil, nil, nil))
+	listener, err := mysql.NewListener("tcp", "127.0.0.1:", mysql.NewAuthServerNone(), vh, 0, 0, false, false, 0, 0, true)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	go listener.Accept()
+
+	addr := listener.Addr().(*net.TCPAddr)
+	params := &mysql.ConnParams{
+		Host:  addr.IP.String(),
+		Port:  addr.Port,
+		Uname: "user1",
+		Pass:  "password1",
+	}
+
+	conn, err := mysql.Connect(t.Context(), params)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	result, err := conn.ExecuteFetch("update user set name = 'foo' where id = 1", 100, true)
+	require.NoError(t, err)
+	assert.Empty(t, result.Fields)
+	assert.NotZero(t, result.StatusFlags&mysql.ServerQueryWasSlow)
+}
+
 func TestSlowQueryStatusFlagsComStmtExecute(t *testing.T) {
 	executor, sbc1, _, _, _ := createExecutorEnv(t)
 
@@ -1212,6 +1253,55 @@ func TestSlowQueryStatusFlagsStreamExecuteMultiOLAP(t *testing.T) {
 	require.NotNil(t, session)
 	assert.True(t, seenOKOnly)
 	assert.Equal(t, []bool{true, false}, mysqlCtx.slowQueryStates)
+}
+
+func TestSlowQueryStatusFlagsComQueryMultiOLAPErrorAfterSlowRowsWire(t *testing.T) {
+	executor, sbc1, _, _, _ := createExecutorEnv(t)
+
+	oldThreshold := slowQueryThreshold
+	oldDefaultWorkload := mysqlDefaultWorkload
+	slowQueryThreshold = 5 * time.Millisecond
+	mysqlDefaultWorkload = int32(querypb.ExecuteOptions_OLAP)
+	t.Cleanup(func() {
+		slowQueryThreshold = oldThreshold
+		mysqlDefaultWorkload = oldDefaultWorkload
+		sbc1.ExecDelayResponse = 0
+	})
+
+	sbc1.SetResults([]*sqltypes.Result{
+		sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1"),
+	})
+	sbc1.ExecDelayResponse = 20 * time.Millisecond
+
+	vh := newVtgateHandler(newVTGate(executor, nil, nil, nil, nil))
+	listener, err := mysql.NewListener("tcp", "127.0.0.1:", mysql.NewAuthServerNone(), vh, 0, 0, false, false, 0, 0, true)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	go listener.Accept()
+
+	addr := listener.Addr().(*net.TCPAddr)
+	params := &mysql.ConnParams{
+		Host:  addr.IP.String(),
+		Port:  addr.Port,
+		Uname: "user1",
+		Pass:  "password1",
+		Flags: mysql.CapabilityClientMultiStatements,
+	}
+
+	conn, err := mysql.Connect(t.Context(), params)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	result, more, err := conn.ExecuteFetchMulti("select id from user where id = 1; select from", 100, true)
+	require.NoError(t, err)
+	require.True(t, more)
+	assert.NotZero(t, result.StatusFlags&mysql.ServerQueryWasSlow)
+
+	result, more, _, err = conn.ReadQueryResult(100, true)
+	require.Error(t, err)
+	assert.False(t, more)
+	assert.Nil(t, result)
 }
 
 func TestStreamExecuteMultiOLAPTimeoutUsesParentContextPerStatement(t *testing.T) {

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -1065,7 +1065,7 @@ func TestSlowQueryStatusFlagsComQueryMulti(t *testing.T) {
 		Flags: mysql.CapabilityClientMultiStatements,
 	}
 
-	conn, err := mysql.Connect(context.Background(), params)
+	conn, err := mysql.Connect(t.Context(), params)
 	require.NoError(t, err)
 	defer conn.Close()
 
@@ -1114,7 +1114,7 @@ func TestSlowQueryStatusFlagsStreamExecuteMultiOLAP(t *testing.T) {
 	}
 
 	seenOKOnly := false
-	session, err = vh.streamExecuteMultiQuery(context.Background(), mysqlConn, mysqlCtx, session, "select id from user where id = 1; set autocommit = 1", func(qr sqltypes.QueryResponse, more bool, firstPacket bool) error {
+	session, err = vh.streamExecuteMultiQuery(t.Context(), mysqlConn, mysqlCtx, session, "select id from user where id = 1; set autocommit = 1", func(qr sqltypes.QueryResponse, more bool, firstPacket bool) error {
 		if firstPacket && len(qr.QueryResult.Fields) == 0 {
 			seenOKOnly = true
 			assert.False(t, more)

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -29,6 +29,7 @@ import (
 	"syscall"
 	"testing"
 	"testing/synctest"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -941,6 +942,141 @@ func TestComQueryMulti(t *testing.T) {
 			assert.Equal(t, len(tt.queryResponses), idx)
 		})
 	}
+}
+
+func TestSlowQueryStatusFlagsComQuery(t *testing.T) {
+	executor, sbc1, _, _, _ := createExecutorEnv(t)
+
+	oldThreshold := slowQueryThreshold
+	slowQueryThreshold = 5 * time.Millisecond
+	t.Cleanup(func() {
+		slowQueryThreshold = oldThreshold
+		sbc1.ExecDelayResponse = 0
+	})
+
+	sbc1.SetResults([]*sqltypes.Result{
+		sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1"),
+		sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1"),
+	})
+
+	th := &testHandler{}
+	listener, err := mysql.NewListener("tcp", "127.0.0.1:", mysql.NewAuthServerNone(), th, 0, 0, false, false, 0, 0, false)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	mysqlConn := mysql.GetTestServerConn(listener)
+	mysqlConn.ConnectionID = 1
+	mysqlConn.UserData = &mysql.StaticUserData{}
+
+	vh := newVtgateHandler(newVTGate(executor, nil, nil, nil, nil))
+	vh.connections[1] = mysqlConn
+
+	sbc1.ExecDelayResponse = 20 * time.Millisecond
+	err = vh.ComQuery(mysqlConn, "select id from user where id = 1", func(result *sqltypes.Result) error {
+		return nil
+	})
+	require.NoError(t, err)
+	assert.NotZero(t, mysqlConn.StatusFlags&mysql.ServerQueryWasSlow)
+
+	sbc1.ExecDelayResponse = 0
+	err = vh.ComQuery(mysqlConn, "select id from user where id = 1", func(result *sqltypes.Result) error {
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Zero(t, mysqlConn.StatusFlags&mysql.ServerQueryWasSlow)
+}
+
+func TestSlowQueryStatusFlagsComStmtExecute(t *testing.T) {
+	executor, sbc1, _, _, _ := createExecutorEnv(t)
+
+	oldThreshold := slowQueryThreshold
+	slowQueryThreshold = 5 * time.Millisecond
+	t.Cleanup(func() {
+		slowQueryThreshold = oldThreshold
+		sbc1.ExecDelayResponse = 0
+	})
+
+	sbc1.SetResults([]*sqltypes.Result{
+		sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1"),
+		sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1"),
+	})
+
+	th := &testHandler{}
+	listener, err := mysql.NewListener("tcp", "127.0.0.1:", mysql.NewAuthServerNone(), th, 0, 0, false, false, 0, 0, false)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	mysqlConn := mysql.GetTestServerConn(listener)
+	mysqlConn.ConnectionID = 1
+	mysqlConn.UserData = &mysql.StaticUserData{}
+
+	vh := newVtgateHandler(newVTGate(executor, nil, nil, nil, nil))
+	vh.connections[1] = mysqlConn
+
+	prepare := &mysql.PrepareData{
+		PrepareStmt: "select id from user where id = 1",
+		BindVars:    map[string]*querypb.BindVariable{},
+	}
+
+	sbc1.ExecDelayResponse = 20 * time.Millisecond
+	err = vh.ComStmtExecute(mysqlConn, prepare, func(result *sqltypes.Result) error {
+		return nil
+	})
+	require.NoError(t, err)
+	assert.NotZero(t, mysqlConn.StatusFlags&mysql.ServerQueryWasSlow)
+
+	sbc1.ExecDelayResponse = 0
+	err = vh.ComStmtExecute(mysqlConn, prepare, func(result *sqltypes.Result) error {
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Zero(t, mysqlConn.StatusFlags&mysql.ServerQueryWasSlow)
+}
+
+func TestSlowQueryStatusFlagsComQueryMulti(t *testing.T) {
+	executor, sbc1, _, _, _ := createExecutorEnv(t)
+
+	oldThreshold := slowQueryThreshold
+	slowQueryThreshold = 5 * time.Millisecond
+	t.Cleanup(func() {
+		slowQueryThreshold = oldThreshold
+		sbc1.ExecDelayResponse = 0
+	})
+
+	sbc1.SetResults([]*sqltypes.Result{
+		sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1"),
+	})
+	sbc1.ExecDelayResponse = 20 * time.Millisecond
+
+	vh := newVtgateHandler(newVTGate(executor, nil, nil, nil, nil))
+	listener, err := mysql.NewListener("tcp", "127.0.0.1:", mysql.NewAuthServerNone(), vh, 0, 0, false, false, 0, 0, false)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	go listener.Accept()
+
+	addr := listener.Addr().(*net.TCPAddr)
+	params := &mysql.ConnParams{
+		Host:  addr.IP.String(),
+		Port:  addr.Port,
+		Uname: "user1",
+		Pass:  "password1",
+		Flags: mysql.CapabilityClientMultiStatements,
+	}
+
+	conn, err := mysql.Connect(context.Background(), params)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	result, more, err := conn.ExecuteFetchMulti("select id from user where id = 1; select 1", 100, true)
+	require.NoError(t, err)
+	require.True(t, more)
+	assert.NotZero(t, result.StatusFlags&mysql.ServerQueryWasSlow)
+
+	result, more, _, err = conn.ReadQueryResult(100, true)
+	require.NoError(t, err)
+	require.False(t, more)
+	assert.Zero(t, result.StatusFlags&mysql.ServerQueryWasSlow)
 }
 
 func TestGracefulShutdown(t *testing.T) {

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -1075,6 +1075,51 @@ func TestSlowQueryStatusFlagsComStmtExecute(t *testing.T) {
 	assert.Zero(t, mysqlConn.StatusFlags&mysql.ServerQueryWasSlow)
 }
 
+func TestDeferFirstOKOnlyResultForwardsRowChunksAfterFields(t *testing.T) {
+	fields := sqltypes.MakeTestFields("id", "int64")
+	input := []*sqltypes.Result{
+		{Fields: fields},
+		{Rows: [][]sqltypes.Value{{sqltypes.NewInt64(1)}}},
+		{Rows: [][]sqltypes.Value{{sqltypes.NewInt64(2)}}},
+	}
+	var results []*sqltypes.Result
+	callback, deferredResult := deferFirstOKOnlyResult(func(result *sqltypes.Result) error {
+		results = append(results, result)
+		return nil
+	})
+
+	for _, result := range input {
+		require.NoError(t, callback(result))
+	}
+
+	require.Nil(t, deferredResult())
+	assertOLAPRowChunksAfterFields(t, fields, results)
+}
+
+func TestDeferFirstOKOnlyResultDefersOnlyFirstOKResult(t *testing.T) {
+	okResult := &sqltypes.Result{RowsAffected: 1}
+	callback, deferredResult := deferFirstOKOnlyResult(func(result *sqltypes.Result) error {
+		require.Failf(t, "callback called for deferred OK-only result", "%v", result)
+		return nil
+	})
+
+	err := callback(okResult)
+	require.NoError(t, err)
+	assert.Same(t, okResult, deferredResult())
+}
+
+func assertOLAPRowChunksAfterFields(t *testing.T, fields []*querypb.Field, results []*sqltypes.Result) {
+	t.Helper()
+
+	require.Len(t, results, 3)
+	assert.Equal(t, fields, results[0].Fields)
+	assert.Empty(t, results[0].Rows)
+	assert.Empty(t, results[1].Fields)
+	assert.Equal(t, [][]sqltypes.Value{{sqltypes.NewInt64(1)}}, results[1].Rows)
+	assert.Empty(t, results[2].Fields)
+	assert.Equal(t, [][]sqltypes.Value{{sqltypes.NewInt64(2)}}, results[2].Rows)
+}
+
 func TestSlowQueryStatusFlagsComQueryMulti(t *testing.T) {
 	executor, sbc1, _, _, _ := createExecutorEnv(t)
 
@@ -1167,6 +1212,46 @@ func TestSlowQueryStatusFlagsStreamExecuteMultiOLAP(t *testing.T) {
 	require.NotNil(t, session)
 	assert.True(t, seenOKOnly)
 	assert.Equal(t, []bool{true, false}, mysqlCtx.slowQueryStates)
+}
+
+func TestStreamExecuteMultiOLAPTimeoutUsesParentContextPerStatement(t *testing.T) {
+	executor, sbc1, _, _, _ := createExecutorEnv(t)
+
+	oldTimeout := mysqlQueryTimeout
+	mysqlQueryTimeout = time.Second
+	sbc1.ExecDelayResponse = time.Millisecond
+	t.Cleanup(func() {
+		mysqlQueryTimeout = oldTimeout
+		sbc1.ExecDelayResponse = 0
+	})
+
+	vh := newVtgateHandler(newVTGate(executor, nil, nil, nil, nil))
+	mysqlConn := mysql.GetTestServerConn(&mysql.Listener{})
+	mysqlConn.ConnectionID = 1
+	mysqlConn.UserData = &mysql.StaticUserData{}
+	mysqlCtx := &vtgateMySQLConnection{handler: vh, conn: mysqlConn}
+	session := &vtgatepb.Session{
+		Autocommit:           true,
+		EnableSystemSettings: true,
+		TargetString:         "TestExecutor",
+		Options: &querypb.ExecuteOptions{
+			Workload: querypb.ExecuteOptions_OLAP,
+		},
+	}
+
+	var moreFlags []bool
+	session, err := vh.streamExecuteMultiQuery(t.Context(), mysqlConn, mysqlCtx, session, "select id from user where id = 1; select id from user where id = 1", func(qr sqltypes.QueryResponse, more bool, firstPacket bool) error {
+		if qr.QueryError != nil {
+			return qr.QueryError
+		}
+		if firstPacket {
+			moreFlags = append(moreFlags, more)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	assert.Equal(t, []bool{true, false}, moreFlags)
 }
 
 func TestGracefulShutdown(t *testing.T) {

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -43,6 +43,7 @@ import (
 	"vitess.io/vitess/go/trace"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	querypb "vitess.io/vitess/go/vt/proto/query"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/tlstest"
 	"vitess.io/vitess/go/vt/topo/topoproto"
@@ -1077,6 +1078,54 @@ func TestSlowQueryStatusFlagsComQueryMulti(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, more)
 	assert.Zero(t, result.StatusFlags&mysql.ServerQueryWasSlow)
+}
+
+func TestSlowQueryStatusFlagsStreamExecuteMultiOLAP(t *testing.T) {
+	executor, sbc1, _, _, _ := createExecutorEnv(t)
+
+	oldThreshold := slowQueryThreshold
+	slowQueryThreshold = 5 * time.Millisecond
+	t.Cleanup(func() {
+		slowQueryThreshold = oldThreshold
+		sbc1.ExecDelayResponse = 0
+	})
+
+	sbc1.SetResults([]*sqltypes.Result{
+		sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1"),
+	})
+	sbc1.ExecDelayResponse = 20 * time.Millisecond
+
+	vh := newVtgateHandler(newVTGate(executor, nil, nil, nil, nil))
+	listener, err := mysql.NewListener("tcp", "127.0.0.1:", mysql.NewAuthServerNone(), &testHandler{}, 0, 0, false, false, 0, 0, false)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	mysqlConn := mysql.GetTestServerConn(listener)
+	mysqlConn.ConnectionID = 1
+	mysqlConn.UserData = &mysql.StaticUserData{}
+	mysqlCtx := &vtgateMySQLConnection{handler: vh, conn: mysqlConn}
+	session := &vtgatepb.Session{
+		Autocommit:           true,
+		EnableSystemSettings: true,
+		TargetString:         "TestExecutor",
+		Options: &querypb.ExecuteOptions{
+			Workload: querypb.ExecuteOptions_OLAP,
+		},
+	}
+
+	seenOKOnly := false
+	session, err = vh.streamExecuteMultiQuery(context.Background(), mysqlConn, mysqlCtx, session, "select id from user where id = 1; set autocommit = 1", func(qr sqltypes.QueryResponse, more bool, firstPacket bool) error {
+		if firstPacket && len(qr.QueryResult.Fields) == 0 {
+			seenOKOnly = true
+			assert.False(t, more)
+			assert.Zero(t, mysqlConn.StatusFlags&mysql.ServerQueryWasSlow)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	assert.True(t, seenOKOnly)
+	assert.Equal(t, []bool{true, false}, mysqlCtx.slowQueryStates)
 }
 
 func TestGracefulShutdown(t *testing.T) {

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -987,6 +987,47 @@ func TestSlowQueryStatusFlagsComQuery(t *testing.T) {
 	assert.Zero(t, mysqlConn.StatusFlags&mysql.ServerQueryWasSlow)
 }
 
+func TestSlowQueryStatusFlagsComQueryOKOnlyOLAPWire(t *testing.T) {
+	executor, sbc1, _, _, _ := createExecutorEnv(t)
+
+	oldThreshold := slowQueryThreshold
+	oldDefaultWorkload := mysqlDefaultWorkload
+	slowQueryThreshold = 5 * time.Millisecond
+	mysqlDefaultWorkload = int32(querypb.ExecuteOptions_OLAP)
+	t.Cleanup(func() {
+		slowQueryThreshold = oldThreshold
+		mysqlDefaultWorkload = oldDefaultWorkload
+		sbc1.ExecDelayResponse = 0
+	})
+
+	sbc1.SetResults([]*sqltypes.Result{{RowsAffected: 1}})
+	sbc1.ExecDelayResponse = 20 * time.Millisecond
+
+	vh := newVtgateHandler(newVTGate(executor, nil, nil, nil, nil))
+	listener, err := mysql.NewListener("tcp", "127.0.0.1:", mysql.NewAuthServerNone(), vh, 0, 0, false, false, 0, 0, false)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	go listener.Accept()
+
+	addr := listener.Addr().(*net.TCPAddr)
+	params := &mysql.ConnParams{
+		Host:  addr.IP.String(),
+		Port:  addr.Port,
+		Uname: "user1",
+		Pass:  "password1",
+	}
+
+	conn, err := mysql.Connect(t.Context(), params)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	result, err := conn.ExecuteFetch("update user set name = 'foo' where id = 1", 100, true)
+	require.NoError(t, err)
+	assert.Empty(t, result.Fields)
+	assert.NotZero(t, result.StatusFlags&mysql.ServerQueryWasSlow)
+}
+
 func TestSlowQueryStatusFlagsComStmtExecute(t *testing.T) {
 	executor, sbc1, _, _, _ := createExecutorEnv(t)
 

--- a/go/vt/vtgate/querylogz.go
+++ b/go/vt/vtgate/querylogz.go
@@ -51,6 +51,7 @@ var (
 				<th>SQL</th>
 				<th>ShardQueries</th>
 				<th>RowsAffected</th>
+				<th>SlowQuery</th>
 				<th>Error</th>
 			</tr>
 		</thead>
@@ -77,6 +78,7 @@ var (
 			<td>{{.SQL | .Parser.TruncateForUI | unquote | cssWrappable}}</td>
 			<td>{{.ShardQueries}}</td>
 			<td>{{.RowsAffected}}</td>
+			<td>{{.SlowQuery}}</td>
 			<td>{{.ErrorStr}}</td>
 		</tr>
 	`))

--- a/go/vt/vtgate/querylogz_test.go
+++ b/go/vt/vtgate/querylogz_test.go
@@ -68,6 +68,7 @@ func TestQuerylogzHandlerFormatting(t *testing.T) {
 		regexp.QuoteMeta("<td>select name,\u200b &#39;inject &lt;script&gt;alert()\u200b;&lt;/script&gt;&#39; from test_table limit 1000</td>"),
 		`<td>1</td>`,
 		`<td>1000</td>`,
+		`<td>false</td>`,
 		`<td></td>`,
 		`</tr>`,
 	}
@@ -98,6 +99,7 @@ func TestQuerylogzHandlerFormatting(t *testing.T) {
 		regexp.QuoteMeta("<td>select name,\u200b &#39;inject &lt;script&gt;alert()\u200b;&lt;/script&gt;&#39; from test_table limit 1000</td>"),
 		`<td>1</td>`,
 		`<td>1000</td>`,
+		`<td>false</td>`,
 		`<td></td>`,
 		`</tr>`,
 	}
@@ -111,6 +113,7 @@ func TestQuerylogzHandlerFormatting(t *testing.T) {
 	checkQuerylogzHasStats(t, mediumQueryPattern, logStats, body)
 
 	// slow query
+	logStats.SlowQuery = true
 	slowQueryPattern := []string{
 		`<tr class="high">`,
 		`<td>Execute</td>`,
@@ -128,6 +131,7 @@ func TestQuerylogzHandlerFormatting(t *testing.T) {
 		regexp.QuoteMeta("<td>select name,\u200b &#39;inject &lt;script&gt;alert()\u200b;&lt;/script&gt;&#39; from test_table limit 1000</td>"),
 		`<td>1</td>`,
 		`<td>1000</td>`,
+		`<td>true</td>`,
 		`<td></td>`,
 		`</tr>`,
 	}

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -167,6 +167,8 @@ var (
 
 	// vtgate views flags
 	queryTimeout int
+	// slowQueryThreshold marks vtgate queries as slow when TotalTime meets or exceeds it.
+	slowQueryThreshold time.Duration
 
 	// queryLogToFile controls whether query logs are sent to a file
 	queryLogToFile string
@@ -212,6 +214,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.Bool("enable-binlog-dump", enableBinlogDump.Default(), "Allow users to perform binlog dump operations for CDC/replication")
 	utils.SetFlagBoolVar(fs, &enableSchemaChangeSignal, "schema-change-signal", enableSchemaChangeSignal, "Enable the schema tracker; requires queryserver-config-schema-change-signal to be enabled on the underlying vttablets for this to work")
 	fs.IntVar(&queryTimeout, "query-timeout", queryTimeout, "Sets the default query timeout (in ms). Can be overridden by session variable (query_timeout) or comment directive (QUERY_TIMEOUT_MS)")
+	utils.SetFlagDurationVar(fs, &slowQueryThreshold, "slow-query-threshold", slowQueryThreshold, "Mark vtgate queries as slow when their total execution time meets or exceeds this duration. 0 disables slow-query detection.")
 	utils.SetFlagStringVar(fs, &queryLogToFile, "log-queries-to-file", queryLogToFile, "Enable query logging to the specified file")
 	fs.IntVar(&queryLogBufferSize, "querylog-buffer-size", queryLogBufferSize, "Maximum number of buffered query logs before throttling log output")
 	utils.SetFlagDurationVar(fs, &messageStreamGracePeriod, "message-stream-grace-period", messageStreamGracePeriod, "the amount of time to give for a vttablet to resume if it ends a message stream, usually because of a reparent.")

--- a/go/vt/vtgate/vtgateservice/interface.go
+++ b/go/vt/vtgate/vtgateservice/interface.go
@@ -66,4 +66,7 @@ type MySQLConnection interface {
 	KillQuery(uint32) error
 	// KillConnection closes the connection and also stops any executing query on it.
 	KillConnection(context.Context, uint32) error
+	// SetQueryWasSlow stores whether the most recently completed statement
+	// should be marked as slow on the MySQL protocol connection.
+	SetQueryWasSlow(bool)
 }

--- a/go/vt/vttablet/sandboxconn/sandboxconn.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn.go
@@ -83,6 +83,7 @@ type SandboxConn struct {
 	ReserveCount                atomic.Int64
 	ReleaseCount                atomic.Int64
 	GetSchemaCount              atomic.Int64
+	ExecDelayResponse           time.Duration
 	GetSchemaDelayResponse      time.Duration
 
 	queriesRequireLocking bool
@@ -320,6 +321,9 @@ func (sbc *SandboxConn) Execute(ctx context.Context, session queryservice.Sessio
 	if err := sbc.getError(); err != nil {
 		return nil, err
 	}
+	if sbc.ExecDelayResponse > 0 {
+		time.Sleep(sbc.ExecDelayResponse)
+	}
 
 	stmt, _ := sbc.parser.Parse(query) // knowingly ignoring the error
 	if sbc.MustFailExecute[sqlparser.ASTToStatementType(stmt)] > 0 {
@@ -345,6 +349,9 @@ func (sbc *SandboxConn) StreamExecute(ctx context.Context, session queryservice.
 	if err != nil {
 		sbc.sExecMu.Unlock()
 		return err
+	}
+	if sbc.ExecDelayResponse > 0 {
+		time.Sleep(sbc.ExecDelayResponse)
 	}
 	parse, _ := sbc.parser.Parse(query)
 

--- a/go/vt/vttablet/sandboxconn/sandboxconn.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn.go
@@ -170,6 +170,22 @@ func NewSandboxConn(t *topodatapb.Tablet) *SandboxConn {
 	}
 }
 
+func (sbc *SandboxConn) waitForExecDelay(ctx context.Context) error {
+	if sbc.ExecDelayResponse <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(sbc.ExecDelayResponse)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // ResetCounter resets the counters in the sandboxconn.
 func (sbc *SandboxConn) ResetCounter() {
 	sbc.ExecCount.Store(0)
@@ -321,8 +337,8 @@ func (sbc *SandboxConn) Execute(ctx context.Context, session queryservice.Sessio
 	if err := sbc.getError(); err != nil {
 		return nil, err
 	}
-	if sbc.ExecDelayResponse > 0 {
-		time.Sleep(sbc.ExecDelayResponse)
+	if err := sbc.waitForExecDelay(ctx); err != nil {
+		return nil, err
 	}
 
 	stmt, _ := sbc.parser.Parse(query) // knowingly ignoring the error
@@ -350,8 +366,9 @@ func (sbc *SandboxConn) StreamExecute(ctx context.Context, session queryservice.
 		sbc.sExecMu.Unlock()
 		return err
 	}
-	if sbc.ExecDelayResponse > 0 {
-		time.Sleep(sbc.ExecDelayResponse)
+	if err := sbc.waitForExecDelay(ctx); err != nil {
+		sbc.sExecMu.Unlock()
+		return err
 	}
 	parse, _ := sbc.parser.Parse(query)
 

--- a/go/vt/vttablet/sandboxconn/sandboxconn_test.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn_test.go
@@ -1,32 +1,62 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package sandboxconn
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
+func waitForCanceledCall(t *testing.T, name string, execDelay time.Duration, errCh <-chan error) error {
+	t.Helper()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-time.After((9 * execDelay) / 10):
+		require.FailNowf(t, "%s did not return before ExecDelayResponse elapsed", name, "exec delay: %v", execDelay)
+		return nil
+	}
+}
+
 func TestExecuteHonorsCanceledContextDuringExecDelay(t *testing.T) {
 	sbc := NewSandboxConn(&topodatapb.Tablet{Type: topodatapb.TabletType_PRIMARY})
 	sbc.ExecDelayResponse = time.Second
 	target := &querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	start := time.Now()
-	_, err := sbc.Execute(ctx, nil, target, "select 1", nil, 0, 0, nil)
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("Execute error = %v, want %v", err, context.Canceled)
-	}
-	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
-		t.Fatalf("Execute waited %v after context cancellation", elapsed)
-	}
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := sbc.Execute(ctx, nil, target, "select 1", nil, 0, 0, nil)
+		errCh <- err
+	}()
+
+	err := waitForCanceledCall(t, "Execute", sbc.ExecDelayResponse, errCh)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestStreamExecuteHonorsCanceledContextDuringExecDelay(t *testing.T) {
@@ -34,34 +64,28 @@ func TestStreamExecuteHonorsCanceledContextDuringExecDelay(t *testing.T) {
 	sbc.ExecDelayResponse = time.Second
 	target := &querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	callbackCalled := false
-	start := time.Now()
-	err := sbc.StreamExecute(ctx, nil, target, "select 1", nil, 0, 0, nil, func(*sqltypes.Result) error {
-		callbackCalled = true
-		return nil
-	})
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("StreamExecute error = %v, want %v", err, context.Canceled)
-	}
-	if callbackCalled {
-		t.Fatal("StreamExecute callback was called after context cancellation")
-	}
-	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
-		t.Fatalf("StreamExecute waited %v after context cancellation", elapsed)
-	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- sbc.StreamExecute(ctx, nil, target, "select 1", nil, 0, 0, nil, func(*sqltypes.Result) error {
+			callbackCalled = true
+			return nil
+		})
+	}()
+
+	err := waitForCanceledCall(t, "StreamExecute", sbc.ExecDelayResponse, errCh)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, callbackCalled)
 
 	sbc.ExecDelayResponse = 0
-	err = sbc.StreamExecute(context.Background(), nil, target, "select 1", nil, 0, 0, nil, func(*sqltypes.Result) error {
-		callbackCalled = true
+	retryCallbackCalled := false
+	err = sbc.StreamExecute(t.Context(), nil, target, "select 1", nil, 0, 0, nil, func(*sqltypes.Result) error {
+		retryCallbackCalled = true
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("StreamExecute retry error = %v", err)
-	}
-	if !callbackCalled {
-		t.Fatal("StreamExecute callback was not called on retry")
-	}
+	require.NoError(t, err)
+	assert.True(t, retryCallbackCalled)
 }

--- a/go/vt/vttablet/sandboxconn/sandboxconn_test.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn_test.go
@@ -29,14 +29,16 @@ import (
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
-func waitForCanceledCall(t *testing.T, name string, execDelay time.Duration, errCh <-chan error) error {
+const canceledCallTimeout = 3 * time.Second
+
+func waitForCanceledCall(t *testing.T, name string, errCh <-chan error) error {
 	t.Helper()
 
 	select {
 	case err := <-errCh:
 		return err
-	case <-time.After((9 * execDelay) / 10):
-		require.FailNowf(t, "%s did not return before ExecDelayResponse elapsed", name, "exec delay: %v", execDelay)
+	case <-time.After(canceledCallTimeout):
+		require.FailNowf(t, "%s did not return after context cancellation", name, "timeout: %v", canceledCallTimeout)
 		return nil
 	}
 }
@@ -55,7 +57,7 @@ func TestExecuteHonorsCanceledContextDuringExecDelay(t *testing.T) {
 		errCh <- err
 	}()
 
-	err := waitForCanceledCall(t, "Execute", sbc.ExecDelayResponse, errCh)
+	err := waitForCanceledCall(t, "Execute", errCh)
 	require.ErrorIs(t, err, context.Canceled)
 }
 
@@ -76,7 +78,7 @@ func TestStreamExecuteHonorsCanceledContextDuringExecDelay(t *testing.T) {
 		})
 	}()
 
-	err := waitForCanceledCall(t, "StreamExecute", sbc.ExecDelayResponse, errCh)
+	err := waitForCanceledCall(t, "StreamExecute", errCh)
 	require.ErrorIs(t, err, context.Canceled)
 	assert.False(t, callbackCalled)
 

--- a/go/vt/vttablet/sandboxconn/sandboxconn_test.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 const canceledCallTimeout = 3 * time.Second
+const canceledCallExecDelay = canceledCallTimeout * 2
 
 func waitForCanceledCall(t *testing.T, name string, errCh <-chan error) error {
 	t.Helper()
@@ -45,7 +46,7 @@ func waitForCanceledCall(t *testing.T, name string, errCh <-chan error) error {
 
 func TestExecuteHonorsCanceledContextDuringExecDelay(t *testing.T) {
 	sbc := NewSandboxConn(&topodatapb.Tablet{Type: topodatapb.TabletType_PRIMARY})
-	sbc.ExecDelayResponse = time.Second
+	sbc.ExecDelayResponse = canceledCallExecDelay
 	target := &querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -63,7 +64,7 @@ func TestExecuteHonorsCanceledContextDuringExecDelay(t *testing.T) {
 
 func TestStreamExecuteHonorsCanceledContextDuringExecDelay(t *testing.T) {
 	sbc := NewSandboxConn(&topodatapb.Tablet{Type: topodatapb.TabletType_PRIMARY})
-	sbc.ExecDelayResponse = time.Second
+	sbc.ExecDelayResponse = canceledCallExecDelay
 	target := &querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
 
 	ctx, cancel := context.WithCancel(t.Context())

--- a/go/vt/vttablet/sandboxconn/sandboxconn_test.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn_test.go
@@ -1,0 +1,67 @@
+package sandboxconn
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+)
+
+func TestExecuteHonorsCanceledContextDuringExecDelay(t *testing.T) {
+	sbc := NewSandboxConn(&topodatapb.Tablet{Type: topodatapb.TabletType_PRIMARY})
+	sbc.ExecDelayResponse = time.Second
+	target := &querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := sbc.Execute(ctx, nil, target, "select 1", nil, 0, 0, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Execute error = %v, want %v", err, context.Canceled)
+	}
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Fatalf("Execute waited %v after context cancellation", elapsed)
+	}
+}
+
+func TestStreamExecuteHonorsCanceledContextDuringExecDelay(t *testing.T) {
+	sbc := NewSandboxConn(&topodatapb.Tablet{Type: topodatapb.TabletType_PRIMARY})
+	sbc.ExecDelayResponse = time.Second
+	target := &querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	callbackCalled := false
+	start := time.Now()
+	err := sbc.StreamExecute(ctx, nil, target, "select 1", nil, 0, 0, nil, func(*sqltypes.Result) error {
+		callbackCalled = true
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("StreamExecute error = %v, want %v", err, context.Canceled)
+	}
+	if callbackCalled {
+		t.Fatal("StreamExecute callback was called after context cancellation")
+	}
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Fatalf("StreamExecute waited %v after context cancellation", elapsed)
+	}
+
+	sbc.ExecDelayResponse = 0
+	err = sbc.StreamExecute(context.Background(), nil, target, "select 1", nil, 0, 0, nil, func(*sqltypes.Result) error {
+		callbackCalled = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("StreamExecute retry error = %v", err)
+	}
+	if !callbackCalled {
+		t.Fatal("StreamExecute callback was not called on retry")
+	}
+}

--- a/go/vt/vttablet/sandboxconn/sandboxconn_test.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn_test.go
@@ -29,8 +29,10 @@ import (
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 )
 
-const canceledCallTimeout = 3 * time.Second
-const canceledCallExecDelay = canceledCallTimeout * 2
+const (
+	canceledCallTimeout   = 3 * time.Second
+	canceledCallExecDelay = canceledCallTimeout * 2
+)
 
 func waitForCanceledCall(t *testing.T, name string, errCh <-chan error) error {
 	t.Helper()


### PR DESCRIPTION
## Description

Adds vtgate-specific slow-query detection with a separate `--slow-query-threshold` flag. Slow queries are marked in vtgate logstats, counted in a new `SlowQueries` metric, and surfaced to MySQL clients via `SERVER_QUERY_WAS_SLOW`.

The branch also fixes OK-only protocol paths so the slow-query bit is set after vtgate finalizes logstats and cannot leak into later commands on the same connection.

## User-visible behavior

- Configure vtgate slow-query detection with `--slow-query-threshold`. The flag default is `0`, so detection stays disabled unless configured.
- Slow queries are visible in vtgate query logs and `/debug/querylogz`; `querylogz` now has a `SlowQuery` column.
- `/debug/vars` exposes `SlowQueries`, keyed by query type, plan type, and tablet type, for example `UPDATE.Passthrough.PRIMARY`.
- `/metrics` exposes the same counter as `vtgate_slow_queries{query=...,plan=...,tablet=...}`.
- Operators can compare `vtgate_slow_queries` with `vtgate_query_executions` to alert on slow-query percentage, for example slow primary writes.
- MySQL protocol clients that inspect status flags can see `SERVER_QUERY_WAS_SLOW` on slow responses.

## Local example

The local example now enables vtgate slow-query observability by default for demonstration:

```sh
export VTGATE_SLOW_QUERY_THRESHOLD=250ms
./101_initial_cluster.sh
```

The example README shows how to generate reproducible slow traffic, check `/debug/vars`, check Prometheus metrics, create a slow-write alert, and inspect the slow query through the vtgate query log or `/debug/querylogz`.

Example alert shape:

```promql
100 *
sum(rate(vtgate_slow_queries{query=~"INSERT|UPDATE|DELETE",tablet="PRIMARY"}[5m]))
/
sum(rate(vtgate_query_executions{query=~"INSERT|UPDATE|DELETE",tablet="PRIMARY"}[5m]))
> 1
```

## Tests

Added/updated coverage for:

- vtgate logstats slow-query marking
- `SlowQueries` counter behavior
- MySQL protocol `SERVER_QUERY_WAS_SLOW` for COM_QUERY and COM_STMT_EXECUTE
- OK-only OLAP wire behavior in an end-to-end vtgate cluster
- `/debug/querylogz` rendering of the `SlowQuery` column

Tests run locally:

```sh
go test -count=1 vitess.io/vitess/go/vt/vtgate
go test -count=1 -timeout 10m -run '^TestSlowQueryStatusFlagsComQueryOKOnlyOLAPEndToEnd$' vitess.io/vitess/go/test/endtoend/vtgate/queries/misc
```

Earlier branch checks also covered:

```sh
go test ./go/mysql -run 'TestMultiQueryProtocolUsesCurrentSlowFlagForOKOnlyStatements|TestQueryWasSlowFlagDoesNotLeakToLaterCommands'
go test ./go/vt/vtgate/logstats
go test ./go/vt/vtgate -run 'Test(QueryExecutionsByTable_OnError|SlowQueriesCounter|SlowQueryStatusFlagsComQuery|SlowQueryStatusFlagsComStmtExecute|SlowQueryStatusFlagsComQueryMulti)'
go test ./go/vt/vtgate -run 'Test(ComQueryMulti|GracefulShutdown|GracefulShutdownWithTransaction)'
```

## Related Issue(s)

Fixes #6177

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Adds a new vtgate flag, `--slow-query-threshold`. The default remains `0`, which keeps slow-query detection disabled until explicitly configured.

The local example sets a demonstration threshold and can be overridden with `VTGATE_SLOW_QUERY_THRESHOLD`.

### AI Disclosure

Took Claude Code help in tests and local example docs.