### PR TITLE
semantics: allow subqueries to reference parent SELECT aliases

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -5703,6 +5703,33 @@
     "plan": "Column 'foobar' in field list is ambiguous"
   },
   {
+    "comment": "Repeating the same column with the same alias is not ambiguous",
+    "query": "SELECT user_id AS foobar, user_id AS foobar, (SELECT foobar) FROM authoritative WHERE user_id = 1",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "SELECT user_id AS foobar, user_id AS foobar, (SELECT foobar) FROM authoritative WHERE user_id = 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select user_id as foobar, user_id as foobar, (select foobar from dual where 1 != 1) from authoritative where 1 != 1",
+        "Query": "select user_id as foobar, user_id as foobar, (select foobar from dual) from authoritative where user_id = 1",
+        "Values": [
+          "1"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "main.dual",
+        "user.authoritative"
+      ]
+    }
+  },
+  {
     "comment": "Duplicate literal aliases - subquery resolves to first matching alias, matching MySQL behavior",
     "query": "SELECT 1 AS foobar, 2 AS foobar, (SELECT foobar) FROM authoritative WHERE user_id = 1",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -5730,6 +5730,33 @@
     }
   },
   {
+    "comment": "Subquery between duplicate literal aliases resolves to first (earlier) match",
+    "query": "SELECT 1 AS foobar, (SELECT foobar), 2 AS foobar FROM authoritative WHERE user_id = 1",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "SELECT 1 AS foobar, (SELECT foobar), 2 AS foobar FROM authoritative WHERE user_id = 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select 1 as foobar, (select foobar from dual where 1 != 1), 2 as foobar from authoritative where 1 != 1",
+        "Query": "select 1 as foobar, (select foobar from dual), 2 as foobar from authoritative where user_id = 1",
+        "Values": [
+          "1"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "main.dual",
+        "user.authoritative"
+      ]
+    }
+  },
+  {
     "comment": "Forward reference to alias in subquery should fail",
     "query": "SELECT (SELECT foobar FROM authoritative), user_id AS foobar FROM authoritative WHERE user_id = 1",
     "skip_e2e": true,

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -5610,6 +5610,7 @@
   {
     "comment": "Subquery with own non-authoritative FROM treats unknown column as table column",
     "query": "SELECT id AS foobar, (SELECT foobar FROM user_extra WHERE foobar = 1) FROM user WHERE id = 1",
+    "skip_e2e": true,
     "plan": {
       "Type": "Complex",
       "QueryType": "SELECT",
@@ -5658,11 +5659,13 @@
   {
     "comment": "Subquery with own FROM falls back to parent alias when column not in table",
     "query": "SELECT user_id AS foobar, (SELECT foobar FROM authoritative WHERE foobar = 1) FROM authoritative WHERE user_id = 1",
+    "skip_e2e": true,
     "plan": "VT12001: unsupported: correlated subquery is only supported for EXISTS"
   },
   {
     "comment": "Nested subquery resolves alias across multiple scope levels",
     "query": "SELECT user_id AS foobar, (SELECT (SELECT foobar) AS barbaz FROM authoritative WHERE foobar = 1) FROM authoritative WHERE user_id = 1",
+    "skip_e2e": true,
     "plan": "VT12001: unsupported: correlated subquery is only supported for EXISTS"
   },
   {
@@ -5690,6 +5693,7 @@
   {
     "comment": "Subquery referencing compound expression alias is correctly correlated",
     "query": "SELECT user_id + 1 AS foobar, (SELECT foobar FROM authoritative WHERE foobar = 1) FROM authoritative WHERE user_id = 1",
+    "skip_e2e": true,
     "plan": "VT12001: unsupported: correlated subquery is only supported for EXISTS"
   },
   {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -5663,10 +5663,52 @@
     "plan": "VT12001: unsupported: correlated subquery is only supported for EXISTS"
   },
   {
-    "comment": "Literal parent alias referenced by subquery with authoritative FROM is treated as correlated",
+    "comment": "Literal parent alias referenced by subquery is inlined so the subquery stays uncorrelated",
     "query": "SELECT 1 AS foobar, (SELECT foobar FROM authoritative) FROM authoritative WHERE user_id = 1",
     "skip_e2e": true,
-    "plan": "VT12001: unsupported: correlated subquery is only supported for EXISTS"
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "SELECT 1 AS foobar, (SELECT foobar FROM authoritative) FROM authoritative WHERE user_id = 1",
+      "Instructions": {
+        "OperatorType": "UncorrelatedSubquery",
+        "Variant": "PulloutValue",
+        "PulloutVars": [
+          "__sq1"
+        ],
+        "Inputs": [
+          {
+            "InputName": "SubQuery",
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 1 from authoritative where 1 != 1",
+            "Query": "select 1 from authoritative"
+          },
+          {
+            "InputName": "Outer",
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 1 as foobar, :__sq1 /* INT64 */ as `(select 1 from authoritative)` from authoritative where 1 != 1",
+            "Query": "select 1 as foobar, :__sq1 /* INT64 */ as `(select 1 from authoritative)` from authoritative where user_id = 1",
+            "Values": [
+              "1"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.authoritative"
+      ]
+    }
   },
   {
     "comment": "Nested subquery resolves alias across multiple scope levels",

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -5663,6 +5663,12 @@
     "plan": "VT12001: unsupported: correlated subquery is only supported for EXISTS"
   },
   {
+    "comment": "Literal parent alias referenced by subquery with authoritative FROM is treated as correlated",
+    "query": "SELECT 1 AS foobar, (SELECT foobar FROM authoritative) FROM authoritative WHERE user_id = 1",
+    "skip_e2e": true,
+    "plan": "VT12001: unsupported: correlated subquery is only supported for EXISTS"
+  },
+  {
     "comment": "Nested subquery resolves alias across multiple scope levels",
     "query": "SELECT user_id AS foobar, (SELECT (SELECT foobar) AS barbaz FROM authoritative WHERE foobar = 1) FROM authoritative WHERE user_id = 1",
     "skip_e2e": true,

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -5581,6 +5581,12 @@
     }
   },
   {
+    "comment": "Literal parent alias referenced from sharded subquery is correctly tagged as correlated even when outer has no explicit FROM",
+    "query": "SELECT 1 AS x, (SELECT x FROM authoritative)",
+    "skip_e2e": true,
+    "plan": "VT12001: unsupported: correlated subquery is only supported for EXISTS"
+  },
+  {
     "comment": "Subquery WHERE clause can reference parent alias",
     "query": "SELECT user_id AS foobar, (SELECT foobar WHERE foobar = 1) FROM authoritative WHERE user_id = 1",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -5559,6 +5559,204 @@
     }
   },
   {
+    "comment": "Subquery can reference parent alias in dual context",
+    "query": "SELECT 1 AS x, (SELECT x)",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "SELECT 1 AS x, (SELECT x)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select 1 as x, (select x from dual where 1 != 1) from dual where 1 != 1",
+        "Query": "select 1 as x, (select x from dual) from dual"
+      },
+      "TablesUsed": [
+        "main.dual"
+      ]
+    }
+  },
+  {
+    "comment": "Subquery WHERE clause can reference parent alias",
+    "query": "SELECT user_id AS foobar, (SELECT foobar WHERE foobar = 1) FROM authoritative WHERE user_id = 1",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "SELECT user_id AS foobar, (SELECT foobar WHERE foobar = 1) FROM authoritative WHERE user_id = 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select user_id as foobar, (select foobar from dual where 1 != 1) from authoritative where 1 != 1",
+        "Query": "select user_id as foobar, (select foobar from dual where foobar = 1) from authoritative where user_id = 1",
+        "Values": [
+          "1"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "main.dual",
+        "user.authoritative"
+      ]
+    }
+  },
+  {
+    "comment": "Subquery with own non-authoritative FROM treats unknown column as table column",
+    "query": "SELECT id AS foobar, (SELECT foobar FROM user_extra WHERE foobar = 1) FROM user WHERE id = 1",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "SELECT id AS foobar, (SELECT foobar FROM user_extra WHERE foobar = 1) FROM user WHERE id = 1",
+      "Instructions": {
+        "OperatorType": "UncorrelatedSubquery",
+        "Variant": "PulloutValue",
+        "PulloutVars": [
+          "__sq1"
+        ],
+        "Inputs": [
+          {
+            "InputName": "SubQuery",
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select foobar from user_extra where 1 != 1",
+            "Query": "select foobar from user_extra where foobar = 1"
+          },
+          {
+            "InputName": "Outer",
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id as foobar, :__sq1 as `(select foobar from user_extra where foobar = 1)` from `user` where 1 != 1",
+            "Query": "select id as foobar, :__sq1 as `(select foobar from user_extra where foobar = 1)` from `user` where id = 1",
+            "Values": [
+              "1"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "Subquery with own FROM falls back to parent alias when column not in table",
+    "query": "SELECT user_id AS foobar, (SELECT foobar FROM authoritative WHERE foobar = 1) FROM authoritative WHERE user_id = 1",
+    "plan": "VT12001: unsupported: correlated subquery is only supported for EXISTS"
+  },
+  {
+    "comment": "Nested subquery resolves alias across multiple scope levels",
+    "query": "SELECT user_id AS foobar, (SELECT (SELECT foobar) AS barbaz FROM authoritative WHERE foobar = 1) FROM authoritative WHERE user_id = 1",
+    "plan": "VT12001: unsupported: correlated subquery is only supported for EXISTS"
+  },
+  {
+    "comment": "Nested subquery resolves alias across multiple dual scopes",
+    "query": "SELECT 1 AS foobar, (SELECT (SELECT foobar) AS barbaz)",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "SELECT 1 AS foobar, (SELECT (SELECT foobar) AS barbaz)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select 1 as foobar, (select foobar from dual where 1 != 1) as `(select (select foobar from dual) as barbaz from dual)` from dual where 1 != 1",
+        "Query": "select 1 as foobar, (select foobar from dual) as `(select (select foobar from dual) as barbaz from dual)` from dual"
+      },
+      "TablesUsed": [
+        "main.dual"
+      ]
+    }
+  },
+  {
+    "comment": "Subquery referencing compound expression alias is correctly correlated",
+    "query": "SELECT user_id + 1 AS foobar, (SELECT foobar FROM authoritative WHERE foobar = 1) FROM authoritative WHERE user_id = 1",
+    "plan": "VT12001: unsupported: correlated subquery is only supported for EXISTS"
+  },
+  {
+    "comment": "Duplicate aliases - subquery resolves to first matching alias, matching MySQL behavior",
+    "query": "SELECT user_id AS foobar, col1 AS foobar, (SELECT foobar) FROM authoritative WHERE user_id = 1",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "SELECT user_id AS foobar, col1 AS foobar, (SELECT foobar) FROM authoritative WHERE user_id = 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select user_id as foobar, col1 as foobar, (select foobar from dual where 1 != 1) from authoritative where 1 != 1",
+        "Query": "select user_id as foobar, col1 as foobar, (select foobar from dual) from authoritative where user_id = 1",
+        "Values": [
+          "1"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "main.dual",
+        "user.authoritative"
+      ]
+    }
+  },
+  {
+    "comment": "Forward reference to alias in subquery should fail",
+    "query": "SELECT (SELECT foobar FROM authoritative), user_id AS foobar FROM authoritative WHERE user_id = 1",
+    "plan": "column 'foobar' not found"
+  },
+  {
+    "comment": "Qualified column in subquery does not match parent alias",
+    "query": "SELECT user_id AS foobar, (SELECT asdf.foobar) FROM authoritative AS asdf WHERE user_id = 1",
+    "plan": "column 'asdf.foobar' not found"
+  },
+  {
+    "comment": "Subquery can reference parent alias even when parent has FROM clause",
+    "query": "SELECT user_id AS foobar, (SELECT foobar) FROM authoritative WHERE user_id = 1",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "SELECT user_id AS foobar, (SELECT foobar) FROM authoritative WHERE user_id = 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select user_id as foobar, (select foobar from dual where 1 != 1) from authoritative where 1 != 1",
+        "Query": "select user_id as foobar, (select foobar from dual) from authoritative where user_id = 1",
+        "Values": [
+          "1"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "main.dual",
+        "user.authoritative"
+      ]
+    }
+  },
+  {
     "comment": "duplicate uncorrelated subqueries each get their own pullout",
     "query": "SELECT (SELECT count(*) FROM user_extra), (SELECT count(*) FROM user_extra) FROM user WHERE id = 1",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -5697,12 +5697,18 @@
     "plan": "VT12001: unsupported: correlated subquery is only supported for EXISTS"
   },
   {
-    "comment": "Duplicate aliases - subquery resolves to first matching alias, matching MySQL behavior",
-    "query": "SELECT user_id AS foobar, col1 AS foobar, (SELECT foobar) FROM authoritative WHERE user_id = 1",
+    "comment": "Duplicate column aliases in subquery are ambiguous in MySQL",
+    "query": "SELECT user_id AS foobar, col1 AS foobar, (SELECT foobar FROM authoritative WHERE foobar = 1) FROM authoritative WHERE user_id = 1",
+    "skip_e2e": true,
+    "plan": "Column 'foobar' in field list is ambiguous"
+  },
+  {
+    "comment": "Duplicate literal aliases - subquery resolves to first matching alias, matching MySQL behavior",
+    "query": "SELECT 1 AS foobar, 2 AS foobar, (SELECT foobar) FROM authoritative WHERE user_id = 1",
     "plan": {
       "Type": "Passthrough",
       "QueryType": "SELECT",
-      "Original": "SELECT user_id AS foobar, col1 AS foobar, (SELECT foobar) FROM authoritative WHERE user_id = 1",
+      "Original": "SELECT 1 AS foobar, 2 AS foobar, (SELECT foobar) FROM authoritative WHERE user_id = 1",
       "Instructions": {
         "OperatorType": "Route",
         "Variant": "EqualUnique",
@@ -5710,8 +5716,8 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select user_id as foobar, col1 as foobar, (select foobar from dual where 1 != 1) from authoritative where 1 != 1",
-        "Query": "select user_id as foobar, col1 as foobar, (select foobar from dual) from authoritative where user_id = 1",
+        "FieldQuery": "select 1 as foobar, 2 as foobar, (select foobar from dual where 1 != 1) from authoritative where 1 != 1",
+        "Query": "select 1 as foobar, 2 as foobar, (select foobar from dual) from authoritative where user_id = 1",
         "Values": [
           "1"
         ],
@@ -5726,11 +5732,13 @@
   {
     "comment": "Forward reference to alias in subquery should fail",
     "query": "SELECT (SELECT foobar FROM authoritative), user_id AS foobar FROM authoritative WHERE user_id = 1",
+    "skip_e2e": true,
     "plan": "column 'foobar' not found"
   },
   {
     "comment": "Qualified column in subquery does not match parent alias",
     "query": "SELECT user_id AS foobar, (SELECT asdf.foobar) FROM authoritative AS asdf WHERE user_id = 1",
+    "skip_e2e": true,
     "plan": "column 'asdf.foobar' not found"
   },
   {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -5685,8 +5685,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select 1 from authoritative where 1 != 1",
-            "Query": "select 1 from authoritative"
+            "FieldQuery": "select 1 as foobar from authoritative where 1 != 1",
+            "Query": "select 1 as foobar from authoritative"
           },
           {
             "InputName": "Outer",
@@ -5696,8 +5696,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select 1 as foobar, :__sq1 /* INT64 */ as `(select 1 from authoritative)` from authoritative where 1 != 1",
-            "Query": "select 1 as foobar, :__sq1 /* INT64 */ as `(select 1 from authoritative)` from authoritative where user_id = 1",
+            "FieldQuery": "select 1 as foobar, :__sq1 /* INT64 */ as `(select foobar from authoritative)` from authoritative where 1 != 1",
+            "Query": "select 1 as foobar, :__sq1 /* INT64 */ as `(select foobar from authoritative)` from authoritative where user_id = 1",
             "Values": [
               "1"
             ],

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -5663,52 +5663,10 @@
     "plan": "VT12001: unsupported: correlated subquery is only supported for EXISTS"
   },
   {
-    "comment": "Literal parent alias referenced by subquery is inlined so the subquery stays uncorrelated",
+    "comment": "Literal parent alias referenced by subquery rejected as correlated when subquery cannot merge with outer route",
     "query": "SELECT 1 AS foobar, (SELECT foobar FROM authoritative) FROM authoritative WHERE user_id = 1",
     "skip_e2e": true,
-    "plan": {
-      "Type": "Complex",
-      "QueryType": "SELECT",
-      "Original": "SELECT 1 AS foobar, (SELECT foobar FROM authoritative) FROM authoritative WHERE user_id = 1",
-      "Instructions": {
-        "OperatorType": "UncorrelatedSubquery",
-        "Variant": "PulloutValue",
-        "PulloutVars": [
-          "__sq1"
-        ],
-        "Inputs": [
-          {
-            "InputName": "SubQuery",
-            "OperatorType": "Route",
-            "Variant": "Scatter",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select 1 as foobar from authoritative where 1 != 1",
-            "Query": "select 1 as foobar from authoritative"
-          },
-          {
-            "InputName": "Outer",
-            "OperatorType": "Route",
-            "Variant": "EqualUnique",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select 1 as foobar, :__sq1 /* INT64 */ as `(select foobar from authoritative)` from authoritative where 1 != 1",
-            "Query": "select 1 as foobar, :__sq1 /* INT64 */ as `(select foobar from authoritative)` from authoritative where user_id = 1",
-            "Values": [
-              "1"
-            ],
-            "Vindex": "user_index"
-          }
-        ]
-      },
-      "TablesUsed": [
-        "user.authoritative"
-      ]
-    }
+    "plan": "VT12001: unsupported: correlated subquery is only supported for EXISTS"
   },
   {
     "comment": "Nested subquery resolves alias across multiple scope levels",

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -5730,6 +5730,87 @@
     }
   },
   {
+    "comment": "Column + literal sharing an alias - non-column wins, matching MySQL behavior",
+    "query": "SELECT user_id AS foobar, 99 AS foobar, (SELECT foobar) FROM authoritative WHERE user_id = 1",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "SELECT user_id AS foobar, 99 AS foobar, (SELECT foobar) FROM authoritative WHERE user_id = 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select user_id as foobar, 99 as foobar, (select foobar from dual where 1 != 1) from authoritative where 1 != 1",
+        "Query": "select user_id as foobar, 99 as foobar, (select foobar from dual) from authoritative where user_id = 1",
+        "Values": [
+          "1"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "main.dual",
+        "user.authoritative"
+      ]
+    }
+  },
+  {
+    "comment": "Literal + column sharing an alias - non-column wins, matching MySQL behavior",
+    "query": "SELECT 99 AS foobar, user_id AS foobar, (SELECT foobar) FROM authoritative WHERE user_id = 1",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "SELECT 99 AS foobar, user_id AS foobar, (SELECT foobar) FROM authoritative WHERE user_id = 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select 99 as foobar, user_id as foobar, (select foobar from dual where 1 != 1) from authoritative where 1 != 1",
+        "Query": "select 99 as foobar, user_id as foobar, (select foobar from dual) from authoritative where user_id = 1",
+        "Values": [
+          "1"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "main.dual",
+        "user.authoritative"
+      ]
+    }
+  },
+  {
+    "comment": "Non-column earlier in the select list shields later ambiguous columns from error",
+    "query": "SELECT 99 AS foobar, user_id AS foobar, col1 AS foobar, (SELECT foobar) FROM authoritative WHERE user_id = 1",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "SELECT 99 AS foobar, user_id AS foobar, col1 AS foobar, (SELECT foobar) FROM authoritative WHERE user_id = 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select 99 as foobar, user_id as foobar, col1 as foobar, (select foobar from dual where 1 != 1) from authoritative where 1 != 1",
+        "Query": "select 99 as foobar, user_id as foobar, col1 as foobar, (select foobar from dual) from authoritative where user_id = 1",
+        "Values": [
+          "1"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "main.dual",
+        "user.authoritative"
+      ]
+    }
+  },
+  {
     "comment": "Duplicate literal aliases - subquery resolves to first matching alias, matching MySQL behavior",
     "query": "SELECT 1 AS foobar, 2 AS foobar, (SELECT foobar) FROM authoritative WHERE user_id = 1",
     "plan": {

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -387,64 +387,12 @@ func (a *analyzer) analyze(statement sqlparser.Statement) error {
 
 	a.lateInit()
 
-	if err := a.lateAnalyze(statement); err != nil {
-		return err
-	}
-
-	a.applyAliasRewrites(statement)
-	return nil
+	return a.lateAnalyze(statement)
 }
 
 func (a *analyzer) lateAnalyze(statement sqlparser.SQLNode) error {
 	_ = sqlparser.Rewrite(statement, a.analyzeDown, a.analyzeUp)
 	return a.err
-}
-
-// applyAliasRewrites replaces column references that resolved to a parent
-// SELECT alias (whose expression has no table dependencies) with a clone of
-// the alias expression. Before rewriting, any unaliased AliasedExpr whose
-// Expr would change is given an explicit As so its column name in the result
-// set matches the original SQL text.
-func (a *analyzer) applyAliasRewrites(statement sqlparser.SQLNode) {
-	if len(a.binder.aliasRewrites) == 0 {
-		return
-	}
-	sqlparser.Rewrite(statement, func(cursor *sqlparser.Cursor) bool {
-		ae, ok := cursor.Node().(*sqlparser.AliasedExpr)
-		if !ok || ae.As.NotEmpty() {
-			return true
-		}
-		if !a.exprContainsRewrite(ae.Expr) {
-			return true
-		}
-		ae.As = sqlparser.NewIdentifierCI(sqlparser.String(ae.Expr))
-		return true
-	}, func(cursor *sqlparser.Cursor) bool {
-		col, ok := cursor.Node().(*sqlparser.ColName)
-		if !ok {
-			return true
-		}
-		if expr, found := a.binder.aliasRewrites[col]; found {
-			cursor.Replace(sqlparser.Clone(expr))
-		}
-		return true
-	})
-}
-
-// exprContainsRewrite reports whether expr contains a ColName that is
-// scheduled to be replaced by applyAliasRewrites.
-func (a *analyzer) exprContainsRewrite(expr sqlparser.Expr) bool {
-	found := false
-	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
-		if col, ok := node.(*sqlparser.ColName); ok {
-			if _, ok := a.binder.aliasRewrites[col]; ok {
-				found = true
-				return false, nil
-			}
-		}
-		return true, nil
-	}, expr)
-	return found
 }
 
 func (a *analyzer) reAnalyze(statement sqlparser.SQLNode) error {

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -387,14 +387,16 @@ func (a *analyzer) analyze(statement sqlparser.Statement) error {
 
 	a.lateInit()
 
-	return a.lateAnalyze(statement)
+	if err := a.lateAnalyze(statement); err != nil {
+		return err
+	}
+
+	a.applyAliasRewrites(statement)
+	return nil
 }
 
 func (a *analyzer) lateAnalyze(statement sqlparser.SQLNode) error {
 	_ = sqlparser.Rewrite(statement, a.analyzeDown, a.analyzeUp)
-	if a.err == nil {
-		a.applyAliasRewrites(statement)
-	}
 	return a.err
 }
 

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -392,7 +392,57 @@ func (a *analyzer) analyze(statement sqlparser.Statement) error {
 
 func (a *analyzer) lateAnalyze(statement sqlparser.SQLNode) error {
 	_ = sqlparser.Rewrite(statement, a.analyzeDown, a.analyzeUp)
+	if a.err == nil {
+		a.applyAliasRewrites(statement)
+	}
 	return a.err
+}
+
+// applyAliasRewrites replaces column references that resolved to a parent
+// SELECT alias (whose expression has no table dependencies) with a clone of
+// the alias expression. Before rewriting, any unaliased AliasedExpr whose
+// Expr would change is given an explicit As so its column name in the result
+// set matches the original SQL text.
+func (a *analyzer) applyAliasRewrites(statement sqlparser.SQLNode) {
+	if len(a.binder.aliasRewrites) == 0 {
+		return
+	}
+	sqlparser.Rewrite(statement, func(cursor *sqlparser.Cursor) bool {
+		ae, ok := cursor.Node().(*sqlparser.AliasedExpr)
+		if !ok || ae.As.NotEmpty() {
+			return true
+		}
+		if !a.exprContainsRewrite(ae.Expr) {
+			return true
+		}
+		ae.As = sqlparser.NewIdentifierCI(sqlparser.String(ae.Expr))
+		return true
+	}, func(cursor *sqlparser.Cursor) bool {
+		col, ok := cursor.Node().(*sqlparser.ColName)
+		if !ok {
+			return true
+		}
+		if expr, found := a.binder.aliasRewrites[col]; found {
+			cursor.Replace(sqlparser.Clone(expr))
+		}
+		return true
+	})
+}
+
+// exprContainsRewrite reports whether expr contains a ColName that is
+// scheduled to be replaced by applyAliasRewrites.
+func (a *analyzer) exprContainsRewrite(expr sqlparser.Expr) bool {
+	found := false
+	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+		if col, ok := node.(*sqlparser.ColName); ok {
+			if _, ok := a.binder.aliasRewrites[col]; ok {
+				found = true
+				return false, nil
+			}
+		}
+		return true, nil
+	}, expr)
+	return found
 }
 
 func (a *analyzer) reAnalyze(statement sqlparser.SQLNode) error {

--- a/go/vt/vtgate/semantics/analyzer_alias_scope_test.go
+++ b/go/vt/vtgate/semantics/analyzer_alias_scope_test.go
@@ -73,6 +73,45 @@ func TestSubqueryParentAliasResolution(t *testing.T) {
 	}
 }
 
