### PR TITLE
tabletmanager: handle nil Cnf in MysqlHostMetrics to prevent panic

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_query.go
+++ b/go/vt/vttablet/tabletmanager/rpc_query.go
@@ -271,6 +271,9 @@ func (tm *TabletManager) ExecuteFetchAsApp(ctx context.Context, req *tabletmanag
 
 // MysqlHostMetrics gets system metrics from mysqlctl[d]
 func (tm *TabletManager) MysqlHostMetrics(ctx context.Context, req *tabletmanagerdatapb.MysqlHostMetricsRequest) (*tabletmanagerdatapb.MysqlHostMetricsResponse, error) {
+	if tm.Cnf == nil {
+		return &tabletmanagerdatapb.MysqlHostMetricsResponse{}, nil
+	}
 	mysqlResp, err := tm.MysqlDaemon.HostMetrics(ctx, tm.Cnf)
 	if err != nil {
 		return nil, err

--- a/go/vt/vttablet/tabletmanager/rpc_query_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_query_test.go
@@ -114,6 +114,20 @@ func TestAnalyzeExecuteFetchAsDbaMultiQuery(t *testing.T) {
 	}
 }
 
+func TestTabletManager_MysqlHostMetricsNilCnf(t *testing.T) {
+	ctx := context.Background()
+	// When using external MySQL (e.g. Cloud SQL, RDS), Cnf is nil because
+	// vttablet skips loading my.cnf when connection parameters are specified.
+	// MysqlHostMetrics should return an empty response instead of panicking.
+	tm := &TabletManager{
+		Cnf: nil,
+	}
+	resp, err := tm.MysqlHostMetrics(ctx, &tabletmanagerdatapb.MysqlHostMetricsRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.HostMetrics)
+}
+
 func TestTabletManager_ExecuteFetchAsDba(t *testing.T) {
 	ctx := context.Background()
 	cp := mysql.ConnParams{}

--- a/go/vt/vttablet/tabletserver/throttle/base/self_metric_mysqld.go
+++ b/go/vt/vttablet/tabletserver/throttle/base/self_metric_mysqld.go
@@ -91,6 +91,9 @@ func getMysqlHostMetric(ctx context.Context, params *SelfMetricReadParams, mysql
 	if resp == nil {
 		return metric.WithError(ErrNoResultYet)
 	}
+	if resp.HostMetrics == nil || resp.HostMetrics.Metrics == nil {
+		return metric.WithError(ErrNoSuchMetric)
+	}
 	mysqlMetric := resp.HostMetrics.Metrics[mysqlHostMetricName]
 	if mysqlMetric == nil {
 		return metric.WithError(ErrNoSuchMetric)


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

When using external MySQL (e.g. Cloud SQL, RDS), vttablet skips loading my.cnf and Cnf is nil. MysqlHostMetrics now returns an empty response instead of panicking. Also adds a nil guard for HostMetrics in the throttler's getMysqlHostMetric to handle the empty response gracefully.

It would be appreciated if this could be backported.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes #19751 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
