### PR TITLE
vtgate/buffer: lock-free hot-path with atomic state and sync.Map

### DIFF
--- a/go/vt/topo/topoproto/shard.go
+++ b/go/vt/topo/topoproto/shard.go
@@ -24,7 +24,7 @@ import (
 // KeyspaceShardString returns a "keyspace/shard" string taking
 // keyspace and shard as separate inputs.
 func KeyspaceShardString(keyspace, shard string) string {
-	return fmt.Sprintf("%v/%v", keyspace, shard)
+	return keyspace + "/" + shard
 }
 
 // ParseKeyspaceShard parse a "keyspace/shard" or "keyspace:shard"

--- a/go/vt/vtgate/buffer/buffer.go
+++ b/go/vt/vtgate/buffer/buffer.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"golang.org/x/sync/semaphore"
 
@@ -152,19 +153,14 @@ type Buffer struct {
 	bufferSizeSema *semaphore.Weighted
 	bufferSize     int
 
-	// mu guards all fields in this group.
-	// In particular, it is used to serialize the following Go routines:
-	// - 1. Requests which may buffer (RLock, can be run in parallel)
-	// - 2. Request which starts buffering (based on the seen error)
-	// - 3. HealthCheck subscriber ("StatsUpdate") which stops buffering
-	// - 4. Timer which may stop buffering after -buffer-max-failover-duration
-	mu sync.RWMutex
 	// buffers holds a shardBuffer object per shard, even if no failover is in
-	// progress.
-	// Key Format: "<keyspace>/<shard>"
-	buffers map[string]*shardBuffer
+	// progress. Uses sync.Map for lock-free reads on the hot path (every query)
+	// since writes only occur once per shard at startup.
+	// Key: string ("<keyspace>/<shard>"), Value: *shardBuffer
+	buffers sync.Map
+
 	// stopped is true after Shutdown() was run.
-	stopped bool
+	stopped atomic.Bool
 }
 
 // New creates a new Buffer object.
@@ -173,7 +169,7 @@ func New(cfg *Config) *Buffer {
 		config:         cfg,
 		bufferSizeSema: semaphore.NewWeighted(int64(cfg.Size)),
 		bufferSize:     cfg.Size,
-		buffers:        make(map[string]*shardBuffer),
+		// buffers and stopped use zero values (empty sync.Map and false atomic.Bool)
 	}
 }
 
