### PR TITLE
discovery: decouple health check retry backoff cap from timeout

### DIFF
--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -170,6 +170,7 @@ Flags:
       --grpc-use-effective-groups                                        If set, and SSL is not used, will set the immediate caller's security groups from the effective caller id's groups.
       --grpc-use-static-authentication-callerid                          If set, will set the immediate caller id to the username authenticated by the static auth plugin.
       --health-check-interval duration                                   Interval between health checks (default 20s)
+      --healthcheck-max-retry-backoff duration                            maximum delay between health check stream reconnection attempts (default 10s)
       --healthcheck-retry-delay duration                                 health check retry delay (default 2ms)
       --healthcheck-timeout duration                                     the health check timeout period (default 1m0s)
       --heartbeat-enable                                                 If true, vttablet records (if master) or checks (if replica) the current time of a replication heartbeat in the sidecar database's heartbeat table. The result is used to inform the serving state of the vttablet via healthchecks.

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -102,6 +102,7 @@ Flags:
       --grpc-use-effective-callerid                                      If set, and SSL is not used, will set the immediate caller id from the effective caller id's principal.
       --grpc-use-effective-groups                                        If set, and SSL is not used, will set the immediate caller's security groups from the effective caller id's groups.
       --grpc-use-static-authentication-callerid                          If set, will set the immediate caller id to the username authenticated by the static auth plugin.
