### PR TITLE
`EmergencyReparentShard`: fix nil pointer panic in errant GTID detection

### DIFF
--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -973,15 +973,19 @@ func (erp *EmergencyReparenter) findErrantGTIDs(
 		// This exact scenario outlined above, can be found in the test for this function, subtest `Case 5a`.
 		// The idea is that if the tablet is lagged, then even the server UUID that it is replicating from
 		// should not be considered a valid source of writes that no other tablet has.
-		errantGTIDs, err := replication.FindErrantGTIDs(validCandidates[alias].Combined, replication.SID{}, maxLenPositions)
+		candidatePositions := validCandidates[alias]
+		if candidatePositions == nil || candidatePositions.IsZero() {
+			continue
+		}
+		errantGTIDs, err := replication.FindErrantGTIDs(candidatePositions.Combined, replication.SID{}, maxLenPositions)
 		if err != nil {
 			return nil, err
 		}
 		if errantGTIDs != nil {
-			log.Error(fmt.Sprintf("skipping %v with GTIDSet:%v because we detected errant GTIDs - %v", alias, validCandidates[alias], errantGTIDs))
+			log.Error(fmt.Sprintf("skipping %v with GTIDSet:%v because we detected errant GTIDs - %v", alias, candidatePositions, errantGTIDs))
 			continue
 		}
-		updatedValidCandidates[alias] = validCandidates[alias]
+		updatedValidCandidates[alias] = candidatePositions
 	}
 
 	return updatedValidCandidates, nil

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -933,7 +933,7 @@ func (erp *EmergencyReparenter) findErrantGTIDs(
 				continue
 			}
 			otherPosition := validCandidates[otherCandidate]
-			if otherPosition != nil || !otherPosition.IsZero() {
+			if otherPosition != nil && !otherPosition.IsZero() {
 				otherPositions = append(otherPositions, otherPosition.Combined)
 			}
 		}

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -5869,3 +5869,70 @@ func TestEmergencyReparenterFindErrantGTIDs(t *testing.T) {
 		})
 	}
 }
