### PR TITLE
Update dependabot minimum-version-age to 14 days (30 days for npm)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    minimum-version-age: 14
+    cooldown:
+      default-days: 14
     groups:
       go:
         patterns:
@@ -14,7 +15,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    minimum-version-age: 14
+    cooldown:
+      default-days: 14
     groups:
       actions:
         patterns:
@@ -24,7 +26,8 @@ updates:
     directory: "/java"
     schedule:
       interval: "weekly"
-    minimum-version-age: 14
+    cooldown:
+      default-days: 14
     groups:
       java:
         patterns:
@@ -34,7 +37,8 @@ updates:
     directory: "/web/vtadmin"
     schedule:
       interval: "weekly"
-    minimum-version-age: 30
+    cooldown:
+      default-days: 30
     groups:
       vtadmin-npm:
         patterns:
@@ -52,7 +56,8 @@ updates:
       - "/go/mysql/collations/tools/colldump"
     schedule:
       interval: "weekly"
-    minimum-version-age: 14
+    cooldown:
+      default-days: 14
     ignore:
       - dependency-name: "mysql"
         versions:


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Updates Dependabot config so that recommended upgrades are at least 14 days old for all dependencies except npm, which is increased to 30 days, since it has a bit of a track record 😅. Not super duper important in Vitess as most people are not deploying `main` onto their production clusters, but rather be safe than sorry!

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

N/A

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->

Help from Copilot using Opus 4.6.