### PR TITLE
chore: typo `recieved` -> `received` in messaging e2e test comment

### DIFF
--- a/go/test/endtoend/messaging/message_test.go
+++ b/go/test/endtoend/messaging/message_test.go
@@ -513,7 +513,7 @@ func testMessaging(t *testing.T, name, ks string) {
 	validateField(t, res.Fields[1], "tenant_id", querypb.Type_INT64)
 	validateField(t, res.Fields[2], "message", querypb.Type_JSON)
 
-	// validate recieved msgs
+	// validate received msgs
 	resMap := make(map[string]string)
 	res, err = stream.Next()
 	require.Nil(t, err)


### PR DESCRIPTION
One-character typo fix inside `go/test/endtoend/messaging/message_test.go:516`. No functional change.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>