+
+// TestEmergencyReparenterFindErrantGTIDs_NilPosition is a regression test
+// for a bug where a nil *RelayLogPositions entry in validCandidates would
+// cause a nil pointer panic due to using || instead of && in the condition
+// checking otherPosition.
+func TestEmergencyReparenterFindErrantGTIDs_NilPosition(t *testing.T) {
+	u1 := "00000000-0000-0000-0000-000000000001"
+	erp := &EmergencyReparenter{
+		tmc: &testutil.TabletManagerClient{
+			ReadReparentJournalInfoResults: map[string]int32{
+				"zone1-0000000102": 1,
+				"zone1-0000000103": 1,
+			},
+		},
+	}
+	tabletMap := map[string]*topo.TabletInfo{
+		"zone1-0000000102": {
+			Tablet: &topodatapb.Tablet{
+				Hostname: "zone1-0000000102",
+				Alias: &topodatapb.TabletAlias{
+					Cell: "zone1",
+					Uid:  102,
+				},
+				Type: topodatapb.TabletType_REPLICA,
+			},
+		},
+		"zone1-0000000103": {
+			Tablet: &topodatapb.Tablet{
+				Hostname: "zone1-0000000103",
+				Alias: &topodatapb.TabletAlias{
+					Cell: "zone1",
+					Uid:  103,
+				},
+				Type: topodatapb.TabletType_REPLICA,
+			},
+		},
+	}
+	statusMap := map[string]*replicationdatapb.StopReplicationStatus{
+		"zone1-0000000102": {
+			After: &replicationdatapb.Status{
+				RelayLogPosition: getRelayLogPosition("1-100"),
+				SourceUuid:       u1,
+			},
+		},
+		"zone1-0000000103": {
+			After: &replicationdatapb.Status{
+				RelayLogPosition: getRelayLogPosition("1-99"),
+				SourceUuid:       u1,
+			},
+		},
+	}
+	// Construct validCandidates with a nil entry for zone1-0000000103.
+	// Both candidates have the same reparent journal length, so both
+	// will be in maxLenCandidates. When processing zone1-0000000102,
+	// the inner loop looks up zone1-0000000103's position which is nil.
+	// Before the fix, this would panic due to calling IsZero() on nil.
+	validCandidates := map[string]*RelayLogPositions{
+		"zone1-0000000102": {
+			Combined: replication.MustParsePosition(replication.Mysql56FlavorID, u1+":1-100"),
+		},
+		"zone1-0000000103": nil,
+	}
+
+	candidates, err := erp.findErrantGTIDs(t.Context(), validCandidates, statusMap, tabletMap, 10*time.Second)
+	require.NoError(t, err)
+	require.Contains(t, candidates, "zone1-0000000102")
+}

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -5872,15 +5872,18 @@ func TestEmergencyReparenterFindErrantGTIDs(t *testing.T) {
 
 // TestEmergencyReparenterFindErrantGTIDs_NilPosition is a regression test
 // for a bug where a nil *RelayLogPositions entry in validCandidates would
-// cause a nil pointer panic due to using || instead of && in the condition
-// checking otherPosition.
+// cause a nil pointer panic. The test includes:
+//   - zone1-0000000102: valid candidate with max reparent journal length
+//   - zone1-0000000103: nil position with max reparent journal length (exercises the maxLenCandidates loop)
+//   - zone1-0000000104: nil position with a lower reparent journal length (exercises the lagged-candidate loop)
 func TestEmergencyReparenterFindErrantGTIDs_NilPosition(t *testing.T) {
 	u1 := "00000000-0000-0000-0000-000000000001"
 	erp := &EmergencyReparenter{
 		tmc: &testutil.TabletManagerClient{
 			ReadReparentJournalInfoResults: map[string]int32{
-				"zone1-0000000102": 1,
-				"zone1-0000000103": 1,
+				"zone1-0000000102": 2,
+				"zone1-0000000103": 2,
+				"zone1-0000000104": 1,
 			},
 		},
 	}
@@ -5905,6 +5908,16 @@ func TestEmergencyReparenterFindErrantGTIDs_NilPosition(t *testing.T) {
 				Type: topodatapb.TabletType_REPLICA,
 			},
 		},
+		"zone1-0000000104": {
+			Tablet: &topodatapb.Tablet{
+				Hostname: "zone1-0000000104",
+				Alias: &topodatapb.TabletAlias{
+					Cell: "zone1",
+					Uid:  104,
+				},
+				Type: topodatapb.TabletType_REPLICA,
+			},
+		},
 	}
 	statusMap := map[string]*replicationdatapb.StopReplicationStatus{
 		"zone1-0000000102": {
@@ -5919,17 +5932,24 @@ func TestEmergencyReparenterFindErrantGTIDs_NilPosition(t *testing.T) {
 				SourceUuid:       u1,
 			},
 		},
+		"zone1-0000000104": {
+			After: &replicationdatapb.Status{
+				RelayLogPosition: getRelayLogPosition("1-90"),
+				SourceUuid:       u1,
+			},
+		},
 	}
-	// Construct validCandidates with a nil entry for zone1-0000000103.
-	// Both candidates have the same reparent journal length, so both
-	// will be in maxLenCandidates. When processing zone1-0000000102,
-	// the inner loop looks up zone1-0000000103's position which is nil.
-	// Before the fix, this would panic due to calling IsZero() on nil.
+	// Construct validCandidates with nil entries for zone1-0000000103 and
+	// zone1-0000000104. zone1-0000000103 has the same reparent journal length
+	// as zone1-0000000102 (maxLen), so it exercises the nil guard in the
+	// maxLenCandidates loop. zone1-0000000104 has a lower reparent journal
+	// length, so it exercises the nil guard in the lagged-candidate loop.
 	validCandidates := map[string]*RelayLogPositions{
 		"zone1-0000000102": {
 			Combined: replication.MustParsePosition(replication.Mysql56FlavorID, u1+":1-100"),
 		},
 		"zone1-0000000103": nil,
+		"zone1-0000000104": nil,
 	}
 
 	candidates, err := erp.findErrantGTIDs(t.Context(), validCandidates, statusMap, tabletMap, 10*time.Second)


### PR DESCRIPTION
## Description

Fixes a logic bug in `findErrantGTIDs()` where `||` was used instead of `&&` when checking if another candidate's `*RelayLogPositions` is non-nil and non-zero

When `otherPosition` is `nil`, the left side of `||` evaluates to `false`, so Go evaluates the right side: `!otherPosition.IsZero()` — calling `.IsZero()` on a nil pointer, which panics

This should be backported to `release-23.0` + `release-24.0` which this impacts

## Related Issue(s)

Fixes #19845

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

N/A

### AI Disclosure

Test written by Claude Code