### PR TITLE
vreplication: add per-row JSON size limit to prevent target mysqld OOM

### DIFF
--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -428,6 +428,7 @@ Flags:
       --vreplication-enable-http-log                                     Enable the /debug/vrlog HTTP endpoint, which will produce a log of the events replicated on primary tablets in the target keyspace by all VReplication workflows that are in the running/replicating phase.
       --vreplication-experimental-flags int                              (Bitmask) of experimental features in vreplication to enable (default 7)
       --vreplication-heartbeat-update-interval int                       Frequency (in seconds, default 1, max 60) at which the time_updated column of a vreplication stream when idling (default 1)
+      --vreplication-max-row-json-bytes int                              Maximum combined byte size of JSON columns in a single row during VReplication copy and replay phases. 0 means unlimited.
       --vreplication-max-time-to-retry-on-error duration                 stop automatically retrying when we've had consecutive failures with the same error for this long after the first occurrence
       --vreplication-net-read-timeout int                                Session value of net_read_timeout for vreplication, in seconds (default 300)
       --vreplication-net-write-timeout int                               Session value of net_write_timeout for vreplication, in seconds (default 600)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -427,6 +427,7 @@ Flags:
       --vreplication-enable-http-log                                     Enable the /debug/vrlog HTTP endpoint, which will produce a log of the events replicated on primary tablets in the target keyspace by all VReplication workflows that are in the running/replicating phase.
       --vreplication-experimental-flags int                              (Bitmask) of experimental features in vreplication to enable (default 7)
       --vreplication-heartbeat-update-interval int                       Frequency (in seconds, default 1, max 60) at which the time_updated column of a vreplication stream when idling (default 1)
+      --vreplication-max-row-json-bytes int                              Maximum combined byte size of JSON columns in a single row during VReplication copy and replay phases. 0 means unlimited.
       --vreplication-max-time-to-retry-on-error duration                 stop automatically retrying when we've had consecutive failures with the same error for this long after the first occurrence
       --vreplication-net-read-timeout int                                Session value of net_read_timeout for vreplication, in seconds (default 300)
       --vreplication-net-write-timeout int                               Session value of net_write_timeout for vreplication, in seconds (default 600)

