### PR TITLE
stats: reduce counter lock contention with RWMutex and atomics

### DIFF
--- a/go/stats/counters.go
+++ b/go/stats/counters.go
@@ -19,29 +19,53 @@ package stats
 import (
 	"bytes"
 	"fmt"
-	"maps"
 	"strings"
 	"sync"
+	"sync/atomic"
 )
 
 // counters is similar to expvar.Map, except that it doesn't allow floats.
 // It is used to build CountersWithSingleLabel and GaugesWithSingleLabel.
+//
+// The map values are atomic, so add/set on existing keys only requires a
+// read lock, reducing contention when many goroutines update counters
+// concurrently.
 type counters struct {
-	mu     sync.Mutex
-	counts map[string]int64
+	mu     sync.RWMutex
+	counts map[string]*atomic.Int64
 
 	help string
 }
 
-func (c *counters) String() string {
+// getOrCreate returns the atomic counter for the given key, creating it
+// if necessary. The fast path (existing key) takes only an RLock.
+func (c *counters) getOrCreate(key string) *atomic.Int64 {
+	c.mu.RLock()
+	if v, ok := c.counts[key]; ok {
+		c.mu.RUnlock()
+		return v
+	}
+	c.mu.RUnlock()
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if v, ok := c.counts[key]; ok {
+		return v
+	}
+	v := &atomic.Int64{}
+	c.counts[key] = v
+	return v
+}
+
+func (c *counters) String() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	b := &strings.Builder{}
 	fmt.Fprintf(b, "{")
 	prefix := ""
 	for k, v := range c.counts {
-		fmt.Fprintf(b, "%s%q: %v", prefix, k, v)
+		fmt.Fprintf(b, "%s%q: %v", prefix, k, v.Load())
 		prefix = ", "
 	}
 	fmt.Fprintf(b, "}")
@@ -49,15 +73,11 @@ func (c *counters) String() string {
 }
 
 func (c *counters) add(name string, value int64) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.counts[name] = c.counts[name] + value
+	c.getOrCreate(name).Add(value)
 }
 
 func (c *counters) set(name string, value int64) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.counts[name] = value
