### PR TITLE
wrangler: fix testMigraterEnv.close() deadlock with VReplication controller

### DIFF
--- a/go/vt/wrangler/traffic_switcher_env_test.go
+++ b/go/vt/wrangler/traffic_switcher_env_test.go
@@ -949,9 +949,9 @@ func (tme *testShardMigraterEnv) expectNoPreviousJournals() {
 }
 
 func (tme *testMigraterEnv) close(t *testing.T) {
+	tme.stopTablets(t)
 	tme.mu.Lock()
 	defer tme.mu.Unlock()
-	tme.stopTablets(t)
 	for _, dbclient := range tme.dbSourceClients {
 		dbclient.Close()
 	}


### PR DESCRIPTION
## Description

`testMigraterEnv.close()` in `go/vt/wrangler/traffic_switcher_env_test.go` takes `tme.mu` and then calls `stopTablets` while still holding it. `stopTablets` stops each fake tablet, which calls `TabletManager.Stop` → `vreplication.Engine.Close` → `vreplication.controller.Stop`, which blocks on `<-ct.done` until the controller's retry loop observes the cancelled context and exits.

If the retry loop happens to be inside `pickSourceTablet` at that moment, it is calling the tablet dialer registered in each of the three `newTest*Migrater*` constructors — and the dialer itself grabs `tme.mu`. `close()` already holds it, so the dialer blocks; `pickSourceTablet` never returns; `runBlp` never returns; the retry loop never observes `ctx.Done`; the controller never closes `ct.done`; `close()` waits forever. Eventually the Go test binary's 10-minute timeout fires as `panic: test timed out after 10m0s` and aborts the entire `go/vt/wrangler` package. This is the failure I saw on PR #19944's CI run (https://github.com/vitessio/vitess/actions/runs/24844388195/job/72727189736), and in my flakiness survey of the last 50 commits it also fired on `main` commit `b6914c79a2` under `Unit Test (mysql84)`.

The race window is narrow — if the controller is sleeping in its retry backoff when `close()` is called, `ct.cancel()` unblocks the sleep and teardown completes normally — which is why this shows up as a flake rather than a deterministic failure.

Fix: call `stopTablets` *before* taking `tme.mu`. `stopTablets` only iterates the `*Primaries` slices, which are never mutated after test setup, so it doesn't need the lock. The dialer's short critical section no longer contends with teardown, and the deadlock cycle is gone.

## Related Issue(s)

None (internal flakiness finding).

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Test-only change.

### AI Disclosure

This PR was written primarily by Claude Code.