### PR TITLE
vstreamer: restore test globals even when newEngine fails

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -2281,7 +2281,6 @@ func TestMinimalMode(t *testing.T) {
 	engine = nil
 	oldEnv := env
 	env = nil
-	newEngine(t, ctx, "minimal")
 	defer func() {
 		if engine != nil {
 			engine.Close()
@@ -2292,6 +2291,7 @@ func TestMinimalMode(t *testing.T) {
 		engine = oldEngine
 		env = oldEnv
 	}()
+	newEngine(t, ctx, "minimal")
 	err := engine.Stream(context.Background(), "current", nil, nil, throttlerapp.VStreamerName, func(evs []*binlogdatapb.VEvent) error { return nil }, nil)
 	require.Error(t, err, "minimal binlog_row_image is not supported by Vitess VReplication")
 }


### PR DESCRIPTION
## Description

`TestMinimalMode` in `go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go` stashes the package-level `engine`/`env` pointers (setting both to `nil`), calls `newEngine(t, ctx, "minimal")`, and then registers a `defer` that restores them. The defer is registered **after** `newEngine` returns — so if `newEngine` fails via `require.NoError`, `runtime.Goexit` unwinds the test goroutine before the defer is ever registered. `engine` and `env` stay at `nil`, and the next test in the package — `TestStatementMode` — calls `execStatements` → `env.Mysqld.ExecuteSuperQueryList` and segfaults on the nil `env`. The segfault aborts the remaining tests in the package with `rerun aborted because previous run had a suspected panic`, masking all downstream results.

This is exactly the pattern that fires on CI when a runner kills mysqld during `testenv.Init` (surfaces as `could not launch mysql: signal: killed` → `require.NoError` → `Goexit`). I saw it several times while analyzing recent `main` CI failures, e.g. on commit `baf7ac530e` in `Unit Test (mysql80)`.

Fix: move the `defer` block to run before `newEngine`, so the restoration always executes regardless of how `newEngine` exits. The deferred cleanup already nil-checks before calling `Close`, so it handles every partial-failure state from `newEngine` the same way it handles full success. Pure reorder — no behavior change on the success path.

## Related Issue(s)

None (internal flakiness finding).

## Checklist

-   [ ] \"Backport to:\" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Test-only change.

### AI Disclosure

This PR was written primarily by Claude Code.