### PR TITLE
Avoid copying empty bind variable maps in `Executor.fetchOrCreatePlan`

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1139,6 +1139,7 @@ func (e *Executor) fetchOrCreatePlan(
 
 	query, comments := sqlparser.SplitMarginComments(queryString)
 	vcursor, _ = e.newVCursor(safeSession, comments, logStats)
+	emptyBindVars := len(bindVars) == 0
 
 	var setVarComment string
 	if e.vConfig.SetVarEnabled {
@@ -1179,7 +1180,11 @@ func (e *Executor) fetchOrCreatePlan(
 	e.applyQueryHints(vcursor, plan)
 
 	logStats.SQL = comments.Leading + plan.Original + comments.Trailing
-	logStats.BindVariables = sqltypes.CopyBindVariables(bindVars)
+	if emptyBindVars {
+		logStats.BindVariables = bindVars
+	} else {
+		logStats.BindVariables = sqltypes.CopyBindVariables(bindVars)
+	}
 
 	return plan, vcursor, stmt, nil
 }


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Empty bind variable maps still get copied in `Executor.fetchOrCreatePlan`, which adds work to the common no-bind-var path. This changes `fetchOrCreatePlan` to reuse maps that were empty on entry.

On local sysbench oltp and oltp-olap benchmarks, this was showing 2-5% throughput + latency improvements.
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
