### PR TITLE
sqlparser: use strings.EqualFold in IdentifierCI.EqualString

### DIFF
--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -1058,7 +1058,7 @@ func (node IdentifierCI) Equal(in IdentifierCI) bool {
 
 // EqualString performs a case-insensitive compare with str.
 func (node IdentifierCI) EqualString(str string) bool {
-	return node.Lowered() == strings.ToLower(str)
+	return strings.EqualFold(node.val, str)
 }
 
 // EqualsAnyString returns true if any of these strings match

--- a/go/vt/sqlparser/identifier_ci_bench_test.go
+++ b/go/vt/sqlparser/identifier_ci_bench_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqlparser
+
+import "testing"
+
+func BenchmarkIdentifierCI_EqualString(b *testing.B) {
+	benchmarks := []struct {
+		name  string
+		ident string
+		cmp   string
+		match bool
+	}{
+		{"short/match", "id", "ID", true},
+		{"short/nomatch", "id", "name", false},
+		{"medium/match", "column_name", "COLUMN_NAME", true},
+		{"medium/nomatch", "column_name", "table_name", false},
+		{"long/match", "some_really_long_column_name_here", "SOME_REALLY_LONG_COLUMN_NAME_HERE", true},
+		{"long/nomatch", "some_really_long_column_name_here", "another_very_long_column_name_too", false},
+	}
+
+	for _, bm := range benchmarks {
+		node := NewIdentifierCI(bm.ident)
+		b.Run(bm.name, func(b *testing.B) {
+			for b.Loop() {
+				_ = node.EqualString(bm.cmp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Replace `node.Lowered() == strings.ToLower(str)` with `strings.EqualFold(node.val, str)` in `IdentifierCI.EqualString`. The old implementation allocated a new lowercased string on every call. `strings.EqualFold` does the comparison in-place with zero allocations.

> [!NOTE]
> There's a related bug with `.Lowered()`, see https://github.com/vitessio/vitess/pull/19691

`EqualString` is called from ~29 non-test sites across the codebase. The highest-impact callers are in:

- **Query planning** (vtgate/planbuilder, vtgate/semantics) — runs before every query
- **Query normalization & rewriting** (sqlparser/ast_format*.go) — runs on query ingestion to produce normalized SQL for plan cache keys and rewritten queries sent to vttablet
- **VStreamer column lookups** (vstreamer/planbuilder.go) — runs per-row in replication streams
- **Schema column lookups** (schema/schema.go) — runs during query execution

Benchmark results (arm64):

```
                                           │ before  │             after              │
                                           │ sec/op  │   sec/op     vs base           │
IdentifierCI_EqualString/short/match-14      31.25n    2.308n  -92.61% (p=0.000 n=10)
IdentifierCI_EqualString/short/nomatch-14     5.92n    1.797n  -69.64% (p=0.000 n=10)
IdentifierCI_EqualString/medium/match-14     52.38n    7.535n  -85.61% (p=0.000 n=10)
IdentifierCI_EqualString/medium/nomatch-14   14.35n    1.807n  -87.40% (p=0.000 n=10)
IdentifierCI_EqualString/long/match-14       121.0n    20.16n  -83.33% (p=0.000 n=10)
IdentifierCI_EqualString/long/nomatch-14     36.36n    1.813n  -95.01% (p=0.000 n=10)

All match cases go from 1 alloc/op → 0 allocs/op.
```

The `nomatch` cases also improve significantly because `EqualFold` short-circuits on the first differing byte, while the old path had to call `Lowered()` (cached lookup + string comparison).

## Related Issue(s)

N/A

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

None. This is a behavioral no-op — `strings.EqualFold` performs the same case-insensitive comparison as the previous `strings.ToLower` + `==` approach for all valid SQL identifiers.

### AI Disclosure

This PR was written primarily by Claude Code.