### PR TITLE
vtorc: fix data race in forgetAliases cache initialization

### DIFF
--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/patrickmn/go-cache"
@@ -54,7 +53,10 @@ var (
 	instanceWriteSem = semaphore.NewWeighted(config.GetBackendWriteConcurrency())
 )
 
-var forgetAliases *cache.Cache
+var (
+	forgetAliases     *cache.Cache
+	forgetAliasesOnce sync.Once
+)
 
 var (
 	readTopologyInstanceCounter = stats.NewCounter("InstanceReadTopology", "Number of times an instance was read from the topology")
@@ -62,10 +64,7 @@ var (
 	currentErrantGTIDCount      = stats.NewGaugesWithSingleLabel("CurrentErrantGTIDCount", "Number of errant GTIDs a vttablet currently has", "TabletAlias")
 )
 
-var (
-	emptyQuotesRegexp            = regexp.MustCompile(`^""$`)
-	cacheInitializationCompleted atomic.Bool
-)
+var emptyQuotesRegexp = regexp.MustCompile(`^""$`)
 
 func init() {
 	go initializeInstanceDao()
@@ -73,12 +72,18 @@ func init() {
 
 func initializeInstanceDao() {
 	config.WaitForConfigurationToBeLoaded()
-	InitializeForgetAliasesCache()
+	initForgetAliasesCache()
 }
 
+func initForgetAliasesCache() {
+	forgetAliasesOnce.Do(func() {
+		forgetAliases = cache.New(config.GetInstancePollTime()*3, time.Second)
+	})
+}
+
+// InitializeForgetAliasesCache ensures the forgetAliases cache is initialized.
 func InitializeForgetAliasesCache() {
-	forgetAliases = cache.New(config.GetInstancePollTime()*3, time.Second)
-	cacheInitializationCompleted.Store(true)
+	initForgetAliasesCache()
 }
 
 // ExecDBWriteFunc chooses how to execute a write onto the database: whether synchronously or not
@@ -1105,6 +1110,7 @@ func UpdateInstanceLastAttemptedCheck(tabletAlias *topodatapb.TabletAlias) error
 
 // InstanceIsForgotten returns true if an instance was forgotten.
 func InstanceIsForgotten(tabletAlias *topodatapb.TabletAlias) bool {
+	initForgetAliasesCache()
 	tabletAliasString := topoproto.TabletAliasString(tabletAlias)
 	_, found := forgetAliases.Get(tabletAliasString)
 	return found
@@ -1118,6 +1124,7 @@ func ForgetInstance(tabletAlias *topodatapb.TabletAlias) error {
 		log.Error(errMsg)
 		return errors.New(errMsg)
 	}
+	initForgetAliasesCache()
 	tabletAliasString := topoproto.TabletAliasString(tabletAlias)
 	forgetAliases.Set(tabletAliasString, true, cache.DefaultExpiration)
 	log.Info(fmt.Sprintf("Forgetting: %v", tabletAliasString))

--- a/go/vt/vtorc/inst/instance_dao_test.go
+++ b/go/vt/vtorc/inst/instance_dao_test.go
@@ -558,8 +558,8 @@ func TestReadOutdatedInstances(t *testing.T) {
 		},
 	}
 
-	// wait for the forgetAliases cache to be initialized to prevent data race.
-	waitForCacheInitialization()
+	// Ensure the forgetAliases cache is initialized before overriding it.
+	InitializeForgetAliasesCache()
 
 	// We are setting InstancePollSeconds to 59 minutes, just for the test.
 	oldVal := config.GetInstancePollTime()
@@ -747,8 +747,8 @@ func TestForgetInstanceAndInstanceIsForgotten(t *testing.T) {
 		},
 	}
 
-	// wait for the forgetAliases cache to be initialized to prevent data race.
-	waitForCacheInitialization()
+	// Ensure the forgetAliases cache is initialized before overriding it.
+	InitializeForgetAliasesCache()
 
 	oldCache := forgetAliases
 	// Clear the database after the test. The easiest way to do that is to run all the initialization commands again.
@@ -808,17 +808,6 @@ func TestSnapshotTopologies(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, []string{"zone1-0000000100", "zone1-0000000101", "zone1-0000000112", "zone2-0000000200"}, tabletAliases)
-}
-
-// waitForCacheInitialization waits for the cache to be initialized to prevent data race in tests
-// that alter the cache or depend on its behaviour.
-func waitForCacheInitialization() {
-	for {
-		if cacheInitializationCompleted.Load() {
-			return
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
 }
 
 func TestGetDatabaseState(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes a data race in the vtorc `instance_dao` package where the `forgetAliases` cache is accessed before the background init goroutine finishes creating it.

The `init()` function launches `initializeInstanceDao()` as a background goroutine (to wait for config to load), but `InstanceIsForgotten()` and `ForgetInstance()` read/write the cache without synchronization. This race was exposed by Go 1.25's `synctest.Test` in `TestRestartDirectReplicasTimeout`, where the test goroutine runs in an isolated bubble with no scheduling guarantees relative to the init goroutine.

The fix replaces the `atomic.Bool` flag + busy-wait pattern with `sync.Once` for lazy initialization. All cache access points now call `initForgetAliasesCache()` which uses `sync.Once` to ensure the cache is created exactly once, regardless of which goroutine reaches it first.

## Related Issue(s)

Found via analysis of race unit test CI failures.

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [ ] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

Most of this was written by Claude Code — I provided direction and review.