### PR TITLE
test: make vdiff2 restart + cleanup assertions hardware-independent

### DIFF
--- a/go/test/endtoend/vreplication/vdiff2_test.go
+++ b/go/test/endtoend/vreplication/vdiff2_test.go
@@ -201,10 +201,13 @@ func TestVDiff2(t *testing.T) {
 	require.Greater(t, count, 0, "expected VDiffRowsComparedTotal stat to be greater than 0 but got %d", count)
 
 	// The VDiffs should all be cleaned up so the VDiffRowsCompared value, which
-	// is produced from controller info, should be empty.
-	vdrc, err := getDebugVar(t, statsTablet.Port, []string{"VDiffRowsCompared"})
-	require.NoError(t, err, "failed to get VDiffRowsCompared stat from %s-%d tablet: %v", statsTablet.Cell, statsTablet.TabletUID, err)
-	require.Equal(t, "{}", vdrc, "expected VDiffRowsCompared stat to be empty but got %s", vdrc)
+	// is produced from controller info, should be empty. Controller cleanup on
+	// workflow completion can briefly lag the stats sampler, so poll.
+	require.Eventually(t, func() bool {
+		vdrc, err := getDebugVar(t, statsTablet.Port, []string{"VDiffRowsCompared"})
+		require.NoError(t, err, "failed to get VDiffRowsCompared stat from %s-%d tablet: %v", statsTablet.Cell, statsTablet.TabletUID, err)
+		return vdrc == "{}"
+	}, 30*time.Second, 500*time.Millisecond, "expected VDiffRowsCompared stat on %s-%d tablet to eventually be empty", statsTablet.Cell, statsTablet.TabletUID)
 }
 
 func testWorkflow(t *testing.T, vc *VitessCluster, tc *testCase, tks *Keyspace, cells []*Cell) {
@@ -254,9 +257,10 @@ func testWorkflow(t *testing.T, vc *VitessCluster, tc *testCase, tks *Keyspace, 
 		seconds := int64(dur.Seconds())
 		chunkSize := int64(100000)
 		// Take the test host/runner vCPU count into account when generating rows.
-		perVCpuCount := int64(100000)
-		// Cap it at 1M rows per second so that we will create betweeen 100,000 and 1,000,000
-		// rows for each second in the diff duration, depending on the test host vCPU count.
+		// Raise the per-vCPU estimate so that low-vCPU but fast cloud runners (e.g.
+		// Depot 4-vCPU) still hit the 1M/sec cap and generate enough rows to force
+		// a table diff restart within --max-diff-duration.
+		perVCpuCount := int64(250000)
 		perSecondCount := int64(math.Min(float64(perVCpuCount*int64(runtime.NumCPU())), 1000000))
 		totalRowsToCreate := seconds * perSecondCount
 		log.Info(fmt.Sprintf("Test host has %d vCPUs. Generating %d rows in the customer table to test --max-diff-duration", runtime.NumCPU(), totalRowsToCreate))


### PR DESCRIPTION
<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

`TestVDiff2` has two hardware-sensitive assertions that flake on fast cloud CI runners — especially low-vCPU but fast-per-core hosts. Both are test-only and don't touch any product code.

**1. `VDiffRowsCompared` cleanup (line 207)**

The `"{}"` assertion reads through `globalStats.mu`, while controller cleanup in `handleDeleteAction` runs under `vde.mu`. There's a brief window where the stats sampler can observe a non-empty map between `Complete` returning and the controller tearing down. Wrapped in `require.Eventually` with a 30s bound so the test tolerates that lag without becoming permissive.

**2. `--max-diff-duration` restart (line 278)**

The pre-test customer row count was calibrated at 100K rows/sec/vCPU with a 1M/sec cap. On fast 4-vCPU hosts this generates only ~800K rows, which modern hardware can diff in well under the 2s `--max-diff-duration`, leaving `customerRestarts == 0` and failing the `> 0` assertion deterministically. Bumping `perVCpuCount` to 250K means the 1M/sec cap is now hit at vCPU counts ≥ 4, producing ~2M rows on every host size — the same amount that already worked reliably on higher-vCPU hosts.

No product behavior changes. `--max-diff-duration` still operates at whole-second granularity; stats sampling is still async.

## Related Issue(s)

Fixes #19907

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — test-only change.