### PR TITLE
vtgate/buffer: lock-free hot-path with atomic state and sync.Map

### DIFF
--- a/go/vt/vtgate/buffer/buffer.go
+++ b/go/vt/vtgate/buffer/buffer.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"golang.org/x/sync/semaphore"
 
@@ -151,19 +152,14 @@ type Buffer struct {
 	bufferSizeSema *semaphore.Weighted
 	bufferSize     int
 
-	// mu guards all fields in this group.
-	// In particular, it is used to serialize the following Go routines:
-	// - 1. Requests which may buffer (RLock, can be run in parallel)
-	// - 2. Request which starts buffering (based on the seen error)
-	// - 3. HealthCheck subscriber ("StatsUpdate") which stops buffering
-	// - 4. Timer which may stop buffering after -buffer-max-failover-duration
-	mu sync.RWMutex
 	// buffers holds a shardBuffer object per shard, even if no failover is in
-	// progress.
-	// Key Format: "<keyspace>/<shard>"
-	buffers map[string]*shardBuffer
+	// progress. Uses sync.Map for lock-free reads on the hot path (every query)
+	// since writes only occur once per shard at startup.
+	// Key: string ("<keyspace>/<shard>"), Value: *shardBuffer
+	buffers sync.Map
+
 	// stopped is true after Shutdown() was run.
-	stopped bool
+	stopped atomic.Bool
 }
 
 // New creates a new Buffer object.
@@ -172,7 +168,7 @@ func New(cfg *Config) *Buffer {
 		config:         cfg,
 		bufferSizeSema: semaphore.NewWeighted(int64(cfg.Size)),
 		bufferSize:     cfg.Size,
-		buffers:        make(map[string]*shardBuffer),
+		// buffers and stopped use zero values (empty sync.Map and false atomic.Bool)
 	}
 }
 
@@ -220,28 +216,21 @@ func (b *Buffer) HandleKeyspaceEvent(ksevent *discovery.KeyspaceEvent) {
 // getOrCreateBuffer returns the ShardBuffer for the given keyspace and shard.
 // It returns nil if Buffer is shut down and all calls should be ignored.
 func (b *Buffer) getOrCreateBuffer(keyspace, shard string) *shardBuffer {
-	key := topoproto.KeyspaceShardString(keyspace, shard)
-	b.mu.RLock()
-	sb, ok := b.buffers[key]
-	stopped := b.stopped
-	b.mu.RUnlock()
-
-	if stopped {
+	if b.stopped.Load() {
 		return nil
 	}
-	if ok {
-		return sb
+
+	key := topoproto.KeyspaceShardString(keyspace, shard)
+
+	// Hot path: lock-free lookup for existing shard buffers.
+	if v, ok := b.buffers.Load(key); ok {
+		return v.(*shardBuffer)
 	}
 
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	// Look it up again because it could have been created in the meantime.
-	sb, ok = b.buffers[key]
-	if !ok {
-		sb = newShardBufferHealthCheck(b, b.config.bufferingMode(keyspace, shard), keyspace, shard)
-		b.buffers[key] = sb
-	}
-	return sb
+	// Cold path (once per shard): create and store atomically.
+	sb := newShardBufferHealthCheck(b, b.config.bufferingMode(keyspace, shard), keyspace, shard)
+	v, _ := b.buffers.LoadOrStore(key, sb)
+	return v.(*shardBuffer)
 }
 
 // Shutdown blocks until all pending ShardBuffer objects are shut down.
@@ -253,20 +242,16 @@ func (b *Buffer) Shutdown() {
 }
 
 func (b *Buffer) shutdown() {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	for _, sb := range b.buffers {
-		sb.shutdown()
-	}
-	b.stopped = true
+	b.stopped.Store(true)
+	b.buffers.Range(func(_, value any) bool {
+		value.(*shardBuffer).shutdown()
+		return true
+	})
 }
 
 func (b *Buffer) waitForShutdown() {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-
-	for _, sb := range b.buffers {
-		sb.waitForShutdown()
-	}
+	b.buffers.Range(func(_, value any) bool {
+		value.(*shardBuffer).waitForShutdown()
+		return true
+	})
 }

--- a/go/vt/vtgate/buffer/buffer_bench_test.go
+++ b/go/vt/vtgate/buffer/buffer_bench_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buffer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func BenchmarkWaitForFailoverEnd_Idle(b *testing.B) {
+	cfg := NewDefaultConfig()
+	cfg.Enabled = true
+	buf := New(cfg)
+	defer buf.Shutdown()
+
+	ctx := context.Background()
+	// Pre-create the shard buffer so we're benchmarking the steady-state path.
+	buf.getOrCreateBuffer(keyspace, shard)
+
+	b.ResetTimer()
+	for b.Loop() {
+		buf.WaitForFailoverEnd(ctx, keyspace, shard, nil, nil)
+	}
+}
+
+func BenchmarkWaitForFailoverEnd_IdleParallel(b *testing.B) {
+	cfg := NewDefaultConfig()
+	cfg.Enabled = true
+	buf := New(cfg)
+	defer buf.Shutdown()
+
+	ctx := context.Background()
+	buf.getOrCreateBuffer(keyspace, shard)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			buf.WaitForFailoverEnd(ctx, keyspace, shard, nil, nil)
+		}
+	})
+}
+
+func BenchmarkWaitForFailoverEnd_MultiShard(b *testing.B) {
+	cfg := NewDefaultConfig()
+	cfg.Enabled = true
+	buf := New(cfg)
+	defer buf.Shutdown()
+
+	ctx := context.Background()
+	const numShards = 8
+	shards := make([]string, numShards)
+	for i := range numShards {
+		shards[i] = fmt.Sprintf("-%02x", i)
+		buf.getOrCreateBuffer(keyspace, shards[i])
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			buf.WaitForFailoverEnd(ctx, keyspace, shards[i%numShards], nil, nil)
+			i++
+		}
+	})
+}

