### PR TITLE
vtgate: route inserts on pinned sharded tables to their pinned shard

### DIFF
--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -94,6 +94,9 @@ func newInsert(
 	}
 	if table != nil {
 		ins.TableName = table.Name.String()
+		if keyspace != nil && keyspace.Sharded && table.Pinned != nil {
+			ins.TargetDestination = key.DestinationKeyspaceID(table.Pinned)
+		}
 		for _, colVindex := range table.ColumnVindexes {
 			if colVindex.IsPartialVindex() {
 				continue
@@ -142,6 +145,9 @@ func (ins *Insert) insertIntoShardedTable(
 	insertID, err := ins.processGenerateFromValues(ctx, vcursor, ins, bindVars)
 	if err != nil {
 		return nil, err
+	}
+	if ins.TargetDestination != nil {
+		return ins.executeByDestinationTableQuery(ctx, vcursor, ins, bindVars, ins.Query, ins.TargetDestination, uint64(insertID))
 	}
 	rss, queries, err := ins.getInsertShardedQueries(ctx, vcursor, bindVars)
 	if err != nil {
@@ -381,10 +387,11 @@ func (ins *Insert) description() PrimitiveDescription {
 	}
 
 	return PrimitiveDescription{
-		OperatorType: "Insert",
-		Keyspace:     ins.Keyspace,
-		Variant:      ins.Opcode.String(),
-		Other:        other,
+		OperatorType:      "Insert",
+		Keyspace:          ins.Keyspace,
+		TargetDestination: ins.TargetDestination,
+		Variant:           ins.Opcode.String(),
+		Other:             other,
 	}
 }
 

--- a/go/vt/vtgate/engine/insert_common.go
+++ b/go/vt/vtgate/engine/insert_common.go
@@ -46,6 +46,10 @@ type (
 		// Keyspace specifies the keyspace to send the query to.
 		Keyspace *vindexes.Keyspace
 
+		// TargetDestination specifies a fixed shard destination for inserts that
+		// do not need vindex evaluation, such as pinned tables in sharded keyspaces.
+		TargetDestination key.ShardDestination
+
 		// Ignore is for INSERT IGNORE and INSERT...ON DUPLICATE KEY constructs
 		// for sharded cases.
 		Ignore bool
@@ -155,6 +159,30 @@ func (ins *InsertCommon) executeUnshardedTableQuery(ctx context.Context, vcursor
 	// any ids that MySQL might have generated. If both generated
 	// values, we don't return an error because this behavior
 	// is required to support migration.
+	if insertID != 0 {
+		qr.InsertIDChanged = true
+		qr.InsertID = insertID
+	}
+	return qr, nil
+}
+
+func (ins *InsertCommon) executeByDestinationTableQuery(ctx context.Context, vcursor VCursor, loggingPrimitive Primitive, bindVars map[string]*querypb.BindVariable, query string, destination key.ShardDestination, insertID uint64) (*sqltypes.Result, error) {
+	rss, _, err := vcursor.ResolveDestinations(ctx, ins.Keyspace.Name, nil, []key.ShardDestination{destination})
+	if err != nil {
+		return nil, err
+	}
+	if len(rss) != 1 {
+		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "Destination does not have exactly one shard: %v", rss)
+	}
+	err = allowOnlyPrimary(rss...)
+	if err != nil {
+		return nil, err
+	}
+	qr, err := execShard(ctx, loggingPrimitive, vcursor, query, bindVars, rss[0], true, !ins.PreventAutoCommit /* canAutocommit */, ins.FetchLastInsertID)
+	if err != nil {
+		return nil, err
+	}
+
 	if insertID != 0 {
 		qr.InsertIDChanged = true
 		qr.InsertID = insertID

--- a/go/vt/vtgate/engine/insert_select.go
+++ b/go/vt/vtgate/engine/insert_select.go
@@ -72,6 +72,9 @@ func newInsertSelect(
 	}
 	if table != nil {
 		ins.TableName = table.Name.String()
+		if keyspace != nil && keyspace.Sharded && table.Pinned != nil {
+			ins.TargetDestination = key.DestinationKeyspaceID(table.Pinned)
+		}
 		for _, colVindex := range table.ColumnVindexes {
 			if colVindex.IsPartialVindex() {
 				continue
@@ -176,6 +179,10 @@ func (ins *InsertSelect) insertIntoShardedTable(
 	bindVars map[string]*querypb.BindVariable,
 	irr insertRowsResult,
 ) (*sqltypes.Result, error) {
+	if ins.TargetDestination != nil {
+		query := ins.getInsertUnshardedQuery(irr.rows, bindVars)
+		return ins.executeByDestinationTableQuery(ctx, vcursor, ins, bindVars, query, ins.TargetDestination, irr.insertID)
+	}
 	rss, queries, err := ins.getInsertShardedQueries(ctx, vcursor, bindVars, irr.rows)
 	if err != nil {
 		return nil, err
@@ -329,10 +336,11 @@ func (ins *InsertSelect) description() PrimitiveDescription {
 	}
 
 	return PrimitiveDescription{
-		OperatorType: "Insert",
-		Keyspace:     ins.Keyspace,
-		Variant:      "Select",
-		Other:        other,
+		OperatorType:      "Insert",
+		Keyspace:          ins.Keyspace,
+		TargetDestination: ins.TargetDestination,
+		Variant:           "Select",
+		Other:             other,
 	}
 }
 

--- a/go/vt/vtgate/engine/insert_test.go
+++ b/go/vt/vtgate/engine/insert_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/key"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
@@ -172,6 +173,27 @@ func TestInsertUnshardedGenerate_Zeros(t *testing.T) {
 
 	// The insert id returned by ExecuteMultiShard should be overwritten by processGenerateFromValues.
 	expectResult(t, result, &sqltypes.Result{InsertID: 4})
+}
+
+func TestInsertShardedPinned(t *testing.T) {
+	ins := newQueryInsert(
+		InsertSharded,
+		&vindexes.Keyspace{
+			Name:    "sharded",
+			Sharded: true,
+		},
+		"insert into t1(vkey, pkey) values (71, 81000)",
+	)
+	ins.TargetDestination = key.DestinationKeyspaceID([]byte{0x00})
+
+	vc := newTestVCursor("-20", "20-")
+
+	_, err := ins.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+	vc.ExpectLog(t, []string{
+		`ResolveDestinations sharded [] Destinations:DestinationKeyspaceID(00)`,
+		`ExecuteMultiShard sharded.-20: insert into t1(vkey, pkey) values (71, 81000) {} true true`,
+	})
 }
 
 func TestInsertShardedSimple(t *testing.T) {

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -2380,6 +2380,29 @@ func TestInsertBadAutoInc(t *testing.T) {
 	}
 }
 
+func TestInsertPinnedTable(t *testing.T) {
+	vschema := `
+{
+	"sharded": true,
+	"tables": {
+		"t1": {
+			"pinned": "00"
+		}
+	}
+}
+`
+	executor, sbc1, sbc2, _, ctx := createCustomExecutor(t, vschema, config.DefaultMySQLVersion)
+
+	_, err := executorExec(ctx, executor, &vtgatepb.Session{}, "insert into t1(vkey, pkey) values (71, 81000)", nil)
+	require.NoError(t, err)
+
+	assertQueries(t, sbc1, []*querypb.BoundQuery{{
+		Sql:           "insert into t1(vkey, pkey) values (71, 81000)",
+		BindVariables: map[string]*querypb.BindVariable{},
+	}})
+	assertQueries(t, sbc2, nil)
+}
+
 func TestKeyDestRangeQuery(t *testing.T) {
 	type testCase struct {
 		inputQuery, targetString string

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -199,16 +199,20 @@ func transformInsertionSelection(ctx *plancontext.PlanningContext, op *operators
 	}
 
 	ins := dmlOp.(*operators.Insert)
+	ic := engine.InsertCommon{
+		Keyspace:          rb.Routing.Keyspace(),
+		TableName:         ins.VTable.Name.String(),
+		Ignore:            ins.Ignore,
+		ForceNonStreaming:  op.ForceNonStreaming,
+		Generate:          autoIncGenerate(ins.AutoIncrement),
+		ColVindexes:       ins.ColVindexes,
+		FetchLastInsertID: ctx.SemTable.ShouldFetchLastInsertID(),
+	}
+	if len(ins.ColVindexes) == 0 && ins.VTable.Pinned != nil {
+		ic.TargetDestination = key.DestinationKeyspaceID(ins.VTable.Pinned)
+	}
 	eins := &engine.InsertSelect{
-		InsertCommon: engine.InsertCommon{
-			Keyspace:          rb.Routing.Keyspace(),
-			TableName:         ins.VTable.Name.String(),
-			Ignore:            ins.Ignore,
-			ForceNonStreaming: op.ForceNonStreaming,
-			Generate:          autoIncGenerate(ins.AutoIncrement),
-			ColVindexes:       ins.ColVindexes,
-			FetchLastInsertID: ctx.SemTable.ShouldFetchLastInsertID(),
-		},
+		InsertCommon:      ic,
 		VindexValueOffset: ins.VindexValueOffset,
 	}
 

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -24,6 +24,7 @@ import (
 
 	"vitess.io/vitess/go/slice"
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/sysvars"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -679,6 +680,9 @@ func buildInsertPrimitive(
 		Generate:          autoIncGenerate(ins.AutoIncrement),
 		ColVindexes:       ins.ColVindexes,
 		FetchLastInsertID: ctx.SemTable.ShouldFetchLastInsertID(),
+	}
+	if len(ins.ColVindexes) == 0 && ins.VTable.Pinned != nil {
+		ic.TargetDestination = key.DestinationKeyspaceID(ins.VTable.Pinned)
 	}
 	if hints != nil {
 		ic.MultiShardAutocommit = hints.multiShardAutocommit


### PR DESCRIPTION
## Description

This PR fixes inserts for pinned tables in sharded keyspaces.

Pinned tables already carry a fixed keyspace id in the vschema, and generic sharded routing already treats them as single-shard `EqualUnique` routes. The insert pipeline was bypassing that routing path and unconditionally requiring primary vindex values, which caused `INSERT` into pinned tables to fail with `VT09001`.

This change carries the pinned destination through insert planning and execution, then routes inserts directly to the pinned shard when there are no insert vindex columns to evaluate. Regression coverage was added in both the engine and vtgate executor tests.

## Related Issue(s)

Fixes #19529

## Checklist

-   [x] "Backport to:" labels not necessary, not applied
-   [x] Not backported, so no backport justification provided
-   [x] Tests were added
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation is not required

## Deployment Notes

None.

### AI Disclosure

This PR was written with assistance from OpenAI Codex. I reviewed the final diff and local test results.
