### PR TITLE
mysqlctl: expose SOURCE_RETRY_COUNT through --replication-retry-count

### DIFF
--- a/go/cmd/vttablet/cli/cli.go
+++ b/go/cmd/vttablet/cli/cli.go
@@ -84,6 +84,7 @@ Even if a MySQL is external, you can still make vttablet perform some management
 ` +
 			"* `--unmanaged`: This flag indicates that this tablet is running in unmanaged mode. In this mode, any reparent or replica commands are not allowed. These are InitShardPrimary, PlannedReparentShard, EmergencyReparentShard, and ReparentTablet. You should use the TabletExternallyReparented command to inform vitess of the current primary.\n" +
 			"* `--replication-connect-retry`: This value is give to mysql when it connects a replica to the primary as the retry duration parameter.\n" +
+			"* `--replication-retry-count`: This value is given to mysql when it connects a replica to the primary as the retry count parameter.\n" +
 			"* `--heartbeat-enable` and `--heartbeat-interval duration`: cause vttablet to write heartbeats to the sidecar database. This information is also used by the replication reporter to assess replica lag.\n",
 		Example: `
 vttablet \

--- a/go/cmd/vttablet/cli/cli.go
+++ b/go/cmd/vttablet/cli/cli.go
@@ -84,7 +84,7 @@ Even if a MySQL is external, you can still make vttablet perform some management
 ` +
 			"* `--unmanaged`: This flag indicates that this tablet is running in unmanaged mode. In this mode, any reparent or replica commands are not allowed. These are InitShardPrimary, PlannedReparentShard, EmergencyReparentShard, and ReparentTablet. You should use the TabletExternallyReparented command to inform vitess of the current primary.\n" +
 			"* `--replication-connect-retry`: This value is give to mysql when it connects a replica to the primary as the retry duration parameter.\n" +
-			"* `--replication-retry-count`: This value is given to mysql when it connects a replica to the primary as the retry count parameter.\n" +
+			"* `--replication-retry-count`: This value is given to mysql when it connects a replica to the primary as the retry count parameter. If unset, MySQL's default is used; 0 means unlimited retries.\n" +
 			"* `--heartbeat-enable` and `--heartbeat-interval duration`: cause vttablet to write heartbeats to the sidecar database. This information is also used by the replication reporter to assess replica lag.\n",
 		Example: `
 vttablet \

--- a/go/flags/endtoend/mysqlctl.txt
+++ b/go/flags/endtoend/mysqlctl.txt
@@ -83,7 +83,7 @@ Flags:
       --pprof-http                                                  enable pprof http endpoints
       --purge-logs-interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication-connect-retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
-      --replication-retry-count int                                 how many times a replica should retry reconnecting to the primary before giving up. 0 leaves MySQL's default unchanged.
+      --replication-retry-count int                                 how many times a replica should retry reconnecting to the primary before giving up. 0 means unlimited retries. If unset, MySQL's default is used.
       --security-policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --service-map strings                                         comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
       --socket-file string                                          Local unix socket file to listen on

--- a/go/flags/endtoend/mysqlctl.txt
+++ b/go/flags/endtoend/mysqlctl.txt
@@ -83,6 +83,7 @@ Flags:
       --pprof-http                                                  enable pprof http endpoints
       --purge-logs-interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication-connect-retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
+      --replication-retry-count int                                 how many times a replica should retry reconnecting to the primary before giving up. 0 leaves MySQL's default unchanged.
       --security-policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --service-map strings                                         comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
       --socket-file string                                          Local unix socket file to listen on

--- a/go/flags/endtoend/mysqlctld.txt
+++ b/go/flags/endtoend/mysqlctld.txt
@@ -112,6 +112,7 @@ Flags:
       --pprof-http                                                       enable pprof http endpoints
       --purge-logs-interval duration                                     how often try to remove old logs (default 1h0m0s)
       --replication-connect-retry duration                               how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
+      --replication-retry-count int                                      how many times a replica should retry reconnecting to the primary before giving up. 0 leaves MySQL's default unchanged.
       --security-policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --service-map strings                                              comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
       --shutdown-wait-time duration                                      How long to wait for mysqld shutdown (default 5m0s)

--- a/go/flags/endtoend/mysqlctld.txt
+++ b/go/flags/endtoend/mysqlctld.txt
@@ -112,7 +112,7 @@ Flags:
       --pprof-http                                                       enable pprof http endpoints
       --purge-logs-interval duration                                     how often try to remove old logs (default 1h0m0s)
       --replication-connect-retry duration                               how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
-      --replication-retry-count int                                      how many times a replica should retry reconnecting to the primary before giving up. 0 leaves MySQL's default unchanged.
+      --replication-retry-count int                                      how many times a replica should retry reconnecting to the primary before giving up. 0 means unlimited retries. If unset, MySQL's default is used.
       --security-policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --service-map strings                                              comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
       --shutdown-wait-time duration                                      How long to wait for mysqld shutdown (default 5m0s)

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -324,6 +324,7 @@ Flags:
       --relay-log-max-size int                                           Maximum buffer size (in bytes) for vreplication target buffering. If single rows are larger than this, a single row is buffered at a time. (default 250000)
       --remote-operation-timeout duration                                time to wait for a remote operation (default 15s)
       --replication-connect-retry duration                               how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
+      --replication-retry-count int                                      how many times a replica should retry reconnecting to the primary before giving up. 0 leaves MySQL's default unchanged.
       --restore-concurrency int                                          (init restore parameter) how many concurrent files to restore at once (default 4)
       --restore-from-backup                                              (init restore parameter) will check BackupStorage for a recent backup at startup and start there
       --restore-from-backup-allowed-engines strings                      (init restore parameter) if set, only backups taken with the specified engines are eligible to be restored

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -324,7 +324,7 @@ Flags:
       --relay-log-max-size int                                           Maximum buffer size (in bytes) for vreplication target buffering. If single rows are larger than this, a single row is buffered at a time. (default 250000)
       --remote-operation-timeout duration                                time to wait for a remote operation (default 15s)
       --replication-connect-retry duration                               how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
-      --replication-retry-count int                                      how many times a replica should retry reconnecting to the primary before giving up. 0 leaves MySQL's default unchanged.
+      --replication-retry-count int                                      how many times a replica should retry reconnecting to the primary before giving up. 0 means unlimited retries. If unset, MySQL's default is used.
       --restore-concurrency int                                          (init restore parameter) how many concurrent files to restore at once (default 4)
       --restore-from-backup                                              (init restore parameter) will check BackupStorage for a recent backup at startup and start there
       --restore-from-backup-allowed-engines strings                      (init restore parameter) if set, only backups taken with the specified engines are eligible to be restored

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -19,7 +19,7 @@ Even if a MySQL is external, you can still make vttablet perform some management
 
 * `--unmanaged`: This flag indicates that this tablet is running in unmanaged mode. In this mode, any reparent or replica commands are not allowed. These are InitShardPrimary, PlannedReparentShard, EmergencyReparentShard, and ReparentTablet. You should use the TabletExternallyReparented command to inform vitess of the current primary.
 * `--replication-connect-retry`: This value is give to mysql when it connects a replica to the primary as the retry duration parameter.
-* `--replication-retry-count`: This value is given to mysql when it connects a replica to the primary as the retry count parameter.
+* `--replication-retry-count`: This value is given to mysql when it connects a replica to the primary as the retry count parameter. If unset, MySQL's default is used; 0 means unlimited retries.
 * `--heartbeat-enable` and `--heartbeat-interval duration`: cause vttablet to write heartbeats to the sidecar database. This information is also used by the replication reporter to assess replica lag.
 
 Usage:
