### PR TITLE
Fix LAST_INSERT_ID for INSERT ... ON DUPLICATE KEY UPDATE on sharded tables

### DIFF
--- a/go/sqltypes/result.go
+++ b/go/sqltypes/result.go
@@ -367,5 +367,5 @@ func (result *Result) IsInTransaction() bool {
 }
 
 func (result *Result) InsertIDUpdated() bool {
-	return result.InsertIDChanged || result.InsertID > 0
+	return result.InsertIDChanged
 }

--- a/go/test/endtoend/vtgate/queries/dml/last_insert_id_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/last_insert_id_test.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dml
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/endtoend/utils"
+)
+
+// TestLastInsertIDOnDupKey tests that the wire protocol last_insert_id value
+// matches MySQL behavior for INSERT ... ON DUPLICATE KEY UPDATE statements.
+//
+// See https://github.com/vitessio/vitess/issues/15696
+func TestLastInsertIDOnDupKey(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	// On MySQL side, lid_tbl doesn't have AUTO_INCREMENT in the shared DDL,
+	// so we add it here. The Vitess side uses a VSchema sequence instead.
+	utils.Exec(t, mcmp.MySQLConn, "alter table lid_tbl modify id bigint not null auto_increment")
+
+	resetTable := func(t *testing.T) {
+		t.Helper()
+		utils.Exec(t, mcmp.VtConn, "delete from lid_tbl")
+		utils.Exec(t, mcmp.MySQLConn, "delete from lid_tbl")
+		utils.Exec(t, mcmp.MySQLConn, "alter table lid_tbl auto_increment = 1")
+	}
+
+	t.Run("insert new row", func(t *testing.T) {
+		resetTable(t)
+
+		myQr := utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('new@test.com', 'Alice')")
+		vtQr := utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('new@test.com', 'Alice')")
+
+		// MySQL: InsertID > 0, RowsAffected = 1
+		assert.EqualValues(t, 1, myQr.RowsAffected)
+		assert.Greater(t, myQr.InsertID, uint64(0), "MySQL: InsertID should be > 0 for new row")
+
+		// Vitess should match behavior
+		assert.EqualValues(t, 1, vtQr.RowsAffected)
+		assert.Greater(t, vtQr.InsertID, uint64(0), "Vitess: InsertID should be > 0 for new row")
+	})
+
+	t.Run("duplicate row changes", func(t *testing.T) {
+		resetTable(t)
+
+		// Seed a row on each connection
+		myIns := utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('dup@test.com', 'Bob')")
+		vtIns := utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('dup@test.com', 'Bob')")
+
+		// ON DUP KEY UPDATE that changes the name
+		myQr := utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('dup@test.com', 'Bobby') on duplicate key update name = values(name)")
+		vtQr := utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('dup@test.com', 'Bobby') on duplicate key update name = values(name)")
+
+		// MySQL: InsertID = seeded row's id, RowsAffected = 2
+		assert.EqualValues(t, 2, myQr.RowsAffected)
+		assert.EqualValues(t, myIns.InsertID, myQr.InsertID, "MySQL: should return existing row's id")
+
+		// Vitess should match (but currently doesn't — returns new sequence value)
+		assert.EqualValues(t, 2, vtQr.RowsAffected)
+		assert.EqualValues(t, vtIns.InsertID, vtQr.InsertID, "Vitess: should return existing row's id")
+	})
+
+	t.Run("duplicate no change", func(t *testing.T) {
+		resetTable(t)
+
+		// Seed a row on each connection
+		utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('dup@test.com', 'Bob')")
+		utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('dup@test.com', 'Bob')")
+
+		// ON DUP KEY UPDATE with same value (no actual change)
+		myQr := utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('dup@test.com', 'Bob') on duplicate key update name = values(name)")
+		vtQr := utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('dup@test.com', 'Bob') on duplicate key update name = values(name)")
+
+		// MySQL: InsertID = 0, RowsAffected = 0
+		assert.EqualValues(t, 0, myQr.RowsAffected)
+		assert.EqualValues(t, 0, myQr.InsertID, "MySQL: should return 0 for no-change duplicate")
+
+		// Vitess should match (but currently doesn't — returns new sequence value)
+		assert.EqualValues(t, 0, vtQr.RowsAffected)
+		assert.EqualValues(t, 0, vtQr.InsertID, "Vitess: should return 0 for no-change duplicate")
+	})
+
+	t.Run("multi-row all inserts", func(t *testing.T) {
+		resetTable(t)
+
+		myQr := utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('a@test.com', 'A'), ('b@test.com', 'B')")
+		vtQr := utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('a@test.com', 'A'), ('b@test.com', 'B')")
+
+		// MySQL: InsertID = first generated id, RowsAffected = 2
+		assert.EqualValues(t, 2, myQr.RowsAffected)
+		assert.Greater(t, myQr.InsertID, uint64(0), "MySQL: InsertID should be > 0 for new rows")
+
+		// Vitess should match behavior
+		assert.EqualValues(t, 2, vtQr.RowsAffected)
+		assert.Greater(t, vtQr.InsertID, uint64(0), "Vitess: InsertID should be > 0 for new rows")
+	})
+
+	t.Run("multi-row all updates", func(t *testing.T) {
+		resetTable(t)
+
+		// Seed two rows on each connection
+		utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('a@test.com', 'A'), ('b@test.com', 'B')")
+		utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('a@test.com', 'A'), ('b@test.com', 'B')")
+
+		// Find the existing ids on each side
+		myRows := utils.Exec(t, mcmp.MySQLConn, "select id from lid_tbl order by email")
+		vtRows := utils.Exec(t, mcmp.VtConn, "select id from lid_tbl order by email")
+		require.Len(t, myRows.Rows, 2)
+		require.Len(t, vtRows.Rows, 2)
+		myLastID, err := myRows.Rows[1][0].ToUint64()
+		require.NoError(t, err)
+		vtLastID, err := vtRows.Rows[1][0].ToUint64()
+		require.NoError(t, err)
+
+		// ON DUP KEY UPDATE both rows
+		myQr := utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('a@test.com', 'A2'), ('b@test.com', 'B2') on duplicate key update name = values(name)")
+		vtQr := utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('a@test.com', 'A2'), ('b@test.com', 'B2') on duplicate key update name = values(name)")
+
+		// MySQL: InsertID = last updated row's id, RowsAffected = 4 (2 rows * 2)
+		assert.EqualValues(t, 4, myQr.RowsAffected)
+		assert.EqualValues(t, myLastID, myQr.InsertID, "MySQL: should return last updated row's id")
+
+		// Vitess should match (but currently doesn't — returns new sequence value)
+		assert.EqualValues(t, 4, vtQr.RowsAffected)
+		assert.EqualValues(t, vtLastID, vtQr.InsertID, "Vitess: should return last updated row's id")
+	})
+
+	t.Run("multi-row all dups no change", func(t *testing.T) {
+		resetTable(t)
+
+		// Seed two rows on each connection
+		utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('a@test.com', 'A'), ('b@test.com', 'B')")
+		utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('a@test.com', 'A'), ('b@test.com', 'B')")
+
+		// ON DUP KEY UPDATE with same values (no change)
+		myQr := utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('a@test.com', 'A'), ('b@test.com', 'B') on duplicate key update name = values(name)")
+		vtQr := utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('a@test.com', 'A'), ('b@test.com', 'B') on duplicate key update name = values(name)")
+
+		// MySQL: InsertID = 0, RowsAffected = 0
+		assert.EqualValues(t, 0, myQr.RowsAffected)
+		assert.EqualValues(t, 0, myQr.InsertID, "MySQL: should return 0 for no-change duplicates")
+
+		// Vitess should match (but currently doesn't — returns new sequence value)
+		assert.EqualValues(t, 0, vtQr.RowsAffected)
+		assert.EqualValues(t, 0, vtQr.InsertID, "Vitess: should return 0 for no-change duplicates")
+	})
+
+	t.Run("mix insert and update", func(t *testing.T) {
+		resetTable(t)
+
+		// Seed one row on each connection
+		utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('a@test.com', 'A')")
+		utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('a@test.com', 'A')")
+
+		// One duplicate (update), one new (insert)
+		myQr := utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('a@test.com', 'A2'), ('c@test.com', 'C') on duplicate key update name = values(name)")
+		vtQr := utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('a@test.com', 'A2'), ('c@test.com', 'C') on duplicate key update name = values(name)")
+
+		// MySQL: RowsAffected = 3 (2 for update + 1 for insert), InsertID = newly inserted row's id
+		assert.EqualValues(t, 3, myQr.RowsAffected)
+		assert.Greater(t, myQr.InsertID, uint64(0), "MySQL: InsertID should be > 0 for mix with insert")
+
+		// Vitess should match behavior
+		assert.EqualValues(t, 3, vtQr.RowsAffected)
+		assert.Greater(t, vtQr.InsertID, uint64(0), "Vitess: InsertID should be > 0 for mix with insert")
+	})
+
+	t.Run("mix update and no change", func(t *testing.T) {
+		resetTable(t)
+
+		// Seed two rows on each connection
+		utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('a@test.com', 'A'), ('b@test.com', 'B')")
+		utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('a@test.com', 'A'), ('b@test.com', 'B')")
+
+		// Find existing ids — MySQL returns the last row's id that hit a duplicate
+		// key, regardless of whether it actually changed. That's b@test.com.
+		myRows := utils.Exec(t, mcmp.MySQLConn, "select id from lid_tbl where email = 'b@test.com'")
+		vtRows := utils.Exec(t, mcmp.VtConn, "select id from lid_tbl where email = 'b@test.com'")
+		require.Len(t, myRows.Rows, 1)
+		require.Len(t, vtRows.Rows, 1)
+		myLastDupID, err := myRows.Rows[0][0].ToUint64()
+		require.NoError(t, err)
+		vtLastDupID, err := vtRows.Rows[0][0].ToUint64()
+		require.NoError(t, err)
+
+		// a@test.com: changes name (update), b@test.com: same name (no change)
+		myQr := utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('a@test.com', 'A2'), ('b@test.com', 'B') on duplicate key update name = values(name)")
+		vtQr := utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('a@test.com', 'A2'), ('b@test.com', 'B') on duplicate key update name = values(name)")
+
+		// MySQL: RowsAffected = 2, InsertID = last dup row's id (b@test.com)
+		assert.EqualValues(t, 2, myQr.RowsAffected)
+		assert.EqualValues(t, myLastDupID, myQr.InsertID, "MySQL: should return last dup row's id")
+
+		// Vitess should match (but currently doesn't — returns new sequence value)
+		assert.EqualValues(t, 2, vtQr.RowsAffected)
+		assert.EqualValues(t, vtLastDupID, vtQr.InsertID, "Vitess: should return last dup row's id")
+	})
+
+	t.Run("SQL function stickiness", func(t *testing.T) {
+		resetTable(t)
+
+		// Step 1: Insert a new row — both wire and SQL function show the new ID
+		myIns := utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('sticky@test.com', 'Sticky')")
+		vtIns := utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('sticky@test.com', 'Sticky')")
+
+		myFn := utils.Exec(t, mcmp.MySQLConn, "select last_insert_id()")
+		vtFn := utils.Exec(t, mcmp.VtConn, "select last_insert_id()")
+
+		myFnVal, err := myFn.Rows[0][0].ToUint64()
+		require.NoError(t, err)
+		vtFnVal, err := vtFn.Rows[0][0].ToUint64()
+		require.NoError(t, err)
+
+		// After insert, SQL function should match wire protocol InsertID
+		assert.EqualValues(t, myIns.InsertID, myFnVal, "MySQL: SQL function should match wire InsertID after insert")
+		assert.EqualValues(t, vtIns.InsertID, vtFnVal, "Vitess: SQL function should match wire InsertID after insert")
+
+		// Step 2: ON DUP KEY that updates — wire changes, SQL function should stay sticky
+		utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('sticky@test.com', 'Updated') on duplicate key update name = values(name)")
+		utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('sticky@test.com', 'Updated') on duplicate key update name = values(name)")
+
+		myFn2 := utils.Exec(t, mcmp.MySQLConn, "select last_insert_id()")
+		vtFn2 := utils.Exec(t, mcmp.VtConn, "select last_insert_id()")
+
+		myFnVal2, err := myFn2.Rows[0][0].ToUint64()
+		require.NoError(t, err)
+		vtFnVal2, err := vtFn2.Rows[0][0].ToUint64()
+		require.NoError(t, err)
+
+		// MySQL: SQL function stays sticky at the original insert value
+		assert.EqualValues(t, myIns.InsertID, myFnVal2, "MySQL: SQL function should stay sticky after ON DUP KEY UPDATE")
+
+		// Vitess should match (but currently doesn't — SafeSession.LastInsertId gets overwritten)
+		assert.EqualValues(t, vtIns.InsertID, vtFnVal2, "Vitess: SQL function should stay sticky after ON DUP KEY UPDATE")
+
+		// Step 3: ON DUP KEY no-change — wire = 0, SQL function should still stay sticky
+		utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('sticky@test.com', 'Updated') on duplicate key update name = values(name)")
+		utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('sticky@test.com', 'Updated') on duplicate key update name = values(name)")
+
+		myFn3 := utils.Exec(t, mcmp.MySQLConn, "select last_insert_id()")
+		vtFn3 := utils.Exec(t, mcmp.VtConn, "select last_insert_id()")
+
+		myFnVal3, err := myFn3.Rows[0][0].ToUint64()
+		require.NoError(t, err)
+		vtFnVal3, err := vtFn3.Rows[0][0].ToUint64()
+		require.NoError(t, err)
+
+		// MySQL: SQL function still sticky
+		assert.EqualValues(t, myIns.InsertID, myFnVal3, "MySQL: SQL function should stay sticky after no-change ON DUP KEY")
+
+		// Vitess should match
+		assert.EqualValues(t, vtIns.InsertID, vtFnVal3, "Vitess: SQL function should stay sticky after no-change ON DUP KEY")
+	})
+
+	// Print a summary of the Vitess vs MySQL comparison for debugging visibility
+	t.Run("summary", func(t *testing.T) {
+		resetTable(t)
+
+		// Seed and run a representative case to show the divergence
+		myIns := utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('sum@test.com', 'Sum')")
+		vtIns := utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('sum@test.com', 'Sum')")
+
+		myQr := utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('sum@test.com', 'Sum2') on duplicate key update name = values(name)")
+		vtQr := utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('sum@test.com', 'Sum2') on duplicate key update name = values(name)")
+
+		t.Logf("MySQL: seed InsertID=%d, ON DUP InsertID=%d RowsAffected=%d", myIns.InsertID, myQr.InsertID, myQr.RowsAffected)
+		t.Logf("Vitess: seed InsertID=%d, ON DUP InsertID=%d RowsAffected=%d", vtIns.InsertID, vtQr.InsertID, vtQr.RowsAffected)
+
+		if vtQr.InsertID != vtIns.InsertID {
+			t.Logf("MISMATCH: Vitess ON DUP InsertID (%d) != seeded row ID (%d) — see issue #15696", vtQr.InsertID, vtIns.InsertID)
+		}
+	})
+}

