### PR TITLE
VTOrc: Address panic uncovered by Antithesis

### DIFF
--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -489,6 +489,9 @@ func (erp *EmergencyReparenter) findMostAdvanced(
 	opts EmergencyReparentOptions,
 ) (*topodatapb.Tablet, []*topodatapb.Tablet, error) {
 	erp.logger.Infof("started finding the intermediate source")
+	if len(validCandidates) == 0 {
+		return nil, nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no valid candidates for emergency reparent")
+	}
 	// convert the valid candidates into a list so that we can use it for sorting
 	validTablets, tabletPositions, err := getValidCandidatesAndPositionsAsList(validCandidates, tabletMap)
 	if err != nil {

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -281,6 +281,9 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 		if err != nil {
 			return err
 		}
+		if len(validCandidates) == 0 {
+			return vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no valid candidates for emergency reparent: all candidates have errant GTIDs")
+		}
 	}
 
 	// Find the intermediate source for replication that we want other tablets to replicate from.

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -3194,6 +3194,11 @@ func TestEmergencyReparenter_findMostAdvanced(t *testing.T) {
 		err                  string
 	}{
 		{
+			name:            "no valid candidates",
+			validCandidates: map[string]*RelayLogPositions{},
+			tabletMap:       map[string]*topo.TabletInfo{},
+			err:             "no valid candidates for emergency reparent",
+		}, {
 			name: "choose most advanced",
 			validCandidates: map[string]*RelayLogPositions{
 				"zone1-0000000100": positionMostAdvanced,

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -1869,6 +1869,80 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 			shouldErr:        true,
 			errShouldContain: "primary zone1-0000000100 is not equal to expected alias zone1-0000000101",
 		},
+		{
+			// Regression test: if every candidate has mutually errant GTIDs, findErrantGTIDs
+			// returns an empty map, which previously caused findMostAdvanced to panic with
+			// "index out of range [0] with length 0" when indexing the empty tablet slice.
+			name:                 "all candidates filtered out by errant GTID detection",
+			durability:           policy.DurabilityNone,
+			emergencyReparentOps: EmergencyReparentOptions{},
+			tmc: &testutil.TabletManagerClient{
+				ReadReparentJournalInfoResults: map[string]int32{
+					"zone1-0000000100": 3,
+					"zone1-0000000101": 3,
+				},
+				StopReplicationAndGetStatusResults: map[string]struct {
+					StopStatus *replicationdatapb.StopReplicationStatus
+					Error      error
+				}{
+					"zone1-0000000100": {
+						StopStatus: &replicationdatapb.StopReplicationStatus{
+							Before: &replicationdatapb.Status{IoState: int32(replication.ReplicationStateRunning), SqlState: int32(replication.ReplicationStateRunning)},
+							After: &replicationdatapb.Status{
+								SourceUuid:       "00000000-0000-0000-0000-000000000001",
+								RelayLogPosition: getRelayLogPosition("1-100", "1-31", "1-50"),
+							},
+						},
+					},
+					"zone1-0000000101": {
+						StopStatus: &replicationdatapb.StopReplicationStatus{
+							Before: &replicationdatapb.Status{IoState: int32(replication.ReplicationStateRunning), SqlState: int32(replication.ReplicationStateRunning)},
+							After: &replicationdatapb.Status{
+								SourceUuid:       "00000000-0000-0000-0000-000000000001",
+								RelayLogPosition: getRelayLogPosition("1-100", "1-30", "1-51"),
+							},
+						},
+					},
+				},
+				WaitForPositionResults: map[string]map[string]error{
+					"zone1-0000000100": {
+						getRelayLogPosition("1-100", "1-31", "1-50"): nil,
+					},
+					"zone1-0000000101": {
+						getRelayLogPosition("1-100", "1-30", "1-51"): nil,
+					},
+				},
+			},
+			shards: []*vtctldatapb.Shard{
+				{
+					Keyspace: "testkeyspace",
+					Name:     "-",
+				},
+			},
+			tablets: []*topodatapb.Tablet{
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: "zone1",
+						Uid:  100,
+					},
+					Keyspace: "testkeyspace",
+					Shard:    "-",
+				},
+				{
+					Alias: &topodatapb.TabletAlias{
+						Cell: "zone1",
+						Uid:  101,
+					},
+					Keyspace: "testkeyspace",
+					Shard:    "-",
+				},
+			},
+			keyspace:         "testkeyspace",
+			shard:            "-",
+			cells:            []string{"zone1"},
+			shouldErr:        true,
+			errShouldContain: "no valid candidates for emergency reparent",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

You can see the [Antithesis run and analysis here](https://vitess.antithesis.com/report/2iuU2KO3EOYn8pTByQKlTiSX/VdX-HSXY153oy-YOP7v1Q4N2StvjZ22MYTp5p7WFoi8.html?auth=v2.public.eyJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoiVmRYLUhTWFkxNTNveS1ZT1A3djFRNE4yU3R2aloyMk1ZVHA1cDdXRm9pOC5odG1sIiwicmVwb3J0X2lkIjoiMml1VTJLTzNFT1luOHBUQnlRS2xUaVNYIn19LCJuYmYiOiIyMDI2LTA0LTAxVDEzOjQ2OjQwLjk3MTYyOTYxOFoifQ1VkTL63fhelmmWTBhPv-EhWxgpc3GzotklEoDzvG6-uhzul2scoKzcDO_N6fR--AfL-Awy4-zcjg17tQpphwc).

It uncovered an edge case — where all tablets had an errant GTID — and VTOrc always assumed that there was at least 1 valid candidate and blindly used the first one. It would then get stuck in a crash->recovery attempt->crash loop.

>[!NOTE]
>This is a very small and targeted fix, so there's no reason not to backport this as there's no risk added.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/19905

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

### AI Disclosure

This work was done with the help of Claude and the [Antithesis skills](https://github.com/antithesishq/antithesis-skills/tree/main).