### PR TITLE
test: Add missing unit tests in vtgate/schema

### DIFF
--- a/go/vt/vtgate/schema/tracker_test.go
+++ b/go/vt/vtgate/schema/tracker_test.go
@@ -36,6 +36,7 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
+	"vitess.io/vitess/go/vt/vttablet/queryservice/fakes"
 	"vitess.io/vitess/go/vt/vttablet/sandboxconn"
 )
 
@@ -591,6 +592,62 @@ func testTracker(t *testing.T, enableUDFs bool, schemaDefResult []sandboxconn.Sc
 			assert.Equal(t, tcase.expUDFs, tracker.UDFs(keyspace), "mismatch for udfs")
 		})
 	}
+}
+
+func TestTrackerTables(t *testing.T) {
+	tracker := NewTracker(make(chan *discovery.TabletHealth), false, false, sqlparser.NewTestParser())
+
+	got := tracker.Tables("unknown")
+	assert.Empty(t, got)
+
+	tracker.tables.set("ks", "t1", []vindexes.Column{{Name: sqlparser.NewIdentifierCI("id")}}, nil, nil)
+	got = tracker.Tables("ks")
+	assert.Len(t, got, 1)
+	assert.NotNil(t, got["t1"])
+
+	got["t1"] = nil
+	got2 := tracker.Tables("ks")
+	assert.NotNil(t, got2["t1"])
+}
+
+func TestTrackerViews(t *testing.T) {
+	tracker := NewTracker(make(chan *discovery.TabletHealth), false, false, sqlparser.NewTestParser())
+	assert.Nil(t, tracker.Views("ks"))
+
+	tracker = NewTracker(make(chan *discovery.TabletHealth), true, false, sqlparser.NewTestParser())
+	assert.Nil(t, tracker.Views("unknown"))
+
+	tracker.views.set("ks", "v1", "create view v1 as select 1 from t1")
+	got := tracker.Views("ks")
+	assert.Len(t, got, 1)
+	assert.NotNil(t, got["v1"])
+}
+
+func TestTrackerAddNewKeyspace(t *testing.T) {
+	target := &querypb.Target{Keyspace: keyspace, Shard: "-80", TabletType: topodatapb.TabletType_PRIMARY, Cell: cell}
+	tablet := &topodatapb.Tablet{Keyspace: target.Keyspace, Shard: target.Shard, Type: target.TabletType}
+
+	t.Run("success", func(t *testing.T) {
+		tracker := NewTracker(make(chan *discovery.TabletHealth), true, false, sqlparser.NewTestParser())
+		sbc := sandboxconn.NewSandboxConn(tablet)
+		sbc.SetSchemaResult([]sandboxconn.SchemaResult{
+			tables(tbl("t1", "create table t1(id int primary key)")),
+			empty(),
+		})
+		err := tracker.AddNewKeyspace(sbc, target)
+		require.NoError(t, err)
+		_, ok := tracker.tracked[keyspace]
+		assert.True(t, ok)
+		assert.NotNil(t, tracker.GetColumns(keyspace, "t1"))
+	})
+
+	t.Run("load failure", func(t *testing.T) {
+		tracker := NewTracker(make(chan *discovery.TabletHealth), true, false, sqlparser.NewTestParser())
+		err := tracker.AddNewKeyspace(fakes.ErrorQueryService, target)
+		require.Error(t, err)
+		_, ok := tracker.tracked[keyspace]
+		require.True(t, ok)
+	})
 }
 
 func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {

--- a/go/vt/vtgate/schema/tracker_test.go
+++ b/go/vt/vtgate/schema/tracker_test.go
@@ -595,40 +595,74 @@ func testTracker(t *testing.T, enableUDFs bool, schemaDefResult []sandboxconn.Sc
 }
 
 func TestTrackerTables(t *testing.T) {
-	tracker := NewTracker(make(chan *discovery.TabletHealth), false, false, sqlparser.NewTestParser())
+	tabletHealthCh := make(chan *discovery.TabletHealth)
+	parser := sqlparser.NewTestParser()
 
-	got := tracker.Tables("unknown")
-	assert.Empty(t, got)
+	tracker := NewTracker(tabletHealthCh, false, false, parser)
 
-	tracker.tables.set("ks", "t1", []vindexes.Column{{Name: sqlparser.NewIdentifierCI("id")}}, nil, nil)
-	got = tracker.Tables("ks")
-	assert.Len(t, got, 1)
-	assert.NotNil(t, got["t1"])
+	t.Run("unknown keyspace returns empty map", func(t *testing.T) {
+		got := tracker.Tables("unknown")
+		assert.Empty(t, got)
+	})
 
-	got["t1"] = nil
-	got2 := tracker.Tables("ks")
-	assert.NotNil(t, got2["t1"])
+	t.Run("known keyspace returns data and clone", func(t *testing.T) {
+		tracker.tables.set(keyspace, "t1", []vindexes.Column{{Name: sqlparser.NewIdentifierCI("id")}}, nil, nil)
+
+		got := tracker.Tables(keyspace)
+		assert.Len(t, got, 1)
+		assert.NotNil(t, got["t1"])
+
+		// Mutating the returned map should not affect the tracker's internal state.
+		got["t1"] = nil
+		got2 := tracker.Tables(keyspace)
+		assert.NotNil(t, got2["t1"])
+	})
 }
 
 func TestTrackerViews(t *testing.T) {
-	tracker := NewTracker(make(chan *discovery.TabletHealth), false, false, sqlparser.NewTestParser())
-	assert.Nil(t, tracker.Views("ks"))
+	tabletHealthCh := make(chan *discovery.TabletHealth)
+	parser := sqlparser.NewTestParser()
 
-	tracker = NewTracker(make(chan *discovery.TabletHealth), true, false, sqlparser.NewTestParser())
-	assert.Nil(t, tracker.Views("unknown"))
+	t.Run("views disabled returns nil", func(t *testing.T) {
+		tracker := NewTracker(tabletHealthCh, false, false, parser)
+		got := tracker.Views(keyspace)
+		assert.Nil(t, got)
+	})
 
-	tracker.views.set("ks", "v1", "create view v1 as select 1 from t1")
-	got := tracker.Views("ks")
-	assert.Len(t, got, 1)
-	assert.NotNil(t, got["v1"])
+	t.Run("views enabled unknown keyspace returns nil", func(t *testing.T) {
+		tracker := NewTracker(tabletHealthCh, true, false, parser)
+		got := tracker.Views("unknown")
+		assert.Nil(t, got)
+	})
+
+	t.Run("views enabled populated keyspace returns data", func(t *testing.T) {
+		tracker := NewTracker(tabletHealthCh, true, false, parser)
+		tracker.views.set(keyspace, "v1", "create view v1 as select 1 from t1")
+
+		got := tracker.Views(keyspace)
+		assert.Len(t, got, 1)
+		assert.NotNil(t, got["v1"])
+	})
 }
 
 func TestTrackerAddNewKeyspace(t *testing.T) {
-	target := &querypb.Target{Keyspace: keyspace, Shard: "-80", TabletType: topodatapb.TabletType_PRIMARY, Cell: cell}
-	tablet := &topodatapb.Tablet{Keyspace: target.Keyspace, Shard: target.Shard, Type: target.TabletType}
+	tabletHealthCh := make(chan *discovery.TabletHealth)
+	parser := sqlparser.NewTestParser()
+
+	target := &querypb.Target{
+		Keyspace:   keyspace,
+		Shard:      "-80",
+		TabletType: topodatapb.TabletType_PRIMARY,
+		Cell:       cell,
+	}
+	tablet := &topodatapb.Tablet{
+		Keyspace: target.Keyspace,
+		Shard:    target.Shard,
+		Type:     target.TabletType,
+	}
 
 	t.Run("success", func(t *testing.T) {
-		tracker := NewTracker(make(chan *discovery.TabletHealth), true, false, sqlparser.NewTestParser())
+		tracker := NewTracker(tabletHealthCh, true, false, parser)
 		sbc := sandboxconn.NewSandboxConn(tablet)
 		sbc.SetSchemaResult([]sandboxconn.SchemaResult{
 			tables(tbl("t1", "create table t1(id int primary key)")),
@@ -642,7 +676,7 @@ func TestTrackerAddNewKeyspace(t *testing.T) {
 	})
 
 	t.Run("load failure", func(t *testing.T) {
-		tracker := NewTracker(make(chan *discovery.TabletHealth), true, false, sqlparser.NewTestParser())
+		tracker := NewTracker(tabletHealthCh, true, false, parser)
 		err := tracker.AddNewKeyspace(fakes.ErrorQueryService, target)
 		require.Error(t, err)
 		_, ok := tracker.tracked[keyspace]

--- a/go/vt/vtgate/schema/update_controller_flaky_test.go
+++ b/go/vt/vtgate/schema/update_controller_flaky_test.go
@@ -317,3 +317,14 @@ func TestViewsUpdates(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateControllerSetIgnore(t *testing.T) {
+	uc := &updateController{}
+	assert.False(t, uc.ignore)
+
+	uc.setIgnore(true)
+	assert.True(t, uc.ignore)
+
+	uc.setIgnore(false)
+	assert.False(t, uc.ignore)
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR adds missing tests for `go/vt/vtgate/schema`

Coverate gone from 81% to 89%
<img width="1097" height="81" alt="image" src="https://github.com/user-attachments/assets/744ef205-3901-461d-8832-bedafbd5a467" />

The avarage coverage of the package is looking good now.
<img width="2226" height="1684" alt="image" src="https://github.com/user-attachments/assets/fa911f6e-f4bb-4795-9899-12019302df35" />



## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes part of #14931

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->