+	c.getOrCreate(name).Store(value)
 }
 
 func (c *counters) reset() {
@@ -68,21 +88,23 @@ func (c *counters) reset() {
 
 // ZeroAll zeroes out all values
 func (c *counters) ZeroAll() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
-	for k := range c.counts {
-		c.counts[k] = 0
+	for _, v := range c.counts {
+		v.Store(0)
 	}
 }
 
 // Counts returns a copy of the Counters' map.
 func (c *counters) Counts() map[string]int64 {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	counts := make(map[string]int64, len(c.counts))
-	maps.Copy(counts, c.counts)
+	for k, v := range c.counts {
+		counts[k] = v.Load()
+	}
 	return counts
 }
 
@@ -109,7 +131,7 @@ type CountersWithSingleLabel struct {
 func NewCountersWithSingleLabel(name, help, label string, tags ...string) *CountersWithSingleLabel {
 	c := &CountersWithSingleLabel{
 		counters: counters{
-			counts: make(map[string]int64),
+			counts: make(map[string]*atomic.Int64),
 			help:   help,
 		},
 		label:         label,
@@ -117,10 +139,10 @@ func NewCountersWithSingleLabel(name, help, label string, tags ...string) *Count
 	}
 
 	if c.labelCombined {
-		c.counts[StatsAllStr] = 0
+		c.counts[StatsAllStr] = &atomic.Int64{}
 	} else {
 		for _, tag := range tags {
-			c.counts[tag] = 0
+			c.counts[tag] = &atomic.Int64{}
 		}
 	}
 	if name != "" {
@@ -169,7 +191,7 @@ type CountersWithMultiLabels struct {
 func NewCountersWithMultiLabels(name, help string, labels []string) *CountersWithMultiLabels {
 	t := &CountersWithMultiLabels{
 		counters: counters{
-			counts: make(map[string]int64),
+			counts: make(map[string]*atomic.Int64),
 			help:   help,
 		},
 		labels:         labels,
@@ -205,7 +227,6 @@ func (mc *CountersWithMultiLabels) Reset(names []string) {
 	if len(names) != len(mc.labels) {
 		panic("CountersWithMultiLabels: wrong number of values in Reset")
 	}
-
 	mc.set(safeJoinLabels(names, mc.combinedLabels), 0)
 }
 
@@ -302,7 +323,7 @@ func NewGaugesWithSingleLabel(name, help, label string, tags ...string) *GaugesW
 	g := &GaugesWithSingleLabel{
 		CountersWithSingleLabel: CountersWithSingleLabel{
 			counters: counters{
-				counts: make(map[string]int64),
+				counts: make(map[string]*atomic.Int64),
 				help:   help,
 			},
 			label: label,
@@ -310,7 +331,7 @@ func NewGaugesWithSingleLabel(name, help, label string, tags ...string) *GaugesW
 	}
 
 	for _, tag := range tags {
-		g.counts[tag] = 0
+		g.counts[tag] = &atomic.Int64{}
 	}
 	if name != "" {
 		publish(name, g)
@@ -358,7 +379,7 @@ func NewGaugesWithMultiLabels(name, help string, labels []string) *GaugesWithMul
 	t := &GaugesWithMultiLabels{
 		CountersWithMultiLabels: CountersWithMultiLabels{
 			counters: counters{
-				counts: make(map[string]int64),
+				counts: make(map[string]*atomic.Int64),
 				help:   help,
 			},
 			labels: labels,

--- a/go/stats/counters_test.go
+++ b/go/stats/counters_test.go
@@ -18,10 +18,11 @@ package stats
 
 import (
 	"expvar"
-	"math/rand/v2"
+	"fmt"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -165,44 +166,79 @@ func BenchmarkMultiCounters(b *testing.B) {
 	})
 }
 
-func BenchmarkCountersTailLatency(b *testing.B) {
-	// For this one, ignore the time reported by 'go test'.
-	// The 99th Percentile log line is all that matters.
-	// (Cmd: go test -bench=BenchmarkCountersTailLatency -benchtime=30s -cpu=10)
-	clearStats()
-	benchCounter.Add("c1", 1)
-	c := make(chan time.Duration, 100)
-	done := make(chan struct{})
-	go func() {
-		all := make([]int, b.N)
-		i := 0
-		for dur := range c {
-			all[i] = int(dur)
-			i++
-		}
-		sort.Ints(all)
-		p99 := time.Duration(all[b.N*99/100])
-		b.Logf("99th Percentile (for N=%v): %v", b.N, p99)
-		close(done)
-	}()
+// benchmarkContention measures Add() latency under heavy contention.
+// Each goroutine collects latencies locally to avoid measurement skew
+// from shared channels or locks. Percentiles are computed after the
+// benchmark completes.
+//
+// Run with high -cpu to increase goroutine count:
+//
+//	go test -bench=BenchmarkContention -benchtime=5s -cpu=10 -run='^$'
+func benchmarkContention(b *testing.B, addFunc func(i int)) {
+	b.Helper()
+
+	b.SetParallelism(100) // 100 * GOMAXPROCS goroutines
+
+	var mu sync.Mutex
+	var allLatencies []time.Duration
 
 	b.ResetTimer()
-	b.SetParallelism(100) // The actual number of goroutines is 100*GOMAXPROCS
 	b.RunParallel(func(pb *testing.PB) {
-		var start time.Time
-
+		local := make([]time.Duration, 0, 1024)
+		i := 0
 		for pb.Next() {
-			// sleep between 0~200ms to simulate 10 QPS per goroutine.
-			time.Sleep(time.Duration(rand.Int64N(200)) * time.Millisecond)
-			start = time.Now()
-			benchCounter.Add("c1", 1)
-			c <- time.Since(start)
+			start := time.Now()
+			addFunc(i)
+			local = append(local, time.Since(start))
+			i++
 		}
+		mu.Lock()
+		allLatencies = append(allLatencies, local...)
+		mu.Unlock()
 	})
 	b.StopTimer()
 
-	close(c)
-	<-done
+	slices.Sort(allLatencies)
+	n := len(allLatencies)
+	if n > 0 {
+		b.Logf("p50: %v  p99: %v  p999: %v  max: %v  (n=%d)",
+			allLatencies[n*50/100],
+			allLatencies[n*99/100],
+			allLatencies[n*999/1000],
+			allLatencies[n-1],
+			n,
+		)
+	}
+}
+
+func BenchmarkCountersWithSingleLabelContention(b *testing.B) {
+	clearStats()
+	c := NewCountersWithSingleLabel("", "help", "key")
+	c.Add("c1", 0) // pre-create
+
+	benchmarkContention(b, func(_ int) {
+		c.Add("c1", 1)
+	})
+}
+
+func BenchmarkCountersWithMultiLabelsContention(b *testing.B) {
+	clearStats()
+	c := NewCountersWithMultiLabels("", "help", []string{"call", "keyspace", "dbtype"})
+
+	// Pre-create 50 distinct key combos to simulate realistic workload.
+	keys := make([][]string, 50)
+	for i := range keys {
+		keys[i] = []string{
+			fmt.Sprintf("method-%d", i),
+			fmt.Sprintf("ks-%d", i%5),
+			fmt.Sprintf("type-%d", i%3),
+		}
+		c.Add(keys[i], 0)
+	}
+
+	benchmarkContention(b, func(i int) {
+		c.Add(keys[i%len(keys)], 1)
+	})
 }
 
 func TestCountersFuncWithMultiLabels(t *testing.T) {


### PR DESCRIPTION
## Description

Metric Counters are used throughout the Vitess codebase. They're part of the hot path of the query execution flow. When running benchmarks against Vitess, I noticed that counters showed up in the mutex contention and delay profiles.

<img width="2019" height="1196" alt="image" src="https://github.com/user-attachments/assets/0924d404-a794-4e2c-9b54-70842332878f" />

This is not very surprising, if a goroutine gets preempted after locking a counter's mutex, other goroutines that try to update the same counter will get delayed. For multi labeled counters, that's even worse as all per-labelset values share the same lock.

This pull request hanges the `counters` struct (used by `CountersWithSingleLabel`, `CountersWithMultiLabels`,
and their Gauge variants) from using a `sync.Mutex` with `map[string]int64` to using a `sync.RWMutex` with `map[string]*atomic.Int64`.

The hot path for `Add()` on existing keys now takes only a read lock to look up the atomic pointer, then increments lock-free via `atomic.Int64.Add`. Only creating new keys requires an exclusive write lock. This eliminates serialization of concurrent `Add()` calls.

### Benchmark results

Contention benchmarks with 1000 goroutines (`-cpu=10`, `SetParallelism(100)`):

**Before (sync.Mutex):**
```
BenchmarkCountersWithSingleLabelContention-10     48378536    129.0 ns/op
  p50: 42ns  p99: 1.042µs  p999: 36.19ms  (n=48378536)

BenchmarkCountersWithMultiLabelsContention-10     37916492    143.7 ns/op
  p50: 83ns  p99: 17.375µs  p999: 35.55ms  (n=37916492)
```

**After (sync.RWMutex + atomic.Int64):**
```
BenchmarkCountersWithSingleLabelContention-10     50078755    133.3 ns/op
  p50: 917ns  p99: 2.042µs  p999: 8.75µs  (n=50078755)

BenchmarkCountersWithMultiLabelsContention-10     39045795    159.5 ns/op
  p50: 1.25µs  p99: 2.917µs  p999: 13.667µs  (n=39045795)
```

The p999 improvement is the key metric — **36ms → 8.75µs** for single-label,
**35ms → 13.7µs** for multi-label. These extreme tail latencies are caused by
goroutines queuing behind an exclusive mutex under contention.

> [!NOTE]
> There's a lot of variation in these benchmarks, but the general improvement (calls staying in the microsecond range) is there.

### Mutex contention profiles (`-mutexprofile`)

| | Cumulative mutex delay |
|---|---|
| Before (Mutex) | **17.1 hours** |
| After (RWMutex + atomic) | **25.8 minutes** |

40x reduction in mutex contention. In the "after" profile, the counter `Add()` path
no longer appears — the remaining delay is from the benchmark harness itself.

## Related Issue(s)

None.

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [ ] Documentation was added or is not required

## Deployment Notes

None. This is a drop-in change to internal locking; the public API is unchanged.

### AI Disclosure

Most of this was written by Claude Code — I provided direction.