### PR TITLE
reparentutil: fix goroutine count and improve logging

### DIFF
--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -703,17 +703,13 @@ func (erp *EmergencyReparenter) reparentReplicas(
 	// time of slowest replica, instead of the time of the fastest successful
 	// replica, and we want ERS to be fast.
 	//
-	// For non-intermediate reparents, this function returns after the first
-	// successful replica; for intermediate reparents, it waits for all
-	// replicas to finish. On primary failure, replCancel() is called
-	// immediately below, which is safe because cancel functions are
-	// idempotent.
-	//
-	// This goroutine cancels replCtx after all replicas finish, so that
+	// This goroutine also cancels replCtx after all replicas finish, so that
 	// replicas that are still in-flight can complete their SetReplicationSource
-	// calls even when this function returns early. replCancel is NOT deferred
-	// at the function level because the success path intentionally keeps
-	// replCtx alive for background RPCs to finish.
+	// calls even when this function returns early. For non-intermediate
+	// reparents, this function returns after the first successful replica;
+	// for intermediate reparents, it waits for all replicas to finish.
+	// On primary failure, replCancel() is called immediately below,
+	// which is safe because cancel functions are idempotent.
 	go func() {
 		replWg.Wait()
 		allReplicasDoneCancel()

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -670,8 +670,8 @@ func (erp *EmergencyReparenter) reparentReplicas(
 		}
 
 		replicaMutex.Lock()
-		defer replicaMutex.Unlock()
 		replicasStartedReplication = append(replicasStartedReplication, ti.Tablet)
+		replicaMutex.Unlock()
 
 		// Signal that at least one goroutine succeeded to SetReplicationSource.
 		// We do this only when we do not want to wait for all the replicas.

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -670,8 +670,8 @@ func (erp *EmergencyReparenter) reparentReplicas(
 		}
 
 		replicaMutex.Lock()
+		defer replicaMutex.Unlock()
 		replicasStartedReplication = append(replicasStartedReplication, ti.Tablet)
-		replicaMutex.Unlock()
 
 		// Signal that at least one goroutine succeeded to SetReplicationSource.
 		// We do this only when we do not want to wait for all the replicas.
@@ -703,13 +703,17 @@ func (erp *EmergencyReparenter) reparentReplicas(
 	// time of slowest replica, instead of the time of the fastest successful
 	// replica, and we want ERS to be fast.
 	//
-	// This goroutine also cancels replCtx after all replicas finish, so that
+	// For non-intermediate reparents, this function returns after the first
+	// successful replica; for intermediate reparents, it waits for all
+	// replicas to finish. On primary failure, replCancel() is called
+	// immediately below, which is safe because cancel functions are
+	// idempotent.
+	//
+	// This goroutine cancels replCtx after all replicas finish, so that
 	// replicas that are still in-flight can complete their SetReplicationSource
-	// calls even when this function returns early. For non-intermediate
-	// reparents, this function returns after the first successful replica;
-	// for intermediate reparents, it waits for all replicas to finish.
-	// On primary failure, replCancel() is called immediately below,
-	// which is safe because cancel functions are idempotent.
+	// calls even when this function returns early. replCancel is NOT deferred
+	// at the function level because the success path intentionally keeps
+	// replCtx alive for background RPCs to finish.
 	go func() {
 		replWg.Wait()
 		allReplicasDoneCancel()

--- a/go/vt/vtctl/reparentutil/planned_reparenter.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter.go
@@ -637,8 +637,10 @@ func (pr *PlannedReparenter) reparentShardLocked(
 
 	if needsRefresh {
 		// Refresh the state to force the tabletserver to reconnect after db has been created.
+		// This is best-effort — internal components retry initialization on their own, and
+		// returning an error here would report a functionally-successful reparent as failed.
 		if err := pr.tmc.RefreshState(ctx, ev.NewPrimary); err != nil {
-			pr.logger.Warningf("RefreshState failed: %v", err)
+			pr.logger.Warningf("RefreshState failed on new primary %v: %v", topoproto.TabletAliasString(ev.NewPrimary.Alias), err)
 		}
 	}
 	return nil

--- a/go/vt/vtctl/reparentutil/replication.go
+++ b/go/vt/vtctl/reparentutil/replication.go
@@ -368,6 +368,7 @@ func stopReplicationAndBuildStatusMaps(
 	if tabletToWaitFor != nil {
 		tabletAliasToWaitFor = topoproto.TabletAliasString(tabletToWaitFor)
 	}
+	numGoRoutines := 0
 	for alias, tabletInfo := range tabletMap {
 		allTablets = append(allTablets, tabletInfo.Tablet)
 		if !ignoredTablets.Has(alias) {
@@ -379,13 +380,13 @@ func stopReplicationAndBuildStatusMaps(
 			if mustWaitFor {
 				numErrorsToWaitFor++
 			}
+			numGoRoutines++
 			go fillStatus(alias, tabletInfo, mustWaitFor)
 		}
 	}
 
-	numGoRoutines := len(tabletMap) - ignoredTablets.Len()
-	if numGoRoutines <= 0 && ignoredTablets.Len() > 0 {
-		return res, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no tablets available to stop replication on (all %d tablets were ignored)", len(tabletMap))
+	if numGoRoutines == 0 && len(tabletMap) > 0 {
+		return res, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no tablets available to stop replication on (%d tablets in map, %d ignored)", len(tabletMap), ignoredTablets.Len())
 	}
 	// In general we want to wait for n-1 tablets to respond, since we know the primary tablet is down.
 	requiredSuccesses := numGoRoutines - 1

--- a/go/vt/vtctl/reparentutil/replication.go
+++ b/go/vt/vtctl/reparentutil/replication.go
@@ -384,6 +384,9 @@ func stopReplicationAndBuildStatusMaps(
 	}
 
 	numGoRoutines := len(tabletMap) - ignoredTablets.Len()
+	if numGoRoutines <= 0 && ignoredTablets.Len() > 0 {
+		return res, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no tablets available to stop replication on (all %d tablets were ignored)", len(tabletMap))
+	}
 	// In general we want to wait for n-1 tablets to respond, since we know the primary tablet is down.
 	requiredSuccesses := numGoRoutines - 1
 	if waitForAllTablets {

--- a/go/vt/vtctl/reparentutil/replication_test.go
+++ b/go/vt/vtctl/reparentutil/replication_test.go
@@ -1369,6 +1369,101 @@ func Test_stopReplicationAndBuildStatusMaps(t *testing.T) {
 			}},
 			shouldErr: false,
 		},
+		{
+			// ignoredTablets contains a stale alias not present in tabletMap.
+			// The old code computed numGoRoutines as len(tabletMap) - ignoredTablets.Len(),
+			// which would be 2 - 2 = 0 instead of the correct 1.
+			name:       "stale alias in ignoredTablets does not miscount goroutines",
+			durability: policy.DurabilityNone,
+			tmc: &stopReplicationAndBuildStatusMapsTestTMClient{
+				stopReplicationAndGetStatusResults: map[string]*struct {
+					StopStatus *replicationdatapb.StopReplicationStatus
+					Err        error
+				}{
+					"zone1-0000000100": {
+						StopStatus: &replicationdatapb.StopReplicationStatus{
+							Before: &replicationdatapb.Status{Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429100:1-5", IoState: int32(replication.ReplicationStateRunning), SqlState: int32(replication.ReplicationStateRunning)},
+							After:  &replicationdatapb.Status{Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429100:1-9"},
+						},
+					},
+					"zone1-0000000101": {
+						StopStatus: &replicationdatapb.StopReplicationStatus{
+							Before: &replicationdatapb.Status{Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429101:1-5", IoState: int32(replication.ReplicationStateRunning), SqlState: int32(replication.ReplicationStateRunning)},
+							After:  &replicationdatapb.Status{Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429101:1-9"},
+						},
+					},
+				},
+			},
+			tabletMap: map[string]*topo.TabletInfo{
+				"zone1-0000000100": {
+					Tablet: &topodatapb.Tablet{
+						Type: topodatapb.TabletType_REPLICA,
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  100,
+						},
+					},
+				},
+				"zone1-0000000101": {
+					Tablet: &topodatapb.Tablet{
+						Type: topodatapb.TabletType_REPLICA,
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  101,
+						},
+					},
+				},
+			},
+			// zone1-0000000101 is in the map, but zone1-0000000999 is stale/not in the map.
+			// Old code: numGoRoutines = 2 - 2 = 0 (wrong). New code: numGoRoutines = 1 (correct).
+			ignoredTablets: sets.New[string]("zone1-0000000101", "zone1-0000000999"),
+			expectedStatusMap: map[string]*replicationdatapb.StopReplicationStatus{
+				"zone1-0000000100": {
+					Before: &replicationdatapb.Status{Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429100:1-5", IoState: int32(replication.ReplicationStateRunning), SqlState: int32(replication.ReplicationStateRunning)},
+					After:  &replicationdatapb.Status{Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429100:1-9"},
+				},
+			},
+			expectedTakingBackup:     map[string]bool{"zone1-0000000100": false},
+			expectedPrimaryStatusMap: map[string]*replicationdatapb.PrimaryStatus{},
+			expectedTabletsReachable: []*topodatapb.Tablet{{
+				Type: topodatapb.TabletType_REPLICA,
+				Alias: &topodatapb.TabletAlias{
+					Cell: "zone1",
+					Uid:  100,
+				},
+			}},
+			shouldErr: false,
+		},
+		{
+			// All tablets in the map are in the ignored set — the new precondition
+			// guard should return FAILED_PRECONDITION instead of silently proceeding
+			// with numGoRoutines=0 / requiredSuccesses=-1.
+			name:       "all tablets ignored returns FAILED_PRECONDITION",
+			durability: policy.DurabilityNone,
+			tmc:        &stopReplicationAndBuildStatusMapsTestTMClient{},
+			tabletMap: map[string]*topo.TabletInfo{
+				"zone1-0000000100": {
+					Tablet: &topodatapb.Tablet{
+						Type: topodatapb.TabletType_REPLICA,
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  100,
+						},
+					},
+				},
+				"zone1-0000000101": {
+					Tablet: &topodatapb.Tablet{
+						Type: topodatapb.TabletType_REPLICA,
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  101,
+						},
+					},
+				},
+			},
+			ignoredTablets: sets.New[string]("zone1-0000000100", "zone1-0000000101"),
+			shouldErr:      true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

2 x small fixes found during an audit of the `reparentutil` package:

1. **Incorrect goroutine count in `stopReplicationAndBuildStatusMaps()`** — `numGoRoutines` was computed as `len(tabletMap) - ignoredTablets.Len()`, but `ignoredTablets` can contain aliases not present in `tabletMap` _(e.g., stale entries)_, making the subtraction wrong. Now counts goroutines directly in the launch loop. Also added an early `FAILED_PRECONDITION` return when tablets exist but all are excluded by `IgnoreReplicas`, which previously produced `requiredSuccesses = -1` _(invalid `ErrorGroup` parameters)_

2. **`RefreshState` warning missing tablet alias** — The `RefreshState` best-effort warning in `reparentShardLocked()` didn't include the tablet alias, making it hard to debug. Added the alias and a rationale comment explaining why this intentionally does not return an error _(VTOrc and other callers rely on nil returns from successful reparents)_

## Related Issue(s)

Closes: #19896

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

N/A

### AI Disclosure

Development assisted by Claude. Claude prepared this PR summary