### PR TITLE
`ci`: enable `setup-go` composite action to reduce Actions cache

### DIFF
--- a/.github/workflows/check_make_vtadmin_authz_testgen.yml
+++ b/.github/workflows/check_make_vtadmin_authz_testgen.yml
@@ -53,10 +53,9 @@ jobs:
       uses: ./.github/actions/tune-os
 
     - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       if: steps.changes.outputs.vtadmin_changes == 'true'
       with:
-        go-version-file: go.mod
         cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
     - name: Get dependencies

--- a/.github/workflows/check_make_vtadmin_web_proto.yml
+++ b/.github/workflows/check_make_vtadmin_web_proto.yml
@@ -56,10 +56,9 @@ jobs:
             - 'web/vtadmin/package-lock.json'
 
     - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       if: steps.changes.outputs.proto_changes == 'true'
       with:
-        go-version-file: go.mod
         cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
     - name: Setup Node

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -127,9 +127,8 @@ jobs:
 
       - name: Set up Go
         if: steps.changes.outputs.end_to_end == 'true'
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: go.mod
           cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Set up python

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -58,9 +58,8 @@ jobs:
 
     - name: Set up Go
       if: steps.mode.outputs.is_full_run == 'true' || steps.changes.outputs.changed_files == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
     - name: Detect changed Go packages

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -37,9 +37,8 @@ jobs:
           persist-credentials: 'false'
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: go.mod
           cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Tune the OS

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -29,9 +29,8 @@ jobs:
         persist-credentials: 'false'
 
     - name: Set up Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: 'false'
 
     - name: Tune the OS

--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -76,9 +76,8 @@ jobs:
 
       - name: Set up Go
         if: steps.changes.outputs.end_to_end == 'true'
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: go.mod
           cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Tune the OS

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -52,9 +52,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
     - name: Tune the OS

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -52,9 +52,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
     - name: Tune the OS

--- a/.github/workflows/error_code_docs_generate.yml
+++ b/.github/workflows/error_code_docs_generate.yml
@@ -25,9 +25,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: go.mod
           cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Generate error codes

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -67,9 +67,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.examples == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
     - name: Tune the OS

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -67,9 +67,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.examples == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
     - name: Tune the OS

--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -122,9 +122,8 @@ jobs:
 
       - name: Set up Go
         if: (steps.changes.outputs.go_files == 'true' || steps.changes.outputs.parser_changes == 'true' || steps.changes.outputs.proto_changes == 'true')
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: go.mod
           cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Tune the OS

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -112,9 +112,8 @@ jobs:
 
       - name: Set up Go
         if: steps.changes.outputs.unit_tests == 'true'
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: go.mod
           cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Set up python

--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -28,9 +28,8 @@ jobs:
           persist-credentials: 'false'
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: go.mod
           cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Upgrade the Golang Dependencies

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -29,9 +29,8 @@ jobs:
           ref: ${{ matrix.branch }}
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: go.mod
           cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Detect new version and update codebase

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -112,9 +112,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for the last release
@@ -141,9 +140,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for this commit

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -113,9 +113,8 @@ jobs:
 
     - name: Set up Go
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for the next release
@@ -142,9 +141,8 @@ jobs:
 
     - name: Set up Go
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for this commit

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -117,9 +117,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for the last release
@@ -146,9 +145,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for this commit

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -117,9 +117,8 @@ jobs:
 
     - name: Set up Go
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for the next release
@@ -146,9 +145,8 @@ jobs:
 
     - name: Set up Go
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for this commit

--- a/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
+++ b/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
@@ -115,9 +115,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for the last release
@@ -146,9 +145,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for the next release
@@ -176,9 +174,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for this commit

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -122,9 +122,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for the last release

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
@@ -122,9 +122,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for the last release

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
@@ -107,9 +107,8 @@ jobs:
 
     - name: Set up Go
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for the next release
@@ -136,9 +135,8 @@ jobs:
 
     - name: Set up Go
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for this commit

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -107,9 +107,8 @@ jobs:
 
     - name: Set up Go
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for the next release
@@ -136,9 +135,8 @@ jobs:
 
     - name: Set up Go
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for this commit

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -106,9 +106,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for the last release
@@ -135,9 +134,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for this commit

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -107,9 +107,8 @@ jobs:
 
     - name: Set up Go
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for the next release
@@ -136,9 +135,8 @@ jobs:
 
     - name: Set up Go
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for this commit

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -107,9 +107,8 @@ jobs:
 
     - name: Set up Go
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for the next release
@@ -136,9 +135,8 @@ jobs:
 
     - name: Set up Go
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for this commit

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -116,9 +116,8 @@ jobs:
 
     - name: Set up Go
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for the next release
@@ -145,9 +144,8 @@ jobs:
 
     - name: Set up Go
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for this commit

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -106,9 +106,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for the last release
@@ -135,9 +134,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for this commit

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -106,9 +106,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for the last release
@@ -135,9 +134,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: false
 
     - name: Get dependencies for this commit

--- a/.github/workflows/upgrade_downgrade_test_semi_sync.yml
+++ b/.github/workflows/upgrade_downgrade_test_semi_sync.yml
@@ -112,9 +112,8 @@ jobs:
 
       - name: Set up Go
         if: steps.changes.outputs.end_to_end == 'true'
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: go.mod
           cache: false
 
       - name: Get dependencies for the last release
@@ -141,9 +140,8 @@ jobs:
 
       - name: Set up Go
         if: steps.changes.outputs.end_to_end == 'true'
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: go.mod
           cache: false
 
       - name: Get dependencies for this commit

--- a/.github/workflows/vitess_tester_vtgate.yml
+++ b/.github/workflows/vitess_tester_vtgate.yml
@@ -65,9 +65,8 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: ./.github/actions/setup-go
       with:
-        go-version-file: go.mod
         cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
     - name: Set up python

--- a/.github/workflows/vtop_example.yml
+++ b/.github/workflows/vtop_example.yml
@@ -60,9 +60,8 @@ jobs:
 
       - name: Set up Go
         if: steps.changes.outputs.end_to_end == 'true'
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: go.mod
           cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Tune the OS


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

As a follow-up to https://github.com/vitessio/vitess/pull/19784, this PR enables the new `setup-go` action that PR added

This was not possible in one-shot, because previous releases had to first get the `setup-go` composite action, which TL:DR wraps `actions/setup-go` but fixes the cache bloat it's internal caching causes. See https://github.com/vitessio/vitess/pull/19784 for more context

## Related Issue(s)

https://github.com/vitessio/vitess/pull/19784

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

Mass file updates by Claude Code