### PR TITLE
`ci`: skip Code Coverage CI on backports

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -17,6 +17,7 @@ permissions: read-all
 
 jobs:
   test:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'Backport')
     name: Code Coverage
     runs-on: oracle-vm-8cpu-32gb-x86-64
 


### PR DESCRIPTION
## Description

Skips the Code Coverage CI workflow on PRs with the `Backport` label. The code is already shipped so there's not much value in checking coverage on backports — it just wastes CI resources.

Adds a condition to the `codecov.yml` workflow job:

```yaml
if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'Backport')
```

Non-PR events (like pushes) still run as usual.

## Related Issue(s)

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

### AI Disclosure

PR description written by Claude Code.