--- a/go/vt/vtgate/buffer/shard_buffer.go
+++ b/go/vt/vtgate/buffer/shard_buffer.go
@@ -35,16 +35,29 @@ import (
 )
 
 // bufferState represents the different states a shardBuffer object can be in.
-type bufferState string
+type bufferState int32
 
 const (
 	// stateIdle means no failover is currently in progress.
-	stateIdle bufferState = "IDLE"
+	stateIdle bufferState = iota
 	// stateBuffering is the phase when a failover is in progress.
-	stateBuffering bufferState = "BUFFERING"
+	stateBuffering
 	// stateDraining is the phase when a failover ended and the queue is drained.
-	stateDraining bufferState = "DRAINING"
+	stateDraining
 )
+
+func (s bufferState) String() string {
+	switch s {
+	case stateIdle:
+		return "IDLE"
+	case stateBuffering:
+		return "BUFFERING"
+	case stateDraining:
+		return "DRAINING"
+	default:
+		return fmt.Sprintf("UNKNOWN(%d)", s)
+	}
+}
 
 // entry is created per buffered request.
 type entry struct {
@@ -90,9 +103,12 @@ type shardBuffer struct {
 	statsKeyJoined string
 	logTooRecent   *logutil.ThrottledLogger
 
+	// state is read atomically on the hot path (no lock needed for idle check)
+	// and written under mu during state transitions.
+	state atomic.Int32
+
 	// mu guards the fields below.
-	mu    sync.RWMutex
-	state bufferState
+	mu sync.RWMutex
 	// queue is the list of buffered requests (ordered by arrival).
 	queue []*entry
 	// lastStart is the last time we saw the start of a failover.
@@ -124,7 +140,7 @@ func newShardBufferHealthCheck(buf *Buffer, mode bufferMode, keyspace, shard str
 		statsKey:       statsKey,
 		statsKeyJoined: fmt.Sprintf("%s.%s", keyspace, shard),
 		logTooRecent:   logutil.NewThrottledLogger(fmt.Sprintf("FailoverTooRecent-%v", topoproto.KeyspaceShardString(keyspace, shard)), 5*time.Second),
-		state:          stateIdle,
+		// state zero value is stateIdle (via atomic.Int32)
 	}
 }
 
@@ -142,16 +158,14 @@ func (sb *shardBuffer) waitForFailoverEnd(ctx context.Context, keyspace, shard s
 	// Other errors must be filtered at higher layers.
 	failoverDetected := err != nil
 
-	// Fast path (read lock): Check if we should NOT buffer a request.
-	sb.mu.RLock()
-	if !sb.shouldBufferLocked(failoverDetected) {
-		// No buffering required. Return early.
-		sb.mu.RUnlock()
+	// Fast path (lock-free): When no failover is detected (the common case),
+	// check the state atomically. We only need to proceed if the buffer is
+	// actively buffering requests.
+	if !failoverDetected && bufferState(sb.state.Load()) != stateBuffering {
 		return nil, nil
 	}
-	sb.mu.RUnlock()
 
-	// Buffering required. Acquire write lock.
+	// Slow path: Acquire write lock for state transitions or buffering.
 	sb.mu.Lock()
 	// Re-check state because it could have changed in the meantime.
 	if !sb.shouldBufferLocked(failoverDetected) {
@@ -161,7 +175,7 @@ func (sb *shardBuffer) waitForFailoverEnd(ctx context.Context, keyspace, shard s
 	}
 
 	// Start buffering if failover is not detected yet.
-	if sb.state == stateIdle {
+	if bufferState(sb.state.Load()) == stateIdle {
 		// Do not buffer if last failover is too recent. This is the case if:
 		// a) buffering was stopped recently
 		// OR
@@ -238,7 +252,7 @@ func (sb *shardBuffer) waitForFailoverEnd(ctx context.Context, keyspace, shard s
 // shouldBufferLocked returns true if the current request should be buffered
 // (based on the current state and whether the request detected a failover).
 func (sb *shardBuffer) shouldBufferLocked(failoverDetected bool) bool {
-	switch s := sb.state; {
+	switch s := bufferState(sb.state.Load()); {
 	case s == stateIdle && !failoverDetected:
 		// No failover in progress.
 		return false
@@ -276,7 +290,7 @@ func (sb *shardBuffer) startBufferingLocked(ctx context.Context, kev *discovery.
 
 	sb.lastStart = sb.timeNow()
 	sb.logErrorIfStateNotLocked(stateIdle)
-	sb.state = stateBuffering
+	sb.state.Store(int32(stateBuffering))
 	sb.queue = make([]*entry, 0)
 
 	sb.timeoutThread = newTimeoutThread(sb, sb.buf.config.MaxFailoverDuration)
@@ -303,8 +317,8 @@ func (sb *shardBuffer) startBufferingLocked(ctx context.Context, kev *discovery.
 // Note: The prefix "Locked" is not related to the state. Instead, it stresses
 // that "sb.mu" must be locked before calling the method.
 func (sb *shardBuffer) logErrorIfStateNotLocked(state bufferState) {
-	if sb.state != state {
-		log.Errorf("BUG: Buffer state should be '%v' and not '%v'. Full state of buffer object: %#v Stacktrace:\n%s", state, sb.state, sb, debug.Stack())
+	if current := bufferState(sb.state.Load()); current != state {
+		log.Errorf("BUG: Buffer state should be '%v' and not '%v'. shard=%s/%s Stacktrace:\n%s", state, current, sb.keyspace, sb.shard, debug.Stack())
 	}
 }
 
@@ -526,7 +540,7 @@ func (sb *shardBuffer) stopBufferingDueToMaxDuration() {
 }
 
 func (sb *shardBuffer) stopBufferingLocked(reason stopReason, details string) {
-	if sb.state != stateBuffering {
+	if bufferState(sb.state.Load()) != stateBuffering {
 		return
 	}
 
@@ -550,7 +564,7 @@ func (sb *shardBuffer) stopBufferingLocked(reason stopReason, details string) {
 	}
 
 	sb.logErrorIfStateNotLocked(stateBuffering)
-	sb.state = stateDraining
+	sb.state.Store(int32(stateDraining))
 	q := sb.queue
 	// Clear the queue such that remove(), oldestEntry() and evictOldestEntry()
 	// will not work on obsolete data.
@@ -627,7 +641,7 @@ func (sb *shardBuffer) drain(q []*entry, err error) {
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
 	sb.logErrorIfStateNotLocked(stateDraining)
-	sb.state = stateIdle
+	sb.state.Store(int32(stateIdle))
 	sb.timeoutThread = nil
 }
 
@@ -652,7 +666,5 @@ func (sb *shardBuffer) testGetSize() int {
 
 // stateForTesting is used by unit tests only to probe the current state.
 func (sb *shardBuffer) testGetState() bufferState {
-	sb.mu.RLock()
-	defer sb.mu.RUnlock()
-	return sb.state
+	return bufferState(sb.state.Load())
 }


### PR DESCRIPTION
## Description

Replace the mutex-based hot path in the vtgate query buffer with lock-free alternatives. The buffer is checked on every PRIMARY query via `WaitForFailoverEnd`. In the normal case (no failover), this should be near-zero cost, but currently takes two mutex acquisitions per query — a global `RWMutex` for shard map lookup and a per-shard `RWMutex` for state check.

Changes:
- Replace `sync.RWMutex` + `map[string]*shardBuffer` with `sync.Map` for lock-free shard buffer lookups
- Replace per-shard `RLock` + string state check with `atomic.Int32` load on the hot path
- Convert `bufferState` from `string` to `int32` for atomic compatibility and faster comparisons
- Add benchmarks for the idle-check hot path

The hot path now requires **zero lock acquisitions** — just an atomic load and a `sync.Map.Load`.

### Benchmark Results (Apple M1 Max, 10 cores)

**Before (mutex-based)**
```
BenchmarkWaitForFailoverEnd_Idle-10            	 ~104 ns/op     37 B/op    3 allocs/op
BenchmarkWaitForFailoverEnd_IdleParallel-10    	 ~156 ns/op     37 B/op    3 allocs/op
BenchmarkWaitForFailoverEnd_MultiShard-10      	 ~139 ns/op     40 B/op    3 allocs/op
```

**After (lock-free)**
```
BenchmarkWaitForFailoverEnd_Idle-10            	 ~106 ns/op     37 B/op    3 allocs/op
BenchmarkWaitForFailoverEnd_IdleParallel-10    	  ~26 ns/op     37 B/op    3 allocs/op
BenchmarkWaitForFailoverEnd_MultiShard-10      	  ~27 ns/op     40 B/op    3 allocs/op
```

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| Idle (serial) | 104 ns | 106 ns | ~same |
| **Idle (parallel, 10 goroutines)** | **156 ns** | **26 ns** | **-83%** |
| **MultiShard (parallel, 8 shards)** | **139 ns** | **27 ns** | **-81%** |

Serial performance is unchanged (lock was uncontended). Parallel throughput improves ~6x because mutex contention is completely eliminated.

## Related Issue(s)

Fixes #19801

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [ ] Documentation was added or is not required

## Deployment Notes

No deployment changes required. This is a purely internal optimization with no behavioral or configuration changes.

### AI Disclosure

Implementation assisted by Claude Code.