### PR TITLE
`EmergencyReparentShard`: fix cancellation in `reparentReplicas()`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,7 @@ return user.NeedsMigration() && migrate(user) || user
 - **Package naming** - Short, descriptive, lowercase without underscores
 - **Interface naming** - Single-method interfaces end in `-er` (Reader, Writer, Handler)
 - **Context first** - Always pass `context.Context` as the first parameter
+- **Context cancellation** - Prefer `context.WithoutCancel(ctx)` over `context.Background()` when you need a non-cancellable context but still want to preserve context values (tracing, caller ID)
 - **Channels for coordination** - Use channels to coordinate goroutines, not shared memory
 - **No naked returns in non-trivial functions** - For functions with named return values, avoid bare `return` and explicitly return all result values (very small helpers are the only exception). This does not prohibit plain `return` in `func f() { ... }` when used for early-exit/guard clauses.
 - **Reduce nesting** - Prefer early returns and guard clauses over deeply nested `if` conditions

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -705,8 +705,10 @@ func (erp *EmergencyReparenter) reparentReplicas(
 	//
 	// This goroutine also cancels replCtx after all replicas finish, so that
 	// replicas that are still in-flight can complete their SetReplicationSource
-	// calls even when this function returns early (after the first successful
-	// replica). On primary failure, replCancel() is called immediately below,
+	// calls even when this function returns early. For non-intermediate
+	// reparents, this function returns after the first successful replica;
+	// for intermediate reparents, it waits for all replicas to finish.
+	// On primary failure, replCancel() is called immediately below,
 	// which is safe because cancel functions are idempotent.
 	go func() {
 		replWg.Wait()

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -594,7 +594,7 @@ func (erp *EmergencyReparenter) reparentReplicas(
 		replicaMutex               sync.Mutex
 	)
 
-	replCtx, replCancel := context.WithTimeout(ctx, opts.WaitReplicasTimeout)
+	replCtx, replCancel := context.WithTimeout(context.WithoutCancel(ctx), opts.WaitReplicasTimeout)
 	primaryCtx, primaryCancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
 	defer primaryCancel()
 

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -594,6 +594,8 @@ func (erp *EmergencyReparenter) reparentReplicas(
 		replicaMutex               sync.Mutex
 	)
 
+	// WithoutCancel preserves ctx values (tracing, caller ID) but lets replicas
+	// finish SetReplicationSource RPCs after the parent context is cancelled.
 	replCtx, replCancel := context.WithTimeout(context.WithoutCancel(ctx), opts.WaitReplicasTimeout)
 	primaryCtx, primaryCancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
 	defer primaryCancel()

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -594,7 +594,7 @@ func (erp *EmergencyReparenter) reparentReplicas(
 		replicaMutex               sync.Mutex
 	)
 
-	replCtx, replCancel := context.WithTimeout(context.Background(), opts.WaitReplicasTimeout)
+	replCtx, replCancel := context.WithTimeout(ctx, opts.WaitReplicasTimeout)
 	primaryCtx, primaryCancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
 	defer primaryCancel()
 
@@ -700,9 +700,16 @@ func (erp *EmergencyReparenter) reparentReplicas(
 	// in the main body of promoteNewPrimary, we would be bound to the
 	// time of slowest replica, instead of the time of the fastest successful
 	// replica, and we want ERS to be fast.
+	//
+	// This goroutine also cancels replCtx after all replicas finish, so that
+	// replicas that are still in-flight can complete their SetReplicationSource
+	// calls even when this function returns early (after the first successful
+	// replica). On primary failure, replCancel() is called immediately below,
+	// which is safe because cancel functions are idempotent.
 	go func() {
 		replWg.Wait()
 		allReplicasDoneCancel()
+		replCancel()
 	}()
 
 	primaryErr := handlePrimary(topoproto.TabletAliasString(newPrimaryTablet.Alias), newPrimaryTablet)
@@ -712,15 +719,6 @@ func (erp *EmergencyReparenter) reparentReplicas(
 
 		return nil, vterrors.Wrapf(primaryErr, "failed to promote %v to primary", topoproto.TabletAliasString(newPrimaryTablet.Alias))
 	}
-
-	// We should only cancel the context that all the replicas are using when they are done.
-	// Since this function can return early when only 1 replica succeeds, if we cancel this context as a deferred call from this function,
-	// then we would end up having cancelled the context for the replicas who have not yet finished running all the commands.
-	// This leads to some replicas not starting replication properly. So we must wait for all the replicas to finish before cancelling this context.
-	go func() {
-		replWg.Wait()
-		defer replCancel()
-	}()
 
 	select {
 	case <-replSuccessCtx.Done():


### PR DESCRIPTION
## Description

2 x fixes for context lifecycle issues in `reparentReplicas()`:

1. `replCtx` _(the context used for `SetReplicationSource` RPCs on replicas)_ was derived from `context.Background()`, which drops context values like tracing spans and caller IDs from the parent. Changed to `context.WithoutCancel(ctx)` so that context values are preserved for observability, while still not propagating parent cancellation _(replicas must be allowed to finish even after ERS returns, as asserted by `TestParentContextCancelled`)_

2. There were 2 x separate goroutines both calling `replWg.Wait()` — one to signal `allReplicasDoneCancel()` and another to call `replCancel()`. Merged into a single goroutine. On primary failure, `replCancel()` is still called immediately _(cancel funcs are idempotent)_

## Related Issue(s)

Related: #19848

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

N/A

### AI Disclosure

Claude Code assisted with development. Claude prepared this PR summary