### PR TITLE
ci: add workflow to rerun failed CI jobs on open PRs 

### DIFF
--- a/.github/workflows/ci-rerun.yml
+++ b/.github/workflows/ci-rerun.yml
@@ -21,6 +21,7 @@ on:
 
 concurrency:
   group: ci-rerun
+  cancel-in-progress: true
 
 permissions:
   actions: write


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
Replaces the external actions auto-retry with an in-repo GitHub Actions workflow. Runs on a 10-minute cron like the other one. This helps us have more visibility on when our runs do or don't get retried.

Here's an example run from my fork: https://github.com/mhamza15/vitess/actions/runs/23565834813/job/68617026649. It errors since the actions token wouldn't have permissions for this repo.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->

Help from Claude Opus 4.6.