--- a/go/test/endtoend/vtgate/queries/dml/last_insert_id_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/last_insert_id_test.go
@@ -218,7 +218,13 @@ func TestLastInsertIDOnDupKey(t *testing.T) {
 	t.Run("SQL function stickiness", func(t *testing.T) {
 		resetTable(t)
 
-		// Step 1: Insert a new row — both wire and SQL function show the new ID
+		// Seed an existing row FIRST on each connection, so we have a row
+		// with a DIFFERENT id than the one we'll insert next.
+		utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('existing@test.com', 'Existing')")
+		utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('existing@test.com', 'Existing')")
+
+		// Step 1: Insert a NEW row — both wire and SQL function show the new ID.
+		// This is the value that should remain "sticky" throughout the test.
 		myIns := utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('sticky@test.com', 'Sticky')")
 		vtIns := utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('sticky@test.com', 'Sticky')")
 
@@ -234,9 +240,16 @@ func TestLastInsertIDOnDupKey(t *testing.T) {
 		assert.EqualValues(t, myIns.InsertID, myFnVal, "MySQL: SQL function should match wire InsertID after insert")
 		assert.EqualValues(t, vtIns.InsertID, vtFnVal, "Vitess: SQL function should match wire InsertID after insert")
 
-		// Step 2: ON DUP KEY that updates — wire changes, SQL function should stay sticky
-		utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('sticky@test.com', 'Updated') on duplicate key update name = values(name)")
-		utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('sticky@test.com', 'Updated') on duplicate key update name = values(name)")
+		// Step 2: ON DUP KEY UPDATE on the EXISTING row (different id than sticky@).
+		// Wire protocol should change to existing row's id, but SQL function must stay sticky.
+		myDup := utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('existing@test.com', 'Updated') on duplicate key update name = values(name)")
+		vtDup := utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('existing@test.com', 'Updated') on duplicate key update name = values(name)")
+
+		// Wire protocol should show the existing row's id (different from sticky@'s id)
+		assert.EqualValues(t, 2, myDup.RowsAffected)
+		assert.EqualValues(t, 2, vtDup.RowsAffected)
+		assert.NotEqual(t, myIns.InsertID, myDup.InsertID, "MySQL: wire InsertID should be existing row's id, not sticky")
+		assert.NotEqual(t, vtIns.InsertID, vtDup.InsertID, "Vitess: wire InsertID should be existing row's id, not sticky")
 
 		myFn2 := utils.Exec(t, mcmp.MySQLConn, "select last_insert_id()")
 		vtFn2 := utils.Exec(t, mcmp.VtConn, "select last_insert_id()")
@@ -246,15 +259,15 @@ func TestLastInsertIDOnDupKey(t *testing.T) {
 		vtFnVal2, err := vtFn2.Rows[0][0].ToUint64()
 		require.NoError(t, err)
 
-		// MySQL: SQL function stays sticky at the original insert value
+		// MySQL: SQL function stays sticky at the insert value from step 1
 		assert.EqualValues(t, myIns.InsertID, myFnVal2, "MySQL: SQL function should stay sticky after ON DUP KEY UPDATE")
 
-		// Vitess should match (but currently doesn't — SafeSession.LastInsertId gets overwritten)
+		// Vitess should match
 		assert.EqualValues(t, vtIns.InsertID, vtFnVal2, "Vitess: SQL function should stay sticky after ON DUP KEY UPDATE")
 
 		// Step 3: ON DUP KEY no-change — wire = 0, SQL function should still stay sticky
-		utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('sticky@test.com', 'Updated') on duplicate key update name = values(name)")
-		utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('sticky@test.com', 'Updated') on duplicate key update name = values(name)")
+		utils.Exec(t, mcmp.MySQLConn, "insert into lid_tbl(email, name) values ('existing@test.com', 'Updated') on duplicate key update name = values(name)")
+		utils.Exec(t, mcmp.VtConn, "insert into lid_tbl(email, name) values ('existing@test.com', 'Updated') on duplicate key update name = values(name)")
 
 		myFn3 := utils.Exec(t, mcmp.MySQLConn, "select last_insert_id()")
 		vtFn3 := utils.Exec(t, mcmp.VtConn, "select last_insert_id()")

--- a/go/test/endtoend/vtgate/queries/dml/main_test.go
+++ b/go/test/endtoend/vtgate/queries/dml/main_test.go
@@ -60,6 +60,9 @@ var (
     },
     "mixed_seq": {
        "type":   "sequence"
+    },
+    "lid_seq": {
+       "type":   "sequence"
     }
   }
 }`
@@ -136,7 +139,7 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 		tables := []string{
 			"s_tbl", "num_vdx_tbl", "col_vdx_tbl", "user_tbl", "order_tbl", "oevent_tbl", "oextra_tbl",
 			"auto_tbl", "oid_vdx_tbl", "unq_idx", "nonunq_idx", "u_tbl", "mixed_tbl", "j_tbl", "j_utbl",
-			"t1", "t2",
+			"t1", "t2", "lid_tbl",
 		}
 		for _, table := range tables {
 			// TODO (@frouioui): following assertions produce different results between MySQL and Vitess

--- a/go/test/endtoend/vtgate/queries/dml/sharded_schema.sql
+++ b/go/test/endtoend/vtgate/queries/dml/sharded_schema.sql
@@ -131,3 +131,12 @@ create table t2
     col bigint,
     primary key (id)
 ) Engine = InnoDB;
+
+create table lid_tbl
+(
+    id    bigint,
+    email varchar(255) not null,
+    name  varchar(255) not null,
+    primary key (id),
+    unique key (email)
+) Engine = InnoDB;

--- a/go/test/endtoend/vtgate/queries/dml/unsharded_schema.sql
+++ b/go/test/endtoend/vtgate/queries/dml/unsharded_schema.sql
@@ -42,3 +42,14 @@ create table j_utbl
     jdoc json,
     primary key (id)
 ) Engine = InnoDB;
+
+create table lid_seq
+(
+    id      int    default 0,
+    next_id bigint default null,
+    cache   bigint default null,
+    primary key (id)
+) comment 'vitess_sequence' Engine = InnoDB;
+
+insert into lid_seq(id, next_id, cache)
+values (0, 1, 1000);

--- a/go/test/endtoend/vtgate/queries/dml/vschema.json
+++ b/go/test/endtoend/vtgate/queries/dml/vschema.json
@@ -273,6 +273,18 @@
           "name": "hash"
         }
       ]
+    },
+    "lid_tbl": {
+      "auto_increment": {
+        "column": "id",
+        "sequence": "uks.lid_seq"
+      },
+      "column_vindexes": [
+        {
+          "column": "email",
+          "name": "hash_varchar"
+        }
+      ]
     }
   }
 }

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -411,6 +411,7 @@ func (t *noopVCursor) GetDBDDLPluginName() string {
 }
 
 func (t *noopVCursor) SetLastInsertID(uint64) {}
+func (t *noopVCursor) GetLastInsertID() uint64 { return 0 }
 func (t *noopVCursor) VExplainLogging()       {}
 func (t *noopVCursor) DisableLogging()        {}
 func (t *noopVCursor) GetVExplainLogs() []ExecuteEntry {

--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -163,14 +163,47 @@ func (ins *Insert) executeInsertQueries(
 	if err != nil {
 		return nil, err
 	}
+	// Save the session's LastInsertId before ExecuteMultiShard, which may
+	// overwrite it with the shard's LAST_INSERT_ID value. We need this to
+	// restore stickiness for the SQL function LAST_INSERT_ID() in the
+	// ON DUP KEY UPDATE case.
+	var savedLastInsertID uint64
+	if ins.HasOnDupLastInsertID {
+		savedLastInsertID = vcursor.GetLastInsertID()
+	}
+
 	result, errs := vcursor.ExecuteMultiShard(ctx, ins, rss, queries, true /*rollbackOnError*/, autocommit, ins.FetchLastInsertID)
 	if errs != nil {
 		return nil, vterrors.Aggregate(errs)
 	}
 
 	if insertID != 0 {
-		result.InsertID = insertID
-		result.InsertIDChanged = true
+		if ins.HasOnDupLastInsertID {
+			// ON DUPLICATE KEY UPDATE with LAST_INSERT_ID trick.
+			// The shard MySQL returns the existing row's id via LAST_INSERT_ID
+			// for updates, or 0 for new inserts.
+			if result.RowsAffected == 0 {
+				// No change (duplicate with identical values). InsertID = 0.
+				// Restore the session value that ExecuteMultiShard may have overwritten.
+				result.InsertID = 0
+				result.InsertIDChanged = false
+				vcursor.SetLastInsertID(savedLastInsertID)
+			} else if result.InsertID != 0 {
+				// Shard returned existing row's id from LAST_INSERT_ID.
+				// Wire protocol should show this id, but the SQL function
+				// LAST_INSERT_ID() should stay sticky at whatever it was before.
+				result.InsertIDChanged = false
+				vcursor.SetLastInsertID(savedLastInsertID)
+			} else {
+				// Normal insert(s). Use the sequence-generated value.
+				result.InsertID = insertID
+				result.InsertIDChanged = true
+				vcursor.SetLastInsertID(insertID)
+			}
+		} else {
+			result.InsertID = insertID
+			result.InsertIDChanged = true
+		}
 	}
 	return result, nil
 }

--- a/go/vt/vtgate/engine/insert_common.go
+++ b/go/vt/vtgate/engine/insert_common.go
@@ -79,6 +79,11 @@ type (
 
 		FetchLastInsertID bool
 
+		// HasOnDupLastInsertID indicates that the ON DUPLICATE KEY UPDATE clause
+		// was augmented with LAST_INSERT_ID(<auto_inc_col>) at plan time to capture
+		// the existing row's auto-increment value during updates.
+		HasOnDupLastInsertID bool
+
 		// Prefix, Suffix are for sharded insert plans.
 		Prefix string
 		Suffix sqlparser.OnDup
@@ -146,6 +151,14 @@ func (ins *InsertCommon) executeUnshardedTableQuery(ctx context.Context, vcursor
 	if err != nil {
 		return nil, err
 	}
+	// Save the session's LastInsertId before executing, which may overwrite
+	// it with the shard's LAST_INSERT_ID value. We need this to restore
+	// stickiness for the SQL function LAST_INSERT_ID() in the ON DUP KEY UPDATE case.
+	var savedLastInsertID uint64
+	if ins.HasOnDupLastInsertID {
+		savedLastInsertID = vcursor.GetLastInsertID()
+	}
+
 	qr, err := execShard(ctx, loggingPrimitive, vcursor, query, bindVars, rss[0], true, !ins.PreventAutoCommit /* canAutocommit */, ins.FetchLastInsertID)
 	if err != nil {
 		return nil, err
@@ -156,8 +169,30 @@ func (ins *InsertCommon) executeUnshardedTableQuery(ctx context.Context, vcursor
 	// values, we don't return an error because this behavior
 	// is required to support migration.
 	if insertID != 0 {
-		qr.InsertIDChanged = true
-		qr.InsertID = insertID
+		if ins.HasOnDupLastInsertID {
+			// ON DUPLICATE KEY UPDATE with LAST_INSERT_ID trick.
+			if qr.RowsAffected == 0 {
+				// No change (duplicate with identical values). InsertID = 0.
+				// Restore the session value that execShard may have overwritten.
+				qr.InsertID = 0
+				qr.InsertIDChanged = false
+				vcursor.SetLastInsertID(savedLastInsertID)
+			} else if qr.InsertID != 0 {
+				// Shard returned existing row's id from LAST_INSERT_ID.
+				// Wire protocol should show this id, but the SQL function
+				// LAST_INSERT_ID() should stay sticky at whatever it was before.
+				qr.InsertIDChanged = false
+				vcursor.SetLastInsertID(savedLastInsertID)
+			} else {
+				// Normal insert(s). Use the sequence-generated value.
+				qr.InsertID = insertID
+				qr.InsertIDChanged = true
+				vcursor.SetLastInsertID(insertID)
+			}
+		} else {
+			qr.InsertIDChanged = true
+			qr.InsertID = insertID
+		}
 	}
 	return qr, nil
 }

--- a/go/vt/vtgate/engine/insert_select.go
+++ b/go/vt/vtgate/engine/insert_select.go
@@ -132,6 +132,9 @@ func (ins *InsertSelect) TryStreamExecute(ctx context.Context, vcursor VCursor, 
 		if output.InsertID == 0 || output.InsertID > qr.InsertID {
 			output.InsertID = qr.InsertID
 		}
+		if qr.InsertIDChanged {
+			output.InsertIDChanged = true
+		}
 		return nil
 	})
 	if err != nil {
@@ -185,7 +188,10 @@ func (ins *InsertSelect) insertIntoShardedTable(
 	if err != nil {
 		return nil, err
 	}
-	qr.InsertID = uint64(irr.insertID)
+	if irr.insertID != 0 {
+		qr.InsertID = uint64(irr.insertID)
+		qr.InsertIDChanged = true
+	}
 	return qr, nil
 }
 
@@ -208,6 +214,7 @@ func (ins *InsertSelect) executeInsertQueries(
 
 	if insertID != 0 {
 		result.InsertID = insertID
+		result.InsertIDChanged = true
 	}
 	return result, nil
 }

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -149,6 +149,7 @@ type (
 		RecordMirrorStats(time.Duration, time.Duration, error)
 
 		SetLastInsertID(uint64)
+		GetLastInsertID() uint64
 
 		GetExecutionMetrics() *Metrics
 	}

--- a/go/vt/vtgate/engine/sequential.go
+++ b/go/vt/vtgate/engine/sequential.go
@@ -53,6 +53,9 @@ func (s *Sequential) TryExecute(ctx context.Context, vcursor VCursor, bindVars m
 		if finalRes.InsertID == 0 {
 			finalRes.InsertID = res.InsertID
 		}
+		if res.InsertIDChanged {
+			finalRes.InsertIDChanged = true
+		}
 		if res.Info != "" {
 			finalRes.Info = res.Info
 		}

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -1689,3 +1689,9 @@ func (vc *VCursorImpl) SetLastInsertID(id uint64) {
 	defer vc.SafeSession.mu.Unlock()
 	vc.SafeSession.LastInsertId = id
 }
+
+func (vc *VCursorImpl) GetLastInsertID() uint64 {
+	vc.SafeSession.mu.Lock()
+	defer vc.SafeSession.mu.Unlock()
+	return vc.SafeSession.LastInsertId
+}

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -671,14 +671,26 @@ func buildInsertPrimitive(
 ) (engine.Primitive, error) {
 	ins := op.(*operators.Insert)
 
+	// For INSERT ... ON DUPLICATE KEY UPDATE with auto-increment sequences,
+	// add `<auto_inc_col> = LAST_INSERT_ID(<auto_inc_col>)` to the ON DUP clause.
+	// This causes the shard MySQL to report the existing row's id via last_insert_id
+	// when an update occurs, matching MySQL's behavior for tables with AUTO_INCREMENT.
+	// This must happen after vindex checks (which run during operator creation) because
+	// the auto-inc column may also be a vindex column.
+	var hasOnDupLID bool
+	if ins.AutoIncrement != nil && stmt.OnDup != nil {
+		hasOnDupLID = addLastInsertIDToOnDup(stmt, ins.VTable.AutoIncrement.Column)
+	}
+
 	ic := engine.InsertCommon{
-		Opcode:            mapToInsertOpCode(rb.Routing.OpCode()),
-		Keyspace:          rb.Routing.Keyspace(),
-		TableName:         ins.VTable.Name.String(),
-		Ignore:            ins.Ignore,
-		Generate:          autoIncGenerate(ins.AutoIncrement),
-		ColVindexes:       ins.ColVindexes,
-		FetchLastInsertID: ctx.SemTable.ShouldFetchLastInsertID(),
+		Opcode:               mapToInsertOpCode(rb.Routing.OpCode()),
+		Keyspace:             rb.Routing.Keyspace(),
+		TableName:            ins.VTable.Name.String(),
+		Ignore:               ins.Ignore,
+		Generate:             autoIncGenerate(ins.AutoIncrement),
+		ColVindexes:          ins.ColVindexes,
+		FetchLastInsertID:    ctx.SemTable.ShouldFetchLastInsertID() || hasOnDupLID,
+		HasOnDupLastInsertID: hasOnDupLID,
 	}
 	if hints != nil {
 		ic.MultiShardAutocommit = hints.multiShardAutocommit
@@ -749,6 +761,58 @@ func generateInsertShardedQuery(ins *sqlparser.Insert) (prefix string, mids sqlp
 		}
 	}, nil).(sqlparser.OnDup)
 	return
+}
+
+// addLastInsertIDToOnDup appends `<col> = LAST_INSERT_ID(<col>)` to the
+// ON DUPLICATE KEY UPDATE clause when the auto-increment column is not
+// already present. This causes the shard MySQL to set its session
+// last_insert_id to the existing row's value during an update, which
+// allows Vitess to return the correct InsertID to the client.
+// addLastInsertIDToOnDup appends `autoIncCol = LAST_INSERT_ID(autoIncCol)` to the
+// ON DUPLICATE KEY UPDATE clause so the shard MySQL reports the existing row's id.
+// It returns true if it added the expression or if LAST_INSERT_ID(expr) already
+// exists in the clause. It returns false (and does nothing) if:
+//   - the auto-inc column is already explicitly set in the clause, or
+//   - LAST_INSERT_ID(expr) is already called on a different column (we must not
+//     override the user's intent).
+func addLastInsertIDToOnDup(ins *sqlparser.Insert, autoIncCol sqlparser.IdentifierCI) bool {
+	hasLIDFunc := false
+	autoIncInClause := false
+	for _, expr := range ins.OnDup {
+		if expr.Name.Name.EqualString(autoIncCol.String()) {
+			autoIncInClause = true
+		}
+		// Check if LAST_INSERT_ID(expr) is used anywhere in this update expression's value.
+		_ = sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+			funcExpr, ok := node.(*sqlparser.FuncExpr)
+			if ok && funcExpr.Name.EqualString("last_insert_id") && len(funcExpr.Exprs) > 0 {
+				hasLIDFunc = true
+				return false, nil
+			}
+			return true, nil
+		}, expr.Expr, nil)
+	}
+
+	// If the user already uses LAST_INSERT_ID(expr) anywhere in the clause,
+	// don't add our own — it would override their value.
+	if hasLIDFunc {
+		return true
+	}
+
+	// If the auto-inc column is already in the clause (e.g., id = 5),
+	// don't modify the user's expression.
+	if autoIncInClause {
+		return false
+	}
+
+	ins.OnDup = append(ins.OnDup, &sqlparser.UpdateExpr{
+		Name: sqlparser.NewColName(autoIncCol.String()),
+		Expr: &sqlparser.FuncExpr{
+			Name:  sqlparser.NewIdentifierCI("last_insert_id"),
+			Exprs: []sqlparser.Expr{sqlparser.NewColName(autoIncCol.String())},
+		},
+	})
+	return true
 }
 
 // dmlFormatter strips out keyspace name from dmls.

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -1381,15 +1381,71 @@
         },
         "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(1)",
         "InsertIgnore": true,
-        "Query": "insert into `user`(id, `Name`, Costly) values (:_Id_0, :_Name_0, :_Costly_0) on duplicate key update col = 2",
+        "Query": "insert into `user`(id, `Name`, Costly) values (:_Id_0, :_Name_0, :_Costly_0) on duplicate key update col = 2, id = last_insert_id(id)",
         "VindexValues": {
           "costly_map": "null",
           "name_user_map": "null",
           "user_index": ":__seq0"
-        }
+        },
+        "FetchLastInsertID": true
       },
       "TablesUsed": [
         "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "insert on duplicate key with user LAST_INSERT_ID on different column - should not append extra_id = last_insert_id(extra_id)",
+    "query": "insert into user_extra(user_id) values(1) on duplicate key update col = last_insert_id(col)",
+    "plan": {
+      "Type": "MultiShard",
+      "QueryType": "INSERT",
+      "Original": "insert into user_extra(user_id) values(1) on duplicate key update col = last_insert_id(col)",
+      "Instructions": {
+        "OperatorType": "Insert",
+        "Variant": "Sharded",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(null)",
+        "InsertIgnore": true,
+        "FetchLastInsertID": true,
+        "Query": "insert into user_extra(user_id, extra_id) values (:_user_id_0, :__seq0) on duplicate key update col = last_insert_id(col)",
+        "VindexValues": {
+          "user_index": "1"
+        }
+      },
+      "TablesUsed": [
+        "user.user_extra"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "insert on duplicate key with auto-inc column explicitly set - should not modify or add last_insert_id",
+    "query": "insert into user_extra(user_id) values(1) on duplicate key update extra_id = 5",
+    "plan": {
+      "Type": "MultiShard",
+      "QueryType": "INSERT",
+      "Original": "insert into user_extra(user_id) values(1) on duplicate key update extra_id = 5",
+      "Instructions": {
+        "OperatorType": "Insert",
+        "Variant": "Sharded",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "AutoIncrement": "select next :n /* INT64 */ values from seq:Values::(null)",
+        "InsertIgnore": true,
+        "Query": "insert into user_extra(user_id, extra_id) values (:_user_id_0, :__seq0) on duplicate key update extra_id = 5",
+        "VindexValues": {
+          "user_index": "1"
+        }
+      },
+      "TablesUsed": [
+        "user.user_extra"
       ]
     },
     "skip_e2e": true


### PR DESCRIPTION
## Description

This fixes Vitess's handling of `LAST_INSERT_ID` for `INSERT ... ON DUPLICATE KEY UPDATE` on sharded tables with VSchema sequences. Previously, Vitess always returned the sequence-generated id regardless of whether the row was inserted or updated, which diverges from MySQL behavior.

### What MySQL does

MySQL's behavior for `INSERT ... ON DUPLICATE KEY UPDATE` has two separate `LAST_INSERT_ID` surfaces that can diverge:

1. **Wire protocol** (OK packet `last_insert_id`): reports the auto-increment id of the row that was affected — whether it was newly inserted or already existed. For updates of existing rows, this requires the `id = LAST_INSERT_ID(id)` trick in the `ON DUP` clause.
2. **SQL function** `LAST_INSERT_ID()`: "sticky" — it stays at whatever value it was last explicitly set to by an insert or a `LAST_INSERT_ID(expr)` call. An `ON DUP KEY UPDATE` that updates an existing row does **not** change the SQL function's value (unless the user explicitly used `LAST_INSERT_ID(expr)` in their update clause).

### What this PR fixes

| Scenario | MySQL | Vitess before | Vitess after |
|---|---|---|---|
| New row inserted | wire = new id, fn = new id | wire = seq id, fn = seq id | wire = seq id, fn = seq id ✅ |
| Existing row updated | wire = existing id, fn = sticky | wire = seq id, fn = seq id | wire = existing id, fn = sticky ✅ |
| No change (dup with same values) | wire = 0, fn = sticky | wire = seq id, fn = seq id | wire = 0, fn = sticky ✅ |
| User's `LAST_INSERT_ID(expr)` in ON DUP | wire = expr val, fn = expr val | wire = seq id, fn = seq id | wire = expr val, fn = expr val ✅ |

### What this PR does NOT fix

- **Multi-row inserts with mixed insert/update**: MySQL returns the *first* newly inserted row's id on the wire. Vitess returns the sequence-generated id for the batch. This is an existing limitation of the sequence-based auto-increment approach.
- **`rows_affected` count**: MySQL reports 1 for insert, 2 for update, 0 for no-change. This PR does not change `rows_affected` handling.

### How it works

1. **Plan-time injection**: For `INSERT ... ON DUP KEY UPDATE` with a VSchema auto-increment column, the planner appends `auto_inc_col = LAST_INSERT_ID(auto_inc_col)` to the `ON DUP` clause. This causes shard MySQL to report the existing row's id when an update occurs. If the user already has `LAST_INSERT_ID(expr)` in their clause, we skip injection to avoid interfering with their atomic counter pattern.

2. **Tablet-level fetch**: The `FetchLastInsertID` flag is set on the tablet query, which resets the session's `LAST_INSERT_ID` to a sentinel before executing, then runs `SELECT LAST_INSERT_ID()` after to detect if `LAST_INSERT_ID(expr)` was called during the query.

3. **Engine-level save/restore**: The insert engine saves `SafeSession.LastInsertId` before `ExecuteMultiShard` (which may overwrite it with the shard's value), then restores it for update/no-change cases. This preserves the SQL function's stickiness.

4. **InsertIDChanged cleanup**: `InsertIDChanged` is now consistently propagated alongside `InsertID` in `insert_select` and `sequential` engines, allowing `InsertIDUpdated()` to be simplified to just check `InsertIDChanged` (removing the `InsertID > 0` fallback and the `SkipLastInsertIDUpdate` workaround).

## Related Issue(s)

Fixes https://github.com/vitessio/vitess/issues/15696

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [ ] Did the new or modified tests pass consistently locally and on CI?
- [ ] Documentation was added or is not required

## Deployment Notes

No migrations or configuration changes required. The planner will automatically inject `LAST_INSERT_ID()` into `ON DUP` clauses for sharded tables with VSchema sequences. Queries are rewritten at plan time, so there is no runtime overhead beyond the existing `FetchLastInsertID` round-trip on the tablet.

### AI Disclosure

Most of this PR was written by Claude Code with direction and review from the author.