### PR TITLE
ci: add `setup-go` composite action

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -25,6 +25,6 @@ runs:
           ~/go/pkg/mod
           ~/.cache/go-build
         # Cache by version/arch/hash. Construct hash using same method as actions/setup-go.
-        key: go-${{ steps.setup-go.outputs.go-version }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}
+        key: go-${{ steps.setup-go.outputs.go-version }}-${{ toLower(runner.os) }}-${{ toLower(runner.arch) }}-${{ hashFiles('go.sum') }}
         restore-keys: |
-          go-${{ steps.setup-go.outputs.go-version }}-${{ runner.arch }}-
+          go-${{ steps.setup-go.outputs.go-version }}-${{ toLower(runner.os) }}-${{ toLower(runner.arch) }}-


### PR DESCRIPTION
## Description

`actions/setup-go`'s built-in cache key includes `ImageOS`, which means the exact same Go module cache gets stored multiple times — once per runner type _(e.g. `ubuntu-24.04` vs `oracle-vm-*`)_. Each copy is 750mb+, so that adds up fast

This adds a `.github/actions/setup-go` composite action that wraps `setup-go` with its built-in caching disabled and uses `actions/cache` directly with a key based on `go-version`, `arch`, and `go.sum` hash — the only dimensions that actually matter

This PR only introduces the composite action — it doesn't update any workflows to use it yet. The plan:

1. **This PR** — land the action, backport it to release branches
2. **Follow-up PR** — update all 34 workflow files to use the composite action

The backport is needed because upgrade/downgrade test workflows check out a release branch mid-job to build binaries from a different Vitess version. When that happens, `uses: ./.github/actions/setup-go` resolves against the release branch's files, not the PR branch. Without the action on the release branch, those steps fail.

Once both land, this should reduce the repo's Actions cache usage by at least 20%, likely more

## Related Issue(s)

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

N/A — CI-only changes, no runtime impact.

### AI Disclosure

PR summary by Claude Code.