### PR TITLE
fix: typos in user-facing error messages and comments

### DIFF
--- a/go/test/endtoend/tabletgateway/buffer/reshard/sharded_buffer_test.go
+++ b/go/test/endtoend/tabletgateway/buffer/reshard/sharded_buffer_test.go
@@ -48,7 +48,7 @@ func waitForLowLag(t *testing.T, clusterInstance *cluster.LocalProcessCluster, k
 		var resp vtctldatapb.GetWorkflowsResponse
 		err = json2.UnmarshalPB([]byte(output), &resp)
 		require.NoError(t, err)
-		require.GreaterOrEqual(t, len(resp.Workflows), 1, "responce should have at least one workflow")
+		require.GreaterOrEqual(t, len(resp.Workflows), 1, "response should have at least one workflow")
 		lagSeconds := resp.Workflows[0].MaxVReplicationTransactionLag
 
 		require.NoError(t, err, output)

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -464,7 +464,7 @@ func testReplicatingWithPKEnumCols(t *testing.T) {
 	// from the product to the customer keyspace. Let's delete and insert a row to
 	// ensure that the PK -- which is on (cid, typ) with typ being an ENUM -- is
 	// managed correctly in the WHERE clause for the delete. The end result is that
-	// we should see the proper deletes propogate and not get a duplicate key error
+	// we should see the proper deletes propagate and not get a duplicate key error
 	// when we re-insert the same row values and ultimately VDiff shows the table as
 	// being identical in both keyspaces.
 

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -1765,7 +1765,7 @@ func FnReplace(yield Query) {
 		// From / to strings are converted into the collation of
 		// the input string.
 		`REPLACE('fooÿbar', _latin1 0xFF, _latin1 0xFE)`,
-		// First occurence is replaced
+		// First occurrence is replaced
 		`replace('fff', 'ff', 'gg')`,
 	}
 

--- a/web/vtadmin/src/components/routes/transactions/TransactionActions.tsx
+++ b/web/vtadmin/src/components/routes/transactions/TransactionActions.tsx
@@ -28,7 +28,7 @@ const TransactionActions: React.FC<TransactionActionsProps> = ({ refetchTransact
                 loadingText="Concluding"
                 mutation={concludeTransactionMutation}
                 successText="Concluded transaction"
-                errorText={`Error occured while concluding the transaction (ID: ${dtid})`}
+                errorText={`Error occurred while concluding the transaction (ID: ${dtid})`}
                 closeDialog={closeDialog}
                 isOpen={currentDialog === 'Conclude Transaction'}
                 refetchTransactions={refetchTransactions}

--- a/web/vtadmin/src/components/routes/workflows/WorkflowActions.tsx
+++ b/web/vtadmin/src/components/routes/workflows/WorkflowActions.tsx
@@ -338,7 +338,7 @@ const WorkflowActions: React.FC<WorkflowActionsProps> = ({
                 loadingText="Starting"
                 mutation={startWorkflowMutation}
                 successText="Started workflow"
-                errorText={`Error occured while starting workflow ${name}`}
+                errorText={`Error occurred while starting workflow ${name}`}
                 errorDescription={startWorkflowMutation.error ? startWorkflowMutation.error.message : ''}
                 closeDialog={closeDialog}
                 isOpen={currentDialog === 'Start Workflow'}
@@ -362,7 +362,7 @@ const WorkflowActions: React.FC<WorkflowActionsProps> = ({
                 loadingText="Stopping"
                 mutation={stopWorkflowMutation}
                 successText="Stopped workflow"
-                errorText={`Error occured while stopping workflow ${name}`}
+                errorText={`Error occurred while stopping workflow ${name}`}
                 errorDescription={stopWorkflowMutation.error ? stopWorkflowMutation.error.message : ''}
                 closeDialog={closeDialog}
                 isOpen={currentDialog === 'Stop Workflow'}
@@ -388,7 +388,7 @@ const WorkflowActions: React.FC<WorkflowActionsProps> = ({
                 mutation={switchTrafficMutation}
                 description={`Switch traffic for the ${name} workflow.`}
                 successText="Switched Traffic"
-                errorText={`Error occured while switching traffic for workflow ${name}`}
+                errorText={`Error occurred while switching traffic for workflow ${name}`}
                 errorDescription={switchTrafficMutation.error ? switchTrafficMutation.error.message : ''}
                 closeDialog={closeDialog}
                 isOpen={currentDialog === 'Switch Traffic'}
@@ -410,7 +410,7 @@ const WorkflowActions: React.FC<WorkflowActionsProps> = ({
                 mutation={reverseTrafficMutation}
                 description={`Reverse traffic for the ${name} workflow.`}
                 successText="Reversed Traffic"
-                errorText={`Error occured while reversing traffic for workflow ${name}`}
+                errorText={`Error occurred while reversing traffic for workflow ${name}`}
                 errorDescription={reverseTrafficMutation.error ? reverseTrafficMutation.error.message : ''}
                 closeDialog={closeDialog}
                 isOpen={currentDialog === 'Reverse Traffic'}
@@ -432,7 +432,7 @@ const WorkflowActions: React.FC<WorkflowActionsProps> = ({
                 loadingText="Cancelling"
                 mutation={cancelWorkflowMutation}
                 successText="Cancel Workflow"
-                errorText={`Error occured while cancelling workflow ${name}`}
+                errorText={`Error occurred while cancelling workflow ${name}`}
                 errorDescription={cancelWorkflowMutation.error ? cancelWorkflowMutation.error.message : ''}
                 closeDialog={closeDialog}
                 isOpen={currentDialog === 'Cancel Workflow'}
@@ -494,7 +494,7 @@ const WorkflowActions: React.FC<WorkflowActionsProps> = ({
                 loadingText="Completing"
                 hideSuccessDialog={true}
                 mutation={completeMoveTablesMutation}
-                errorText={`Error occured while completing workflow ${name}`}
+                errorText={`Error occurred while completing workflow ${name}`}
                 errorDescription={completeMoveTablesMutation.error ? completeMoveTablesMutation.error.message : ''}
                 closeDialog={closeDialog}
                 isOpen={currentDialog === 'Complete Workflow'}


### PR DESCRIPTION
## Description

Corrects several English typos:

- **'Error occured'** → **'Error occurred'** — 7 vtadmin UI toast messages in `TransactionActions.tsx` and `WorkflowActions.tsx`. These strings are rendered to end users when admin actions fail (conclude transaction; start/stop/switch/reverse/cancel/complete workflow).
- **'responce'** → **'response'** — assertion message in `sharded_buffer_test.go`.
- **'propogate'** → **'propagate'** — comment in `resharding_workflows_v2_test.go`.
- **'occurence'** → **'occurrence'** — comment in `evalengine/testcases/cases.go`.

No behavior change.

## Related Issue(s)

None — trivial typo fix.

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI
- [x] Documentation was added or is not required