### PR TITLE
vreplication: fix OOM on tables with large JSON columns

### DIFF
--- a/go/bytes2/buffer.go
+++ b/go/bytes2/buffer.go
@@ -72,3 +72,9 @@ func (buf *Buffer) Reset() {
 func (buf *Buffer) Len() int {
 	return len(buf.bytes)
 }
+
+// Truncate discards all but the first n bytes from the buffer.
+// It panics if n is negative or greater than the length of the buffer.
+func (buf *Buffer) Truncate(n int) {
+	buf.bytes = buf.bytes[:n]
+}

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -43,6 +43,31 @@ import (
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
+// maxJSONBufferSize is the threshold (in bytes of raw text JSON) above which
+// VReplication encodes JSON column values using CAST(... AS JSON) instead of
+// the default JSON_OBJECT(...)/JSON_ARRAY(...) tree encoding. The tree encoding
+// has ~60x memory amplification and can OOM tablets on large JSON values.
+// Values below this threshold use the existing tree encoding which preserves
+// MySQL-specific JSON type information. Set to 0 to always use CAST, or
+// negative to always use the tree encoding.
+var maxJSONBufferSize int64 = 1024 * 1024 // 1 MiB
+
+// marshalJSONForSQL converts raw text JSON bytes to a SQL expression suitable
+// for INSERT/UPDATE statements. For values larger than maxJSONBufferSize it
+// uses CAST(... AS JSON) to avoid the ~60x memory amplification of parsing
+// the JSON into a Go object tree. For smaller values it uses the traditional
+// JSON_OBJECT/JSON_ARRAY tree encoding.
+func marshalJSONForSQL(raw []byte) (*sqltypes.Value, error) {
+	if maxJSONBufferSize >= 0 && int64(len(raw)) > maxJSONBufferSize {
+		// Use _utf8mb4 introducer to ensure MySQL interprets the string as UTF-8
+		// regardless of connection charset, matching the JSON_OBJECT path behavior.
+		castExpr := "CAST(_utf8mb4" + sqltypes.EncodeStringSQL(string(raw)) + " as JSON)"
+		v := sqltypes.MakeTrusted(querypb.Type_RAW, []byte(castExpr))
+		return &v, nil
+	}
+	return vjson.MarshalSQLValue(raw)
+}
+
 // ReplicatorPlan is the execution plan for the replicator. It contains
 // plans for all the tables it's replicating. Every phase of vreplication
 // builds its own instance of the ReplicatorPlan. This is because the plan
@@ -255,23 +280,70 @@ func (tp *TablePlan) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&v)
 }
 
