### PR TITLE
tabletserver: unify streaming and buffered query planning, remove PlanSelectStream

### DIFF
--- a/go/vt/vttablet/tabletserver/planbuilder/builder.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/builder.go
@@ -28,22 +28,14 @@ import (
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
-func analyzeUnion(stmt *sqlparser.Union, noRowslimit bool) *Plan {
-	if noRowslimit {
-		return &Plan{PlanID: PlanSelect, FullQuery: GenerateFullQuery(stmt)}
-	}
-	return &Plan{PlanID: PlanSelect, FullQuery: GenerateLimitQuery(stmt)}
+func analyzeUnion(stmt *sqlparser.Union) *Plan {
+	return &Plan{PlanID: PlanSelect, FullQuery: GenerateFullQuery(stmt)}
 }
 
-func analyzeSelect(env *vtenv.Environment, sel *sqlparser.Select, tables map[string]*schema.Table, noRowsLimit bool) (plan *Plan, err error) {
-	plan = &Plan{}
-
-	if noRowsLimit {
-		plan.PlanID = PlanSelectNoLimit
-		plan.FullQuery = GenerateFullQuery(sel)
-	} else {
-		plan.PlanID = PlanSelect
-		plan.FullQuery = GenerateLimitQuery(sel)
+func analyzeSelect(env *vtenv.Environment, sel *sqlparser.Select, tables map[string]*schema.Table) (plan *Plan, err error) {
+	plan = &Plan{
+		PlanID:    PlanSelect,
+		FullQuery: GenerateFullQuery(sel),
 	}
 
 	plan.Table = lookupTables(sel.From, tables)

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -61,7 +61,6 @@ const (
 	// PlanOtherAdmin is for statements like repair, lock table, etc.
 	PlanOtherAdmin
 	PlanSelectNoLimit
-	PlanSelectStream
 	// PlanMessageStream is for "stream" statements.
 	PlanMessageStream
 	PlanSavepoint
@@ -100,7 +99,6 @@ var planName = []string{
 	"OtherRead",
 	"OtherAdmin",
 	"SelectNoLimit",
-	"SelectStream",
 	"MessageStream",
 	"Savepoint",
 	"Release",
@@ -202,12 +200,58 @@ func (plan *Plan) TableNames() (names []string) {
 }
 
 // Build builds a plan based on the schema.
+// It calls BuildStreaming for the base plan, then applies Build-specific
+// overrides: safety LIMITs for SELECT and UNION.
 func Build(env *vtenv.Environment, statement sqlparser.Statement, tables map[string]*schema.Table, dbName string, noRowsLimit bool) (plan *Plan, err error) {
+	plan, err = BuildStreaming(env, statement, tables, dbName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply Build-specific overrides: result-size LIMITs for SELECT and UNION.
 	switch stmt := statement.(type) {
-	case *sqlparser.Union:
-		plan = analyzeUnion(stmt, noRowsLimit)
 	case *sqlparser.Select:
-		plan, err = analyzeSelect(env, stmt, tables, noRowsLimit)
+		switch plan.PlanID {
+		case PlanSelect:
+			if noRowsLimit {
+				plan.PlanID = PlanSelectNoLimit
+			} else {
+				plan.FullQuery = GenerateLimitQuery(stmt)
+			}
+		case PlanSelectImpossible, PlanSelectLockFunc:
+			if !noRowsLimit {
+				plan.FullQuery = GenerateLimitQuery(stmt)
+			}
+		}
+	case *sqlparser.Union:
+		if !noRowsLimit {
+			plan.FullQuery = GenerateLimitQuery(stmt)
+		}
+	}
+	return plan, nil
+}
+
+// BuildStreaming builds a streaming plan based on the schema.
+// It shares analysis logic with Build but does not add result-size LIMITs for
+// SELECT/UNION. The write-safety LIMIT for UPDATE/DELETE is applied here, since
+// it bounds transaction size regardless of streaming.
+func BuildStreaming(env *vtenv.Environment, statement sqlparser.Statement, tables map[string]*schema.Table, dbName string) (*Plan, error) {
+	var plan *Plan
+	var err error
+
+	switch stmt := statement.(type) {
+	case *sqlparser.Select:
+		plan, err = analyzeSelect(env, stmt, tables)
+	case *sqlparser.Union:
+		plan = analyzeUnion(stmt)
+	case *sqlparser.Show:
+		plan, err = analyzeShow(stmt, dbName)
+	case *sqlparser.CallProc:
+		plan = &Plan{PlanID: PlanCallProc, FullQuery: GenerateFullQuery(stmt)}
+	case *sqlparser.Analyze, sqlparser.Explain:
+		// Analyze and Explain are treated as read-only queries.
+		// We send down a string, and get a table result back.
+		plan = &Plan{PlanID: PlanSelect, FullQuery: GenerateFullQuery(stmt)}
 	case *sqlparser.Insert:
 		plan, err = analyzeInsert(stmt, tables)
 	case *sqlparser.Update:
@@ -228,15 +272,6 @@ func Build(env *vtenv.Environment, statement sqlparser.Statement, tables map[str
 		plan = &Plan{PlanID: PlanShowThrottledApps, FullStmt: stmt}
 	case *sqlparser.ShowThrottlerStatus:
 		plan = &Plan{PlanID: PlanShowThrottlerStatus, FullStmt: stmt}
-	case *sqlparser.Show:
-		plan, err = analyzeShow(stmt, dbName)
-	case *sqlparser.Analyze, sqlparser.Explain:
-		// Analyze and Explain are treated as read-only queries.
-		// We send down a string, and get a table result back.
-		plan = &Plan{
-			PlanID:    PlanSelect,
-			FullQuery: GenerateFullQuery(stmt),
-		}
 	case *sqlparser.OtherAdmin:
 		plan = &Plan{PlanID: PlanOtherAdmin}
 	case *sqlparser.Savepoint:
@@ -251,51 +286,8 @@ func Build(env *vtenv.Environment, statement sqlparser.Statement, tables map[str
 		plan, err = analyzeFlush(stmt, tables)
 	case *sqlparser.UnlockTables:
 		plan = &Plan{PlanID: PlanUnlockTables}
-	case *sqlparser.CallProc:
-		plan = &Plan{PlanID: PlanCallProc, FullQuery: GenerateFullQuery(stmt)}
 	default:
 		return nil, vterrors.New(vtrpcpb.Code_INVALID_ARGUMENT, "invalid SQL")
-	}
-	if err != nil {
-		return nil, err
-	}
-	plan.AllTables = lookupAllTables(statement, tables)
-	plan.Permissions = BuildPermissions(statement)
-	return plan, nil
-}
-
-// BuildStreaming builds a streaming plan based on the schema.
-func BuildStreaming(statement sqlparser.Statement, tables map[string]*schema.Table) (*Plan, error) {
-	var plan *Plan
-	var err error
-	switch stmt := statement.(type) {
-	case *sqlparser.Select:
-		plan = &Plan{
-			PlanID:    PlanSelectStream,
-			FullQuery: GenerateFullQuery(statement),
-		}
-		if hasLockFunc(stmt) {
-			plan.NeedsReservedConn = true
-		}
-		plan.Table = lookupTables(stmt.From, tables)
-	case *sqlparser.Show, *sqlparser.Union, *sqlparser.CallProc, sqlparser.Explain:
-		plan = &Plan{
-			PlanID:    PlanSelectStream,
-			FullQuery: GenerateFullQuery(statement),
-		}
-	case *sqlparser.Analyze:
-		plan = &Plan{
-			PlanID:    PlanOtherRead,
-			FullQuery: GenerateFullQuery(statement),
-		}
-	case *sqlparser.Insert:
-		plan, err = analyzeInsert(stmt, tables)
-	case *sqlparser.Update:
-		plan, err = analyzeUpdate(stmt, tables)
-	case *sqlparser.Delete:
-		plan, err = analyzeDelete(stmt, tables)
-	default:
-		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "%s not allowed for streaming", sqlparser.ASTToStatementType(statement))
 	}
 	if err != nil {
 		return nil, err

--- a/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
@@ -193,7 +193,7 @@ func TestStreamPlan(t *testing.T) {
 		var err error
 		statement, err := parser.Parse(tcase.input)
 		if err == nil {
-			plan, err = BuildStreaming(statement, testSchema)
+			plan, err = BuildStreaming(vtenv.NewTestEnv(), statement, testSchema, "dbName")
 		}
 		var out string
 		if err != nil {

--- a/go/vt/vttablet/tabletserver/planbuilder/testdata/stream_cases.txt
+++ b/go/vt/vttablet/tabletserver/planbuilder/testdata/stream_cases.txt
@@ -1,7 +1,7 @@
 # select
 "select * from a"
 {
-  "PlanID": "SelectStream",
+  "PlanID": "Select",
   "TableName": "a",
   "Permissions":[{"TableName":"a","Role":0}],
   "FullQuery": "select * from a"
@@ -10,7 +10,7 @@
 # select join
 "select * from a join b"
 {
-  "PlanID": "SelectStream",
+  "PlanID": "Select",
   "TableName": "",
   "Permissions":[{"TableName":"a","Role":0},{"TableName":"b","Role":0}],
   "FullQuery": "select * from a join b"
@@ -19,7 +19,7 @@
 # select for update
 "select * from a for update"
 {
-  "PlanID": "SelectStream",
+  "PlanID": "Select",
   "TableName": "a",
   "Permissions":[{"TableName":"a","Role":0}],
   "FullQuery": "select * from a for update"
@@ -28,7 +28,7 @@
 # union
 "select * from a union select * from b"
 {
-  "PlanID": "SelectStream",
+  "PlanID": "Select",
   "TableName": "",
   "Permissions":[{"TableName":"a","Role":0},{"TableName":"b","Role":0}],
   "FullQuery": "select * from a union select * from b"
@@ -37,7 +37,7 @@
 # show
 "show tables"
 {
-  "PlanID": "SelectStream",
+  "PlanID": "Show",
   "TableName": "",
   "FullQuery": "show tables"
 }
@@ -45,7 +45,7 @@
 # show table status
 "show table status"
 {
-  "PlanID": "SelectStream",
+  "PlanID": "Show",
   "TableName": "",
   "FullQuery": "show table status"
 }
@@ -53,20 +53,47 @@
 # show binary log status
 "show binary log status"
 {
-  "PlanID": "SelectStream",
-  "TableName": "",
-  "FullQuery": "show binary log status"
+  "PlanID": "OtherRead",
+  "TableName": ""
 }
 
 # other
 "desc foo"
 {
-  "PlanID": "SelectStream",
+  "PlanID": "Select",
   "TableName": "",
   "FullQuery": "explain foo"
 }
 
-# dml update
+# insert
+"insert into a(eid, id) values (1, 2)"
+{
+  "PlanID": "Insert",
+  "TableName": "a",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 1
+    }
+  ],
+  "FullQuery": "insert into a(eid, id) values (1, 2)"
+}
+
+# insert with on duplicate key
+"insert into a(eid, id) values (1, 2) on duplicate key update id = 3"
+{
+  "PlanID": "Insert",
+  "TableName": "a",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 1
+    }
+  ],
+  "FullQuery": "insert into a(eid, id) values (1, 2) on duplicate key update id = 3"
+}
+
+# update
 "update a set b = 1"
 {
   "PlanID": "UpdateLimit",
@@ -80,10 +107,10 @@
   "FullQuery": "update a set b = 1 limit :#maxLimit"
 }
 
-# dml insert
-"insert into a(foo) values (1)"
+# update with where clause
+"update a set b = 1 where eid = 2"
 {
-  "PlanID": "Insert",
+  "PlanID": "UpdateLimit",
   "TableName": "a",
   "Permissions": [
     {
@@ -91,11 +118,12 @@
       "Role": 1
     }
   ],
-  "FullQuery": "insert into a(foo) values (1)"
+  "FullQuery": "update a set b = 1 where eid = 2 limit :#maxLimit",
+  "WhereClause": " where eid = 2"
 }
 
-# dml delete
-"delete from a where foo = 1"
+# delete
+"delete from a"
 {
   "PlanID": "DeleteLimit",
   "TableName": "a",
@@ -105,8 +133,73 @@
       "Role": 1
     }
   ],
-  "FullQuery": "delete from a where foo = 1 limit :#maxLimit",
-  "WhereClause": " where foo = 1"
+  "FullQuery": "delete from a limit :#maxLimit"
+}
+
+# delete with where clause
+"delete from a where eid = 1"
+{
+  "PlanID": "DeleteLimit",
+  "TableName": "a",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 1
+    }
+  ],
+  "FullQuery": "delete from a where eid = 1 limit :#maxLimit",
+  "WhereClause": " where eid = 1"
+}
+
+# ddl - alter table
+"alter table a add column phone varchar(20)"
+{
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "alter table a add column phone varchar(20)"
+}
+
+# ddl - drop table
+"drop table a"
+{
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "drop table a"
+}
+
+# ddl - create table
+"create table test_table (id int primary key)"
+{
+  "PlanID": "DDL",
+  "TableName": "",
+  "Permissions": [
+    {
+      "TableName": "test_table",
+      "Role": 2
+    }
+  ],
+  "FullQuery": "create table test_table (\n\tid int primary key\n)"
+}
+
+# set user-defined variable
+"set @udv = 10"
+{
+  "PlanID": "Set",
+  "TableName": "",
+  "FullQuery": "set @udv = 10",
+  "NeedsReservedConn": true
 }
 
 # syntax error
@@ -116,20 +209,16 @@
 # named locks are unsafe with server-side connection pooling, plan is generated with NeedReservedConn set to true
 "select get_lock('foo', 10) from dual"
 {
-  "PlanID": "SelectStream",
+  "PlanID": "SelectLockFunc",
   "TableName": "",
   "FullQuery": "select get_lock('foo', 10) from dual",
   "NeedsReservedConn": true
 }
 
-# set statement unsafe with pooling
-"set @udv = 10"
-"SET not allowed for streaming"
-
 # analyze statement
 "analyze table a"
 {
-  "PlanID": "OtherRead",
+  "PlanID": "Select",
   "TableName": "",
   "Permissions": [
     {

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -426,7 +426,7 @@ func (qe *QueryEngine) getStreamPlan(curSchema *currentSchema, sql string) (*Tab
 		return nil, err
 	}
 
-	splan, err := planbuilder.BuildStreaming(statement, curSchema.tables)
+	splan, err := planbuilder.BuildStreaming(qe.env.Environment(), statement, curSchema.tables, qe.env.Config().DB.DBName)
 	if err != nil {
 		return nil, err
 	}
@@ -605,7 +605,7 @@ func (qe *QueryEngine) AddStats(plan *TabletPlan, tableName, workload string, ta
 	// But there are special cases like `SELECT ... INTO OUTFILE ''` which return positive rows affected
 	// So we check if it is positive and add that too.
 	switch plan.PlanID {
-	case planbuilder.PlanSelect, planbuilder.PlanSelectStream, planbuilder.PlanSelectImpossible, planbuilder.PlanShow, planbuilder.PlanOtherRead:
+	case planbuilder.PlanSelect, planbuilder.PlanSelectImpossible, planbuilder.PlanShow, planbuilder.PlanOtherRead:
 		qe.queryRowsReturned.Add(keys, rowsReturned)
 		if rowsAffected > 0 {
 			qe.queryRowsAffected.Add(keys, rowsAffected)

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -397,8 +397,12 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) (err error) {
 		}
 	}
 
+	// Match Execute's schema-name rewrite. PlanSelectLockFunc is included for parity
+	// even though only information_schema reads carry BvReplaceSchemaName, so the
+	// rewrite is a no-op for it; PlanSelectNoLimit is Build-only and never reaches
+	// the streaming path.
 	switch qre.plan.PlanID {
-	case p.PlanSelect:
+	case p.PlanSelect, p.PlanSelectImpossible, p.PlanShow, p.PlanSelectLockFunc:
 		if qre.bindVars[sqltypes.BvReplaceSchemaName] != nil {
 			qre.bindVars[sqltypes.BvSchemaName] = sqltypes.StringBindVariable(qre.tsv.config.DB.DBName)
 		}

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -131,27 +131,13 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 		qre.tsv.stats.QueryTimingsByTabletType.Add(qre.targetTabletType.String(), duration)
 		qre.recordUserQuery("Execute", int64(duration))
 
-		mysqlTime := qre.logStats.MysqlResponseTime
-		tableName := qre.plan.TableName().String()
-		if tableName == "" {
-			tableName = "Join"
-		}
-
-		var errCode string
-		vtErrorCode := vterrors.Code(err)
-		errCode = vtErrorCode.String()
-
 		if reply == nil {
-			qre.tsv.qe.AddStats(qre.plan, tableName, qre.options.GetWorkloadName(), qre.targetTabletType, 1, duration, mysqlTime, 0, 0, 1, errCode)
-			qre.plan.AddStats(1, duration, mysqlTime, 0, 0, 1)
+			qre.recordQueryStats(err, duration, 0, 0, 1)
 			return
 		}
-
-		qre.tsv.qe.AddStats(qre.plan, tableName, qre.options.GetWorkloadName(), qre.targetTabletType, 1, duration, mysqlTime, int64(reply.RowsAffected), int64(len(reply.Rows)), 0, errCode)
-		qre.plan.AddStats(1, duration, mysqlTime, reply.RowsAffected, uint64(len(reply.Rows)), 0)
 		qre.logStats.RowsAffected = int(reply.RowsAffected)
 		qre.logStats.Rows = reply.Rows
-		qre.tsv.Stats().ResultHistogram.Add(int64(len(reply.Rows)))
+		qre.recordQueryStats(err, duration, reply.RowsAffected, uint64(len(reply.Rows)), 0)
 	}(time.Now())
 
 	if err = qre.checkPermissions(); err != nil {
@@ -363,19 +349,11 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) (err error) {
 	var totalRows int64
 	defer func(start time.Time) {
 		duration := time.Since(start)
-		mysqlTime := qre.logStats.MysqlResponseTime
-		tableName := qre.plan.TableName().String()
-		if tableName == "" {
-			tableName = "Join"
-		}
-		errCode := vterrors.Code(err).String()
 		var errorCount int64
 		if err != nil {
 			errorCount = 1
 		}
-		qre.tsv.qe.AddStats(qre.plan, tableName, qre.options.GetWorkloadName(), qre.targetTabletType, 1, duration, mysqlTime, 0, totalRows, errorCount, errCode)
-		qre.plan.AddStats(1, duration, mysqlTime, 0, uint64(totalRows), uint64(errorCount))
-		qre.tsv.Stats().ResultHistogram.Add(totalRows)
+		qre.recordQueryStats(err, duration, 0, uint64(totalRows), errorCount)
 	}(time.Now())
 
 	// Wrap the callback to track total rows for the stats recorded above.
@@ -526,26 +504,13 @@ func (qre *QueryExecutor) streamDML(callback StreamCallback) (err error) {
 	// the failure path), the query-log fields and the result histogram.
 	defer func(start time.Time) {
 		duration := time.Since(start)
-		mysqlTime := qre.logStats.MysqlResponseTime
-		// Plans without a single table (e.g. multi-table statements) have an
-		// empty TableName; bucket their stats under "Join", like Execute.
-		tableName := qre.plan.TableName().String()
-		if tableName == "" {
-			tableName = "Join"
-		}
-		errCode := vterrors.Code(err).String()
-
 		if reply == nil {
-			qre.tsv.qe.AddStats(qre.plan, tableName, qre.options.GetWorkloadName(), qre.targetTabletType, 1, duration, mysqlTime, 0, 0, 1, errCode)
-			qre.plan.AddStats(1, duration, mysqlTime, 0, 0, 1)
+			qre.recordQueryStats(err, duration, 0, 0, 1)
 			return
 		}
-
-		qre.tsv.qe.AddStats(qre.plan, tableName, qre.options.GetWorkloadName(), qre.targetTabletType, 1, duration, mysqlTime, int64(reply.RowsAffected), int64(len(reply.Rows)), 0, errCode)
-		qre.plan.AddStats(1, duration, mysqlTime, reply.RowsAffected, uint64(len(reply.Rows)), 0)
 		qre.logStats.RowsAffected = int(reply.RowsAffected)
 		qre.logStats.Rows = reply.Rows
-		qre.tsv.Stats().ResultHistogram.Add(int64(len(reply.Rows)))
+		qre.recordQueryStats(err, duration, reply.RowsAffected, uint64(len(reply.Rows)), 0)
 	}(time.Now())
 
 	if err = qre.checkPermissions(); err != nil {
@@ -590,6 +555,27 @@ func (qre *QueryExecutor) streamDML(callback StreamCallback) (err error) {
 	}
 	err = callback(reply)
 	return err
+}
+
+// recordQueryStats records the per-table/per-plan QueryEngine stats and plan
+// counters for a finished query, plus the result histogram on success. It is the
+// shared tail of Execute, streamDML and the streaming read path. errorCount is 1
+// on failure; the caller decides what counts as a failure (a nil reply for the
+// single-reply paths, a non-nil error for streaming reads). The histogram is
+// recorded only when errorCount is 0, matching Execute, which skips it when no
+// result was produced.
+func (qre *QueryExecutor) recordQueryStats(err error, duration time.Duration, rowsAffected, rowsReturned uint64, errorCount int64) {
+	tableName := qre.plan.TableName().String()
+	if tableName == "" {
+		tableName = "Join"
+	}
+	mysqlTime := qre.logStats.MysqlResponseTime
+	errCode := vterrors.Code(err).String()
+	qre.tsv.qe.AddStats(qre.plan, tableName, qre.options.GetWorkloadName(), qre.targetTabletType, 1, duration, mysqlTime, int64(rowsAffected), int64(rowsReturned), errorCount, errCode)
+	qre.plan.AddStats(1, duration, mysqlTime, rowsAffected, rowsReturned, uint64(errorCount))
+	if errorCount == 0 {
+		qre.tsv.Stats().ResultHistogram.Add(int64(rowsReturned))
+	}
 }
 
 // MessageStream streams messages from a message table.

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -404,7 +404,7 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) (err error) {
 			return err
 		}
 		if reply == nil {
-			reply = &sqltypes.Result{}
+			return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] %s produced no result on the streaming path", qre.plan.PlanID.String())
 		}
 		return countingCallback(reply)
 	}

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -356,27 +356,28 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) (err error) {
 	// streamDML, so reads on the streaming path match Execute. Registered after
 	// the DML dispatch above so DML statements are not double-counted.
 	var totalRows int64
+	var totalRowsAffected uint64
 	defer func(start time.Time) {
 		duration := time.Since(start)
 		var errorCount int64
 		if err != nil {
 			errorCount = 1
 		}
-		// TODO: rowsAffected is hardcoded to 0, which is a parity gap with Execute.
-		// Execute records reply.RowsAffected, which captures reads that report
-		// affected rows but no result set (e.g. SELECT ... INTO OUTFILE). The
-		// streaming path cannot observe this today: ExecuteStreamFetch in
-		// go/mysql/streaming_query.go drops the OK packet's affectedRows in its
-		// `colNumber == 0` branch. Fixing this means surfacing affectedRows there
-		// and threading it through connpool's Conn.Stream/StreamOnce
-		// (go/vt/vttablet/tabletserver/connpool/dbconn.go) so the callback below
-		// can accumulate it, like totalRows.
-		qre.recordQueryStats(err, duration, 0, uint64(totalRows), errorCount)
+		qre.recordQueryStats(err, duration, totalRowsAffected, uint64(totalRows), errorCount)
 	}(time.Now())
 
-	// Wrap the callback to track total rows for the stats recorded above.
+	// Wrap the callback to track the totals for the stats recorded above.
+	// totalRowsAffected covers statements run through executeBuffered (DDL, LOAD,
+	// ...) whose single reply carries the affected-rows count.
+	//
+	// TODO: a streaming read that returns an OK packet with affected rows
+	// (SELECT ... INTO OUTFILE) is still missed: ExecuteStreamFetch in
+	// go/mysql/streaming_query.go drops the OK packet's affectedRows in its
+	// `colNumber == 0` branch, so the callback never sees it. Closing that needs a
+	// protocol-level change there, threaded through connpool's Conn.Stream.
 	countingCallback := func(result *sqltypes.Result) error {
 		totalRows += int64(len(result.Rows))
+		totalRowsAffected += result.RowsAffected
 		return callback(result)
 	}
 
@@ -487,11 +488,10 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) (err error) {
 		// returned to the pool once the callback has fully returned
 		defer returnStreamResult(result)
 
-		totalRows += int64(len(result.Rows))
 		if replaceKeyspace != "" {
 			result.ReplaceKeyspace(qre.tsv.config.DB.DBName, replaceKeyspace)
 		}
-		return callback(result)
+		return countingCallback(result)
 	})
 }
 

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -148,14 +148,23 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 		return nil, reqThrottledErr
 	}
 
+	return qre.executeBuffered()
+}
+
+// executeBuffered runs the plan to completion and returns a single buffered
+// result. It is the shared dispatch used by Execute for non-streaming queries
+// and by Stream for every plan type that is not a streaming read, so both paths
+// handle DDL, migrations, savepoints, SET and the other non-read statements the
+// same way. Callers run checkPermissions and the request throttler before
+// calling this.
+func (qre *QueryExecutor) executeBuffered() (*sqltypes.Result, error) {
 	if qre.plan.PlanID == p.PlanNextval {
 		return qre.execNextval()
 	}
 
 	if qre.connID != 0 {
-		var conn *StatefulConnection
 		// Need upfront connection for DMLs and transactions
-		conn, err = qre.tsv.te.txPool.GetAndLock(qre.connID, "for query")
+		conn, err := qre.tsv.te.txPool.GetAndLock(qre.connID, "for query")
 		if err != nil {
 			return nil, err
 		}
@@ -379,37 +388,29 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) (err error) {
 		return reqThrottledErr
 	}
 
-	// Handle plans that don't use generic SQL execution.
+	// Streaming reads stream their results from MySQL through the generic path
+	// below. Every other plan type produces a single buffered result: run it
+	// through the same dispatch Execute uses (executeBuffered) and deliver that
+	// result through the callback, so the streaming path matches Execute for
+	// every statement BuildStreaming accepts (DDL, migrations, savepoints, SET,
+	// ...). executeBuffered's default also fails fast on any unhandled plan type.
 	switch qre.plan.PlanID {
-	case p.PlanNextval:
-		result, err := qre.execNextval()
+	case p.PlanSelect, p.PlanSelectImpossible, p.PlanShow, p.PlanSelectLockFunc, p.PlanOtherRead, p.PlanCallProc:
+		// Streaming reads: handled by the generic streaming path below.
+	default:
+		reply, err := qre.executeBuffered()
 		if err != nil {
 			return err
 		}
-		return countingCallback(result)
-	case p.PlanShowMigrations:
-		result, err := qre.execShowMigrations(nil)
-		if err != nil {
-			return err
+		if reply == nil {
+			reply = &sqltypes.Result{}
 		}
-		return countingCallback(result)
-	case p.PlanSet:
-		// Mirror Execute: without a reserved connection the SET is not executed,
-		// it is applied to the pooled connection of subsequent queries via
-		// qre.setting. With a reserved connection (connID != 0) the SET runs on
-		// it, so fall through to the generic path below.
-		if qre.connID == 0 {
-			if qre.setting == nil {
-				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "[BUG] %s not allowed without setting connection", qre.query)
-			}
-			return countingCallback(&sqltypes.Result{})
-		}
+		return countingCallback(reply)
 	}
 
 	// Match Execute's schema-name rewrite. PlanSelectLockFunc is included for parity
 	// even though only information_schema reads carry BvReplaceSchemaName, so the
-	// rewrite is a no-op for it; PlanSelectNoLimit is Build-only and never reaches
-	// the streaming path.
+	// rewrite is a no-op for it.
 	switch qre.plan.PlanID {
 	case p.PlanSelect, p.PlanSelectImpossible, p.PlanShow, p.PlanSelectLockFunc:
 		if qre.bindVars[sqltypes.BvReplaceSchemaName] != nil {

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -340,7 +340,7 @@ func (qre *QueryExecutor) txConnExec(conn *StatefulConnection) (*sqltypes.Result
 }
 
 // Stream performs a streaming query execution.
-func (qre *QueryExecutor) Stream(callback StreamCallback) error {
+func (qre *QueryExecutor) Stream(callback StreamCallback) (err error) {
 	qre.logStats.PlanType = qre.plan.PlanID.String()
 
 	defer func(start time.Time) {
@@ -357,6 +357,29 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 		return qre.streamDML(callback)
 	}
 
+	// Record the per-table and per-plan stats that the DML path records in
+	// streamDML, so reads on the streaming path match Execute. Registered after
+	// the DML dispatch above so DML statements are not double-counted.
+	var totalRows int64
+	defer func(start time.Time) {
+		duration := time.Since(start)
+		mysqlTime := qre.logStats.MysqlResponseTime
+		tableName := qre.plan.TableName().String()
+		if tableName == "" {
+			tableName = "Join"
+		}
+		errCode := vterrors.Code(err).String()
+		qre.tsv.qe.AddStats(qre.plan, tableName, qre.options.GetWorkloadName(), qre.targetTabletType, 1, duration, mysqlTime, 0, totalRows, 0, errCode)
+		qre.plan.AddStats(1, duration, mysqlTime, 0, uint64(totalRows), 0)
+		qre.tsv.Stats().ResultHistogram.Add(totalRows)
+	}(time.Now())
+
+	// Wrap the callback to track total rows for the stats recorded above.
+	countingCallback := func(result *sqltypes.Result) error {
+		totalRows += int64(len(result.Rows))
+		return callback(result)
+	}
+
 	if err := qre.checkPermissions(); err != nil {
 		return err
 	}
@@ -365,16 +388,40 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 		return reqThrottledErr
 	}
 
+	// Handle plans that don't use generic SQL execution.
 	switch qre.plan.PlanID {
-	case p.PlanSelectStream:
+	case p.PlanNextval:
+		result, err := qre.execNextval()
+		if err != nil {
+			return err
+		}
+		return countingCallback(result)
+	case p.PlanShowMigrations:
+		result, err := qre.execShowMigrations(nil)
+		if err != nil {
+			return err
+		}
+		return countingCallback(result)
+	}
+
+	switch qre.plan.PlanID {
+	case p.PlanSelect:
 		if qre.bindVars[sqltypes.BvReplaceSchemaName] != nil {
 			qre.bindVars[sqltypes.BvSchemaName] = sqltypes.StringBindVariable(qre.tsv.config.DB.DBName)
 		}
 	}
 
-	sql, sqlWithoutComments, err := qre.generateFinalSQL(qre.plan.FullQuery, qre.bindVars)
-	if err != nil {
-		return err
+	var sql string
+	var sqlWithoutComments string
+	if qre.plan.FullQuery != nil {
+		var err error
+		sql, sqlWithoutComments, err = qre.generateFinalSQL(qre.plan.FullQuery, qre.bindVars)
+		if err != nil {
+			return err
+		}
+	} else {
+		sql = qre.query
+		sqlWithoutComments, _ = sqlparser.SplitMarginComments(qre.query)
 	}
 
 	var replaceKeyspace string
@@ -383,8 +430,8 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 	}
 
 	if consolidator := qre.tsv.qe.streamConsolidator; consolidator != nil {
-		if qre.connID == 0 && qre.plan.PlanID == p.PlanSelectStream && qre.shouldConsolidate() {
-			return consolidator.Consolidate(qre.tsv.stats.WaitTimings, qre.logStats, sqlWithoutComments, callback,
+		if qre.connID == 0 && qre.plan.PlanID == p.PlanSelect && qre.shouldConsolidate() {
+			return consolidator.Consolidate(qre.tsv.stats.WaitTimings, qre.logStats, sqlWithoutComments, countingCallback,
 				func(callback StreamCallback) error {
 					dbConn, err := qre.getStreamConn()
 					if err != nil {
@@ -433,6 +480,7 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 		// returned to the pool once the callback has fully returned
 		defer returnStreamResult(result)
 
+		totalRows += int64(len(result.Rows))
 		if replaceKeyspace != "" {
 			result.ReplaceKeyspace(qre.tsv.config.DB.DBName, replaceKeyspace)
 		}

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -353,6 +353,15 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) (err error) {
 		if err != nil {
 			errorCount = 1
 		}
+		// TODO: rowsAffected is hardcoded to 0, which is a parity gap with Execute.
+		// Execute records reply.RowsAffected, which captures reads that report
+		// affected rows but no result set (e.g. SELECT ... INTO OUTFILE). The
+		// streaming path cannot observe this today: ExecuteStreamFetch in
+		// go/mysql/streaming_query.go drops the OK packet's affectedRows in its
+		// `colNumber == 0` branch. Fixing this means surfacing affectedRows there
+		// and threading it through connpool's Conn.Stream/StreamOnce
+		// (go/vt/vttablet/tabletserver/connpool/dbconn.go) so the callback below
+		// can accumulate it, like totalRows.
 		qre.recordQueryStats(err, duration, 0, uint64(totalRows), errorCount)
 	}(time.Now())
 

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -369,8 +369,12 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) (err error) {
 			tableName = "Join"
 		}
 		errCode := vterrors.Code(err).String()
-		qre.tsv.qe.AddStats(qre.plan, tableName, qre.options.GetWorkloadName(), qre.targetTabletType, 1, duration, mysqlTime, 0, totalRows, 0, errCode)
-		qre.plan.AddStats(1, duration, mysqlTime, 0, uint64(totalRows), 0)
+		var errorCount int64
+		if err != nil {
+			errorCount = 1
+		}
+		qre.tsv.qe.AddStats(qre.plan, tableName, qre.options.GetWorkloadName(), qre.targetTabletType, 1, duration, mysqlTime, 0, totalRows, errorCount, errCode)
+		qre.plan.AddStats(1, duration, mysqlTime, 0, uint64(totalRows), uint64(errorCount))
 		qre.tsv.Stats().ResultHistogram.Add(totalRows)
 	}(time.Now())
 

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -402,6 +402,17 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) (err error) {
 			return err
 		}
 		return countingCallback(result)
+	case p.PlanSet:
+		// Mirror Execute: without a reserved connection the SET is not executed,
+		// it is applied to the pooled connection of subsequent queries via
+		// qre.setting. With a reserved connection (connID != 0) the SET runs on
+		// it, so fall through to the generic path below.
+		if qre.connID == 0 {
+			if qre.setting == nil {
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "[BUG] %s not allowed without setting connection", qre.query)
+			}
+			return countingCallback(&sqltypes.Result{})
+		}
 	}
 
 	switch qre.plan.PlanID {

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1472,7 +1472,8 @@ func TestReplaceSchemaName(t *testing.T) {
 	// Test streaming execute.
 	{
 		qre := newTestQueryExecutorStreaming(ctx, tsv, inQuery, 0)
-		// Stream only replaces schema name when plan is PlanSelect.
+		// Stream replaces the schema name for read plans like PlanSelect
+		// (PlanShow and PlanSelectImpossible are covered separately).
 		assert.Equal(t, planbuilder.PlanSelect, qre.plan.PlanID)
 		// Any value other than nil should cause QueryExecutor to replace the
 		// schema name.
@@ -1483,6 +1484,70 @@ func TestReplaceSchemaName(t *testing.T) {
 			return nil
 		})
 		require.NoError(t, err)
+	}
+}
+
+// Stream must apply the schema-name rewrite for the same read plan types as
+// Execute -- PlanShow, PlanSelectImpossible and PlanSelectLockFunc as well as
+// PlanSelect. In the merged base every streaming query was PlanSelectStream and
+// always rewritten; once BuildStreaming returns real plan types, a streaming SHOW
+// or impossible SELECT would skip the rewrite (a regression) and run scoped to the
+// wrong schema name or fail with a missing bind variable. PlanSelectLockFunc is
+// included for parity with Execute even though it never carries the bind variable
+// in practice, so its rewrite is a no-op.
+func TestStreamReplaceSchemaNameByPlanType(t *testing.T) {
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+
+	ctx := t.Context()
+	tsv := newTestTabletServer(ctx, noFlags, db)
+	defer tsv.StopService()
+
+	testcases := []struct {
+		name     string
+		query    string
+		dbQuery  string
+		planWant planbuilder.PlanType
+	}{
+		{
+			name:     "PlanShow",
+			query:    "show tables",
+			dbQuery:  "show tables",
+			planWant: planbuilder.PlanShow,
+		},
+		{
+			name:     "PlanSelectImpossible",
+			query:    "select * from test_table where 1 != 1",
+			dbQuery:  "select * from test_table where 1 != 1",
+			planWant: planbuilder.PlanSelectImpossible,
+		},
+		{
+			name:     "PlanSelectLockFunc",
+			query:    "select get_lock('foo', 10) from dual",
+			dbQuery:  "select get_lock('foo', 10) from dual",
+			planWant: planbuilder.PlanSelectLockFunc,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			db.AddQuery(tc.dbQuery, &sqltypes.Result{Fields: getTestTableFields()})
+
+			// Without BvReplaceSchemaName the rewrite is a no-op: BvSchemaName
+			// stays unset, matching Execute.
+			qreNoop := newTestQueryExecutorStreaming(ctx, tsv, tc.query, 0)
+			require.Equal(t, tc.planWant, qreNoop.plan.PlanID)
+			require.NoError(t, qreNoop.Stream(func(_ *sqltypes.Result) error { return nil }))
+			_, ok := qreNoop.bindVars[sqltypes.BvSchemaName]
+			require.False(t, ok, "Stream must not set the schema name for %s without BvReplaceSchemaName", tc.planWant)
+
+			// With BvReplaceSchemaName set the rewrite fires, matching Execute.
+			qre := newTestQueryExecutorStreaming(ctx, tsv, tc.query, 0)
+			qre.bindVars[sqltypes.BvReplaceSchemaName] = sqltypes.NullBindVariable
+			require.NoError(t, qre.Stream(func(_ *sqltypes.Result) error { return nil }))
+			_, ok = qre.bindVars[sqltypes.BvSchemaName]
+			require.True(t, ok, "Stream must replace the schema name for %s, like Execute", tc.planWant)
+		})
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1607,6 +1607,64 @@ func TestQueryExecutorStreamDMLErrorStatsOnPermissionDenied(t *testing.T) {
 		"streamed DML rejected by checkPermissions must record per-table error stats like Execute")
 }
 
+// A streaming read that fails must record per-table and per-plan error stats,
+// matching the non-streaming Execute path. The read-path stats defer records the
+// error counters from the named return, so a failed streaming read has to bump
+// QueryErrorCounts, QueryErrorCountsWithCode and the per-plan ErrorCount, not just
+// leave them flat.
+func TestQueryExecutorStreamReadErrorStatsOnPermissionDenied(t *testing.T) {
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+
+	query := "select * from test_table"
+
+	bannedAddr := "127.0.0.1"
+	bannedUser := "u2"
+
+	denyRule := rules.NewQueryRule("disable select", "disable select", rules.QRFail)
+	denyRule.SetIPCond(bannedAddr)
+	denyRule.SetUserCond(bannedUser)
+	denyRule.AddPlanCond(planbuilder.PlanSelect)
+	denyRule.AddTableCond("test_table")
+
+	rulesName := "denyListStreamReadQRFail"
+	qrs := rules.New()
+	qrs.Add(denyRule)
+
+	callInfo := &fakecallinfo.FakeCallInfo{
+		Remote: bannedAddr,
+		User:   bannedUser,
+	}
+	ctx := callinfo.NewContext(t.Context(), callInfo)
+	tsv := newTestTabletServer(ctx, noFlags, db)
+	defer tsv.StopService()
+	tsv.qe.queryRuleSources.UnRegisterSource(rulesName)
+	tsv.qe.queryRuleSources.RegisterSource(rulesName)
+	defer tsv.qe.queryRuleSources.UnRegisterSource(rulesName)
+	require.NoError(t, tsv.qe.queryRuleSources.SetRules(rulesName, qrs))
+
+	qre := newTestQueryExecutorStreaming(ctx, tsv, query, 0)
+	require.Equal(t, planbuilder.PlanSelect, qre.plan.PlanID)
+
+	errCountBefore := tsv.qe.queryErrorCounts.Counts()["test_table.Select"]
+	errCodeCountBefore := tsv.qe.queryErrorCountsWithCode.Counts()["test_table.Select.INVALID_ARGUMENT"]
+	planErrBefore := qre.plan.ErrorCount
+
+	err := qre.Stream(func(*sqltypes.Result) error { return nil })
+	require.Equal(t, vtrpcpb.Code_INVALID_ARGUMENT, vterrors.Code(err))
+
+	errCountAfter := tsv.qe.queryErrorCounts.Counts()["test_table.Select"]
+	errCodeCountAfter := tsv.qe.queryErrorCountsWithCode.Counts()["test_table.Select.INVALID_ARGUMENT"]
+	planErrAfter := qre.plan.ErrorCount
+
+	assert.Equal(t, errCountBefore+1, errCountAfter,
+		"failed streamed read must record per-table QueryErrorCounts like Execute")
+	assert.Equal(t, errCodeCountBefore+1, errCodeCountAfter,
+		"failed streamed read must record QueryErrorCountsWithCode like Execute")
+	assert.Equal(t, planErrBefore+1, planErrAfter,
+		"failed streamed read must record the per-plan ErrorCount like Execute")
+}
+
 // TestQueryExecutorStreamDMLAppliesQueryTimeout verifies that autocommit DML on
 // the streaming path runs under the query timeout, like the non-streaming
 // Execute path. StreamExecute leaves the request timeout unset when there is no

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1551,6 +1551,42 @@ func TestStreamReplaceSchemaNameByPlanType(t *testing.T) {
 	}
 }
 
+// A statement that runs through the buffered dispatch on the streaming path and
+// reports affected rows -- e.g. ALTER TABLE -- must record QueryRowsAffected like
+// Execute. Its single reply reaches the streaming callback with RowsAffected set,
+// but the stats defer previously discarded it (recorded 0).
+func TestStreamRecordsBufferedRowsAffected(t *testing.T) {
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+
+	ctx := t.Context()
+	tsv := newTestTabletServer(ctx, noFlags, db)
+	tsv.config.DB.DBName = "ks"
+	defer tsv.StopService()
+
+	const ddl = "alter table test_table add zipcode int"
+	db.AddQuery("alter table test_table add column zipcode int", &sqltypes.Result{RowsAffected: 7})
+
+	// DDL has no single table, so its stats bucket under "Join".
+	const key = "Join.DDL"
+
+	// Execute records the affected rows.
+	qreExec := newTestQueryExecutor(ctx, tsv, ddl, 0)
+	require.Equal(t, planbuilder.PlanDDL, qreExec.plan.PlanID)
+	execBefore := tsv.qe.queryRowsAffected.Counts()[key]
+	_, err := qreExec.Execute()
+	require.NoError(t, err)
+	require.Equal(t, execBefore+7, tsv.qe.queryRowsAffected.Counts()[key])
+
+	// Stream must record the same.
+	streamBefore := tsv.qe.queryRowsAffected.Counts()[key]
+	qreStream := newTestQueryExecutorStreaming(ctx, tsv, ddl, 0)
+	require.Equal(t, planbuilder.PlanDDL, qreStream.plan.PlanID)
+	require.NoError(t, qreStream.Stream(func(*sqltypes.Result) error { return nil }))
+	assert.Equal(t, streamBefore+7, tsv.qe.queryRowsAffected.Counts()[key],
+		"streamed DDL must record QueryRowsAffected like Execute")
+}
+
 // TestQueryExecutorStreamDML verifies that DML executed on the streaming path
 // (StreamExecute) runs through the same transactional machinery as Execute and
 // delivers its single result through the callback. Before the fix for #19561

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1472,8 +1472,8 @@ func TestReplaceSchemaName(t *testing.T) {
 	// Test streaming execute.
 	{
 		qre := newTestQueryExecutorStreaming(ctx, tsv, inQuery, 0)
-		// Stream only replaces schema name when plan is PlanSelectStream.
-		assert.Equal(t, planbuilder.PlanSelectStream, qre.plan.PlanID)
+		// Stream only replaces schema name when plan is PlanSelect.
+		assert.Equal(t, planbuilder.PlanSelect, qre.plan.PlanID)
 		// Any value other than nil should cause QueryExecutor to replace the
 		// schema name.
 		qre.bindVars[sqltypes.BvReplaceSchemaName] = sqltypes.NullBindVariable

--- a/go/vt/vttablet/tabletserver/stream_execute_compat_test.go
+++ b/go/vt/vttablet/tabletserver/stream_execute_compat_test.go
@@ -700,3 +700,112 @@ func TestStreamExecuteCompat_LoadDataViaStreamExecute(t *testing.T) {
 	assert.NoError(t, err,
 		"BuildStreaming should accept LOAD DATA statements")
 }
+
+// A DDL inside a transaction must be rejected on the streaming path the same way
+// Execute rejects it. The pre-unification streaming path ran the DDL raw on the
+// transaction connection, bypassing execDDL's "DDL inside a transaction" guard.
+func TestStreamExecuteCompat_DDLInTransactionRejected(t *testing.T) {
+	ctx := t.Context()
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+	tsv := newTestTabletServer(ctx, noFlags, db)
+	tsv.config.DB.DBName = "ks"
+	defer tsv.StopService()
+
+	const ddl = "alter table test_table add zipcode int"
+	// Add the rewritten DDL so that on the raw path MySQL would accept it and the
+	// only thing that can produce an error is the transaction guard itself.
+	db.AddQuery("alter table test_table add column zipcode int", &sqltypes.Result{})
+
+	const wantErr = "DDL statement executed inside a transaction"
+	target := tsv.sm.Target()
+
+	// Execute rejects DDL inside a transaction.
+	execState, err := tsv.Begin(ctx, nil, target, nil)
+	require.NoError(t, err)
+	defer tsv.Commit(ctx, target, execState.TransactionID)
+	_, execErr := newTestQueryExecutor(ctx, tsv, ddl, execState.TransactionID).Execute()
+	require.ErrorContains(t, execErr, wantErr)
+
+	// Stream must reject it identically.
+	streamState, err := tsv.Begin(ctx, nil, target, nil)
+	require.NoError(t, err)
+	defer tsv.Commit(ctx, target, streamState.TransactionID)
+	streamErr := newTestQueryExecutorStreaming(ctx, tsv, ddl, streamState.TransactionID).
+		Stream(func(*sqltypes.Result) error { return nil })
+	require.ErrorContains(t, streamErr, wantErr)
+}
+
+// A savepoint on the streaming path must be recorded in the transaction's query
+// log (via execSavepointQuery), just like Execute, so transaction redo can
+// replay it. The pre-unification raw streaming path skipped this bookkeeping.
+func TestStreamExecuteCompat_SavepointRecordsTxProperty(t *testing.T) {
+	ctx := t.Context()
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+	tsv := newTestTabletServer(ctx, noFlags, db)
+	defer tsv.StopService()
+
+	db.AddQuery("savepoint sp1", &sqltypes.Result{})
+
+	target := tsv.sm.Target()
+	state, err := tsv.Begin(ctx, nil, target, nil)
+	require.NoError(t, err)
+	defer tsv.Commit(ctx, target, state.TransactionID)
+
+	streamErr := newTestQueryExecutorStreaming(ctx, tsv, "savepoint sp1", state.TransactionID).
+		Stream(func(*sqltypes.Result) error { return nil })
+	require.NoError(t, streamErr)
+
+	conn, err := tsv.te.txPool.GetAndLock(state.TransactionID, "inspect savepoint bookkeeping")
+	require.NoError(t, err)
+	defer conn.Unlock()
+
+	var found bool
+	for _, q := range conn.TxProperties().Queries {
+		if q.Savepoint == "sp1" {
+			found = true
+		}
+	}
+	assert.True(t, found, "streamed savepoint should be recorded in TxProperties.Queries")
+}
+
+// UNLOCK TABLES without an existing connection must fail fast on the streaming
+// path exactly like Execute, rather than being sent to MySQL on a pooled
+// connection. The statement is deliberately not registered with the fake db, so
+// reaching MySQL would surface as a different "query not found" error.
+func TestStreamExecuteCompat_UnlockTablesRequiresConn(t *testing.T) {
+	ctx := t.Context()
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+	tsv := newTestTabletServer(ctx, noFlags, db)
+	defer tsv.StopService()
+
+	const wantErr = "unlock tables should be executed with an existing connection"
+
+	_, execErr := newTestQueryExecutor(ctx, tsv, "unlock tables", 0).Execute()
+	require.ErrorContains(t, execErr, wantErr)
+
+	streamErr := newTestQueryExecutorStreaming(ctx, tsv, "unlock tables", 0).
+		Stream(func(*sqltypes.Result) error { return nil })
+	require.ErrorContains(t, streamErr, wantErr)
+}
+
+// A Vitess migration statement is not MySQL SQL: the streaming path must route
+// it to the migration executor (execAlterMigration) and never send the raw
+// statement to MySQL, as the pre-unification raw path did.
+func TestStreamExecuteCompat_MigrationNotSentToMySQL(t *testing.T) {
+	ctx := t.Context()
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+	tsv := newTestTabletServer(ctx, noFlags, db)
+	defer tsv.StopService()
+
+	// We don't assert on the executor's outcome here, only that the raw statement
+	// was not handed to MySQL.
+	_ = newTestQueryExecutorStreaming(ctx, tsv, "alter vitess_migration 'abc' cancel", 0).
+		Stream(func(*sqltypes.Result) error { return nil })
+
+	assert.NotContains(t, db.QueryLog(), "vitess_migration",
+		"migration statement must not be sent to MySQL on the streaming path")
+}

--- a/go/vt/vttablet/tabletserver/stream_execute_compat_test.go
+++ b/go/vt/vttablet/tabletserver/stream_execute_compat_test.go
@@ -1,0 +1,658 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletserver
+
+// Tests that verify parity between StreamExecute and Execute.
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/streamlog"
+	"vitess.io/vitess/go/vt/callerid"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/tableacl"
+	"vitess.io/vitess/go/vt/tableacl/simpleacl"
+	"vitess.io/vitess/go/vt/vtenv"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/planbuilder"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	tableaclpb "vitess.io/vitess/go/vt/proto/tableacl"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+)
+
+// BuildStreaming accepts DML and DDL statement types.
+func TestStreamExecuteCompat_BuildStreamingRejectsDML(t *testing.T) {
+	parser := sqlparser.NewTestParser()
+
+	testcases := []struct {
+		name  string
+		query string
+	}{
+		{"INSERT", "insert into test_table(a) values(1)"},
+		{"UPDATE", "update test_table set a = 1"},
+		{"DELETE", "delete from test_table"},
+		{"DDL", "alter table test_table add zipcode int"},
+		{"SET", "set @udv = 10"},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt, err := parser.Parse(tc.query)
+			require.NoError(t, err)
+
+			_, err = planbuilder.BuildStreaming(vtenv.NewTestEnv(), stmt, map[string]*schema.Table{}, "dbName")
+			assert.NoError(t, err, "BuildStreaming should accept %s statements", tc.name)
+		})
+	}
+}
+
+// Stream() handles plan types that Execute() handles.
+func TestStreamExecuteCompat_StreamMissingPlanTypes(t *testing.T) {
+	ctx := t.Context()
+	db, tsv := setupTabletServerTest(t, ctx, "")
+	defer tsv.StopService()
+	defer db.Close()
+
+	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
+
+	selectSQL := "select * from test_table limit 1000"
+	db.AddQuery(selectSQL, &sqltypes.Result{
+		Fields: []*querypb.Field{{Type: sqltypes.VarBinary}},
+		Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("row01")}},
+	})
+
+	var gotRows int
+	callback := func(qr *sqltypes.Result) error {
+		gotRows += len(qr.Rows)
+		return nil
+	}
+	err := tsv.StreamExecute(ctx, nil, &target, selectSQL, nil, 0, 0, nil, callback)
+	require.NoError(t, err, "SELECT should work in streaming mode")
+	assert.Equal(t, 1, gotRows)
+}
+
+// ACL error messages are identical between Execute and Stream.
+func TestStreamExecuteCompat_ACLErrorMessageConsistency(t *testing.T) {
+	aclName := fmt.Sprintf("simpleacl-test-%d", rand.Int64())
+	tableacl.Register(aclName, &simpleacl.Factory{})
+	tableacl.SetDefaultACL(aclName)
+
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+
+	ctx := t.Context()
+	tsv := newTestTabletServer(ctx, enableStrictTableACL, db)
+	defer tsv.StopService()
+
+	config := &tableaclpb.Config{
+		TableGroups: []*tableaclpb.TableGroupSpec{{
+			Name:                 "group01",
+			TableNamesOrPrefixes: []string{"test_table"},
+			Readers:              []string{"allowed_user"},
+		}},
+	}
+	require.NoError(t, tableacl.InitFromProto(config))
+
+	// Use a user that does NOT have read access.
+	callerID := &querypb.VTGateCallerID{Username: "denied_user"}
+	ctx = callerid.NewContext(ctx, nil, callerID)
+
+	query := "select * from test_table"
+
+	qreExec := newTestQueryExecutor(ctx, tsv, query, 0)
+	_, execErr := qreExec.Execute()
+	require.Error(t, execErr)
+
+	qreStream := newTestQueryExecutorStreaming(ctx, tsv, query, 0)
+	streamErr := qreStream.Stream(func(*sqltypes.Result) error { return nil })
+	require.Error(t, streamErr)
+
+	assert.Equal(t, execErr.Error(), streamErr.Error(),
+		"ACL error messages should be identical between Execute and Stream")
+}
+
+// Execute records with "Execute" label; Stream records with "Stream" label.
+// This is intentional so operators can distinguish between the two workloads.
+func TestStreamExecuteCompat_MetricKeyConsistency(t *testing.T) {
+	ctx := t.Context()
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+
+	query := "select * from test_table limit 1000"
+	db.AddQuery(query, &sqltypes.Result{
+		Fields: []*querypb.Field{{Type: sqltypes.VarBinary}},
+		Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("row01")}},
+	})
+
+	callerID := &querypb.VTGateCallerID{Username: "test_user"}
+	ctx = callerid.NewContext(ctx, nil, callerID)
+
+	tsv := newTestTabletServer(ctx, noFlags, db)
+	defer tsv.StopService()
+
+	// Execute path records with "Execute" label.
+	qreExec := newTestQueryExecutor(ctx, tsv, query, 0)
+	_, err := qreExec.Execute()
+	require.NoError(t, err)
+
+	executeCount := tsv.Stats().UserTableQueryCount.Counts()["test_table.test_user.Execute"]
+	assert.Greater(t, executeCount, int64(0), "Execute should record with 'Execute' label")
+
+	// Stream path records with "Stream" label.
+	qreStream := newTestQueryExecutorStreaming(ctx, tsv, query, 0)
+	err = qreStream.Stream(func(*sqltypes.Result) error { return nil })
+	require.NoError(t, err)
+
+	streamCount := tsv.Stats().UserTableQueryCount.Counts()["test_table.test_user.Stream"]
+	assert.Greater(t, streamCount, int64(0), "Stream should record with 'Stream' label")
+}
+
+// Execute and Stream log the same PlanType for equivalent queries.
+func TestStreamExecuteCompat_PlanTypeInLogStats(t *testing.T) {
+	ctx := t.Context()
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+
+	query := "select * from test_table limit 1000"
+	db.AddQuery(query, &sqltypes.Result{
+		Fields: []*querypb.Field{{Type: sqltypes.VarBinary}},
+		Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("row01")}},
+	})
+
+	tsv := newTestTabletServer(ctx, noFlags, db)
+	defer tsv.StopService()
+
+	qreExec := newTestQueryExecutor(ctx, tsv, query, 0)
+	_, err := qreExec.Execute()
+	require.NoError(t, err)
+
+	qreStream := newTestQueryExecutorStreaming(ctx, tsv, query, 0)
+	err = qreStream.Stream(func(*sqltypes.Result) error { return nil })
+	require.NoError(t, err)
+
+	assert.Equal(t, qreExec.logStats.PlanType, qreStream.logStats.PlanType,
+		"Stream should log the same PlanType as Execute for equivalent queries")
+}
+
+// DML works through the full TabletServer.StreamExecute path.
+func TestStreamExecuteCompat_DMLViaTabletServer(t *testing.T) {
+	ctx := t.Context()
+	db, tsv := setupTabletServerTest(t, ctx, "")
+	defer tsv.StopService()
+	defer db.Close()
+
+	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
+
+	dmlResult := &sqltypes.Result{RowsAffected: 1}
+
+	testcases := []struct {
+		name  string
+		query string
+		dbSQL string
+	}{
+		{
+			name:  "INSERT",
+			query: "insert into test_table(pk) values(1)",
+			dbSQL: "insert into test_table(pk) values (1)",
+		},
+		{
+			name:  "UPDATE",
+			query: "update test_table set pk = 1 where pk = 2",
+			dbSQL: "update test_table set pk = 1 where pk = 2 limit 10001",
+		},
+		{
+			name:  "DELETE",
+			query: "delete from test_table where pk = 1",
+			dbSQL: "delete from test_table where pk = 1 limit 10001",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			db.AddQuery(tc.dbSQL, dmlResult)
+
+			callback := func(*sqltypes.Result) error { return nil }
+			err := tsv.StreamExecute(ctx, nil, &target, tc.query, nil, 0, 0, nil, callback)
+			assert.NoError(t, err, "StreamExecute should accept %s statements", tc.name)
+		})
+	}
+}
+
+// StreamExecute honors query timeout hints.
+func TestStreamExecuteCompat_QueryTimeoutHint(t *testing.T) {
+	ctx := t.Context()
+	db, tsv := setupTabletServerTest(t, ctx, "")
+	defer tsv.StopService()
+	defer db.Close()
+
+	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
+
+	selectSQL := "select /*vt+ QUERY_TIMEOUT_MS=1 */ sleep(10) from test_table limit 1000"
+	db.AddQuery(selectSQL, &sqltypes.Result{
+		Fields: []*querypb.Field{{Type: sqltypes.VarBinary}},
+	})
+
+	_, execErr := tsv.Execute(ctx, nil, &target, selectSQL, nil, 0, 0, nil)
+
+	callback := func(*sqltypes.Result) error { return nil }
+	streamErr := tsv.StreamExecute(ctx, nil, &target, selectSQL, nil, 0, 0, nil, callback)
+
+	if execErr != nil {
+		assert.Error(t, streamErr,
+			"StreamExecute should honor QUERY_TIMEOUT_MS hint like Execute does")
+	}
+}
+
+// ACL denial errors use "Select" (not "SelectStream") in streaming mode.
+func TestStreamExecuteCompat_ACLErrorFormat(t *testing.T) {
+	aclName := fmt.Sprintf("simpleacl-test-%d", rand.Int64())
+	tableacl.Register(aclName, &simpleacl.Factory{})
+	tableacl.SetDefaultACL(aclName)
+
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+
+	ctx := t.Context()
+	tsv := newTestTabletServer(ctx, enableStrictTableACL, db)
+	defer tsv.StopService()
+
+	config := &tableaclpb.Config{
+		TableGroups: []*tableaclpb.TableGroupSpec{{
+			Name:                 "group01",
+			TableNamesOrPrefixes: []string{"test_table"},
+			Readers:              []string{"allowed_user"},
+		}},
+	}
+	require.NoError(t, tableacl.InitFromProto(config))
+
+	callerID := &querypb.VTGateCallerID{Username: "denied_user"}
+	ctx = callerid.NewContext(ctx, nil, callerID)
+
+	query := "select * from test_table"
+
+	qreStream := newTestQueryExecutorStreaming(ctx, tsv, query, 0)
+	err := qreStream.Stream(func(*sqltypes.Result) error { return nil })
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "Select command denied",
+		"ACL error should say 'Select command denied', got: %s", err.Error())
+	assert.NotContains(t, err.Error(), "SelectStream",
+		"ACL error should not contain 'SelectStream', got: %s", err.Error())
+}
+
+// Stream() handles PlanNextval via execNextval().
+func TestStreamExecuteCompat_NextvalHandling(t *testing.T) {
+	ctx := t.Context()
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+
+	tsv := newTestTabletServer(ctx, noFlags, db)
+	defer tsv.StopService()
+
+	// Set up the sequence table responses that execNextval would need.
+	db.AddQuery("select next_id, cache from seq where id = 0 for update", &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{Name: "next_id", Type: sqltypes.Int64},
+			{Name: "cache", Type: sqltypes.Int64},
+		},
+		Rows: [][]sqltypes.Value{{
+			sqltypes.NewInt64(1),
+			sqltypes.NewInt64(3),
+		}},
+	})
+	db.AddQuery("update seq set next_id = 4 where id = 0", &sqltypes.Result{})
+
+	query := "select next 1 values from seq"
+
+	qreExec := newTestQueryExecutor(ctx, tsv, query, 0)
+	execResult, err := qreExec.Execute()
+	require.NoError(t, err, "Execute should handle NEXT VALUES")
+	require.NotNil(t, execResult)
+
+	logStats := tabletenv.NewLogStats(ctx, "TestNextval", streamlog.NewQueryLogConfigForTest())
+	plan, err := tsv.qe.GetStreamPlan(ctx, logStats, query, false)
+	require.NoError(t, err)
+
+	qreStream := &QueryExecutor{
+		ctx:      ctx,
+		query:    query,
+		bindVars: make(map[string]*querypb.BindVariable),
+		plan:     plan,
+		logStats: logStats,
+		tsv:      tsv,
+	}
+	streamErr := qreStream.Stream(func(*sqltypes.Result) error { return nil })
+	assert.NoError(t, streamErr,
+		"Stream should handle PlanNextval like Execute does")
+}
+
+// StreamExecute handles DML statements.
+func TestStreamExecuteCompat_ImplicitTransactionForDML(t *testing.T) {
+	ctx := t.Context()
+	db, tsv := setupTabletServerTest(t, ctx, "")
+	defer tsv.StopService()
+	defer db.Close()
+
+	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
+
+	insertSQL := "insert into test_table(pk) values(1)"
+	db.AddQuery("insert into test_table(pk) values (1)", &sqltypes.Result{RowsAffected: 1})
+
+	result, err := tsv.Execute(ctx, nil, &target, insertSQL, nil, 0, 0, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	callback := func(*sqltypes.Result) error { return nil }
+	err = tsv.StreamExecute(ctx, nil, &target, insertSQL, nil, 0, 0, nil, callback)
+	assert.NoError(t, err,
+		"StreamExecute should handle INSERT statements")
+}
+
+// StreamExecute handles DDL statements.
+func TestStreamExecuteCompat_DDLViaStreamExecute(t *testing.T) {
+	ctx := t.Context()
+	db, tsv := setupTabletServerTest(t, ctx, "")
+	defer tsv.StopService()
+	defer db.Close()
+
+	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
+
+	ddlSQL := "alter table test_table add zipcode int"
+	db.AddQuery("alter table test_table add column zipcode int", &sqltypes.Result{})
+
+	callback := func(*sqltypes.Result) error { return nil }
+	err := tsv.StreamExecute(ctx, nil, &target, ddlSQL, nil, 0, 0, nil, callback)
+	assert.NoError(t, err,
+		"StreamExecute should handle DDL statements")
+}
+
+// StreamExecute handles savepoint statements within a transaction.
+func TestStreamExecuteCompat_SavepointViaStreamExecute(t *testing.T) {
+	ctx := t.Context()
+	db, tsv := setupTabletServerTest(t, ctx, "")
+	defer tsv.StopService()
+	defer db.Close()
+
+	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
+
+	// Start a transaction first since savepoints require one.
+	state, err := tsv.Begin(ctx, nil, &target, nil)
+	require.NoError(t, err)
+
+	savepointSQL := "savepoint sp1"
+	db.AddQuery(savepointSQL, &sqltypes.Result{})
+
+	callback := func(*sqltypes.Result) error { return nil }
+	err = tsv.StreamExecute(ctx, nil, &target, savepointSQL, nil, state.TransactionID, 0, nil, callback)
+	assert.NoError(t, err,
+		"StreamExecute should handle savepoint statements within a transaction")
+
+	_, err = tsv.Commit(ctx, &target, state.TransactionID)
+	require.NoError(t, err)
+}
+
+// SET requires a reserved connection (NeedsReservedConn=true).
+// Use ReserveStreamExecute which provides sys settings context.
+func TestStreamExecuteCompat_SetViaStreamExecute(t *testing.T) {
+	ctx := t.Context()
+	db, tsv := setupTabletServerTest(t, ctx, "")
+	defer tsv.StopService()
+	defer db.Close()
+
+	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
+
+	setSQL := "set @my_var = 42"
+	db.AddQuery(setSQL, &sqltypes.Result{})
+	db.AddQuery("set sql_mode = ''", &sqltypes.Result{})
+
+	// SET needs a reserved connection. ReserveStreamExecute provides sys settings
+	// context which satisfies the NeedsReservedConn requirement.
+	callback := func(*sqltypes.Result) error { return nil }
+	_, err := tsv.ReserveStreamExecute(ctx, nil, &target, []string{"set sql_mode = ''"}, setSQL, nil, 0, nil, callback)
+	assert.NoError(t, err,
+		"ReserveStreamExecute should handle SET statements")
+}
+
+// Stream() records to ResultHistogram like Execute does.
+func TestStreamExecuteCompat_ResultStatsRecording(t *testing.T) {
+	ctx := t.Context()
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+
+	query := "select * from test_table limit 1000"
+	db.AddQuery(query, &sqltypes.Result{
+		Fields: []*querypb.Field{{Type: sqltypes.VarBinary}},
+		Rows: [][]sqltypes.Value{
+			{sqltypes.NewVarBinary("row01")},
+			{sqltypes.NewVarBinary("row02")},
+		},
+	})
+
+	tsv := newTestTabletServer(ctx, noFlags, db)
+	defer tsv.StopService()
+
+	baselineCount := tsv.Stats().ResultHistogram.Total()
+
+	qreExec := newTestQueryExecutor(ctx, tsv, query, 0)
+	_, err := qreExec.Execute()
+	require.NoError(t, err)
+	afterExecute := tsv.Stats().ResultHistogram.Total()
+	assert.Greater(t, afterExecute, baselineCount,
+		"Execute should record to ResultHistogram")
+
+	qreStream := newTestQueryExecutorStreaming(ctx, tsv, query, 0)
+	err = qreStream.Stream(func(*sqltypes.Result) error { return nil })
+	require.NoError(t, err)
+	afterStream := tsv.Stats().ResultHistogram.Total()
+
+	assert.Greater(t, afterStream, afterExecute,
+		"Stream should record to ResultHistogram like Execute does")
+}
+
+// BuildStreaming accepts Vitess-specific migration statements.
+func TestStreamExecuteCompat_BuildStreamingRejectsMigration(t *testing.T) {
+	parser := sqlparser.NewTestParser()
+
+	testcases := []struct {
+		name  string
+		query string
+	}{
+		{"ALTER_VITESS_MIGRATION", "alter vitess_migration 'abc' cancel"},
+		{"REVERT_VITESS_MIGRATION", "revert vitess_migration 'abc'"},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt, err := parser.Parse(tc.query)
+			require.NoError(t, err, "Failed to parse: %s", tc.query)
+
+			_, err = planbuilder.BuildStreaming(vtenv.NewTestEnv(), stmt, map[string]*schema.Table{}, "dbName")
+			assert.NoError(t, err,
+				"BuildStreaming should accept %s", tc.name)
+		})
+	}
+}
+
+// All plan types handled by Execute() are also accepted by BuildStreaming.
+func TestStreamExecuteCompat_AllExecutePlanTypesSupported(t *testing.T) {
+	parser := sqlparser.NewTestParser()
+
+	testcases := []struct {
+		name  string
+		query string
+	}{
+		{"Select", "select * from test_table"},
+		{"Show", "show tables"},
+		{"Union", "select * from test_table union select * from test_table"},
+		{"Explain", "desc test_table"},
+		{"Analyze", "analyze table test_table"},
+		{"Insert", "insert into test_table(pk) values(1)"},
+		{"Update", "update test_table set pk = 1"},
+		{"Delete", "delete from test_table"},
+		{"DDL", "alter table test_table add zipcode int"},
+		{"Set", "set @udv = 10"},
+		{"Savepoint", "savepoint sp1"},
+		{"Release", "release savepoint sp1"},
+		{"RollbackSavepoint", "rollback to savepoint sp1"},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt, err := parser.Parse(tc.query)
+			require.NoError(t, err, "Failed to parse: %s", tc.query)
+
+			_, err = planbuilder.BuildStreaming(vtenv.NewTestEnv(), stmt, map[string]*schema.Table{}, "dbName")
+			assert.NoError(t, err, "BuildStreaming should accept %s", tc.name)
+		})
+	}
+}
+
+// ACL stats keys don't contain "SelectStream".
+func TestStreamExecuteCompat_ACLStatsKeyConsistency(t *testing.T) {
+	aclName := fmt.Sprintf("simpleacl-test-%d", rand.Int64())
+	tableacl.Register(aclName, &simpleacl.Factory{})
+	tableacl.SetDefaultACL(aclName)
+
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+
+	ctx := t.Context()
+	tsv := newTestTabletServer(ctx, noFlags, db)
+	defer tsv.StopService()
+
+	config := &tableaclpb.Config{
+		TableGroups: []*tableaclpb.TableGroupSpec{{
+			Name:                 "group01",
+			TableNamesOrPrefixes: []string{"test_table"},
+			Readers:              []string{"test_user"},
+		}},
+	}
+	require.NoError(t, tableacl.InitFromProto(config))
+
+	callerID := &querypb.VTGateCallerID{Username: "test_user"}
+	ctx = callerid.NewContext(ctx, nil, callerID)
+
+	query := "select * from test_table limit 1000"
+	db.AddQuery(query, &sqltypes.Result{
+		Fields: []*querypb.Field{{Type: sqltypes.VarBinary}},
+		Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("row01")}},
+	})
+
+	qreExec := newTestQueryExecutor(ctx, tsv, query, 0)
+	_, err := qreExec.Execute()
+	require.NoError(t, err)
+
+	qreStream := newTestQueryExecutorStreaming(ctx, tsv, query, 0)
+	err = qreStream.Stream(func(*sqltypes.Result) error { return nil })
+	require.NoError(t, err)
+
+	for key := range tsv.Stats().TableaclAllowed.Counts() {
+		assert.NotContains(t, key, "SelectStream",
+			"ACL stats should not use 'SelectStream' as a plan type, found key: %s", key)
+	}
+}
+
+// StreamExecute within a transaction works for SELECT.
+func TestStreamExecuteCompat_TransactionalSelect(t *testing.T) {
+	ctx := t.Context()
+	db, tsv := setupTabletServerTest(t, ctx, "")
+	defer tsv.StopService()
+	defer db.Close()
+
+	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
+
+	selectSQL := "select * from test_table limit 1000"
+	db.AddQuery(selectSQL, &sqltypes.Result{
+		Fields: []*querypb.Field{{Type: sqltypes.VarBinary}},
+		Rows:   [][]sqltypes.Value{{sqltypes.NewVarBinary("row01")}},
+	})
+
+	// Start a transaction.
+	state, err := tsv.Begin(ctx, nil, &target, nil)
+	require.NoError(t, err)
+
+	var gotRows int
+	callback := func(qr *sqltypes.Result) error {
+		gotRows += len(qr.Rows)
+		return nil
+	}
+
+	// StreamExecute within a transaction should work for SELECT.
+	err = tsv.StreamExecute(ctx, nil, &target, selectSQL, nil, state.TransactionID, 0, nil, callback)
+	require.NoError(t, err)
+	assert.Equal(t, 1, gotRows)
+
+	_, err = tsv.Commit(ctx, &target, state.TransactionID)
+	require.NoError(t, err)
+}
+
+// StreamExecute handles CALL statements.
+func TestStreamExecuteCompat_CallProcHandling(t *testing.T) {
+	ctx := t.Context()
+	db, tsv := setupTabletServerTest(t, ctx, "")
+	defer tsv.StopService()
+	defer db.Close()
+
+	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
+
+	callSQL := "call test_proc()"
+	db.AddQuery(callSQL, &sqltypes.Result{})
+
+	callback := func(*sqltypes.Result) error { return nil }
+	err := tsv.StreamExecute(ctx, nil, &target, callSQL, nil, 0, 0, nil, callback)
+	assert.NoError(t, err, "StreamExecute should handle CALL statements")
+}
+
+// StreamExecute handles FLUSH statements.
+func TestStreamExecuteCompat_FlushViaStreamExecute(t *testing.T) {
+	ctx := t.Context()
+	db, tsv := setupTabletServerTest(t, ctx, "")
+	defer tsv.StopService()
+	defer db.Close()
+
+	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
+
+	flushSQL := "flush tables"
+	db.AddQuery(flushSQL, &sqltypes.Result{})
+
+	callback := func(*sqltypes.Result) error { return nil }
+	err := tsv.StreamExecute(ctx, nil, &target, flushSQL, nil, 0, 0, nil, callback)
+	assert.NoError(t, err,
+		"StreamExecute should handle FLUSH statements")
+}
+
+// BuildStreaming accepts LOAD DATA statements.
+func TestStreamExecuteCompat_LoadDataViaStreamExecute(t *testing.T) {
+	parser := sqlparser.NewTestParser()
+
+	stmt, err := parser.Parse("load data infile 'data.txt' into table test_table")
+	if err != nil {
+		t.Skip("Parser doesn't support LOAD DATA syntax in this context")
+	}
+
+	_, err = planbuilder.BuildStreaming(vtenv.NewTestEnv(), stmt, map[string]*schema.Table{}, "dbName")
+	assert.NoError(t, err,
+		"BuildStreaming should accept LOAD DATA statements")
+}

