### PR TITLE
sqlparser: eagerly compute IdentifierCI.lowered at construction

### DIFF
--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -738,7 +738,8 @@ func (node *ColName) Equal(c *ColName) bool {
 // NewIdentifierCI makes a new IdentifierCI.
 func NewIdentifierCI(str string) IdentifierCI {
 	return IdentifierCI{
-		val: str,
+		val:     str,
+		lowered: strings.ToLower(str),
 	}
 }
 
@@ -1042,12 +1043,6 @@ func (node IdentifierCI) CompliantName() string {
 // This function should generally be used only for optimizing
 // comparisons.
 func (node IdentifierCI) Lowered() string {
-	if node.val == "" {
-		return ""
-	}
-	if node.lowered == "" {
-		node.lowered = strings.ToLower(node.val)
-	}
 	return node.lowered
 }
 
@@ -1079,6 +1074,7 @@ func (node *IdentifierCI) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	node.val = result
+	node.lowered = strings.ToLower(result)
 	return nil
 }
 


### PR DESCRIPTION
## Description

`IdentifierCI.Lowered()` had a broken cache — it uses a value receiver, so the line `node.lowered = strings.ToLower(node.val)` writes to a copy that's immediately discarded. Every call to `Lowered()` unconditionally ran `strings.ToLower`, despite the code looking like it caches the result.

There are 115 call sites for `Lowered()` across 34 files (query planning, semantic analysis, normalization, VStreamer, schemadiff, etc.), all silently paying for a fresh `strings.ToLower` on every call.

### The fix

Compute `lowered` eagerly in the two construction paths (`NewIdentifierCI` and `UnmarshalJSON`). `Lowered()` becomes a simple field return.

### Why not a pointer receiver?

The obvious alternative is to make `Lowered()` a pointer receiver method so the cache actually works. We benchmarked this and it's **significantly worse** — switching to a pointer receiver causes `IdentifierCI` values to escape to the heap (the compiler can't prove the pointer doesn't outlive the value). Since `IdentifierCI` is used everywhere as a value type (in slices, struct fields, passed by value), this triggers massive heap allocation overhead:

```
                                  │     before      │    pointer receiver     │
                                  │     sec/op      │   sec/op    vs base     │
Planner/from_cases.json-gen4-14       5.902m ± 29%   8.352m ± 24%  +41.51%
Planner/filter_cases.json-gen4-14     102.2m ±  2%   141.3m ± 10%  +38.21%
geomean                               5.665m         6.313m        +11.46%
```

### Tradeoff: parsing vs planning

This change moves the `strings.ToLower` cost from `Lowered()` call sites to identifier construction time in `NewIdentifierCI`. The per-query hot path is: parse → normalize → format → plan cache lookup. Here's how each stage is affected:

- **Parsing** creates identifiers via `NewIdentifierCI`, so it now pays `strings.ToLower` upfront for each one. This adds ~4% to parse micro-benchmarks.
- **Normalization** calls `Lowered()` but only for system variable and function rewrites (`sysVarRewrite`, `funcRewrite`) — not for every identifier. The `BenchmarkNormalize` result shows no measurable change.
- **Formatting** (`sqlparser.String`) runs on most DML/DQL to produce the plan cache key, but its only `Lowered()` call is for the `ORDER BY rand()` edge case — effectively zero impact.
- **Plan cache lookup** doesn't involve `Lowered()` at all.
- **Planning** (cache miss only) calls `Lowered()` heavily across semantic analysis, plan building, and operator construction. This is where the savings land: 10-13% on significant BenchmarkPlanner cases.

Since planning only runs on cache misses while parsing runs on every query, the net effect depends on cache hit rate. For workloads with a warm plan cache, the ~4% parse regression applies to every query while the planning improvement is rarely exercised. For cold-start, cache churn, or diverse-query workloads, the planning savings dominate.

**Query planning** (BenchmarkPlanner, cache miss path):
```
                                  │     before      │       eager compute          │
                                  │     sec/op      │   sec/op     vs base         │
Planner/filter_cases.json-gen4-14     102.22m ±  2%   88.76m ±  4%  -13.16% (p=0.000)
Planner/large_cases.json-gen4-14      177.3µ  ±  4%   159.4µ ±  4%  -10.09% (p=0.000)

                                  │   allocs/op     │ allocs/op   vs base          │
Planner/from_cases.json-gen4-14       96.09k ± 0%     95.73k ± 0%  -0.37% (p=0.000)
Planner/filter_cases.json-gen4-14     480.0k ± 0%     479.1k ± 0%  -0.18% (p=0.000)
Planner/aggr_cases.json-gen4-14       154.9k ± 0%     153.8k ± 0%  -0.69% (p=0.000)
Planner/union_cases.json-gen4-14      51.66k ± 0%     51.09k ± 0%  -1.10% (p=0.000)
```

**Query parsing** (every query):
```
                                  │     before      │       eager compute          │
                                  │     sec/op      │   sec/op     vs base         │
Normalize-14                          1.679µ ± 23%    1.629µ ± 16%       ~ (p=0.143)
ParseStress/sql0-14                   2.692µ ±  3%    2.851µ ±  4%  +5.91% (p=0.000)
ParseStress/sql1-14                   8.285µ ±  3%    8.586µ ±  7%  +3.63% (p=0.009)
Parse3/normal-14                      1.500m ±  3%    1.566m ±  2%  +4.39% (p=0.005)
```

## Related Issue(s)

N/A

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

This PR was written primarily by Claude Code.