### PR TITLE
`ci`: set dependabot group name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,7 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      vtadmin-npm:
         patterns:
           - "*"
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This PR changes the `all` group names in `.github/dependabot.yml` to contain more context

This will result in less-confusing PR titles. Currently PRs are opened with `Bump the all group ...`, whereas this PR will cause the PRs to be titled `Bump the docker group...` for docker, for example

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