+      --healthcheck-max-retry-backoff duration                            maximum delay between health check stream reconnection attempts (default 10s)
       --healthcheck-retry-delay duration                                 health check retry delay (default 2ms)
       --healthcheck-timeout duration                                     the health check timeout period (default 1m0s)
   -h, --help                                                             help for vtgate

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -118,6 +118,7 @@ var (
 const (
 	DefaultHealthCheckRetryDelay = 5 * time.Second
 	DefaultHealthCheckTimeout    = 1 * time.Minute
+	DefaultMaxRetryBackoff       = 10 * time.Second
 
 	// healthCheckTemplate is the HTML code to display a TabletsCacheStatusList, it takes a parameter for the title
 	// as the template can be used for both HealthCheck's cache and healthy tablets list.
@@ -283,8 +284,14 @@ type HealthCheckImpl struct {
 	// Immutable fields set at construction time.
 	retryDelay         time.Duration
 	healthCheckTimeout time.Duration
-	ts                 *topo.Server
-	cell               string
+	// maxRetryBackoff caps the exponential backoff on stream reconnection
+	// attempts. This is separate from healthCheckTimeout, which controls
+	// how long to wait for a health response before marking a tablet down.
+	// A lower maxRetryBackoff ensures vtgates reconnect quickly after a
+	// tablet recovers from a prolonged outage.
+	maxRetryBackoff time.Duration
+	ts              *topo.Server
+	cell            string
 	// mu protects all the following fields.
 	mu sync.Mutex
 	// authoritative map of tabletHealth by alias
@@ -370,6 +377,7 @@ func NewHealthCheck(
 		cell:               localCell,
 		retryDelay:         retryDelay,
 		healthCheckTimeout: healthCheckTimeout,
+		maxRetryBackoff:    DefaultMaxRetryBackoff,
 		healthByAlias:      make(map[tabletAliasString]*tabletHealthCheck),
 		healthData:         make(map[KeyspaceShardTabletType]map[tabletAliasString]*TabletHealth),
 		healthy:            make(map[KeyspaceShardTabletType][]*TabletHealth),
@@ -406,6 +414,12 @@ func NewHealthCheck(
 	}
 
 	return hc
+}
+
+// SetMaxRetryBackoff sets the maximum delay between health check stream
+// reconnection attempts. This must be called before AddTablet.
+func (hc *HealthCheckImpl) SetMaxRetryBackoff(d time.Duration) {
+	hc.maxRetryBackoff = d
 }
 
 // AddTablet adds the tablet, and starts health check.

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -419,6 +419,9 @@ func NewHealthCheck(
 // SetMaxRetryBackoff sets the maximum delay between health check stream
 // reconnection attempts. This must be called before AddTablet.
 func (hc *HealthCheckImpl) SetMaxRetryBackoff(d time.Duration) {
+	if d <= 0 {
+		return
+	}
 	hc.maxRetryBackoff = d
 }
 

--- a/go/vt/discovery/tablet_health_check.go
+++ b/go/vt/discovery/tablet_health_check.go
@@ -324,9 +324,11 @@ func (thc *tabletHealthCheck) checkConn(hc *HealthCheckImpl) {
 		case <-time.After(retryDelay):
 			// Exponentially back-off to prevent tight-loop.
 			retryDelay *= 2
-			// Limit the retry delay backoff to the health check timeout
-			if retryDelay > hc.healthCheckTimeout {
-				retryDelay = hc.healthCheckTimeout
+			// Limit the retry delay backoff to maxRetryBackoff so that
+			// vtgates reconnect quickly after a tablet recovers from a
+			// prolonged outage.
+			if retryDelay > hc.maxRetryBackoff {
+				retryDelay = hc.maxRetryBackoff
 			}
 		}
 	}

--- a/go/vt/vtgate/tabletgateway.go
+++ b/go/vt/vtgate/tabletgateway.go
@@ -115,13 +115,15 @@ type TabletGateway struct {
 	balancerMode balancer.Mode
 }
 
-func createHealthCheck(ctx context.Context, retryDelay, timeout time.Duration, ts *topo.Server, cell, cellsToWatch string) discovery.HealthCheck {
+func createHealthCheck(ctx context.Context, retryDelay, timeout, maxRetryBackoff time.Duration, ts *topo.Server, cell, cellsToWatch string) discovery.HealthCheck {
 	filters, err := discovery.NewVTGateHealthCheckFilters()
 	if err != nil {
 		log.Error(fmt.Sprint(err))
 		os.Exit(1)
 	}
-	return discovery.NewHealthCheck(ctx, retryDelay, timeout, ts, cell, cellsToWatch, filters)
+	hc := discovery.NewHealthCheck(ctx, retryDelay, timeout, ts, cell, cellsToWatch, filters)
+	hc.SetMaxRetryBackoff(maxRetryBackoff)
+	return hc
 }
 
 // NewTabletGateway creates and returns a new TabletGateway
@@ -137,7 +139,7 @@ func NewTabletGateway(ctx context.Context, hc discovery.HealthCheck, serv srvtop
 				os.Exit(1)
 			}
 		}
-		hc = createHealthCheck(ctx, healthCheckRetryDelay, healthCheckTimeout, topoServer, localCell, CellsToWatch)
+		hc = createHealthCheck(ctx, healthCheckRetryDelay, healthCheckTimeout, healthCheckMaxRetryBackoff, topoServer, localCell, CellsToWatch)
 	}
 	gw := &TabletGateway{
 		hc:                hc,

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -90,6 +90,11 @@ var (
 	healthCheckRetryDelay = 2 * time.Millisecond
 	// healthCheckTimeout is the timeout on the RPC call to tablets
 	healthCheckTimeout = time.Minute
+	// healthCheckMaxRetryBackoff caps the exponential backoff on health
+	// check stream reconnection attempts. This is intentionally lower than
+	// healthCheckTimeout to ensure vtgates reconnect quickly after a tablet
+	// recovers from a prolonged outage.
+	healthCheckMaxRetryBackoff = discovery.DefaultMaxRetryBackoff
 
 	// System settings related flags
 	sysVarSetEnabled = true
@@ -196,6 +201,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&enableShardRouting, "enable-partial-keyspace-migration", enableShardRouting, "(Experimental) Follow shard routing rules: enable only while migrating a keyspace shard by shard. See documentation on Partial MoveTables for more. (default false)")
 	utils.SetFlagDurationVar(fs, &healthCheckRetryDelay, "healthcheck-retry-delay", healthCheckRetryDelay, "health check retry delay")
 	utils.SetFlagDurationVar(fs, &healthCheckTimeout, "healthcheck-timeout", healthCheckTimeout, "the health check timeout period")
+	utils.SetFlagDurationVar(fs, &healthCheckMaxRetryBackoff, "healthcheck-max-retry-backoff", healthCheckMaxRetryBackoff, "maximum delay between health check stream reconnection attempts")
 	utils.SetFlagIntVar(fs, &maxPayloadSize, "max-payload-size", maxPayloadSize, "The threshold for query payloads in bytes. A payload greater than this threshold will result in a failure to handle the query.")
 	utils.SetFlagIntVar(fs, &warnPayloadSize, "warn-payload-size", warnPayloadSize, "The warning threshold for query payloads in bytes. A payload greater than this threshold will cause the VtGateWarnings.WarnPayloadSizeExceeded counter to be incremented.")
 	utils.SetFlagBoolVar(fs, &sysVarSetEnabled, "enable-system-settings", sysVarSetEnabled, "This will enable the system settings to be changed per session at the database connection level")


### PR DESCRIPTION
## Description

The health check stream reconnection backoff in `checkConn` is capped at `healthCheckTimeout` (default 60s), which also controls how long to wait before marking a tablet as down. These are different concerns — the silence timeout should be moderate (60s) while the retry backoff cap should be low (5-10s) to ensure fast rediscovery after a tablet recovers from a prolonged outage.

This adds a separate `maxRetryBackoff` field (default 10s) and a new `--healthcheck-max-retry-backoff` flag. The backoff sequence changes from `5s→10s→20s→40s→60s` to `5s→10s→10s→10s`, ensuring all vtgates reconnect within ~10 seconds of a tablet recovery regardless of how long it was down.

## Related Issue(s)

Fixes #19894

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [ ] Documentation was added or is not required

## Deployment Notes

New vtgate flag `--healthcheck-max-retry-backoff` (default `10s`). The default changes behavior: vtgates will now reconnect to recovered tablets faster (within ~10s instead of up to ~60s). This is strictly an improvement and should not require operator action. The flag exists for tuning if needed.

### AI Disclosure

This PR was primarily written by Claude Code with direction and review.