### PR TITLE
fix: Add sqlerror.ERRestartServerFailed to clone errors

### DIFF
--- a/go/mysql/sqlerror/constants.go
+++ b/go/mysql/sqlerror/constants.go
@@ -301,6 +301,12 @@ const (
 	ErrNotImplementedForProjectedSRS = ErrorCode(3705)
 	ErrNonPositiveRadius             = ErrorCode(3706)
 
+	// ERRestartServerFailed is ER_RESTART_SERVER_FAILED.
+	// Returned when CLONE INSTANCE FROM completes data transfer but mysqld cannot
+	// restart itself because it is not managed by a supervisor process. The clone
+	// data has already been transferred successfully when this error is returned.
+	ERRestartServerFailed = ErrorCode(3707)
+
 	// server not available
 	ERServerIsntAvailable = ErrorCode(3168)
 )

--- a/go/vt/mysqlctl/clone.go
+++ b/go/vt/mysqlctl/clone.go
@@ -347,7 +347,7 @@ func isCloneConnError(err error) bool {
 		return false
 	}
 	switch sqlErr.Number() {
-	case sqlerror.CRServerGone, sqlerror.CRServerLost:
+	case sqlerror.CRServerGone, sqlerror.CRServerLost, sqlerror.ERRestartServerFailed:
 		return true
 	default:
 		return false

--- a/go/vt/mysqlctl/clone_test.go
+++ b/go/vt/mysqlctl/clone_test.go
@@ -157,6 +157,11 @@ func TestIsCloneConnError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "restart server failed (no supervisor)",
+			err:      sqlerror.NewSQLError(sqlerror.ERRestartServerFailed, sqlerror.SSUnknownSQLState, "Restart server failed (mysqld is not managed by supervisor process)."),
+			expected: true,
+		},
+		{
 			name:     "access denied",
 			err:      accessDenied,
 			expected: false,


### PR DESCRIPTION
## Description

When `CLONE INSTANCE FROM` completes in an environment where mysqld is not managed by a supervisor process (e.g., no mysqld_safe), MySQL cannot self-restart and returns errno 3707 (ER_CLONE_PLUGIN_RESTART) instead of dropping the connection. The clone data transfer has completed successfully at this point — MySQL simply exits rather than restarting.

This fix adds `ERRestartServerFailed (errno 3707)` to `isCloneConnError` so it is treated the same as a connection drop — a normal outcome of a clone that completed successfully in a supervisor-less environment. After detecting this error, vtbackup proceeds to restart mysqld externally and verify clone completion via waitForCloneComplete.

## Related Issue(s)

Resolves: #19758 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

No deployment changes required. This is a pure code fix in the clone error handling path.

### AI Disclosure

This PR was written primarily by Claude Code.
