### PR TITLE
Add username extensions for target and OLAP workload

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -463,6 +463,27 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 		defer connCountByTLSVer.Add(versionNoTLS, -1)
 	}
 
+	// Parse username for optional target, alias, and workload.
+	// Format: user|target|alias|workload (e.g., "vt_repl|commerce:0@primary|zone1-100|olap").
+	var workload string
+	parts := strings.Split(user, "|")
+	switch len(parts) {
+	case 2:
+		user = parts[0]
+		c.schemaName = parts[1]
+	case 3:
+		user = parts[0]
+		c.schemaName = parts[1] + "|" + parts[2]
+	case 4:
+		user = parts[0]
+		c.schemaName = parts[1] + "|" + parts[2]
+		if !strings.EqualFold(parts[3], "olap") {
+			c.writeErrorPacketFromError(fmt.Errorf("invalid workload in username: %q (only 'olap' is supported)", parts[3]))
+			return
+		}
+		workload = "olap"
+	}
+
 	// See what auth method the AuthServer wants to use for that user.
 	negotiatedAuthMethod, err := negotiateAuthMethod(c, l.authServer, user, clientAuthMethod)
 
@@ -530,9 +551,20 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 		defer connCountPerUser.Add(c.User, -1)
 	}
 
-	// Set initial db name.
+	// Set initial db name (or target string for binlog replication).
 	if c.schemaName != "" {
 		err = l.handler.ComQuery(c, "use "+sqlescape.EscapeID(c.schemaName), func(result *sqltypes.Result) error {
+			return nil
+		})
+		if err != nil {
+			c.writeErrorPacketFromError(err)
+			return
+		}
+	}
+
+	// Set initial workload if specified in the username (e.g., "user|target|alias|olap").
+	if workload != "" {
+		err = l.handler.ComQuery(c, "set workload = '"+workload+"'", func(result *sqltypes.Result) error {
 			return nil
 		})
 		if err != nil {

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -81,12 +81,19 @@ type testHandler struct {
 	result   *sqltypes.Result
 	err      error
 	warnings uint16
+	queries  []string
 }
 
 func (th *testHandler) LastConn() *Conn {
 	th.mu.Lock()
 	defer th.mu.Unlock()
 	return th.lastConn
+}
+
+func (th *testHandler) Queries() []string {
+	th.mu.Lock()
+	defer th.mu.Unlock()
+	return th.queries
 }
 
 func (th *testHandler) Result() *sqltypes.Result {
@@ -120,6 +127,10 @@ func (th *testHandler) NewConnection(c *Conn) {
 }
 
 func (th *testHandler) ComQuery(c *Conn, query string, callback func(*sqltypes.Result) error) error {
+	th.mu.Lock()
+	th.queries = append(th.queries, query)
+	th.mu.Unlock()
+
 	if result := th.Result(); result != nil {
 		callback(result)
 		return nil
@@ -320,6 +331,137 @@ func TestConnectionFromListener(t *testing.T) {
 	c, err := Connect(ctx, params)
 	require.NoError(t, err, "Should be able to connect to server")
 	c.Close()
+}
+
+// TestConnectionWithPipeInUsername tests that usernames with the format "user|target"
+// are correctly parsed - the target is extracted into schemaName and the user is stripped.
+func TestConnectionWithPipeInUsername(t *testing.T) {
+	ctx := utils.LeakCheckContext(t)
+	th := &testHandler{}
+
+	authServer := NewAuthServerStatic("", "", 0)
+	authServer.entries["vt_repl"] = []*AuthServerStaticEntry{{
+		Password: "password1",
+		UserData: "userData1",
+	}}
+	defer authServer.close()
+
+	l, err := NewListener("tcp", "127.0.0.1:", authServer, th, 0, 0, false, false, 0, 0, false)
+	require.NoError(t, err, "NewListener failed")
+	host, port := getHostPort(t, l.Addr())
+	// Connect with username containing pipe-separated target
+	params := &ConnParams{
+		Host:  host,
+		Port:  port,
+		Uname: "vt_repl|commerce:0@primary|zone1-100",
+		Pass:  "password1",
+	}
+	go l.Accept()
+	defer cleanupListener(ctx, l, params)
+
+	c, err := Connect(ctx, params)
+	require.NoError(t, err, "Should be able to connect to server")
+	defer c.Close()
+
+	// The schemaName should contain the target (everything after the first pipe)
+	// Note: The USE statement will be issued with this schemaName, which in vtgate
+	// sets the session's TargetString.
+	require.Equal(t, "commerce:0@primary|zone1-100", th.LastConn().schemaName, "Schema name should contain the target from username")
+	require.NotContains(t, th.Queries(), "set workload = 'olap'", "Workload should not be set without olap suffix")
+}
+
+// TestConnectionWithPipeInUsernameOLAP tests the 4-piece username format "user|target|alias|olap"
+// which issues a "set workload = 'olap'" query in addition to parsing the target.
+func TestConnectionWithPipeInUsernameOLAP(t *testing.T) {
+	ctx := utils.LeakCheckContext(t)
+	th := &testHandler{}
+
+	authServer := NewAuthServerStatic("", "", 0)
+	authServer.entries["vt_repl"] = []*AuthServerStaticEntry{{
+		Password: "password1",
+		UserData: "userData1",
+	}}
+	defer authServer.close()
+
+	l, err := NewListener("tcp", "127.0.0.1:", authServer, th, 0, 0, false, false, 0, 0, false)
+	require.NoError(t, err, "NewListener failed")
+	host, port := getHostPort(t, l.Addr())
+	params := &ConnParams{
+		Host:  host,
+		Port:  port,
+		Uname: "vt_repl|commerce:0@primary|zone1-100|olap",
+		Pass:  "password1",
+	}
+	go l.Accept()
+	defer cleanupListener(ctx, l, params)
+
+	c, err := Connect(ctx, params)
+	require.NoError(t, err, "Should be able to connect to server")
+	defer c.Close()
+
+	require.Equal(t, "commerce:0@primary|zone1-100", th.LastConn().schemaName, "Schema name should contain target and alias")
+	require.Contains(t, th.Queries(), "set workload = 'olap'", "Workload should be set via SET query with olap suffix")
+}
+
+// TestConnectionWithPipeInUsernameInvalidWorkload tests that a 4-piece username with an
+// invalid workload (not "olap") is rejected during handshake.
+func TestConnectionWithPipeInUsernameInvalidWorkload(t *testing.T) {
+	ctx := utils.LeakCheckContext(t)
+	th := &testHandler{}
+
+	authServer := NewAuthServerStatic("", "", 0)
+	authServer.entries["vt_repl"] = []*AuthServerStaticEntry{{
+		Password: "password1",
+		UserData: "userData1",
+	}}
+	defer authServer.close()
+
+	l, err := NewListener("tcp", "127.0.0.1:", authServer, th, 0, 0, false, false, 0, 0, false)
+	require.NoError(t, err, "NewListener failed")
+	host, port := getHostPort(t, l.Addr())
+	params := &ConnParams{
+		Host:  host,
+		Port:  port,
+		Uname: "vt_repl|commerce:0@primary|zone1-100|bogus",
+		Pass:  "password1",
+	}
+	go l.Accept()
+	defer cleanupListener(ctx, l, params)
+
+	_, err = Connect(ctx, params)
+	require.Error(t, err, "Connection should fail with invalid workload")
+	require.Contains(t, err.Error(), "invalid workload")
+}
+
+// TestConnectionWithPipeInUsernameTwoPieces tests the 2-piece username format "user|target".
+func TestConnectionWithPipeInUsernameTwoPieces(t *testing.T) {
+	ctx := utils.LeakCheckContext(t)
+	th := &testHandler{}
+
+	authServer := NewAuthServerStatic("", "", 0)
+	authServer.entries["vt_repl"] = []*AuthServerStaticEntry{{
+		Password: "password1",
+		UserData: "userData1",
+	}}
+	defer authServer.close()
+
+	l, err := NewListener("tcp", "127.0.0.1:", authServer, th, 0, 0, false, false, 0, 0, false)
+	require.NoError(t, err, "NewListener failed")
+	host, port := getHostPort(t, l.Addr())
+	params := &ConnParams{
+		Host:  host,
+		Port:  port,
+		Uname: "vt_repl|commerce:0@primary",
+		Pass:  "password1",
+	}
+	go l.Accept()
+	defer cleanupListener(ctx, l, params)
+
+	c, err := Connect(ctx, params)
+	require.NoError(t, err, "Should be able to connect to server")
+	defer c.Close()
+
+	require.Equal(t, "commerce:0@primary", th.LastConn().schemaName, "Schema name should contain the target")
 }
 
 func TestConnectionWithoutSourceHost(t *testing.T) {

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -289,6 +289,14 @@ func TestDefaultWorkloadOLAP(t *testing.T) {
 	}
 }
 
+func TestOLAPModeNotSetByDefault(t *testing.T) {
+	vh := &vtgateHandler{}
+	mysqlDefaultWorkload = int32(querypb.ExecuteOptions_OLTP)
+	conn := &mysql.Conn{}
+	sess := vh.session(conn)
+	require.Equal(t, querypb.ExecuteOptions_OLTP, sess.Options.Workload)
+}
+
 func TestInitTLSConfigWithoutServerCA(t *testing.T) {
 	testInitTLSConfig(t, false)
 }


### PR DESCRIPTION
## Description

Adds support for pipe-separated username extensions in the MySQL handshake. Clients can now encode a session target, tablet alias, and/or OLAP workload directly in the username field:

- `user|target` — sets the session target (via `USE`)
- `user|target|alias` — sets target including tablet alias
- `user|target|alias|olap` — also switches workload to OLAP

This is useful for CDC / replication clients that need to specify a target tablet and workload mode without issuing separate queries after connecting.

## Related Issue(s)

Extracted from #18731.

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [ ] Documentation was added or is not required

## Deployment Notes

No migrations or deployment changes required.

### AI Disclosure

Tests and PR description were written with Claude Code. The implementation was written with direction from Arthur.