@@ -314,7 +314,7 @@ Flags:
       --relay-log-max-size int                                           Maximum buffer size (in bytes) for vreplication target buffering. If single rows are larger than this, a single row is buffered at a time. (default 250000)
       --remote-operation-timeout duration                                time to wait for a remote operation (default 15s)
       --replication-connect-retry duration                               how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
-      --replication-retry-count int                                      how many times a replica should retry reconnecting to the primary before giving up. 0 leaves MySQL's default unchanged.
+      --replication-retry-count int                                      how many times a replica should retry reconnecting to the primary before giving up. 0 means unlimited retries. If unset, MySQL's default is used.
       --restore-concurrency int                                          (init restore parameter) how many concurrent files to restore at once (default 4)
       --restore-from-backup                                              (init restore parameter) will check BackupStorage for a recent backup at startup and start there
       --restore-from-backup-allowed-engines strings                      (init restore parameter) if set, only backups taken with the specified engines are eligible to be restored

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -19,6 +19,7 @@ Even if a MySQL is external, you can still make vttablet perform some management
 
 * `--unmanaged`: This flag indicates that this tablet is running in unmanaged mode. In this mode, any reparent or replica commands are not allowed. These are InitShardPrimary, PlannedReparentShard, EmergencyReparentShard, and ReparentTablet. You should use the TabletExternallyReparented command to inform vitess of the current primary.
 * `--replication-connect-retry`: This value is give to mysql when it connects a replica to the primary as the retry duration parameter.
+* `--replication-retry-count`: This value is given to mysql when it connects a replica to the primary as the retry count parameter.
 * `--heartbeat-enable` and `--heartbeat-interval duration`: cause vttablet to write heartbeats to the sidecar database. This information is also used by the replication reporter to assess replica lag.
 
 Usage:
@@ -313,6 +314,7 @@ Flags:
       --relay-log-max-size int                                           Maximum buffer size (in bytes) for vreplication target buffering. If single rows are larger than this, a single row is buffered at a time. (default 250000)
       --remote-operation-timeout duration                                time to wait for a remote operation (default 15s)
       --replication-connect-retry duration                               how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
+      --replication-retry-count int                                      how many times a replica should retry reconnecting to the primary before giving up. 0 leaves MySQL's default unchanged.
       --restore-concurrency int                                          (init restore parameter) how many concurrent files to restore at once (default 4)
       --restore-from-backup                                              (init restore parameter) will check BackupStorage for a recent backup at startup and start there
       --restore-from-backup-allowed-engines strings                      (init restore parameter) if set, only backups taken with the specified engines are eligible to be restored

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -123,6 +123,7 @@ Flags:
       --rdonly-count int                                                 Rdonly tablets per shard (default 1)
       --replica-count int                                                Replica tablets per shard (includes primary) (default 2)
       --replication-connect-retry duration                               how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
+      --replication-retry-count int                                      how many times a replica should retry reconnecting to the primary before giving up. 0 leaves MySQL's default unchanged.
       --rng-seed int                                                     The random number generator seed to use when initializing with random data (see also --initialize-with-random-data). Multiple runs with the same seed will result with the same initial data. (default 123)
       --schema-dir string                                                Directory for initial schema files. Within this dir, there should be a subdir for each keyspace. Within each keyspace dir, each file is executed as SQL after the database is created on each shard. If the directory contains a vschema.json file, it will be used as the vschema for the V3 API.
       --security-policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -123,7 +123,7 @@ Flags:
       --rdonly-count int                                                 Rdonly tablets per shard (default 1)
       --replica-count int                                                Replica tablets per shard (includes primary) (default 2)
       --replication-connect-retry duration                               how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
-      --replication-retry-count int                                      how many times a replica should retry reconnecting to the primary before giving up. 0 leaves MySQL's default unchanged.
+      --replication-retry-count int                                      how many times a replica should retry reconnecting to the primary before giving up. 0 means unlimited retries. If unset, MySQL's default is used.
       --rng-seed int                                                     The random number generator seed to use when initializing with random data (see also --initialize-with-random-data). Multiple runs with the same seed will result with the same initial data. (default 123)
       --schema-dir string                                                Directory for initial schema files. Within this dir, there should be a subdir for each keyspace. Within each keyspace dir, each file is executed as SQL after the database is created on each shard. If the directory contains a vschema.json file, it will be used as the vschema for the V3 API.
       --security-policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -402,8 +402,25 @@ func (c *Conn) SetReplicationPositionCommands(pos replication.Position) []string
 // as the new replication source (without changing any GTID position).
 // It is guaranteed to be called with replication stopped.
 // It should not start or stop replication.
-func (c *Conn) SetReplicationSourceCommand(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int, retryCount int) string {
-	return c.flavor.setReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry, retryCount)
+func (c *Conn) SetReplicationSourceCommand(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int) string {
+	return c.SetReplicationSourceCommandWithRetry(params, host, port, heartbeatInterval, connectRetry, 0)
+}
+
+func (c *Conn) SetReplicationSourceCommandWithRetry(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int, retryCount int) string {
+	return c.flavor.setReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry, c.replicationSourceRetryCount(retryCount))
+}
+
+func (c *Conn) replicationSourceRetryCount(retryCount int) int {
+	if retryCount <= 0 || !c.IsMariaDB() {
+		return retryCount
+	}
+
+	atLeast, err := c.ServerVersionAtLeast(12, 0, 1)
+	if err != nil || !atLeast {
+		return 0
+	}
+
+	return retryCount
 }
 
 // resultToMap is a helper function used by ShowReplicationStatus.

