### PR TITLE
docker: add arm64 support to `install_dependencies.sh`

### DIFF
--- a/docker/utils/install_dependencies.sh
+++ b/docker/utils/install_dependencies.sh
@@ -68,6 +68,35 @@ percona_mysql_shell_package() {
 	printf 'percona-mysql-shell=%s-1-1.%s\n' "${version}" "${DEBIAN_CODENAME}"
 }
 
+# Oracle's Debian repo does not publish arm64 .deb packages for the MySQL
+# flavors we use here, so on arm64 we install `mysql80` and `mysql84` from
+# Oracle's generic aarch64 tarballs and pair them with Percona's arm64
+# `percona-mysql-shell` and xtrabackup packages.
+#
+# Those Oracle tarballs still link against libaio.so.1, but trixie's t64
+# transition renamed the packaged soname to libaio.so.1t64. Create a
+# compatibility symlink so the tarball-installed mysqld starts successfully on
+# arm64 trixie images.
+ensure_mysql_tarball_compat() {
+	local libdir="/usr/lib/aarch64-linux-gnu"
+
+	if [[ "${ARCH}" != "arm64" ]]; then
+		return
+	fi
+
+	if [[ "${FLAVOR}" != "mysql80" && "${FLAVOR}" != "mysql84" ]]; then
+		return
+	fi
+
+	if [[ "${LIBAIO}" != "libaio1t64" ]]; then
+		return
+	fi
+
+	if [[ ! -e "${libdir}/libaio.so.1" ]]; then
+		ln -s "${libdir}/libaio.so.1t64" "${libdir}/libaio.so.1"
+	fi
+}
+
 # Install base packages that are common to all flavors.
 BASE_PACKAGES=(
 	bzip2
@@ -95,6 +124,7 @@ BASE_PACKAGES=(
 
 apt-get update
 apt-get install -y --no-install-recommends "${BASE_PACKAGES[@]}"
+ensure_mysql_tarball_compat
 
 # Packages specific to certain flavors.
 case "${FLAVOR}" in


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
The lite dependency installer only supported amd64 MySQL/Precona. Oracle's Debian repo does not publish arm64 .deb packages for `mysql80` and `mysql84`, and it also does not provide matching `mysql-shell` Debian packages on arm64. This changes the script to detect arm64, install those MySQL flavors from Oracle's generic aarch64 tarballs, use Percona's arm64 repos for `percona-mysql-shell` and xtrabackup, and keep the existing amd64 and Percona package flows in place.

This is mostly so it can be ran locally on ARM Macs without emulation.
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->

Help from Codex 5.4.