### PR TITLE
`ci`: only cache `action/setup-go` action on `main`

### DIFF
--- a/.github/workflows/check_make_vtadmin_authz_testgen.yml
+++ b/.github/workflows/check_make_vtadmin_authz_testgen.yml
@@ -57,7 +57,7 @@ jobs:
       if: steps.changes.outputs.vtadmin_changes == 'true'
       with:
         go-version-file: go.mod
-        cache: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'true' || 'false' }}
+        cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
     - name: Get dependencies
       if: steps.changes.outputs.vtadmin_changes == 'true'

--- a/.github/workflows/check_make_vtadmin_web_proto.yml
+++ b/.github/workflows/check_make_vtadmin_web_proto.yml
@@ -60,7 +60,7 @@ jobs:
       if: steps.changes.outputs.proto_changes == 'true'
       with:
         go-version-file: go.mod
-        cache: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'true' || 'false' }}
+        cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
     - name: Setup Node
       if: steps.changes.outputs.proto_changes == 'true'

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -130,7 +130,7 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'true' || 'false' }}
+          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Set up python
         if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -60,7 +60,7 @@ jobs:
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version-file: go.mod
-        cache: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'true' || 'false' }}
+        cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
     - name: Detect changed Go packages
       if: steps.mode.outputs.is_full_run != 'true' && steps.changes.outputs.changed_files == 'true'

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'true' || 'false' }}
+          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Tune the OS
         uses: ./.github/actions/tune-os

--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'true' || 'false' }}
+          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Tune the OS
         if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -55,7 +55,7 @@ jobs:
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version-file: go.mod
-        cache: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'true' || 'false' }}
+        cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -55,7 +55,7 @@ jobs:
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version-file: go.mod
-        cache: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'true' || 'false' }}
+        cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/error_code_docs_generate.yml
+++ b/.github/workflows/error_code_docs_generate.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'true' || 'false' }}
+          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Generate error codes
         run: |

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -70,7 +70,7 @@ jobs:
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version-file: go.mod
-        cache: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'true' || 'false' }}
+        cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
     - name: Tune the OS
       if: steps.changes.outputs.examples == 'true'

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -70,7 +70,7 @@ jobs:
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version-file: go.mod
-        cache: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'true' || 'false' }}
+        cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
     - name: Tune the OS
       if: steps.changes.outputs.examples == 'true'

--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -125,7 +125,7 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'true' || 'false' }}
+          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Tune the OS
         if: steps.changes.outputs.go_files == 'true'

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -115,7 +115,7 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'true' || 'false' }}
+          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Set up python
         if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'true' || 'false' }}
+          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Upgrade the Golang Dependencies
         id: detect-and-update

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'true' || 'false' }}
+          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Detect new version and update codebase
         env:

--- a/.github/workflows/vitess_tester_vtgate.yml
+++ b/.github/workflows/vitess_tester_vtgate.yml
@@ -68,7 +68,7 @@ jobs:
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version-file: go.mod
-        cache: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'true' || 'false' }}
+        cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/vtop_example.yml
+++ b/.github/workflows/vtop_example.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'true' || 'false' }}
+          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Tune the OS
         if: steps.changes.outputs.end_to_end == 'true'


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR disables the caching of go versions in the GitHub Actions cache for branches that are not `main`. `main` is the branch most PRs are built against, making it's go-version the most important to be cached

Currently, release-building aside, we always cache `actions/setup-go` builds in our GitHub Actions cache, regardless of branch. Each version-SHA of go versions is stored as a separate 900MB+ cache entry, which is a major part of our cache usage

The tradeoff here is non-`main` builds will pull their probably-older go version from the real source vs the GitHub Actions cache. The cache is 100% full at all times and is probably already evicting non-`main` builds, so this might have no impact in practice

Example of `cache: true` from this PR, because it's to `main`:
<img width="500" height="249" alt="Screenshot 2026-03-13 at 00 51 57" src="https://github.com/user-attachments/assets/426d267f-d1a3-4a39-976c-b24235c1f9f6" />

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