+// TestSubqueryParentAliasDualFallback covers the path where the subquery has
+// no explicit FROM and the parser injects `dual`. `dual` is non-authoritative,
+// so resolveColumnInScope returns an uncertain dep at the inner scope and the
+// loop short-circuits before ever reaching the parent-alias check. The end-
+// user query still works (the dual subquery merges with the outer route at
+// planbuilder time and MySQL resolves the alias itself), but the binder
+// resolves the inner column reference to the inner subquery's `dual`, not to
+// the outer alias. This test pins that behaviour so future refactors don't
+// silently change which path handles these shapes.
+func TestSubqueryParentAliasDualFallback(t *testing.T) {
+	tcases := []struct {
+		sql string
+	}{{
+		// Both outer and inner have no FROM — each gets its own implicit dual.
+		sql: "select 1 as x, (select x)",
+	}, {
+		// Outer has a real authoritative FROM, inner gets an implicit dual.
+		sql: "select id as foobar, (select foobar) from t1",
+	}, {
+		// Same as above but with a literal alias.
+		sql: "select 1 as foobar, (select foobar) from t1",
+	}}
+	for _, tc := range tcases {
+		t.Run(tc.sql, func(t *testing.T) {
+			stmt, semTable := parseAndAnalyze(t, tc.sql, "d")
+			sel := stmt.(*sqlparser.Select)
+
+			subq := extract(sel, 1).(*sqlparser.Subquery).Select.(*sqlparser.Select)
+			innerDual := subq.From[0].(*sqlparser.AliasedTableExpr)
+			innerCol := extract(subq, 0)
+
+			require.NoError(t, semTable.NotSingleRouteErr)
+			// The inner column's deps point to the inner subquery's own dual,
+			// not to the outer scope — i.e. the alias path was not used.
+			assert.Equal(t, semTable.TableSetFor(innerDual), semTable.RecursiveDeps(innerCol))
+		})
+	}
+}
+
 // TestSubqueryParentAliasNestedResolution covers the nested case: an inner
 // subquery references an alias defined two scope levels above. Both inner
 // subqueries use authoritative FROM tables that don't contain `foobar`.