--- a/go/test/endtoend/vreplication/vdiff2_test.go
+++ b/go/test/endtoend/vreplication/vdiff2_test.go
@@ -272,7 +272,7 @@ func testWorkflow(t *testing.T, vc *VitessCluster, tc *testCase, tks *Keyspace, 
 		waitForShardsToCatchup()
 
 		// This flag is only implemented in vtctldclient.
-		doVtctldclientVDiff(t, tc.targetKs, tc.workflow, allCellNames, nil, "--max-diff-duration", diffDuration)
+		doVtctldclientVDiffWithTimeout(t, tc.targetKs, tc.workflow, allCellNames, nil, maxDiffDurationTimeout, "--max-diff-duration", diffDuration)
 
 		// Confirm that the customer table diff was restarted but not others.
 		tablet := vc.getPrimaryTablet(t, tc.targetKs, arrTargetShards[0])

--- a/go/test/endtoend/vreplication/vdiff_helper_test.go
+++ b/go/test/endtoend/vreplication/vdiff_helper_test.go
@@ -36,6 +36,7 @@ import (
 
 const (
 	vdiffTimeout             = 180 * time.Second // We can leverage auto retry on error with this longer-than-usual timeout
+	maxDiffDurationTimeout   = 5 * time.Minute
 	vdiffRetryTimeout        = 30 * time.Second
 	vdiffStatusCheckInterval = 5 * time.Second
 	vdiffRetryInterval       = 5 * time.Second
@@ -55,6 +56,10 @@ func doVDiff(t *testing.T, ksWorkflow, cells string) {
 }
 
 func waitForVDiff2ToComplete(t *testing.T, ksWorkflow, cells, uuid string, completedAtMin time.Time) *vdiffInfo {
+	return waitForVDiff2ToCompleteWithTimeout(t, ksWorkflow, cells, uuid, completedAtMin, vdiffTimeout)
+}
+
+func waitForVDiff2ToCompleteWithTimeout(t *testing.T, ksWorkflow, cells, uuid string, completedAtMin time.Time, timeout time.Duration) *vdiffInfo {
 	var info *vdiffInfo
 	var jsonStr string
 	first := true
@@ -108,7 +113,7 @@ func waitForVDiff2ToComplete(t *testing.T, ksWorkflow, cells, uuid string, compl
 	select {
 	case <-ch:
 		return info
-	case <-time.After(vdiffTimeout):
+	case <-time.After(timeout):
 		log.Error(fmt.Sprintf("VDiff never completed for UUID %s. Latest output: %s", uuid, jsonStr))
 		require.FailNow(t, "VDiff never completed for UUID "+uuid)
 		return nil
@@ -123,6 +128,10 @@ type expectedVDiff2Result struct {
 }
 
 func doVtctldclientVDiff(t *testing.T, keyspace, workflow, cells string, want *expectedVDiff2Result, extraFlags ...string) {
+	doVtctldclientVDiffWithTimeout(t, keyspace, workflow, cells, want, vdiffTimeout, extraFlags...)
+}
+
+func doVtctldclientVDiffWithTimeout(t *testing.T, keyspace, workflow, cells string, want *expectedVDiff2Result, timeout time.Duration, extraFlags ...string) {
 	ksWorkflow := fmt.Sprintf("%s.%s", keyspace, workflow)
 	t.Run("vtctldclient vdiff "+ksWorkflow, func(t *testing.T) {
 		// update-table-stats is needed in order to test progress reports.
@@ -131,7 +140,7 @@ func doVtctldclientVDiff(t *testing.T, keyspace, workflow, cells string, want *e
 			flags = append(flags, extraFlags...)
 		}
 		uuid, _ := performVDiff2Action(t, ksWorkflow, cells, "create", "", false, flags...)
-		info := waitForVDiff2ToComplete(t, ksWorkflow, cells, uuid, time.Time{})
+		info := waitForVDiff2ToCompleteWithTimeout(t, ksWorkflow, cells, uuid, time.Time{}, timeout)
 		require.NotNil(t, info)
 		require.Equal(t, workflow, info.Workflow)
 		require.Equal(t, keyspace, info.Keyspace)

--- a/go/vt/vttablet/common/config.go
+++ b/go/vt/vttablet/common/config.go
@@ -51,6 +51,7 @@ type VReplicationConfig struct {
 	ParallelInsertWorkers   int
 	TabletTypesStr          string
 	EnableHttpLog           bool // Enable the /debug/vrlog endpoint
+	MaxRowJSONBytes         int64
 
 	// Config parameters applicable to the source side (vstreamer)
 	// The coresponding Override fields are used to determine if the user has provided a value for the parameter so
@@ -96,6 +97,7 @@ func GetVReplicationConfigDefaults(useCached bool) *VReplicationConfig {
 		ParallelInsertWorkers:   vreplicationParallelInsertWorkers,
 		TabletTypesStr:          vreplicationTabletTypesStr,
 		EnableHttpLog:           vreplicationEnableHttpLog,
+		MaxRowJSONBytes:         vreplicationMaxRowJSONBytes,
 
 		VStreamPacketSizeOverride:              false,
 		VStreamPacketSize:                      VStreamerDefaultPacketSize,
@@ -244,6 +246,13 @@ func NewVReplicationConfig(overrides map[string]string) (*VReplicationConfig, er
 				c.VStreamBinlogRotationThresholdOverride = true
 				c.VStreamBinlogRotationThreshold = value
 			}
+		case "max-row-json-bytes", "max_row_json_bytes":
+			value, err := strconv.ParseInt(v, 10, 64)
+			if err != nil {
+				errors = append(errors, getError(k, v))
+			} else {
+				c.MaxRowJSONBytes = value
+			}
 		default:
 			errors = append(errors, "unknown vreplication config flag: "+k)
 		}
@@ -278,6 +287,8 @@ func (c VReplicationConfig) Map() map[string]string {
 		"vstream-dynamic-packet-size":             strconv.FormatBool(c.VStreamDynamicPacketSize),
 		"vstream_dynamic_packet_size":             strconv.FormatBool(c.VStreamDynamicPacketSize),
 		"vstream_binlog_rotation_threshold":       strconv.FormatInt(c.VStreamBinlogRotationThreshold, 10),
+		"max-row-json-bytes":                      strconv.FormatInt(c.MaxRowJSONBytes, 10),
+		"max_row_json_bytes":                      strconv.FormatInt(c.MaxRowJSONBytes, 10),
 	}
 }
 

--- a/go/vt/vttablet/common/config.go
+++ b/go/vt/vttablet/common/config.go
@@ -246,9 +246,9 @@ func NewVReplicationConfig(overrides map[string]string) (*VReplicationConfig, er
 				c.VStreamBinlogRotationThresholdOverride = true
 				c.VStreamBinlogRotationThreshold = value
 			}
-		case "max-row-json-bytes", "max_row_json_bytes":
+		case "max-row-json-bytes":
 			value, err := strconv.ParseInt(v, 10, 64)
-			if err != nil {
+			if err != nil || value < 0 {
 				errors = append(errors, getError(k, v))
 			} else {
 				c.MaxRowJSONBytes = value
@@ -288,7 +288,6 @@ func (c VReplicationConfig) Map() map[string]string {
 		"vstream_dynamic_packet_size":             strconv.FormatBool(c.VStreamDynamicPacketSize),
 		"vstream_binlog_rotation_threshold":       strconv.FormatInt(c.VStreamBinlogRotationThreshold, 10),
 		"max-row-json-bytes":                      strconv.FormatInt(c.MaxRowJSONBytes, 10),
-		"max_row_json_bytes":                      strconv.FormatInt(c.MaxRowJSONBytes, 10),
 	}
 }
 

--- a/go/vt/vttablet/common/config_test.go
+++ b/go/vt/vttablet/common/config_test.go
@@ -161,3 +161,27 @@ func TestNewVReplicationConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestMaxRowJSONBytesOverride(t *testing.T) {
+	InitVReplicationConfigDefaults()
+	for _, key := range []string{"max-row-json-bytes", "max_row_json_bytes"} {
+		t.Run(key, func(t *testing.T) {
+			cfg, err := NewVReplicationConfig(map[string]string{key: "1048576"})
+			require.NoError(t, err)
+			require.EqualValues(t, int64(1048576), cfg.MaxRowJSONBytes)
+			m := cfg.Map()
+			require.Equal(t, "1048576", m["max-row-json-bytes"])
+			require.Equal(t, "1048576", m["max_row_json_bytes"])
+		})
+	}
+	t.Run("zero preserves default", func(t *testing.T) {
+		cfg, err := NewVReplicationConfig(map[string]string{"max-row-json-bytes": "0"})
+		require.NoError(t, err)
+		require.EqualValues(t, int64(0), cfg.MaxRowJSONBytes)
+	})
+	t.Run("invalid value returns error", func(t *testing.T) {
+		_, err := NewVReplicationConfig(map[string]string{"max-row-json-bytes": "notanumber"})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "invalid value for max-row-json-bytes")
+	})
+}

--- a/go/vt/vttablet/common/config_test.go
+++ b/go/vt/vttablet/common/config_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package vttablet
 
 import (
+	"io"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/utils"
@@ -164,16 +166,13 @@ func TestNewVReplicationConfig(t *testing.T) {
 
 func TestMaxRowJSONBytesOverride(t *testing.T) {
 	InitVReplicationConfigDefaults()
-	for _, key := range []string{"max-row-json-bytes", "max_row_json_bytes"} {
-		t.Run(key, func(t *testing.T) {
-			cfg, err := NewVReplicationConfig(map[string]string{key: "1048576"})
-			require.NoError(t, err)
-			require.EqualValues(t, int64(1048576), cfg.MaxRowJSONBytes)
-			m := cfg.Map()
-			require.Equal(t, "1048576", m["max-row-json-bytes"])
-			require.Equal(t, "1048576", m["max_row_json_bytes"])
-		})
-	}
+	cfg, err := NewVReplicationConfig(map[string]string{"max-row-json-bytes": "1048576"})
+	require.NoError(t, err)
+	require.EqualValues(t, int64(1048576), cfg.MaxRowJSONBytes)
+	m := cfg.Map()
+	require.Equal(t, "1048576", m["max-row-json-bytes"])
+	require.NotContains(t, m, "max_row_json_bytes")
+
 	t.Run("zero preserves default", func(t *testing.T) {
 		cfg, err := NewVReplicationConfig(map[string]string{"max-row-json-bytes": "0"})
 		require.NoError(t, err)
@@ -184,4 +183,24 @@ func TestMaxRowJSONBytesOverride(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorContains(t, err, "invalid value for max-row-json-bytes")
 	})
+	t.Run("negative value returns error", func(t *testing.T) {
+		_, err := NewVReplicationConfig(map[string]string{"max-row-json-bytes": "-1"})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "invalid value for max-row-json-bytes")
+	})
+	t.Run("underscore key returns error", func(t *testing.T) {
+		_, err := NewVReplicationConfig(map[string]string{"max_row_json_bytes": "1048576"})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unknown vreplication config flag: max_row_json_bytes")
+	})
+}
+
+func TestVReplicationMaxRowJSONBytesFlagRejectsNegative(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	registerFlags(fs)
+
+	err := fs.Parse([]string{"--vreplication-max-row-json-bytes=-1"})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "must be non-negative")
 }

--- a/go/vt/vttablet/common/flags.go
+++ b/go/vt/vttablet/common/flags.go
@@ -17,6 +17,8 @@ limitations under the License.
 package vttablet
 
 import (
+	"errors"
+	"strconv"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -32,6 +34,35 @@ const (
 	VReplicationExperimentalFlagAllowNoBlobBinlogRowImage = int64(2)
 	VReplicationExperimentalFlagVPlayerBatching           = int64(4)
 )
+
+type (
+	nonNegativeInt64Flag struct {
+		value *int64
+	}
+)
+
+func (f nonNegativeInt64Flag) Set(v string) error {
+	value, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return err
+	}
+	if value < 0 {
+		return errors.New("must be non-negative")
+	}
+	*f.value = value
+	return nil
+}
+
+func (f nonNegativeInt64Flag) String() string {
+	if f.value == nil {
+		return "0"
+	}
+	return strconv.FormatInt(*f.value, 10)
+}
+
+func (f nonNegativeInt64Flag) Type() string {
+	return "int"
+}
 
 var (
 	vreplicationExperimentalFlags   = VReplicationExperimentalFlagOptimizeInserts | VReplicationExperimentalFlagAllowNoBlobBinlogRowImage | VReplicationExperimentalFlagVPlayerBatching
@@ -104,5 +135,5 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.Uint64Var(&mysql.ZstdInMemoryDecompressorMaxSize, "binlog-in-memory-decompressor-max-size", mysql.ZstdInMemoryDecompressorMaxSize, "This value sets the uncompressed transaction payload size at which we switch from in-memory buffer based decompression to the slower streaming mode.")
 
 	fs.BoolVar(&vreplicationEnableHttpLog, "vreplication-enable-http-log", vreplicationEnableHttpLog, "Enable the /debug/vrlog HTTP endpoint, which will produce a log of the events replicated on primary tablets in the target keyspace by all VReplication workflows that are in the running/replicating phase.")
-	fs.Int64Var(&vreplicationMaxRowJSONBytes, "vreplication-max-row-json-bytes", vreplicationMaxRowJSONBytes, "Maximum combined byte size of JSON columns in a single row during VReplication copy and replay phases. 0 means unlimited.")
+	fs.Var(nonNegativeInt64Flag{value: &vreplicationMaxRowJSONBytes}, "vreplication-max-row-json-bytes", "Maximum combined byte size of JSON columns in a single row during VReplication copy and replay phases. 0 means unlimited.")
 }

--- a/go/vt/vttablet/common/flags.go
+++ b/go/vt/vttablet/common/flags.go
@@ -52,6 +52,7 @@ var (
 
 	vreplicationStoreCompressedGTID   = false
 	vreplicationParallelInsertWorkers = 1
+	vreplicationMaxRowJSONBytes       = int64(0)
 
 	// VStreamerBinlogRotationThreshold is the threshold, above which we rotate binlogs, before taking a GTID snapshot
 	VStreamerBinlogRotationThreshold = int64(64 * 1024 * 1024) // 64MiB
@@ -103,4 +104,5 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.Uint64Var(&mysql.ZstdInMemoryDecompressorMaxSize, "binlog-in-memory-decompressor-max-size", mysql.ZstdInMemoryDecompressorMaxSize, "This value sets the uncompressed transaction payload size at which we switch from in-memory buffer based decompression to the slower streaming mode.")
 
 	fs.BoolVar(&vreplicationEnableHttpLog, "vreplication-enable-http-log", vreplicationEnableHttpLog, "Enable the /debug/vrlog HTTP endpoint, which will produce a log of the events replicated on primary tablets in the target keyspace by all VReplication workflows that are in the running/replicating phase.")
+	fs.Int64Var(&vreplicationMaxRowJSONBytes, "vreplication-max-row-json-bytes", vreplicationMaxRowJSONBytes, "Maximum combined byte size of JSON columns in a single row during VReplication copy and replay phases. 0 means unlimited.")
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -255,6 +255,38 @@ func (tp *TablePlan) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&v)
 }
 
+// checkJSONRowSize sums the byte lengths of all JSON-typed columns in row and
+// returns an error if the sum exceeds limit. When limit <= 0 the check is a
+// no-op. Indices beyond len(tp.Fields) are silently skipped.
+func (tp *TablePlan) checkJSONRowSize(row []sqltypes.Value, limit int64) error {
+	if limit <= 0 {
+		return nil
+	}
+	var total int64
+	var largestName string
+	var largestSize int64
+	for i, field := range tp.Fields {
+		if i >= len(row) {
+			break
+		}
+		if field.Type != querypb.Type_JSON {
+			continue
+		}
+		sz := int64(row[i].Len())
+		total += sz
+		if sz > largestSize {
+			largestSize = sz
+			largestName = field.Name
+		}
+	}
+	if total > limit {
+		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
+			"vreplication: row JSON payload %d bytes exceeds vreplication-max-row-json-bytes=%d (table=%s, largest_json_column=%s @ %d bytes)",
+			total, limit, tp.TargetName, largestName, largestSize)
+	}
+	return nil
+}
+
 func (tp *TablePlan) applyBulkInsert(sqlbuffer *bytes2.Buffer, rows []*querypb.Row, executor func(string) (*sqltypes.Result, error), maxQuerySize int64) (*sqltypes.Result, error) {
 	insertPrefix := tp.BulkInsertFront.Query + " values "
 	insertSuffixLen := 0
@@ -280,6 +312,14 @@ func (tp *TablePlan) applyBulkInsert(sqlbuffer *bytes2.Buffer, rows []*querypb.R
 	var lastResult *sqltypes.Result
 	rowCount := 0
 	for _, row := range rows {
+		if tp.WorkflowConfig != nil {
+			if limit := tp.WorkflowConfig.MaxRowJSONBytes; limit > 0 {
+				vals := sqltypes.MakeRowTrusted(tp.Fields, row)
+				if err := tp.checkJSONRowSize(vals, limit); err != nil {
+					return nil, err
+				}
+			}
+		}
 		beforeLen := sqlbuffer.Len()
 		if rowCount > 0 {
 			sqlbuffer.WriteString(", ")
@@ -437,6 +477,9 @@ func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor fun
 		jsonIndex := 0
 		after = true
 		afterVals = sqltypes.MakeRowTrusted(tp.Fields, rowChange.After)
+		if err := tp.checkJSONRowSize(afterVals, tp.WorkflowConfig.MaxRowJSONBytes); err != nil {
+			return nil, err
+		}
 		for i, field := range tp.Fields {
 			var (
 				bindVar *querypb.BindVariable

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -306,33 +306,33 @@ func (tp *TablePlan) checkJSONRowSize(row *querypb.Row, limit int64) error {
 	})
 }
 
+func jsonRowChangeSize(afterRow, beforeRow *querypb.Row, partialJSONColumns *binlogdatapb.RowChange_Bitmap, fieldIndex, jsonIndex int) int64 {
+	if fieldIndex >= len(afterRow.Lengths) {
+		return 0
+	}
+	afterLen := afterRow.Lengths[fieldIndex]
+	if afterLen < 0 {
+		return 0
+	}
+	if partialJSONColumns == nil || beforeRow == nil || !isBitSet(partialJSONColumns.Cols, jsonIndex) {
+		return afterLen
+	}
+	if afterLen == 0 {
+		if fieldIndex >= len(beforeRow.Lengths) || beforeRow.Lengths[fieldIndex] < 0 {
+			return 0
+		}
+		return beforeRow.Lengths[fieldIndex]
+	}
+	beforeLen := int64(0)
+	if fieldIndex < len(beforeRow.Lengths) && beforeRow.Lengths[fieldIndex] > 0 {
+		beforeLen = beforeRow.Lengths[fieldIndex]
+	}
+	return beforeLen + afterLen
+}
+
 func (tp *TablePlan) checkInsertJSONRowSize(afterRow, beforeRow *querypb.Row, partialJSONColumns *binlogdatapb.RowChange_Bitmap, limit int64) error {
 	if afterRow == nil {
 		return nil
-	}
-
-	jsonInsertSize := func(fieldIndex, jsonIndex int) int64 {
-		if fieldIndex >= len(afterRow.Lengths) {
-			return 0
-		}
-		afterLen := afterRow.Lengths[fieldIndex]
-		if afterLen < 0 {
-			return 0
-		}
-		if partialJSONColumns == nil || beforeRow == nil || !isBitSet(partialJSONColumns.Cols, jsonIndex) {
-			return afterLen
-		}
-		if afterLen == 0 {
-			if fieldIndex >= len(beforeRow.Lengths) || beforeRow.Lengths[fieldIndex] < 0 {
-				return 0
-			}
-			return beforeRow.Lengths[fieldIndex]
-		}
-		beforeLen := int64(0)
-		if fieldIndex < len(beforeRow.Lengths) && beforeRow.Lengths[fieldIndex] > 0 {
-			beforeLen = beforeRow.Lengths[fieldIndex]
-		}
-		return beforeLen + afterLen
 	}
 
 	return tp.checkJSONFieldSizes(limit, func(add func(field *querypb.Field, size int64)) {
@@ -352,7 +352,7 @@ func (tp *TablePlan) checkInsertJSONRowSize(afterRow, beforeRow *querypb.Row, pa
 						continue
 					}
 					if field.Type == querypb.Type_JSON {
-						add(field, jsonInsertSize(fieldIndex, fieldJSONIndex))
+						add(field, jsonRowChangeSize(afterRow, beforeRow, partialJSONColumns, fieldIndex, fieldJSONIndex))
 					}
 					break
 				}
@@ -373,18 +373,19 @@ func (tp *TablePlan) checkInsertJSONRowSize(afterRow, beforeRow *querypb.Row, pa
 				continue
 			}
 			if field.Type == querypb.Type_JSON {
-				add(field, jsonInsertSize(i, fieldJSONIndex))
+				add(field, jsonRowChangeSize(afterRow, beforeRow, partialJSONColumns, i, fieldJSONIndex))
 			}
 		}
 	})
 }
 
-func (tp *TablePlan) checkUpdateJSONRowSize(afterRow *querypb.Row, dataColumns *binlogdatapb.RowChange_Bitmap, limit int64) error {
+func (tp *TablePlan) checkUpdateJSONRowSize(afterRow, beforeRow *querypb.Row, dataColumns, partialJSONColumns *binlogdatapb.RowChange_Bitmap, limit int64) error {
 	if afterRow == nil {
 		return nil
 	}
 
 	return tp.checkJSONFieldSizes(limit, func(add func(field *querypb.Field, size int64)) {
+		jsonIndex := 0
 		for i, field := range tp.Fields {
 			if i >= len(afterRow.Lengths) {
 				break
@@ -392,13 +393,15 @@ func (tp *TablePlan) checkUpdateJSONRowSize(afterRow *querypb.Row, dataColumns *
 			if field.Type != querypb.Type_JSON {
 				continue
 			}
+			fieldJSONIndex := jsonIndex
+			jsonIndex++
 			if tp.FieldsToSkip[strings.ToLower(field.Name)] {
 				continue
 			}
 			if dataColumns != nil && dataColumns.Count > 0 && !isBitSet(dataColumns.Cols, i) {
 				continue
 			}
-			add(field, afterRow.Lengths[i])
+			add(field, jsonRowChangeSize(afterRow, beforeRow, partialJSONColumns, i, fieldJSONIndex))
 		}
 	})
 }
@@ -672,7 +675,7 @@ func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor fun
 	case before && after:
 		if !tp.pkChanged(bindvars) && !tp.HasExtraSourcePkColumns {
 			if limit > 0 {
-				if err := tp.checkUpdateJSONRowSize(rowChange.After, rowChange.DataColumns, limit); err != nil {
+				if err := tp.checkUpdateJSONRowSize(rowChange.After, rowChange.Before, rowChange.DataColumns, rowChange.JsonPartialValues, limit); err != nil {
 					return nil, err
 				}
 			}

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -871,6 +871,9 @@ func (tp *TablePlan) applyBulkInsertChanges(rowInserts []*binlogdatapb.RowChange
 		bindvars := make(map[string]*querypb.BindVariable, len(tp.Fields))
 		vals := sqltypes.MakeRowTrusted(tp.Fields, rowInsert.After)
 		for n, field := range tp.Fields {
+			if tp.FieldsToSkip[strings.ToLower(field.Name)] {
+				continue
+			}
 			if field.Type == querypb.Type_JSON {
 				var jsVal *sqltypes.Value
 				if vals[n].IsNull() { // An SQL NULL and not an actual JSON value

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -255,36 +255,25 @@ func (tp *TablePlan) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&v)
 }
 
-// checkJSONRowSize sums the byte lengths of all JSON-typed columns in row and
-// returns an error if the sum exceeds limit. When limit <= 0 the check is a
-// no-op. It reads column sizes directly from row.Lengths so it can run in
-// hot loops without materializing []sqltypes.Value. Indices beyond
-// len(row.Lengths) are silently skipped. NULL columns (Lengths[i] < 0) are
-// treated as zero-size.
-func (tp *TablePlan) checkJSONRowSize(row *querypb.Row, limit int64) error {
-	if limit <= 0 || row == nil {
+func (tp *TablePlan) checkJSONFieldSizes(limit int64, addJSONFieldSizes func(add func(field *querypb.Field, size int64))) error {
+	if limit <= 0 {
 		return nil
 	}
+
 	var total int64
 	var largestName string
 	var largestSize int64
-	for i, field := range tp.Fields {
-		if i >= len(row.Lengths) {
-			break
+	addJSONFieldSizes(func(field *querypb.Field, size int64) {
+		if field == nil || size < 0 {
+			return
 		}
-		if field.Type != querypb.Type_JSON {
-			continue
-		}
-		n := row.Lengths[i]
-		if n < 0 {
-			continue
-		}
-		total += n
-		if n > largestSize {
-			largestSize = n
+		total += size
+		if size > largestSize {
+			largestSize = size
 			largestName = field.Name
 		}
-	}
+	})
+
 	if total > limit {
 		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
 			"vreplication: row JSON payload %d bytes exceeds vreplication-max-row-json-bytes=%d (table=%s, largest_json_column=%s @ %d bytes)",
@@ -293,59 +282,84 @@ func (tp *TablePlan) checkJSONRowSize(row *querypb.Row, limit int64) error {
 	return nil
 }
 
-func (tp *TablePlan) checkInsertJSONRowSize(afterRow, beforeRow *querypb.Row, partialJSONColumns *binlogdatapb.RowChange_Bitmap, limit int64) error {
-	if limit <= 0 || afterRow == nil {
+// checkJSONRowSize sums the byte lengths of all JSON-typed columns in row and
+// returns an error if the sum exceeds limit. When limit <= 0 the check is a
+// no-op. It reads column sizes directly from row.Lengths so it can run in
+// hot loops without materializing []sqltypes.Value. Indices beyond
+// len(row.Lengths) are silently skipped. NULL columns (Lengths[i] < 0) are
+// treated as zero-size.
+func (tp *TablePlan) checkJSONRowSize(row *querypb.Row, limit int64) error {
+	if row == nil {
 		return nil
 	}
 
-	jsonLength := func(fieldIndex, jsonIndex int) int64 {
-		if partialJSONColumns != nil && beforeRow != nil && isBitSet(partialJSONColumns.Cols, jsonIndex) {
+	return tp.checkJSONFieldSizes(limit, func(add func(field *querypb.Field, size int64)) {
+		for i, field := range tp.Fields {
+			if i >= len(row.Lengths) {
+				break
+			}
+			if field.Type != querypb.Type_JSON {
+				continue
+			}
+			add(field, row.Lengths[i])
+		}
+	})
+}
+
+func (tp *TablePlan) checkInsertJSONRowSize(afterRow, beforeRow *querypb.Row, partialJSONColumns *binlogdatapb.RowChange_Bitmap, limit int64) error {
+	if afterRow == nil {
+		return nil
+	}
+
+	jsonInsertSize := func(fieldIndex, jsonIndex int) int64 {
+		if fieldIndex >= len(afterRow.Lengths) {
+			return 0
+		}
+		afterLen := afterRow.Lengths[fieldIndex]
+		if afterLen < 0 {
+			return 0
+		}
+		if partialJSONColumns == nil || beforeRow == nil || !isBitSet(partialJSONColumns.Cols, jsonIndex) {
+			return afterLen
+		}
+		if afterLen == 0 {
 			if fieldIndex >= len(beforeRow.Lengths) || beforeRow.Lengths[fieldIndex] < 0 {
 				return 0
 			}
 			return beforeRow.Lengths[fieldIndex]
 		}
-		if fieldIndex >= len(afterRow.Lengths) || afterRow.Lengths[fieldIndex] < 0 {
-			return 0
+		beforeLen := int64(0)
+		if fieldIndex < len(beforeRow.Lengths) && beforeRow.Lengths[fieldIndex] > 0 {
+			beforeLen = beforeRow.Lengths[fieldIndex]
 		}
-		return afterRow.Lengths[fieldIndex]
+		return beforeLen + afterLen
 	}
 
-	var total int64
-	var largestName string
-	var largestSize int64
-	addJSONField := func(fieldIndex, jsonIndex int, field *querypb.Field) {
-		if field.Type != querypb.Type_JSON {
+	return tp.checkJSONFieldSizes(limit, func(add func(field *querypb.Field, size int64)) {
+		if tp.BulkInsertValues != nil && len(tp.BulkInsertValues.BindLocations()) > 0 {
+			fieldsIndex := 0
+			jsonIndex := 0
+			for range tp.BulkInsertValues.BindLocations() {
+				for fieldsIndex < len(tp.Fields) {
+					field := tp.Fields[fieldsIndex]
+					fieldIndex := fieldsIndex
+					fieldJSONIndex := jsonIndex
+					fieldsIndex++
+					if field.Type == querypb.Type_JSON {
+						jsonIndex++
+					}
+					if tp.FieldsToSkip[strings.ToLower(field.Name)] {
+						continue
+					}
+					if field.Type == querypb.Type_JSON {
+						add(field, jsonInsertSize(fieldIndex, fieldJSONIndex))
+					}
+					break
+				}
+			}
 			return
 		}
-		n := jsonLength(fieldIndex, jsonIndex)
-		total += n
-		if n > largestSize {
-			largestSize = n
-			largestName = field.Name
-		}
-	}
 
-	if tp.BulkInsertValues != nil && len(tp.BulkInsertValues.BindLocations()) > 0 {
-		fieldsIndex := 0
-		jsonIndex := 0
-		for range tp.BulkInsertValues.BindLocations() {
-			for fieldsIndex < len(tp.Fields) {
-				field := tp.Fields[fieldsIndex]
-				fieldIndex := fieldsIndex
-				fieldJSONIndex := jsonIndex
-				fieldsIndex++
-				if field.Type == querypb.Type_JSON {
-					jsonIndex++
-				}
-				if tp.FieldsToSkip[strings.ToLower(field.Name)] {
-					continue
-				}
-				addJSONField(fieldIndex, fieldJSONIndex, field)
-				break
-			}
-		}
-	} else {
 		jsonIndex := 0
 		for i, field := range tp.Fields {
 			if i >= len(afterRow.Lengths) {
@@ -358,16 +372,35 @@ func (tp *TablePlan) checkInsertJSONRowSize(afterRow, beforeRow *querypb.Row, pa
 			if tp.FieldsToSkip[strings.ToLower(field.Name)] {
 				continue
 			}
-			addJSONField(i, fieldJSONIndex, field)
+			if field.Type == querypb.Type_JSON {
+				add(field, jsonInsertSize(i, fieldJSONIndex))
+			}
 		}
+	})
+}
+
+func (tp *TablePlan) checkUpdateJSONRowSize(afterRow *querypb.Row, dataColumns *binlogdatapb.RowChange_Bitmap, limit int64) error {
+	if afterRow == nil {
+		return nil
 	}
 
-	if total > limit {
-		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
-			"vreplication: row JSON payload %d bytes exceeds vreplication-max-row-json-bytes=%d (table=%s, largest_json_column=%s @ %d bytes)",
-			total, limit, tp.TargetName, largestName, largestSize)
-	}
-	return nil
+	return tp.checkJSONFieldSizes(limit, func(add func(field *querypb.Field, size int64)) {
+		for i, field := range tp.Fields {
+			if i >= len(afterRow.Lengths) {
+				break
+			}
+			if field.Type != querypb.Type_JSON {
+				continue
+			}
+			if tp.FieldsToSkip[strings.ToLower(field.Name)] {
+				continue
+			}
+			if dataColumns != nil && dataColumns.Count > 0 && !isBitSet(dataColumns.Cols, i) {
+				continue
+			}
+			add(field, afterRow.Lengths[i])
+		}
+	})
 }
 
 func (tp *TablePlan) maxRowJSONBytes() int64 {
@@ -639,7 +672,7 @@ func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor fun
 	case before && after:
 		if !tp.pkChanged(bindvars) && !tp.HasExtraSourcePkColumns {
 			if limit > 0 {
-				if err := tp.checkJSONRowSize(rowChange.After, limit); err != nil {
+				if err := tp.checkUpdateJSONRowSize(rowChange.After, rowChange.DataColumns, limit); err != nil {
 					return nil, err
 				}
 			}

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -257,25 +257,31 @@ func (tp *TablePlan) MarshalJSON() ([]byte, error) {
 
 // checkJSONRowSize sums the byte lengths of all JSON-typed columns in row and
 // returns an error if the sum exceeds limit. When limit <= 0 the check is a
-// no-op. Indices beyond len(tp.Fields) are silently skipped.
-func (tp *TablePlan) checkJSONRowSize(row []sqltypes.Value, limit int64) error {
-	if limit <= 0 {
+// no-op. It reads column sizes directly from row.Lengths so it can run in
+// hot loops without materializing []sqltypes.Value. Indices beyond
+// len(row.Lengths) are silently skipped. NULL columns (Lengths[i] < 0) are
+// treated as zero-size.
+func (tp *TablePlan) checkJSONRowSize(row *querypb.Row, limit int64) error {
+	if limit <= 0 || row == nil {
 		return nil
 	}
 	var total int64
 	var largestName string
 	var largestSize int64
 	for i, field := range tp.Fields {
-		if i >= len(row) {
+		if i >= len(row.Lengths) {
 			break
 		}
 		if field.Type != querypb.Type_JSON {
 			continue
 		}
-		sz := int64(row[i].Len())
-		total += sz
-		if sz > largestSize {
-			largestSize = sz
+		n := row.Lengths[i]
+		if n < 0 {
+			continue
+		}
+		total += n
+		if n > largestSize {
+			largestSize = n
 			largestName = field.Name
 		}
 	}
@@ -313,11 +319,8 @@ func (tp *TablePlan) applyBulkInsert(sqlbuffer *bytes2.Buffer, rows []*querypb.R
 	rowCount := 0
 	for _, row := range rows {
 		if tp.WorkflowConfig != nil {
-			if limit := tp.WorkflowConfig.MaxRowJSONBytes; limit > 0 {
-				vals := sqltypes.MakeRowTrusted(tp.Fields, row)
-				if err := tp.checkJSONRowSize(vals, limit); err != nil {
-					return nil, err
-				}
+			if err := tp.checkJSONRowSize(row, tp.WorkflowConfig.MaxRowJSONBytes); err != nil {
+				return nil, err
 			}
 		}
 		beforeLen := sqlbuffer.Len()
@@ -474,12 +477,12 @@ func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor fun
 		}
 	}
 	if rowChange.After != nil {
+		if err := tp.checkJSONRowSize(rowChange.After, tp.WorkflowConfig.MaxRowJSONBytes); err != nil {
+			return nil, err
+		}
 		jsonIndex := 0
 		after = true
 		afterVals = sqltypes.MakeRowTrusted(tp.Fields, rowChange.After)
-		if err := tp.checkJSONRowSize(afterVals, tp.WorkflowConfig.MaxRowJSONBytes); err != nil {
-			return nil, err
-		}
 		for i, field := range tp.Fields {
 			var (
 				bindVar *querypb.BindVariable

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -293,6 +293,90 @@ func (tp *TablePlan) checkJSONRowSize(row *querypb.Row, limit int64) error {
 	return nil
 }
 
+func (tp *TablePlan) checkInsertJSONRowSize(afterRow, beforeRow *querypb.Row, partialJSONColumns *binlogdatapb.RowChange_Bitmap, limit int64) error {
+	if limit <= 0 || afterRow == nil {
+		return nil
+	}
+
+	jsonLength := func(fieldIndex, jsonIndex int) int64 {
+		if partialJSONColumns != nil && beforeRow != nil && isBitSet(partialJSONColumns.Cols, jsonIndex) {
+			if fieldIndex >= len(beforeRow.Lengths) || beforeRow.Lengths[fieldIndex] < 0 {
+				return 0
+			}
+			return beforeRow.Lengths[fieldIndex]
+		}
+		if fieldIndex >= len(afterRow.Lengths) || afterRow.Lengths[fieldIndex] < 0 {
+			return 0
+		}
+		return afterRow.Lengths[fieldIndex]
+	}
+
+	var total int64
+	var largestName string
+	var largestSize int64
+	addJSONField := func(fieldIndex, jsonIndex int, field *querypb.Field) {
+		if field.Type != querypb.Type_JSON {
+			return
+		}
+		n := jsonLength(fieldIndex, jsonIndex)
+		total += n
+		if n > largestSize {
+			largestSize = n
+			largestName = field.Name
+		}
+	}
+
+	if tp.BulkInsertValues != nil && len(tp.BulkInsertValues.BindLocations()) > 0 {
+		fieldsIndex := 0
+		jsonIndex := 0
+		for range tp.BulkInsertValues.BindLocations() {
+			for fieldsIndex < len(tp.Fields) {
+				field := tp.Fields[fieldsIndex]
+				fieldIndex := fieldsIndex
+				fieldJSONIndex := jsonIndex
+				fieldsIndex++
+				if field.Type == querypb.Type_JSON {
+					jsonIndex++
+				}
+				if tp.FieldsToSkip[strings.ToLower(field.Name)] {
+					continue
+				}
+				addJSONField(fieldIndex, fieldJSONIndex, field)
+				break
+			}
+		}
+	} else {
+		jsonIndex := 0
+		for i, field := range tp.Fields {
+			if i >= len(afterRow.Lengths) {
+				break
+			}
+			fieldJSONIndex := jsonIndex
+			if field.Type == querypb.Type_JSON {
+				jsonIndex++
+			}
+			if tp.FieldsToSkip[strings.ToLower(field.Name)] {
+				continue
+			}
+			addJSONField(i, fieldJSONIndex, field)
+		}
+	}
+
+	if total > limit {
+		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
+			"vreplication: row JSON payload %d bytes exceeds vreplication-max-row-json-bytes=%d (table=%s, largest_json_column=%s @ %d bytes)",
+			total, limit, tp.TargetName, largestName, largestSize)
+	}
+	return nil
+}
+
+func (tp *TablePlan) maxRowJSONBytes() int64 {
+	if tp.WorkflowConfig == nil {
+		return 0
+	}
+	return tp.WorkflowConfig.MaxRowJSONBytes
+}
+
 func (tp *TablePlan) applyBulkInsert(sqlbuffer *bytes2.Buffer, rows []*querypb.Row, executor func(string) (*sqltypes.Result, error), maxQuerySize int64) (*sqltypes.Result, error) {
 	insertPrefix := tp.BulkInsertFront.Query + " values "
 	insertSuffixLen := 0
@@ -316,10 +400,11 @@ func (tp *TablePlan) applyBulkInsert(sqlbuffer *bytes2.Buffer, rows []*querypb.R
 	sqlbuffer.WriteString(insertPrefix)
 
 	var lastResult *sqltypes.Result
+	limit := tp.maxRowJSONBytes()
 	rowCount := 0
 	for _, row := range rows {
-		if tp.WorkflowConfig != nil {
-			if err := tp.checkJSONRowSize(row, tp.WorkflowConfig.MaxRowJSONBytes); err != nil {
+		if limit > 0 {
+			if err := tp.checkInsertJSONRowSize(row, nil, nil, limit); err != nil {
 				return nil, err
 			}
 		}
@@ -477,9 +562,6 @@ func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor fun
 		}
 	}
 	if rowChange.After != nil {
-		if err := tp.checkJSONRowSize(rowChange.After, tp.WorkflowConfig.MaxRowJSONBytes); err != nil {
-			return nil, err
-		}
 		jsonIndex := 0
 		after = true
 		afterVals = sqltypes.MakeRowTrusted(tp.Fields, rowChange.After)
@@ -527,11 +609,17 @@ func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor fun
 			bindvars["a_"+field.Name] = bindVar
 		}
 	}
+	limit := tp.maxRowJSONBytes()
 	switch {
 	case !before && after:
 		// Only apply inserts for rows whose primary keys are within the range of rows already copied.
 		if tp.isOutsidePKRange(bindvars, before, after, "insert") {
 			return nil, nil
+		}
+		if limit > 0 {
+			if err := tp.checkInsertJSONRowSize(rowChange.After, nil, nil, limit); err != nil {
+				return nil, err
+			}
 		}
 		if tp.isPartial(rowChange) {
 			ins, err := tp.getPartialInsertQuery(rowChange.DataColumns)
@@ -550,6 +638,11 @@ func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor fun
 		return execParsedQuery(tp.Delete, bindvars, executor)
 	case before && after:
 		if !tp.pkChanged(bindvars) && !tp.HasExtraSourcePkColumns {
+			if limit > 0 {
+				if err := tp.checkJSONRowSize(rowChange.After, limit); err != nil {
+					return nil, err
+				}
+			}
 			if tp.isPartial(rowChange) {
 				upd, err := tp.getPartialUpdateQuery(rowChange.DataColumns)
 				if err != nil {
@@ -561,12 +654,18 @@ func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor fun
 				return execParsedQuery(tp.Update, bindvars, executor)
 			}
 		}
+		skipInsert := tp.isOutsidePKRange(bindvars, before, after, "insert")
+		if !skipInsert && limit > 0 {
+			if err := tp.checkInsertJSONRowSize(rowChange.After, rowChange.Before, rowChange.JsonPartialValues, limit); err != nil {
+				return nil, err
+			}
+		}
 		if tp.Delete != nil {
 			if _, err := execParsedQuery(tp.Delete, bindvars, executor); err != nil {
 				return nil, err
 			}
 		}
-		if tp.isOutsidePKRange(bindvars, before, after, "insert") {
+		if skipInsert {
 			return nil, nil
 		}
 		if tp.isPartial(rowChange) {
@@ -720,8 +819,14 @@ func (tp *TablePlan) applyBulkInsertChanges(rowInserts []*binlogdatapb.RowChange
 		return executor(insertPrefix + vals.String())
 	}
 
+	limit := tp.maxRowJSONBytes()
 	newStmt := true
 	for _, rowInsert := range rowInserts {
+		if limit > 0 {
+			if err := tp.checkInsertJSONRowSize(rowInsert.After, nil, nil, limit); err != nil {
+				return nil, err
+			}
+		}
 		var (
 			err     error
 			bindVar *querypb.BindVariable

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -616,6 +616,15 @@ func (tp *TablePlan) bindAfterJSONFieldVals(rowChange *binlogdatapb.RowChange, a
 		if i >= len(afterVals) {
 			break
 		}
+		// FieldsToSkip columns (e.g. target-side generated columns) are never
+		// referenced by the generated SQL, so there is no bindvar to populate.
+		// jsonIndex must still advance: JsonPartialValues bits are indexed by
+		// the source's JSON-column ordering, so a skipped JSON column still
+		// consumes a bit position.
+		if tp.FieldsToSkip[strings.ToLower(field.Name)] {
+			jsonIndex++
+			continue
+		}
 
 		var (
 			bindVar *querypb.BindVariable
@@ -759,6 +768,14 @@ func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor fun
 			jsonIndex := 0
 			for i, field := range tp.Fields {
 				if field.Type == querypb.Type_JSON && rowChange.JsonPartialValues != nil {
+					// Skipped JSON columns (e.g. target-side generated columns)
+					// are not referenced by the INSERT, so there is no bindvar
+					// to rewrite. jsonIndex must still advance so subsequent
+					// JSON columns read the correct JsonPartialValues bit.
+					if tp.FieldsToSkip[strings.ToLower(field.Name)] {
+						jsonIndex++
+						continue
+					}
 					switch {
 					case !isBitSet(rowChange.JsonPartialValues.Cols, jsonIndex):
 						// We use the full AFTER value which we already have.

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -579,6 +579,80 @@ func (tp *TablePlan) bindFieldVal(field *querypb.Field, val *sqltypes.Value) (*q
 	return sqltypes.ValueBindVariable(*val), nil
 }
 
+func (tp *TablePlan) clearEmptyPartialJSONDataColumns(rowChange *binlogdatapb.RowChange, afterVals []sqltypes.Value) {
+	if rowChange.JsonPartialValues == nil || rowChange.DataColumns == nil {
+		return
+	}
+
+	jsonIndex := 0
+	for i, field := range tp.Fields {
+		if field.Type != querypb.Type_JSON {
+			continue
+		}
+		if i >= len(afterVals) {
+			break
+		}
+		if !afterVals[i].IsNull() &&
+			isBitSet(rowChange.JsonPartialValues.Cols, jsonIndex) &&
+			!slices.Equal(afterVals[i].Raw(), sqltypes.NullBytes) &&
+			len(afterVals[i].Raw()) == 0 {
+			// If the JSON column was NOT updated then the JSON column is marked as
+			// partial and the diff is empty as a way to exclude it from the AFTER image.
+			// It still has the data bit set, however, even though it's not really
+			// present. So we have to account for this by unsetting the data bit so
+			// that the column's current JSON value is not lost.
+			setBit(rowChange.DataColumns.Cols, i, false)
+		}
+		jsonIndex++
+	}
+}
+
+func (tp *TablePlan) bindAfterJSONFieldVals(rowChange *binlogdatapb.RowChange, afterVals []sqltypes.Value, bindvars map[string]*querypb.BindVariable) error {
+	jsonIndex := 0
+	for i, field := range tp.Fields {
+		if field.Type != querypb.Type_JSON {
+			continue
+		}
+		if i >= len(afterVals) {
+			break
+		}
+
+		var (
+			bindVar *querypb.BindVariable
+			newVal  *sqltypes.Value
+			err     error
+		)
+		switch {
+		case afterVals[i].IsNull(): // An SQL NULL and not an actual JSON value
+			newVal = &sqltypes.NULL
+		case rowChange.JsonPartialValues != nil && isBitSet(rowChange.JsonPartialValues.Cols, jsonIndex) &&
+			!slices.Equal(afterVals[i].Raw(), sqltypes.NullBytes):
+			// An SQL expression that can be converted to a JSON value such as JSON_INSERT().
+			// This occurs when using partial JSON values as a result of mysqld using
+			// binlog-row-value-options=PARTIAL_JSON.
+			if len(afterVals[i].Raw()) == 0 {
+				tp.clearEmptyPartialJSONDataColumns(rowChange, afterVals)
+				newVal = new(sqltypes.MakeTrusted(querypb.Type_EXPRESSION, nil))
+			} else {
+				newVal = new(sqltypes.MakeTrusted(querypb.Type_EXPRESSION,
+					fmt.Appendf(nil, afterVals[i].RawStr(), sqlescape.EscapeID(field.Name))))
+			}
+		default: // A JSON value (which may be a JSON null literal value)
+			newVal, err = vjson.MarshalSQLValue(afterVals[i].Raw())
+			if err != nil {
+				return err
+			}
+		}
+		bindVar, err = tp.bindFieldVal(field, newVal)
+		if err != nil {
+			return err
+		}
+		bindvars["a_"+field.Name] = bindVar
+		jsonIndex++
+	}
+	return nil
+}
+
 func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor func(string) (*sqltypes.Result, error)) (*sqltypes.Result, error) {
 	// MakeRowTrusted is needed here because Proto3ToResult is not convenient.
 	var (
@@ -598,52 +672,16 @@ func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor fun
 		}
 	}
 	if rowChange.After != nil {
-		jsonIndex := 0
 		after = true
 		afterVals = sqltypes.MakeRowTrusted(tp.Fields, rowChange.After)
 		for i, field := range tp.Fields {
-			var (
-				bindVar *querypb.BindVariable
-				newVal  *sqltypes.Value
-				err     error
-			)
-			if field.Type == querypb.Type_JSON {
-				switch {
-				case afterVals[i].IsNull(): // An SQL NULL and not an actual JSON value
-					newVal = &sqltypes.NULL
-				case rowChange.JsonPartialValues != nil && isBitSet(rowChange.JsonPartialValues.Cols, jsonIndex) &&
-					!slices.Equal(afterVals[i].Raw(), sqltypes.NullBytes):
-					// An SQL expression that can be converted to a JSON value such as JSON_INSERT().
-					// This occurs when using partial JSON values as a result of mysqld using
-					// binlog-row-value-options=PARTIAL_JSON.
-					if len(afterVals[i].Raw()) == 0 {
-						// If the JSON column was NOT updated then the JSON column is marked as
-						// partial and the diff is empty as a way to exclude it from the AFTER image.
-						// It still has the data bit set, however, even though it's not really
-						// present. So we have to account for this by unsetting the data bit so
-						// that the column's current JSON value is not lost.
-						setBit(rowChange.DataColumns.Cols, i, false)
-						newVal = new(sqltypes.MakeTrusted(querypb.Type_EXPRESSION, nil))
-					} else {
-						newVal = new(sqltypes.MakeTrusted(querypb.Type_EXPRESSION,
-							fmt.Appendf(nil, afterVals[i].RawStr(), sqlescape.EscapeID(field.Name))))
-					}
-				default: // A JSON value (which may be a JSON null literal value)
-					newVal, err = vjson.MarshalSQLValue(afterVals[i].Raw())
-					if err != nil {
-						return nil, err
-					}
-				}
-				bindVar, err = tp.bindFieldVal(field, newVal)
-				jsonIndex++
-			} else {
-				bindVar, err = tp.bindFieldVal(field, &afterVals[i])
-			}
+			bindVar, err := tp.bindFieldVal(field, &afterVals[i])
 			if err != nil {
 				return nil, err
 			}
 			bindvars["a_"+field.Name] = bindVar
 		}
+		tp.clearEmptyPartialJSONDataColumns(rowChange, afterVals)
 	}
 	limit := tp.maxRowJSONBytes()
 	switch {
@@ -656,6 +694,9 @@ func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor fun
 			if err := tp.checkInsertJSONRowSize(rowChange.After, nil, nil, limit); err != nil {
 				return nil, err
 			}
+		}
+		if err := tp.bindAfterJSONFieldVals(rowChange, afterVals, bindvars); err != nil {
+			return nil, err
 		}
 		if tp.isPartial(rowChange) {
 			ins, err := tp.getPartialInsertQuery(rowChange.DataColumns)
@@ -679,6 +720,9 @@ func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor fun
 					return nil, err
 				}
 			}
+			if err := tp.bindAfterJSONFieldVals(rowChange, afterVals, bindvars); err != nil {
+				return nil, err
+			}
 			if tp.isPartial(rowChange) {
 				upd, err := tp.getPartialUpdateQuery(rowChange.DataColumns)
 				if err != nil {
@@ -693,6 +737,11 @@ func (tp *TablePlan) applyChange(rowChange *binlogdatapb.RowChange, executor fun
 		skipInsert := tp.isOutsidePKRange(bindvars, before, after, "insert")
 		if !skipInsert && limit > 0 {
 			if err := tp.checkInsertJSONRowSize(rowChange.After, rowChange.Before, rowChange.JsonPartialValues, limit); err != nil {
+				return nil, err
+			}
+		}
+		if !skipInsert {
+			if err := tp.bindAfterJSONFieldVals(rowChange, afterVals, bindvars); err != nil {
 				return nil, err
 			}
 		}

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -1252,6 +1252,97 @@ func BenchmarkMarshalJSONForSQL(b *testing.B) {
 	}
 }
 
+func TestCheckJSONRowSize(t *testing.T) {
+	newTablePlan := func(fields []*querypb.Field) *TablePlan {
+		return &TablePlan{
+			TargetName: "mytable",
+			Fields:     fields,
+		}
+	}
+
+	jsonField := func(name string) *querypb.Field {
+		return &querypb.Field{Name: name, Type: querypb.Type_JSON}
+	}
+	intField := func(name string) *querypb.Field {
+		return &querypb.Field{Name: name, Type: querypb.Type_INT64}
+	}
+	jsonVal := func(s string) sqltypes.Value {
+		return sqltypes.MakeTrusted(querypb.Type_JSON, []byte(s))
+	}
+	intVal := func(s string) sqltypes.Value {
+		return sqltypes.MakeTrusted(querypb.Type_INT64, []byte(s))
+	}
+
+	t.Run("disabled when limit is zero", func(t *testing.T) {
+		tp := newTablePlan([]*querypb.Field{jsonField("j")})
+		row := []sqltypes.Value{jsonVal(`{"key":"` + strings.Repeat("x", 1_000_000) + `"}`)}
+		require.NoError(t, tp.checkJSONRowSize(row, 0))
+	})
+
+	t.Run("disabled when limit is negative", func(t *testing.T) {
+		tp := newTablePlan([]*querypb.Field{jsonField("j")})
+		row := []sqltypes.Value{jsonVal(`{"key":"` + strings.Repeat("x", 1_000_000) + `"}`)}
+		require.NoError(t, tp.checkJSONRowSize(row, -1))
+	})
+
+	t.Run("no JSON columns is a no-op", func(t *testing.T) {
+		tp := newTablePlan([]*querypb.Field{intField("id")})
+		row := []sqltypes.Value{intVal("42")}
+		require.NoError(t, tp.checkJSONRowSize(row, 100))
+	})
+
+	t.Run("empty row is a no-op", func(t *testing.T) {
+		tp := newTablePlan([]*querypb.Field{jsonField("j")})
+		require.NoError(t, tp.checkJSONRowSize([]sqltypes.Value{}, 100))
+	})
+
+	t.Run("under limit passes", func(t *testing.T) {
+		tp := newTablePlan([]*querypb.Field{jsonField("j")})
+		row := []sqltypes.Value{jsonVal(`{"k":"v"}`)}
+		require.NoError(t, tp.checkJSONRowSize(row, 1000))
+	})
+
+	t.Run("exactly at limit passes", func(t *testing.T) {
+		payload := `{"k":"v"}`
+		tp := newTablePlan([]*querypb.Field{jsonField("j")})
+		row := []sqltypes.Value{jsonVal(payload)}
+		require.NoError(t, tp.checkJSONRowSize(row, int64(len(payload))))
+	})
+
+	t.Run("over limit returns error", func(t *testing.T) {
+		tp := newTablePlan([]*querypb.Field{jsonField("j")})
+		row := []sqltypes.Value{jsonVal(`{"key":"value"}`)}
+		err := tp.checkJSONRowSize(row, 5)
+		require.ErrorContains(t, err, "vreplication: row JSON payload")
+		require.ErrorContains(t, err, "vreplication-max-row-json-bytes=5")
+		require.ErrorContains(t, err, "table=mytable")
+		require.ErrorContains(t, err, "largest_json_column=j")
+	})
+
+	t.Run("multi-column sum triggers error", func(t *testing.T) {
+		tp := newTablePlan([]*querypb.Field{jsonField("j1"), jsonField("j2")})
+		row := []sqltypes.Value{jsonVal(`{"a":"bb"}`), jsonVal(`{"c":"dd"}`)}
+		// each is ~10 bytes; limit 15 should fail on their sum
+		err := tp.checkJSONRowSize(row, 15)
+		require.ErrorContains(t, err, "vreplication: row JSON payload")
+	})
+
+	t.Run("multi-column under limit passes", func(t *testing.T) {
+		tp := newTablePlan([]*querypb.Field{jsonField("j1"), jsonField("j2")})
+		row := []sqltypes.Value{jsonVal(`{"a":"b"}`), jsonVal(`{"c":"d"}`)}
+		require.NoError(t, tp.checkJSONRowSize(row, 1000))
+	})
+
+	t.Run("non-JSON columns not counted", func(t *testing.T) {
+		tp := newTablePlan([]*querypb.Field{intField("id"), jsonField("j"), intField("ts")})
+		// Only j (9 bytes) counted; id and ts are ints
+		row := []sqltypes.Value{intVal("1"), jsonVal(`{"k":"v"}`), intVal("99")}
+		require.NoError(t, tp.checkJSONRowSize(row, 10))
+		err := tp.checkJSONRowSize(row, 8)
+		require.ErrorContains(t, err, "vreplication: row JSON payload")
+	})
+}
+
 func BenchmarkAppendFromRowLargeJSON(b *testing.B) {
 	raw := []byte(`[` + strings.Repeat(`12345678,`, 150000) + `0]`)
 	tp := &TablePlan{

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -1548,8 +1548,8 @@ func TestApplyChangeChecksPartialJSONDiffSizeForDeleteInsert(t *testing.T) {
 	require.Empty(t, executed)
 }
 
-func TestApplyChangeChecksPartialJSONBaseSizeForUpdate(t *testing.T) {
-	beforeJSON := []byte(`{"big":"` + strings.Repeat("x", 64) + `"}`)
+func TestApplyChangeFailsFastForLargeExistingJSONWithTinyPartialUpdate(t *testing.T) {
+	beforeJSON := []byte(`{"big":"` + strings.Repeat("x", 1<<20) + `"}`)
 	diff := []byte(`JSON_INSERT(%s, _utf8mb4'$.small', CAST(1 as JSON))`)
 	idCol := &colExpr{
 		colName: sqlparser.NewIdentifierCI("id"),
@@ -1606,13 +1606,12 @@ func TestApplyChangeChecksPartialJSONBaseSizeForUpdate(t *testing.T) {
 		},
 	}
 
-	var executed []string
 	_, err := tp.applyChange(rowChange, func(sql string) (*sqltypes.Result, error) {
-		executed = append(executed, sql)
-		return &sqltypes.Result{RowsAffected: 1}, nil
+		require.Failf(t, "executor should not be called", "unexpected SQL: %s", sql)
+		return nil, nil
 	})
 	require.ErrorContains(t, err, "vreplication: row JSON payload")
-	require.Empty(t, executed)
+	require.ErrorContains(t, err, "largest_json_column=j")
 }
 
 func BenchmarkAppendFromRowLargeJSON(b *testing.B) {

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -1582,6 +1582,34 @@ func TestApplyChangeChecksPartialJSONDiffSizeForDeleteInsert(t *testing.T) {
 	require.Empty(t, executed)
 }
 
+func TestApplyChangeChecksJSONSizeBeforeMarshalling(t *testing.T) {
+	raw := []byte(`{"big":"` + strings.Repeat("x", 64))
+	tp := &TablePlan{
+		TargetName: "t",
+		Insert: sqlparser.BuildParsedQuery("insert into t(j) values (%a)",
+			":a_j",
+		),
+		Fields: []*querypb.Field{
+			{Name: "j", Type: querypb.Type_JSON},
+		},
+		FieldsToSkip:   map[string]bool{},
+		WorkflowConfig: &vttablet.VReplicationConfig{MaxRowJSONBytes: 16},
+	}
+	rowChange := &binlogdatapb.RowChange{
+		After: &querypb.Row{
+			Lengths: []int64{int64(len(raw))},
+			Values:  raw,
+		},
+	}
+
+	_, err := tp.applyChange(rowChange, func(sql string) (*sqltypes.Result, error) {
+		require.Failf(t, "executor should not be called", "unexpected SQL: %s", sql)
+		return nil, nil
+	})
+	require.ErrorContains(t, err, "vreplication: row JSON payload")
+	require.ErrorContains(t, err, "largest_json_column=j")
+}
+
 func TestApplyChangeFailsFastForLargeExistingJSONWithTinyPartialUpdate(t *testing.T) {
 	beforeJSON := []byte(`{"big":"` + strings.Repeat("x", 1<<20) + `"}`)
 	diff := []byte(`JSON_INSERT(%s, _utf8mb4'$.small', CAST(1 as JSON))`)

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -1536,6 +1536,116 @@ func TestApplyChangeIgnoresSkippedJSONColumnsWhenCheckingUpdateLimit(t *testing.
 	assert.Equal(t, "update t set v='new' where id=1", executed[0])
 }
 
+func TestApplyChangeSkipsMarshallingGeneratedJSONColumns(t *testing.T) {
+	// The skipped column's bytes are intentionally not valid JSON:
+	// vjson.MarshalSQLValue errors on this input, so if bindAfterJSONFieldVals
+	// wastefully marshals a FieldsToSkip column, applyChange returns that
+	// error. A passing test proves we bypass the marshal for skipped fields.
+	skippedInvalid := []byte(`not-json`)
+	validJSON := []byte(`{"ok":true}`)
+	tp := &TablePlan{
+		TargetName: "t",
+		Insert: sqlparser.BuildParsedQuery("insert into t(id, j) values (%a, %a)",
+			":a_id", ":a_j",
+		),
+		Fields: []*querypb.Field{
+			{Name: "id", Type: querypb.Type_INT64},
+			{Name: "j_gen", Type: querypb.Type_JSON},
+			{Name: "j", Type: querypb.Type_JSON},
+		},
+		FieldsToSkip: map[string]bool{
+			"j_gen": true,
+		},
+		PKReferences:   []string{"id"},
+		WorkflowConfig: &vttablet.VReplicationConfig{MaxRowJSONBytes: 0},
+	}
+	rowChange := &binlogdatapb.RowChange{
+		After: &querypb.Row{
+			Lengths: []int64{1, int64(len(skippedInvalid)), int64(len(validJSON))},
+			Values:  append(append([]byte("1"), skippedInvalid...), validJSON...),
+		},
+	}
+
+	var executed []string
+	_, err := tp.applyChange(rowChange, func(sql string) (*sqltypes.Result, error) {
+		executed = append(executed, sql)
+		return &sqltypes.Result{RowsAffected: 1}, nil
+	})
+	require.NoError(t, err)
+	require.Len(t, executed, 1)
+	assert.Contains(t, executed[0], "JSON_OBJECT(")
+	assert.NotContains(t, executed[0], "not-json")
+}
+
+func TestApplyChangePartialRebuildSkipsGeneratedJSONColumns(t *testing.T) {
+	// Exercises the DELETE+INSERT partial-rebuild loop. The skipped generated
+	// JSON column has its partial bit set AND an empty AFTER diff, which
+	// routes into the "marshal the BEFORE value" branch. The BEFORE bytes
+	// are intentionally not valid JSON, so vjson.MarshalSQLValue errors if
+	// called. A passing test proves the rebuild loop skips the column
+	// instead of wastefully marshalling it — and keeps jsonIndex aligned
+	// so the non-skipped JSON column's partial bit is read correctly.
+	skippedInvalidBefore := []byte(`not-json`)
+	validBeforeJSON := []byte(`{"k":"before"}`)
+	validAfterJSON := []byte(`{"k":"after"}`)
+
+	beforeVals := append([]byte("1"), skippedInvalidBefore...)
+	beforeVals = append(beforeVals, validBeforeJSON...)
+	afterVals := append([]byte("2"), validAfterJSON...)
+
+	tp := &TablePlan{
+		TargetName: "t",
+		Insert: sqlparser.BuildParsedQuery("insert into t(id, j) values (%a, %a)",
+			":a_id", ":a_j",
+		),
+		Delete: sqlparser.BuildParsedQuery("delete from t where id=%a",
+			":b_id",
+		),
+		Fields: []*querypb.Field{
+			{Name: "id", Type: querypb.Type_INT64},
+			{Name: "j_gen", Type: querypb.Type_JSON},
+			{Name: "j", Type: querypb.Type_JSON},
+		},
+		FieldsToSkip: map[string]bool{
+			"j_gen": true,
+		},
+		PKReferences:   []string{"id"},
+		WorkflowConfig: &vttablet.VReplicationConfig{MaxRowJSONBytes: 0},
+	}
+	rowChange := &binlogdatapb.RowChange{
+		Before: &querypb.Row{
+			Lengths: []int64{1, int64(len(skippedInvalidBefore)), int64(len(validBeforeJSON))},
+			Values:  beforeVals,
+		},
+		After: &querypb.Row{
+			// j_gen has an empty AFTER diff ("column not updated").
+			Lengths: []int64{1, 0, int64(len(validAfterJSON))},
+			Values:  afterVals,
+		},
+		DataColumns: &binlogdatapb.RowChange_Bitmap{
+			Count: 3,
+			Cols:  []byte{0x07},
+		},
+		JsonPartialValues: &binlogdatapb.RowChange_Bitmap{
+			Count: 2,
+			// j_gen is partial (bit 0); j is not (bit 1 unset).
+			Cols: []byte{0x01},
+		},
+	}
+
+	var executed []string
+	_, err := tp.applyChange(rowChange, func(sql string) (*sqltypes.Result, error) {
+		executed = append(executed, sql)
+		return &sqltypes.Result{RowsAffected: 1}, nil
+	})
+	require.NoError(t, err)
+	require.Len(t, executed, 2)
+	assert.Equal(t, "delete from t where id=1", executed[0])
+	assert.Contains(t, executed[1], "insert into t(id, j) values (2,")
+	assert.Contains(t, executed[1], "JSON_OBJECT(")
+	assert.NotContains(t, executed[1], "not-json")
+}
+
 func TestApplyChangeChecksPartialJSONDiffSizeForDeleteInsert(t *testing.T) {
 	beforeJSON := []byte(`{"small":"x"}`)
 	diff := []byte(`JSON_INSERT(%s, _utf8mb4'$.big', CAST(JSON_QUOTE(_utf8mb4'` + strings.Repeat("x", 64) + `') as JSON))`)

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -1463,6 +1463,91 @@ func TestApplyChangeChecksEffectiveJSONSizeForPartialDeleteInsert(t *testing.T) 
 	require.Empty(t, executed)
 }
 
+func TestApplyChangeIgnoresSkippedJSONColumnsWhenCheckingUpdateLimit(t *testing.T) {
+	skippedJSON := []byte(`{"big":"` + strings.Repeat("x", 64) + `"}`)
+	tp := &TablePlan{
+		TargetName: "t",
+		Update: sqlparser.BuildParsedQuery("update t set v=%a where id=%a",
+			":a_v", ":b_id",
+		),
+		Fields: []*querypb.Field{
+			{Name: "id", Type: querypb.Type_INT64},
+			{Name: "v", Type: querypb.Type_VARCHAR},
+			{Name: "j_generated", Type: querypb.Type_JSON},
+		},
+		FieldsToSkip: map[string]bool{
+			"j_generated": true,
+		},
+		PKReferences:   []string{"id"},
+		WorkflowConfig: &vttablet.VReplicationConfig{MaxRowJSONBytes: 16},
+	}
+	rowChange := &binlogdatapb.RowChange{
+		Before: &querypb.Row{
+			Lengths: []int64{1, 3, int64(len(skippedJSON))},
+			Values:  append([]byte("1old"), skippedJSON...),
+		},
+		After: &querypb.Row{
+			Lengths: []int64{1, 3, int64(len(skippedJSON))},
+			Values:  append([]byte("1new"), skippedJSON...),
+		},
+	}
+
+	var executed []string
+	_, err := tp.applyChange(rowChange, func(sql string) (*sqltypes.Result, error) {
+		executed = append(executed, sql)
+		return &sqltypes.Result{RowsAffected: 1}, nil
+	})
+	require.NoError(t, err)
+	require.Len(t, executed, 1)
+	assert.Equal(t, "update t set v='new' where id=1", executed[0])
+}
+
+func TestApplyChangeChecksPartialJSONDiffSizeForDeleteInsert(t *testing.T) {
+	beforeJSON := []byte(`{"small":"x"}`)
+	diff := []byte(`JSON_INSERT(%s, _utf8mb4'$.big', CAST(JSON_QUOTE(_utf8mb4'` + strings.Repeat("x", 64) + `') as JSON))`)
+	tp := &TablePlan{
+		TargetName: "t",
+		Insert: sqlparser.BuildParsedQuery("insert into t(id, j) values (%a, %a)",
+			":a_id", ":a_j",
+		),
+		Delete: sqlparser.BuildParsedQuery("delete from t where id=%a",
+			":b_id",
+		),
+		Fields: []*querypb.Field{
+			{Name: "id", Type: querypb.Type_INT64},
+			{Name: "j", Type: querypb.Type_JSON},
+		},
+		PKReferences:   []string{"id"},
+		WorkflowConfig: &vttablet.VReplicationConfig{MaxRowJSONBytes: 16},
+	}
+	rowChange := &binlogdatapb.RowChange{
+		Before: &querypb.Row{
+			Lengths: []int64{1, int64(len(beforeJSON))},
+			Values:  append([]byte("1"), beforeJSON...),
+		},
+		After: &querypb.Row{
+			Lengths: []int64{1, int64(len(diff))},
+			Values:  append([]byte("2"), diff...),
+		},
+		DataColumns: &binlogdatapb.RowChange_Bitmap{
+			Count: 2,
+			Cols:  []byte{0x03},
+		},
+		JsonPartialValues: &binlogdatapb.RowChange_Bitmap{
+			Count: 1,
+			Cols:  []byte{0x01},
+		},
+	}
+
+	var executed []string
+	_, err := tp.applyChange(rowChange, func(sql string) (*sqltypes.Result, error) {
+		executed = append(executed, sql)
+		return &sqltypes.Result{RowsAffected: 1}, nil
+	})
+	require.ErrorContains(t, err, "vreplication: row JSON payload")
+	require.Empty(t, executed)
+}
+
 func BenchmarkAppendFromRowLargeJSON(b *testing.B) {
 	raw := []byte(`[` + strings.Repeat(`12345678,`, 150000) + `0]`)
 	tp := &TablePlan{

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -1056,6 +1056,38 @@ func TestApplyBulkInsertMaxQuerySize(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, uint64(3), result.RowsAffected)
 	})
+
+	t.Run("ignores skipped JSON columns when enforcing limit", func(t *testing.T) {
+		jsonTP := &TablePlan{
+			BulkInsertFront: sqlparser.BuildParsedQuery("insert into t(j1)"),
+			BulkInsertValues: sqlparser.BuildParsedQuery("(%a)",
+				":j1",
+			),
+			Fields: []*querypb.Field{
+				{Name: "j1", Type: querypb.Type_JSON},
+				{Name: "j2_generated", Type: querypb.Type_JSON},
+			},
+			FieldsToSkip: map[string]bool{
+				"j2_generated": true,
+			},
+			WorkflowConfig: &vttablet.VReplicationConfig{MaxRowJSONBytes: 32},
+		}
+		visibleJSON := []byte(`{"ok":true}`)
+		skippedJSON := []byte(`{"big":"` + strings.Repeat("x", 128) + `"}`)
+		row := &querypb.Row{
+			Lengths: []int64{int64(len(visibleJSON)), int64(len(skippedJSON))},
+			Values:  append(append([]byte{}, visibleJSON...), skippedJSON...),
+		}
+
+		var executed []string
+		_, err := jsonTP.applyBulkInsert(&bytes2.Buffer{}, []*querypb.Row{row}, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 0)
+		require.NoError(t, err)
+		require.Len(t, executed, 1)
+		assert.Contains(t, executed[0], "insert into t(j1) values")
+	})
 }
 
 func TestApplyBulkInsertChangesMaxQuerySize(t *testing.T) {
@@ -1112,6 +1144,31 @@ func TestApplyBulkInsertChangesMaxQuerySize(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, executed, 1, "single row must still execute even if it exceeds maxQuerySize")
 		assert.Equal(t, expected, executed[0])
+	})
+
+	t.Run("enforces max row JSON bytes", func(t *testing.T) {
+		jsonTP := &TablePlan{
+			BulkInsertFront: sqlparser.BuildParsedQuery("insert into t(j)"),
+			BulkInsertValues: sqlparser.BuildParsedQuery("(%a)",
+				":a_j",
+			),
+			Fields: []*querypb.Field{
+				{Name: "j", Type: querypb.Type_JSON},
+			},
+			FieldsToSkip:     map[string]bool{},
+			TablePlanBuilder: &tablePlanBuilder{stats: binlogplayer.NewStats()},
+			WorkflowConfig:   &vttablet.VReplicationConfig{MaxRowJSONBytes: 16},
+		}
+		rowInserts := []*binlogdatapb.RowChange{{
+			After: sqltypes.RowToProto3([]sqltypes.Value{
+				sqltypes.MakeTrusted(querypb.Type_JSON, []byte(`{"big":"`+strings.Repeat("x", 32)+`"}`)),
+			}),
+		}}
+
+		_, err := jsonTP.applyBulkInsertChanges(rowInserts, func(sql string) (*sqltypes.Result, error) {
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 0)
+		require.ErrorContains(t, err, "vreplication: row JSON payload")
 	})
 }
 
@@ -1359,6 +1416,51 @@ func TestCheckJSONRowSize(t *testing.T) {
 		err := tp.checkJSONRowSize(row, 8)
 		require.ErrorContains(t, err, "vreplication: row JSON payload")
 	})
+}
+
+func TestApplyChangeChecksEffectiveJSONSizeForPartialDeleteInsert(t *testing.T) {
+	beforeJSON := []byte(`{"big":"` + strings.Repeat("x", 64) + `"}`)
+	tp := &TablePlan{
+		TargetName: "t",
+		Insert: sqlparser.BuildParsedQuery("insert into t(id, j) values (%a, %a)",
+			":a_id", ":a_j",
+		),
+		Delete: sqlparser.BuildParsedQuery("delete from t where id=%a",
+			":b_id",
+		),
+		Fields: []*querypb.Field{
+			{Name: "id", Type: querypb.Type_INT64},
+			{Name: "j", Type: querypb.Type_JSON},
+		},
+		PKReferences:   []string{"id"},
+		WorkflowConfig: &vttablet.VReplicationConfig{MaxRowJSONBytes: 16},
+	}
+	rowChange := &binlogdatapb.RowChange{
+		Before: &querypb.Row{
+			Lengths: []int64{1, int64(len(beforeJSON))},
+			Values:  append([]byte("1"), beforeJSON...),
+		},
+		After: &querypb.Row{
+			Lengths: []int64{1, 0},
+			Values:  []byte("2"),
+		},
+		DataColumns: &binlogdatapb.RowChange_Bitmap{
+			Count: 2,
+			Cols:  []byte{0x03},
+		},
+		JsonPartialValues: &binlogdatapb.RowChange_Bitmap{
+			Count: 1,
+			Cols:  []byte{0x01},
+		},
+	}
+
+	var executed []string
+	_, err := tp.applyChange(rowChange, func(sql string) (*sqltypes.Result, error) {
+		executed = append(executed, sql)
+		return &sqltypes.Result{RowsAffected: 1}, nil
+	})
+	require.ErrorContains(t, err, "vreplication: row JSON payload")
+	require.Empty(t, executed)
 }
 
 func BenchmarkAppendFromRowLargeJSON(b *testing.B) {

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -1266,52 +1266,70 @@ func TestCheckJSONRowSize(t *testing.T) {
 	intField := func(name string) *querypb.Field {
 		return &querypb.Field{Name: name, Type: querypb.Type_INT64}
 	}
-	jsonVal := func(s string) sqltypes.Value {
-		return sqltypes.MakeTrusted(querypb.Type_JSON, []byte(s))
-	}
-	intVal := func(s string) sqltypes.Value {
-		return sqltypes.MakeTrusted(querypb.Type_INT64, []byte(s))
+	// makeRow builds a *querypb.Row from per-column byte slices. A nil slice
+	// encodes a SQL NULL (Lengths[i] = -1).
+	makeRow := func(cols ...[]byte) *querypb.Row {
+		row := &querypb.Row{}
+		for _, c := range cols {
+			if c == nil {
+				row.Lengths = append(row.Lengths, -1)
+				continue
+			}
+			row.Lengths = append(row.Lengths, int64(len(c)))
+			row.Values = append(row.Values, c...)
+		}
+		return row
 	}
 
 	t.Run("disabled when limit is zero", func(t *testing.T) {
 		tp := newTablePlan([]*querypb.Field{jsonField("j")})
-		row := []sqltypes.Value{jsonVal(`{"key":"` + strings.Repeat("x", 1_000_000) + `"}`)}
+		row := makeRow([]byte(`{"key":"` + strings.Repeat("x", 1_000_000) + `"}`))
 		require.NoError(t, tp.checkJSONRowSize(row, 0))
 	})
 
 	t.Run("disabled when limit is negative", func(t *testing.T) {
 		tp := newTablePlan([]*querypb.Field{jsonField("j")})
-		row := []sqltypes.Value{jsonVal(`{"key":"` + strings.Repeat("x", 1_000_000) + `"}`)}
+		row := makeRow([]byte(`{"key":"` + strings.Repeat("x", 1_000_000) + `"}`))
 		require.NoError(t, tp.checkJSONRowSize(row, -1))
+	})
+
+	t.Run("nil row is a no-op", func(t *testing.T) {
+		tp := newTablePlan([]*querypb.Field{jsonField("j")})
+		require.NoError(t, tp.checkJSONRowSize(nil, 100))
 	})
 
 	t.Run("no JSON columns is a no-op", func(t *testing.T) {
 		tp := newTablePlan([]*querypb.Field{intField("id")})
-		row := []sqltypes.Value{intVal("42")}
+		row := makeRow([]byte("42"))
 		require.NoError(t, tp.checkJSONRowSize(row, 100))
 	})
 
 	t.Run("empty row is a no-op", func(t *testing.T) {
 		tp := newTablePlan([]*querypb.Field{jsonField("j")})
-		require.NoError(t, tp.checkJSONRowSize([]sqltypes.Value{}, 100))
+		require.NoError(t, tp.checkJSONRowSize(makeRow(), 100))
+	})
+
+	t.Run("NULL JSON column is a no-op", func(t *testing.T) {
+		tp := newTablePlan([]*querypb.Field{jsonField("j")})
+		require.NoError(t, tp.checkJSONRowSize(makeRow(nil), 10))
 	})
 
 	t.Run("under limit passes", func(t *testing.T) {
 		tp := newTablePlan([]*querypb.Field{jsonField("j")})
-		row := []sqltypes.Value{jsonVal(`{"k":"v"}`)}
+		row := makeRow([]byte(`{"k":"v"}`))
 		require.NoError(t, tp.checkJSONRowSize(row, 1000))
 	})
 
 	t.Run("exactly at limit passes", func(t *testing.T) {
-		payload := `{"k":"v"}`
+		payload := []byte(`{"k":"v"}`)
 		tp := newTablePlan([]*querypb.Field{jsonField("j")})
-		row := []sqltypes.Value{jsonVal(payload)}
+		row := makeRow(payload)
 		require.NoError(t, tp.checkJSONRowSize(row, int64(len(payload))))
 	})
 
 	t.Run("over limit returns error", func(t *testing.T) {
 		tp := newTablePlan([]*querypb.Field{jsonField("j")})
-		row := []sqltypes.Value{jsonVal(`{"key":"value"}`)}
+		row := makeRow([]byte(`{"key":"value"}`))
 		err := tp.checkJSONRowSize(row, 5)
 		require.ErrorContains(t, err, "vreplication: row JSON payload")
 		require.ErrorContains(t, err, "vreplication-max-row-json-bytes=5")
@@ -1321,7 +1339,7 @@ func TestCheckJSONRowSize(t *testing.T) {
 
 	t.Run("multi-column sum triggers error", func(t *testing.T) {
 		tp := newTablePlan([]*querypb.Field{jsonField("j1"), jsonField("j2")})
-		row := []sqltypes.Value{jsonVal(`{"a":"bb"}`), jsonVal(`{"c":"dd"}`)}
+		row := makeRow([]byte(`{"a":"bb"}`), []byte(`{"c":"dd"}`))
 		// each is ~10 bytes; limit 15 should fail on their sum
 		err := tp.checkJSONRowSize(row, 15)
 		require.ErrorContains(t, err, "vreplication: row JSON payload")
@@ -1329,14 +1347,14 @@ func TestCheckJSONRowSize(t *testing.T) {
 
 	t.Run("multi-column under limit passes", func(t *testing.T) {
 		tp := newTablePlan([]*querypb.Field{jsonField("j1"), jsonField("j2")})
-		row := []sqltypes.Value{jsonVal(`{"a":"b"}`), jsonVal(`{"c":"d"}`)}
+		row := makeRow([]byte(`{"a":"b"}`), []byte(`{"c":"d"}`))
 		require.NoError(t, tp.checkJSONRowSize(row, 1000))
 	})
 
 	t.Run("non-JSON columns not counted", func(t *testing.T) {
 		tp := newTablePlan([]*querypb.Field{intField("id"), jsonField("j"), intField("ts")})
-		// Only j (9 bytes) counted; id and ts are ints
-		row := []sqltypes.Value{intVal("1"), jsonVal(`{"k":"v"}`), intVal("99")}
+		// Only j (9 bytes) counted; id and ts are ints.
+		row := makeRow([]byte("1"), []byte(`{"k":"v"}`), []byte("99"))
 		require.NoError(t, tp.checkJSONRowSize(row, 10))
 		err := tp.checkJSONRowSize(row, 8)
 		require.ErrorContains(t, err, "vreplication: row JSON payload")

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -1548,6 +1548,73 @@ func TestApplyChangeChecksPartialJSONDiffSizeForDeleteInsert(t *testing.T) {
 	require.Empty(t, executed)
 }
 
+func TestApplyChangeChecksPartialJSONBaseSizeForUpdate(t *testing.T) {
+	beforeJSON := []byte(`{"big":"` + strings.Repeat("x", 64) + `"}`)
+	diff := []byte(`JSON_INSERT(%s, _utf8mb4'$.small', CAST(1 as JSON))`)
+	idCol := &colExpr{
+		colName: sqlparser.NewIdentifierCI("id"),
+		colType: querypb.Type_INT64,
+		expr: &sqlparser.ColName{
+			Name: sqlparser.NewIdentifierCI("id"),
+		},
+		references: map[string]bool{"id": true},
+		isPK:       true,
+	}
+	jsonCol := &colExpr{
+		colName: sqlparser.NewIdentifierCI("j"),
+		colType: querypb.Type_JSON,
+		expr: &sqlparser.ColName{
+			Name: sqlparser.NewIdentifierCI("j"),
+		},
+		references: map[string]bool{"j": true},
+	}
+	stats := binlogplayer.NewStats()
+	tp := &TablePlan{
+		TargetName: "t",
+		Fields: []*querypb.Field{
+			{Name: "id", Type: querypb.Type_INT64},
+			{Name: "j", Type: querypb.Type_JSON},
+		},
+		FieldsToSkip:   map[string]bool{},
+		PKReferences:   []string{"id"},
+		Stats:          stats,
+		PartialUpdates: map[string]*sqlparser.ParsedQuery{},
+		TablePlanBuilder: &tablePlanBuilder{
+			name:     sqlparser.NewIdentifierCS("t"),
+			colExprs: []*colExpr{idCol, jsonCol},
+			pkCols:   []*colExpr{idCol},
+			stats:    stats,
+		},
+		WorkflowConfig: &vttablet.VReplicationConfig{MaxRowJSONBytes: int64(len(diff) + 1)},
+	}
+	rowChange := &binlogdatapb.RowChange{
+		Before: sqltypes.RowToProto3([]sqltypes.Value{
+			sqltypes.NewInt64(1),
+			sqltypes.MakeTrusted(querypb.Type_JSON, beforeJSON),
+		}),
+		After: sqltypes.RowToProto3([]sqltypes.Value{
+			sqltypes.NewInt64(1),
+			sqltypes.MakeTrusted(querypb.Type_JSON, diff),
+		}),
+		DataColumns: &binlogdatapb.RowChange_Bitmap{
+			Count: 2,
+			Cols:  []byte{0x03},
+		},
+		JsonPartialValues: &binlogdatapb.RowChange_Bitmap{
+			Count: 1,
+			Cols:  []byte{0x01},
+		},
+	}
+
+	var executed []string
+	_, err := tp.applyChange(rowChange, func(sql string) (*sqltypes.Result, error) {
+		executed = append(executed, sql)
+		return &sqltypes.Result{RowsAffected: 1}, nil
+	})
+	require.ErrorContains(t, err, "vreplication: row JSON payload")
+	require.Empty(t, executed)
+}
+
 func BenchmarkAppendFromRowLargeJSON(b *testing.B) {
 	raw := []byte(`[` + strings.Repeat(`12345678,`, 150000) + `0]`)
 	tp := &TablePlan{

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -1170,6 +1170,40 @@ func TestApplyBulkInsertChangesMaxQuerySize(t *testing.T) {
 		}, 0)
 		require.ErrorContains(t, err, "vreplication: row JSON payload")
 	})
+
+	t.Run("skips generated JSON columns before marshalling", func(t *testing.T) {
+		jsonTP := &TablePlan{
+			BulkInsertFront: sqlparser.BuildParsedQuery("insert into t(j)"),
+			BulkInsertValues: sqlparser.BuildParsedQuery("(%a)",
+				":a_j",
+			),
+			Fields: []*querypb.Field{
+				{Name: "j", Type: querypb.Type_JSON},
+				{Name: "j_generated", Type: querypb.Type_JSON},
+			},
+			FieldsToSkip: map[string]bool{
+				"j_generated": true,
+			},
+			TablePlanBuilder: &tablePlanBuilder{stats: binlogplayer.NewStats()},
+			WorkflowConfig:   &vttablet.VReplicationConfig{MaxRowJSONBytes: 32},
+		}
+		rowInserts := []*binlogdatapb.RowChange{{
+			After: sqltypes.RowToProto3([]sqltypes.Value{
+				sqltypes.MakeTrusted(querypb.Type_JSON, []byte(`{"ok":true}`)),
+				sqltypes.MakeTrusted(querypb.Type_JSON, []byte(`not-json`)),
+			}),
+		}}
+
+		var executed []string
+		_, err := jsonTP.applyBulkInsertChanges(rowInserts, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 0)
+		require.NoError(t, err)
+		require.Len(t, executed, 1)
+		assert.Contains(t, executed[0], "insert into t(j) values")
+		assert.NotContains(t, executed[0], "not-json")
+	})
 }
 
 func TestMarshalJSONForSQL(t *testing.T) {


### PR DESCRIPTION
## Description

Adds a configurable cap on the combined byte-size of JSON columns in a single row during VReplication copy and replay. When a row exceeds the limit, the workflow transitions to `Error` state with an actionable message naming the table, the largest JSON column, and its size, instead of OOM-killing the target `mysqld` and entering a `vcopier` crash loop.

The cap is off by default (flag value `0` = unlimited) so upstream behavior is unchanged. Operators set it per deployment tier based on the target `mysqld`'s memory budget; individual workflows can override via the existing `WorkflowOptions.config` map (no proto change). The existing pattern for per-workflow config (e.g. `relay-log-max-items`) is reused verbatim.

### Why

Vitess VReplication re-emits JSON columns as nested `JSON_OBJECT(CAST(JSON_QUOTE(_utf8mb4'...') as JSON), ...)` expressions to preserve MySQL's extended JSON types (dates, times, binary, bit). For standard JSON content — especially large arrays of short strings — this form is pathological on the target `mysqld`: a ~20 MB JSON array becomes ~40–50 MB of SQL containing ~1M nested function calls, each of which `mysqld` parses into an AST node and evaluates into a `Json_dom` tree. Empirical amplification from row wire-size to `mysqld` RAM is ~60–100× for JSON-heavy rows, versus ~8–10× for BLOB/TEXT.

#19878 reduced amplification on the `vttablet` side but did not address the target `mysqld` side. This PR refuses to construct the oversized SQL in the first place when a per-row limit is exceeded, so the poison row produces a clean workflow failure instead of a container crash loop.

This is the first of two planned changes:
1. **This PR** — per-row byte cap for JSON columns, target-side, fail-fast.
2. **Future** — weighted cost model (JSON ~80×, BLOB/TEXT ~8×) if operators hit false positives on the flat byte cap.

## Related Issue(s)

Fixes #19915

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

Unit tests: `checkJSONRowSize` — under/over limit, boundary, multi-JSON-column sum, no-JSON-column no-op, empty row, `limit=0` disabled, non-JSON columns ignored. Config override round-trip from `map[string]string` (hyphen and underscore key forms). `go build ./...` clean. Full `vreplication` package integration tests require `bin/mysqlctl` — CI will exercise them.

## Deployment Notes

Zero-impact by default; `--vreplication-max-row-json-bytes` defaults to `0` (unlimited). Operators on memory-constrained tiers should set this to a value within the target `mysqld`'s safe per-row budget (empirically ~16 MB on a 1672 MiB `mysqld` tier; scales proportionally with target memory).

No proto change. The per-workflow override reuses the existing `WorkflowOptions.config` map keys — any tooling that already forwards that map (e.g. MoveTables / OnlineDDL workflow-options passthrough) picks it up for free.

### AI Disclosure

This PR was written primarily by Claude Code; I investigated the root cause (including heap profiling a production vttablet under repro), set direction on the design, and reviewed and validated the changes before pushing.