### PR TITLE
Involve VTGateService team in vtgateservice RPC changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -87,6 +87,7 @@ go.sum @harshit-gangal @mattlord @rohit-nayak-ps @systay @frouioui @timvaillanco
 /proto/vtadmin.proto @beingnoble03 @mattlord
 /proto/vtctldata.proto @mattlord
 /proto/vtctlservice.proto @mattlord
+/proto/vtgateservice.proto @vitessio/vtgateservice
 /proto/vtorcdata.proto @mattlord @shlomi-noach @timvaillancourt
 /test/ @frouioui @rohit-nayak-ps @mattlord @harshit-gangal
 /tools/ @frouioui @rohit-nayak-ps


### PR DESCRIPTION
## Description

There are some downstream consumers of the [VTGateService RPCs](https://pkg.go.dev/vitess.io/vitess/go/vt/vtgate). I created [a team in the `vitessio` org](https://github.com/orgs/vitessio/teams/vtgateservice/members) where we can add people involved in these dependent projects. Here I'm adding that team as a `CODEOWNER` for [the relevant proto file](https://github.com/vitessio/vitess/blob/main/proto/vtgateservice.proto) so that they can at least be made aware of changes being made to the service which may impact them and they can offer input around future development work.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required