### PR TITLE
vtbackup: handle MySQL termination during CLONE restart

### DIFF
--- a/go/cmd/vtbackup/cli/mysql_term_handler.go
+++ b/go/cmd/vtbackup/cli/mysql_term_handler.go
@@ -17,23 +17,18 @@ limitations under the License.
 package cli
 
 import (
-	"context"
 	"sync/atomic"
 
 	"vitess.io/vitess/go/vt/log"
 )
 
 type mySQLTermHandler struct {
-	cancelCtx           context.CancelFunc
-	cancelBackgroundCtx context.CancelFunc
-	ignoreTerms         atomic.Bool
+	onTermFn    func()
+	ignoreTerms atomic.Bool
 }
 
-func newMySQLTermHandler(cancelCtx, cancelBackgroundCtx context.CancelFunc) *mySQLTermHandler {
-	return &mySQLTermHandler{
-		cancelCtx:           cancelCtx,
-		cancelBackgroundCtx: cancelBackgroundCtx,
-	}
+func newMySQLTermHandler(onTermFn func()) *mySQLTermHandler {
+	return &mySQLTermHandler{onTermFn: onTermFn}
 }
 
 func (h *mySQLTermHandler) ignoreTermsFor(fn func() error) error {
@@ -47,7 +42,5 @@ func (h *mySQLTermHandler) onTerm() {
 		log.Info("Ignoring expected MySQL termination during clone restart")
 		return
 	}
-	log.Warn("Cancelling vtbackup as MySQL has terminated")
-	h.cancelCtx()
-	h.cancelBackgroundCtx()
+	h.onTermFn()
 }

--- a/go/cmd/vtbackup/cli/mysql_term_handler.go
+++ b/go/cmd/vtbackup/cli/mysql_term_handler.go
@@ -39,7 +39,7 @@ func (h *mySQLTermHandler) ignoreTermsFor(fn func() error) error {
 
 func (h *mySQLTermHandler) onTerm() {
 	if h.ignoreTerms.Load() {
-		log.Info("Ignoring expected MySQL termination during clone restart")
+		log.Info("Ignoring MySQL termination while term suppression is enabled")
 		return
 	}
 	h.onTermFn()

--- a/go/cmd/vtbackup/cli/mysql_term_handler.go
+++ b/go/cmd/vtbackup/cli/mysql_term_handler.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"sync/atomic"
+
+	"vitess.io/vitess/go/vt/log"
+)
+
+type mySQLTermHandler struct {
+	cancelCtx           context.CancelFunc
+	cancelBackgroundCtx context.CancelFunc
+	ignoreTerms         atomic.Bool
+}
+
+func newMySQLTermHandler(cancelCtx, cancelBackgroundCtx context.CancelFunc) *mySQLTermHandler {
+	return &mySQLTermHandler{
+		cancelCtx:           cancelCtx,
+		cancelBackgroundCtx: cancelBackgroundCtx,
+	}
+}
+
+func (h *mySQLTermHandler) ignoreTermsFor(fn func() error) error {
+	h.ignoreTerms.Store(true)
+	defer h.ignoreTerms.Store(false)
+	return fn()
+}
+
+func (h *mySQLTermHandler) onTerm() {
+	if h.ignoreTerms.Load() {
+		log.Info("Ignoring expected MySQL termination during clone restart")
+		return
+	}
+	log.Warn("Cancelling vtbackup as MySQL has terminated")
+	h.cancelCtx()
+	h.cancelBackgroundCtx()
+}

--- a/go/cmd/vtbackup/cli/mysql_term_handler_test.go
+++ b/go/cmd/vtbackup/cli/mysql_term_handler_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMySQLTermHandlerOnTermCancelsContexts(t *testing.T) {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	backgroundCtx, cancelBackgroundCtx := context.WithCancel(context.Background())
+
+	handler := newMySQLTermHandler(cancelCtx, cancelBackgroundCtx)
+	handler.onTerm()
+
+	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+	assert.ErrorIs(t, backgroundCtx.Err(), context.Canceled)
+}
+
+func TestMySQLTermHandlerIgnoreTermsForSuppressesCancellation(t *testing.T) {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	backgroundCtx, cancelBackgroundCtx := context.WithCancel(context.Background())
+
+	handler := newMySQLTermHandler(cancelCtx, cancelBackgroundCtx)
+	err := handler.ignoreTermsFor(func() error {
+		handler.onTerm()
+		assert.NoError(t, ctx.Err())
+		assert.NoError(t, backgroundCtx.Err())
+		return nil
+	})
+
+	assert.NoError(t, err)
+	assert.NoError(t, ctx.Err())
+	assert.NoError(t, backgroundCtx.Err())
+
+	handler.onTerm()
+	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+	assert.ErrorIs(t, backgroundCtx.Err(), context.Canceled)
+}

--- a/go/cmd/vtbackup/cli/mysql_term_handler_test.go
+++ b/go/cmd/vtbackup/cli/mysql_term_handler_test.go
@@ -17,40 +17,32 @@ limitations under the License.
 package cli
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMySQLTermHandlerOnTermCancelsContexts(t *testing.T) {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	backgroundCtx, cancelBackgroundCtx := context.WithCancel(context.Background())
-
-	handler := newMySQLTermHandler(cancelCtx, cancelBackgroundCtx)
+func TestMySQLTermHandlerOnTermCallsCallback(t *testing.T) {
+	called := false
+	handler := newMySQLTermHandler(func() { called = true })
 	handler.onTerm()
 
-	assert.ErrorIs(t, ctx.Err(), context.Canceled)
-	assert.ErrorIs(t, backgroundCtx.Err(), context.Canceled)
+	assert.True(t, called)
 }
 
-func TestMySQLTermHandlerIgnoreTermsForSuppressesCancellation(t *testing.T) {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	backgroundCtx, cancelBackgroundCtx := context.WithCancel(context.Background())
+func TestMySQLTermHandlerIgnoreTermsForSuppressesCallback(t *testing.T) {
+	callCount := 0
+	handler := newMySQLTermHandler(func() { callCount++ })
 
-	handler := newMySQLTermHandler(cancelCtx, cancelBackgroundCtx)
 	err := handler.ignoreTermsFor(func() error {
 		handler.onTerm()
-		assert.NoError(t, ctx.Err())
-		assert.NoError(t, backgroundCtx.Err())
+		assert.Equal(t, 0, callCount)
 		return nil
 	})
 
 	assert.NoError(t, err)
-	assert.NoError(t, ctx.Err())
-	assert.NoError(t, backgroundCtx.Err())
+	assert.Equal(t, 0, callCount)
 
 	handler.onTerm()
-	assert.ErrorIs(t, ctx.Err(), context.Canceled)
-	assert.ErrorIs(t, backgroundCtx.Err(), context.Canceled)
+	assert.Equal(t, 1, callCount)
 }

--- a/go/cmd/vtbackup/cli/vtbackup.go
+++ b/go/cmd/vtbackup/cli/vtbackup.go
@@ -359,17 +359,15 @@ func takeBackup(ctx, backgroundCtx context.Context, topoServer *topo.Server, bac
 	if err != nil {
 		return fmt.Errorf("failed to initialize mysql config: %v", err)
 	}
+
 	ctx, cancelCtx := context.WithCancel(ctx)
 	backgroundCtx, cancelBackgroundCtx := context.WithCancel(backgroundCtx)
 	defer func() {
 		cancelCtx()
 		cancelBackgroundCtx()
 	}()
-	mysqld.OnTerm(func() {
-		log.Warn("Cancelling vtbackup as MySQL has terminated")
-		cancelCtx()
-		cancelBackgroundCtx()
-	})
+	mysqlTermHandler := newMySQLTermHandler(cancelCtx, cancelBackgroundCtx)
+	mysqld.OnTerm(mysqlTermHandler.onTerm)
 
 	initCtx, initCancel := context.WithTimeout(ctx, mysqlTimeout)
 	defer initCancel()
@@ -462,7 +460,13 @@ func takeBackup(ctx, backgroundCtx context.Context, topoServer *topo.Server, bac
 
 	var restorePos replication.Position
 	if restoreWithClone {
-		restorePos, err = mysqlctl.CloneFromDonor(ctx, topoServer, mysqld, initKeyspace, initShard)
+		// CLONE intentionally restarts mysqld. Suppress the resulting OnTerm
+		// cancellation and pass mycnf so CloneFromDonor can restart mysqld
+		// itself if no process supervisor does.
+		err = mysqlTermHandler.ignoreTermsFor(func() error {
+			restorePos, err = mysqlctl.CloneFromDonor(ctx, topoServer, mysqld, mycnf, initKeyspace, initShard)
+			return err
+		})
 		if err != nil {
 			return vterrors.Wrap(err, "restore with clone failed")
 		}

--- a/go/cmd/vtbackup/cli/vtbackup.go
+++ b/go/cmd/vtbackup/cli/vtbackup.go
@@ -366,7 +366,11 @@ func takeBackup(ctx, backgroundCtx context.Context, topoServer *topo.Server, bac
 		cancelCtx()
 		cancelBackgroundCtx()
 	}()
-	mysqlTermHandler := newMySQLTermHandler(cancelCtx, cancelBackgroundCtx)
+	mysqlTermHandler := newMySQLTermHandler(func() {
+		log.Warn("Cancelling vtbackup as MySQL has terminated")
+		cancelCtx()
+		cancelBackgroundCtx()
+	})
 	mysqld.OnTerm(mysqlTermHandler.onTerm)
 
 	initCtx, initCancel := context.WithTimeout(ctx, mysqlTimeout)

--- a/go/cmd/vtbackup/cli/vtbackup.go
+++ b/go/cmd/vtbackup/cli/vtbackup.go
@@ -306,7 +306,7 @@ func run(cc *cobra.Command, args []string) error {
 		return fmt.Errorf("Can't take backup: %w", err)
 	}
 	if doBackup {
-		if err := takeBackup(ctx, cc.Context(), topoServer, backupStorage); err != nil {
+		if err := takeBackup(ctx, topoServer, backupStorage); err != nil {
 			return fmt.Errorf("Failed to take backup: %w", err)
 		}
 	}
@@ -328,7 +328,9 @@ func run(cc *cobra.Command, args []string) error {
 	return nil
 }
 
-func takeBackup(ctx, backgroundCtx context.Context, topoServer *topo.Server, backupStorage backupstorage.BackupStorage) error {
+// takeBackup restores or clones the shard data into a temporary mysqld,
+// catches replication up to the primary, and writes a new backup.
+func takeBackup(ctx context.Context, topoServer *topo.Server, backupStorage backupstorage.BackupStorage) error {
 	// This is an imaginary tablet alias. The value doesn't matter for anything,
 	// except that we generate a random UID to ensure the target backup
 	// directory is unique if multiple vtbackup instances are launched for the
@@ -360,20 +362,28 @@ func takeBackup(ctx, backgroundCtx context.Context, topoServer *topo.Server, bac
 		return fmt.Errorf("failed to initialize mysql config: %v", err)
 	}
 
-	ctx, cancelCtx := context.WithCancel(ctx)
-	backgroundCtx, cancelBackgroundCtx := context.WithCancel(backgroundCtx)
+	// shutdownCtx is a separate context for local mysqld work in this function.
+	// We do not use the main job context for this because mysqld can stop as
+	// part of normal CLONE work. Local mysqld calls should stop when that
+	// happens, but allow the rest of the backup job to continue.
+	shutdownCtx, cancelShutdownCtx := context.WithCancel(ctx)
+
+	// cleanupCtx is only for cleanup work at the end.
+	cleanupCtx, cancelCleanupCtx := context.WithCancel(ctx)
+
 	defer func() {
-		cancelCtx()
-		cancelBackgroundCtx()
+		cancelShutdownCtx()
+		cancelCleanupCtx()
 	}()
+
 	mysqlTermHandler := newMySQLTermHandler(func() {
 		log.Warn("Cancelling vtbackup as MySQL has terminated")
-		cancelCtx()
-		cancelBackgroundCtx()
+		cancelShutdownCtx()
+		cancelCleanupCtx()
 	})
 	mysqld.OnTerm(mysqlTermHandler.onTerm)
 
-	initCtx, initCancel := context.WithTimeout(ctx, mysqlTimeout)
+	initCtx, initCancel := context.WithTimeout(shutdownCtx, mysqlTimeout)
 	defer initCancel()
 	initMysqldAt := time.Now()
 	if err := mysqld.Init(initCtx, mycnf, initDBSQLFile); err != nil {
@@ -382,9 +392,8 @@ func takeBackup(ctx, backgroundCtx context.Context, topoServer *topo.Server, bac
 	deprecatedDurationByPhase.Set("InitMySQLd", int64(time.Since(initMysqldAt).Seconds()))
 	// Shut down mysqld when we're done.
 	defer func() {
-		// Be careful use the background context, not the init one, because we don't want to
-		// skip shutdown just because we timed out waiting for init.
-		mysqlShutdownCtx, mysqlShutdownCancel := context.WithTimeout(backgroundCtx, mysqlShutdownTimeout+10*time.Second)
+		// Use cleanupCtx here so we still try to clean up even if startup timed out.
+		mysqlShutdownCtx, mysqlShutdownCancel := context.WithTimeout(cleanupCtx, mysqlShutdownTimeout+10*time.Second)
 		defer mysqlShutdownCancel()
 		if err := mysqld.Shutdown(mysqlShutdownCtx, mycnf, false, mysqlShutdownTimeout); err != nil {
 			log.Error(fmt.Sprintf("failed to shutdown mysqld: %v", err))
@@ -428,11 +437,11 @@ func takeBackup(ctx, backgroundCtx context.Context, topoServer *topo.Server, bac
 		// produces a result that can be used to skip InitShardPrimary entirely.
 		// This involves resetting replication (to erase any history) and then
 		// creating the main database and some Vitess system tables.
-		if err := mysqld.ResetReplication(ctx); err != nil {
+		if err := mysqld.ResetReplication(shutdownCtx); err != nil {
 			return fmt.Errorf("can't reset replication: %v", err)
 		}
 		// We need to switch off super_read_only before we create the database.
-		resetFunc, err := mysqld.SetSuperReadOnly(ctx, false)
+		resetFunc, err := mysqld.SetSuperReadOnly(shutdownCtx, false)
 		if err != nil {
 			return fmt.Errorf("failed to disable super_read_only during backup: %v", err)
 		}
@@ -445,7 +454,7 @@ func takeBackup(ctx, backgroundCtx context.Context, topoServer *topo.Server, bac
 			}()
 		}
 		cmd := mysqlctl.GenerateInitialBinlogEntry()
-		if err := mysqld.ExecuteSuperQueryList(ctx, []string{cmd}); err != nil {
+		if err := mysqld.ExecuteSuperQueryList(shutdownCtx, []string{cmd}); err != nil {
 			return err
 		}
 
@@ -453,7 +462,7 @@ func takeBackup(ctx, backgroundCtx context.Context, topoServer *topo.Server, bac
 		// Now we're ready to take the backup.
 		phase.Set(phaseNameInitialBackup, int64(1))
 		defer phase.Set(phaseNameInitialBackup, int64(0))
-		if err := mysqlctl.Backup(ctx, backupParams); err != nil {
+		if err := mysqlctl.Backup(shutdownCtx, backupParams); err != nil {
 			return fmt.Errorf("backup failed: %v", err)
 		}
 		deprecatedDurationByPhase.Set("InitialBackup", int64(time.Since(backupParams.BackupTime).Seconds()))
@@ -462,56 +471,96 @@ func takeBackup(ctx, backgroundCtx context.Context, topoServer *topo.Server, bac
 		return nil
 	}
 
-	var restorePos replication.Position
+	// Set up the context for the restore phase. If we are restoring from
+	// backup, use shutdownCtx so local mysqld work stops if mysqld exits. If
+	// we are cloning, use the main job context because CLONE makes mysqld
+	// restart on purpose and we do not want the restore to stop for that.
+	restoreCtx := shutdownCtx
 	if restoreWithClone {
+		restoreCtx = ctx
+	}
+
+	restorePos, err := restoreForBackup(restoreCtx, mysqlTermHandler, topoServer, mysqld, mycnf, dbName, extraEnv)
+	if err != nil {
+		return err
+	}
+
+	if err := runBackup(shutdownCtx, topoServer, mysqld, mycnf, restorePos, &backupParams); err != nil {
+		return err
+	}
+
+	log.Info("Backup successful.")
+	return nil
+}
+
+// restoreForBackup runs the restore step and returns the position the rest of
+// the backup job should use.
+func restoreForBackup(ctx context.Context, mysqlTermHandler *mySQLTermHandler, topoServer *topo.Server, mysqld mysqlctl.MysqlDaemon, mycnf *mysqlctl.Mycnf, dbName string, extraEnv map[string]string) (replication.Position, error) {
+	if restoreWithClone {
+		var restorePos replication.Position
+
 		// CLONE intentionally restarts mysqld. Suppress the resulting OnTerm
 		// cancellation and pass mycnf so CloneFromDonor can restart mysqld
 		// itself if no process supervisor does.
-		err = mysqlTermHandler.ignoreTermsFor(func() error {
+		err := mysqlTermHandler.ignoreTermsFor(func() error {
+			var err error
+
 			restorePos, err = mysqlctl.CloneFromDonor(ctx, topoServer, mysqld, mycnf, initKeyspace, initShard)
+
 			return err
 		})
 		if err != nil {
-			return vterrors.Wrap(err, "restore with clone failed")
+			return replication.Position{}, vterrors.Wrap(err, "restore with clone failed")
 		}
-	} else {
-		phase.Set(phaseNameRestoreLastBackup, int64(1))
-		defer phase.Set(phaseNameRestoreLastBackup, int64(0))
-		backupDir := mysqlctl.GetBackupDir(initKeyspace, initShard)
-		log.Info(fmt.Sprintf("Restoring latest backup from directory %v", backupDir))
-		restoreAt := time.Now()
-		params := mysqlctl.RestoreParams{
-			Cnf:                  mycnf,
-			Mysqld:               mysqld,
-			Logger:               logutil.NewConsoleLogger(),
-			Concurrency:          concurrency,
-			HookExtraEnv:         extraEnv,
-			DeleteBeforeRestore:  true,
-			DbName:               dbName,
-			Keyspace:             initKeyspace,
-			Shard:                initShard,
-			Stats:                backupstats.RestoreStats(),
-			MysqlShutdownTimeout: mysqlShutdownTimeout,
-		}
-		backupManifest, err := mysqlctl.Restore(ctx, params)
-		switch err {
-		case nil:
-			// if err is nil, we expect backupManifest to be non-nil
-			restorePos = backupManifest.Position
-			log.Info(fmt.Sprintf("Successfully restored from backup at replication position %v", restorePos))
-		case mysqlctl.ErrNoBackup:
-			// There is no backup found, but we may be taking the initial backup of a shard
-			if !allowFirstBackup {
-				return vterrors.New(vtrpc.Code_FAILED_PRECONDITION, "no backup found; not starting up empty since --initial_backup flag was not enabled")
-			}
-			restorePos = replication.Position{}
-		default:
-			return vterrors.Wrap(err, "can't restore from backup")
-		}
-		deprecatedDurationByPhase.Set("RestoreLastBackup", int64(time.Since(restoreAt).Seconds()))
-		phase.Set(phaseNameRestoreLastBackup, int64(0))
+
+		return restorePos, nil
 	}
 
+	phase.Set(phaseNameRestoreLastBackup, int64(1))
+	defer phase.Set(phaseNameRestoreLastBackup, int64(0))
+
+	backupDir := mysqlctl.GetBackupDir(initKeyspace, initShard)
+	log.Info(fmt.Sprintf("Restoring latest backup from directory %v", backupDir))
+
+	restoreAt := time.Now()
+
+	params := mysqlctl.RestoreParams{
+		Cnf:                  mycnf,
+		Mysqld:               mysqld,
+		Logger:               logutil.NewConsoleLogger(),
+		Concurrency:          concurrency,
+		HookExtraEnv:         extraEnv,
+		DeleteBeforeRestore:  true,
+		DbName:               dbName,
+		Keyspace:             initKeyspace,
+		Shard:                initShard,
+		Stats:                backupstats.RestoreStats(),
+		MysqlShutdownTimeout: mysqlShutdownTimeout,
+	}
+
+	backupManifest, err := mysqlctl.Restore(ctx, params)
+	switch err {
+	case nil:
+		// If err is nil, we expect backupManifest to be non-nil.
+		log.Info(fmt.Sprintf("Successfully restored from backup at replication position %v", backupManifest.Position))
+		deprecatedDurationByPhase.Set("RestoreLastBackup", int64(time.Since(restoreAt).Seconds()))
+		return backupManifest.Position, nil
+	case mysqlctl.ErrNoBackup:
+		// There is no backup found, but we may be taking the initial backup of a shard.
+		if !allowFirstBackup {
+			return replication.Position{}, vterrors.New(vtrpc.Code_FAILED_PRECONDITION, "no backup found; not starting up empty since --initial_backup flag was not enabled")
+		}
+
+		deprecatedDurationByPhase.Set("RestoreLastBackup", int64(time.Since(restoreAt).Seconds()))
+		return replication.Position{}, nil
+	default:
+		return replication.Position{}, vterrors.Wrap(err, "can't restore from backup")
+	}
+}
+
+// runBackup starts replication from the restore position, catches up to the
+// current primary position, and takes a new backup.
+func runBackup(ctx context.Context, topoServer *topo.Server, mysqld *mysqlctl.Mysqld, mycnf *mysqlctl.Mycnf, restorePos replication.Position, backupParams *mysqlctl.BackupParams) error {
 	// As of MySQL 8.0.21, you can disable redo logging using the ALTER INSTANCE
 	// DISABLE INNODB REDO_LOG statement. This functionality is intended for
 	// loading data into a new MySQL instance. Disabling redo logging speeds up
@@ -542,17 +591,20 @@ func takeBackup(ctx, backgroundCtx context.Context, topoServer *topo.Server, bac
 	// catch up to live changes, we'd rather take a backup of something rather
 	// than timing out.
 	tmc := tmclient.NewTabletManagerClient()
+
 	// Keep retrying if we can't contact the primary. The primary might be
 	// changing, moving, or down temporarily.
 	var primaryPos replication.Position
-	err = retryOnError(ctx, func() error {
+	err := retryOnError(ctx, func() error {
 		// Add a per-operation timeout so we re-read topo if the primary is unreachable.
 		opCtx, optCancel := context.WithTimeout(ctx, operationTimeout)
 		defer optCancel()
+
 		pos, err := getPrimaryPosition(opCtx, tmc, topoServer)
 		if err != nil {
 			return fmt.Errorf("can't get the primary replication position: %v", err)
 		}
+
 		primaryPos = pos
 		return nil
 	})
@@ -562,6 +614,75 @@ func takeBackup(ctx, backgroundCtx context.Context, topoServer *topo.Server, bac
 
 	log.Info("takeBackup: primary position is: " + primaryPos.String())
 
+	status, err := catchUpReplicationForBackup(ctx, topoServer, mysqld, restorePos, primaryPos)
+	if err != nil {
+		return err
+	}
+
+	// Re-enable redo logging before running init SQL, so that init SQL
+	// queries run with full crash safety.
+	if disabledRedoLog {
+		if err := mysqld.EnableRedoLog(ctx); err != nil {
+			return fmt.Errorf("failed to re-enable redo log: %v", err)
+		}
+	}
+
+	// Perform any requested backup initialization queries after catch-up replication.
+	if err := mysqlctl.ExecuteBackupInitSQL(ctx, backupParams); err != nil {
+		return vterrors.Wrap(err, "failed to execute backup init SQL queries")
+	}
+
+	// Set BackupTime after catch-up and init SQL, so the timestamp on the
+	// backup postdates any changes made by init SQL queries.
+	backupParams.BackupTime = time.Now()
+
+	if restartBeforeBackup {
+		restartAt := time.Now()
+		log.Info("Proceeding with clean MySQL shutdown and startup to flush all buffers.")
+
+		// Prep for full/clean shutdown (not typically the default)
+		if err := mysqld.ExecuteSuperQuery(ctx, "SET GLOBAL innodb_fast_shutdown=0"); err != nil {
+			return fmt.Errorf("Could not prep for full shutdown: %v", err)
+		}
+
+		// Shutdown, waiting for it to finish
+		if err := mysqld.Shutdown(ctx, mycnf, true, mysqlShutdownTimeout); err != nil {
+			return fmt.Errorf("Something went wrong during full MySQL shutdown: %v", err)
+		}
+
+		// Start MySQL, waiting for it to come up
+		if err := mysqld.Start(ctx, mycnf); err != nil {
+			return fmt.Errorf("Could not start MySQL after full shutdown: %v", err)
+		}
+
+		deprecatedDurationByPhase.Set("RestartBeforeBackup", int64(time.Since(restartAt).Seconds()))
+	}
+
+	// Now we can take a new backup.
+	backupAt := time.Now()
+	phase.Set(phaseNameTakeNewBackup, int64(1))
+	defer phase.Set(phaseNameTakeNewBackup, int64(0))
+
+	if err := mysqlctl.Backup(ctx, *backupParams); err != nil {
+		return fmt.Errorf("error taking backup: %v", err)
+	}
+
+	deprecatedDurationByPhase.Set("TakeNewBackup", int64(time.Since(backupAt).Seconds()))
+	phase.Set(phaseNameTakeNewBackup, int64(0))
+
+	// Return a non-zero exit code if we didn't meet the replication position
+	// goal, even though we took a backup that pushes the high-water mark up.
+	if !status.Position.AtLeast(primaryPos) {
+		return fmt.Errorf("replication caught up to %v but didn't make it to the goal of %v; a backup was taken anyway to save partial progress, but the operation should still be retried since not all expected data is backed up", status.Position, primaryPos)
+	}
+
+	return nil
+}
+
+// catchUpReplicationForBackup catches a restored mysqld up to the current
+// primary position and returns the final replication status after it stops
+// replication again.
+func catchUpReplicationForBackup(ctx context.Context, topoServer *topo.Server, mysqld mysqlctl.MysqlDaemon, restorePos, primaryPos replication.Position) (replication.ReplicationStatus, error) {
 	// Wait for replication to catch up.
 	phase.Set(phaseNameCatchupReplication, int64(1))
 	defer phase.Set(phaseNameCatchupReplication, int64(0))
@@ -577,12 +698,12 @@ func takeBackup(ctx, backgroundCtx context.Context, topoServer *topo.Server, bac
 	lastErr := vterrors.NewLastError("replication catch up", timeoutWaitingForReplicationStatus)
 	for {
 		if !lastErr.ShouldRetry() {
-			return fmt.Errorf("timeout waiting for replication status after %.0f seconds", timeoutWaitingForReplicationStatus.Seconds())
+			return replication.ReplicationStatus{}, fmt.Errorf("timeout waiting for replication status after %.0f seconds", timeoutWaitingForReplicationStatus.Seconds())
 		}
 
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("error in replication catch up: %v", ctx.Err())
+			return replication.ReplicationStatus{}, fmt.Errorf("error in replication catch up: %v", ctx.Err())
 		case <-time.After(time.Second):
 		}
 
@@ -593,6 +714,7 @@ func takeBackup(ctx, backgroundCtx context.Context, topoServer *topo.Server, bac
 			log.Warn(fmt.Sprintf("Error getting replication status: %v", statusErr))
 			continue
 		}
+
 		if status.Position.AtLeast(primaryPos) {
 			// We're caught up on replication to at least the point the primary
 			// was at when this vtbackup run started.
@@ -600,6 +722,7 @@ func takeBackup(ctx, backgroundCtx context.Context, topoServer *topo.Server, bac
 			deprecatedDurationByPhase.Set("CatchUpReplication", int64(time.Since(waitStartTime).Seconds()))
 			break
 		}
+
 		if !lastStatus.Position.IsZero() {
 			if status.Position.Equal(lastStatus.Position) {
 				phaseStatus.Set([]string{phaseNameCatchupReplication, phaseStatusCatchupReplicationStalled}, 1)
@@ -607,6 +730,7 @@ func takeBackup(ctx, backgroundCtx context.Context, topoServer *topo.Server, bac
 				phaseStatus.Set([]string{phaseNameCatchupReplication, phaseStatusCatchupReplicationStalled}, 0)
 			}
 		}
+
 		if !status.Healthy() {
 			errStr := "Replication has stopped before backup could be taken. Trying to restart replication."
 			log.Warn(errStr)
@@ -620,77 +744,29 @@ func takeBackup(ctx, backgroundCtx context.Context, topoServer *topo.Server, bac
 			phaseStatus.Set([]string{phaseNameCatchupReplication, phaseStatusCatchupReplicationStopped}, 0)
 		}
 	}
+
 	phase.Set(phaseNameCatchupReplication, int64(0))
 
 	// Stop replication and see where we are.
 	if err := mysqld.StopReplication(ctx, nil); err != nil {
-		return fmt.Errorf("can't stop replication: %v", err)
+		return replication.ReplicationStatus{}, fmt.Errorf("can't stop replication: %v", err)
 	}
 
 	// Did we make any progress?
 	status, statusErr = mysqld.ReplicationStatus(ctx)
 	if statusErr != nil {
-		return fmt.Errorf("can't get replication status: %v", err)
+		return replication.ReplicationStatus{}, fmt.Errorf("can't get replication status: %v", statusErr)
 	}
+
 	log.Info(fmt.Sprintf("Replication caught up to %v", status.Position))
 	if !status.Position.AtLeast(primaryPos) && status.Position.Equal(restorePos) {
-		return fmt.Errorf("not taking backup: replication did not make any progress from restore point: %v", restorePos)
+		return replication.ReplicationStatus{}, fmt.Errorf("not taking backup: replication did not make any progress from restore point: %v", restorePos)
 	}
+
 	phaseStatus.Set([]string{phaseNameCatchupReplication, phaseStatusCatchupReplicationStalled}, 0)
 	phaseStatus.Set([]string{phaseNameCatchupReplication, phaseStatusCatchupReplicationStopped}, 0)
 
-	// Re-enable redo logging before running init SQL, so that init SQL
-	// queries run with full crash safety.
-	if disabledRedoLog {
-		if err := mysqld.EnableRedoLog(ctx); err != nil {
-			return fmt.Errorf("failed to re-enable redo log: %v", err)
-		}
-	}
-
-	// Perform any requested backup initialization queries after catch-up replication.
-	if err := mysqlctl.ExecuteBackupInitSQL(ctx, &backupParams); err != nil {
-		return vterrors.Wrap(err, "failed to execute backup init SQL queries")
-	}
-
-	// Set BackupTime after catch-up and init SQL, so the timestamp on the
-	// backup postdates any changes made by init SQL queries.
-	backupParams.BackupTime = time.Now()
-
-	if restartBeforeBackup {
-		restartAt := time.Now()
-		log.Info("Proceeding with clean MySQL shutdown and startup to flush all buffers.")
-		// Prep for full/clean shutdown (not typically the default)
-		if err := mysqld.ExecuteSuperQuery(ctx, "SET GLOBAL innodb_fast_shutdown=0"); err != nil {
-			return fmt.Errorf("Could not prep for full shutdown: %v", err)
-		}
-		// Shutdown, waiting for it to finish
-		if err := mysqld.Shutdown(ctx, mycnf, true, mysqlShutdownTimeout); err != nil {
-			return fmt.Errorf("Something went wrong during full MySQL shutdown: %v", err)
-		}
-		// Start MySQL, waiting for it to come up
-		if err := mysqld.Start(ctx, mycnf); err != nil {
-			return fmt.Errorf("Could not start MySQL after full shutdown: %v", err)
-		}
-		deprecatedDurationByPhase.Set("RestartBeforeBackup", int64(time.Since(restartAt).Seconds()))
-	}
-
-	// Now we can take a new backup.
-	backupAt := time.Now()
-	phase.Set(phaseNameTakeNewBackup, int64(1))
-	defer phase.Set(phaseNameTakeNewBackup, int64(0))
-	if err := mysqlctl.Backup(ctx, backupParams); err != nil {
-		return fmt.Errorf("error taking backup: %v", err)
-	}
-	deprecatedDurationByPhase.Set("TakeNewBackup", int64(time.Since(backupAt).Seconds()))
-	phase.Set(phaseNameTakeNewBackup, int64(0))
-
-	// Return a non-zero exit code if we didn't meet the replication position
-	// goal, even though we took a backup that pushes the high-water mark up.
-	if !status.Position.AtLeast(primaryPos) {
-		return fmt.Errorf("replication caught up to %v but didn't make it to the goal of %v; a backup was taken anyway to save partial progress, but the operation should still be retried since not all expected data is backed up", status.Position, primaryPos)
-	}
-	log.Info("Backup successful.")
-	return nil
+	return status, nil
 }
 
 func resetReplication(ctx context.Context, pos replication.Position, mysqld mysqlctl.MysqlDaemon) error {

--- a/go/test/endtoend/clone/clone_test.go
+++ b/go/test/endtoend/clone/clone_test.go
@@ -18,6 +18,7 @@ package clone
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -259,6 +260,31 @@ func connectToTablet(ctx context.Context, tablet *cluster.Vttablet) (*mysql.Conn
 	return mysql.Connect(ctx, &params)
 }
 
+// stopMysqldSafeForTablet stops mysqld_safe for a tablet without stopping
+// mysqld itself. This is used to exercise the case where MySQL finishes the
+// clone but cannot restart itself.
+func stopMysqldSafeForTablet(tablet *cluster.Vttablet) error {
+	mysqldSafePattern := fmt.Sprintf("mysqld_safe.*vt_%010d", tablet.TabletUID)
+
+	output, err := exec.Command("pkill", "-9", "-f", mysqldSafePattern).CombinedOutput()
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok && exitErr.ExitCode() == 1 {
+		// pkill exits 1 when no process matched. That is fine if the local
+		// MySQL install already starts mysqld directly.
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf(
+			"failed to stop mysqld_safe for tablet %d: %w, output: %s",
+			tablet.TabletUID,
+			err,
+			output,
+		)
+	}
+
+	return nil
+}
+
 // createMysqldForTablet creates a Mysqld instance for CloneExecutor
 func createMysqldForTablet(tablet *cluster.Vttablet) *mysqlctl.Mysqld {
 	socketPath := path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("vt_%010d", tablet.TabletUID), "mysql.sock")
@@ -328,6 +354,19 @@ func TestCloneRemote(t *testing.T) {
 	recipientMysqld := createMysqldForTablet(recipientTablet)
 	defer recipientMysqld.Close()
 
+	// Keep the tablet my.cnf available for the recovery path. The clone stops
+	// mysqld, and this test expects mysqlctl to start mysqld again afterward.
+	recipientMycnf, err := mysqlctl.ReadMycnf(
+		mysqlctl.NewMycnf(uint32(recipientTablet.TabletUID), recipientTablet.MySQLPort),
+		30*time.Second,
+	)
+	require.NoError(t, err, "Failed to read recipient my.cnf")
+
+	// Stop only mysqld_safe. The mysqld process must stay alive for CLONE to
+	// run, but mysqld_safe should not restart it when CLONE finishes.
+	err = stopMysqldSafeForTablet(recipientTablet)
+	require.NoError(t, err, "Failed to stop recipient mysqld_safe")
+
 	// Enable MySQL CLONE for the test
 	mysqlctl.SetMySQLCloneEnabled(true)
 	defer mysqlctl.SetMySQLCloneEnabled(false)
@@ -341,7 +380,7 @@ func TestCloneRemote(t *testing.T) {
 		UseSSL:        false,
 	}
 
-	err = executor.ExecuteClone(ctx, recipientMysqld, nil, 5*time.Minute)
+	err = executor.ExecuteClone(ctx, recipientMysqld, recipientMycnf, 5*time.Minute)
 	require.NoError(t, err, "Clone operation failed")
 
 	// Connect to recipient and verify data
@@ -349,7 +388,7 @@ func TestCloneRemote(t *testing.T) {
 	require.NoError(t, err, "Failed to connect to recipient after clone")
 	defer recipientConn.Close()
 
-	// Verify clone succeeded at MySQL level via performance_schema.clone_status
+	// Verify clone succeeded at MySQL level using performance_schema.clone_status
 	qr, err = recipientConn.ExecuteFetch(
 		"SELECT STATE, ERROR_NO, ERROR_MESSAGE FROM performance_schema.clone_status ORDER BY ID DESC LIMIT 1", 1, false)
 	require.NoError(t, err, "Failed to query clone_status")

--- a/go/test/endtoend/clone/clone_test.go
+++ b/go/test/endtoend/clone/clone_test.go
@@ -341,7 +341,7 @@ func TestCloneRemote(t *testing.T) {
 		UseSSL:        false,
 	}
 
-	err = executor.ExecuteClone(ctx, recipientMysqld, 5*time.Minute)
+	err = executor.ExecuteClone(ctx, recipientMysqld, nil, 5*time.Minute)
 	require.NoError(t, err, "Clone operation failed")
 
 	// Connect to recipient and verify data

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -556,7 +556,7 @@ func ExecuteBackupInitSQL(ctx context.Context, params *BackupParams) error {
 	// may have been started with super-read-only enabled via my.cnf.
 	resetFunc, err := params.Mysqld.SetSuperReadOnly(initCtx, false)
 	if err != nil {
-		if sqlErr, ok := err.(*sqlerror.SQLError); ok && sqlErr.Number() == sqlerror.ERUnknownSystemVariable {
+		if sqlErr, ok := errors.AsType[*sqlerror.SQLError](err); ok && sqlErr.Number() == sqlerror.ERUnknownSystemVariable {
 			params.Logger.Infof("Server does not support super_read_only, continuing with init SQL queries: %v", err)
 		} else if params.InitSQL.FailOnError {
 			return vterrors.Wrap(err, "failed to disable super_read_only for init SQL queries")

--- a/go/vt/mysqlctl/clone.go
+++ b/go/vt/mysqlctl/clone.go
@@ -363,6 +363,14 @@ func (c *CloneExecutor) prepareCloneVerification(ctx context.Context, mysqld Mys
 			verifyCancel()
 			return nil, nil, vterrors.Wrapf(cloneErr, "mysqld could not restart itself after clone and no my.cnf available for manual restart")
 		}
+
+		// mysqlctld exits when mysqld stops on its own, so there is no remote
+		// server left to handle a restart request in --mysqlctl-socket mode.
+		if socketFile != "" {
+			verifyCancel()
+			return nil, nil, vterrors.Wrapf(cloneErr, "mysqld could not restart itself after clone, and manual restart is not supported with --mysqlctl-socket")
+		}
+
 		log.Info("MySQL could not restart itself after CLONE; restarting manually")
 		if err := mysqld.StartAfterExit(verifyCtx, mycnf); err != nil {
 			verifyCancel()

--- a/go/vt/mysqlctl/clone.go
+++ b/go/vt/mysqlctl/clone.go
@@ -67,7 +67,9 @@ func registerCloneFlags(fs *pflag.FlagSet) {
 
 // CloneFromDonor clones data from the specified donor tablet using MySQL CLONE REMOTE.
 // It returns the GTID position of the cloned data.
-func CloneFromDonor(ctx context.Context, topoServer *topo.Server, mysqld MysqlDaemon, keyspace, shard string) (replication.Position, error) {
+// If mycnf is non-nil, CloneFromDonor may use it to restart mysqld locally when
+// CLONE completes but MySQL cannot restart itself.
+func CloneFromDonor(ctx context.Context, topoServer *topo.Server, mysqld MysqlDaemon, mycnf *Mycnf, keyspace, shard string) (replication.Position, error) {
 	var donorAlias *topodatapb.TabletAlias
 	var err error
 
@@ -116,6 +118,9 @@ func CloneFromDonor(ctx context.Context, topoServer *topo.Server, mysqld MysqlDa
 		DonorUser:     cloneConfig.User,
 		DonorPassword: cloneConfig.Password,
 		UseSSL:        cloneConfig.UseSSL,
+		// Pass mycnf through so ExecuteClone can fall back to a local restart
+		// when CLONE succeeds but mysqld cannot restart itself.
+		Mycnf: mycnf,
 	}
 
 	log.Info(fmt.Sprintf("Clone executor configured for donor %s:%d", executor.DonorHost, executor.DonorPort))
@@ -127,8 +132,13 @@ func CloneFromDonor(ctx context.Context, topoServer *topo.Server, mysqld MysqlDa
 		return replication.Position{}, fmt.Errorf("clone execution failed: %v", err)
 	}
 
-	// Get the GTID position from the cloned data.
-	pos, err := mysqld.PrimaryPosition(ctx)
+	// Use a detached context for post-clone operations: the parent context may
+	// have been canceled by an OnTerm callback when MySQL exited during the
+	// clone-induced restart.
+	posCtx, posCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer posCancel()
+
+	pos, err := mysqld.PrimaryPosition(posCtx)
 	if err != nil {
 		return replication.Position{}, fmt.Errorf("failed to get position after clone: %v", err)
 	}
@@ -150,6 +160,9 @@ type CloneExecutor struct {
 	DonorPassword string
 	// UseSSL indicates whether to use SSL for the clone connection.
 	UseSSL bool
+	// Mycnf, if set, is used to restart mysqld after a CLONE operation returns
+	// ERRestartServerFailed.
+	Mycnf *Mycnf
 }
 
 // validateRecipient checks that the recipient MySQL instance meets all prerequisites for cloning.
@@ -307,20 +320,52 @@ func (c *CloneExecutor) ExecuteClone(ctx context.Context, mysqld MysqlDaemon, wa
 	// Execute the clone command. When clone completes, MySQL restarts automatically
 	// which will cause the connection to drop. We ignore this error and verify
 	// success by checking clone_status after MySQL comes back up.
-	if err := mysqld.ExecuteSuperQuery(ctx, cloneCmd); err != nil {
-		if !isCloneConnError(err) {
-			return vterrors.Wrapf(err, "clone command failed")
-		}
-		log.Info(fmt.Sprintf("CLONE command returned (connection likely lost due to MySQL restart): %v", err))
+	cloneErr := mysqld.ExecuteSuperQuery(ctx, cloneCmd)
+	if cloneErr != nil && !isCloneConnError(cloneErr) {
+		return vterrors.Wrapf(cloneErr, "clone command failed")
 	}
 
-	// Wait for MySQL to restart and verify clone completed successfully
-	if err := c.waitForCloneComplete(ctx, mysqld, waitTimeout); err != nil {
+	verifyCtx, verifyCancel, err := c.prepareCloneVerification(ctx, mysqld, cloneErr, waitTimeout)
+	if err != nil {
+		return err
+	}
+	defer verifyCancel()
+
+	// Wait for MySQL to restart and verify clone completed successfully.
+	if err := c.waitForCloneComplete(verifyCtx, mysqld, waitTimeout); err != nil {
 		return vterrors.Wrapf(err, "clone success verification failed")
 	}
 
 	log.Info(fmt.Sprintf("CLONE REMOTE completed successfully from %s:%d", c.DonorHost, c.DonorPort))
 	return nil
+}
+
+// prepareCloneVerification returns the context used for the post-clone
+// verification phase. If the CLONE command caused mysqld to exit, it detaches
+// verification from the parent context so caller cancellation triggered by that
+// exit does not abort the success check. It also performs a manual restart when
+// CLONE completed but mysqld could not restart itself.
+func (c *CloneExecutor) prepareCloneVerification(ctx context.Context, mysqld MysqlDaemon, cloneErr error, waitTimeout time.Duration) (context.Context, context.CancelFunc, error) {
+	if cloneErr == nil {
+		return ctx, func() {}, nil
+	}
+
+	log.Info(fmt.Sprintf("CLONE command returned (connection likely lost due to MySQL restart): %v", cloneErr))
+
+	verifyCtx, verifyCancel := context.WithTimeout(context.WithoutCancel(ctx), waitTimeout)
+	if isRestartServerFailed(cloneErr) {
+		if c.Mycnf == nil {
+			verifyCancel()
+			return nil, nil, vterrors.Wrapf(cloneErr, "mysqld could not restart itself after clone and no my.cnf available for manual restart")
+		}
+		log.Info("MySQL could not restart itself after CLONE; restarting manually")
+		if err := restartMysqldAfterClone(verifyCtx, mysqld, c.Mycnf); err != nil {
+			verifyCancel()
+			return nil, nil, vterrors.Wrapf(err, "failed to restart MySQL after clone")
+		}
+	}
+
+	return verifyCtx, verifyCancel, nil
 }
 
 // buildCloneCommand constructs the CLONE INSTANCE SQL command.
@@ -352,6 +397,28 @@ func isCloneConnError(err error) bool {
 	default:
 		return false
 	}
+}
+
+// isRestartServerFailed reports whether err is an ERRestartServerFailed error,
+// meaning MySQL completed the clone but could not restart itself because it is
+// not managed by a process supervisor.
+func isRestartServerFailed(err error) bool {
+	var sqlErr *sqlerror.SQLError
+	return errors.As(err, &sqlErr) && sqlErr.Number() == sqlerror.ERRestartServerFailed
+}
+
+// restartMysqldAfterClone waits for the CLONE-induced mysqld shutdown to fully
+// complete before starting mysqld again. CLONE shuts MySQL down itself, so a
+// replacement process must not be started until the original process has really
+// exited and released its files.
+func restartMysqldAfterClone(ctx context.Context, mysqld MysqlDaemon, mycnf *Mycnf) error {
+	if err := mysqld.WaitForExit(ctx, mycnf); err != nil {
+		return fmt.Errorf("timed out waiting for mysqld to exit after clone: %w", err)
+	}
+	if err := mysqld.Start(ctx, mycnf); err != nil {
+		return fmt.Errorf("failed to start mysqld after clone: %w", err)
+	}
+	return nil
 }
 
 // checkClonePluginInstalled verifies that the clone plugin is loaded.

--- a/go/vt/mysqlctl/clone.go
+++ b/go/vt/mysqlctl/clone.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -351,7 +352,10 @@ func (c *CloneExecutor) prepareCloneVerification(ctx context.Context, mysqld Mys
 		return ctx, func() {}, nil
 	}
 
-	log.Info(fmt.Sprintf("CLONE command returned (connection likely lost due to MySQL restart): %v", cloneErr))
+	log.Info(
+		"CLONE command returned, connection was likely lost during MySQL restart",
+		slog.Any("error", cloneErr),
+	)
 
 	verifyCtx, verifyCancel := context.WithTimeout(context.WithoutCancel(ctx), waitTimeout)
 	if isRestartServerFailed(cloneErr) {

--- a/go/vt/mysqlctl/clone.go
+++ b/go/vt/mysqlctl/clone.go
@@ -70,10 +70,7 @@ func registerCloneFlags(fs *pflag.FlagSet) {
 	utils.SetFlagDurationVar(fs, &cloneRestartWaitTimeout, "clone-restart-wait-timeout", cloneRestartWaitTimeout, "Timeout for waiting for MySQL to restart after CLONE REMOTE.")
 }
 
-// CloneFromDonor clones data from the specified donor tablet using MySQL CLONE REMOTE.
-// It returns the GTID position of the cloned data.
-// If mycnf is non-nil, CloneFromDonor may use it to restart mysqld locally when
-// CLONE completes but MySQL cannot restart itself.
+// CloneFromDonor clones data from the specified donor tablet using MySQL CLONE REMOTE and returns the GTID position of the cloned data. If mycnf is non-nil, CloneFromDonor may use it to restart mysqld locally when CLONE completes but MySQL cannot restart itself.
 func CloneFromDonor(ctx context.Context, topoServer *topo.Server, mysqld MysqlDaemon, mycnf *Mycnf, keyspace, shard string) (replication.Position, error) {
 	var donorAlias *topodatapb.TabletAlias
 	var err error
@@ -134,13 +131,11 @@ func CloneFromDonor(ctx context.Context, topoServer *topo.Server, mysqld MysqlDa
 		return replication.Position{}, fmt.Errorf("clone execution failed: %v", err)
 	}
 
-	// Use a detached context for post-clone operations: the parent context may
-	// have been canceled by an OnTerm callback when MySQL exited during the
-	// clone-induced restart.
-	posCtx, posCancel := context.WithTimeout(context.WithoutCancel(ctx), clonePrimaryPositionTimeout)
-	defer posCancel()
+	// After CLONE, keep going across the expected mysqld restart.
+	ctx, cancel := context.WithTimeout(ctx, clonePrimaryPositionTimeout)
+	defer cancel()
 
-	pos, err := mysqld.PrimaryPosition(posCtx)
+	pos, err := mysqld.PrimaryPosition(ctx)
 	if err != nil {
 		return replication.Position{}, fmt.Errorf("failed to get position after clone: %v", err)
 	}
@@ -294,7 +289,6 @@ func (c *CloneExecutor) ExecuteClone(ctx context.Context, mysqld MysqlDaemon, my
 		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "MySQL CLONE not enabled; set --mysql-clone-enabled=true on both donor and recipient")
 	}
 
-	// Validate recipient prerequisites
 	if err := c.validateRecipient(ctx, mysqld); err != nil {
 		return vterrors.Wrapf(err, "recipient validation failed")
 	}
@@ -342,11 +336,7 @@ func (c *CloneExecutor) ExecuteClone(ctx context.Context, mysqld MysqlDaemon, my
 	return nil
 }
 
-// prepareCloneVerification returns the context used for the post-clone
-// verification phase. If the CLONE command caused mysqld to exit, it detaches
-// verification from the parent context so caller cancellation triggered by that
-// exit does not abort the success check. It also performs a manual restart when
-// CLONE completed but mysqld could not restart itself.
+// prepareCloneVerification returns the context used after CLONE finishes.
 func (c *CloneExecutor) prepareCloneVerification(ctx context.Context, mysqld MysqlDaemon, mycnf *Mycnf, cloneErr error, waitTimeout time.Duration) (context.Context, context.CancelFunc, error) {
 	if cloneErr == nil {
 		return ctx, func() {}, nil
@@ -357,28 +347,28 @@ func (c *CloneExecutor) prepareCloneVerification(ctx context.Context, mysqld Mys
 		slog.Any("error", cloneErr),
 	)
 
-	verifyCtx, verifyCancel := context.WithTimeout(context.WithoutCancel(ctx), waitTimeout)
+	ctx, cancel := context.WithTimeout(ctx, waitTimeout)
 	if isRestartServerFailed(cloneErr) {
 		if mycnf == nil {
-			verifyCancel()
+			cancel()
 			return nil, nil, vterrors.Wrapf(cloneErr, "mysqld could not restart itself after clone and no my.cnf available for manual restart")
 		}
 
 		// mysqlctld exits when mysqld stops on its own, so there is no remote
 		// server left to handle a restart request in --mysqlctl-socket mode.
 		if socketFile != "" {
-			verifyCancel()
+			cancel()
 			return nil, nil, vterrors.Wrapf(cloneErr, "mysqld could not restart itself after clone, and manual restart is not supported with --mysqlctl-socket")
 		}
 
 		log.Info("MySQL could not restart itself after CLONE; restarting manually")
-		if err := mysqld.StartAfterExit(verifyCtx, mycnf); err != nil {
-			verifyCancel()
+		if err := mysqld.StartAfterExit(ctx, mycnf); err != nil {
+			cancel()
 			return nil, nil, vterrors.Wrapf(err, "failed to restart MySQL after clone")
 		}
 	}
 
-	return verifyCtx, verifyCancel, nil
+	return ctx, cancel, nil
 }
 
 // buildCloneCommand constructs the CLONE INSTANCE SQL command.

--- a/go/vt/mysqlctl/clone.go
+++ b/go/vt/mysqlctl/clone.go
@@ -45,6 +45,10 @@ import (
 const (
 	clonePluginStatusQuery = "SELECT PLUGIN_STATUS FROM information_schema.PLUGINS WHERE PLUGIN_NAME = 'clone'"
 	cloneStatusQuery       = "SELECT STATE, ERROR_NO, ERROR_MESSAGE FROM performance_schema.clone_status ORDER BY ID DESC LIMIT 1"
+
+	// clonePrimaryPositionTimeout is how long we wait to read the GTID position
+	// after the clone is done.
+	clonePrimaryPositionTimeout = 30 * time.Second
 )
 
 var (
@@ -132,7 +136,7 @@ func CloneFromDonor(ctx context.Context, topoServer *topo.Server, mysqld MysqlDa
 	// Use a detached context for post-clone operations: the parent context may
 	// have been canceled by an OnTerm callback when MySQL exited during the
 	// clone-induced restart.
-	posCtx, posCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	posCtx, posCancel := context.WithTimeout(context.WithoutCancel(ctx), clonePrimaryPositionTimeout)
 	defer posCancel()
 
 	pos, err := mysqld.PrimaryPosition(posCtx)

--- a/go/vt/mysqlctl/clone.go
+++ b/go/vt/mysqlctl/clone.go
@@ -400,8 +400,8 @@ func (c *CloneExecutor) buildCloneCommand() string {
 }
 
 func isCloneConnError(err error) bool {
-	var sqlErr *sqlerror.SQLError
-	if !errors.As(err, &sqlErr) {
+	sqlErr, ok := errors.AsType[*sqlerror.SQLError](err)
+	if !ok {
 		return false
 	}
 	switch sqlErr.Number() {
@@ -416,8 +416,8 @@ func isCloneConnError(err error) bool {
 // meaning MySQL completed the clone but could not restart itself because it is
 // not managed by a process supervisor.
 func isRestartServerFailed(err error) bool {
-	var sqlErr *sqlerror.SQLError
-	return errors.As(err, &sqlErr) && sqlErr.Number() == sqlerror.ERRestartServerFailed
+	sqlErr, ok := errors.AsType[*sqlerror.SQLError](err)
+	return ok && sqlErr.Number() == sqlerror.ERRestartServerFailed
 }
 
 // checkClonePluginInstalled verifies that the clone plugin is loaded.

--- a/go/vt/mysqlctl/clone.go
+++ b/go/vt/mysqlctl/clone.go
@@ -118,9 +118,6 @@ func CloneFromDonor(ctx context.Context, topoServer *topo.Server, mysqld MysqlDa
 		DonorUser:     cloneConfig.User,
 		DonorPassword: cloneConfig.Password,
 		UseSSL:        cloneConfig.UseSSL,
-		// Pass mycnf through so ExecuteClone can fall back to a local restart
-		// when CLONE succeeds but mysqld cannot restart itself.
-		Mycnf: mycnf,
 	}
 
 	log.Info(fmt.Sprintf("Clone executor configured for donor %s:%d", executor.DonorHost, executor.DonorPort))
@@ -128,7 +125,7 @@ func CloneFromDonor(ctx context.Context, topoServer *topo.Server, mysqld MysqlDa
 	// Execute the clone operation.
 	// Note: ExecuteClone will wait for mysqld to restart and for the CLONE plugin to report successful completion
 	// success via performance_schema before returning.
-	if err := executor.ExecuteClone(ctx, mysqld, cloneRestartWaitTimeout); err != nil {
+	if err := executor.ExecuteClone(ctx, mysqld, mycnf, cloneRestartWaitTimeout); err != nil {
 		return replication.Position{}, fmt.Errorf("clone execution failed: %v", err)
 	}
 
@@ -160,9 +157,6 @@ type CloneExecutor struct {
 	DonorPassword string
 	// UseSSL indicates whether to use SSL for the clone connection.
 	UseSSL bool
-	// Mycnf, if set, is used to restart mysqld after a CLONE operation returns
-	// ERRestartServerFailed.
-	Mycnf *Mycnf
 }
 
 // validateRecipient checks that the recipient MySQL instance meets all prerequisites for cloning.
@@ -283,11 +277,14 @@ func (c *CloneExecutor) donorConnParams() *mysql.ConnParams {
 // 2. Execute CLONE INSTANCE FROM on the recipient
 // 3. Wait for MySQL to restart and verify clone completed successfully
 //
+// If mycnf is non-nil, ExecuteClone may use it to restart mysqld when CLONE
+// completes but MySQL cannot restart itself (ERRestartServerFailed).
+//
 // The waitTimeout specifies how long to wait for MySQL to restart and
 // report clone completion after the CLONE command finishes.
 //
 // Note: This operation will DESTROY all existing data on the recipient.
-func (c *CloneExecutor) ExecuteClone(ctx context.Context, mysqld MysqlDaemon, waitTimeout time.Duration) error {
+func (c *CloneExecutor) ExecuteClone(ctx context.Context, mysqld MysqlDaemon, mycnf *Mycnf, waitTimeout time.Duration) error {
 	if !MySQLCloneEnabled() {
 		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "MySQL CLONE not enabled; set --mysql-clone-enabled=true on both donor and recipient")
 	}
@@ -325,7 +322,7 @@ func (c *CloneExecutor) ExecuteClone(ctx context.Context, mysqld MysqlDaemon, wa
 		return vterrors.Wrapf(cloneErr, "clone command failed")
 	}
 
-	verifyCtx, verifyCancel, err := c.prepareCloneVerification(ctx, mysqld, cloneErr, waitTimeout)
+	verifyCtx, verifyCancel, err := c.prepareCloneVerification(ctx, mysqld, mycnf, cloneErr, waitTimeout)
 	if err != nil {
 		return err
 	}
@@ -345,7 +342,7 @@ func (c *CloneExecutor) ExecuteClone(ctx context.Context, mysqld MysqlDaemon, wa
 // verification from the parent context so caller cancellation triggered by that
 // exit does not abort the success check. It also performs a manual restart when
 // CLONE completed but mysqld could not restart itself.
-func (c *CloneExecutor) prepareCloneVerification(ctx context.Context, mysqld MysqlDaemon, cloneErr error, waitTimeout time.Duration) (context.Context, context.CancelFunc, error) {
+func (c *CloneExecutor) prepareCloneVerification(ctx context.Context, mysqld MysqlDaemon, mycnf *Mycnf, cloneErr error, waitTimeout time.Duration) (context.Context, context.CancelFunc, error) {
 	if cloneErr == nil {
 		return ctx, func() {}, nil
 	}
@@ -354,12 +351,12 @@ func (c *CloneExecutor) prepareCloneVerification(ctx context.Context, mysqld Mys
 
 	verifyCtx, verifyCancel := context.WithTimeout(context.WithoutCancel(ctx), waitTimeout)
 	if isRestartServerFailed(cloneErr) {
-		if c.Mycnf == nil {
+		if mycnf == nil {
 			verifyCancel()
 			return nil, nil, vterrors.Wrapf(cloneErr, "mysqld could not restart itself after clone and no my.cnf available for manual restart")
 		}
 		log.Info("MySQL could not restart itself after CLONE; restarting manually")
-		if err := restartMysqldAfterClone(verifyCtx, mysqld, c.Mycnf); err != nil {
+		if err := mysqld.StartAfterExit(verifyCtx, mycnf); err != nil {
 			verifyCancel()
 			return nil, nil, vterrors.Wrapf(err, "failed to restart MySQL after clone")
 		}
@@ -405,20 +402,6 @@ func isCloneConnError(err error) bool {
 func isRestartServerFailed(err error) bool {
 	var sqlErr *sqlerror.SQLError
 	return errors.As(err, &sqlErr) && sqlErr.Number() == sqlerror.ERRestartServerFailed
-}
-
-// restartMysqldAfterClone waits for the CLONE-induced mysqld shutdown to fully
-// complete before starting mysqld again. CLONE shuts MySQL down itself, so a
-// replacement process must not be started until the original process has really
-// exited and released its files.
-func restartMysqldAfterClone(ctx context.Context, mysqld MysqlDaemon, mycnf *Mycnf) error {
-	if err := mysqld.WaitForExit(ctx, mycnf); err != nil {
-		return fmt.Errorf("timed out waiting for mysqld to exit after clone: %w", err)
-	}
-	if err := mysqld.Start(ctx, mycnf); err != nil {
-		return fmt.Errorf("failed to start mysqld after clone: %w", err)
-	}
-	return nil
 }
 
 // checkClonePluginInstalled verifies that the clone plugin is loaded.

--- a/go/vt/mysqlctl/clone_test.go
+++ b/go/vt/mysqlctl/clone_test.go
@@ -756,13 +756,40 @@ func TestCloneFromDonor(t *testing.T) {
 			wantErrContains: "no my.cnf available for manual restart",
 		},
 		{
-			name:            "ERRestartServerFailed succeeds even if parent ctx is canceled on MySQL exit",
+			name:            "clone verification stops when root ctx is canceled after clone restart",
 			cloneFromTablet: "cell1-100",
 			setup: func(t *testing.T, env *cloneFromDonorTestEnv) {
 				cloneCmd := fmt.Sprintf("CLONE INSTANCE FROM 'clone_user'@'%s':%d IDENTIFIED BY 'password' REQUIRE NO SSL", env.donorHost, env.donorPort)
 				env.mysqld.ExpectedExecuteSuperQueryList = []string{
 					fmt.Sprintf("SET GLOBAL clone_valid_donor_list = '%s:%d'", env.donorHost, env.donorPort),
 				}
+				env.mysqld.FetchSuperQueryMap[cloneStatusQuery] = sqltypes.MakeTestResult(
+					sqltypes.MakeTestFields("STATE|ERROR_NO|ERROR_MESSAGE", "varchar|varchar|varchar"),
+					"In Progress|0|",
+				)
+				env.mysqld.ExecuteSuperQueryErrorMap = map[string]error{
+					cloneCmd: &execError{
+						msg:   fmt.Sprintf("ExecuteFetch(%v) failed: Lost connection to MySQL server during query (errno 2013) (sqlstate HY000)", cloneCmd),
+						cause: sqlerror.NewSQLError(sqlerror.CRServerLost, sqlerror.SSUnknownSQLState, "Lost connection to MySQL server during query"),
+					},
+				}
+			},
+			cancelCtxOnClone: true,
+			wantErr:          true,
+			wantErrContains:  "context canceled",
+			assertResult: func(t *testing.T, env *cloneFromDonorTestEnv) {
+				assert.Equal(t, 0, env.mysqld.StartAfterExitCalls)
+			},
+		},
+		{
+			name:            "manual restart stops when root ctx is canceled after clone restart",
+			cloneFromTablet: "cell1-100",
+			setup: func(t *testing.T, env *cloneFromDonorTestEnv) {
+				cloneCmd := fmt.Sprintf("CLONE INSTANCE FROM 'clone_user'@'%s':%d IDENTIFIED BY 'password' REQUIRE NO SSL", env.donorHost, env.donorPort)
+				env.mysqld.ExpectedExecuteSuperQueryList = []string{
+					fmt.Sprintf("SET GLOBAL clone_valid_donor_list = '%s:%d'", env.donorHost, env.donorPort),
+				}
+				env.mysqld.StartAfterExitTime = time.Minute
 				env.mysqld.ExecuteSuperQueryErrorMap = map[string]error{
 					cloneCmd: &execError{
 						msg:   fmt.Sprintf("ExecuteFetch(%v) failed: Restart server failed (mysqld is not managed by supervisor process). (errno 3707) (sqlstate HY000)", cloneCmd),
@@ -772,7 +799,12 @@ func TestCloneFromDonor(t *testing.T) {
 			},
 			mycnf:            &Mycnf{},
 			cancelCtxOnClone: true,
-			wantErr:          false,
+			wantErr:          true,
+			wantErrContains:  "context canceled",
+			assertResult: func(t *testing.T, env *cloneFromDonorTestEnv) {
+				assert.Equal(t, 1, env.mysqld.StartAfterExitCalls)
+				assert.False(t, env.mysqld.Running)
+			},
 		},
 		{
 			name:            "ERRestartServerFailed with remote mysqlctld fails fast",
@@ -826,13 +858,14 @@ func TestCloneFromDonor(t *testing.T) {
 			}
 
 			ctx := env.ctx
+
+			var cancelCtx context.CancelFunc
 			if tc.cancelCtxOnClone {
-				// Simulate OnTerm canceling the context when MySQL exits during
-				// clone: cancel the context when the CLONE command executes.
-				// ExecuteSuperQuery delegates to ExecuteSuperQueryList with a
-				// single query, so the 2nd callback corresponds to CLONE.
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithCancel(env.ctx)
+				ctx, cancelCtx = context.WithCancel(env.ctx)
+				t.Cleanup(cancelCtx)
+			}
+
+			if tc.cancelCtxOnClone {
 				callCount := 0
 				oldCallback := env.mysqld.ExecuteSuperQueryListCallback
 				env.mysqld.ExecuteSuperQueryListCallback = func() {
@@ -844,7 +877,9 @@ func TestCloneFromDonor(t *testing.T) {
 						if tc.mycnf != nil {
 							env.mysqld.Running = false
 						}
-						cancel()
+						if cancelCtx != nil {
+							cancelCtx()
+						}
 					}
 				}
 			}
@@ -861,9 +896,10 @@ func TestCloneFromDonor(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.NotEmpty(t, pos)
-				if tc.assertResult != nil {
-					tc.assertResult(t, env)
-				}
+			}
+
+			if tc.assertResult != nil {
+				tc.assertResult(t, env)
 			}
 		})
 	}

--- a/go/vt/mysqlctl/clone_test.go
+++ b/go/vt/mysqlctl/clone_test.go
@@ -733,7 +733,7 @@ func TestCloneFromDonor(t *testing.T) {
 			mycnf:   &Mycnf{},
 			wantErr: false,
 			assertResult: func(t *testing.T, env *cloneFromDonorTestEnv) {
-				assert.Equal(t, 1, env.mysqld.WaitForExitCalls)
+				assert.Equal(t, 1, env.mysqld.StartAfterExitCalls)
 				assert.True(t, env.mysqld.Running)
 			},
 		},

--- a/go/vt/mysqlctl/clone_test.go
+++ b/go/vt/mysqlctl/clone_test.go
@@ -774,6 +774,27 @@ func TestCloneFromDonor(t *testing.T) {
 			cancelCtxOnClone: true,
 			wantErr:          false,
 		},
+		{
+			name:            "ERRestartServerFailed with remote mysqlctld fails fast",
+			cloneFromTablet: "cell1-100",
+			setup: func(t *testing.T, env *cloneFromDonorTestEnv) {
+				socketFile = "/tmp/mysqlctld.sock"
+
+				cloneCmd := fmt.Sprintf("CLONE INSTANCE FROM 'clone_user'@'%s':%d IDENTIFIED BY 'password' REQUIRE NO SSL", env.donorHost, env.donorPort)
+				env.mysqld.ExpectedExecuteSuperQueryList = []string{
+					fmt.Sprintf("SET GLOBAL clone_valid_donor_list = '%s:%d'", env.donorHost, env.donorPort),
+				}
+				env.mysqld.ExecuteSuperQueryErrorMap = map[string]error{
+					cloneCmd: &execError{
+						msg:   fmt.Sprintf("ExecuteFetch(%v) failed: Restart server failed (mysqld is not managed by supervisor process). (errno 3707) (sqlstate HY000)", cloneCmd),
+						cause: sqlerror.NewSQLError(sqlerror.ERRestartServerFailed, sqlerror.SSUnknownSQLState, "Restart server failed (mysqld is not managed by supervisor process)."),
+					},
+				}
+			},
+			mycnf:           &Mycnf{},
+			wantErr:         true,
+			wantErrContains: "manual restart is not supported with --mysqlctl-socket",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -785,11 +806,13 @@ func TestCloneFromDonor(t *testing.T) {
 			oldCloneFromTablet := cloneFromTablet
 			oldCloneUser := dbconfigs.GlobalDBConfigs.CloneUser
 			oldMysqlCloneEnabled := mysqlCloneEnabled
+			oldSocketFile := socketFile
 			defer func() {
 				cloneFromPrimary = oldCloneFromPrimary
 				cloneFromTablet = oldCloneFromTablet
 				dbconfigs.GlobalDBConfigs.CloneUser = oldCloneUser
 				mysqlCloneEnabled = oldMysqlCloneEnabled
+				socketFile = oldSocketFile
 			}()
 
 			// Set test flag values

--- a/go/vt/mysqlctl/clone_test.go
+++ b/go/vt/mysqlctl/clone_test.go
@@ -162,6 +162,16 @@ func TestIsCloneConnError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "restart server failed wrapped by executeSuperQueryListConn",
+			// Simulate exactly what executeSuperQueryListConn returns: a %v-redacted
+			// message with the underlying SQLError as the cause.
+			err: &execError{
+				msg:   "ExecuteFetch(CLONE INSTANCE FROM ...) failed: Restart server failed (mysqld is not managed by supervisor process). (errno 3707) (sqlstate HY000)",
+				cause: sqlerror.NewSQLError(sqlerror.ERRestartServerFailed, sqlerror.SSUnknownSQLState, "Restart server failed (mysqld is not managed by supervisor process)."),
+			},
+			expected: true,
+		},
+		{
 			name:     "access denied",
 			err:      accessDenied,
 			expected: false,
@@ -593,8 +603,13 @@ func TestCloneFromDonor(t *testing.T) {
 		cloneFromPrimary bool
 		cloneFromTablet  string
 		setup            func(*testing.T, *cloneFromDonorTestEnv)
+		// mycnf controls whether CloneFromDonor may attempt a local mysqld
+		// restart after CLONE returns ERRestartServerFailed.
+		mycnf            *Mycnf
+		cancelCtxOnClone bool // cancel the ctx when the CLONE command executes
 		wantErr          bool
 		wantErrContains  string
+		assertResult     func(*testing.T, *cloneFromDonorTestEnv)
 	}{
 		{
 			name:             "both cloneFromPrimary and cloneFromTablet specified",
@@ -689,6 +704,76 @@ func TestCloneFromDonor(t *testing.T) {
 			cloneFromTablet: "cell1-100",
 			wantErr:         false,
 		},
+		{
+			name:            "ERRestartServerFailed triggers manual restart and succeeds",
+			cloneFromTablet: "cell1-100",
+			setup: func(t *testing.T, env *cloneFromDonorTestEnv) {
+				cloneCmd := fmt.Sprintf("CLONE INSTANCE FROM 'clone_user'@'%s':%d IDENTIFIED BY 'password' REQUIRE NO SSL", env.donorHost, env.donorPort)
+				// Only SET GLOBAL is expected normally; CLONE returns error via error map.
+				env.mysqld.ExpectedExecuteSuperQueryList = []string{
+					fmt.Sprintf("SET GLOBAL clone_valid_donor_list = '%s:%d'", env.donorHost, env.donorPort),
+				}
+				callCount := 0
+				env.mysqld.ExecuteSuperQueryListCallback = func() {
+					callCount++
+					// ExecuteSuperQuery delegates to ExecuteSuperQueryList with a
+					// single query, so the 2nd callback corresponds to the CLONE
+					// command (after SET GLOBAL clone_valid_donor_list).
+					if callCount == 2 {
+						env.mysqld.Running = false
+					}
+				}
+				env.mysqld.ExecuteSuperQueryErrorMap = map[string]error{
+					cloneCmd: &execError{
+						msg:   fmt.Sprintf("ExecuteFetch(%v) failed: Restart server failed (mysqld is not managed by supervisor process). (errno 3707) (sqlstate HY000)", cloneCmd),
+						cause: sqlerror.NewSQLError(sqlerror.ERRestartServerFailed, sqlerror.SSUnknownSQLState, "Restart server failed (mysqld is not managed by supervisor process)."),
+					},
+				}
+			},
+			mycnf:   &Mycnf{},
+			wantErr: false,
+			assertResult: func(t *testing.T, env *cloneFromDonorTestEnv) {
+				assert.Equal(t, 1, env.mysqld.WaitForExitCalls)
+				assert.True(t, env.mysqld.Running)
+			},
+		},
+		{
+			name:            "ERRestartServerFailed without restart capability fails fast",
+			cloneFromTablet: "cell1-100",
+			setup: func(t *testing.T, env *cloneFromDonorTestEnv) {
+				cloneCmd := fmt.Sprintf("CLONE INSTANCE FROM 'clone_user'@'%s':%d IDENTIFIED BY 'password' REQUIRE NO SSL", env.donorHost, env.donorPort)
+				env.mysqld.ExpectedExecuteSuperQueryList = []string{
+					fmt.Sprintf("SET GLOBAL clone_valid_donor_list = '%s:%d'", env.donorHost, env.donorPort),
+				}
+				env.mysqld.ExecuteSuperQueryErrorMap = map[string]error{
+					cloneCmd: &execError{
+						msg:   fmt.Sprintf("ExecuteFetch(%v) failed: Restart server failed (mysqld is not managed by supervisor process). (errno 3707) (sqlstate HY000)", cloneCmd),
+						cause: sqlerror.NewSQLError(sqlerror.ERRestartServerFailed, sqlerror.SSUnknownSQLState, "Restart server failed (mysqld is not managed by supervisor process)."),
+					},
+				}
+			},
+			wantErr:         true,
+			wantErrContains: "no my.cnf available for manual restart",
+		},
+		{
+			name:            "ERRestartServerFailed succeeds even if parent ctx is canceled on MySQL exit",
+			cloneFromTablet: "cell1-100",
+			setup: func(t *testing.T, env *cloneFromDonorTestEnv) {
+				cloneCmd := fmt.Sprintf("CLONE INSTANCE FROM 'clone_user'@'%s':%d IDENTIFIED BY 'password' REQUIRE NO SSL", env.donorHost, env.donorPort)
+				env.mysqld.ExpectedExecuteSuperQueryList = []string{
+					fmt.Sprintf("SET GLOBAL clone_valid_donor_list = '%s:%d'", env.donorHost, env.donorPort),
+				}
+				env.mysqld.ExecuteSuperQueryErrorMap = map[string]error{
+					cloneCmd: &execError{
+						msg:   fmt.Sprintf("ExecuteFetch(%v) failed: Restart server failed (mysqld is not managed by supervisor process). (errno 3707) (sqlstate HY000)", cloneCmd),
+						cause: sqlerror.NewSQLError(sqlerror.ERRestartServerFailed, sqlerror.SSUnknownSQLState, "Restart server failed (mysqld is not managed by supervisor process)."),
+					},
+				}
+			},
+			mycnf:            &Mycnf{},
+			cancelCtxOnClone: true,
+			wantErr:          false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -717,8 +802,32 @@ func TestCloneFromDonor(t *testing.T) {
 				tc.setup(t, env)
 			}
 
+			ctx := env.ctx
+			if tc.cancelCtxOnClone {
+				// Simulate OnTerm canceling the context when MySQL exits during
+				// clone: cancel the context when the CLONE command executes.
+				// ExecuteSuperQuery delegates to ExecuteSuperQueryList with a
+				// single query, so the 2nd callback corresponds to CLONE.
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(env.ctx)
+				callCount := 0
+				oldCallback := env.mysqld.ExecuteSuperQueryListCallback
+				env.mysqld.ExecuteSuperQueryListCallback = func() {
+					if oldCallback != nil {
+						oldCallback()
+					}
+					callCount++
+					if callCount == 2 {
+						if tc.mycnf != nil {
+							env.mysqld.Running = false
+						}
+						cancel()
+					}
+				}
+			}
+
 			// Execute CloneFromDonor
-			pos, err := CloneFromDonor(env.ctx, env.ts, env.mysqld, env.keyspace, env.shard)
+			pos, err := CloneFromDonor(ctx, env.ts, env.mysqld, tc.mycnf, env.keyspace, env.shard)
 
 			// Verify results
 			if tc.wantErr {
@@ -729,6 +838,9 @@ func TestCloneFromDonor(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.NotEmpty(t, pos)
+				if tc.assertResult != nil {
+					tc.assertResult(t, env)
+				}
 			}
 		})
 	}

--- a/go/vt/mysqlctl/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon.go
@@ -64,6 +64,16 @@ type FakeMysqlDaemon struct {
 	// It is used by Shutdown.
 	ShutdownTime time.Duration
 
+	// WaitForExitTime is used to simulate mysqlds that take some time to
+	// disappear after shutting themselves down.
+	WaitForExitTime time.Duration
+
+	// WaitForExitError is used by WaitForExit.
+	WaitForExitError error
+
+	// WaitForExitCalls tracks how many times WaitForExit was called.
+	WaitForExitCalls int
+
 	// MysqlPort will be returned by GetMysqlPort(). Set to -1 to
 	// return an error.
 	MysqlPort atomic.Int32
@@ -194,6 +204,12 @@ type FakeMysqlDaemon struct {
 	// queries we expect.
 	ExpectedExecuteSuperQueryCurrent int
 
+	// ExecuteSuperQueryErrorMap maps query strings to errors. When a query
+	// matches a key in this map, the corresponding error is returned immediately,
+	// bypassing the normal ExpectedExecuteSuperQueryList validation. Useful for
+	// simulating errors on specific queries without consuming from the expected list.
+	ExecuteSuperQueryErrorMap map[string]error
+
 	// FetchSuperQueryResults is used by FetchSuperQuery.
 	FetchSuperQueryMap map[string]*sqltypes.Result
 
@@ -303,6 +319,25 @@ func (fmd *FakeMysqlDaemon) RefreshConfig(ctx context.Context, cnf *Mycnf) error
 
 // Wait is part of the MysqlDaemon interface.
 func (fmd *FakeMysqlDaemon) Wait(ctx context.Context, cnf *Mycnf) error {
+	return nil
+}
+
+// WaitForExit waits for mysqld to exit.
+func (fmd *FakeMysqlDaemon) WaitForExit(ctx context.Context, cnf *Mycnf) error {
+	fmd.mu.Lock()
+	fmd.WaitForExitCalls++
+	fmd.mu.Unlock()
+
+	if fmd.WaitForExitTime > 0 {
+		select {
+		case <-time.After(fmd.WaitForExitTime):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if fmd.WaitForExitError != nil {
+		return fmd.WaitForExitError
+	}
 	return nil
 }
 
@@ -627,6 +662,14 @@ func (fmd *FakeMysqlDaemon) ExecuteSuperQueryList(ctx context.Context, queryList
 		fmd.ExecuteSuperQueryListCallback()
 	}
 	for _, query := range queryList {
+		// Return a specific error for this query if one is configured, bypassing
+		// the normal expected-query validation.
+		if fmd.ExecuteSuperQueryErrorMap != nil {
+			if err, ok := fmd.ExecuteSuperQueryErrorMap[query]; ok {
+				return err
+			}
+		}
+
 		// test we still have a query to compare
 		if fmd.ExpectedExecuteSuperQueryCurrent >= len(fmd.ExpectedExecuteSuperQueryList) {
 			return fmt.Errorf("unexpected extra query in ExecuteSuperQueryList: %v", query)

--- a/go/vt/mysqlctl/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon.go
@@ -64,15 +64,15 @@ type FakeMysqlDaemon struct {
 	// It is used by Shutdown.
 	ShutdownTime time.Duration
 
-	// WaitForExitTime is used to simulate mysqlds that take some time to
-	// disappear after shutting themselves down.
-	WaitForExitTime time.Duration
+	// StartAfterExitTime is used to simulate mysqlds that take some time to
+	// disappear after shutting themselves down before restarting.
+	StartAfterExitTime time.Duration
 
-	// WaitForExitError is used by WaitForExit.
-	WaitForExitError error
+	// StartAfterExitError is used by StartAfterExit.
+	StartAfterExitError error
 
-	// WaitForExitCalls tracks how many times WaitForExit was called.
-	WaitForExitCalls int
+	// StartAfterExitCalls tracks how many times StartAfterExit was called.
+	StartAfterExitCalls int
 
 	// MysqlPort will be returned by GetMysqlPort(). Set to -1 to
 	// return an error.
@@ -322,22 +322,23 @@ func (fmd *FakeMysqlDaemon) Wait(ctx context.Context, cnf *Mycnf) error {
 	return nil
 }
 
-// WaitForExit waits for mysqld to exit.
-func (fmd *FakeMysqlDaemon) WaitForExit(ctx context.Context, cnf *Mycnf) error {
+// StartAfterExit simulates waiting for mysqld to exit and then restarting it.
+func (fmd *FakeMysqlDaemon) StartAfterExit(ctx context.Context, cnf *Mycnf) error {
 	fmd.mu.Lock()
-	fmd.WaitForExitCalls++
+	fmd.StartAfterExitCalls++
 	fmd.mu.Unlock()
 
-	if fmd.WaitForExitTime > 0 {
+	if fmd.StartAfterExitTime > 0 {
 		select {
-		case <-time.After(fmd.WaitForExitTime):
+		case <-time.After(fmd.StartAfterExitTime):
 		case <-ctx.Done():
 			return ctx.Err()
 		}
 	}
-	if fmd.WaitForExitError != nil {
-		return fmd.WaitForExitError
+	if fmd.StartAfterExitError != nil {
+		return fmd.StartAfterExitError
 	}
+	fmd.Running = true
 	return nil
 }
 

--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -42,7 +42,7 @@ type MysqlDaemon interface {
 	ReadBinlogFilesTimestamps(ctx context.Context, req *mysqlctlpb.ReadBinlogFilesTimestampsRequest) (*mysqlctlpb.ReadBinlogFilesTimestampsResponse, error)
 	ReinitConfig(ctx context.Context, cnf *Mycnf) error
 	Wait(ctx context.Context, cnf *Mycnf) error
-	WaitForExit(ctx context.Context, cnf *Mycnf) error
+	StartAfterExit(ctx context.Context, cnf *Mycnf) error
 	WaitForDBAGrants(ctx context.Context, waitTime time.Duration) (err error)
 
 	// GetMysqlPort returns the current port mysql is listening on.

--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -42,6 +42,7 @@ type MysqlDaemon interface {
 	ReadBinlogFilesTimestamps(ctx context.Context, req *mysqlctlpb.ReadBinlogFilesTimestampsRequest) (*mysqlctlpb.ReadBinlogFilesTimestampsResponse, error)
 	ReinitConfig(ctx context.Context, cnf *Mycnf) error
 	Wait(ctx context.Context, cnf *Mycnf) error
+	WaitForExit(ctx context.Context, cnf *Mycnf) error
 	WaitForDBAGrants(ctx context.Context, waitTime time.Duration) (err error)
 
 	// GetMysqlPort returns the current port mysql is listening on.

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -1515,7 +1515,7 @@ func (mysqld *Mysqld) ApplyBinlogFile(ctx context.Context, req *mysqlctlpb.Apply
 		log.Info("ApplyBinlogFile: disabling super_read_only")
 		resetFunc, err := mysqld.SetSuperReadOnly(ctx, false)
 		if err != nil {
-			if sqlErr, ok := err.(*sqlerror.SQLError); ok && sqlErr.Number() == sqlerror.ERUnknownSystemVariable {
+			if sqlErr, ok := errors.AsType[*sqlerror.SQLError](err); ok && sqlErr.Number() == sqlerror.ERUnknownSystemVariable {
 				log.Warn("ApplyBinlogFile: server does not know about super_read_only, continuing anyway...")
 			} else {
 				log.Error(fmt.Sprintf("ApplyBinlogFile: unexpected error while trying to set super_read_only: %v", err))

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -705,23 +705,36 @@ func (mysqld *Mysqld) Shutdown(ctx context.Context, cnf *Mycnf, waitForMysqld bo
 	// didn't start.
 	if waitForMysqld {
 		log.Info(fmt.Sprintf("Mysqld.Shutdown: waiting for socket file (%v) and pid file (%v) to disappear", cnf.SocketFile, cnf.PidFile))
-
-		for {
-			select {
-			case <-ctx.Done():
-				return errors.New("gave up waiting for mysqld to stop")
-			default:
-			}
-
-			_, socketPathErr = os.Stat(cnf.SocketFile)
-			_, pidPathErr = os.Stat(cnf.PidFile)
-			if os.IsNotExist(socketPathErr) && os.IsNotExist(pidPathErr) {
-				return nil
-			}
-			time.Sleep(100 * time.Millisecond)
+		if err := waitForMysqldExit(ctx, cnf.SocketFile, cnf.PidFile); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+// WaitForExit blocks until the mysqld process has fully exited, identified by
+// the disappearance of its socket and pid files. It is used when MySQL shuts
+// itself down (e.g. after a CLONE operation) and the caller needs to know when
+// it is safe to start a new mysqld process.
+func (mysqld *Mysqld) WaitForExit(ctx context.Context, cnf *Mycnf) error {
+	return waitForMysqldExit(ctx, cnf.SocketFile, cnf.PidFile)
+}
+
+// waitForMysqldExit polls until both socketFile and pidFile have been removed,
+// which signals that the mysqld process has fully exited.
+func waitForMysqldExit(ctx context.Context, socketFile, pidFile string) error {
+	for {
+		_, socketErr := os.Stat(socketFile)
+		_, pidErr := os.Stat(pidFile)
+		if os.IsNotExist(socketErr) && os.IsNotExist(pidErr) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return errors.New("gave up waiting for mysqld to stop")
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
 }
 
 // execCmd searches the PATH for a command and runs it, logging the output.

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -712,12 +712,14 @@ func (mysqld *Mysqld) Shutdown(ctx context.Context, cnf *Mycnf, waitForMysqld bo
 	return nil
 }
 
-// WaitForExit blocks until the mysqld process has fully exited, identified by
-// the disappearance of its socket and pid files. It is used when MySQL shuts
-// itself down (e.g. after a CLONE operation) and the caller needs to know when
-// it is safe to start a new mysqld process.
-func (mysqld *Mysqld) WaitForExit(ctx context.Context, cnf *Mycnf) error {
-	return waitForMysqldExit(ctx, cnf.SocketFile, cnf.PidFile)
+// StartAfterExit waits for a mysqld process that shut itself down (e.g. after a
+// CLONE operation) to fully exit, then starts a new one. It polls for the
+// disappearance of the socket and pid files before calling Start.
+func (mysqld *Mysqld) StartAfterExit(ctx context.Context, cnf *Mycnf) error {
+	if err := waitForMysqldExit(ctx, cnf.SocketFile, cnf.PidFile); err != nil {
+		return err
+	}
+	return mysqld.Start(ctx, cnf)
 }
 
 // waitForMysqldExit polls until both socketFile and pidFile have been removed,

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -459,10 +459,12 @@ func (mysqld *Mysqld) startNoWait(cnf *Mycnf, mysqldArgs ...string) error {
 			case <-cancel:
 			default:
 				mysqld.mutex.Lock()
-				for _, callback := range mysqld.onTermFuncs {
-					go callback()
-				}
+				callbacks := append([]func(){}, mysqld.onTermFuncs...)
 				mysqld.mutex.Unlock()
+
+				for _, callback := range callbacks {
+					callback()
+				}
 			}
 		}(mysqld.cancelWaitCmd)
 		mysqld.mutex.Unlock()

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -74,6 +74,12 @@ const maxLogFileSampleSize = 4096
 // DbaGrantWaitTime is the amount of time to wait for the grants to have applied
 const DbaGrantWaitTime = 10 * time.Second
 
+const (
+	// mysqldExitPollInterval is how often waitForMysqldExit checks whether
+	// mysqld has removed its socket and pid files.
+	mysqldExitPollInterval = 100 * time.Millisecond
+)
+
 var (
 	// DisableActiveReparents is a flag to disable active
 	// reparents for safety reasons. It is used in three places:
@@ -734,7 +740,7 @@ func waitForMysqldExit(ctx context.Context, socketFile, pidFile string) error {
 		select {
 		case <-ctx.Done():
 			return errors.New("gave up waiting for mysqld to stop")
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(mysqldExitPollInterval):
 		}
 	}
 }

--- a/go/vt/mysqlctl/query.go
+++ b/go/vt/mysqlctl/query.go
@@ -29,6 +29,16 @@ import (
 	"vitess.io/vitess/go/vt/log"
 )
 
+// execError wraps a SQL execution error, preserving the error chain for
+// errors.As while surfacing a redacted message safe for logging and propagation.
+type execError struct {
+	msg   string
+	cause error
+}
+
+func (e *execError) Error() string { return e.msg }
+func (e *execError) Unwrap() error { return e.cause }
+
 // getPoolReconnect gets a connection from a pool, tests it, and reconnects if
 // the connection is lost.
 func getPoolReconnect(ctx context.Context, pool *dbconnpool.ConnectionPool) (*dbconnpool.PooledDBConnection, error) {
@@ -80,8 +90,9 @@ func (mysqld *Mysqld) executeSuperQueryListConn(ctx context.Context, conn *dbcon
 	for _, query := range queryList {
 		log.Info("exec " + limitString(redactPassword(query), LogQueryLengthLimit))
 		if _, err := mysqld.executeFetchContext(ctx, conn, query, 10000, false); err != nil {
-			log.Error(fmt.Sprintf("ExecuteFetch(%v) failed: %v", redactPassword(query), redactPassword(err.Error())))
-			return fmt.Errorf("ExecuteFetch(%v) failed: %v", redactPassword(query), redactPassword(err.Error()))
+			msg := fmt.Sprintf("ExecuteFetch(%v) failed: %v", redactPassword(query), redactPassword(err.Error()))
+			log.Error(msg)
+			return &execError{msg: msg, cause: err}
 		}
 	}
 	return nil

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -323,7 +323,9 @@ func (tm *TabletManager) restoreFromCloneLocked(
 	}
 
 	tablet := tm.Tablet()
-	pos, err := mysqlctl.CloneFromDonor(ctx, tm.TopoServer, tm.MysqlDaemon, tablet.Keyspace, tablet.Shard)
+	// Pass tm.Cnf so clone restore can fall back to a local mysqld restart if
+	// CLONE completes but MySQL cannot restart itself.
+	pos, err := mysqlctl.CloneFromDonor(ctx, tm.TopoServer, tm.MysqlDaemon, tm.Cnf, tablet.Keyspace, tablet.Shard)
 	if err != nil {
 		err = vterrors.Wrap(err, "failed to clone from donor")
 		if err := rsm.abort(); err != nil {

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -18,6 +18,7 @@ package tabletmanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"runtime"
@@ -406,7 +407,7 @@ func (tm *TabletManager) InitPrimary(ctx context.Context, semiSync bool) (string
 
 	// Setting super_read_only `OFF` so that we can run the DDL commands
 	if _, err := tm.MysqlDaemon.SetSuperReadOnly(ctx, false); err != nil {
-		if sqlErr, ok := err.(*sqlerror.SQLError); ok && sqlErr.Number() == sqlerror.ERUnknownSystemVariable {
+		if sqlErr, ok := errors.AsType[*sqlerror.SQLError](err); ok && sqlErr.Number() == sqlerror.ERUnknownSystemVariable {
 			log.Warn("server does not know about super_read_only, continuing anyway...")
 		} else {
 			return "", err
@@ -687,7 +688,7 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 	// previous demotion, or because we are not primary anyway, this should be
 	// idempotent.
 	if _, err := tm.MysqlDaemon.SetSuperReadOnly(ctx, true); err != nil {
-		if sqlErr, ok := err.(*sqlerror.SQLError); ok && sqlErr.Number() == sqlerror.ERUnknownSystemVariable {
+		if sqlErr, ok := errors.AsType[*sqlerror.SQLError](err); ok && sqlErr.Number() == sqlerror.ERUnknownSystemVariable {
 			log.Warn("server does not know about super_read_only, continuing anyway...")
 		} else {
 			return nil, err

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -824,7 +824,7 @@ func (tm *TabletManager) redoPreparedTransactionsAndSetReadWrite(ctx context.Con
 	if err != nil {
 		// Ignore the error if the sever doesn't support super read only variable.
 		// We should just redo the preapred transactions before we set it to read-write.
-		if sqlErr, ok := err.(*sqlerror.SQLError); ok && sqlErr.Number() == sqlerror.ERUnknownSystemVariable {
+		if sqlErr, ok := errors.AsType[*sqlerror.SQLError](err); ok && sqlErr.Number() == sqlerror.ERUnknownSystemVariable {
 			log.Warn("server does not know about super_read_only, continuing anyway...")
 		} else {
 			return err


### PR DESCRIPTION
## Description

When vtbackup uses `CLONE INSTANCE` to restore data, MySQL restarts itself as part of the clone process. This restart fires the `OnTerm` callback which cancels vtbackup's context, aborting the operation even though the clone succeeded. Additionally, when MySQL isn't managed by a process supervisor (e.g. running in containers without mysqld_safe), it returns `ERRestartServerFailed` and `vtbackup` has no way to bring it back up.

## How it works

- Introduces a `mySQLTermHandler` that wraps the `OnTerm` callback with an `ignoreTermsFor` toggle — MySQL terminations during CLONE are expected and suppressed instead of canceling vtbackup. The handler accepts a callback function, so the caller decides what happens on termination.
- Adds an `execError` type in `query.go` that preserves the original `SQLError` through `errors.As` unwrapping, so callers can detect specific MySQL error codes (like `ERRestartServerFailed`) even after `executeSuperQueryListConn` redacts the message.
- When CLONE returns `ERRestartServerFailed`, `ExecuteClone` falls back to a manual restart via `mysqld.StartAfterExit`, which waits for the old process to fully exit before starting a new one.
- `mycnf` is passed as a parameter to `ExecuteClone` rather than stored on `CloneExecutor`, keeping the executor as pure donor connection config.
- Post-clone verification uses `context.WithoutCancel` so it isn't aborted by the parent context cancellation that the MySQL exit may trigger.
- Extracts `waitForMysqldExit` from `Shutdown` and adds `StartAfterExit` to the `MysqlDaemon` interface, combining the wait-for-exit and start operations.

 
## Related Issue(s)

Continuing the work from #19759 to fix restart related issues in clone.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

No migrations or deployment changes required.

### AI Disclosure

Mostly written by Codex, heavily directed by me.