### PR TITLE
vtgate: normalize viperutil keys and flag references to use dashes

### DIFF
--- a/go/cmd/vtgate/cli/cli.go
+++ b/go/cmd/vtgate/cli/cli.go
@@ -67,7 +67,7 @@ var (
 	--grpc-port 15991 \
 	--mysql-server-port 15306 \
 	--cell test \
-	--cells_to_watch test \
+	--cells-to-watch test \
 	--tablet-types-to-wait PRIMARY,REPLICA \
 	--service-map 'grpc-vtgateservice' \
 	--pid-file $VTDATAROOT/tmp/vtgate.pid \
@@ -85,7 +85,7 @@ func init() {
 	srvTopoCounts = stats.NewCountersWithSingleLabel("ResilientSrvTopoServer", "Resilient srvtopo server operations", "type")
 }
 
-// CheckCellFlags will check validation of cell and cells_to_watch flag
+// CheckCellFlags will check validation of cell and cells-to-watch flag
 // it will help to avoid strange behaviors when vtgate runs but actually does not work
 func CheckCellFlags(ctx context.Context, serv srvtopo.Server, cell string, cellsToWatch string) error {
 	// topo check
@@ -116,7 +116,7 @@ func CheckCellFlags(ctx context.Context, serv srvtopo.Server, cell string, cells
 		return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cell:[%v] does not exist in topo", cell)
 	}
 
-	// cells_to_watch valid check
+	// cells-to-watch valid check
 	cells := make([]string, 0, 1)
 	for c := range strings.SplitSeq(cellsToWatch, ",") {
 		if c == "" {
@@ -129,7 +129,7 @@ func CheckCellFlags(ctx context.Context, serv srvtopo.Server, cell string, cells
 		cells = append(cells, c)
 	}
 	if len(cells) == 0 {
-		return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cells_to_watch flag cannot be empty")
+		return vterrors.Errorf(vtrpc.Code_INVALID_ARGUMENT, "cells-to-watch flag cannot be empty")
 	}
 
 	return nil
@@ -164,7 +164,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	err := CheckCellFlags(ctx, resilientServer, cell, vtgate.CellsToWatch)
 	if err != nil {
-		return fmt.Errorf("cells_to_watch validation failed: %v", err)
+		return fmt.Errorf("cells-to-watch validation failed: %v", err)
 	}
 
 	plannerVersion, _ := plancontext.PlannerNameToVersion(plannerName)

--- a/go/cmd/vtgate/cli/cli_test.go
+++ b/go/cmd/vtgate/cli/cli_test.go
@@ -89,7 +89,7 @@ func TestMainCommandMetadata(t *testing.T) {
 	require.NotEmpty(t, Main.Version)
 }
 
-// CheckCellFlags tests cover validation of cell and cells_to_watch. We use
+// CheckCellFlags tests cover validation of cell and cells-to-watch. We use
 // memorytopo + fakes so we don't need a real topo. The len(cellsInTopo)==0
 // branch isn't covered here—that would need a topo that returns [] from
 // GetKnownCells, and memorytopo doesn't give us that.
@@ -151,7 +151,7 @@ func TestCheckCellFlags_CellsToWatchInvalidCell(t *testing.T) {
 	fake := &fakesrvtopo.FakeSrvTopo{Ts: ts}
 
 	err := CheckCellFlags(ctx, fake, "c1", "c1,bad")
-	require.ErrorContains(t, err, "is not valid") // cells_to_watch entries should be in topo
+	require.ErrorContains(t, err, "is not valid") // cells-to-watch entries should be in topo
 	require.ErrorContains(t, err, "Available cells")
 }
 
@@ -162,7 +162,7 @@ func TestCheckCellFlags_CellsToWatchEmpty(t *testing.T) {
 	fake := &fakesrvtopo.FakeSrvTopo{Ts: ts}
 
 	err := CheckCellFlags(ctx, fake, "c1", "")
-	require.ErrorContains(t, err, "cells_to_watch flag cannot be empty") // empty string should fail
+	require.ErrorContains(t, err, "cells-to-watch flag cannot be empty") // empty string should fail
 }
 
 func TestCheckCellFlags_CellsToWatchEmptyAfterSplit(t *testing.T) {
@@ -172,7 +172,7 @@ func TestCheckCellFlags_CellsToWatchEmptyAfterSplit(t *testing.T) {
 	fake := &fakesrvtopo.FakeSrvTopo{Ts: ts}
 
 	err := CheckCellFlags(ctx, fake, "c1", ",")
-	require.ErrorContains(t, err, "cells_to_watch flag cannot be empty") // comma-only should count as empty
+	require.ErrorContains(t, err, "cells-to-watch flag cannot be empty") // comma-only should count as empty
 }
 
 func TestCheckCellFlags_Success(t *testing.T) {

--- a/go/vt/vtgate/buffer/flags.go
+++ b/go/vt/vtgate/buffer/flags.go
@@ -81,7 +81,7 @@ func verifyFlags() error {
 	}
 
 	if bufferKeyspaceShards != "" && !bufferEnabled {
-		return fmt.Errorf("--buffer-keyspace-shards=%v also requires that --enable_buffer is set", bufferKeyspaceShards)
+		return fmt.Errorf("--buffer-keyspace-shards=%v also requires that --enable-buffer is set", bufferKeyspaceShards)
 	}
 	if bufferEnabled && bufferEnabledDryRun && bufferKeyspaceShards == "" {
 		return errors.New("both the dry-run mode and actual buffering is enabled. To avoid ambiguity, keyspaces and shards for actual buffering must be explicitly listed in --buffer-keyspace-shards")

--- a/go/vt/vtgate/legacy_scatter_conn_test.go
+++ b/go/vt/vtgate/legacy_scatter_conn_test.go
@@ -619,7 +619,7 @@ func TestReservePrequeries(t *testing.T) {
 
 func newTestScatterConn(ctx context.Context, hc discovery.HealthCheck, serv srvtopo.Server, cell string) *ScatterConn {
 	// The topo.Server is used to start watching the cells described
-	// in '-cells_to_watch' command line parameter, which is
+	// in '--cells-to-watch' command line parameter, which is
 	// empty by default. So it's unused in this test, set to nil.
 	gw := NewTabletGateway(ctx, hc, serv, cell)
 	tc := NewTxConn(gw, &StaticConfig{

--- a/go/vt/vtgate/vschemaacl/vschemaacl.go
+++ b/go/vt/vtgate/vschemaacl/vschemaacl.go
@@ -64,6 +64,7 @@ var AuthorizedDDLUsers = viperutil.Configure(
 	"vschema-ddl-authorized-users",
 	viperutil.Options[*authorizedDDLUsers]{
 		FlagName: "vschema-ddl-authorized-users",
+		Aliases:  []string{"vschema_ddl_authorized_users"},
 		Default:  &authorizedDDLUsers{},
 		Dynamic:  true,
 		GetFunc: func(v *viper.Viper) func(key string) *authorizedDDLUsers {

--- a/go/vt/vtgate/vschemaacl/vschemaacl.go
+++ b/go/vt/vtgate/vschemaacl/vschemaacl.go
@@ -61,7 +61,7 @@ func (a *authorizedDDLUsers) String() string {
 
 // AuthorizedDDLUsers specifies the users that can perform ddl operations
 var AuthorizedDDLUsers = viperutil.Configure(
-	"vschema_ddl_authorized_users",
+	"vschema-ddl-authorized-users",
 	viperutil.Options[*authorizedDDLUsers]{
 		FlagName: "vschema-ddl-authorized-users",
 		Default:  &authorizedDDLUsers{},

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -103,7 +103,7 @@ var (
 	defaultDDLStrategy = string(schema.DDLStrategyDirect)
 
 	enableOnlineDDL = viperutil.Configure(
-		"enable_online_ddl",
+		"enable-online-ddl",
 		viperutil.Options[bool]{
 			FlagName: "enable-online-ddl",
 			Default:  true,
@@ -112,7 +112,7 @@ var (
 	)
 
 	enableDirectDDL = viperutil.Configure(
-		"enable_direct_ddl",
+		"enable-direct-ddl",
 		viperutil.Options[bool]{
 			FlagName: "enable-direct-ddl",
 			Default:  true,
@@ -121,7 +121,7 @@ var (
 	)
 
 	enableBinlogDump = viperutil.Configure(
-		"enable_binlog_dump",
+		"enable-binlog-dump",
 		viperutil.Options[bool]{
 			FlagName: "enable-binlog-dump",
 			Default:  false,
@@ -130,7 +130,7 @@ var (
 	)
 
 	transactionMode = viperutil.Configure(
-		"transaction_mode",
+		"transaction-mode",
 		viperutil.Options[vtgatepb.TransactionMode]{
 			FlagName: "transaction-mode",
 			Default:  vtgatepb.TransactionMode_MULTI,
@@ -147,7 +147,7 @@ var (
 						return vtgatepb.TransactionMode_TWOPC
 					default:
 						fmt.Printf("Invalid option: %v\n", txMode)
-						fmt.Println("Usage: -transaction_mode {SINGLE | MULTI | TWOPC}")
+						fmt.Println("Usage: --transaction-mode {SINGLE | MULTI | TWOPC}")
 						os.Exit(1)
 						return -1
 					}

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -106,6 +106,7 @@ var (
 		"enable-online-ddl",
 		viperutil.Options[bool]{
 			FlagName: "enable-online-ddl",
+			Aliases:  []string{"enable_online_ddl"},
 			Default:  true,
 			Dynamic:  true,
 		},
@@ -115,6 +116,7 @@ var (
 		"enable-direct-ddl",
 		viperutil.Options[bool]{
 			FlagName: "enable-direct-ddl",
+			Aliases:  []string{"enable_direct_ddl"},
 			Default:  true,
 			Dynamic:  true,
 		},
@@ -124,6 +126,7 @@ var (
 		"enable-binlog-dump",
 		viperutil.Options[bool]{
 			FlagName: "enable-binlog-dump",
+			Aliases:  []string{"enable_binlog_dump"},
 			Default:  false,
 			Dynamic:  true,
 		},
@@ -133,6 +136,7 @@ var (
 		"transaction-mode",
 		viperutil.Options[vtgatepb.TransactionMode]{
 			FlagName: "transaction-mode",
+			Aliases:  []string{"transaction_mode"},
 			Default:  vtgatepb.TransactionMode_MULTI,
 			Dynamic:  true,
 			GetFunc: func(v *viper.Viper) func(key string) vtgatepb.TransactionMode {


### PR DESCRIPTION
## Description

`viperutil.Configure` keys in vtgate used underscore format (`"enable_online_ddl"`,
`"transaction_mode"`, etc.) while their corresponding `FlagName` values already used
dashes. This mismatch causes Viper's internal key lookup to silently fail during
dynamic config reloads, falling back to defaults instead of applying the configured
value.

This PR aligns vtgate with the dash-based pattern already established in `vtorc`,
updating the following keys: `enable_online_ddl`, `enable_direct_ddl`,
`enable_binlog_dump`, `transaction_mode`, `vschema_ddl_authorized_users`.
Also normalizes remaining underscore references in error messages, comments, and
the `--cells_to_watch` example in the cobra command help text.

This change does not need to be backported to previous releases — the
`NormalizeUnderscoresToDashes` normalization function and `viperutil.Configure`
are part of the v24 flag standardization work and are not present in older branches.

## Related Issue(s)

Related to #17687
Related to #17880

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

No deployment changes required. No behavior change for users — old underscore flags
continue to work via the existing `NormalizeUnderscoresToDashes` deprecation shim.

### AI Disclosure
AI was used to scale and identify the inconsistencies among the codebase.