--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -19,7 +19,6 @@ package mysql
 import (
 	"context"
 	"errors"
-	"strconv"
 	"strings"
 
 	"vitess.io/vitess/go/mysql/capabilities"
@@ -197,8 +196,8 @@ func GetFlavor(serverVersion string, flavorFunc func(serverVersion string) flavo
 		canonicalVersion = serverVersion[len(mariaDBReplicationHackPrefix):]
 		f = mariadbFlavor101{mariadbFlavor{serverVersion: canonicalVersion}}
 	case strings.Contains(serverVersion, mariaDBVersionString):
-		mariadbVersion, err := strconv.ParseFloat(serverVersion[:4], 64)
-		if err != nil || mariadbVersion < 10.2 {
+		atLeast, err := capabilities.ServerVersionAtLeast(canonicalVersion, 10, 2, 0)
+		if err != nil || !atLeast {
 			f = mariadbFlavor101{mariadbFlavor{serverVersion: canonicalVersion}}
 		} else {
 			f = mariadbFlavor102{mariadbFlavor{serverVersion: canonicalVersion}}
@@ -399,12 +398,16 @@ func (c *Conn) SetReplicationPositionCommands(pos replication.Position) []string
 
 // SetReplicationSourceCommand returns the command to use the provided host/port
 // as the new replication source (without changing any GTID position).
+// It preserves the historical behavior of omitting an explicit retry-count clause.
 // It is guaranteed to be called with replication stopped.
 // It should not start or stop replication.
 func (c *Conn) SetReplicationSourceCommand(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int) string {
-	return c.SetReplicationSourceCommandWithRetry(params, host, port, heartbeatInterval, connectRetry, 0)
+	return c.SetReplicationSourceCommandWithRetry(params, host, port, heartbeatInterval, connectRetry, -1)
 }
 
+// SetReplicationSourceCommandWithRetry returns the command to use the provided host/port
+// as the new replication source (without changing any GTID position).
+// A negative retryCount omits the retry-count clause and leaves the server default unchanged.
 func (c *Conn) SetReplicationSourceCommandWithRetry(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int, retryCount int) string {
 	return c.flavor.setReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry, retryCount)
 }

--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -133,7 +133,7 @@ type flavor interface {
 
 	// setReplicationSourceCommand returns the command to use the provided host/port
 	// as the new replication source (without changing any GTID position).
-	setReplicationSourceCommand(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int) string
+	setReplicationSourceCommand(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int, retryCount int) string
 
 	// resetBinaryLogsCommand returns the command to reset the binary logs.
 	resetBinaryLogsCommand() string
@@ -402,8 +402,8 @@ func (c *Conn) SetReplicationPositionCommands(pos replication.Position) []string
 // as the new replication source (without changing any GTID position).
 // It is guaranteed to be called with replication stopped.
 // It should not start or stop replication.
-func (c *Conn) SetReplicationSourceCommand(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int) string {
-	return c.flavor.setReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry)
+func (c *Conn) SetReplicationSourceCommand(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int, retryCount int) string {
+	return c.flavor.setReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry, retryCount)
 }
 
 // resultToMap is a helper function used by ShowReplicationStatus.

--- a/go/mysql/flavor.go
+++ b/go/mysql/flavor.go
@@ -19,7 +19,6 @@ package mysql
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -200,9 +199,9 @@ func GetFlavor(serverVersion string, flavorFunc func(serverVersion string) flavo
 	case strings.Contains(serverVersion, mariaDBVersionString):
 		mariadbVersion, err := strconv.ParseFloat(serverVersion[:4], 64)
 		if err != nil || mariadbVersion < 10.2 {
-			f = mariadbFlavor101{mariadbFlavor{serverVersion: fmt.Sprintf("%f", mariadbVersion)}}
+			f = mariadbFlavor101{mariadbFlavor{serverVersion: canonicalVersion}}
 		} else {
-			f = mariadbFlavor102{mariadbFlavor{serverVersion: fmt.Sprintf("%f", mariadbVersion)}}
+			f = mariadbFlavor102{mariadbFlavor{serverVersion: canonicalVersion}}
 		}
 	case strings.HasPrefix(serverVersion, mysql8VersionPrefix):
 		if latest, _ := capabilities.ServerVersionAtLeast(serverVersion, 8, 2, 0); latest {
@@ -407,20 +406,7 @@ func (c *Conn) SetReplicationSourceCommand(params *ConnParams, host string, port
 }
 
 func (c *Conn) SetReplicationSourceCommandWithRetry(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int, retryCount int) string {
-	return c.flavor.setReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry, c.replicationSourceRetryCount(retryCount))
-}
-
-func (c *Conn) replicationSourceRetryCount(retryCount int) int {
-	if retryCount <= 0 || !c.IsMariaDB() {
-		return retryCount
-	}
-
-	atLeast, err := c.ServerVersionAtLeast(12, 0, 1)
-	if err != nil || !atLeast {
-		return 0
-	}
-
-	return retryCount
+	return c.flavor.setReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry, retryCount)
 }
 
 // resultToMap is a helper function used by ShowReplicationStatus.

--- a/go/mysql/flavor_filepos.go
+++ b/go/mysql/flavor_filepos.go
@@ -242,7 +242,7 @@ func (flv *filePosFlavor) setReplicationPositionCommands(pos replication.Positio
 }
 
 // setReplicationSourceCommand is part of the Flavor interface.
-func (flv *filePosFlavor) setReplicationSourceCommand(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int) string {
+func (flv *filePosFlavor) setReplicationSourceCommand(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int, retryCount int) string {
 	return "unsupported"
 }
 

--- a/go/mysql/flavor_mariadb.go
+++ b/go/mysql/flavor_mariadb.go
@@ -205,7 +205,7 @@ func (m mariadbFlavor) setReplicationSourceCommand(params *ConnParams, host stri
 		fmt.Sprintf("MASTER_PASSWORD = '%s'", params.Pass),
 		fmt.Sprintf("MASTER_CONNECT_RETRY = %d", connectRetry),
 	}
-	if retryCount > 0 && m.supportsReplicationRetryCount() {
+	if retryCount >= 0 && m.supportsReplicationRetryCount() {
 		args = append(args, fmt.Sprintf("MASTER_RETRY_COUNT = %d", retryCount))
 	}
 	if params.SslEnabled() {

--- a/go/mysql/flavor_mariadb.go
+++ b/go/mysql/flavor_mariadb.go
@@ -197,7 +197,7 @@ func (mariadbFlavor) setReplicationPositionCommands(pos replication.Position) []
 	}
 }
 
-func (mariadbFlavor) setReplicationSourceCommand(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int, retryCount int) string {
+func (m mariadbFlavor) setReplicationSourceCommand(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int, retryCount int) string {
 	args := []string{
 		fmt.Sprintf("MASTER_HOST = '%s'", host),
 		fmt.Sprintf("MASTER_PORT = %d", port),
@@ -205,7 +205,7 @@ func (mariadbFlavor) setReplicationSourceCommand(params *ConnParams, host string
 		fmt.Sprintf("MASTER_PASSWORD = '%s'", params.Pass),
 		fmt.Sprintf("MASTER_CONNECT_RETRY = %d", connectRetry),
 	}
-	if retryCount > 0 {
+	if retryCount > 0 && m.supportsReplicationRetryCount() {
 		args = append(args, fmt.Sprintf("MASTER_RETRY_COUNT = %d", retryCount))
 	}
 	if params.SslEnabled() {
@@ -228,6 +228,11 @@ func (mariadbFlavor) setReplicationSourceCommand(params *ConnParams, host string
 	}
 	args = append(args, "MASTER_USE_GTID = current_pos")
 	return "CHANGE MASTER TO\n  " + strings.Join(args, ",\n  ")
+}
+
+func (m mariadbFlavor) supportsReplicationRetryCount() bool {
+	atLeast, err := capabilities.ServerVersionAtLeast(m.serverVersion, 12, 0, 1)
+	return err == nil && atLeast
 }
 
 func (mariadbFlavor) resetBinaryLogsCommand() string {

--- a/go/mysql/flavor_mariadb.go
+++ b/go/mysql/flavor_mariadb.go
@@ -197,13 +197,16 @@ func (mariadbFlavor) setReplicationPositionCommands(pos replication.Position) []
 	}
 }
 
-func (mariadbFlavor) setReplicationSourceCommand(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int) string {
+func (mariadbFlavor) setReplicationSourceCommand(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int, retryCount int) string {
 	args := []string{
 		fmt.Sprintf("MASTER_HOST = '%s'", host),
 		fmt.Sprintf("MASTER_PORT = %d", port),
 		fmt.Sprintf("MASTER_USER = '%s'", params.Uname),
 		fmt.Sprintf("MASTER_PASSWORD = '%s'", params.Pass),
 		fmt.Sprintf("MASTER_CONNECT_RETRY = %d", connectRetry),
+	}
+	if retryCount > 0 {
+		args = append(args, fmt.Sprintf("MASTER_RETRY_COUNT = %d", retryCount))
 	}
 	if params.SslEnabled() {
 		args = append(args, "MASTER_SSL = 1")

--- a/go/mysql/flavor_mariadb_test.go
+++ b/go/mysql/flavor_mariadb_test.go
@@ -74,7 +74,8 @@ func TestMariadbSetReplicationSourceCommandRetryCount(t *testing.T) {
   MASTER_RETRY_COUNT = 5678,
   MASTER_USE_GTID = current_pos`
 
-	conn := &Conn{flavor: mariadbFlavor102{}, ServerVersion: "12.0.1-MariaDB"}
+	flavor, _, canonicalVersion := GetFlavor("12.0.1-MariaDB", nil)
+	conn := &Conn{flavor: flavor, ServerVersion: canonicalVersion}
 	got := conn.SetReplicationSourceCommandWithRetry(params, host, port, 0, connectRetry, retryCount)
 	assert.Equal(t, want, got)
 }
@@ -95,7 +96,8 @@ func TestMariadbSetReplicationSourceCommandRetryCountUnsupportedVersion(t *testi
   MASTER_CONNECT_RETRY = 1234,
   MASTER_USE_GTID = current_pos`
 
-	conn := &Conn{flavor: mariadbFlavor101{}, ServerVersion: "10.1.48-MariaDB"}
+	flavor, _, canonicalVersion := GetFlavor("10.5.15-MariaDB", nil)
+	conn := &Conn{flavor: flavor, ServerVersion: canonicalVersion}
 	got := conn.SetReplicationSourceCommandWithRetry(params, host, port, 0, connectRetry, 5678)
 	assert.Equal(t, want, got)
 }

--- a/go/mysql/flavor_mariadb_test.go
+++ b/go/mysql/flavor_mariadb_test.go
@@ -38,8 +38,8 @@ func TestMariadbSetReplicationSourceCommand(t *testing.T) {
   MASTER_CONNECT_RETRY = 1234,
   MASTER_USE_GTID = current_pos`
 
-	conn := &Conn{flavor: mariadbFlavor101{}}
-	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry, 0)
+	conn := &Conn{flavor: mariadbFlavor101{}, ServerVersion: "10.1.48-MariaDB"}
+	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry)
 	assert.Equal(t, want, got, "mariadbFlavor.SetReplicationSourceCommand(%#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, connectRetry, got, want)
 
 	heartbeatInterval := 5.4
@@ -52,7 +52,7 @@ func TestMariadbSetReplicationSourceCommand(t *testing.T) {
   MASTER_HEARTBEAT_PERIOD = 5.4,
   MASTER_USE_GTID = current_pos`
 
-	got = conn.SetReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry, 0)
+	got = conn.SetReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry)
 	assert.Equal(t, want, got, "mariadbFlavor.SetReplicationSourceCommand(%#v, %#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, heartbeatInterval, connectRetry, got, want)
 }
 
@@ -74,8 +74,29 @@ func TestMariadbSetReplicationSourceCommandRetryCount(t *testing.T) {
   MASTER_RETRY_COUNT = 5678,
   MASTER_USE_GTID = current_pos`
 
-	conn := &Conn{flavor: mariadbFlavor101{}}
-	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry, retryCount)
+	conn := &Conn{flavor: mariadbFlavor102{}, ServerVersion: "12.0.1-MariaDB"}
+	got := conn.SetReplicationSourceCommandWithRetry(params, host, port, 0, connectRetry, retryCount)
+	assert.Equal(t, want, got)
+}
+
+func TestMariadbSetReplicationSourceCommandRetryCountUnsupportedVersion(t *testing.T) {
+	params := &ConnParams{
+		Uname: "username",
+		Pass:  "password",
+	}
+	host := "localhost"
+	port := int32(123)
+	connectRetry := 1234
+	want := `CHANGE MASTER TO
+  MASTER_HOST = 'localhost',
+  MASTER_PORT = 123,
+  MASTER_USER = 'username',
+  MASTER_PASSWORD = 'password',
+  MASTER_CONNECT_RETRY = 1234,
+  MASTER_USE_GTID = current_pos`
+
+	conn := &Conn{flavor: mariadbFlavor101{}, ServerVersion: "10.1.48-MariaDB"}
+	got := conn.SetReplicationSourceCommandWithRetry(params, host, port, 0, connectRetry, 5678)
 	assert.Equal(t, want, got)
 }
 
@@ -105,7 +126,7 @@ func TestMariadbSetReplicationSourceCommandSSL(t *testing.T) {
   MASTER_SSL_KEY = 'ssl-key',
   MASTER_USE_GTID = current_pos`
 
-	conn := &Conn{flavor: mariadbFlavor101{}}
-	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry, 0)
+	conn := &Conn{flavor: mariadbFlavor101{}, ServerVersion: "10.1.48-MariaDB"}
+	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry)
 	assert.Equal(t, want, got, "mariadbFlavor.SetReplicationSourceCommand(%#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, connectRetry, got, want)
 }

--- a/go/mysql/flavor_mariadb_test.go
+++ b/go/mysql/flavor_mariadb_test.go
@@ -39,7 +39,7 @@ func TestMariadbSetReplicationSourceCommand(t *testing.T) {
   MASTER_USE_GTID = current_pos`
 
 	conn := &Conn{flavor: mariadbFlavor101{}}
-	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry)
+	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry, 0)
 	assert.Equal(t, want, got, "mariadbFlavor.SetReplicationSourceCommand(%#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, connectRetry, got, want)
 
 	heartbeatInterval := 5.4
@@ -52,8 +52,31 @@ func TestMariadbSetReplicationSourceCommand(t *testing.T) {
   MASTER_HEARTBEAT_PERIOD = 5.4,
   MASTER_USE_GTID = current_pos`
 
-	got = conn.SetReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry)
+	got = conn.SetReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry, 0)
 	assert.Equal(t, want, got, "mariadbFlavor.SetReplicationSourceCommand(%#v, %#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, heartbeatInterval, connectRetry, got, want)
+}
+
+func TestMariadbSetReplicationSourceCommandRetryCount(t *testing.T) {
+	params := &ConnParams{
+		Uname: "username",
+		Pass:  "password",
+	}
+	host := "localhost"
+	port := int32(123)
+	connectRetry := 1234
+	retryCount := 5678
+	want := `CHANGE MASTER TO
+  MASTER_HOST = 'localhost',
+  MASTER_PORT = 123,
+  MASTER_USER = 'username',
+  MASTER_PASSWORD = 'password',
+  MASTER_CONNECT_RETRY = 1234,
+  MASTER_RETRY_COUNT = 5678,
+  MASTER_USE_GTID = current_pos`
+
+	conn := &Conn{flavor: mariadbFlavor101{}}
+	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry, retryCount)
+	assert.Equal(t, want, got)
 }
 
 func TestMariadbSetReplicationSourceCommandSSL(t *testing.T) {
@@ -83,6 +106,6 @@ func TestMariadbSetReplicationSourceCommandSSL(t *testing.T) {
   MASTER_USE_GTID = current_pos`
 
 	conn := &Conn{flavor: mariadbFlavor101{}}
-	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry)
+	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry, 0)
 	assert.Equal(t, want, got, "mariadbFlavor.SetReplicationSourceCommand(%#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, connectRetry, got, want)
 }

--- a/go/mysql/flavor_mariadb_test.go
+++ b/go/mysql/flavor_mariadb_test.go
@@ -80,6 +80,29 @@ func TestMariadbSetReplicationSourceCommandRetryCount(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestMariadbSetReplicationSourceCommandRetryCountZero(t *testing.T) {
+	params := &ConnParams{
+		Uname: "username",
+		Pass:  "password",
+	}
+	host := "localhost"
+	port := int32(123)
+	connectRetry := 1234
+	want := `CHANGE MASTER TO
+  MASTER_HOST = 'localhost',
+  MASTER_PORT = 123,
+  MASTER_USER = 'username',
+  MASTER_PASSWORD = 'password',
+  MASTER_CONNECT_RETRY = 1234,
+  MASTER_RETRY_COUNT = 0,
+  MASTER_USE_GTID = current_pos`
+
+	flavor, _, canonicalVersion := GetFlavor("12.0.1-MariaDB", nil)
+	conn := &Conn{flavor: flavor, ServerVersion: canonicalVersion}
+	got := conn.SetReplicationSourceCommandWithRetry(params, host, port, 0, connectRetry, 0)
+	assert.Equal(t, want, got)
+}
+
 func TestMariadbSetReplicationSourceCommandRetryCountUnsupportedVersion(t *testing.T) {
 	params := &ConnParams{
 		Uname: "username",

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -561,13 +561,16 @@ func (mysqlFlavor) baseShowIndexCardinalities() string {
 	return ShowIndexCardinalities
 }
 
-func (mysqlFlavor) setReplicationSourceCommand(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int) string {
+func (mysqlFlavor) setReplicationSourceCommand(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int, retryCount int) string {
 	args := []string{
 		fmt.Sprintf("SOURCE_HOST = '%s'", host),
 		fmt.Sprintf("SOURCE_PORT = %d", port),
 		fmt.Sprintf("SOURCE_USER = '%s'", params.Uname),
 		fmt.Sprintf("SOURCE_PASSWORD = '%s'", params.Pass),
 		fmt.Sprintf("SOURCE_CONNECT_RETRY = %d", connectRetry),
+	}
+	if retryCount > 0 {
+		args = append(args, fmt.Sprintf("SOURCE_RETRY_COUNT = %d", retryCount))
 	}
 	if params.SslEnabled() {
 		args = append(args, "SOURCE_SSL = 1")

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -569,7 +569,7 @@ func (mysqlFlavor) setReplicationSourceCommand(params *ConnParams, host string, 
 		fmt.Sprintf("SOURCE_PASSWORD = '%s'", params.Pass),
 		fmt.Sprintf("SOURCE_CONNECT_RETRY = %d", connectRetry),
 	}
-	if retryCount > 0 {
+	if retryCount >= 0 {
 		args = append(args, fmt.Sprintf("SOURCE_RETRY_COUNT = %d", retryCount))
 	}
 	if params.SslEnabled() {

--- a/go/mysql/flavor_mysql_legacy.go
+++ b/go/mysql/flavor_mysql_legacy.go
@@ -233,7 +233,7 @@ func (mysqlFlavorLegacy) setReplicationSourceCommand(params *ConnParams, host st
 		fmt.Sprintf("MASTER_PASSWORD = '%s'", params.Pass),
 		fmt.Sprintf("MASTER_CONNECT_RETRY = %d", connectRetry),
 	}
-	if retryCount > 0 {
+	if retryCount >= 0 {
 		args = append(args, fmt.Sprintf("MASTER_RETRY_COUNT = %d", retryCount))
 	}
 	if params.SslEnabled() {

--- a/go/mysql/flavor_mysql_legacy.go
+++ b/go/mysql/flavor_mysql_legacy.go
@@ -225,13 +225,16 @@ func (mysqlFlavorLegacy) catchupToGTIDCommands(params *ConnParams, replPos repli
 	return cmds
 }
 
-func (mysqlFlavorLegacy) setReplicationSourceCommand(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int) string {
+func (mysqlFlavorLegacy) setReplicationSourceCommand(params *ConnParams, host string, port int32, heartbeatInterval float64, connectRetry int, retryCount int) string {
 	args := []string{
 		fmt.Sprintf("MASTER_HOST = '%s'", host),
 		fmt.Sprintf("MASTER_PORT = %d", port),
 		fmt.Sprintf("MASTER_USER = '%s'", params.Uname),
 		fmt.Sprintf("MASTER_PASSWORD = '%s'", params.Pass),
 		fmt.Sprintf("MASTER_CONNECT_RETRY = %d", connectRetry),
+	}
+	if retryCount > 0 {
+		args = append(args, fmt.Sprintf("MASTER_RETRY_COUNT = %d", retryCount))
 	}
 	if params.SslEnabled() {
 		args = append(args, "MASTER_SSL = 1")

--- a/go/mysql/flavor_mysql_test.go
+++ b/go/mysql/flavor_mysql_test.go
@@ -42,7 +42,7 @@ func TestMysql8SetReplicationSourceCommand(t *testing.T) {
   SOURCE_AUTO_POSITION = 1`
 
 	conn := &Conn{flavor: mysqlFlavor8{}}
-	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry, 0)
+	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry)
 	assert.Equal(t, want, got, "mysqlFlavor.SetReplicationSourceCommand(%#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, connectRetry, got, want)
 
 	heartbeatInterval := 5.4
@@ -56,7 +56,7 @@ func TestMysql8SetReplicationSourceCommand(t *testing.T) {
   SOURCE_HEARTBEAT_PERIOD = 5.4,
   SOURCE_AUTO_POSITION = 1`
 
-	got = conn.SetReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry, 0)
+	got = conn.SetReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry)
 	assert.Equal(t, want, got, "mysqlFlavor.SetReplicationSourceCommand(%#v, %#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, heartbeatInterval, connectRetry, got, want)
 }
 
@@ -80,7 +80,31 @@ func TestMysql8SetReplicationSourceCommandRetryCount(t *testing.T) {
   SOURCE_AUTO_POSITION = 1`
 
 	conn := &Conn{flavor: mysqlFlavor8{}}
-	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry, retryCount)
+	got := conn.SetReplicationSourceCommandWithRetry(params, host, port, 0, connectRetry, retryCount)
+	assert.Equal(t, want, got)
+}
+
+func TestMysql57SetReplicationSourceCommandRetryCount(t *testing.T) {
+	params := &ConnParams{
+		Uname: "username",
+		Pass:  "password",
+	}
+	host := "localhost"
+	port := int32(123)
+	connectRetry := 1234
+	retryCount := 5678
+	want := `CHANGE MASTER TO
+  MASTER_HOST = 'localhost',
+  MASTER_PORT = 123,
+  MASTER_USER = 'username',
+  MASTER_PASSWORD = 'password',
+  MASTER_CONNECT_RETRY = 1234,
+  MASTER_RETRY_COUNT = 5678,
+  GET_MASTER_PUBLIC_KEY = 1,
+  MASTER_AUTO_POSITION = 1`
+
+	conn := &Conn{flavor: mysqlFlavor57{}}
+	got := conn.SetReplicationSourceCommandWithRetry(params, host, port, 0, connectRetry, retryCount)
 	assert.Equal(t, want, got)
 }
 
@@ -111,7 +135,7 @@ func TestMysql8SetReplicationSourceCommandSSL(t *testing.T) {
   SOURCE_AUTO_POSITION = 1`
 
 	conn := &Conn{flavor: mysqlFlavor8{}}
-	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry, 0)
+	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry)
 	assert.Equal(t, want, got, "mysqlFlavor.SetReplicationSourceCommand(%#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, connectRetry, got, want)
 }
 
@@ -172,7 +196,7 @@ func TestMysql9SetReplicationSourceCommand(t *testing.T) {
   SOURCE_AUTO_POSITION = 1`
 
 	conn := &Conn{flavor: mysqlFlavor9{}}
-	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry, 0)
+	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry)
 	assert.Equal(t, want, got, "mysqlFlavor9.SetReplicationSourceCommand(%#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, connectRetry, got, want)
 
 	heartbeatInterval := 5.4
@@ -186,7 +210,7 @@ func TestMysql9SetReplicationSourceCommand(t *testing.T) {
   SOURCE_HEARTBEAT_PERIOD = 5.4,
   SOURCE_AUTO_POSITION = 1`
 
-	got = conn.SetReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry, 0)
+	got = conn.SetReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry)
 	assert.Equal(t, want, got, "mysqlFlavor9.SetReplicationSourceCommand(%#v, %#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, heartbeatInterval, connectRetry, got, want)
 }
 
@@ -217,6 +241,12 @@ func TestMysql9SetReplicationSourceCommandSSL(t *testing.T) {
   SOURCE_AUTO_POSITION = 1`
 
 	conn := &Conn{flavor: mysqlFlavor9{}}
-	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry, 0)
+	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry)
 	assert.Equal(t, want, got, "mysqlFlavor9.SetReplicationSourceCommand(%#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, connectRetry, got, want)
+}
+
+func TestFilePosSetReplicationSourceCommandWithRetry(t *testing.T) {
+	conn := &Conn{flavor: &filePosFlavor{}}
+	got := conn.SetReplicationSourceCommandWithRetry(&ConnParams{}, "localhost", 123, 0, 456, 789)
+	assert.Equal(t, "unsupported", got)
 }

--- a/go/mysql/flavor_mysql_test.go
+++ b/go/mysql/flavor_mysql_test.go
@@ -42,7 +42,7 @@ func TestMysql8SetReplicationSourceCommand(t *testing.T) {
   SOURCE_AUTO_POSITION = 1`
 
 	conn := &Conn{flavor: mysqlFlavor8{}}
-	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry)
+	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry, 0)
 	assert.Equal(t, want, got, "mysqlFlavor.SetReplicationSourceCommand(%#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, connectRetry, got, want)
 
 	heartbeatInterval := 5.4
@@ -56,8 +56,32 @@ func TestMysql8SetReplicationSourceCommand(t *testing.T) {
   SOURCE_HEARTBEAT_PERIOD = 5.4,
   SOURCE_AUTO_POSITION = 1`
 
-	got = conn.SetReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry)
+	got = conn.SetReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry, 0)
 	assert.Equal(t, want, got, "mysqlFlavor.SetReplicationSourceCommand(%#v, %#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, heartbeatInterval, connectRetry, got, want)
+}
+
+func TestMysql8SetReplicationSourceCommandRetryCount(t *testing.T) {
+	params := &ConnParams{
+		Uname: "username",
+		Pass:  "password",
+	}
+	host := "localhost"
+	port := int32(123)
+	connectRetry := 1234
+	retryCount := 5678
+	want := `CHANGE REPLICATION SOURCE TO
+  SOURCE_HOST = 'localhost',
+  SOURCE_PORT = 123,
+  SOURCE_USER = 'username',
+  SOURCE_PASSWORD = 'password',
+  SOURCE_CONNECT_RETRY = 1234,
+  SOURCE_RETRY_COUNT = 5678,
+  GET_SOURCE_PUBLIC_KEY = 1,
+  SOURCE_AUTO_POSITION = 1`
+
+	conn := &Conn{flavor: mysqlFlavor8{}}
+	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry, retryCount)
+	assert.Equal(t, want, got)
 }
 
 func TestMysql8SetReplicationSourceCommandSSL(t *testing.T) {
@@ -87,7 +111,7 @@ func TestMysql8SetReplicationSourceCommandSSL(t *testing.T) {
   SOURCE_AUTO_POSITION = 1`
 
 	conn := &Conn{flavor: mysqlFlavor8{}}
-	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry)
+	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry, 0)
 	assert.Equal(t, want, got, "mysqlFlavor.SetReplicationSourceCommand(%#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, connectRetry, got, want)
 }
 
@@ -148,7 +172,7 @@ func TestMysql9SetReplicationSourceCommand(t *testing.T) {
   SOURCE_AUTO_POSITION = 1`
 
 	conn := &Conn{flavor: mysqlFlavor9{}}
-	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry)
+	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry, 0)
 	assert.Equal(t, want, got, "mysqlFlavor9.SetReplicationSourceCommand(%#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, connectRetry, got, want)
 
 	heartbeatInterval := 5.4
@@ -162,7 +186,7 @@ func TestMysql9SetReplicationSourceCommand(t *testing.T) {
   SOURCE_HEARTBEAT_PERIOD = 5.4,
   SOURCE_AUTO_POSITION = 1`
 
-	got = conn.SetReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry)
+	got = conn.SetReplicationSourceCommand(params, host, port, heartbeatInterval, connectRetry, 0)
 	assert.Equal(t, want, got, "mysqlFlavor9.SetReplicationSourceCommand(%#v, %#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, heartbeatInterval, connectRetry, got, want)
 }
 
@@ -193,6 +217,6 @@ func TestMysql9SetReplicationSourceCommandSSL(t *testing.T) {
   SOURCE_AUTO_POSITION = 1`
 
 	conn := &Conn{flavor: mysqlFlavor9{}}
-	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry)
+	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry, 0)
 	assert.Equal(t, want, got, "mysqlFlavor9.SetReplicationSourceCommand(%#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, connectRetry, got, want)
 }

--- a/go/mysql/flavor_mysql_test.go
+++ b/go/mysql/flavor_mysql_test.go
@@ -84,6 +84,29 @@ func TestMysql8SetReplicationSourceCommandRetryCount(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestMysql8SetReplicationSourceCommandRetryCountZero(t *testing.T) {
+	params := &ConnParams{
+		Uname: "username",
+		Pass:  "password",
+	}
+	host := "localhost"
+	port := int32(123)
+	connectRetry := 1234
+	want := `CHANGE REPLICATION SOURCE TO
+  SOURCE_HOST = 'localhost',
+  SOURCE_PORT = 123,
+  SOURCE_USER = 'username',
+  SOURCE_PASSWORD = 'password',
+  SOURCE_CONNECT_RETRY = 1234,
+  SOURCE_RETRY_COUNT = 0,
+  GET_SOURCE_PUBLIC_KEY = 1,
+  SOURCE_AUTO_POSITION = 1`
+
+	conn := &Conn{flavor: mysqlFlavor8{}}
+	got := conn.SetReplicationSourceCommandWithRetry(params, host, port, 0, connectRetry, 0)
+	assert.Equal(t, want, got)
+}
+
 func TestMysql57SetReplicationSourceCommandRetryCount(t *testing.T) {
 	params := &ConnParams{
 		Uname: "username",
@@ -105,6 +128,29 @@ func TestMysql57SetReplicationSourceCommandRetryCount(t *testing.T) {
 
 	conn := &Conn{flavor: mysqlFlavor57{}}
 	got := conn.SetReplicationSourceCommandWithRetry(params, host, port, 0, connectRetry, retryCount)
+	assert.Equal(t, want, got)
+}
+
+func TestMysql57SetReplicationSourceCommandRetryCountZero(t *testing.T) {
+	params := &ConnParams{
+		Uname: "username",
+		Pass:  "password",
+	}
+	host := "localhost"
+	port := int32(123)
+	connectRetry := 1234
+	want := `CHANGE MASTER TO
+  MASTER_HOST = 'localhost',
+  MASTER_PORT = 123,
+  MASTER_USER = 'username',
+  MASTER_PASSWORD = 'password',
+  MASTER_CONNECT_RETRY = 1234,
+  MASTER_RETRY_COUNT = 0,
+  GET_MASTER_PUBLIC_KEY = 1,
+  MASTER_AUTO_POSITION = 1`
+
+	conn := &Conn{flavor: mysqlFlavor57{}}
+	got := conn.SetReplicationSourceCommandWithRetry(params, host, port, 0, connectRetry, 0)
 	assert.Equal(t, want, got)
 }
 

--- a/go/mysql/flavor_test.go
+++ b/go/mysql/flavor_test.go
@@ -255,6 +255,11 @@ func TestGetFlavor(t *testing.T) {
 			expectedType: "mariadbFlavor102",
 			description:  "MariaDB 10.5 with suffix should use mariadbFlavor102",
 		},
+		{
+			version:      "10.11.12-MariaDB-log",
+			expectedType: "mariadbFlavor102",
+			description:  "MariaDB 10.11 with suffix should use mariadbFlavor102",
+		},
 		// Default/unknown versions should get mysqlFlavor57
 		{
 			version:      "5.6.45",

--- a/go/test/endtoend/utils/mysql_test.go
+++ b/go/test/endtoend/utils/mysql_test.go
@@ -211,7 +211,7 @@ func TestReplicationStatus(t *testing.T) {
 	require.NoError(t, err)
 	host := "localhost"
 
-	q := conn.SetReplicationSourceCommand(&mysqlParams, host, port, 0, int(port), 0)
+	q := conn.SetReplicationSourceCommand(&mysqlParams, host, port, 0, int(port))
 	res := Exec(t, conn, q)
 	require.NotNil(t, res)
 

--- a/go/test/endtoend/utils/mysql_test.go
+++ b/go/test/endtoend/utils/mysql_test.go
@@ -211,7 +211,7 @@ func TestReplicationStatus(t *testing.T) {
 	require.NoError(t, err)
 	host := "localhost"
 
-	q := conn.SetReplicationSourceCommand(&mysqlParams, host, port, 0, int(port))
+	q := conn.SetReplicationSourceCommand(&mysqlParams, host, port, 0, int(port), 0)
 	res := Exec(t, conn, q)
 	require.NotNil(t, res)
 

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -97,8 +97,9 @@ var (
 	socketFile        string
 	mysqlCloneEnabled bool
 
-	replicationConnectRetry = 10 * time.Second
-	replicationRetryCount   = 0
+	replicationConnectRetry   = 10 * time.Second
+	replicationRetryCount     = 0
+	replicationRetryCountFlag *pflag.Flag
 
 	versionRegex = regexp.MustCompile(versionStringPrefix + "([0-9]+)\\.([0-9]+)\\.([0-9]+)")
 	// versionSQLQuery will return a version string directly from
@@ -149,7 +150,8 @@ func registerMySQLDFlags(fs *pflag.FlagSet) {
 	utils.SetFlagStringVar(fs, &mycnfTemplateFile, "mysqlctl-mycnf-template", mycnfTemplateFile, "template file to use for generating the my.cnf file during server init")
 	utils.SetFlagStringVar(fs, &socketFile, "mysqlctl-socket", socketFile, "socket file to use for remote mysqlctl actions (empty for local actions)")
 	utils.SetFlagDurationVar(fs, &replicationConnectRetry, "replication-connect-retry", replicationConnectRetry, "how long to wait in between replica reconnect attempts. Only precise to the second.")
-	utils.SetFlagIntVar(fs, &replicationRetryCount, "replication-retry-count", replicationRetryCount, "how many times a replica should retry reconnecting to the primary before giving up. 0 leaves MySQL's default unchanged.")
+	utils.SetFlagIntVar(fs, &replicationRetryCount, "replication-retry-count", replicationRetryCount, "how many times a replica should retry reconnecting to the primary before giving up. 0 means unlimited retries. If unset, MySQL's default is used.")
+	replicationRetryCountFlag = fs.Lookup("replication-retry-count")
 }
 
 // MySQLCloneEnabled returns whether MySQL CLONE support is enabled.

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -98,6 +98,7 @@ var (
 	mysqlCloneEnabled bool
 
 	replicationConnectRetry = 10 * time.Second
+	replicationRetryCount   = 0
 
 	versionRegex = regexp.MustCompile(versionStringPrefix + "([0-9]+)\\.([0-9]+)\\.([0-9]+)")
 	// versionSQLQuery will return a version string directly from
@@ -148,6 +149,7 @@ func registerMySQLDFlags(fs *pflag.FlagSet) {
 	utils.SetFlagStringVar(fs, &mycnfTemplateFile, "mysqlctl-mycnf-template", mycnfTemplateFile, "template file to use for generating the my.cnf file during server init")
 	utils.SetFlagStringVar(fs, &socketFile, "mysqlctl-socket", socketFile, "socket file to use for remote mysqlctl actions (empty for local actions)")
 	utils.SetFlagDurationVar(fs, &replicationConnectRetry, "replication-connect-retry", replicationConnectRetry, "how long to wait in between replica reconnect attempts. Only precise to the second.")
+	utils.SetFlagIntVar(fs, &replicationRetryCount, "replication-retry-count", replicationRetryCount, "how many times a replica should retry reconnecting to the primary before giving up. 0 leaves MySQL's default unchanged.")
 }
 
 // MySQLCloneEnabled returns whether MySQL CLONE support is enabled.

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -494,9 +494,6 @@ func (mysqld *Mysqld) SetReplicationPosition(ctx context.Context, pos replicatio
 // SetReplicationSource makes the provided host / port the primary. It optionally
 // stops replication before, and starts it after.
 func (mysqld *Mysqld) SetReplicationSource(ctx context.Context, host string, port int32, heartbeatInterval float64, stopReplicationBefore bool, startReplicationAfter bool) error {
-	if replicationRetryCount < 0 {
-		return fmt.Errorf("--replication-retry-count must be non-negative; got %d", replicationRetryCount)
-	}
 	params, err := mysqld.dbcfgs.ReplConnector().MysqlParams()
 	if err != nil {
 		return err
@@ -511,7 +508,14 @@ func (mysqld *Mysqld) SetReplicationSource(ctx context.Context, host string, por
 	if stopReplicationBefore {
 		cmds = append(cmds, conn.Conn.StopReplicationCommand())
 	}
-	smc := conn.Conn.SetReplicationSourceCommandWithRetry(params, host, port, heartbeatInterval, int(replicationConnectRetry.Seconds()), replicationRetryCount)
+	retryCount := -1
+	if replicationRetryCountFlag != nil && replicationRetryCountFlag.Changed {
+		if replicationRetryCount < 0 {
+			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "--replication-retry-count must be >= 0, got %d", replicationRetryCount)
+		}
+		retryCount = replicationRetryCount
+	}
+	smc := conn.Conn.SetReplicationSourceCommandWithRetry(params, host, port, heartbeatInterval, int(replicationConnectRetry.Seconds()), retryCount)
 	cmds = append(cmds, smc)
 	if startReplicationAfter {
 		cmds = append(cmds, conn.Conn.StartReplicationCommand())

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -511,7 +511,7 @@ func (mysqld *Mysqld) SetReplicationSource(ctx context.Context, host string, por
 	if stopReplicationBefore {
 		cmds = append(cmds, conn.Conn.StopReplicationCommand())
 	}
-	smc := conn.Conn.SetReplicationSourceCommand(params, host, port, heartbeatInterval, int(replicationConnectRetry.Seconds()), replicationRetryCount)
+	smc := conn.Conn.SetReplicationSourceCommandWithRetry(params, host, port, heartbeatInterval, int(replicationConnectRetry.Seconds()), replicationRetryCount)
 	cmds = append(cmds, smc)
 	if startReplicationAfter {
 		cmds = append(cmds, conn.Conn.StartReplicationCommand())

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -494,6 +494,9 @@ func (mysqld *Mysqld) SetReplicationPosition(ctx context.Context, pos replicatio
 // SetReplicationSource makes the provided host / port the primary. It optionally
 // stops replication before, and starts it after.
 func (mysqld *Mysqld) SetReplicationSource(ctx context.Context, host string, port int32, heartbeatInterval float64, stopReplicationBefore bool, startReplicationAfter bool) error {
+	if replicationRetryCount < 0 {
+		return fmt.Errorf("--replication-retry-count must be non-negative; got %d", replicationRetryCount)
+	}
 	params, err := mysqld.dbcfgs.ReplConnector().MysqlParams()
 	if err != nil {
 		return err
@@ -508,7 +511,7 @@ func (mysqld *Mysqld) SetReplicationSource(ctx context.Context, host string, por
 	if stopReplicationBefore {
 		cmds = append(cmds, conn.Conn.StopReplicationCommand())
 	}
-	smc := conn.Conn.SetReplicationSourceCommand(params, host, port, heartbeatInterval, int(replicationConnectRetry.Seconds()))
+	smc := conn.Conn.SetReplicationSourceCommand(params, host, port, heartbeatInterval, int(replicationConnectRetry.Seconds()), replicationRetryCount)
 	cmds = append(cmds, smc)
 	if startReplicationAfter {
 		cmds = append(cmds, conn.Conn.StartReplicationCommand())

--- a/go/vt/mysqlctl/replication_test.go
+++ b/go/vt/mysqlctl/replication_test.go
@@ -431,6 +431,34 @@ func TestSetReplicationSource(t *testing.T) {
 	assert.ErrorContains(t, err, `CHANGE REPLICATION SOURCE TO`)
 }
 
+func TestSetReplicationSourceRetryCount(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+
+	params := db.ConnParams()
+	cp := *params
+	dbc := dbconfigs.NewTestDBConfigs(cp, cp, "fakesqldb")
+
+	db.AddQuery("SELECT 1", &sqltypes.Result{})
+	db.AddQuery("RESET MASTER", &sqltypes.Result{})
+	db.AddQuery("RESET BINARY LOGS AND GTIDS", &sqltypes.Result{})
+	db.AddQuery("STOP REPLICA", &sqltypes.Result{})
+
+	oldRetryCount := replicationRetryCount
+	replicationRetryCount = 12
+	t.Cleanup(func() {
+		replicationRetryCount = oldRetryCount
+	})
+
+	testMysqld := NewMysqld(dbc)
+	defer testMysqld.Close()
+
+	ctx := context.Background()
+
+	err := testMysqld.SetReplicationSource(ctx, "test_host", 2, 0, true, true)
+	assert.ErrorContains(t, err, `SOURCE_RETRY_COUNT = 12`)
+}
+
 func TestResetReplication(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()

--- a/go/vt/mysqlctl/replication_test.go
+++ b/go/vt/mysqlctl/replication_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -431,6 +432,22 @@ func TestSetReplicationSource(t *testing.T) {
 	assert.ErrorContains(t, err, `CHANGE REPLICATION SOURCE TO`)
 }
 
+func setReplicationRetryCountFlagForTest(t *testing.T, value string) {
+	t.Helper()
+
+	oldRetryCount := replicationRetryCount
+	oldRetryCountFlag := replicationRetryCountFlag
+
+	fs := pflag.NewFlagSet("test-mysqlctl-flags", pflag.ContinueOnError)
+	registerMySQLDFlags(fs)
+	require.NoError(t, fs.Set("replication-retry-count", value))
+
+	t.Cleanup(func() {
+		replicationRetryCount = oldRetryCount
+		replicationRetryCountFlag = oldRetryCountFlag
+	})
+}
+
 func TestSetReplicationSourceRetryCount(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
@@ -444,11 +461,7 @@ func TestSetReplicationSourceRetryCount(t *testing.T) {
 	db.AddQuery("RESET BINARY LOGS AND GTIDS", &sqltypes.Result{})
 	db.AddQuery("STOP REPLICA", &sqltypes.Result{})
 
-	oldRetryCount := replicationRetryCount
-	replicationRetryCount = 12
-	t.Cleanup(func() {
-		replicationRetryCount = oldRetryCount
-	})
+	setReplicationRetryCountFlagForTest(t, "12")
 
 	testMysqld := NewMysqld(dbc)
 	defer testMysqld.Close()
@@ -457,6 +470,51 @@ func TestSetReplicationSourceRetryCount(t *testing.T) {
 
 	err := testMysqld.SetReplicationSource(ctx, "test_host", 2, 0, true, true)
 	assert.ErrorContains(t, err, `SOURCE_RETRY_COUNT = 12`)
+}
+
+func TestSetReplicationSourceRetryCountZero(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+
+	params := db.ConnParams()
+	cp := *params
+	dbc := dbconfigs.NewTestDBConfigs(cp, cp, "fakesqldb")
+
+	db.AddQuery("SELECT 1", &sqltypes.Result{})
+	db.AddQuery("RESET MASTER", &sqltypes.Result{})
+	db.AddQuery("RESET BINARY LOGS AND GTIDS", &sqltypes.Result{})
+	db.AddQuery("STOP REPLICA", &sqltypes.Result{})
+
+	setReplicationRetryCountFlagForTest(t, "0")
+
+	testMysqld := NewMysqld(dbc)
+	defer testMysqld.Close()
+
+	ctx := context.Background()
+
+	err := testMysqld.SetReplicationSource(ctx, "test_host", 2, 0, true, true)
+	assert.ErrorContains(t, err, `SOURCE_RETRY_COUNT = 0`)
+}
+
+func TestSetReplicationSourceRetryCountNegative(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+
+	params := db.ConnParams()
+	cp := *params
+	dbc := dbconfigs.NewTestDBConfigs(cp, cp, "fakesqldb")
+
+	db.AddQuery("SELECT 1", &sqltypes.Result{})
+
+	setReplicationRetryCountFlagForTest(t, "-1")
+
+	testMysqld := NewMysqld(dbc)
+	defer testMysqld.Close()
+
+	ctx := context.Background()
+
+	err := testMysqld.SetReplicationSource(ctx, "test_host", 2, 0, true, true)
+	assert.ErrorContains(t, err, "--replication-retry-count must be >= 0, got -1")
 }
 
 func TestResetReplication(t *testing.T) {


### PR DESCRIPTION
## Description

This PR exposes MySQL's replication retry count through a new `--replication-retry-count` flag.

Vitess already exposes `SOURCE_CONNECT_RETRY` via `--replication-connect-retry`, but there was no way to set `SOURCE_RETRY_COUNT` when issuing `CHANGE REPLICATION SOURCE TO`. That makes it harder to tune replica reconnect behavior on newer MySQL versions where configuring this in `my.cnf` is deprecated.

This change threads the new flag through `mysqlctl` and the flavor-specific replication source command builders. The flag defaults to `0`, which leaves MySQL's server default unchanged unless the operator explicitly sets a retry count. The corresponding help output snapshots were also updated.

## Related Issue(s)

Fixes #19279

## Checklist

-   [x] "Backport to:" labels not necessary, not applied
-   [x] Not backported, so no backport justification provided
-   [x] Tests were added or updated
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or updated

## Deployment Notes

The new `--replication-retry-count` flag is opt-in. Leaving it unset preserves the existing replication source command text.

### AI Disclosure

This PR was written with assistance from OpenAI Codex. I reviewed the final diff and local test results.