--- a/go/vt/vtgate/semantics/analyzer_alias_scope_test.go
+++ b/go/vt/vtgate/semantics/analyzer_alias_scope_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package semantics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+// Each test in this file uses a subquery with its own authoritative FROM
+// table that does NOT contain the alias name as a column. That forces the
+// inner resolveColumnInScope to return `nothing` (empty deps), which in turn
+// triggers the parent-alias path on the outer scope — exactly the behaviour
+// this PR adds. If the subquery had no FROM, the parser would inject `dual`,
+// which is non-authoritative and short-circuits with an uncertain dep before
+// the alias path ever runs.
+
+// TestSubqueryParentAliasResolution covers the resolveColumn parent-alias path:
+// a subquery column reference that resolves against a parent SELECT alias must
+// take on the alias expression's table dependencies — or, when the alias has
+// no table deps (literal alias), be marked as correlated to the outer scope.
+func TestSubqueryParentAliasResolution(t *testing.T) {
+	tcases := []struct {
+		sql  string
+		deps TableSet
+	}{{
+		// Column alias propagates the outer table dep.
+		sql:  "select id as foobar, (select foobar from t2) from t1",
+		deps: TS0,
+	}, {
+		// Compound alias still propagates the outer table dep.
+		sql:  "select id+1 as foobar, (select foobar from t2) from t1",
+		deps: TS0,
+	}, {
+		// Literal alias has no table deps; the reference is correlated to the
+		// outer scope's tables.
+		sql:  "select 1 as foobar, (select foobar from t2) from t1",
+		deps: TS0,
+	}, {
+		// An outer WHERE clause does not change the resolution.
+		sql:  "select id as foobar, (select foobar from t2) from t1 where id = 1",
+		deps: TS0,
+	}}
+	for _, tc := range tcases {
+		t.Run(tc.sql, func(t *testing.T) {
+			stmt, semTable := parseAndAnalyze(t, tc.sql, "d")
+			sel := stmt.(*sqlparser.Select)
+
+			subq := extract(sel, 1).(*sqlparser.Subquery).Select.(*sqlparser.Select)
+			innerCol := extract(subq, 0)
+
+			require.NoError(t, semTable.NotSingleRouteErr)
+			assert.Equal(t, tc.deps, semTable.RecursiveDeps(innerCol))
+		})
+	}
+}
+
+// TestSubqueryParentAliasNestedResolution covers the nested case: an inner
+// subquery references an alias defined two scope levels above. Both inner
+// subqueries use authoritative FROM tables that don't contain `foobar`.
+func TestSubqueryParentAliasNestedResolution(t *testing.T) {
+	stmt, semTable := parseAndAnalyze(t, "select 1 as foobar, (select (select foobar from t2) as barbaz from t3) from t1", "d")
+	sel := stmt.(*sqlparser.Select)
+
+	middle := extract(sel, 1).(*sqlparser.Subquery).Select.(*sqlparser.Select)
+	inner := extract(middle, 0).(*sqlparser.Subquery).Select.(*sqlparser.Select)
+	innerCol := extract(inner, 0)
+
+	require.NoError(t, semTable.NotSingleRouteErr)
+	assert.Equal(t, TS0, semTable.RecursiveDeps(innerCol))
+}
+
+// TestSubqueryParentAliasErrors covers the gates that reject invalid alias
+// references: forward references, qualified column refs, same-scope refs, and
+// duplicate-alias ambiguity.
+func TestSubqueryParentAliasErrors(t *testing.T) {
+	tcases := []struct {
+		name string
+		sql  string
+		// errSubstr is matched against either the analyze error or
+		// SemTable.NotUnshardedErr, whichever surfaces first.
+		errSubstr string
+	}{{
+		name:      "forward reference rejected",
+		sql:       "select (select foobar from t2), id as foobar from t1",
+		errSubstr: "column 'foobar' not found",
+	}, {
+		name:      "qualified column does not match alias",
+		sql:       "select id as foobar, (select x.foobar from t2) from t1 as x",
+		errSubstr: "column 'x.foobar' not found",
+	}, {
+		name:      "same-scope alias reference is not resolved as alias",
+		sql:       "select 1 as x, x from t1",
+		errSubstr: "column 'x' not found",
+	}, {
+		name:      "duplicate bare-column aliases are ambiguous",
+		sql:       "select id as foobar, uid as foobar, (select foobar from t3) from t1, t2",
+		errSubstr: "Column 'foobar' in field list is ambiguous",
+	}}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			parse, err := sqlparser.NewTestParser().Parse(tc.sql)
+			require.NoError(t, err)
+
+			st, err := Analyze(parse, "d", fakeSchemaInfo())
+			if err != nil {
+				assert.ErrorContains(t, err, tc.errSubstr)
+				return
+			}
+			require.NotNil(t, st.NotUnshardedErr, "expected an error from Analyze or via NotUnshardedErr")
+			assert.ErrorContains(t, st.NotUnshardedErr, tc.errSubstr)
+		})
+	}
+}
+
+// TestSubqueryParentAliasDuplicateResolution covers the non-error cases of the
+// duplicate-alias logic: same-column-same-alias, non-column expression beats
+// bare column, and shielded ambiguity.
+func TestSubqueryParentAliasDuplicateResolution(t *testing.T) {
+	tcases := []struct {
+		sql  string
+		deps TableSet
+	}{{
+		// Repeated same column under same alias is not ambiguous.
+		sql:  "select id as foobar, id as foobar, (select foobar from t2) from t1",
+		deps: TS0,
+	}, {
+		// Non-column expression beats bare column when both share an alias.
+		sql:  "select id as foobar, 99 as foobar, (select foobar from t2) from t1",
+		deps: TS0,
+	}, {
+		// Order doesn't matter — non-column still wins.
+		sql:  "select 99 as foobar, id as foobar, (select foobar from t2) from t1",
+		deps: TS0,
+	}, {
+		// Shielded ambiguity: a non-column already in the match buffer
+		// protects against a later column-vs-column collision. The literal
+		// alias has empty deps, so the reference is correlated to the union
+		// of the outer scope's tables.
+		sql:  "select 99 as foobar, id as foobar, uid as foobar, (select foobar from t3) from t1, t2",
+		deps: MergeTableSets(TS0, TS1),
+	}}
+	for _, tc := range tcases {
+		t.Run(tc.sql, func(t *testing.T) {
+			stmt, semTable := parseAndAnalyze(t, tc.sql, "d")
+			sel := stmt.(*sqlparser.Select)
+
+			// Locate the subquery — it's the last AliasedExpr whose Expr is a
+			// Subquery.
+			var subq *sqlparser.Subquery
+			for _, se := range sel.SelectExprs.Exprs {
+				ae, ok := se.(*sqlparser.AliasedExpr)
+				if !ok {
+					continue
+				}
+				if s, ok := ae.Expr.(*sqlparser.Subquery); ok {
+					subq = s
+				}
+			}
+			require.NotNil(t, subq, "no subquery found in: %s", tc.sql)
+
+			innerSel := subq.Select.(*sqlparser.Select)
+			innerCol := extract(innerSel, 0)
+
+			require.NoError(t, semTable.NotSingleRouteErr)
+			assert.Equal(t, tc.deps, semTable.RecursiveDeps(innerCol))
+		})
+	}
+}

