### PR TITLE
sqlparser: document codegen in AGENTS.md

### DIFF
--- a/go/vt/sqlparser/AGENTS.md
+++ b/go/vt/sqlparser/AGENTS.md
@@ -1,5 +1,40 @@
 # SQL Parser
 
+## Code Generation
+
+Many files in this package are generated. **Never edit generated files directly.**
+
+### Commands
+
+| Command | What it does |
+|---|---|
+| `make codegen` | Runs both `make sqlparser` and `make sizegen` |
+| `make sqlparser` | Runs `go generate ./go/vt/sqlparser/...` (parser + AST helpers + formatter) |
+| `make sizegen` | Runs `sizegen` to regenerate `cached_size.go` files across the repo |
+
+### Generated file map
+
+| Generated file | Source / generator | Regenerate with |
+|---|---|---|
+| `sql.go` | `sql.y` via `goyacc` | `make sqlparser` |
+| `ast_clone.go` | `ast.go` via `asthelpergen` | `make sqlparser` |
+| `ast_copy_on_rewrite.go` | `ast.go` via `asthelpergen` | `make sqlparser` |
+| `ast_equals.go` | `ast.go` via `asthelpergen` | `make sqlparser` |
+| `ast_path.go` | `ast.go` via `asthelpergen` | `make sqlparser` |
+| `ast_rewrite.go` | `ast.go` via `asthelpergen` | `make sqlparser` |
+| `ast_visit.go` | `ast.go` via `asthelpergen` | `make sqlparser` |
+| `ast_format_fast.go` | AST types via `astfmtgen` | `make sqlparser` |
+| `cached_size.go` | AST types via `sizegen` | `make sizegen` |
+
+The `go:generate` directives live in `generate.go`.
+
+### When to regenerate
+
+- **Modified `sql.y`** → `make sqlparser` (or `make codegen` to also update sizes)
+- **Modified AST types in `ast.go`** → `make codegen`
+- **Modified size-cached types** → `make sizegen`
+- **Resolving merge conflicts in generated files** → resolve the *source* file conflict, then regenerate
+
 ## Tokenizer
 
 The tokenizer (`token.go`) processes SQL input character-by-character. When


### PR DESCRIPTION
## Description

Documents the codegen commands and generated file mapping in the sqlparser `AGENTS.md` so AI agents (and humans) know which files are generated, what generates them, and which `make` target to run.

## Related Issue(s)

N/A

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

Written by Claude Code.