### PR TITLE
Use existing maintainers for steering committee

### DIFF
--- a/STEERING.md
+++ b/STEERING.md
@@ -33,12 +33,12 @@ We will form a bootstrap Steering Committee to serve for one year. The responsib
 * Conduct elections to form the next Steering Committee.
 
 ### Members
-* Rafael Chacon @rafael
-* Michael Demmer @demmer
-* Paul Hemberger @pH14
+* Andres Taylor @systay
+* Arthur Schreiber @arthurschreiber
 * Derek Perkins @derekperkins
-* Deepthi Sigireddi @deepthi
-* Sugu Sougoumarane @sougou, Chair
+* Matt Lord @mattlord
+* Rohit Nayak @rohit-nayak-ps
+* Tim Vaillancourt @timvaillancourt
 
 ## Credits
 This document was inspired by


### PR DESCRIPTION
## Description

The steering committee document still listed people, with one exception (Derek), who are no longer active maintainers. This committee has not served any practical purpose, at least to my knowledge, in recent history so for now I'm adding a subset of current maintainers that can serve in this capacity if needed in the future.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required