--- a/go/vt/vttablet/tabletserver/stream_execute_compat_test.go
+++ b/go/vt/vttablet/tabletserver/stream_execute_compat_test.go
@@ -435,6 +435,50 @@ func TestStreamExecuteCompat_SetViaStreamExecute(t *testing.T) {
 		"ReserveStreamExecute should handle SET statements")
 }
 
+// A PlanSet carrying system settings but no reserved connection (connID == 0)
+// must behave the same on both paths: Execute short-circuits the SET to an empty
+// result without sending it to MySQL (the setting is applied to the pooled
+// connection of later queries), and Stream must do likewise instead of executing
+// the SET text against a stream connection.
+func TestStreamExecuteCompat_SetWithSysSettingsNotExecuted(t *testing.T) {
+	ctx := t.Context()
+	db, tsv := setupTabletServerTest(t, ctx, "")
+	defer tsv.StopService()
+	defer db.Close()
+
+	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
+
+	setSQL := "set @my_var = 42"
+	settings := []string{"set sql_mode = ''"}
+	db.AddQuery(setSQL, &sqltypes.Result{})
+	db.AddQuery("set sql_mode = ''", &sqltypes.Result{})
+
+	// Execute short-circuits PlanSet: empty result, SET never sent to MySQL.
+	db.ResetQueryLog()
+	execResult, err := tsv.execute(ctx, &target, setSQL, nil, 0, 0, settings, nil)
+	require.NoError(t, err)
+	require.NotNil(t, execResult)
+	assert.Empty(t, execResult.Rows)
+	assert.Zero(t, execResult.RowsAffected)
+	assert.NotContains(t, db.QueryLog(), "my_var",
+		"Execute must not send the SET statement to MySQL")
+
+	// StreamExecute must match Execute: empty result, SET never sent to MySQL.
+	db.ResetQueryLog()
+	var streamRows int
+	var streamAffected uint64
+	err = tsv.streamExecute(ctx, &target, setSQL, nil, 0, 0, settings, nil, func(r *sqltypes.Result) error {
+		streamRows += len(r.Rows)
+		streamAffected += r.RowsAffected
+		return nil
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, db.QueryLog(), "my_var",
+		"StreamExecute must not send the SET statement to MySQL")
+	assert.Zero(t, streamRows, "streamed SET should return no rows")
+	assert.Zero(t, streamAffected, "streamed SET should affect no rows")
+}
+
 // Stream() records to ResultHistogram like Execute does.
 func TestStreamExecuteCompat_ResultStatsRecording(t *testing.T) {
 	ctx := t.Context()


### PR DESCRIPTION
## Description

> [!NOTE]
> #20268 has merged, so this is now rebased onto `main` and contains only the refactor that sits on top of it.

With #20268 (now merged) adding DML on the `StreamExecute` path, the planner still carried two parallel code paths: `Build` (buffered) and `BuildStreaming` (streaming, built around the catch-all `PlanSelectStream`). This PR collapses that duplication.

- **`BuildStreaming` becomes the full planner** — it accepts every statement type `Build` does and returns the real plan types (`Select`, `Show`, `OtherRead`, `SelectLockFunc`, ...) instead of `PlanSelectStream`.
- **`Build` becomes a thin wrapper** over `BuildStreaming` that overlays only the result-size `LIMIT` for `SELECT`/`UNION` — the result-buffering guard, which streaming reads don't need.
- **`PlanSelectStream` is removed entirely**, which fixes ACL error messages and stats keys that leaked `"SelectStream"` into user-visible output.
- **`Stream()` now records the same per-table/per-plan stats and result histogram as `Execute()`** for reads (DML stats already come from `streamDML`), captures the real error code, and handles the plan types it previously didn't (`PlanNextval`, `PlanShowMigrations`, nil-`FullQuery` fallback).
- **Streaming consolidation now matches `Execute` and no longer folds `CALL`s together** — a correctness fix. The streaming consolidator runs one execution and shares its result with all concurrent identical callers, so it is only safe for side-effect-free reads. Its gate was keyed on the catch-all `PlanSelectStream`, so it consolidated *every* streaming read, including `CALL` — collapsing N concurrent stored-procedure invocations (which can write, lock, or change session state) into a single execution while telling the other callers it succeeded. `Execute` never did this (it only consolidates inside `execSelect`, never for `CALL`). The gate is now `PlanSelect`, so `SELECT`/`UNION` still consolidate, `CALL` no longer does, and the remaining reads (`SHOW`, impossible `SELECT`, `OtherRead`) simply run independently. `get_lock(...)` was never consolidated on either path since it forces a reserved connection.

The write-safety `LIMIT` for `UPDATE`/`DELETE` is deliberately unchanged: it bounds transaction size regardless of streaming, so it still applies on both paths. Streamed DML keeps `UpdateLimit`/`DeleteLimit` and flows through `streamDML` → `execDMLLimit`. Only the SELECT/UNION result-buffering limit is buffered-path-only.

A new `stream_execute_compat_test.go` suite pins StreamExecute/Execute parity across the full statement range (DML, DDL, SET, savepoints, CALL, FLUSH, LOAD, migrations, ACL messages, stats keys).

## Related Issue(s)

- Builds on #20268 (merged)
- Fixes #19562 — `Stream()` didn't handle special plan types
- Fixes #19563 — ACL error said `SelectStream command denied`
- Fixes #20327 — streaming reads didn't record engine/plan stats or the result histogram

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

Eliminating `PlanSelectStream` changes the plan type reported for streaming queries in query-serving metrics, the query log, and ACL error messages. Streaming plans now report their real plan type, matching the buffered (`Execute`) path:

| Streaming statement | Plan type before | after |
| --- | --- | --- |
| `SELECT` / `UNION` | `SelectStream` | `Select` |
| `SELECT ... get_lock(...)` | `SelectStream` | `SelectLockFunc` |
| `SHOW` | `SelectStream` | `Show` |
| `ANALYZE` | `OtherRead` | `Select` |
| `EXPLAIN` / `DESC` | `SelectStream` | `Select` |
| `show binary log status` | `SelectStream` | `OtherRead` |

**Metrics that change label value** (these already recorded `SelectStream` on the streaming path): `Queries` (`plan_type`), `TableACLAllowed` / `TableACLDenied` / `TableACLPseudoDenied` (`PlanID`). The `SelectStream` series in these go to zero.

**Metrics that gain streaming reads under `Select`** for the first time — `Stream()` now records the same per-table/per-plan stats as `Execute()`, which it previously did not: `QueryCounts`, `QueryTimesNs`, `QueryRowsReturned`, `QueryRowsAffected`, `QueryErrorCounts`, `QueryErrorCountsWithCode`, `QueryCountsWithTabletType`, `QueryTextCharsProcessed`, and `ResultHistogram` (plus the per-plan stats at `/debug/query_plans`).

Operator impact:

- Dashboards/alerts filtering on `plan_type="SelectStream"` (or `PlanID="SelectStream"`) will read empty — repoint them to `Select` (and `Show`/`SelectLockFunc`/`OtherRead` as above).
- The `Select`-labeled series now blend OLTP (`Execute`) and OLAP (`StreamExecute`) traffic, and pick up newly-counted streaming reads, so expect a one-time step-up in `Select` counts/latency/rows that is **not** a real load change.
- Streaming-vs-buffered breakdown is no longer available via the plan label; it remains available via the `Stream` vs `Execute` query-type label on `UserTableQueryCount` / `UserTableQueryTimesNs`.
- ACL denial error messages for streamed queries now read e.g. `Select command denied ...` instead of `SelectStream command denied ...`.
- Streaming query consolidation now applies only to `SELECT`/`UNION` (`PlanSelect`), matching `Execute`. Previously it folded together all streaming reads: concurrent identical `SHOW` / impossible-`SELECT` / `OtherRead` now run independently instead of sharing one execution (a minor increase in MySQL load, no semantic change), and concurrent `CALL`s are no longer consolidated (a correctness fix — a stored procedure may have side effects, and consolidation would run it once on behalf of all callers).

### AI Disclosure

This PR was written primarily by Claude Code; I provided direction and review.

