### PR TITLE
`CLAUDE.md`: add further recommendations based on testing 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,7 @@ return user.NeedsMigration() && migrate(user) || user
 - **Never** directly edit files under `go/vt/proto/` - they are generated from `proto/*.proto` protobuf definitions
 - After modifying `proto/*.proto` files, run `make proto` to regenerate
 - Avoid storing timestamps or time durations as integers; use `vttime.Time` for timestamps and `vttime.Duration` (or `google.protobuf.Duration`, as appropriate) for durations instead
+- Avoid storing tablet aliases as a string: use `topodata.TabletAlias`
 
 #### SQL Parser
 - **Never** directly edit these generated files in `go/vt/sqlparser/`: `sql.go`, `ast_clone.go`, `ast_copy_on_rewrite.go`, `ast_equals.go`, `ast_format_fast.go`, `ast_path.go`, `ast_rewrite.go`, `ast_visit.go`, `cached_size.go`


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR adds a few tweaks to `CLAUDE.md` ~~and the `e2e-tests` Claude-skill~~ based on some snags I've ran into while using Claude Code

For the most part, there are few cases where Claude is missing project-specific context and norms. It's also forgetting to run `gofumpt` often, so that signal is strengthened

~~For `e2e-tests`, the main issue is the skill has trouble understanding how to teardown the cluster, despite there being a script clearly named that~~

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
