### PR TITLE
tabletserver: fix data race in testLogger global log function pointers

### DIFF
--- a/go/vt/log/log.go
+++ b/go/vt/log/log.go
@@ -58,6 +58,13 @@ func init() {
 	structured.Store(true)
 }
 
+// SwapLogger atomically replaces the structured logger with a new one
+// and returns the previous logger. This is safe for concurrent use and is
+// intended for tests that need to intercept log output.
+func SwapLogger(newLogger *slog.Logger) *slog.Logger {
+	return logger.Swap(newLogger)
+}
+
 // log is a helper that logs with glog or slog depending on the configured flags.
 func log(level slog.Level, depth int, msg string, attrs ...slog.Attr) {
 	if !structured.Load() {

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -1756,60 +1756,68 @@ func TestQueryAsString(t *testing.T) {
 	assert.Equal(t, want, query)
 }
 
-type testLogger struct {
-	logsMu sync.Mutex
-	logs   []string
+// testLogHandler is a slog.Handler that records log messages for test assertions
+// while forwarding them to the original handler. It uses the atomic logger swap
+// mechanism in the log package instead of mutating global function pointers,
+// which avoids data races with background goroutines that call log functions.
+type testLogHandler struct {
+	mu      sync.Mutex
+	logs    []string
+	wrapped slog.Handler
+}
 
-	savedInfo  func(msg string, attrs ...slog.Attr)
-	savedError func(msg string, attrs ...slog.Attr)
+func (h *testLogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return true
+}
+
+func (h *testLogHandler) Handle(ctx context.Context, r slog.Record) error {
+	h.mu.Lock()
+	h.logs = append(h.logs, r.Message)
+	h.mu.Unlock()
+	return h.wrapped.Handle(ctx, r)
+}
+
+func (h *testLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &testLogHandler{wrapped: h.wrapped.WithAttrs(attrs), logs: h.logs}
+}
+
+func (h *testLogHandler) WithGroup(name string) slog.Handler {
+	return &testLogHandler{wrapped: h.wrapped.WithGroup(name), logs: h.logs}
+}
+
+type testLogger struct {
+	handler     *testLogHandler
+	savedLogger *slog.Logger
 }
 
 func newTestLogger() *testLogger {
-	tl := &testLogger{
-		savedInfo:  log.Info,
-		savedError: log.Error,
+	savedLogger := log.SwapLogger(slog.New(&slog.TextHandler{}))
+	handler := &testLogHandler{wrapped: savedLogger.Handler()}
+	newLogger := slog.New(handler)
+	log.SwapLogger(newLogger)
+	return &testLogger{
+		handler:     handler,
+		savedLogger: savedLogger,
 	}
-	tl.logsMu.Lock()
-	defer tl.logsMu.Unlock()
-	log.Info = tl.recordInfo
-	log.Error = tl.recordError
-	return tl
 }
 
 func (tl *testLogger) Close() {
-	tl.logsMu.Lock()
-	defer tl.logsMu.Unlock()
-	log.Info = tl.savedInfo
-	log.Error = tl.savedError
-}
-
-func (tl *testLogger) recordInfo(msg string, attrs ...slog.Attr) {
-	tl.logsMu.Lock()
-	defer tl.logsMu.Unlock()
-	tl.logs = append(tl.logs, msg)
-	tl.savedInfo(msg, attrs...)
-}
-
-func (tl *testLogger) recordError(msg string, attrs ...slog.Attr) {
-	tl.logsMu.Lock()
-	defer tl.logsMu.Unlock()
-	tl.logs = append(tl.logs, msg)
-	tl.savedError(msg, attrs...)
+	log.SwapLogger(tl.savedLogger)
 }
 
 func (tl *testLogger) getLog(i int) string {
-	tl.logsMu.Lock()
-	defer tl.logsMu.Unlock()
-	if i < len(tl.logs) {
-		return tl.logs[i]
+	tl.handler.mu.Lock()
+	defer tl.handler.mu.Unlock()
+	if i < len(tl.handler.logs) {
+		return tl.handler.logs[i]
 	}
-	return fmt.Sprintf("ERROR: log %d/%d does not exist", i, len(tl.logs))
+	return fmt.Sprintf("ERROR: log %d/%d does not exist", i, len(tl.handler.logs))
 }
 
 func (tl *testLogger) getLogs() []string {
-	tl.logsMu.Lock()
-	defer tl.logsMu.Unlock()
-	return tl.logs
+	tl.handler.mu.Lock()
+	defer tl.handler.mu.Unlock()
+	return tl.handler.logs
 }
 
 func TestHandleExecTabletError(t *testing.T) {
@@ -2105,7 +2113,7 @@ func TestTerseErrorsIgnoreFailoverInProgress(t *testing.T) {
 	}
 
 	// errors during failover aren't logged at all
-	require.Empty(t, tl.logs, "unexpected error log during failover")
+	require.Empty(t, tl.getLogs(), "unexpected error log during failover")
 }
 
 var aclJSON1 = `{

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -1756,47 +1756,54 @@ func TestQueryAsString(t *testing.T) {
 	assert.Equal(t, want, query)
 }
 
+// testLogState holds the shared mutable state for testLogHandler instances.
+// All handlers derived via WithAttrs/WithGroup share the same state so that
+// log messages are captured regardless of which derived handler records them.
+type testLogState struct {
+	mu   sync.Mutex
+	logs []string
+}
+
 // testLogHandler is a slog.Handler that records log messages for test assertions
 // while forwarding them to the original handler. It uses the atomic logger swap
 // mechanism in the log package instead of mutating global function pointers,
 // which avoids data races with background goroutines that call log functions.
 type testLogHandler struct {
-	mu      sync.Mutex
-	logs    []string
+	state   *testLogState
 	wrapped slog.Handler
 }
 
 func (h *testLogHandler) Enabled(ctx context.Context, level slog.Level) bool {
-	return true
+	return h.wrapped.Enabled(ctx, level)
 }
 
 func (h *testLogHandler) Handle(ctx context.Context, r slog.Record) error {
-	h.mu.Lock()
-	h.logs = append(h.logs, r.Message)
-	h.mu.Unlock()
+	h.state.mu.Lock()
+	h.state.logs = append(h.state.logs, r.Message)
+	h.state.mu.Unlock()
 	return h.wrapped.Handle(ctx, r)
 }
 
 func (h *testLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return &testLogHandler{wrapped: h.wrapped.WithAttrs(attrs), logs: h.logs}
+	return &testLogHandler{state: h.state, wrapped: h.wrapped.WithAttrs(attrs)}
 }
 
 func (h *testLogHandler) WithGroup(name string) slog.Handler {
-	return &testLogHandler{wrapped: h.wrapped.WithGroup(name), logs: h.logs}
+	return &testLogHandler{state: h.state, wrapped: h.wrapped.WithGroup(name)}
 }
 
 type testLogger struct {
-	handler     *testLogHandler
+	state       *testLogState
 	savedLogger *slog.Logger
 }
 
 func newTestLogger() *testLogger {
-	savedLogger := log.SwapLogger(slog.New(&slog.TextHandler{}))
-	handler := &testLogHandler{wrapped: savedLogger.Handler()}
-	newLogger := slog.New(handler)
-	log.SwapLogger(newLogger)
+	savedLogger := log.SwapLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	state := &testLogState{}
+	handler := &testLogHandler{state: state, wrapped: savedLogger.Handler()}
+	log.SwapLogger(slog.New(handler))
 	return &testLogger{
-		handler:     handler,
+		state:       state,
 		savedLogger: savedLogger,
 	}
 }
@@ -1806,18 +1813,20 @@ func (tl *testLogger) Close() {
 }
 
 func (tl *testLogger) getLog(i int) string {
-	tl.handler.mu.Lock()
-	defer tl.handler.mu.Unlock()
-	if i < len(tl.handler.logs) {
-		return tl.handler.logs[i]
+	tl.state.mu.Lock()
+	defer tl.state.mu.Unlock()
+	if i < len(tl.state.logs) {
+		return tl.state.logs[i]
 	}
-	return fmt.Sprintf("ERROR: log %d/%d does not exist", i, len(tl.handler.logs))
+	return fmt.Sprintf("ERROR: log %d/%d does not exist", i, len(tl.state.logs))
 }
 
 func (tl *testLogger) getLogs() []string {
-	tl.handler.mu.Lock()
-	defer tl.handler.mu.Unlock()
-	return tl.handler.logs
+	tl.state.mu.Lock()
+	defer tl.state.mu.Unlock()
+	logs := make([]string, len(tl.state.logs))
+	copy(logs, tl.state.logs)
+	return logs
 }
 
 func TestHandleExecTabletError(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes a data race where the `testLogger` test helper in `tabletserver_test.go` replaces global `log.Info` and `log.Error` function pointers to capture log output, racing with background goroutines from `stateManager.checkMySQL()` that read those same pointers concurrently.

The race manifests when a TabletServer's `checkMySQL` goroutine (which calls `closeAll()` → `QueryEngine.Close()` → `smartconnpool.Close()` → `log.Error()`) outlives the test that spawned it, and a subsequent test's `testLogger.Close()` restores the global function pointers while the goroutine is reading them.

### Fix

The log package's internal logger is already an `atomic.Pointer[slog.Logger]`, so swapping loggers is inherently thread-safe. This PR:

1. Adds `log.SwapLogger()` to atomically swap the structured logger
2. Rewrites `testLogger` to install a custom `slog.Handler` that records log messages while forwarding to the original handler, instead of mutating global function pointer variables

## Related Issue(s)

Found via analysis of race unit test CI failures.

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [ ] Documentation was added or is not required

## Deployment Notes

None — test-only change aside from the new `log.SwapLogger()` helper.

### AI Disclosure

Most of this was written by Claude Code — I provided direction and review.