### PR TITLE
Add Mohamed as a Vitess maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,6 +9,7 @@ The following is the full list, alphabetically ordered.
 * Florent Poinsard ([frouioui](https://github.com/frouioui)) florent@planetscale.com
 * Harshit Gangal ([harshit-gangal](https://github.com/harshit-gangal)) harshit.gangal@gmail.com
 * Matt Lord ([mattlord](https://github.com/mattlord)) mattalord@gmail.com
+* Mohamed Hamza ([mhamza15](https://github.com/mhamza15)) mhamza@fastmail.com
 * Nick Van Wiggeren ([nickvanw](https://github.com/nickvanw)) nick@planetscale.com
 * Noble Mittal ([beingnoble03](https://github.com/beingnoble03)) noble@planetscale.com
 * Rohit Nayak ([rohit-nayak-ps](https://github.com/rohit-nayak-ps)) rohit@planetscale.com


### PR DESCRIPTION
## Description

This adds @mhamza15 as an official Vitess maintainer after the existing maintainers voted on the proposal. 

Welcome, @mhamza15 ! ❤️ 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required