### PR TITLE
test: use testify assert/require in go/sync2

### DIFF
--- a/go/sync2/batcher_test.go
+++ b/go/sync2/batcher_test.go
@@ -20,6 +20,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // makeAfterFnWithLatch returns a fake alternative to time.After that blocks until
@@ -35,7 +37,7 @@ func makeAfterFnWithLatch(t *testing.T) (func(time.Duration) <-chan time.Time, f
 		select {
 		case latch <- time.Now():
 		default:
-			t.Errorf("Previous batch still hasn't been released")
+			assert.Fail(t, "Previous batch still hasn't been released")
 		}
 	}
 	return afterFn, releaseFn
@@ -52,9 +54,7 @@ func TestBatcher(t *testing.T) {
 	startWaiter := func(testcase string, want int) {
 		go func() {
 			id := b.Wait()
-			if id != want {
-				t.Errorf("%s: got %d, want %d", testcase, id, want)
-			}
+			assert.Equal(t, want, id, testcase)
 			waitersFinished.Add(1)
 		}()
 	}
@@ -63,7 +63,7 @@ func TestBatcher(t *testing.T) {
 		for count := 0; val.Load() != expected; count++ {
 			time.Sleep(50 * time.Millisecond)
 			if count > 5 {
-				t.Errorf("Timed out waiting for %s to be %v", name, expected)
+				assert.Fail(t, "Timed out waiting", "%s to be %v", name, expected)
 				return
 			}
 		}
@@ -73,9 +73,7 @@ func TestBatcher(t *testing.T) {
 		// Wait for all the waiters to register
 		awaitVal("Batcher.waiters for "+name, &b.waiters, n)
 		// Release the batch and wait for the batcher to catch up.
-		if waitersFinished.Load() != 0 {
-			t.Errorf("Waiters finished before being released")
-		}
+		assert.Equal(t, int32(0), waitersFinished.Load(), "Waiters finished before being released")
 		releaseBatch()
 		awaitVal("Batcher.waiters for "+name, &b.waiters, 0)
 		// Make sure the waiters actually run so they can verify their batch number.

--- a/go/sync2/consolidator_test.go
+++ b/go/sync2/consolidator_test.go
@@ -76,8 +76,8 @@ func TestConsolidator(t *testing.T) {
 	}()
 	dup.Wait()
 
-	assert.Equal(t, result, orig.Result(), "failed to pass result")
-	require.Equal(t, orig.Result(), dup.Result(), "failed to share the result")
+	assert.Same(t, result, orig.Result(), "failed to pass result")
+	require.Same(t, orig.Result(), dup.Result(), "failed to share the result")
 
 	want = []ConsolidatorCacheItem{{Query: sql, Count: 1}}
 	require.Equal(t, want, con.Items(), "expected consolidator to have one item")

--- a/go/sync2/consolidator_test.go
+++ b/go/sync2/consolidator_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package sync2
 
 import (
-	"reflect"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/sqltypes"
 )
@@ -49,9 +51,7 @@ func TestAddWaiterCount(t *testing.T) {
 	wgAdd.Wait()
 	wgSub.Wait()
 
-	if *pr.AddWaiterCounter(0) != 0 {
-		t.Fatalf("Expect 0 totalWaiterCount but got: %v", *pr.AddWaiterCounter(0))
-	}
+	require.Equal(t, int64(0), *pr.AddWaiterCounter(0), "expected 0 totalWaiterCount")
 }
 
 func TestConsolidator(t *testing.T) {
@@ -59,23 +59,15 @@ func TestConsolidator(t *testing.T) {
 	sql := "select * from SomeTable"
 
 	want := []ConsolidatorCacheItem{}
-	if !reflect.DeepEqual(con.Items(), want) {
-		t.Fatalf("expected consolidator to have no items")
-	}
+	require.Equal(t, want, con.Items(), "expected consolidator to have no items")
 
 	orig, added := con.Create(sql)
-	if !added {
-		t.Fatalf("expected consolidator to register a new entry")
-	}
+	require.True(t, added, "expected consolidator to register a new entry")
 
-	if !reflect.DeepEqual(con.Items(), want) {
-		t.Fatalf("expected consolidator to still have no items")
-	}
+	require.Equal(t, want, con.Items(), "expected consolidator to still have no items")
 
 	dup, added := con.Create(sql)
-	if added {
-		t.Fatalf("did not expect consolidator to register a new entry")
-	}
+	require.False(t, added, "did not expect consolidator to register a new entry")
 
 	result := &sqltypes.Result{}
 	go func() {
@@ -84,24 +76,16 @@ func TestConsolidator(t *testing.T) {
 	}()
 	dup.Wait()
 
-	if orig.Result() != result {
-		t.Errorf("failed to pass result")
-	}
-	if orig.Result() != dup.Result() {
-		t.Fatalf("failed to share the result")
-	}
+	assert.Equal(t, result, orig.Result(), "failed to pass result")
+	require.Equal(t, orig.Result(), dup.Result(), "failed to share the result")
 
 	want = []ConsolidatorCacheItem{{Query: sql, Count: 1}}
-	if !reflect.DeepEqual(con.Items(), want) {
-		t.Fatalf("expected consolidator to have one items %v", con.Items())
-	}
+	require.Equal(t, want, con.Items(), "expected consolidator to have one item")
 
 	// Running the query again should add a new entry since the original
 	// query execution completed
 	second, added := con.Create(sql)
-	if !added {
-		t.Fatalf("expected consolidator to register a new entry")
-	}
+	require.True(t, added, "expected consolidator to register a new entry")
 
 	go func() {
 		second.SetResult(result)
@@ -110,7 +94,5 @@ func TestConsolidator(t *testing.T) {
 	dup.Wait()
 
 	want = []ConsolidatorCacheItem{{Query: sql, Count: 2}}
-	if !reflect.DeepEqual(con.Items(), want) {
-		t.Fatalf("expected consolidator to have two items %v", con.Items())
-	}
+	require.Equal(t, want, con.Items(), "expected consolidator to have two items")
 }


### PR DESCRIPTION
## Description
- Replace instances of `t.Errorf` and `t.Fatalf` with `assert` and `require` from testify in the `go/sync2` package
- Replace `reflect.DeepEqual` comparisons with `require.Equal`
- `t.Errorf` -> `assert` (non-fatal, safe in goroutines)
- `t.Fatalf` -> `require` (fatal, stops test immediately)

## Related Issue(s)

- #15182

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

No deployment changes required - test-only changes.