--- a/go/vt/vtgate/semantics/analyzer_alias_scope_test.go
+++ b/go/vt/vtgate/semantics/analyzer_alias_scope_test.go
@@ -25,37 +25,24 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
-// Each test in this file uses a subquery with its own authoritative FROM
-// table that does NOT contain the alias name as a column. That forces the
-// inner resolveColumnInScope to return `nothing` (empty deps), which in turn
-// triggers the parent-alias path on the outer scope — exactly the behaviour
-// this PR adds. If the subquery had no FROM, the parser would inject `dual`,
-// which is non-authoritative and short-circuits with an uncertain dep before
-// the alias path ever runs.
-
-// TestSubqueryParentAliasResolution covers the resolveColumn parent-alias path:
-// a subquery column reference that resolves against a parent SELECT alias must
-// take on the alias expression's table dependencies — or, when the alias has
-// no table deps (literal alias), be marked as correlated to the outer scope.
+// TestSubqueryParentAliasResolution checks that a subquery column reference
+// that matches a parent SELECT alias is reported as depending on the alias
+// expression's tables. Literal aliases (no table dependencies of their own)
+// are reported as correlated to the outer scope.
 func TestSubqueryParentAliasResolution(t *testing.T) {
 	tcases := []struct {
 		sql  string
 		deps TableSet
 	}{{
-		// Column alias propagates the outer table dep.
 		sql:  "select id as foobar, (select foobar from t2) from t1",
 		deps: TS0,
 	}, {
-		// Compound alias still propagates the outer table dep.
 		sql:  "select id+1 as foobar, (select foobar from t2) from t1",
 		deps: TS0,
 	}, {
-		// Literal alias has no table deps; the reference is correlated to the
-		// outer scope's tables.
 		sql:  "select 1 as foobar, (select foobar from t2) from t1",
 		deps: TS0,
 	}, {
-		// An outer WHERE clause does not change the resolution.
 		sql:  "select id as foobar, (select foobar from t2) from t1 where id = 1",
 		deps: TS0,
 	}}
@@ -73,26 +60,20 @@ func TestSubqueryParentAliasResolution(t *testing.T) {
 	}
 }
 
