### PR TITLE
VTOp: Add support for cluster and keyspace level backup schedules

### DIFF
--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -7988,8 +7988,7 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: vitess-operator
-          image: vitess-operator-pr:latest
-          imagePullPolicy: Never
+          image: planetscale/vitess-operator:latest
           name: vitess-operator
           resources:
             limits:


### PR DESCRIPTION
## Description

This adds the updated operator with support for cluster and keyspace level backup schedules.

## Related Issue(s)

  - Follow-up to: https://github.com/planetscale/vitess-operator/pull/758

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