@@ -221,28 +217,21 @@ func (b *Buffer) HandleKeyspaceEvent(ksevent *discovery.KeyspaceEvent) {
 // getOrCreateBuffer returns the ShardBuffer for the given keyspace and shard.
 // It returns nil if Buffer is shut down and all calls should be ignored.
 func (b *Buffer) getOrCreateBuffer(keyspace, shard string) *shardBuffer {
-	key := topoproto.KeyspaceShardString(keyspace, shard)
-	b.mu.RLock()
-	sb, ok := b.buffers[key]
-	stopped := b.stopped
-	b.mu.RUnlock()
-
-	if stopped {
+	if b.stopped.Load() {
 		return nil
 	}
-	if ok {
-		return sb
+
+	key := topoproto.KeyspaceShardString(keyspace, shard)
+
+	// Hot path: lock-free lookup for existing shard buffers.
+	if v, ok := b.buffers.Load(key); ok {
+		return v.(*shardBuffer)
 	}
 
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	// Look it up again because it could have been created in the meantime.
-	sb, ok = b.buffers[key]
-	if !ok {
-		sb = newShardBufferHealthCheck(b, b.config.bufferingMode(keyspace, shard), keyspace, shard)
-		b.buffers[key] = sb
-	}
-	return sb
+	// Cold path (once per shard): create and store atomically.
+	sb := newShardBufferHealthCheck(b, b.config.bufferingMode(keyspace, shard), keyspace, shard)
+	v, _ := b.buffers.LoadOrStore(key, sb)
+	return v.(*shardBuffer)
 }
 
 // Shutdown blocks until all pending ShardBuffer objects are shut down.
@@ -254,20 +243,16 @@ func (b *Buffer) Shutdown() {
 }
 
 func (b *Buffer) shutdown() {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	for _, sb := range b.buffers {
-		sb.shutdown()
-	}
-	b.stopped = true
+	b.stopped.Store(true)
+	b.buffers.Range(func(_, value any) bool {
+		value.(*shardBuffer).shutdown()
+		return true
+	})
 }
 
 func (b *Buffer) waitForShutdown() {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-
-	for _, sb := range b.buffers {
-		sb.waitForShutdown()
-	}
+	b.buffers.Range(func(_, value any) bool {
+		value.(*shardBuffer).waitForShutdown()
+		return true
+	})
 }

--- a/go/vt/vtgate/buffer/buffer.go
+++ b/go/vt/vtgate/buffer/buffer.go
@@ -169,7 +169,6 @@ func New(cfg *Config) *Buffer {
 		config:         cfg,
 		bufferSizeSema: semaphore.NewWeighted(int64(cfg.Size)),
 		bufferSize:     cfg.Size,
-		// buffers and stopped use zero values (empty sync.Map and false atomic.Bool)
 	}
 }
 
@@ -223,15 +222,28 @@ func (b *Buffer) getOrCreateBuffer(keyspace, shard string) *shardBuffer {
 
 	key := topoproto.KeyspaceShardString(keyspace, shard)
 
-	// Hot path: lock-free lookup for existing shard buffers.
 	if v, ok := b.buffers.Load(key); ok {
 		return v.(*shardBuffer)
 	}
 
-	// Cold path (once per shard): create and store atomically.
+	// First access for this shard: create and store atomically.
 	sb := newShardBufferHealthCheck(b, b.config.bufferingMode(keyspace, shard), keyspace, shard)
-	v, _ := b.buffers.LoadOrStore(key, sb)
-	return v.(*shardBuffer)
+	v, loaded := b.buffers.LoadOrStore(key, sb)
+	if loaded {
+		return v.(*shardBuffer)
+	}
+
+	// Shutdown may have completed its Range between our stopped check above
+	// and the LoadOrStore, so this buffer would never be visited. Clean it up.
+	if b.stopped.Load() {
+		if actual, ok := b.buffers.LoadAndDelete(key); ok && actual == sb {
+			sb.shutdown()
+			sb.waitForShutdown()
+		}
+		return nil
+	}
+
+	return sb
 }
 
 // Shutdown blocks until all pending ShardBuffer objects are shut down.

--- a/go/vt/vtgate/buffer/buffer_bench_test.go
+++ b/go/vt/vtgate/buffer/buffer_bench_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buffer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func BenchmarkWaitForFailoverEnd_Idle(b *testing.B) {
+	cfg := NewDefaultConfig()
+	cfg.Enabled = true
+	buf := New(cfg)
+	defer buf.Shutdown()
+
+	ctx := context.Background()
+	// Pre-create the shard buffer so we're benchmarking the steady-state path.
+	buf.getOrCreateBuffer(keyspace, shard)
+
+	b.ResetTimer()
+	for b.Loop() {
+		buf.WaitForFailoverEnd(ctx, keyspace, shard, nil, nil)
+	}
+}
+
+func BenchmarkWaitForFailoverEnd_IdleParallel(b *testing.B) {
+	cfg := NewDefaultConfig()
+	cfg.Enabled = true
+	buf := New(cfg)
+	defer buf.Shutdown()
+
+	ctx := context.Background()
+	buf.getOrCreateBuffer(keyspace, shard)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			buf.WaitForFailoverEnd(ctx, keyspace, shard, nil, nil)
+		}
+	})
+}
+
+func BenchmarkWaitForFailoverEnd_MultiShard(b *testing.B) {
+	cfg := NewDefaultConfig()
+	cfg.Enabled = true
+	buf := New(cfg)
+	defer buf.Shutdown()
+
+	ctx := context.Background()
+	const numShards = 8
+	shards := make([]string, numShards)
+	for i := range numShards {
+		shards[i] = fmt.Sprintf("-%02x", i)
+		buf.getOrCreateBuffer(keyspace, shards[i])
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			buf.WaitForFailoverEnd(ctx, keyspace, shards[i%numShards], nil, nil)
+			i++
+		}
+	})
+}