-// TestSubqueryParentAliasDualFallback covers the path where the subquery has
-// no explicit FROM and the parser injects `dual`. `dual` is non-authoritative,
-// so resolveColumnInScope returns an uncertain dep at the inner scope and the
-// loop short-circuits before ever reaching the parent-alias check. The end-
-// user query still works (the dual subquery merges with the outer route at
-// planbuilder time and MySQL resolves the alias itself), but the binder
-// resolves the inner column reference to the inner subquery's `dual`, not to
-// the outer alias. This test pins that behaviour so future refactors don't
-// silently change which path handles these shapes.
+// TestSubqueryParentAliasDualFallback covers subqueries with no explicit FROM,
+// where the parser injects an implicit `dual`. The inner column reference is
+// reported as depending on that implicit `dual` rather than on the outer
+// alias. End-user behaviour still matches MySQL because the dual subquery is
+// merged into the outer route at planning time and MySQL itself resolves the
+// alias on the merged single-shard query.
 func TestSubqueryParentAliasDualFallback(t *testing.T) {
 	tcases := []struct {
 		sql string
 	}{{
-		// Both outer and inner have no FROM — each gets its own implicit dual.
 		sql: "select 1 as x, (select x)",
 	}, {
-		// Outer has a real authoritative FROM, inner gets an implicit dual.
 		sql: "select id as foobar, (select foobar) from t1",
 	}, {
-		// Same as above but with a literal alias.
 		sql: "select 1 as foobar, (select foobar) from t1",
 	}}
 	for _, tc := range tcases {
@@ -105,16 +86,13 @@ func TestSubqueryParentAliasDualFallback(t *testing.T) {
 			innerCol := extract(subq, 0)
 
 			require.NoError(t, semTable.NotSingleRouteErr)
-			// The inner column's deps point to the inner subquery's own dual,
-			// not to the outer scope — i.e. the alias path was not used.
 			assert.Equal(t, semTable.TableSetFor(innerDual), semTable.RecursiveDeps(innerCol))
 		})
 	}
 }
 
