### PR TITLE
vtgate: preserve target keyspace when routing rule rewrites table AST

### DIFF
--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -839,9 +839,12 @@ func TestSemiJoin(t *testing.T) {
 
 // TestTabletTypeRouting tests that the tablet type routing works as intended.
 func TestTabletTypeRouting(t *testing.T) {
-	// We are gonna configure the routing rules to send the
-	// query for a replica tablet in ks_misc.t1 to go to a table that doesn't exist.
-	// I know this doesn't make much practical sense, but makes testing really easy.
+	// We are gonna configure the routing rules to send the query for a replica
+	// tablet in ks_misc.t1 to a table in a different keyspace (uks). Since uks
+	// is started with 0 replica tablets (see TestMain), the replica-side query
+	// will fail with "no healthy tablet available" for the uks keyspace —
+	// which is the signal that the @replica routing rule fired and rewrote the
+	// target keyspace correctly. The primary-side query still reaches ks_misc.t1.
 	routingRules := `{"rules": [
 	{
 	"from_table": "ks_misc.t1@replica",
@@ -867,9 +870,11 @@ func TestTabletTypeRouting(t *testing.T) {
 	utils.AssertMatches(t, vtConn, "select * from ks_misc.t1", `[[INT64(0) INT64(0)]]`)
 	// Now we change the connection's target
 	utils.Exec(t, vtConn, "use ks_misc@replica")
-	// We verify that querying the replica tablet creates an unknown table error.
+	// We verify that the replica-side query is redirected to uks by the routing rule.
 	_, err = utils.ExecAllowError(t, vtConn, "select * from ks_misc.t1")
-	require.ErrorContains(t, err, "table unknown not found")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "uks")
+	require.ErrorContains(t, err, "replica")
 }
 
 // TestJoinMixedCaseExpr tests that join condition with expression from both table having in clause is handled correctly.

--- a/go/vt/vtgate/planbuilder/rewrite.go
+++ b/go/vt/vtgate/planbuilder/rewrite.go
@@ -67,9 +67,14 @@ func (r *rewriter) rewriteDown(cursor *sqlparser.Cursor) bool {
 		if node.As.IsEmpty() {
 			node.As = tableName.Name
 		}
-		// replace the table name with the original table
-		tableName.Qualifier = sqlparser.IdentifierCS{}
+		// Replace the table name with the resolved routed table, fully qualified
+		// by the target keyspace. Preserving the keyspace keeps the AST
+		// self-consistent so any later FindTableOrVindex lookup resolves to the
+		// same target instead of falling back to the session's default keyspace.
+		// RemoveKeyspaceIgnoreSysSchema in the SQL builder strips the qualifier
+		// before the query is sent to vttablet.
 		tableName.Name = vindexTable.Name
+		tableName.Qualifier = sqlparser.NewIdentifierCS(vindexTable.Keyspace.Name)
 		node.Expr = tableName
 	}
 	return true

--- a/go/vt/vtgate/planbuilder/testdata/select_cases_with_default.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases_with_default.json
@@ -1,5 +1,49 @@
 [
   {
+    "comment": "routing rule redirects an unqualified table reference that renames across keyspaces (issue #19947)",
+    "query": "select intcol from bar",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select intcol from bar",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select intcol from music as bar where 1 != 1",
+        "Query": "select intcol from music as bar"
+      },
+      "TablesUsed": [
+        "user.music"
+      ]
+    }
+  },
+  {
+    "comment": "routing rule redirects a qualified table reference that renames across keyspaces (issue #19947 sibling)",
+    "query": "select intcol from second_user.bar",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select intcol from second_user.bar",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select intcol from music as bar where 1 != 1",
+        "Query": "select intcol from music as bar"
+      },
+      "TablesUsed": [
+        "user.music"
+      ]
+    }
+  },
+  {
     "comment": "EXISTS subquery when the default ks is different than the inner query",
     "query": "select exists(select * from user where id = 5)",
     "plan": {


### PR DESCRIPTION
## Description

Schema routing rules (e.g. `customer.migrations → commerce.commerce_migrations`) correctly redirect fully-qualified queries, but — when the reference is unqualified and the session's default keyspace is the source (`USE customer; SELECT count(1) FROM migrations;`) — the redirect only half-applies: the table name is rewritten, but the target keyspace is lost, so the query is sent to the source keyspace and errors with `Table 'vt_customer.commerce_migrations' doesn't exist`.

The root cause is in `go/vt/vtgate/planbuilder/rewrite.go`: when the AST is rewritten to point at the routed table, the code clears the qualifier (`tableName.Qualifier = sqlparser.IdentifierCS{}`). Any subsequent `FindTableOrVindex` call on the rewritten `TableName` then falls back to the session's default keyspace and looks for the routed table name there — which doesn't exist.

This PR keeps the AST self-consistent by setting the qualifier to the routed table's keyspace. `RemoveKeyspaceIgnoreSysSchema` in the SQL builder still strips the qualifier before the query is sent to vttablet, so the emitted SQL is unchanged.

This is a correctness fix; the docs already promise that the unqualified reference "need not be explicit" (https://vitess.io/docs/23.0/reference/features/schema-routing-rules/#additional-details). I think this should be backported to v23 and v24.

## Related Issue(s)

Fixes #19947

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

No action required. The fix is internal to vtgate's query planner and the generated SQL is byte-identical to the fully-qualified path that was already working. No schema changes, no flag changes, no migrations.

### AI Disclosure

This PR was written primarily by Claude Code — I provided direction and validated the fix.