-func (tp *TablePlan) applyBulkInsert(sqlbuffer *bytes2.Buffer, rows []*querypb.Row, executor func(string) (*sqltypes.Result, error)) (*sqltypes.Result, error) {
-	sqlbuffer.Reset()
-	sqlbuffer.WriteString(tp.BulkInsertFront.Query)
-	sqlbuffer.WriteString(" values ")
+func (tp *TablePlan) applyBulkInsert(sqlbuffer *bytes2.Buffer, rows []*querypb.Row, executor func(string) (*sqltypes.Result, error), maxQuerySize int64) (*sqltypes.Result, error) {
+	insertPrefix := tp.BulkInsertFront.Query + " values "
 
-	for i, row := range rows {
-		if i > 0 {
+	flush := func(final bool) (*sqltypes.Result, error) {
+		if tp.BulkInsertOnDup != nil {
+			sqlbuffer.WriteString(tp.BulkInsertOnDup.Query)
+		}
+		if final {
+			// Last flush: safe to use StringUnsafe since we won't reuse the buffer.
+			return executor(sqlbuffer.StringUnsafe())
+		}
+		// Mid-batch flush: must copy because we'll reuse the buffer for the next batch.
+		return executor(sqlbuffer.String())
+	}
+
+	sqlbuffer.Reset()
+	sqlbuffer.WriteString(insertPrefix)
+
+	var lastResult *sqltypes.Result
+	rowCount := 0
+	for _, row := range rows {
+		beforeLen := sqlbuffer.Len()
+		if rowCount > 0 {
 			sqlbuffer.WriteString(", ")
 		}
 		if err := tp.appendFromRow(sqlbuffer, row); err != nil {
 			return nil, err
 		}
+		rowCount++
+
+		// If the buffer exceeds maxQuerySize and we have more than one
+		// row, flush everything before this row and start a new statement.
+		if maxQuerySize > 0 && int64(sqlbuffer.Len()) > maxQuerySize && rowCount > 1 {
+			// Roll back to before this row was appended.
+			sqlbuffer.Truncate(beforeLen)
+			result, err := flush(false)
+			if err != nil {
+				return nil, err
+			}
+			if lastResult == nil {
+				lastResult = result
+			} else {
+				lastResult.RowsAffected += result.RowsAffected
+			}
+
+			// Start a new INSERT with this row.
+			sqlbuffer.Reset()
+			sqlbuffer.WriteString(insertPrefix)
+			if err := tp.appendFromRow(sqlbuffer, row); err != nil {
+				return nil, err
+			}
+			rowCount = 1
+		}
 	}
-	if tp.BulkInsertOnDup != nil {
-		sqlbuffer.WriteString(tp.BulkInsertOnDup.Query)
+
+	result, err := flush(true)
+	if err != nil {
+		return nil, err
 	}
-	return executor(sqlbuffer.StringUnsafe())
+	if lastResult != nil {
+		lastResult.RowsAffected += result.RowsAffected
+		return lastResult, nil
+	}
+	return result, nil
 }
 
 // During the copy phase we run catchup and fastforward, which stream binlogs. While streaming we should only process
@@ -414,7 +486,7 @@ func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor fun
 							fmt.Appendf(nil, afterVals[i].RawStr(), sqlescape.EscapeID(field.Name))))
 					}
 				default: // A JSON value (which may be a JSON null literal value)
-					newVal, err = vjson.MarshalSQLValue(afterVals[i].Raw())
+					newVal, err = marshalJSONForSQL(afterVals[i].Raw())
 					if err != nil {
 						return nil, err
 					}
@@ -485,7 +557,7 @@ func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor fun
 						// If the JSON column was NOT updated then the JSON column is marked as partial
 						// and the diff is empty as a way to exclude it from the AFTER image. So we
 						// want to use the BEFORE image value.
-						beforeVal, err := vjson.MarshalSQLValue(bindvars["b_"+field.Name].Value)
+						beforeVal, err := marshalJSONForSQL(bindvars["b_"+field.Name].Value)
 						if err != nil {
 							return nil, vterrors.Wrapf(err, "failed to convert JSON to SQL field value for %s.%s when building insert query",
 								tp.TargetName, field.Name)
@@ -635,7 +707,7 @@ func (tp *TablePlan) applyBulkInsertChanges(rowInserts []*binlogdatapb.RowChange
 				if vals[n].IsNull() { // An SQL NULL and not an actual JSON value
 					jsVal = &sqltypes.NULL
 				} else { // A JSON value (which may be a JSON null literal value)
-					jsVal, err = vjson.MarshalSQLValue(vals[n].Raw())
+					jsVal, err = marshalJSONForSQL(vals[n].Raw())
 					if err != nil {
 						return nil, err
 					}
@@ -754,6 +826,16 @@ func (tp *TablePlan) appendFromRow(buf *bytes2.Buffer, row *querypb.Row) error {
 		case querypb.Type_JSON:
 			if length < 0 { // An SQL NULL and not an actual JSON value
 				buf.WriteString(sqltypes.NullStr)
+			} else if maxJSONBufferSize >= 0 && length > maxJSONBufferSize {
+				// Large JSON value: use CAST(... AS JSON) to avoid the ~60x memory
+				// amplification of parsing text JSON into a Go tree. The input is already
+				// valid text JSON (from MySQL SELECT or binlog text conversion).
+				// Use _utf8mb4 introducer to ensure MySQL interprets the string as UTF-8
+				// regardless of connection charset, matching the JSON_OBJECT path behavior.
+				buf.WriteString("CAST(_utf8mb4")
+				raw := row.Values[offset : offset+length]
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, raw).EncodeSQLBytes2(buf)
+				buf.WriteString(" as JSON)")
 			} else { // A JSON value (which may be a JSON null literal value)
 				buf2 := row.Values[offset : offset+length]
 				vv, err := vjson.MarshalSQLValue(buf2)

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -52,6 +52,14 @@ import (
 // negative to always use the tree encoding.
 var maxJSONBufferSize int64 = 1024 * 1024 // 1 MiB
 
+func appendCastJSONForSQL(buf *bytes2.Buffer, raw []byte) {
+	// Use _utf8mb4 introducer to ensure MySQL interprets the string as UTF-8
+	// regardless of connection charset, matching the JSON_OBJECT path behavior.
+	buf.WriteString("CAST(_utf8mb4")
+	sqltypes.MakeTrusted(querypb.Type_VARCHAR, raw).EncodeSQLBytes2(buf)
+	buf.WriteString(" as JSON)")
+}
+
 // marshalJSONForSQL converts raw text JSON bytes to a SQL expression suitable
 // for INSERT/UPDATE statements. For values larger than maxJSONBufferSize it
 // uses CAST(... AS JSON) to avoid the ~60x memory amplification of parsing
@@ -59,10 +67,9 @@ var maxJSONBufferSize int64 = 1024 * 1024 // 1 MiB
 // JSON_OBJECT/JSON_ARRAY tree encoding.
 func marshalJSONForSQL(raw []byte) (*sqltypes.Value, error) {
 	if maxJSONBufferSize >= 0 && int64(len(raw)) > maxJSONBufferSize {
-		// Use _utf8mb4 introducer to ensure MySQL interprets the string as UTF-8
-		// regardless of connection charset, matching the JSON_OBJECT path behavior.
-		castExpr := "CAST(_utf8mb4" + sqltypes.EncodeStringSQL(string(raw)) + " as JSON)"
-		v := sqltypes.MakeTrusted(querypb.Type_RAW, []byte(castExpr))
+		buf := &bytes2.Buffer{}
+		appendCastJSONForSQL(buf, raw)
+		v := sqltypes.MakeTrusted(querypb.Type_RAW, buf.Bytes())
 		return &v, nil
 	}
 	return vjson.MarshalSQLValue(raw)
@@ -282,6 +289,10 @@ func (tp *TablePlan) MarshalJSON() ([]byte, error) {
 
 func (tp *TablePlan) applyBulkInsert(sqlbuffer *bytes2.Buffer, rows []*querypb.Row, executor func(string) (*sqltypes.Result, error), maxQuerySize int64) (*sqltypes.Result, error) {
 	insertPrefix := tp.BulkInsertFront.Query + " values "
+	insertSuffixLen := 0
+	if tp.BulkInsertOnDup != nil {
+		insertSuffixLen = len(tp.BulkInsertOnDup.Query)
+	}
 
 	flush := func(final bool) (*sqltypes.Result, error) {
 		if tp.BulkInsertOnDup != nil {
@@ -312,7 +323,7 @@ func (tp *TablePlan) applyBulkInsert(sqlbuffer *bytes2.Buffer, rows []*querypb.R
 
 		// If the buffer exceeds maxQuerySize and we have more than one
 		// row, flush everything before this row and start a new statement.
-		if maxQuerySize > 0 && int64(sqlbuffer.Len()) > maxQuerySize && rowCount > 1 {
+		if maxQuerySize > 0 && int64(sqlbuffer.Len()+insertSuffixLen) > maxQuerySize && rowCount > 1 {
 			// Roll back to before this row was appended.
 			sqlbuffer.Truncate(beforeLen)
 			result, err := flush(false)
@@ -681,6 +692,9 @@ func (tp *TablePlan) applyBulkInsertChanges(rowInserts []*binlogdatapb.RowChange
 	prefix.WriteString(tp.BulkInsertFront.Query)
 	prefix.WriteString(" values ")
 	insertPrefix := prefix.String()
+	if tp.BulkInsertOnDup != nil {
+		maxQuerySize -= int64(len(tp.BulkInsertOnDup.Query))
+	}
 	maxQuerySize -= int64(len(insertPrefix))
 	values := &strings.Builder{}
 
@@ -724,7 +738,7 @@ func (tp *TablePlan) applyBulkInsertChanges(rowInserts []*binlogdatapb.RowChange
 		if err := tp.BulkInsertValues.Append(rowValues, bindvars, nil); err != nil {
 			return nil, err
 		}
-		if int64(values.Len()+2+rowValues.Len()) > maxQuerySize { // Plus 2 for the comma and space
+		if !newStmt && int64(values.Len()+2+rowValues.Len()) > maxQuerySize { // Plus 2 for the comma and space
 			if _, err := execQuery(values); err != nil {
 				return nil, err
 			}
@@ -830,12 +844,8 @@ func (tp *TablePlan) appendFromRow(buf *bytes2.Buffer, row *querypb.Row) error {
 				// Large JSON value: use CAST(... AS JSON) to avoid the ~60x memory
 				// amplification of parsing text JSON into a Go tree. The input is already
 				// valid text JSON (from MySQL SELECT or binlog text conversion).
-				// Use _utf8mb4 introducer to ensure MySQL interprets the string as UTF-8
-				// regardless of connection charset, matching the JSON_OBJECT path behavior.
-				buf.WriteString("CAST(_utf8mb4")
 				raw := row.Values[offset : offset+length]
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, raw).EncodeSQLBytes2(buf)
-				buf.WriteString(" as JSON)")
+				appendCastJSONForSQL(buf, raw)
 			} else { // A JSON value (which may be a JSON null literal value)
 				buf2 := row.Values[offset : offset+length]
 				vv, err := vjson.MarshalSQLValue(buf2)

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -1014,6 +1014,25 @@ func TestApplyBulkInsertMaxQuerySize(t *testing.T) {
 		assert.Equal(t, "insert into t(c1, c2) values (3, 'c')", executed[1])
 	})
 
+	t.Run("split accounts for on duplicate key suffix", func(t *testing.T) {
+		tpWithOnDup := *tp
+		tpWithOnDup.BulkInsertOnDup = sqlparser.BuildParsedQuery(" on duplicate key update c2=values(c2)")
+
+		rows := []*querypb.Row{makeRow(1, "a"), makeRow(2, "b")}
+		var executed []string
+		buf := &bytes2.Buffer{}
+		// Two rows fit without the suffix, but exceed this limit once the ON DUPLICATE
+		// KEY UPDATE clause is appended. One row plus the suffix still fits.
+		_, err := tpWithOnDup.applyBulkInsert(buf, rows, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 82)
+		require.NoError(t, err)
+		require.Len(t, executed, 2)
+		assert.Equal(t, "insert into t(c1, c2) values (1, 'a') on duplicate key update c2=values(c2)", executed[0])
+		assert.Equal(t, "insert into t(c1, c2) values (2, 'b') on duplicate key update c2=values(c2)", executed[1])
+	})
+
 	t.Run("single row exceeds limit", func(t *testing.T) {
 		longVal := strings.Repeat("x", 100)
 		rows := []*querypb.Row{makeRow(1, longVal)}
@@ -1035,6 +1054,63 @@ func TestApplyBulkInsertMaxQuerySize(t *testing.T) {
 		}, 40) // Force each row into its own statement
 		require.NoError(t, err)
 		assert.Equal(t, uint64(3), result.RowsAffected)
+	})
+}
+
+func TestApplyBulkInsertChangesMaxQuerySize(t *testing.T) {
+	tp := &TablePlan{
+		BulkInsertFront: sqlparser.BuildParsedQuery("insert into t(c1, c2)"),
+		BulkInsertValues: sqlparser.BuildParsedQuery("(%a, %a)",
+			":a_c1", ":a_c2",
+		),
+		BulkInsertOnDup: sqlparser.BuildParsedQuery(" on duplicate key update c2=values(c2)"),
+		Fields: []*querypb.Field{
+			{Name: "c1", Type: querypb.Type_INT32},
+			{Name: "c2", Type: querypb.Type_VARCHAR},
+		},
+		FieldsToSkip:     map[string]bool{},
+		TablePlanBuilder: &tablePlanBuilder{stats: binlogplayer.NewStats()},
+	}
+
+	makeRowInsert := func(id int, val string) *binlogdatapb.RowChange {
+		return &binlogdatapb.RowChange{
+			After: sqltypes.RowToProto3([]sqltypes.Value{
+				sqltypes.NewInt64(int64(id)),
+				sqltypes.NewVarChar(val),
+			}),
+		}
+	}
+
+	t.Run("split accounts for on duplicate key suffix", func(t *testing.T) {
+		rowInserts := []*binlogdatapb.RowChange{
+			makeRowInsert(1, "a"),
+			makeRowInsert(2, "b"),
+		}
+		expectedFirst := "insert into t(c1, c2) values (1, 'a') on duplicate key update c2=values(c2)"
+		expectedSecond := "insert into t(c1, c2) values (2, 'b') on duplicate key update c2=values(c2)"
+		var executed []string
+		_, err := tp.applyBulkInsertChanges(rowInserts, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, int64(len(expectedFirst)))
+		require.NoError(t, err)
+		require.Len(t, executed, 2)
+		assert.Equal(t, expectedFirst, executed[0])
+		assert.Equal(t, expectedSecond, executed[1])
+	})
+
+	t.Run("single row exceeds limit", func(t *testing.T) {
+		longVal := strings.Repeat("x", 100)
+		rowInserts := []*binlogdatapb.RowChange{makeRowInsert(1, longVal)}
+		expected := "insert into t(c1, c2) values (1, '" + longVal + "') on duplicate key update c2=values(c2)"
+		var executed []string
+		_, err := tp.applyBulkInsertChanges(rowInserts, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 10)
+		require.NoError(t, err)
+		require.Len(t, executed, 1, "single row must still execute even if it exceeds maxQuerySize")
+		assert.Equal(t, expected, executed[0])
 	})
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -964,3 +964,226 @@ func TestAppendFromRow(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyBulkInsertMaxQuerySize(t *testing.T) {
+	tp := &TablePlan{
+		BulkInsertFront: sqlparser.BuildParsedQuery("insert into t(c1, c2)"),
+		BulkInsertValues: sqlparser.BuildParsedQuery("(%a, %a)",
+			":c1", ":c2",
+		),
+		Fields: []*querypb.Field{
+			{Name: "c1", Type: querypb.Type_INT32},
+			{Name: "c2", Type: querypb.Type_VARCHAR},
+		},
+		FieldsToSkip: map[string]bool{},
+	}
+
+	makeRow := func(id int, val string) *querypb.Row {
+		return sqltypes.RowToProto3([]sqltypes.Value{
+			sqltypes.NewInt64(int64(id)),
+			sqltypes.NewVarChar(val),
+		})
+	}
+
+	t.Run("no limit", func(t *testing.T) {
+		rows := []*querypb.Row{makeRow(1, "a"), makeRow(2, "b"), makeRow(3, "c")}
+		var executed []string
+		buf := &bytes2.Buffer{}
+		_, err := tp.applyBulkInsert(buf, rows, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 0)
+		require.NoError(t, err)
+		require.Len(t, executed, 1)
+		assert.Equal(t, "insert into t(c1, c2) values (1, 'a'), (2, 'b'), (3, 'c')", executed[0])
+	})
+
+	t.Run("split after second row", func(t *testing.T) {
+		rows := []*querypb.Row{makeRow(1, "a"), makeRow(2, "b"), makeRow(3, "c")}
+		var executed []string
+		buf := &bytes2.Buffer{}
+		// Set limit small enough that 3 rows exceed it but 2 rows don't.
+		// "insert into t(c1, c2) values (1, 'a'), (2, 'b')" = 51 chars
+		_, err := tp.applyBulkInsert(buf, rows, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 55)
+		require.NoError(t, err)
+		require.Len(t, executed, 2)
+		assert.Equal(t, "insert into t(c1, c2) values (1, 'a'), (2, 'b')", executed[0])
+		assert.Equal(t, "insert into t(c1, c2) values (3, 'c')", executed[1])
+	})
+
+	t.Run("single row exceeds limit", func(t *testing.T) {
+		longVal := strings.Repeat("x", 100)
+		rows := []*querypb.Row{makeRow(1, longVal)}
+		var executed []string
+		buf := &bytes2.Buffer{}
+		_, err := tp.applyBulkInsert(buf, rows, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 10) // Very small limit — single row exceeds it
+		require.NoError(t, err)
+		require.Len(t, executed, 1, "single row must still execute even if it exceeds maxQuerySize")
+	})
+
+	t.Run("rows affected accumulated", func(t *testing.T) {
+		rows := []*querypb.Row{makeRow(1, "a"), makeRow(2, "b"), makeRow(3, "c")}
+		buf := &bytes2.Buffer{}
+		result, err := tp.applyBulkInsert(buf, rows, func(sql string) (*sqltypes.Result, error) {
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 40) // Force each row into its own statement
+		require.NoError(t, err)
+		assert.Equal(t, uint64(3), result.RowsAffected)
+	})
+}
+
+func TestMarshalJSONForSQL(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		wantCAST bool // true if expected to use CAST path
+	}{
+		{
+			name:     "small object uses tree encoding",
+			input:    `{"key": "value"}`,
+			wantCAST: false,
+		},
+		{
+			name:     "small array uses tree encoding",
+			input:    `[1, 2, 3]`,
+			wantCAST: false,
+		},
+		{
+			name:     "large value uses CAST",
+			input:    `[` + strings.Repeat(`"test",`, 200000) + `"end"]`,
+			wantCAST: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := marshalJSONForSQL([]byte(tc.input))
+			require.NoError(t, err)
+
+			sql := result.RawStr()
+			if tc.wantCAST {
+				assert.Contains(t, sql, "CAST(")
+				assert.Contains(t, sql, " as JSON)")
+			} else {
+				assert.NotContains(t, sql, "CAST(")
+			}
+		})
+	}
+}
+
+func TestMarshalJSONForSQLCorrectness(t *testing.T) {
+	// Verify that both encoding paths produce valid SQL expressions for the
+	// same JSON input. We can't compare SQL strings directly (they use
+	// different formats), but we can verify both produce non-empty output.
+	testCases := []struct {
+		name  string
+		input string
+	}{
+		{name: "object", input: `{"key": "value", "num": 42}`},
+		{name: "array of ints", input: `[1, 2, 3, 930701976723823]`},
+		{name: "nested", input: `{"a": [1, {"b": true}], "c": null}`},
+		{name: "special chars", input: `{"q": "it's a \"test\"", "bs": "back\\slash"}`},
+		{name: "unicode", input: `{"emoji": "hello \u0041"}`},
+		{name: "empty object", input: `{}`},
+		{name: "empty array", input: `[]`},
+		{name: "boolean", input: `true`},
+		{name: "null", input: `null`},
+		{name: "number", input: `42`},
+		{name: "large integer (original bug #8686)", input: `{"keywordSourceId": 930701976723823}`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := []byte(tc.input)
+
+			// Force CAST path
+			saved := maxJSONBufferSize
+			maxJSONBufferSize = 0
+			t.Cleanup(func() { maxJSONBufferSize = saved })
+
+			castResult, err := marshalJSONForSQL(raw)
+			require.NoError(t, err)
+			assert.Contains(t, castResult.RawStr(), "CAST(", "expected CAST encoding")
+
+			// Force tree path
+			maxJSONBufferSize = -1
+			treeResult, err := marshalJSONForSQL(raw)
+			require.NoError(t, err)
+
+			// Both should be non-empty valid SQL expressions
+			assert.NotEmpty(t, castResult.RawStr())
+			assert.NotEmpty(t, treeResult.RawStr())
+		})
+	}
+
+	// Verify the specific bug from issue #8686: large integers must not
+	// be converted to scientific notation in either path.
+	t.Run("large integer preserved in CAST path", func(t *testing.T) {
+		saved := maxJSONBufferSize
+		maxJSONBufferSize = 0
+		t.Cleanup(func() { maxJSONBufferSize = saved })
+
+		raw := []byte(`{"keywordSourceId": 930701976723823}`)
+		result, err := marshalJSONForSQL(raw)
+		require.NoError(t, err)
+		assert.Contains(t, result.RawStr(), "930701976723823")
+		assert.NotContains(t, result.RawStr(), "e+")
+	})
+}
+
+func TestAppendFromRowLargeJSON(t *testing.T) {
+	// Verify that large JSON values (> maxJSONBufferSize) use CAST path in appendFromRow.
+	// Build a JSON array > 1MB.
+	largeJSON := `[` + strings.Repeat(`12345678,`, 150000) + `0]`
+	require.Greater(t, len(largeJSON), 1024*1024, "test JSON must exceed 1MB threshold")
+
+	tp := &TablePlan{
+		BulkInsertValues: sqlparser.BuildParsedQuery("(%a)",
+			":c1",
+		),
+		Fields: []*querypb.Field{
+			{Name: "c1", Type: querypb.Type_JSON},
+		},
+		FieldsToSkip: map[string]bool{},
+	}
+
+	row := sqltypes.RowToProto3([]sqltypes.Value{
+		sqltypes.MakeTrusted(querypb.Type_JSON, []byte(largeJSON)),
+	})
+
+	buf := &bytes2.Buffer{}
+	err := tp.appendFromRow(buf, row)
+	require.NoError(t, err)
+	result := buf.String()
+	assert.Contains(t, result, "CAST(")
+	assert.Contains(t, result, " as JSON)")
+}
+
+func TestAppendFromRowSmallJSON(t *testing.T) {
+	// Verify that small JSON values use the tree encoding (JSON_OBJECT/JSON_ARRAY).
+	tp := &TablePlan{
+		BulkInsertValues: sqlparser.BuildParsedQuery("(%a)",
+			":c1",
+		),
+		Fields: []*querypb.Field{
+			{Name: "c1", Type: querypb.Type_JSON},
+		},
+		FieldsToSkip: map[string]bool{},
+	}
+
+	row := sqltypes.RowToProto3([]sqltypes.Value{
+		sqltypes.MakeTrusted(querypb.Type_JSON, []byte(`{"key": "value"}`)),
+	})
+
+	buf := &bytes2.Buffer{}
+	err := tp.appendFromRow(buf, row)
+	require.NoError(t, err)
+	result := buf.String()
+	assert.Contains(t, result, "JSON_OBJECT(")
+}

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -1161,6 +1161,7 @@ func (vbc *vcopierCopyWorker) insertRows(ctx context.Context, rows []*querypb.Ro
 		func(sql string) (*sqltypes.Result, error) {
 			return vbc.ExecuteWithRetry(ctx, sql)
 		},
+		vbc.maxBatchSize,
 	)
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -137,6 +137,7 @@ type vcopierCopyWorker struct {
 	closeDbClient   bool
 	copyStateInsert *sqlparser.ParsedQuery
 	isOpen          bool
+	maxQuerySize    int64
 	pkfields        []*querypb.Field
 	sqlbuffer       bytes2.Buffer
 	tablePlan       *TablePlan
@@ -207,9 +208,11 @@ func newVCopierCopyWorkQueue(
 func newVCopierCopyWorker(
 	closeDbClient bool,
 	vdbClient *vdbClient,
+	maxQuerySize int64,
 ) *vcopierCopyWorker {
 	return &vcopierCopyWorker{
 		closeDbClient: closeDbClient,
+		maxQuerySize:  maxQuerySize,
 		vdbClient:     vdbClient,
 	}
 }
@@ -406,7 +409,8 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 	defer copyStateGCTicker.Stop()
 
 	parallelism := int(math.Max(1, float64(vc.vr.workflowConfig.ParallelInsertWorkers)))
-	copyWorkerFactory := vc.newCopyWorkerFactory(parallelism)
+	maxQuerySize := vc.vr.maxQuerySize(vc.vr.dbClient)
+	copyWorkerFactory := vc.newCopyWorkerFactory(parallelism, maxQuerySize)
 	copyWorkQueue := vc.newCopyWorkQueue(parallelism, copyWorkerFactory)
 	defer copyWorkQueue.close()
 
@@ -717,7 +721,7 @@ func (vc *vcopier) newCopyWorkQueue(
 	return newVCopierCopyWorkQueue(concurrent, parallelism, workerFactory)
 }
 
-func (vc *vcopier) newCopyWorkerFactory(parallelism int) func(context.Context) (*vcopierCopyWorker, error) {
+func (vc *vcopier) newCopyWorkerFactory(parallelism int, maxQuerySize int64) func(context.Context) (*vcopierCopyWorker, error) {
 	if parallelism > 1 {
 		return func(ctx context.Context) (*vcopierCopyWorker, error) {
 			dbClient, err := vc.vr.newClientConnection(ctx)
@@ -727,6 +731,7 @@ func (vc *vcopier) newCopyWorkerFactory(parallelism int) func(context.Context) (
 			return newVCopierCopyWorker(
 				true, /* close db client */
 				dbClient,
+				maxQuerySize,
 			), nil
 		}
 	}
@@ -734,6 +739,7 @@ func (vc *vcopier) newCopyWorkerFactory(parallelism int) func(context.Context) (
 		return newVCopierCopyWorker(
 			false, /* close db client */
 			vc.vr.dbClient,
+			maxQuerySize,
 		), nil
 	}
 }
@@ -1161,7 +1167,7 @@ func (vbc *vcopierCopyWorker) insertRows(ctx context.Context, rows []*querypb.Ro
 		func(sql string) (*sqltypes.Result, error) {
 			return vbc.ExecuteWithRetry(ctx, sql)
 		},
-		vbc.maxBatchSize,
+		vbc.maxQuerySize,
 	)
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
@@ -85,8 +85,8 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 	defer rowsCopiedTicker.Stop()
 
 	parallelism := int(math.Max(1, float64(vc.vr.workflowConfig.ParallelInsertWorkers)))
-
-	copyWorkerFactory := vc.newCopyWorkerFactory(parallelism)
+	maxQuerySize := vc.vr.maxQuerySize(vc.vr.dbClient)
+	copyWorkerFactory := vc.newCopyWorkerFactory(parallelism, maxQuerySize)
 	var copyWorkQueue *vcopierCopyWorkQueue
 
 	// Allocate a result channel to collect results from tasks. To not block fast workers, we allocate a buffer of

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_test.go
@@ -31,6 +31,7 @@ import (
 
 	"vitess.io/vitess/go/vt/log"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -39,6 +40,102 @@ import (
 	qh "vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication/queryhistory"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer"
 )
+
+func TestNewCopyWorkerFactoryUsesMaxQuerySize(t *testing.T) {
+	stats := binlogplayer.NewStats()
+	dbClient := binlogplayer.NewMockDBClient(t)
+	vr := &vreplicator{
+		dbClient: newVDBClient(dbClient, stats, vttablet.DefaultVReplicationConfig.RelayLogMaxItems),
+		stats:    stats,
+	}
+
+	workerFactory := newVCopier(vr).newCopyWorkerFactory(1, 123)
+	worker, err := workerFactory(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, worker)
+	assert.Equal(t, int64(123), worker.maxQuerySize)
+	assert.Same(t, vr.dbClient, worker.vdbClient)
+}
+
+func TestPlayerCopyRespectsMaxQuerySize(t *testing.T) {
+	testVcopierTestCases(t, testPlayerCopyRespectsMaxQuerySize, commonVcopierTestCases())
+}
+
+func testPlayerCopyRespectsMaxQuerySize(t *testing.T) {
+	defer deleteTablet(addTablet(100))
+
+	reset := vstreamer.AdjustPacketSize(1 << 20)
+	defer reset()
+
+	ctx := t.Context()
+	qr, err := env.Mysqld.FetchSuperQuery(ctx, "select @@global.max_allowed_packet")
+	require.NoError(t, err)
+	originalMaxAllowedPacket, err := qr.Rows[0][0].ToInt64()
+	require.NoError(t, err)
+
+	val1 := strings.Repeat("a", 350)
+	val2 := strings.Repeat("b", 350)
+	val3 := strings.Repeat("c", 350)
+
+	execStatements(t, []string{
+		"create table src(id int, val varchar(512), primary key(id))",
+		fmt.Sprintf("create table %s.dst(id int, val varchar(512), primary key(id))", vrepldb),
+		fmt.Sprintf("insert into src values(1, '%s')", val1),
+		fmt.Sprintf("insert into src values(2, '%s')", val2),
+		fmt.Sprintf("insert into src values(3, '%s')", val3),
+		"set @@global.max_allowed_packet=1024",
+	})
+	defer execStatements(t, []string{
+		fmt.Sprintf("set @@global.max_allowed_packet=%d", originalMaxAllowedPacket),
+		"drop table src",
+		fmt.Sprintf("drop table %s.dst", vrepldb),
+	})
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match:  "dst",
+			Filter: "select * from src",
+		}},
+	}
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
+	}
+
+	query := binlogplayer.CreateVReplicationState("test", bls, "", binlogdatapb.VReplicationWorkflowState_Init, playerEngine.dbName, 0, 0)
+	vrqr, err := playerEngine.Exec(query)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		query := fmt.Sprintf("delete from _vt.vreplication where id = %d", vrqr.InsertID)
+		if _, err := playerEngine.Exec(query); err != nil {
+			t.Fatal(err)
+		}
+		expectDeleteQueries(t)
+		playerEngine.Close()
+		playerEngine.Open(context.WithoutCancel(t.Context()))
+	})
+
+	expectNontxQueries(t, qh.Expect(
+		"/insert into _vt.vreplication",
+		"/update _vt.vreplication set message='Picked source tablet.*",
+		"/insert into _vt.copy_state",
+		"/update _vt.vreplication set state='Copying'",
+		fmt.Sprintf("insert into dst(id,val) values (1,'%s'), (2,'%s')", val1, val2),
+		fmt.Sprintf("insert into dst(id,val) values (3,'%s')", val3),
+		"/insert into _vt.copy_state",
+		"/delete cs, pca from _vt.copy_state as cs left join _vt.post_copy_action as pca on cs.vrepl_id=pca.vrepl_id and cs.table_name=pca.table_name.*dst",
+		"/update _vt.vreplication set state='Running",
+	), recvTimeout)
+
+	expectData(t, "dst", [][]string{
+		{"1", val1},
+		{"2", val2},
+		{"3", val3},
+	})
+}
 
 type vcopierTestCase struct {
 	vreplicationExperimentalFlags     int64

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -137,23 +137,7 @@ func newVPlayer(vr *vreplicator, settings binlogplayer.VRSettings, copyState map
 	batchMode := len(copyState) == 0 && vr.workflowConfig.ExperimentalFlags&vttablet.VReplicationExperimentalFlagVPlayerBatching != 0
 
 	if batchMode {
-		// relayLogMaxSize is effectively the limit used when not batching.
-		maxAllowedPacket := int64(vr.workflowConfig.RelayLogMaxSize)
-		// We explicitly do NOT want to batch this, we want to send it down the wire
-		// immediately so we use ExecuteFetch directly.
-		res, err := vr.dbClient.ExecuteFetch(SqlMaxAllowedPacket, 1)
-		if err != nil {
-			log.Error(fmt.Sprintf("Error getting max_allowed_packet, will use the relay-log-max-size value of %d bytes: %v", vr.workflowConfig.RelayLogMaxSize, err))
-		} else {
-			if maxAllowedPacket, err = res.Rows[0][0].ToInt64(); err != nil {
-				log.Error(fmt.Sprintf("Error getting max_allowed_packet, will use the relay-log-max-size value of %d bytes: %v", vr.workflowConfig.RelayLogMaxSize, err))
-			}
-		}
-		// Leave 64 bytes of room for the commit to be sure that we have a more than
-		// ample buffer left. The default value of max_allowed_packet is 4MiB in 5.7
-		// and 64MiB in 8.0 -- and the default for max_relay_log_size is 250000
-		// bytes -- so we have plenty of room.
-		maxAllowedPacket -= 64
+		maxAllowedPacket := vr.maxQuerySize(vr.dbClient)
 		queryFunc = func(ctx context.Context, sql string) (*sqltypes.Result, error) {
 			if !vr.dbClient.InTransaction { // Should be sent down the wire immediately
 				return vr.dbClient.Execute(sql)

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -90,7 +90,8 @@ const (
 	json_unquote(json_extract(action, '$.type'))=%a and vrepl_id=%a and table_name=%a`
 	sqlDeletePostCopyAction = `delete from _vt.post_copy_action where vrepl_id=%a and
 	table_name=%a and id=%a`
-	SqlMaxAllowedPacket = "select @@session.max_allowed_packet as max_allowed_packet"
+	SqlMaxAllowedPacket  = "select @@session.max_allowed_packet as max_allowed_packet"
+	maxQuerySizeHeadroom = int64(64)
 )
 
 // vreplicator provides the core logic to start vreplication streams
@@ -501,6 +502,23 @@ func (vr *vreplicator) setMessage(message string) (err error) {
 	}
 	insertLog(vr.dbClient, LogMessage, vr.id, vr.state.String(), message)
 	return nil
+}
+
+func (vr *vreplicator) maxQuerySize(dbc *vdbClient) int64 {
+	maxQuerySize := int64(vr.workflowConfig.RelayLogMaxSize)
+	res, err := dbc.DBClient.ExecuteFetch(SqlMaxAllowedPacket, 1)
+	if err != nil {
+		log.Error(fmt.Sprintf("Error getting max_allowed_packet, will use the relay-log-max-size value of %d bytes: %v", vr.workflowConfig.RelayLogMaxSize, err))
+	} else {
+		if maxQuerySize, err = res.Rows[0][0].ToInt64(); err != nil {
+			log.Error(fmt.Sprintf("Error getting max_allowed_packet, will use the relay-log-max-size value of %d bytes: %v", vr.workflowConfig.RelayLogMaxSize, err))
+			maxQuerySize = int64(vr.workflowConfig.RelayLogMaxSize)
+		}
+	}
+	if maxQuerySize > maxQuerySizeHeadroom {
+		maxQuerySize -= maxQuerySizeHeadroom
+	}
+	return maxQuerySize
 }
 
 func (vr *vreplicator) insertLog(typ, message string) {

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/replication"
+	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/mysqlctl"
@@ -41,6 +42,44 @@ import (
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 )
+
+func TestMaxQuerySize(t *testing.T) {
+	makeVR := func(dbClient binlogplayer.DBClient, relayLogMaxSize int) *vreplicator {
+		stats := binlogplayer.NewStats()
+		return &vreplicator{
+			dbClient: newVDBClient(dbClient, stats, vttablet.DefaultVReplicationConfig.RelayLogMaxItems),
+			stats:    stats,
+			workflowConfig: &vttablet.VReplicationConfig{
+				RelayLogMaxSize: relayLogMaxSize,
+			},
+		}
+	}
+
+	t.Run("uses session max allowed packet", func(t *testing.T) {
+		dbClient := binlogplayer.NewMockDBClient(t)
+		dbClient.ExpectRequest(
+			SqlMaxAllowedPacket,
+			sqltypes.MakeTestResult(
+				sqltypes.MakeTestFields("max_allowed_packet", "int64"),
+				"1024",
+			),
+			nil,
+		)
+
+		vr := makeVR(dbClient, 4096)
+		assert.Equal(t, int64(960), vr.maxQuerySize(vr.dbClient))
+		assert.Nil(t, vr.dbClient.queries)
+	})
+
+	t.Run("falls back to relay log max size", func(t *testing.T) {
+		dbClient := binlogplayer.NewMockDBClient(t)
+		dbClient.ExpectRequest(SqlMaxAllowedPacket, nil, assert.AnError)
+
+		vr := makeVR(dbClient, 4096)
+		assert.Equal(t, int64(4032), vr.maxQuerySize(vr.dbClient))
+		assert.Nil(t, vr.dbClient.queries)
+	})
+}
 
 func TestRecalculatePKColsInfoByColumnNames(t *testing.T) {
 	tt := []struct {


### PR DESCRIPTION
## What's this?

VReplication can OOM vttablet when copying or replicating tables with large JSON columns (>1MB per column value). Two compounding issues:

1. **`applyBulkInsert` has no SQL buffer size guard** — the copy phase combines all rows from a VStream packet into one unbounded SQL string. The replay phase (`applyBulkInsertChanges`) already has a `maxQuerySize` guard that flushes at `max_allowed_packet`. This adds the same guard to the copy phase.

2. **`vjson.MarshalSQLValue()` has ~60x memory amplification** — it parses text JSON into a Go object tree (one `json.Value` struct per JSON element), then serializes to `JSON_OBJECT(...)`/`JSON_ARRAY(...)` SQL. Measured:

   | Input | Peak Alloc | Ratio |
   |-------|-----------|-------|
   | 1 MB | 61 MB | 61x |
   | 5 MB | 302 MB | 60x |
   | 22 MB | 1,452 MB | 66x |

   A single 2.5MB JSON column is enough to OOM a vttablet with GOMEMLIMIT=150Mi. For JSON values above a configurable threshold (default 1MB), this skips the tree and uses `CAST(_utf8mb4'...' AS JSON)` instead — passing the already-valid text JSON straight to MySQL's native parser.

## How it works

**Change 1 — `applyBulkInsert` maxQuerySize guard:** After encoding each row, checks if the SQL buffer exceeds `max_allowed_packet`. If so, flushes the accumulated INSERT, resets the buffer, and continues with the current row in a new statement. Mirrors the existing pattern in `applyBulkInsertChanges`.

**Change 2 — Size-gated CAST for large JSON:** All four `MarshalSQLValue` call sites now route through `marshalJSONForSQL()`. Below the threshold (1MB), the existing `JSON_OBJECT(...)` tree encoding is used — it's proven correct and handles MySQL-specific JSON type preservation. Above the threshold, `CAST(_utf8mb4'...' AS JSON)` skips the Go tree entirely. The `_utf8mb4` introducer ensures correct charset handling regardless of connection settings.

The CAST path is safe because:
- The input is always valid text JSON by the time it reaches these call sites (copy phase: MySQL SELECT returns text; replay phase: `CellValue()` converts binary→text upstream)
- `CAST(... AS JSON)` is MySQL's native JSON text parser — same code path as `INSERT INTO t (json_col) VALUES ('...')`
- The `JSON_OBJECT(...)` approach was introduced in #12761 to fix integer precision loss (#8686), but the upstream text conversion was also fixed in the same PR, so the text JSON already has correct integers

Fixes #19875

---
_Mostly written by Claude Code — I provided direction and review._