### PR TITLE
planbuilder: fix LEFT JOIN predicate pushdown breaking outer join semantics

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -297,16 +297,21 @@ func (qb *queryBuilder) joinWith(other *queryBuilder, onCondition sqlparser.Expr
 		}
 	}
 
-	qb.mergeWhereClauses(stmt, otherStmt)
-
 	var newFromClause []sqlparser.TableExpr
 	switch joinType {
 	case sqlparser.NormalJoinType:
+		qb.mergeWhereClauses(stmt, otherStmt)
 		newFromClause = append(stmt.GetFrom(), otherStmt.GetFrom()...)
 		for _, pred := range sqlparser.SplitAndExpression(nil, onCondition) {
 			qb.addPredicate(pred)
 		}
 	default:
+		rhsWhere := otherStmt.GetWherePredicate()
+		if rhsWhere != nil {
+			otherStmt.SetWherePredicate(nil)
+			onCondition = sqlparser.AndExpressions(onCondition, rhsWhere)
+		}
+		qb.mergeWhereClauses(stmt, otherStmt)
 		newFromClause = []sqlparser.TableExpr{buildJoin(stmt, otherStmt, onCondition, joinType)}
 	}
 

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -4846,5 +4846,29 @@
         "Query": "select information_schema.`table`.col from information_schema.`table` order by information_schema.`table`.`name` asc"
       }
     }
+  },
+  {
+    "comment": "issue #19557: colocated inner join ON predicate inside LEFT JOIN must stay in ON clause",
+    "query": "select u.Id from user u left join (user_extra ue join ref on ue.col = ref.col) on u.Id = ue.user_id",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select u.Id from user u left join (user_extra ue join ref on ue.col = ref.col) on u.Id = ue.user_id",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select u.Id from `user` as u left join (user_extra as ue, ref) on u.Id = ue.user_id and ue.col = ref.col where 1 != 1",
+        "Query": "select u.Id from `user` as u left join (user_extra as ue, ref) on u.Id = ue.user_id and ue.col = ref.col"
+      },
+      "TablesUsed": [
+        "user.ref",
+        "user.user",
+        "user.user_extra"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
  ## Summary

  Fixes a correctness bug in VTGate's query planner where predicates from the right-hand side of a
  LEFT/RIGHT JOIN were being incorrectly pushed into the outer WHERE clause during query planning.
  This silently converted outer joins into inner joins, causing NULL-extended rows to be filtered out
  and producing wrong results.

  ## Root cause

  In `joinWith` (SQL_builder.go), ON-clause predicates were being merged into the outer WHERE clause 
  regardless of join type. For inner joins this is semantically safe, but for outer joins it changes 
  the query semantics — a WHERE predicate on the RHS of a LEFT JOIN eliminates NULL rows, effectively 
  turning it into an INNER JOIN.

  ## Fix

  The merge logic is now gated on join type:
  - **Inner joins** — predicates continue to merge into WHERE as before (no behavior change).
  - **Outer joins (LEFT/RIGHT/FULL)** — RHS WHERE predicates are folded back into the ON condition 
  instead, preserving NULL row semantics.

  ## Impact

  Any query using a LEFT/RIGHT JOIN where VTGate was planning a colocated join could silently return 
  fewer rows than expected. This is a correctness regression with no error surfaced to the user.

  ## Testing

  Added a test case in `from_cases.json` covering the colocated LEFT JOIN scenario from issue #19557.

  ---
  ## Backport Reason
  
  this is a silent correctness regression — LEFT JOIN queries planned as colocated
  joins can return fewer rows than correct without any error. Users have no way to detect this without
   manually cross-checking results. The fix is minimal and self-contained (one conditional in
  SQL_builder.go, one test case), so backport risk is low.

  ---
  ## Issue
  
  Fixes #19557
  
  ---
  ## Deployment Notes
  
  No docs update needed, this is a correctness fix for existing LEFT JOIN behavior, not a new feature
   or changed API.
