### PR TITLE
ci: use `bash -e {0}` in composite actions 

### DIFF
--- a/.github/actions/setup-minio/action.yml
+++ b/.github/actions/setup-minio/action.yml
@@ -12,7 +12,7 @@ runs:
 
     - name: Get Minio (on cache miss)
       if: steps.cache-minio.outputs.cache-hit != 'true'
-      shell: bash
+      shell: bash -e {0}
       run: |
         curl -sLo minio_20250907161309.0.0_amd64.deb.tmp https://dl.min.io/community/server/minio/release/linux-amd64/minio_20250907161309.0.0_amd64.deb
 
@@ -21,7 +21,7 @@ runs:
         [[ "$?" -eq 0 ]] && mv minio_20250907161309.0.0_amd64.deb.tmp minio_20250907161309.0.0_amd64.deb
 
     - name: Install Minio package
-      shell: bash
+      shell: bash -e {0}
       run: |
         sudo dpkg -i minio_20250907161309.0.0_amd64.deb
         sudo systemctl disable minio

--- a/.github/actions/setup-mysql/action.yml
+++ b/.github/actions/setup-mysql/action.yml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup MySQL
-      shell: bash
+      shell: bash -e {0}
       run: |
         export DEBIAN_FRONTEND="noninteractive"
         sudo apt-get update

--- a/.github/actions/setup-percona-repo/action.yml
+++ b/.github/actions/setup-percona-repo/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Build weekly cache key
-      shell: bash
+      shell: bash -e {0}
       run: echo "PERCONA_RELEASE_CACHE_WEEK=$(date +%G-%V)" >> "$GITHUB_ENV"
 
     - name: Cache percona-release package
@@ -16,12 +16,12 @@ runs:
 
     - name: Get Percona Apt Repo package (on cache miss)
       if: steps.cache-percona-release.outputs.cache-hit != 'true'
-      shell: bash
+      shell: bash -e {0}
       run: |
         curl -sLo percona-release_latest.deb https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
 
     - name: Install Percona Apt Repo package
-      shell: bash
+      shell: bash -e {0}
       run: |
         sudo apt-get -qq install -y gnupg2 lsb-release
         sudo DEBIAN_FRONTEND="noninteractive" dpkg -i percona-release_latest.deb

--- a/.github/actions/tune-os/action.yml
+++ b/.github/actions/tune-os/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Tune the OS
-      shell: bash
+      shell: bash -e {0}
       run: |
         # Install eatmydata and ensure it's used for every operation
         sudo apt-get update && sudo apt-get install -y eatmydata


### PR DESCRIPTION
## Description

Steps in composite actions require explicitly specifying the shell that should be used. Contrary to what one might expect, `shell: bash` is not the same as the "default" shell setting in "regular" workflow steps (`bash -e {0}`).

This meant that failures in the composite action steps didn't fail the composite action, causing the job to continue with a potentially broken environment.

This replaces `shell: bash` with `shell: bash -e {0}` so errors are properly caught.

---

I noticed this with some builds where installing `libaio` failed (https://github.com/vitessio/vitess/actions/runs/23517002990/job/68506990848?pr=19675), but the build carried on and would fail way, way later in the process.

I think it's better to fail early and not waste CI resources.

## Related Issue(s)

N/A

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

This PR was written primarily by Claude Code.