### PR TITLE
vtgate: fix goroutine leak on failure in buffering tests

### DIFF
--- a/go/vt/vtgate/tabletgateway_flaky_test.go
+++ b/go/vt/vtgate/tabletgateway_flaky_test.go
@@ -113,10 +113,10 @@ func TestGatewayBufferingWhenPrimarySwitchesServingState(t *testing.T) {
 	waitForBuffering(true)
 
 	// execute the query in a go routine since it should be buffered, and check that it eventually succeed
-	queryChan := make(chan struct{})
+	done := make(chan struct{}, 1)
 	go func() {
 		res, err = tg.Execute(ctx, nil, target, "query", nil, 0, 0, nil)
-		queryChan <- struct{}{}
+		done <- struct{}{}
 	}()
 
 	// set the serving type for the primary tablet true and broadcast it so that the buffering code registers this change
@@ -128,7 +128,7 @@ func TestGatewayBufferingWhenPrimarySwitchesServingState(t *testing.T) {
 
 	// wait for the query to execute before checking for results
 	select {
-	case <-queryChan:
+	case <-done:
 		require.NoError(t, err)
 		require.Equal(t, sqlResult1, res)
 	case <-time.After(15 * time.Second):
@@ -226,10 +226,10 @@ func TestGatewayBufferingWhileReparenting(t *testing.T) {
 		sbcReplica.SetResults([]*sqltypes.Result{sqlResult1})
 
 		// execute the query in a go routine since it should be buffered, and check that it eventually succeed
-		queryChan := make(chan struct{})
+		done := make(chan struct{}, 1)
 		go func() {
 			res, err = tg.Execute(ctx, nil, target, "query", nil, 0, 0, nil)
-			queryChan <- struct{}{}
+			done <- struct{}{}
 		}()
 
 		// set the serving type for the new primary tablet true and broadcast it so that the buffering code registers this change
@@ -260,7 +260,7 @@ func TestGatewayBufferingWhileReparenting(t *testing.T) {
 
 		// wait for the query to execute before checking for results
 		select {
-		case <-queryChan:
+		case <-done:
 			require.NoError(t, err)
 			require.Equal(t, sqlResult1, res)
 		case <-time.After(15 * time.Second):
@@ -335,14 +335,14 @@ func TestInconsistentStateDetectedBuffering(t *testing.T) {
 
 	var res *sqltypes.Result
 	var err error
-	queryChan := make(chan struct{})
+	done := make(chan struct{}, 1)
 	go func() {
 		res, err = tg.Execute(ctx, nil, target, "query", nil, 0, 0, nil)
-		queryChan <- struct{}{}
+		done <- struct{}{}
 	}()
 
 	select {
-	case <-queryChan:
+	case <-done:
 		require.Nil(t, res)
 		require.Error(t, err)
 		// depending on whether the health check ticks before or after the buffering code, we might get different errors


### PR DESCRIPTION
## Description

Three tests in `go/vt/vtgate/tabletgateway_flaky_test.go` — `TestGatewayBufferingWhenPrimarySwitchesServingState`, `TestGatewayBufferingWhileReparenting`, and `TestInconsistentStateDetectedBuffering` — spawn a worker goroutine that calls `tg.Execute` and then sends on an **unbuffered** `chan struct{}`. The main goroutine receives from that channel inside a `select` with a timeout. If the surrounding test calls `require.Fail` (or otherwise `t.FailNow`s) before reaching the receive, the send blocks forever and the worker goroutine leaks.

Because these tests use `utils.LeakCheckContext`, that leaked goroutine fails the leak check — but `LeakCheckContext` is also used by every other test in the `go/vt/vtgate` package, so the leaked goroutine cascades into `noleak.go:56: found unexpected goroutines` failures on every subsequent test. One flake becomes 40+ red tests in the same CI job — a pattern I saw a few times when analyzing recent `main` CI failures, e.g. commit `cbcdc5379d` under `Unit Test (Race)`.

Fix: give each channel a capacity of 1 so the worker's send always completes and the goroutine can exit whether the test passes or fails. Also rename `queryChan` → `done` since that's what the channel signals.

## Related Issue(s)

None (internal flakiness finding).

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Test-only change.

### AI Disclosure

This PR was written primarily by Claude Code.