### PR TITLE
Add ZooKeeper connection metrics to zk2topo

### DIFF
--- a/go/vt/topo/zk2topo/zk_conn.go
+++ b/go/vt/topo/zk2topo/zk_conn.go
@@ -59,8 +59,8 @@ var (
 
 	certPath, keyPath, caPath, authFile string
 
-	zkConnAcquisition = stats.NewGaugeDuration(
-		"ZkConnAcquisition",
+	zkLockAcquisition = stats.NewGaugeDuration(
+		"ZkLockAcquisition",
 		"Time to acquire a zookeeper lock")
 	zkConnAcquisitionRetry = stats.NewCounter(
 		"ZkConnAcquisitionRetry",
@@ -253,7 +253,7 @@ func (c *ZkConn) withRetry(ctx context.Context, action func(conn *zk.Conn) error
 		return err
 	}
 	duration := time.Since(start)
-	defer zkConnAcquisition.Set(duration)
+	zkLockAcquisition.Set(duration)
 	defer c.sem.Release(1)
 
 	for i := range maxAttempts {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Adds ZooKeeper connection metrics to the zk2topo package:                                                                                               
                                                                                                                                                         
  - `ZkLockAcquisition` (GaugeDuration) — time spent waiting to acquire the ZK connection semaphore                                                      
  - `ZkConnAcquisitionRetry` (Counter) — number of connection retry attempts                                                                             
  - `ZkConnState` (CountersWithSingleLabel) — ZK connection state transitions by state                                                                   
                  
 These stats have been running in our internal v14 Vitess fork  and have been useful for debugging ZK connectivity issues.

We'd appreciate a backport to the 22.0 release branch as well — we're currently upgrading to v22 and need these metrics for ZK connection observability.                                                                                        
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes #19756 
## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required - These are net new metrics, nothing new to be tested
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
Three new stats will appear in `/debug/vars`: `ZkLockAcquisition`, `ZkConnAcquisitionRetry`, `ZkConnState`
### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
This change was written with Claude Code and verified by humans