### PR TITLE
vtgate: prevent buffer restart after shutdown

### DIFF
--- a/go/vt/vtgate/buffer/buffer_test.go
+++ b/go/vt/vtgate/buffer/buffer_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -820,6 +821,50 @@ func testShutdown1(t *testing.T, fail failover) {
 	if err := waitForPoolSlots(b, cfg.Size); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestShutdown_WaitForFailoverEndAfterShutdownIsNoop(t *testing.T) {
+	cfg := NewDefaultConfig()
+	cfg.Enabled = true
+	cfg.MaxFailoverDuration = 500 * time.Millisecond
+	b := New(cfg)
+
+	sb := b.getOrCreateBuffer(keyspace, shard)
+	require.NotNil(t, sb)
+	require.Equal(t, stateIdle, sb.testGetState())
+
+	b.Shutdown()
+
+	type result struct {
+		retryDone RetryDoneFunc
+		err       error
+	}
+	resCh := make(chan result, 1)
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	go func() {
+		rd, err := sb.waitForFailoverEnd(ctx, keyspace, shard, nil, failoverErr)
+		resCh <- result{rd, err}
+	}()
+
+	var r result
+	require.Eventually(t, func() bool {
+		select {
+		case r = <-resCh:
+			if r.retryDone != nil {
+				r.retryDone()
+			}
+			return true
+		default:
+			return false
+		}
+	}, 30*time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, stateIdle, sb.testGetState(),
+		"sb transitioned out of stateIdle after Buffer.Shutdown returned")
+	assert.Nil(t, r.retryDone, "waitForFailoverEnd should return nil RetryDoneFunc after Buffer.Shutdown")
+	assert.NoError(t, r.err, "waitForFailoverEnd should return nil error after Buffer.Shutdown")
 }
 
 func TestParallelRangeIndex(t *testing.T) {

--- a/go/vt/vtgate/buffer/shard_buffer.go
+++ b/go/vt/vtgate/buffer/shard_buffer.go
@@ -166,6 +166,11 @@ func (sb *shardBuffer) waitForFailoverEnd(ctx context.Context, keyspace, shard s
 
 	// Slow path: acquire lock for state transitions or to enqueue a request.
 	sb.mu.Lock()
+	// Do not start a new buffering cycle after Buffer.Shutdown() has begun.
+	if sb.buf.stopped.Load() {
+		sb.mu.Unlock()
+		return nil, nil
+	}
 	// Re-check state because it could have changed in the meantime.
 	if !sb.shouldBufferLocked(failoverDetected) {
 		// Buffering no longer required. Return early.


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

This fixes a shutdown race in `vtgate/buffer`: a request goroutine that already captured a `*shardBuffer` could start a new buffering cycle after `Buffer.Shutdown()` returned.

The fix checks whether the parent buffer has started shutdown after taking the shard buffer lock, before the slow path can transition the shard into `stateBuffering`.

Backport requested to `release-23.0` and `release-24.0` because this is a small, low-risk vtgate fix for a shutdown race that can make queries wait up to `MaxFailoverDuration` during shutdown or restart.

## Related Issue(s)

Fixes #19927

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

No deployment notes.

### AI Disclosure

The initial fix was drafted by Claude Code and finalized by GPT-5 Codex with maintainer direction.

Local tests:

```sh
go test -count=1 -run 'TestShutdown_WaitForFailoverEndAfterShutdownIsNoop' ./go/vt/vtgate/buffer
go test -count=1 -race -run 'TestShutdown_WaitForFailoverEndAfterShutdownIsNoop' ./go/vt/vtgate/buffer
go test -count=1 ./go/vt/vtgate/buffer
```
