### PR TITLE
`vtgate`: extract `VT_SPAN_CONTEXT` for prepared statements

### DIFF
--- a/changelog/24.0/24.0.0/summary.md
+++ b/changelog/24.0/24.0.0/summary.md
@@ -208,7 +208,7 @@ To enable session mode, set the flag when starting VTGate:
 
 VTGate now extracts the `VT_SPAN_CONTEXT` query directive from prepared statements, enabling distributed tracing for queries that use the MySQL prepared statement protocol (`COM_STMT_PREPARE` / `COM_STMT_EXECUTE`).
 
-**Limitation**: The span context is extracted once at prepare time and reused for all subsequent executions. `COM_STMT_EXECUTE` does not carry SQL text, so there is no way to inject a fresh span context per-execute without re-preparing. In practice, Go's `database/sql` does implicit prepare+execute for `db.Query(..., args)`, so each call gets a fresh context.
+**Limitation**: The span context is extracted on first execution and cached for all subsequent executions of the same prepared statement. `COM_STMT_EXECUTE` does not carry SQL text, so there is no way to inject a fresh span context per-execute without re-preparing. In practice, Go's `database/sql` does implicit prepare+execute for `db.Query(..., args)`, so each call gets a fresh context.
 
 See [#19958](https://github.com/vitessio/vitess/pull/19958) for details.
 

--- a/changelog/24.0/24.0.0/summary.md
+++ b/changelog/24.0/24.0.0/summary.md
@@ -21,6 +21,7 @@
         - [Removed `--grpc-send-session-in-streaming` flag](#vtgate-removed-grpc-send-session-in-streaming)
         - [New default for `--legacy-replication-lag-algorithm` flag](#vtgate-new-default-legacy-replication-lag-algorithm)
         - [New "session" mode for `--vtgate-balancer-mode` flag](#vtgate-session-balancer-mode)
+        - [`VT_SPAN_CONTEXT` extraction for prepared statements](#vtgate-vt-span-context-prepared-stmts)
     - **[Query Serving](#minor-changes-query-serving)**
         - [JSON_EXTRACT now supports dynamic path arguments](#query-serving-json-extract-dynamic-args)
     - **[VTTablet](#minor-changes-vttablet)**
@@ -202,6 +203,14 @@ To enable session mode, set the flag when starting VTGate:
 ```
 --vtgate-balancer-mode=session
 ```
+
+#### <a id="vtgate-vt-span-context-prepared-stmts"/>`VT_SPAN_CONTEXT` extraction for prepared statements</a>
+
+VTGate now extracts the `VT_SPAN_CONTEXT` query directive from prepared statements, enabling distributed tracing for queries that use the MySQL prepared statement protocol (`COM_STMT_PREPARE` / `COM_STMT_EXECUTE`).
+
+**Limitation**: The span context is extracted once at prepare time and reused for all subsequent executions. `COM_STMT_EXECUTE` does not carry SQL text, so there is no way to inject a fresh span context per-execute without re-preparing. In practice, Go's `database/sql` does implicit prepare+execute for `db.Query(..., args)`, so each call gets a fresh context.
+
+See [#19958](https://github.com/vitessio/vitess/pull/19958) for details.
 
 ### <a id="minor-changes-query-serving"/>Query Serving</a>
 

--- a/changelog/24.0/24.0.0/summary.md
+++ b/changelog/24.0/24.0.0/summary.md
@@ -21,7 +21,6 @@
         - [Removed `--grpc-send-session-in-streaming` flag](#vtgate-removed-grpc-send-session-in-streaming)
         - [New default for `--legacy-replication-lag-algorithm` flag](#vtgate-new-default-legacy-replication-lag-algorithm)
         - [New "session" mode for `--vtgate-balancer-mode` flag](#vtgate-session-balancer-mode)
-        - [`VT_SPAN_CONTEXT` extraction for prepared statements](#vtgate-vt-span-context-prepared-stmts)
     - **[Query Serving](#minor-changes-query-serving)**
         - [JSON_EXTRACT now supports dynamic path arguments](#query-serving-json-extract-dynamic-args)
     - **[VTTablet](#minor-changes-vttablet)**
@@ -203,14 +202,6 @@ To enable session mode, set the flag when starting VTGate:
 ```
 --vtgate-balancer-mode=session
 ```
-
-#### <a id="vtgate-vt-span-context-prepared-stmts"/>`VT_SPAN_CONTEXT` extraction for prepared statements</a>
-
-VTGate now extracts the `VT_SPAN_CONTEXT` query directive from prepared statements, enabling distributed tracing for queries that use the MySQL prepared statement protocol (`COM_STMT_PREPARE` / `COM_STMT_EXECUTE`).
-
-**Limitation**: The span context is extracted on first execution and cached for all subsequent executions of the same prepared statement. `COM_STMT_EXECUTE` does not carry SQL text, so there is no way to inject a fresh span context per-execute without re-preparing. In practice, Go's `database/sql` does implicit prepare+execute for `db.Query(..., args)`, so each call gets a fresh context.
-
-See [#19958](https://github.com/vitessio/vitess/pull/19958) for details.
 
 ### <a id="minor-changes-query-serving"/>Query Serving</a>
 

--- a/go.mod
+++ b/go.mod
@@ -105,6 +105,7 @@ require (
 	github.com/xlab/treeprint v1.2.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
+	go.opentelemetry.io/proto/otlp v1.10.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
 	golang.org/x/sync v0.20.0
@@ -142,7 +143,6 @@ require (
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/vbatts/tar-split v0.12.2 // indirect
 	github.com/vitessio/goyacc v0.0.0-20260327210057-9f3cb834a13f // indirect
-	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	gotest.tools/gotestsum v1.13.0 // indirect

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -232,6 +232,9 @@ type PrepareData struct {
 	BindVars    map[string]*querypb.BindVariable
 	StatementID uint32
 	ParamsCount uint16
+	// SpanContext caches the extracted VT_SPAN_CONTEXT value from PrepareStmt.
+	// nil means not yet extracted; non-nil stores the cached value (empty string = no context found).
+	SpanContext *string
 }
 
 // execResult is an enum signifying the result of executing a query

--- a/go/test/endtoend/vtgate/trace/main_test.go
+++ b/go/test/endtoend/vtgate/trace/main_test.go
@@ -242,8 +242,7 @@ func TestVTSpanContextPreparedStatement(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		return vtgateWarningCount(t) > before
 	}, 30*time.Second, 500*time.Millisecond,
-		"expected VT_SPAN_CONTEXT warning in vtgate stderr for prepared statement path — "+
-			"this fails because ComPrepare/ComStmtExecute do not call startSpan()")
+		"expected VT_SPAN_CONTEXT warning in vtgate stderr for prepared statement path")
 }
 
 // TestVTSpanContextValidTraceComQuery sends a valid VT_SPAN_CONTEXT via
@@ -287,7 +286,7 @@ func TestVTSpanContextValidTracePreparedStatement(t *testing.T) {
 	traceparent := fmt.Sprintf("00-%s-%s-01", traceID, spanID)
 	carrier := buildCarrier(traceparent)
 
-	connStr := fmt.Sprintf("@tcp(%s:%d)/%s", hostname, clusterInstance.VtgateMySQLPort, keyspaceName)
+	connStr := fmt.Sprintf("@tcp(%s:%d)/%s?interpolateParams=false", hostname, clusterInstance.VtgateMySQLPort, keyspaceName)
 	db, err := sql.Open("mysql", connStr)
 	require.NoError(t, err)
 	defer db.Close()

--- a/go/test/endtoend/vtgate/trace/main_test.go
+++ b/go/test/endtoend/vtgate/trace/main_test.go
@@ -1,0 +1,312 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trace
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	collectortracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/grpc"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/utils"
+)
+
+var (
+	clusterInstance *cluster.LocalProcessCluster
+	vtParams        mysql.ConnParams
+	collector       *otlpCollector
+	cell            = "zone1"
+	hostname        = "localhost"
+	keyspaceName    = "ks"
+
+	schemaSQL = `CREATE TABLE t1 (id BIGINT NOT NULL PRIMARY KEY) ENGINE=InnoDB;`
+	vschema   = `{"sharded": false, "tables": {"t1": {}}}`
+)
+
+// otlpCollector is a minimal OTLP gRPC trace collector that records
+// received spans in memory for test assertions.
+type otlpCollector struct {
+	collectortracepb.UnimplementedTraceServiceServer
+
+	mu    sync.Mutex
+	spans []*tracepb.Span
+	srv   *grpc.Server
+	port  int
+}
+
+func (c *otlpCollector) Export(_ context.Context, req *collectortracepb.ExportTraceServiceRequest) (*collectortracepb.ExportTraceServiceResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, rs := range req.GetResourceSpans() {
+		for _, ss := range rs.GetScopeSpans() {
+			c.spans = append(c.spans, ss.GetSpans()...)
+		}
+	}
+	return &collectortracepb.ExportTraceServiceResponse{}, nil
+}
+
+// spanWithTraceID returns the first span whose trace ID matches (hex-encoded), or nil.
+func (c *otlpCollector) spanWithTraceID(traceID string) *tracepb.Span {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, s := range c.spans {
+		if hex.EncodeToString(s.GetTraceId()) == traceID {
+			return s
+		}
+	}
+	return nil
+}
+
+// spanWithAttribute returns the first span that has the given string attribute key=value.
+func (c *otlpCollector) spanWithAttribute(key, value string) *tracepb.Span {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, s := range c.spans {
+		for _, attr := range s.GetAttributes() {
+			if attr.GetKey() == key && attr.GetValue().GetStringValue() == value {
+				return s
+			}
+		}
+	}
+	return nil
+}
+
+// dumpSpans returns a debug string of all collected spans.
+func (c *otlpCollector) dumpSpans() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var b strings.Builder
+	for i, s := range c.spans {
+		fmt.Fprintf(&b, "  [%d] name=%q traceID=%x attrs=[", i, s.GetName(), s.GetTraceId())
+		for _, a := range s.GetAttributes() {
+			fmt.Fprintf(&b, "%s=%s ", a.GetKey(), attrValueStr(a.GetValue()))
+		}
+		fmt.Fprintln(&b, "]")
+	}
+	return b.String()
+}
+
+func attrValueStr(v *commonpb.AnyValue) string {
+	if v == nil {
+		return "<nil>"
+	}
+	if sv := v.GetStringValue(); sv != "" {
+		return sv
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	exitCode := func() int {
+		clusterInstance = cluster.NewCluster(cell, hostname)
+		defer clusterInstance.Teardown()
+
+		if err := clusterInstance.StartTopo(); err != nil {
+			fmt.Fprintf(os.Stderr, "StartTopo: %v\n", err)
+			return 1
+		}
+
+		keyspace := &cluster.Keyspace{
+			Name:      keyspaceName,
+			SchemaSQL: schemaSQL,
+			VSchema:   vschema,
+		}
+		if err := clusterInstance.StartUnshardedKeyspace(*keyspace, 0, false, cell); err != nil {
+			fmt.Fprintf(os.Stderr, "StartUnshardedKeyspace: %v\n", err)
+			return 1
+		}
+
+		// Start a minimal OTLP collector that records exported spans.
+		collectorPort := clusterInstance.GetAndReservePort()
+		lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", collectorPort))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "collector listen on port %d: %v\n", collectorPort, err)
+			return 1
+		}
+		collector = &otlpCollector{
+			srv:  grpc.NewServer(),
+			port: collectorPort,
+		}
+		collectortracepb.RegisterTraceServiceServer(collector.srv, collector)
+		go func() { _ = collector.srv.Serve(lis) }()
+		defer collector.srv.GracefulStop()
+
+		// Start vtgate with OpenTelemetry tracing pointed at our collector.
+		clusterInstance.VtGateExtraArgs = append(clusterInstance.VtGateExtraArgs,
+			"--tracer", "opentelemetry",
+			"--otel-insecure",
+			"--otel-endpoint", fmt.Sprintf("localhost:%d", collector.port),
+			"--tracing-sampling-rate", "1.0",
+		)
+		if err := clusterInstance.StartVtgate(); err != nil {
+			fmt.Fprintf(os.Stderr, "StartVtgate: %v\n", err)
+			return 1
+		}
+
+		vtParams = clusterInstance.GetVTParams(keyspaceName)
+		return m.Run()
+	}()
+	os.Exit(exitCode)
+}
+
+const warnSubstring = "Unable to parse VT_SPAN_CONTEXT"
+
+// vtgateWarningCount returns the number of VT_SPAN_CONTEXT warnings in vtgate's stderr log.
+func vtgateWarningCount(t *testing.T) int {
+	t.Helper()
+	data, err := os.ReadFile(clusterInstance.VtgateProcess.ErrorLog)
+	require.NoError(t, err)
+	return strings.Count(string(data), warnSubstring)
+}
+
+// buildCarrier creates a valid base64-encoded VT_SPAN_CONTEXT carrier for
+// the given W3C traceparent string.
+func buildCarrier(traceparent string) string {
+	carrier := map[string]string{"traceparent": traceparent}
+	jsonBytes, _ := json.Marshal(carrier)
+	return base64.StdEncoding.EncodeToString(jsonBytes)
+}
+
+// TestVTSpanContextComQuery verifies that VT_SPAN_CONTEXT is parsed when
+// a query is sent via COM_QUERY (the standard text protocol path).
+func TestVTSpanContextComQuery(t *testing.T) {
+	ctx := t.Context()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	before := vtgateWarningCount(t)
+
+	// Send a query with an invalid VT_SPAN_CONTEXT via COM_QUERY.
+	qr := utils.Exec(t, conn, "/*VT_SPAN_CONTEXT=invalid*/SELECT 1")
+	require.Len(t, qr.Rows, 1)
+
+	assert.Eventually(t, func() bool {
+		return vtgateWarningCount(t) > before
+	}, 30*time.Second, 500*time.Millisecond,
+		"expected VT_SPAN_CONTEXT warning in vtgate stderr for COM_QUERY path")
+}
+
+// TestVTSpanContextPreparedStatement verifies that VT_SPAN_CONTEXT is parsed
+// when a query is sent via prepared statements (COM_STMT_PREPARE / COM_STMT_EXECUTE).
+//
+// Reproduces https://github.com/vitessio/vitess/issues/19942
+func TestVTSpanContextPreparedStatement(t *testing.T) {
+	connStr := fmt.Sprintf("@tcp(%s:%d)/%s", hostname, clusterInstance.VtgateMySQLPort, keyspaceName)
+	db, err := sql.Open("mysql", connStr)
+	require.NoError(t, err)
+	defer db.Close()
+
+	before := vtgateWarningCount(t)
+
+	var result int
+	err = db.QueryRow("/*VT_SPAN_CONTEXT=invalid*/SELECT ?", 1).Scan(&result)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result)
+
+	assert.Eventually(t, func() bool {
+		return vtgateWarningCount(t) > before
+	}, 30*time.Second, 500*time.Millisecond,
+		"expected VT_SPAN_CONTEXT warning in vtgate stderr for prepared statement path — "+
+			"this fails because ComPrepare/ComStmtExecute do not call startSpan()")
+}
+
+// TestVTSpanContextValidTraceComQuery sends a valid VT_SPAN_CONTEXT via
+// COM_QUERY and verifies that the trace span is exported to the collector
+// with the expected trace ID.
+func TestVTSpanContextValidTraceComQuery(t *testing.T) {
+	const traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+	const spanID = "00f067aa0ba902b7"
+	traceparent := fmt.Sprintf("00-%s-%s-01", traceID, spanID)
+	carrier := buildCarrier(traceparent)
+
+	ctx := t.Context()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	before := vtgateWarningCount(t)
+
+	qr := utils.Exec(t, conn, fmt.Sprintf("/*VT_SPAN_CONTEXT=%s*/SELECT 1", carrier))
+	require.Len(t, qr.Rows, 1)
+
+	// The OTLP batch exporter flushes on a timer (default 5s).
+	// Wait for the span to arrive at our collector.
+	require.Eventually(t, func() bool {
+		return collector.spanWithTraceID(traceID) != nil
+	}, 30*time.Second, 500*time.Millisecond,
+		"expected collector to receive a span with traceID %s for COM_QUERY; collected spans:\n%s",
+		traceID, collector.dumpSpans())
+
+	// No warning should be logged for a valid carrier.
+	assert.Equal(t, before, vtgateWarningCount(t),
+		"valid VT_SPAN_CONTEXT should not produce a warning")
+}
+
+// TestVTSpanContextValidTracePreparedStatement sends a valid VT_SPAN_CONTEXT
+// via prepared statement and verifies that the trace span is exported to the
+// collector with the expected trace ID.
+func TestVTSpanContextValidTracePreparedStatement(t *testing.T) {
+	const traceID = "abcdef1234567890abcdef1234567890"
+	const spanID = "1234567890abcdef"
+	traceparent := fmt.Sprintf("00-%s-%s-01", traceID, spanID)
+	carrier := buildCarrier(traceparent)
+
+	connStr := fmt.Sprintf("@tcp(%s:%d)/%s", hostname, clusterInstance.VtgateMySQLPort, keyspaceName)
+	db, err := sql.Open("mysql", connStr)
+	require.NoError(t, err)
+	defer db.Close()
+
+	before := vtgateWarningCount(t)
+
+	var result int
+	err = db.QueryRow(fmt.Sprintf("/*VT_SPAN_CONTEXT=%s*/SELECT ?", carrier), 1).Scan(&result)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result)
+
+	// Wait for the span to arrive at our collector.
+	require.Eventually(t, func() bool {
+		return collector.spanWithTraceID(traceID) != nil
+	}, 30*time.Second, 500*time.Millisecond,
+		"expected collector to receive a span with traceID %s for prepared statement; collected spans:\n%s",
+		traceID, collector.dumpSpans())
+
+	// No warning should be logged for a valid carrier.
+	assert.Equal(t, before, vtgateWarningCount(t),
+		"valid VT_SPAN_CONTEXT should not produce a warning")
+}

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -220,6 +220,50 @@ func startSpan(ctx context.Context, query, label string) (trace.Span, context.Co
 	return startSpanTestable(ctx, query, label, trace.NewSpan, trace.NewFromString)
 }
 
+// extractSpanContext extracts the VT_SPAN_CONTEXT value from a query's leading comments.
+// Returns empty string if no span context is found.
+func extractSpanContext(query string) string {
+	_, comments := sqlparser.SplitMarginComments(query)
+	match := r.FindStringSubmatch(comments.Leading)
+	if len(match) != 0 {
+		return match[1]
+	}
+	return ""
+}
+
+// startSpanFromPrepareTestable creates a span for a prepared statement execution,
+// caching the extracted VT_SPAN_CONTEXT on the PrepareData to avoid re-parsing
+// the SQL comments on every execution.
+func startSpanFromPrepareTestable(ctx context.Context, prepare *mysql.PrepareData, label string,
+	newSpan func(context.Context, string) (trace.Span, context.Context),
+	newSpanFromString func(context.Context, string, string) (trace.Span, context.Context, error),
+) (trace.Span, context.Context, error) {
+	if prepare.SpanContext == nil {
+		sc := extractSpanContext(prepare.PrepareStmt)
+		prepare.SpanContext = &sc
+	}
+
+	var span trace.Span
+	if *prepare.SpanContext != "" {
+		var err error
+		span, ctx, err = newSpanFromString(ctx, *prepare.SpanContext, label)
+		if err == nil {
+			trace.AnnotateSQL(span, sqlparser.Preview(prepare.PrepareStmt))
+			return span, ctx, nil
+		}
+		log.Warn("Unable to parse VT_SPAN_CONTEXT: " + err.Error())
+		// Clear the cached value so subsequent executions skip the parse attempt.
+		*prepare.SpanContext = ""
+	}
+	span, ctx = newSpan(ctx, label)
+	trace.AnnotateSQL(span, sqlparser.Preview(prepare.PrepareStmt))
+	return span, ctx, nil
+}
+
+func startSpanFromPrepare(ctx context.Context, prepare *mysql.PrepareData, label string) (trace.Span, context.Context, error) {
+	return startSpanFromPrepareTestable(ctx, prepare, label, trace.NewSpan, trace.NewFromString)
+}
+
 func (vh *vtgateHandler) ComQuery(c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
 	session := vh.session(c)
 	if c.IsShuttingDown() && !session.InTransaction {
@@ -429,7 +473,7 @@ func (vh *vtgateHandler) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareDat
 		defer cancel()
 	}
 
-	span, ctx, err := startSpan(ctx, prepare.PrepareStmt, "vtgateHandler.ComStmtExecute")
+	span, ctx, err := startSpanFromPrepare(ctx, prepare, "vtgateHandler.ComStmtExecute")
 	if err != nil {
 		return vterrors.Wrap(err, "failed to extract span")
 	}

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -186,7 +186,7 @@ func (vh *vtgateHandler) ConnectionClosed(c *mysql.Conn) {
 }
 
 // Regexp to extract parent span id over the sql query
-var r = regexp.MustCompile(`/\*VT_SPAN_CONTEXT=(.*)\*/`)
+var r = regexp.MustCompile(`/\*VT_SPAN_CONTEXT=(.*?)\*/`)
 
 // this function is here to make this logic easy to test by decoupling the logic from the `trace.NewSpan` and `trace.NewFromString` functions
 func startSpanTestable(ctx context.Context, query, label string,

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -429,6 +429,12 @@ func (vh *vtgateHandler) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareDat
 		defer cancel()
 	}
 
+	span, ctx, err := startSpan(ctx, prepare.PrepareStmt, "vtgateHandler.ComStmtExecute")
+	if err != nil {
+		return vterrors.Wrap(err, "failed to extract span")
+	}
+	defer span.Finish()
+
 	ctx = callinfo.MysqlCallInfo(ctx, c)
 
 	// Fill in the ImmediateCallerID with the UserData returned by

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -19,6 +19,7 @@ package vtgate
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"os/signal"
@@ -251,7 +252,7 @@ func startSpanFromPrepareTestable(ctx context.Context, prepare *mysql.PrepareDat
 			trace.AnnotateSQL(span, sqlparser.Preview(prepare.PrepareStmt))
 			return span, ctx, nil
 		}
-		log.Warn("Unable to parse VT_SPAN_CONTEXT: " + err.Error())
+		log.Warn("Unable to parse VT_SPAN_CONTEXT", slog.Any("error", err))
 		// Clear the cached value so subsequent executions skip the parse attempt.
 		*prepare.SpanContext = ""
 	}

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -274,6 +274,12 @@ func TestSpanContextPassedInEvenAroundOtherComments(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestSpanContextWithMultipleLeadingComments(t *testing.T) {
+	_, _, err := startSpanTestable(context.Background(), "/*VT_SPAN_CONTEXT=123*//*vt+ SCATTER_ERRORS_AS_WARNINGS */ SELECT col1 FROM TABLE", "someLabel",
+		newSpanFail(t), newFromStringExpect(t, "123"))
+	assert.NoError(t, err)
+}
+
 func TestSpanContextNotParsable(t *testing.T) {
 	hasRun := false
 	_, _, err := startSpanTestable(context.Background(), "/*VT_SPAN_CONTEXT=123*/SQL QUERY", "someLabel",

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -286,6 +286,77 @@ func TestSpanContextNotParsable(t *testing.T) {
 	assert.True(t, hasRun, "Should have continued execution despite failure to parse VT_SPAN_CONTEXT")
 }
 
+func TestStartSpanFromPrepare_NoSpanContext(t *testing.T) {
+	prepare := &mysql.PrepareData{PrepareStmt: "SELECT 1"}
+	_, _, err := startSpanFromPrepareTestable(context.Background(), prepare, "someLabel", newSpanOK, newFromStringFail(t))
+	assert.NoError(t, err)
+	require.NotNil(t, prepare.SpanContext)
+	assert.Empty(t, *prepare.SpanContext)
+}
+
+func TestStartSpanFromPrepare_WithSpanContext(t *testing.T) {
+	prepare := &mysql.PrepareData{PrepareStmt: "/*VT_SPAN_CONTEXT=123*/SELECT 1"}
+	_, _, err := startSpanFromPrepareTestable(context.Background(), prepare, "someLabel",
+		newSpanFail(t), newFromStringExpect(t, "123"))
+	assert.NoError(t, err)
+	require.NotNil(t, prepare.SpanContext)
+	assert.Equal(t, "123", *prepare.SpanContext)
+}
+
+func TestStartSpanFromPrepare_CachesSpanContext(t *testing.T) {
+	prepare := &mysql.PrepareData{PrepareStmt: "/*VT_SPAN_CONTEXT=456*/SELECT 1"}
+	// First call extracts and caches the span context.
+	_, _, err := startSpanFromPrepareTestable(context.Background(), prepare, "someLabel",
+		newSpanFail(t), newFromStringExpect(t, "456"))
+	assert.NoError(t, err)
+	require.NotNil(t, prepare.SpanContext)
+	assert.Equal(t, "456", *prepare.SpanContext)
+
+	// Second call reuses the cached span context (PrepareStmt is not re-parsed).
+	prepare.PrepareStmt = "modified query that would not match"
+	_, _, err = startSpanFromPrepareTestable(context.Background(), prepare, "someLabel",
+		newSpanFail(t), newFromStringExpect(t, "456"))
+	assert.NoError(t, err)
+}
+
+func TestStartSpanFromPrepare_SpanContextNotParsable(t *testing.T) {
+	prepare := &mysql.PrepareData{PrepareStmt: "/*VT_SPAN_CONTEXT=123*/SELECT 1"}
+	newFromStringCalls := 0
+	newSpanCalls := 0
+	_, _, err := startSpanFromPrepareTestable(context.Background(), prepare, "someLabel",
+		func(c context.Context, s string) (trace.Span, context.Context) {
+			newSpanCalls++
+			return trace.NoopSpan{}, context.Background()
+		},
+		func(ctx context.Context, parentSpan string, label string) (trace.Span, context.Context, error) {
+			newFromStringCalls++
+			return trace.NoopSpan{}, context.Background(), errors.New("parse error")
+		})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, newFromStringCalls, "newFromString should be called on first execution")
+	assert.Equal(t, 1, newSpanCalls, "newSpan should be called as fallback")
+	// After the first failure, the cached SpanContext should be cleared so
+	// subsequent executions skip the parse attempt entirely.
+	require.NotNil(t, prepare.SpanContext)
+	assert.Empty(t, *prepare.SpanContext)
+
+	// Second execution should not call newFromString again.
+	newFromStringCalls = 0
+	newSpanCalls = 0
+	_, _, err = startSpanFromPrepareTestable(context.Background(), prepare, "someLabel",
+		func(c context.Context, s string) (trace.Span, context.Context) {
+			newSpanCalls++
+			return trace.NoopSpan{}, context.Background()
+		},
+		func(ctx context.Context, parentSpan string, label string) (trace.Span, context.Context, error) {
+			newFromStringCalls++
+			return trace.NoopSpan{}, context.Background(), errors.New("parse error")
+		})
+	assert.NoError(t, err)
+	assert.Equal(t, 0, newFromStringCalls, "newFromString should not be called after cached failure")
+	assert.Equal(t, 1, newSpanCalls, "newSpan should be called directly")
+}
+
 func newTestAuthServerStatic() *mysql.AuthServerStatic {
 	jsonConfig := "{\"user1\":{\"Password\":\"password1\", \"UserData\":\"userData1\", \"SourceHost\":\"localhost\"}}"
 	return mysql.NewAuthServerStatic("", jsonConfig, 0)


### PR DESCRIPTION
## Description

`VT_SPAN_CONTEXT` extraction was only wired into `ComQuery` and `ComQueryMulti` — prepared statements (`ComStmtExecute`) never called `startSpan()`, so clients using the MySQL binary protocol _(PHP/Laravel, Python, Go's `database/sql` with params, etc.)_ had their trace context silently ignored

The fix adds span context extraction to `ComStmtExecute` via a new `startSpanFromPrepare()` path that caches the extracted `VT_SPAN_CONTEXT` on `PrepareData.SpanContext`. The SQL comment parsing happens once on first execution and is reused for subsequent executions of the same prepared statement. Invalid span contexts are also cached after the first parse failure to prevent repeated warning logs

This PR also adds the first e2e tracing test infrastructure. The test suite at `go/test/endtoend/vtgate/trace/` starts `vtgate` with `--tracer=opentelemetry` pointed at a minimal in-process OTLP gRPC collector:
- **Invalid carrier tests**: send `/*VT_SPAN_CONTEXT=invalid*/` via `COM_QUERY` and prepared statement, assert `vtgate` logs the parse warning for both paths
- **Valid carrier tests**: send a proper base64-encoded W3C traceparent via both paths, assert the collector receives spans with the expected trace ID

**Limitation**: The span context is extracted once at prepare time and reused for all subsequent executions. `COM_STMT_EXECUTE` does not carry SQL text, so there is no way to inject a fresh span context per-execute without re-preparing. In practice, Go's `database/sql` does implicit prepare+execute for `db.Query(..., args)`, so each call gets a fresh context

## Related Issue(s)

Resolves https://github.com/vitessio/vitess/issues/19957

Related: https://github.com/vitessio/vitess/issues/19942

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

No deployment notes — this is a bug fix with no behavioural change for clients that don't use `VT_SPAN_CONTEXT`

### AI Disclosure

This PR was written primarily by Claude Code — I provided direction and review. Claude prepared this PR summary