### PR TITLE
proto: fix incorrect flag bits on `RAW` and `ROW_TUPLE` types

### DIFF
--- a/go/vt/proto/query/query.pb.go
+++ b/go/vt/proto/query/query.pb.go
@@ -321,10 +321,10 @@ const (
 	Type_VECTOR Type = 2083
 	// RAW specifies a type which won't be quoted but the value used as-is while encoding.
 	// Properties: 36, None.
-	Type_RAW Type = 2084
+	Type_RAW Type = 36
 	// ROW_TUPLE represents multiple rows.
 	// Properties: 37, None.
-	Type_ROW_TUPLE Type = 2085
+	Type_ROW_TUPLE Type = 37
 )
 
 // Enum value maps for Type.
@@ -366,8 +366,8 @@ var (
 		4129:  "HEXVAL",
 		4130:  "BITNUM",
 		2083:  "VECTOR",
-		2084:  "RAW",
-		2085:  "ROW_TUPLE",
+		36:    "RAW",
+		37:    "ROW_TUPLE",
 	}
 	Type_value = map[string]int32{
 		"NULL_TYPE":  0,
@@ -406,8 +406,8 @@ var (
 		"HEXVAL":     4129,
 		"BITNUM":     4130,
 		"VECTOR":     2083,
-		"RAW":        2084,
-		"ROW_TUPLE":  2085,
+		"RAW":        36,
+		"ROW_TUPLE":  37,
 	}
 )
 
@@ -6255,7 +6255,7 @@ const file_query_proto_rawDesc = "" +
 	"\aISFLOAT\x10\x80\b\x12\r\n" +
 	"\bISQUOTED\x10\x80\x10\x12\v\n" +
 	"\x06ISTEXT\x10\x80 \x12\r\n" +
-	"\bISBINARY\x10\x80@*\xe7\x03\n" +
+	"\bISBINARY\x10\x80@*\xe5\x03\n" +
 	"\x04Type\x12\r\n" +
 	"\tNULL_TYPE\x10\x00\x12\t\n" +
 	"\x04INT8\x10\x81\x02\x12\n" +
@@ -6298,9 +6298,9 @@ const file_query_proto_rawDesc = "" +
 	"\x06HEXNUM\x10\xa0 \x12\v\n" +
 	"\x06HEXVAL\x10\xa1 \x12\v\n" +
 	"\x06BITNUM\x10\xa2 \x12\v\n" +
-	"\x06VECTOR\x10\xa3\x10\x12\b\n" +
-	"\x03RAW\x10\xa4\x10\x12\x0e\n" +
-	"\tROW_TUPLE\x10\xa5\x10*6\n" +
+	"\x06VECTOR\x10\xa3\x10\x12\a\n" +
+	"\x03RAW\x10$\x12\r\n" +
+	"\tROW_TUPLE\x10%*6\n" +
 	"\x10StartCommitState\x12\v\n" +
 	"\aUnknown\x10\x00\x12\b\n" +
 	"\x04Fail\x10\x01\x12\v\n" +

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -220,10 +220,10 @@ enum Type {
   VECTOR = 2083;
   // RAW specifies a type which won't be quoted but the value used as-is while encoding.
   // Properties: 36, None.
-  RAW = 2084;
+  RAW = 36;
   // ROW_TUPLE represents multiple rows.
   // Properties: 37, None.
-  ROW_TUPLE = 2085;
+  ROW_TUPLE = 37;
 }
 
 // Value represents a typed value.

--- a/web/vtadmin/src/proto/vtadmin.d.ts
+++ b/web/vtadmin/src/proto/vtadmin.d.ts
@@ -42952,8 +42952,8 @@ export namespace query {
         HEXVAL = 4129,
         BITNUM = 4130,
         VECTOR = 2083,
-        RAW = 2084,
-        ROW_TUPLE = 2085
+        RAW = 36,
+        ROW_TUPLE = 37
     }
 
     /** Properties of a Value. */


### PR DESCRIPTION
## Description

The Type enum values for `RAW` and `ROW_TUPLE` were incorrectly carrying the `ISQUOTED` flag bit (`0x800`) because they were assigned by incrementing from VECTOR (2083) rather than using bare ordinals.

Their comments document `Properties: None` but the values `2084` and `2085` had `ISQUOTED` set. This caused `IsQuoted(Type_RAW)` to return `true`, which meant `ValidateBindVariable` accepted `Type_RAW` from external gRPC clients even though it's an internal-only type.

Fix the values to match their documented properties: `RAW = 36`, `ROW_TUPLE = 37` (bare ordinals, no flag bits).

I think this should be backported to v23 and v24.

## Related Issue(s)

None - this was reported by @JohannesLks

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

This PR was written primarily by Claude Code.