--- a/go/vt/vtgate/buffer/shard_buffer.go
+++ b/go/vt/vtgate/buffer/shard_buffer.go
@@ -158,9 +158,9 @@ func (sb *shardBuffer) waitForFailoverEnd(ctx context.Context, keyspace, shard s
 	// Other errors must be filtered at higher layers.
 	failoverDetected := err != nil
 
-	// Lock-free fast path: most queries arrive with no failover and the shard
-	// is idle. An atomic load is sufficient to confirm nothing needs buffering.
-	if !failoverDetected && bufferState(sb.state.Load()) != stateBuffering {
+	// Lock-free fast path: an atomic state read determines whether buffering
+	// is possible. Most queries see idle state with no failover and return here.
+	if !sb.shouldBuffer(failoverDetected) {
 		return nil, nil
 	}
 
@@ -248,8 +248,22 @@ func (sb *shardBuffer) waitForFailoverEnd(ctx context.Context, keyspace, shard s
 	return sb.wait(ctx, entry)
 }
 
-// shouldBufferLocked returns true if the current request should be buffered
-// (based on the current state and whether the request detected a failover).
+// shouldBuffer returns true if the request may need buffering based on an
+// atomic state read. This is the lock-free guard: when it returns false the
+// caller can skip acquiring mu entirely.
+func (sb *shardBuffer) shouldBuffer(failoverDetected bool) bool {
+	switch s := bufferState(sb.state.Load()); {
+	case s == stateBuffering:
+		return true
+	case s == stateIdle && failoverDetected:
+		return true
+	default:
+		return false
+	}
+}
+
+// shouldBufferLocked is the authoritative check under mu. It re-reads state
+// atomically (safe because writes also hold mu) and covers the full matrix.
 func (sb *shardBuffer) shouldBufferLocked(failoverDetected bool) bool {
 	switch s := bufferState(sb.state.Load()); {
 	case s == stateIdle && !failoverDetected:

--- a/go/vt/vtgate/buffer/shard_buffer.go
+++ b/go/vt/vtgate/buffer/shard_buffer.go
@@ -35,16 +35,29 @@ import (
 )
 
 // bufferState represents the different states a shardBuffer object can be in.
-type bufferState string
+type bufferState int32
 
 const (
 	// stateIdle means no failover is currently in progress.
-	stateIdle bufferState = "IDLE"
+	stateIdle bufferState = iota
 	// stateBuffering is the phase when a failover is in progress.
-	stateBuffering bufferState = "BUFFERING"
+	stateBuffering
 	// stateDraining is the phase when a failover ended and the queue is drained.
-	stateDraining bufferState = "DRAINING"
+	stateDraining
 )
+
+func (s bufferState) String() string {
+	switch s {
+	case stateIdle:
+		return "IDLE"
+	case stateBuffering:
+		return "BUFFERING"
+	case stateDraining:
+		return "DRAINING"
+	default:
+		return fmt.Sprintf("UNKNOWN(%d)", s)
+	}
+}
 
 // entry is created per buffered request.
 type entry struct {
@@ -90,9 +103,12 @@ type shardBuffer struct {
 	statsKeyJoined string
 	logTooRecent   *logutil.ThrottledLogger
 
+	// state is read atomically on the hot path (no lock needed for idle check)
+	// and written under mu during state transitions.
+	state atomic.Int32
+
 	// mu guards the fields below.
-	mu    sync.RWMutex
-	state bufferState
+	mu sync.RWMutex
 	// queue is the list of buffered requests (ordered by arrival).
 	queue []*entry
 	// lastStart is the last time we saw the start of a failover.
@@ -124,7 +140,7 @@ func newShardBufferHealthCheck(buf *Buffer, mode bufferMode, keyspace, shard str
 		statsKey:       statsKey,
 		statsKeyJoined: fmt.Sprintf("%s.%s", keyspace, shard),
 		logTooRecent:   logutil.NewThrottledLogger(fmt.Sprintf("FailoverTooRecent-%v", topoproto.KeyspaceShardString(keyspace, shard)), 5*time.Second),
-		state:          stateIdle,
+		// state zero value is stateIdle (via atomic.Int32)
 	}
 }
 
@@ -142,16 +158,14 @@ func (sb *shardBuffer) waitForFailoverEnd(ctx context.Context, keyspace, shard s
 	// Other errors must be filtered at higher layers.
 	failoverDetected := err != nil
 
-	// Fast path (read lock): Check if we should NOT buffer a request.
-	sb.mu.RLock()
-	if !sb.shouldBufferLocked(failoverDetected) {
-		// No buffering required. Return early.
-		sb.mu.RUnlock()
+	// Fast path (lock-free): When no failover is detected (the common case),
+	// check the state atomically. We only need to proceed if the buffer is
+	// actively buffering requests.
+	if !failoverDetected && bufferState(sb.state.Load()) != stateBuffering {
 		return nil, nil
 	}
-	sb.mu.RUnlock()
 
-	// Buffering required. Acquire write lock.
+	// Slow path: Acquire write lock for state transitions or buffering.
 	sb.mu.Lock()
 	// Re-check state because it could have changed in the meantime.
 	if !sb.shouldBufferLocked(failoverDetected) {
@@ -161,7 +175,7 @@ func (sb *shardBuffer) waitForFailoverEnd(ctx context.Context, keyspace, shard s
 	}
 
 	// Start buffering if failover is not detected yet.
-	if sb.state == stateIdle {
+	if bufferState(sb.state.Load()) == stateIdle {
 		// Do not buffer if last failover is too recent. This is the case if:
 		// a) buffering was stopped recently
 		// OR
@@ -238,7 +252,7 @@ func (sb *shardBuffer) waitForFailoverEnd(ctx context.Context, keyspace, shard s
 // shouldBufferLocked returns true if the current request should be buffered
 // (based on the current state and whether the request detected a failover).
 func (sb *shardBuffer) shouldBufferLocked(failoverDetected bool) bool {
-	switch s := sb.state; {
+	switch s := bufferState(sb.state.Load()); {
 	case s == stateIdle && !failoverDetected:
 		// No failover in progress.
 		return false
@@ -276,7 +290,7 @@ func (sb *shardBuffer) startBufferingLocked(ctx context.Context, kev *discovery.
 
 	sb.lastStart = sb.timeNow()
 	sb.logErrorIfStateNotLocked(stateIdle)
-	sb.state = stateBuffering
+	sb.state.Store(int32(stateBuffering))
 	sb.queue = make([]*entry, 0)
 
 	sb.timeoutThread = newTimeoutThread(sb, sb.buf.config.MaxFailoverDuration)
@@ -301,8 +315,8 @@ func (sb *shardBuffer) startBufferingLocked(ctx context.Context, kev *discovery.
 // Note: The prefix "Locked" is not related to the state. Instead, it stresses
 // that "sb.mu" must be locked before calling the method.
 func (sb *shardBuffer) logErrorIfStateNotLocked(state bufferState) {
-	if sb.state != state {
-		log.Error(fmt.Sprintf("BUG: Buffer state should be '%v' and not '%v'. Full state of buffer object: %#v Stacktrace:\n%s", state, sb.state, sb, debug.Stack()))
+	if current := bufferState(sb.state.Load()); current != state {
+		log.Error(fmt.Sprintf("BUG: Buffer state should be '%v' and not '%v'. shard=%s/%s Stacktrace:\n%s", state, current, sb.keyspace, sb.shard, debug.Stack()))
 	}
 }
 
@@ -523,7 +537,7 @@ func (sb *shardBuffer) stopBufferingDueToMaxDuration() {
 }
 
 func (sb *shardBuffer) stopBufferingLocked(reason stopReason, details string) {
-	if sb.state != stateBuffering {
+	if bufferState(sb.state.Load()) != stateBuffering {
 		return
 	}
 
@@ -547,7 +561,7 @@ func (sb *shardBuffer) stopBufferingLocked(reason stopReason, details string) {
 	}
 
 	sb.logErrorIfStateNotLocked(stateBuffering)
-	sb.state = stateDraining
+	sb.state.Store(int32(stateDraining))
 	q := sb.queue
 	// Clear the queue such that remove(), oldestEntry() and evictOldestEntry()
 	// will not work on obsolete data.
@@ -623,7 +637,7 @@ func (sb *shardBuffer) drain(q []*entry, err error) {
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
 	sb.logErrorIfStateNotLocked(stateDraining)
-	sb.state = stateIdle
+	sb.state.Store(int32(stateIdle))
 	sb.timeoutThread = nil
 }
 
@@ -648,7 +662,5 @@ func (sb *shardBuffer) testGetSize() int {
 
 // stateForTesting is used by unit tests only to probe the current state.
 func (sb *shardBuffer) testGetState() bufferState {
-	sb.mu.RLock()
-	defer sb.mu.RUnlock()
-	return sb.state
+	return bufferState(sb.state.Load())
 }

--- a/go/vt/vtgate/buffer/shard_buffer.go
+++ b/go/vt/vtgate/buffer/shard_buffer.go
@@ -103,11 +103,11 @@ type shardBuffer struct {
 	statsKeyJoined string
 	logTooRecent   *logutil.ThrottledLogger
 
-	// state is read atomically on the hot path (no lock needed for idle check)
-	// and written under mu during state transitions.
+	// state tracks the shard's buffering lifecycle (idle/buffering/draining).
+	// Read atomically on every query; written under mu during transitions.
 	state atomic.Int32
 
-	// mu guards the fields below.
+	// mu guards the mutable fields below (queue, timers, timestamps).
 	mu sync.RWMutex
 	// queue is the list of buffered requests (ordered by arrival).
 	queue []*entry
@@ -140,7 +140,7 @@ func newShardBufferHealthCheck(buf *Buffer, mode bufferMode, keyspace, shard str
 		statsKey:       statsKey,
 		statsKeyJoined: fmt.Sprintf("%s.%s", keyspace, shard),
 		logTooRecent:   logutil.NewThrottledLogger(fmt.Sprintf("FailoverTooRecent-%v", topoproto.KeyspaceShardString(keyspace, shard)), 5*time.Second),
-		// state zero value is stateIdle (via atomic.Int32)
+		// state defaults to stateIdle (zero value).
 	}
 }
 
@@ -158,14 +158,13 @@ func (sb *shardBuffer) waitForFailoverEnd(ctx context.Context, keyspace, shard s
 	// Other errors must be filtered at higher layers.
 	failoverDetected := err != nil
 
-	// Fast path (lock-free): When no failover is detected (the common case),
-	// check the state atomically. We only need to proceed if the buffer is
-	// actively buffering requests.
+	// Lock-free fast path: most queries arrive with no failover and the shard
+	// is idle. An atomic load is sufficient to confirm nothing needs buffering.
 	if !failoverDetected && bufferState(sb.state.Load()) != stateBuffering {
 		return nil, nil
 	}
 
-	// Slow path: Acquire write lock for state transitions or buffering.
+	// Slow path: acquire lock for state transitions or to enqueue a request.
 	sb.mu.Lock()
 	// Re-check state because it could have changed in the meantime.
 	if !sb.shouldBufferLocked(failoverDetected) {


### PR DESCRIPTION
## Description

Replace the mutex-based hot path in the vtgate query buffer with lock-free alternatives. The buffer is checked on every PRIMARY query via `WaitForFailoverEnd`. In the normal case (no failover), this should be near-zero cost, but currently takes two mutex acquisitions per query — a global `RWMutex` for shard map lookup and a per-shard `RWMutex` for state check.

Changes:
- Replace `sync.RWMutex` + `map[string]*shardBuffer` with `sync.Map` for lock-free shard buffer lookups
- Replace per-shard `RLock` + string state check with `atomic.Int32` load on the hot path
- Convert `bufferState` from `string` to `int32` for atomic compatibility and faster comparisons
- Replace `fmt.Sprintf` with string concatenation in `KeyspaceShardString` (3 allocs → 1)
- Add benchmarks for the idle-check hot path

The hot path now requires **zero lock acquisitions** — just an atomic load and a `sync.Map.Load`.

### Benchmark Results (Apple M1 Max, 10 cores)

**Before (mutex-based, upstream/main)**
```
BenchmarkWaitForFailoverEnd_Idle-10            	 ~104 ns/op     37 B/op    3 allocs/op
BenchmarkWaitForFailoverEnd_IdleParallel-10    	 ~142 ns/op     37 B/op    3 allocs/op
BenchmarkWaitForFailoverEnd_MultiShard-10      	 ~135 ns/op     40 B/op    3 allocs/op
```

**After (lock-free + allocation reduction)**
```
BenchmarkWaitForFailoverEnd_Idle-10            	  ~45 ns/op      5 B/op    1 allocs/op
BenchmarkWaitForFailoverEnd_IdleParallel-10    	  ~10 ns/op      5 B/op    1 allocs/op
BenchmarkWaitForFailoverEnd_MultiShard-10      	  ~13 ns/op      8 B/op    1 allocs/op
```

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| **Idle (serial)** | **104 ns, 3 allocs** | **45 ns, 1 alloc** | **-57%** |
| **Idle (parallel, 10 goroutines)** | **142 ns, 3 allocs** | **10 ns, 1 alloc** | **-93%** |
| **MultiShard (parallel, 8 shards)** | **135 ns, 3 allocs** | **13 ns, 1 alloc** | **-90%** |

## Related Issue(s)

Fixes #19801

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

No deployment changes required. This is a purely internal optimization with no behavioral or configuration changes.

### AI Disclosure

Implementation assisted by Claude Code.