-// TestSubqueryParentAliasNestedResolution covers the nested case: an inner
-// subquery references an alias defined two scope levels above. Both inner
-// subqueries use authoritative FROM tables that don't contain `foobar`.
+// TestSubqueryParentAliasNestedResolution checks that an alias defined two
+// scope levels above the reference is still reachable.
 func TestSubqueryParentAliasNestedResolution(t *testing.T) {
 	stmt, semTable := parseAndAnalyze(t, "select 1 as foobar, (select (select foobar from t2) as barbaz from t3) from t1", "d")
 	sel := stmt.(*sqlparser.Select)
@@ -127,15 +105,13 @@ func TestSubqueryParentAliasNestedResolution(t *testing.T) {
 	assert.Equal(t, TS0, semTable.RecursiveDeps(innerCol))
 }
 
-// TestSubqueryParentAliasErrors covers the gates that reject invalid alias
-// references: forward references, qualified column refs, same-scope refs, and
-// duplicate-alias ambiguity.
+// TestSubqueryParentAliasErrors covers the cases that match MySQL by failing
+// rather than resolving: forward alias references, qualified column refs,
+// same-scope references, and ambiguous duplicate aliases.
 func TestSubqueryParentAliasErrors(t *testing.T) {
 	tcases := []struct {
-		name string
-		sql  string
-		// errSubstr is matched against either the analyze error or
-		// SemTable.NotUnshardedErr, whichever surfaces first.
+		name      string
+		sql       string
 		errSubstr string
 	}{{
 		name:      "forward reference rejected",
@@ -170,30 +146,25 @@ func TestSubqueryParentAliasErrors(t *testing.T) {
 	}
 }
 
-// TestSubqueryParentAliasDuplicateResolution covers the non-error cases of the
-// duplicate-alias logic: same-column-same-alias, non-column expression beats
-// bare column, and shielded ambiguity.
+// TestSubqueryParentAliasDuplicateResolution covers the duplicate-alias cases
+// that resolve cleanly: the same column repeated under the same alias, a
+// non-column expression sharing an alias with a bare column (the non-column
+// wins regardless of order), and the same alias on three or more expressions
+// where at least one is a non-column.
 func TestSubqueryParentAliasDuplicateResolution(t *testing.T) {
 	tcases := []struct {
 		sql  string
 		deps TableSet
 	}{{
-		// Repeated same column under same alias is not ambiguous.
 		sql:  "select id as foobar, id as foobar, (select foobar from t2) from t1",
 		deps: TS0,
 	}, {
-		// Non-column expression beats bare column when both share an alias.
 		sql:  "select id as foobar, 99 as foobar, (select foobar from t2) from t1",
 		deps: TS0,
 	}, {
-		// Order doesn't matter — non-column still wins.
 		sql:  "select 99 as foobar, id as foobar, (select foobar from t2) from t1",
 		deps: TS0,
 	}, {
-		// Shielded ambiguity: a non-column already in the match buffer
-		// protects against a later column-vs-column collision. The literal
-		// alias has empty deps, so the reference is correlated to the union
-		// of the outer scope's tables.
 		sql:  "select 99 as foobar, id as foobar, uid as foobar, (select foobar from t3) from t1, t2",
 		deps: MergeTableSets(TS0, TS1),
 	}}
@@ -202,8 +173,6 @@ func TestSubqueryParentAliasDuplicateResolution(t *testing.T) {
 			stmt, semTable := parseAndAnalyze(t, tc.sql, "d")
 			sel := stmt.(*sqlparser.Select)
 
-			// Locate the subquery — it's the last AliasedExpr whose Expr is a
-			// Subquery.
 			var subq *sqlparser.Subquery
 			for _, se := range sel.SelectExprs.Exprs {
 				ae, ok := se.(*sqlparser.AliasedExpr)

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -499,7 +499,7 @@ func (b *binder) resolveColumnInScope(current *scope, expr *sqlparser.ColName, a
 
 func (b *binder) findMatchingAlias(sel *sqlparser.Select, lowered string) (*sqlparser.AliasedExpr, error) {
 	var match *sqlparser.AliasedExpr
-	for _, selExpr := range sel.SelectExprs.Exprs {
+	for _, selExpr := range sel.GetColumns() {
 		ae, ok := selExpr.(*sqlparser.AliasedExpr)
 		if !ok {
 			continue

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -47,6 +47,12 @@ type binder struct {
 	// walked. This is used to reject forward references to aliases in
 	// subqueries, matching MySQL's behavior.
 	availableAliases map[*sqlparser.AliasedExpr]struct{}
+
+	// aliasRewrites records column references that resolved to a parent
+	// SELECT alias whose expression has no table dependencies. These
+	// references are replaced with a clone of the alias expression so the
+	// subquery stays uncorrelated and can be planned as a standalone query.
+	aliasRewrites map[*sqlparser.ColName]sqlparser.Expr
 }
 
 func newBinder(scoper *scoper, org originable, tc *tableCollector, typer *typer) *binder {
@@ -59,6 +65,7 @@ func newBinder(scoper *scoper, org originable, tc *tableCollector, typer *typer)
 		typer:            typer,
 		usingJoinInfo:    map[TableSet]map[string]TableSet{},
 		availableAliases: map[*sqlparser.AliasedExpr]struct{}{},
+		aliasRewrites:    map[*sqlparser.ColName]sqlparser.Expr{},
 	}
 }
 
@@ -69,7 +76,13 @@ func (b *binder) up(cursor *sqlparser.Cursor) error {
 	case *sqlparser.JoinCondition:
 		return b.bindJoinCondition(node)
 	case *sqlparser.ColName:
-		return b.bindColName(node)
+		if err := b.bindColName(node); err != nil {
+			return err
+		}
+		if expr, ok := b.aliasRewrites[node]; ok {
+			cursor.Replace(sqlparser.Clone(expr))
+		}
+		return nil
 	case *sqlparser.CountStar:
 		return b.bindCountStar(node)
 	case *sqlparser.Union:
@@ -331,16 +344,13 @@ func (b *binder) resolveColumn(colName *sqlparser.ColName, current *scope, allow
 					typ := b.typer.exprType(ae.Expr)
 					if recursive.IsEmpty() && direct.IsEmpty() {
 						// The aliased expression has no table dependencies
-						// (e.g. a literal such as `1 AS x`). Attach the parent
-						// scope's tables so the subquery is still classified
-						// as correlated; otherwise the planner may pull it out
-						// and emit SQL that references the alias name as if it
-						// were a column of the subquery's own tables.
-						for _, tbl := range current.tables {
-							ts := tbl.getTableSet(b.org)
-							recursive = recursive.Merge(ts)
-							direct = direct.Merge(ts)
-						}
+						// (e.g. a literal such as `1 AS x`). Schedule a
+						// rewrite of this column reference to a clone of the
+						// alias expression so the subquery stays truly
+						// uncorrelated and can be planned as a standalone
+						// query instead of emitting SQL that references the
+						// alias name as if it were a column of the subquery.
+						b.aliasRewrites[colName] = ae.Expr
 					}
 					return dependency{certain: true, recursive: recursive, direct: direct, typ: typ}, nil
 				}

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -515,11 +515,11 @@ func (b *binder) findMatchingAlias(sel *sqlparser.Select, lowered string) (*sqlp
 			continue
 		}
 		// MySQL only reports ambiguity when two different bare column
-		// references share the same alias. Literals and expressions
-		// are allowed to duplicate.
+		// references share the same alias. Repeating the same column,
+		// literals, and expressions are allowed to duplicate.
 		_, matchIsCol := match.Expr.(*sqlparser.ColName)
 		_, thisIsCol := ae.Expr.(*sqlparser.ColName)
-		if matchIsCol && thisIsCol {
+		if matchIsCol && thisIsCol && !sqlparser.Equals.Expr(match.Expr, ae.Expr) {
 			return nil, newAmbiguousColumnError(sqlparser.NewColName(lowered))
 		}
 	}

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -329,6 +329,19 @@ func (b *binder) resolveColumn(colName *sqlparser.ColName, current *scope, allow
 					recursive := b.recursive.dependencies(ae.Expr)
 					direct := b.direct.dependencies(ae.Expr)
 					typ := b.typer.exprType(ae.Expr)
+					if recursive.IsEmpty() && direct.IsEmpty() {
+						// The aliased expression has no table dependencies
+						// (e.g. a literal such as `1 AS x`). Attach the parent
+						// scope's tables so the subquery is still classified
+						// as correlated; otherwise the planner may pull it out
+						// and emit SQL that references the alias name as if it
+						// were a column of the subquery's own tables.
+						for _, tbl := range current.tables {
+							ts := tbl.getTableSet(b.org)
+							recursive = recursive.Merge(ts)
+							direct = direct.Merge(ts)
+						}
+					}
 					return dependency{certain: true, recursive: recursive, direct: direct, typ: typ}, nil
 				}
 			}

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -42,17 +42,23 @@ type binder struct {
 	// that this map is joined with using USING.
 	// This information is used to expand `*` correctly, and is not available post-analysis
 	usingJoinInfo map[TableSet]map[string]TableSet
+
+	// availableAliases tracks which AliasedExpr nodes have been fully
+	// walked. This is used to reject forward references to aliases in
+	// subqueries, matching MySQL's behavior.
+	availableAliases map[*sqlparser.AliasedExpr]struct{}
 }
 
 func newBinder(scoper *scoper, org originable, tc *tableCollector, typer *typer) *binder {
 	return &binder{
-		recursive:     map[sqlparser.Expr]TableSet{},
-		direct:        map[sqlparser.Expr]TableSet{},
-		scoper:        scoper,
-		org:           org,
-		tc:            tc,
-		typer:         typer,
-		usingJoinInfo: map[TableSet]map[string]TableSet{},
+		recursive:        map[sqlparser.Expr]TableSet{},
+		direct:           map[sqlparser.Expr]TableSet{},
+		scoper:           scoper,
+		org:              org,
+		tc:               tc,
+		typer:            typer,
+		usingJoinInfo:    map[TableSet]map[string]TableSet{},
+		availableAliases: map[*sqlparser.AliasedExpr]struct{}{},
 	}
 }
 
@@ -74,6 +80,11 @@ func (b *binder) up(cursor *sqlparser.Cursor) error {
 		return b.bindUpdateExpr(node)
 	case *sqlparser.OverClause:
 		return b.bindOverClause(node)
+	case *sqlparser.AliasedExpr:
+		if node.As.NotEmpty() {
+			b.availableAliases[node] = struct{}{}
+		}
+		return nil
 	default:
 		return nil
 	}
@@ -299,6 +310,25 @@ func (b *binder) resolveColumn(colName *sqlparser.ColName, current *scope, allow
 		if !thisDeps.empty() {
 			return thisDeps.get(colName)
 		}
+		// For parent scopes only (not the original scope), check if a
+		// SELECT alias satisfies the column reference. Table columns from
+		// resolveColumnInScope above take precedence over aliases.
+		// Same-scope alias references (e.g. SELECT 1 AS x, x) are not
+		// valid in MySQL, so this is gated on !first.
+		if !first && colName.Qualifier.IsEmpty() {
+			if sel, ok := current.stmt.(*sqlparser.Select); ok {
+				if ae := b.findMatchingAlias(sel, colName.Name.String()); ae != nil {
+					// Use the dependencies of the aliased expression so the
+					// reference is correctly tracked as correlated.
+					// We use .dependencies() instead of direct map lookup
+					// to handle compound expressions (e.g. user_id+1 AS foobar).
+					recursive := b.recursive.dependencies(ae.Expr)
+					direct := b.direct.dependencies(ae.Expr)
+					typ := b.typer.exprType(ae.Expr)
+					return dependency{certain: true, recursive: recursive, direct: direct, typ: typ}, nil
+				}
+			}
+		}
 		if current.parent == nil &&
 			len(current.tables) == 1 &&
 			first &&
@@ -461,6 +491,24 @@ func (b *binder) resolveColumnInScope(current *scope, expr *sqlparser.ColName, a
 		return nil, NotSingleRouteErr{Inner: newAmbiguousColumnError(expr)}
 	}
 	return deps, nil
+}
+
+func (b *binder) findMatchingAlias(sel *sqlparser.Select, name string) *sqlparser.AliasedExpr {
+	lowered := strings.ToLower(name)
+	for _, selExpr := range sel.SelectExprs.Exprs {
+		ae, ok := selExpr.(*sqlparser.AliasedExpr)
+		if !ok {
+			continue
+		}
+		if ae.As.Lowered() != lowered {
+			continue
+		}
+		if _, available := b.availableAliases[ae]; !available {
+			return nil
+		}
+		return ae
+	}
+	return nil
 }
 
 // GetSubqueryAndOtherSide returns the subquery and other side of a comparison, iff one of the sides is a SubQuery

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -317,7 +317,11 @@ func (b *binder) resolveColumn(colName *sqlparser.ColName, current *scope, allow
 		// valid in MySQL, so this is gated on !first.
 		if !first && colName.Qualifier.IsEmpty() {
 			if sel, ok := current.stmt.(*sqlparser.Select); ok {
-				if ae := b.findMatchingAlias(sel, colName.Name.Lowered()); ae != nil {
+				ae, err := b.findMatchingAlias(sel, colName.Name.Lowered())
+				if err != nil {
+					return dependency{}, err
+				}
+				if ae != nil {
 					// Use the dependencies of the aliased expression so the
 					// reference is correctly tracked as correlated.
 					// We use .dependencies() instead of direct map lookup
@@ -493,7 +497,8 @@ func (b *binder) resolveColumnInScope(current *scope, expr *sqlparser.ColName, a
 	return deps, nil
 }
 
-func (b *binder) findMatchingAlias(sel *sqlparser.Select, lowered string) *sqlparser.AliasedExpr {
+func (b *binder) findMatchingAlias(sel *sqlparser.Select, lowered string) (*sqlparser.AliasedExpr, error) {
+	var match *sqlparser.AliasedExpr
 	for _, selExpr := range sel.SelectExprs.Exprs {
 		ae, ok := selExpr.(*sqlparser.AliasedExpr)
 		if !ok {
@@ -503,11 +508,22 @@ func (b *binder) findMatchingAlias(sel *sqlparser.Select, lowered string) *sqlpa
 			continue
 		}
 		if _, available := b.availableAliases[ae]; !available {
-			return nil
+			return nil, nil
 		}
-		return ae
+		if match == nil {
+			match = ae
+			continue
+		}
+		// MySQL only reports ambiguity when two different bare column
+		// references share the same alias. Literals and expressions
+		// are allowed to duplicate.
+		_, matchIsCol := match.Expr.(*sqlparser.ColName)
+		_, thisIsCol := ae.Expr.(*sqlparser.ColName)
+		if matchIsCol && thisIsCol {
+			return nil, newAmbiguousColumnError(sqlparser.NewColName(lowered))
+		}
 	}
-	return nil
+	return match, nil
 }
 
 // GetSubqueryAndOtherSide returns the subquery and other side of a comparison, iff one of the sides is a SubQuery

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -508,7 +508,7 @@ func (b *binder) findMatchingAlias(sel *sqlparser.Select, lowered string) (*sqlp
 			continue
 		}
 		if _, available := b.availableAliases[ae]; !available {
-			return nil, nil
+			continue
 		}
 		if match == nil {
 			match = ae

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -47,12 +47,6 @@ type binder struct {
 	// walked. This is used to reject forward references to aliases in
 	// subqueries, matching MySQL's behavior.
 	availableAliases map[*sqlparser.AliasedExpr]struct{}
-
-	// aliasRewrites records column references that resolved to a parent
-	// SELECT alias whose expression has no table dependencies. These
-	// references are replaced with a clone of the alias expression so the
-	// subquery stays uncorrelated and can be planned as a standalone query.
-	aliasRewrites map[*sqlparser.ColName]sqlparser.Expr
 }
 
 func newBinder(scoper *scoper, org originable, tc *tableCollector, typer *typer) *binder {
@@ -65,7 +59,6 @@ func newBinder(scoper *scoper, org originable, tc *tableCollector, typer *typer)
 		typer:            typer,
 		usingJoinInfo:    map[TableSet]map[string]TableSet{},
 		availableAliases: map[*sqlparser.AliasedExpr]struct{}{},
-		aliasRewrites:    map[*sqlparser.ColName]sqlparser.Expr{},
 	}
 }
 
@@ -338,13 +331,17 @@ func (b *binder) resolveColumn(colName *sqlparser.ColName, current *scope, allow
 					typ := b.typer.exprType(ae.Expr)
 					if recursive.IsEmpty() && direct.IsEmpty() {
 						// The aliased expression has no table dependencies
-						// (e.g. a literal such as `1 AS x`). Schedule a
-						// rewrite of this column reference to a clone of the
-						// alias expression so the subquery stays truly
-						// uncorrelated and can be planned as a standalone
-						// query instead of emitting SQL that references the
-						// alias name as if it were a column of the subquery.
-						b.aliasRewrites[colName] = ae.Expr
+						// (e.g. a literal such as `1 AS x`). Mark the
+						// reference as correlated to the outer scope so
+						// planning falls into the same path as other
+						// correlated references — single-route cases still
+						// merge cleanly, and split-route cases surface the
+						// existing "unsupported correlated subquery" error
+						// instead of emitting SQL that references the alias
+						// as a non-existent column at runtime.
+						outer := scopeTableSet(current, b.org)
+						recursive = outer
+						direct = outer
 					}
 					return dependency{certain: true, recursive: recursive, direct: direct, typ: typ}, nil
 				}
@@ -547,6 +544,16 @@ func (b *binder) findMatchingAlias(sel *sqlparser.Select, lowered string) (*sqlp
 		}
 	}
 	return match, nil
+}
+
+// scopeTableSet returns the union of TableSets for every table directly
+// reachable from the given scope.
+func scopeTableSet(s *scope, org originable) TableSet {
+	id := EmptyTableSet()
+	for _, table := range s.tables {
+		id = id.Merge(table.getTableSet(org))
+	}
+	return id
 }
 
 // GetSubqueryAndOtherSide returns the subquery and other side of a comparison, iff one of the sides is a SubQuery

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -317,7 +317,7 @@ func (b *binder) resolveColumn(colName *sqlparser.ColName, current *scope, allow
 		// valid in MySQL, so this is gated on !first.
 		if !first && colName.Qualifier.IsEmpty() {
 			if sel, ok := current.stmt.(*sqlparser.Select); ok {
-				if ae := b.findMatchingAlias(sel, colName.Name.String()); ae != nil {
+				if ae := b.findMatchingAlias(sel, colName.Name.Lowered()); ae != nil {
 					// Use the dependencies of the aliased expression so the
 					// reference is correctly tracked as correlated.
 					// We use .dependencies() instead of direct map lookup
@@ -493,8 +493,7 @@ func (b *binder) resolveColumnInScope(current *scope, expr *sqlparser.ColName, a
 	return deps, nil
 }
 
-func (b *binder) findMatchingAlias(sel *sqlparser.Select, name string) *sqlparser.AliasedExpr {
-	lowered := strings.ToLower(name)
+func (b *binder) findMatchingAlias(sel *sqlparser.Select, lowered string) *sqlparser.AliasedExpr {
 	for _, selExpr := range sel.SelectExprs.Exprs {
 		ae, ok := selExpr.(*sqlparser.AliasedExpr)
 		if !ok {

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -514,13 +514,19 @@ func (b *binder) findMatchingAlias(sel *sqlparser.Select, lowered string) (*sqlp
 			match = ae
 			continue
 		}
-		// MySQL only reports ambiguity when two different bare column
-		// references share the same alias. Repeating the same column,
-		// literals, and expressions are allowed to duplicate.
+		// MySQL prefers non-column expressions over bare column references
+		// when duplicate aliases appear. Ambiguity is only raised when two
+		// different bare columns compete with no non-column alternative
+		// already in the running.
 		_, matchIsCol := match.Expr.(*sqlparser.ColName)
 		_, thisIsCol := ae.Expr.(*sqlparser.ColName)
-		if matchIsCol && thisIsCol && !sqlparser.Equals.Expr(match.Expr, ae.Expr) {
-			return nil, newAmbiguousColumnError(sqlparser.NewColName(lowered))
+		switch {
+		case matchIsCol && thisIsCol:
+			if !sqlparser.Equals.Expr(match.Expr, ae.Expr) {
+				return nil, newAmbiguousColumnError(sqlparser.NewColName(lowered))
+			}
+		case matchIsCol && !thisIsCol:
+			match = ae
 		}
 	}
 	return match, nil

--- a/go/vt/vtgate/semantics/binder.go
+++ b/go/vt/vtgate/semantics/binder.go
@@ -76,13 +76,7 @@ func (b *binder) up(cursor *sqlparser.Cursor) error {
 	case *sqlparser.JoinCondition:
 		return b.bindJoinCondition(node)
 	case *sqlparser.ColName:
-		if err := b.bindColName(node); err != nil {
-			return err
-		}
-		if expr, ok := b.aliasRewrites[node]; ok {
-			cursor.Replace(sqlparser.Clone(expr))
-		}
-		return nil
+		return b.bindColName(node)
 	case *sqlparser.CountStar:
 		return b.bindCountStar(node)
 	case *sqlparser.Union:


### PR DESCRIPTION
## Description

MySQL allows subqueries to resolve column names against aliases defined in a parent SELECT scope (e.g. `SELECT id AS foobar, (SELECT foobar) FROM test`). Previously, Vitess rejected these queries with a "column not found" error because the semantic analyzer didn't check parent aliases during column resolution.

This PR adds alias resolution when walking to parent scopes in `resolveColumn`, with semantics that line up with MySQL:

- Table columns take precedence over aliases.
- Same-scope alias references (e.g. `SELECT 1 AS x, x`) remain disallowed.
- Forward references to aliases (subquery before the alias in the SELECT list) are rejected, matching MySQL.
- Dependencies are propagated using `.dependencies()` so compound aliases like `user_id + 1 AS foobar` are correctly detected as correlated, and expression types are propagated for type inference.

### Duplicate aliases

`findMatchingAlias` now matches MySQL's resolution rules when the same alias appears multiple times:

- Non-column expressions/literals beat bare column references.
- First wins among same-kind candidates.
- Repeating the same column under the same alias is not ambiguous.
- Ambiguity is raised only when two *different* bare columns compete with no non-column alternative already in scope.

## Related Issue(s)

Split out from #19579, as this has nothing to do with `DUAL` tables and #19579 is already very unwieldy.

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [ ] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

Most of this was written by Claude Code — I provided direction and review.