### PR TITLE
planner: mint subquery placeholders as typed Argument

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing.go
@@ -114,8 +114,8 @@ func pushAggregationThroughSubquery(
 
 	for _, aggr := range pushedAggr.Aggregations {
 		// we rewrite columns in the aggregation to use the argument form of the subquery
-		aggr.Original.Expr = rewriteColNameToArgument(ctx, aggr.Original.Expr, aggr.SubQueryExpression, src.Inner...)
-		pushedAggr.Columns[aggr.ColOffset].Expr = rewriteColNameToArgument(ctx, pushedAggr.Columns[aggr.ColOffset].Expr, aggr.SubQueryExpression, src.Inner...)
+		aggr.Original.Expr = rewriteSubqueryArgsForPullout(ctx, aggr.Original.Expr, aggr.SubQueryExpression, src.Inner...)
+		pushedAggr.Columns[aggr.ColOffset].Expr = rewriteSubqueryArgsForPullout(ctx, pushedAggr.Columns[aggr.ColOffset].Expr, aggr.SubQueryExpression, src.Inner...)
 	}
 
 	if !rootAggr.Original {

--- a/go/vt/vtgate/planbuilder/operators/projection_pushing.go
+++ b/go/vt/vtgate/planbuilder/operators/projection_pushing.go
@@ -152,7 +152,7 @@ func pushProjectionToOuter(ctx *plancontext.PlanningContext, p *Projection, sq *
 
 		se, ok := pe.Info.(SubQueryExpression)
 		if ok {
-			pe.EvalExpr = rewriteColNameToArgument(ctx, pe.EvalExpr, se, sq)
+			pe.EvalExpr = rewriteSubqueryArgsForPullout(ctx, pe.EvalExpr, se, sq)
 		}
 	}
 	// all projections can be pushed to the outer
@@ -193,7 +193,7 @@ func pushProjectionToOuterContainer(ctx *plancontext.PlanningContext, p *Project
 		}
 
 		if se, ok := pe.Info.(SubQueryExpression); ok {
-			pe.EvalExpr = rewriteColNameToArgument(ctx, pe.EvalExpr, se, src.Inner...)
+			pe.EvalExpr = rewriteSubqueryArgsForPullout(ctx, pe.EvalExpr, se, src.Inner...)
 		}
 	}
 	// all projections can be pushed to the outer

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -179,7 +179,7 @@ func (sq *SubQuery) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparse
 func (sq *SubQuery) AddColumn(ctx *plancontext.PlanningContext, reuseExisting bool, addToGroupBy bool, ae *sqlparser.AliasedExpr) int {
 	ae = sqlparser.Clone(ae)
 	// we need to rewrite the column name to an argument if it's the same as the subquery column name
-	ae.Expr = rewriteColNameToArgument(ctx, ae.Expr, []*SubQuery{sq}, sq)
+	ae.Expr = rewriteSubqueryArgsForPullout(ctx, ae.Expr, []*SubQuery{sq}, sq)
 	return sq.Outer.AddColumn(ctx, reuseExisting, addToGroupBy, ae)
 }
 

--- a/go/vt/vtgate/planbuilder/operators/subquery_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_builder.go
@@ -415,19 +415,29 @@ func (sqb *SubQueryBuilder) pullOutValueSubqueries(
 // replaceSubqueryNode replaces the current cursor node with the appropriate
 // argument placeholder for the given bind var name and opcode.
 //
-// For non-list non-DML placeholders we mint a typed *Argument carrying the
-// resolved type of the inner subquery's first SELECT column. The semantic
-// type pipeline (typer.up handling *Argument with Type >= 0) propagates that
-// type into ExprTypes the same way it would for a typed bind variable, so
-// downstream callers that consult ctx.TypeForExpr on the placeholder see
-// the same type information they used to see when the placeholder was a
-// *ColName flowing through column-resolution. When the inner column's
-// type can't be resolved (schemaless test tables, volatile functions like
-// uuid(), nested subqueries whose first column is itself a placeholder),
-// we fall back to an untyped *Argument — which matches today's behaviour
-// for those queries: their *ColName placeholder also fails to acquire a
-// type via the binder, so the emitted SQL has bare `:argName` without a
-// `/* TYPE */` annotation in either case.
+// For scalar (PulloutValue) non-DML placeholders we mint a typed *Argument
+// carrying the resolved type of the inner subquery's first SELECT column.
+// The semantic type pipeline (typer.up handling *Argument with Type >= 0)
+// propagates that type into ExprTypes the same way it would for a typed
+// bind variable, so downstream callers that consult ctx.TypeForExpr on
+// the placeholder see the same type information they used to see when the
+// placeholder was a *ColName flowing through column-resolution. When the
+// inner column's type can't be resolved (schemaless test tables, volatile
+// functions like uuid(), nested subqueries whose first column is itself a
+// placeholder), we fall back to an untyped *Argument — which matches
+// today's behaviour for those queries: their *ColName placeholder also
+// fails to acquire a type via the binder, so the emitted SQL has bare
+// `:argName` without a `/* TYPE */` annotation in either case.
+//
+// EXISTS placeholders are intentionally untyped: their runtime value is a
+// 0/1 flag, completely independent of the inner subquery's first-column
+// type. Inheriting that inner type would be wrong (it could be
+// VARCHAR/Decimal/Datetime/etc.) and could produce invalid emitted SQL via
+// Argument.Format's CAST emissions for those types, plus mislead
+// type-aware planning decisions (e.g. NeedsWeightString triggering on a
+// VARCHAR-typed flag). The eventual rewriteSubqueryArgsForPullout pass
+// replaces this placeholder with NewArgument(HasValuesName) (also
+// untyped), so leaving it untyped here matches the end state.
 func (sqb *SubQueryBuilder) replaceSubqueryNode(
 	ctx *plancontext.PlanningContext,
 	cursor *sqlparser.Cursor,
@@ -438,6 +448,10 @@ func (sqb *SubQueryBuilder) replaceSubqueryNode(
 ) {
 	if filterType.NeedsListArg() {
 		cursor.Replace(sqlparser.NewListArg(argName))
+		return
+	}
+	if filterType == opcode.PulloutExists {
+		cursor.Replace(sqlparser.NewArgument(argName))
 		return
 	}
 	if isDML {

--- a/go/vt/vtgate/planbuilder/operators/subquery_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_builder.go
@@ -389,7 +389,7 @@ func (sqb *SubQueryBuilder) pullOutValueSubqueries(
 		sqInner := createSubquery(ctx, original, sq, outerID, original, argName, filterType, true)
 		allSubqs = append(allSubqs, sqInner)
 		sqb.Inner = append(sqb.Inner, sqInner)
-		sqb.replaceSubqueryNode(cursor, argName, filterType, isDML)
+		sqb.replaceSubqueryNode(ctx, cursor, sq, argName, filterType, isDML)
 	}
 
 	expr = sqlparser.Rewrite(expr, nil, func(cursor *sqlparser.Cursor) bool {
@@ -414,16 +414,69 @@ func (sqb *SubQueryBuilder) pullOutValueSubqueries(
 
 // replaceSubqueryNode replaces the current cursor node with the appropriate
 // argument placeholder for the given bind var name and opcode.
-func (sqb *SubQueryBuilder) replaceSubqueryNode(cursor *sqlparser.Cursor, argName string, filterType opcode.PulloutOpcode, isDML bool) {
-	if isDML {
-		if filterType.NeedsListArg() {
-			cursor.Replace(sqlparser.NewListArg(argName))
-		} else {
-			cursor.Replace(sqlparser.NewArgument(argName))
-		}
-	} else {
-		cursor.Replace(sqlparser.NewColName(argName))
+//
+// For non-list non-DML placeholders we mint a typed *Argument carrying the
+// resolved type of the inner subquery's first SELECT column. The semantic
+// type pipeline (typer.up handling *Argument with Type >= 0) propagates that
+// type into ExprTypes the same way it would for a typed bind variable, so
+// downstream callers that consult ctx.TypeForExpr on the placeholder see
+// the same type information they used to see when the placeholder was a
+// *ColName flowing through column-resolution. When the inner column's
+// type can't be resolved (schemaless test tables, volatile functions like
+// uuid(), nested subqueries whose first column is itself a placeholder),
+// we fall back to an untyped *Argument — which matches today's behaviour
+// for those queries: their *ColName placeholder also fails to acquire a
+// type via the binder, so the emitted SQL has bare `:argName` without a
+// `/* TYPE */` annotation in either case.
+func (sqb *SubQueryBuilder) replaceSubqueryNode(
+	ctx *plancontext.PlanningContext,
+	cursor *sqlparser.Cursor,
+	sq *sqlparser.Subquery,
+	argName string,
+	filterType opcode.PulloutOpcode,
+	isDML bool,
+) {
+	if filterType.NeedsListArg() {
+		cursor.Replace(sqlparser.NewListArg(argName))
+		return
 	}
+	if isDML {
+		// DML placeholders historically use untyped *Argument; preserved
+		// here to avoid touching DML behaviour as part of this change.
+		cursor.Replace(sqlparser.NewArgument(argName))
+		return
+	}
+	cursor.Replace(typedArgumentFromSubquery(ctx, sq, argName))
+}
+
+// typedArgumentFromSubquery mints an Argument carrying the inner subquery's
+// first-column type, falling back to an untyped Argument when no type can be
+// derived. Goes through ctx.TypeForExpr (not SemTable.TypeForExpr directly)
+// so that lazy evalengine type calculation kicks in for expressions whose
+// types aren't pre-populated in ExprTypes — e.g. uuid() resolves to VARCHAR
+// via evalengine.Translate but isn't entered into ExprTypes by the binder.
+// This matches what the *ColName placeholder used to acquire when consumers
+// later asked ctx.TypeForExpr about it.
+func typedArgumentFromSubquery(ctx *plancontext.PlanningContext, sq *sqlparser.Subquery, argName string) sqlparser.Expr {
+	if sq == nil || sq.Select == nil {
+		return sqlparser.NewArgument(argName)
+	}
+	cols := sq.Select.GetColumns()
+	if len(cols) == 0 {
+		return sqlparser.NewArgument(argName)
+	}
+	ae, ok := cols[0].(*sqlparser.AliasedExpr)
+	if !ok {
+		return sqlparser.NewArgument(argName)
+	}
+	typ, found := ctx.TypeForExpr(ae.Expr)
+	if !found || !typ.Valid() {
+		return sqlparser.NewArgument(argName)
+	}
+	arg := sqlparser.NewTypedArgument(argName, typ.Type())
+	arg.Size = typ.Size()
+	arg.Scale = typ.Scale()
+	return arg
 }
 
 // getOpCodeFromParent determines the pullout opcode for a subquery based on its parent expression type.

--- a/go/vt/vtgate/planbuilder/operators/subquery_builder_test.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_builder_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operators
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/engine/opcode"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+	"vitess.io/vitess/go/vt/vtgate/semantics"
+)
+
+// TestReplaceSubqueryNode_ExistsPlaceholderUntyped verifies that
+// replaceSubqueryNode mints an untyped *Argument for PulloutExists pullouts,
+// regardless of the inner subquery's first SELECT column type.
+//
+// EXISTS evaluates to a 0/1 flag at runtime; inheriting the inner column's
+// type would be wrong — for non-INT types it leads to incorrect planning
+// decisions (NeedsWeightString misfiring) and Argument.Format emitting
+// invalid CASTs (CAST(:arg AS DECIMAL(...)) etc. for what's a 0/1 integer).
+//
+// Plantest doesn't currently surface this because rewriteSubqueryArgsForPullout
+// later replaces the placeholder with NewArgument(HasValuesName) before SQL
+// is emitted, so Argument.Format never sees the buggy type. This unit test
+// asserts the property directly at the mint site.
+//
+// Caught by GitHub Copilot in PR review (#19963).
+func TestReplaceSubqueryNode_ExistsPlaceholderUntyped(t *testing.T) {
+	cases := []struct {
+		name      string
+		innerType sqltypes.Type
+	}{
+		{"Decimal inner", sqltypes.Decimal},
+		{"VarChar inner", sqltypes.VarChar},
+		{"Datetime inner", sqltypes.Datetime},
+		{"Time inner", sqltypes.Time},
+		{"Float64 inner", sqltypes.Float64},
+		{"Uint64 inner", sqltypes.Uint64},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			arg := mintExistsPlaceholder(t, c.innerType)
+			assert.Equal(t, sqltypes.Unknown, arg.Type,
+				"PulloutExists placeholder must be untyped, but got %v from inner %v",
+				arg.Type, c.innerType)
+			assert.Equal(t, "__sq1", arg.Name)
+		})
+	}
+}
+
+// TestReplaceSubqueryNode_ValuePlaceholderTyped verifies that the typed-Argument
+// path still kicks in for PulloutValue (scalar subqueries). This guards against
+// an over-eager fix accidentally widening the EXISTS untyped path to other
+// pullout kinds.
+func TestReplaceSubqueryNode_ValuePlaceholderTyped(t *testing.T) {
+	parser := sqlparser.NewTestParser()
+	colExpr, err := parser.ParseExpr("col")
+	require.NoError(t, err)
+
+	// Inner subquery: SELECT col FROM dual, with col typed as Decimal.
+	inner := &sqlparser.Select{
+		SelectExprs: &sqlparser.SelectExprs{
+			Exprs: []sqlparser.SelectExpr{&sqlparser.AliasedExpr{Expr: colExpr}},
+		},
+		From: []sqlparser.TableExpr{
+			&sqlparser.AliasedTableExpr{Expr: sqlparser.TableName{Name: sqlparser.NewIdentifierCS("dual")}},
+		},
+	}
+	sq := &sqlparser.Subquery{Select: inner}
+
+	st := semantics.EmptySemTable()
+	st.ExprTypes[colExpr] = evalengine.NewType(sqltypes.Decimal, collations.Unknown)
+	ctx := &plancontext.PlanningContext{SemTable: st}
+
+	// Run Rewrite with sq as the root so cursor.Replace lands somewhere
+	// observable. We use a wrapper Cmp so the Subquery has a parent slot
+	// the cursor can write into.
+	wrapper := &sqlparser.ComparisonExpr{Operator: sqlparser.EqualOp, Left: sqlparser.NewIntLiteral("1"), Right: sq}
+	sqb := &SubQueryBuilder{}
+	result := sqlparser.Rewrite(wrapper, func(c *sqlparser.Cursor) bool {
+		if _, ok := c.Node().(*sqlparser.Subquery); ok {
+			sqb.replaceSubqueryNode(ctx, c, sq, "__sq1", opcode.PulloutValue, false)
+			return false
+		}
+		return true
+	}, nil)
+
+	cmp := result.(*sqlparser.ComparisonExpr)
+	arg, ok := cmp.Right.(*sqlparser.Argument)
+	require.True(t, ok, "expected *Argument replacement for PulloutValue, got %T", cmp.Right)
+	assert.Equal(t, sqltypes.Decimal, arg.Type,
+		"PulloutValue placeholder should inherit the inner column's type")
+}
+
+// mintExistsPlaceholder constructs a minimal Subquery whose first SELECT
+// column has the given type, runs replaceSubqueryNode with PulloutExists,
+// and returns the resulting Argument.
+//
+// The scaffolding mirrors what pullOutValueSubqueries does in production:
+// the cursor sits on the ExistsExpr (not the inner Subquery), and
+// cursor.Replace substitutes the ExistsExpr with the *Argument. We wrap
+// the ExistsExpr in a ComparisonExpr so the cursor's parent slot is an
+// Expr (which can hold either *ExistsExpr or *Argument).
+func mintExistsPlaceholder(t *testing.T, innerType sqltypes.Type) *sqlparser.Argument {
+	t.Helper()
+	parser := sqlparser.NewTestParser()
+	colExpr, err := parser.ParseExpr("col")
+	require.NoError(t, err)
+
+	inner := &sqlparser.Select{
+		SelectExprs: &sqlparser.SelectExprs{
+			Exprs: []sqlparser.SelectExpr{&sqlparser.AliasedExpr{Expr: colExpr}},
+		},
+		From: []sqlparser.TableExpr{
+			&sqlparser.AliasedTableExpr{Expr: sqlparser.TableName{Name: sqlparser.NewIdentifierCS("dual")}},
+		},
+	}
+	sq := &sqlparser.Subquery{Select: inner}
+
+	st := semantics.EmptySemTable()
+	st.ExprTypes[colExpr] = evalengine.NewType(innerType, collations.Unknown)
+	ctx := &plancontext.PlanningContext{SemTable: st}
+
+	// Wrap ExistsExpr as the right side of a comparison so it sits in an
+	// Expr slot the cursor can rewrite into an *Argument.
+	wrapper := &sqlparser.ComparisonExpr{
+		Operator: sqlparser.EqualOp,
+		Left:     sqlparser.NewIntLiteral("1"),
+		Right:    &sqlparser.ExistsExpr{Subquery: sq},
+	}
+	sqb := &SubQueryBuilder{}
+	result := sqlparser.Rewrite(wrapper, func(c *sqlparser.Cursor) bool {
+		if exists, ok := c.Node().(*sqlparser.ExistsExpr); ok {
+			sqb.replaceSubqueryNode(ctx, c, exists.Subquery, "__sq1", opcode.PulloutExists, false)
+			return false
+		}
+		return true
+	}, nil)
+
+	cmp, ok := result.(*sqlparser.ComparisonExpr)
+	require.True(t, ok)
+	arg, ok := cmp.Right.(*sqlparser.Argument)
+	require.True(t, ok, "expected *Argument replacement, got %T", cmp.Right)
+	return arg
+}

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -119,17 +119,9 @@ func (o *Ordering) settleOrderingExpressions(ctx *plancontext.PlanningContext) {
 	for idx := range o.Order {
 		for arg, sq := range ctx.MergedSubqueries {
 			expr := sqlparser.Rewrite(o.Order[idx].SimplifiedExpr, nil, func(cursor *sqlparser.Cursor) bool {
-				switch expr := cursor.Node().(type) {
-				case *sqlparser.ColName:
-					if expr.Name.String() == arg {
-						cursor.Replace(sq)
-					}
-				case *sqlparser.Argument:
-					if expr.Name == arg {
-						cursor.Replace(sq)
-					}
+				if a, ok := cursor.Node().(*sqlparser.Argument); ok && a.Name == arg {
+					cursor.Replace(sq)
 				}
-
 				return true
 			})
 			o.Order[idx].SimplifiedExpr = expr.(sqlparser.Expr)
@@ -161,16 +153,8 @@ func rewriteMergedSubqueryExpr(ctx *plancontext.PlanningContext, se SubQueryExpr
 				continue
 			}
 			expr = sqlparser.Rewrite(expr, nil, func(cursor *sqlparser.Cursor) bool {
-				switch expr := cursor.Node().(type) {
-				case *sqlparser.ColName:
-					if expr.Name.String() != sq.ArgName { // TODO systay 2023.09.15 - This is not safe enough. We should figure out a better way.
-						return true
-					}
-				case *sqlparser.Argument:
-					if expr.Name != sq.ArgName {
-						return true
-					}
-				default:
+				arg, ok := cursor.Node().(*sqlparser.Argument)
+				if !ok || arg.Name != sq.ArgName {
 					return true
 				}
 				rewritten = true
@@ -382,17 +366,30 @@ func rewriteOriginalPushedToRHS(ctx *plancontext.PlanningContext, expression sql
 	return result.(sqlparser.Expr)
 }
 
-// rewriteColNameToArgument rewrites the column names in the expression to use the argument names instead
-// this is used when we push an operator from above the subquery into the outer side of the subquery
+// rewriteColNameToArgument rewrites subquery placeholder Arguments in the
+// expression to the argument shape appropriate for their pullout type:
+//   - PulloutIn / PulloutNotIn → ListArg keyed by the placeholder name
+//   - PulloutExists → typed Argument keyed by the SubQuery's HasValuesName
+//     (allocated lazily on first use)
+//   - default (scalar value subquery) → typed Argument carrying the type of
+//     the inner subquery's first SELECT column
+//
+// Used when an operator is pushed from above a subquery into the outer side
+// of the subquery, so its expression now needs the bind-var-shaped form
+// instead of the placeholder it was minted with.
+//
+// The function name is historical: subquery placeholders used to be minted
+// as unqualified *ColName instances and this helper converted them to
+// *Argument. After the typed-Argument migration of replaceSubqueryNode
+// (subquery_builder.go), placeholders are always *Argument; this function
+// now converts placeholder *Argument values to the pullout-aware
+// *Argument / ListArg shape.
 func rewriteColNameToArgument(
 	ctx *plancontext.PlanningContext,
 	in sqlparser.Expr, // the expression to rewrite
 	se SubQueryExpression, // the subquery expression we are rewriting
 	subqueries ...*SubQuery, // the inner subquery operators
 ) sqlparser.Expr {
-	// the visitor function that will rewrite the expression tree
-	// it will be invoked on unqualified column names, and replace them with arguments
-	// when the column is representing a subquery
 	rewriteIt := func(s string) sqlparser.SQLNode {
 		var sq1, sq2 *SubQuery
 		for _, sq := range se {
@@ -441,17 +438,16 @@ func rewriteColNameToArgument(
 		}
 	}
 
-	// replace the ColNames with Argument inside the subquery
 	result := sqlparser.Rewrite(in, nil, func(cursor *sqlparser.Cursor) bool {
-		col, ok := cursor.Node().(*sqlparser.ColName)
-		if !ok || !col.Qualifier.IsEmpty() {
+		arg, ok := cursor.Node().(*sqlparser.Argument)
+		if !ok {
 			return true
 		}
-		arg := rewriteIt(col.Name.String())
-		if arg == nil {
+		repl := rewriteIt(arg.Name)
+		if repl == nil {
 			return true
 		}
-		cursor.Replace(arg)
+		cursor.Replace(repl)
 		return true
 	})
 	return result.(sqlparser.Expr)

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -366,25 +366,19 @@ func rewriteOriginalPushedToRHS(ctx *plancontext.PlanningContext, expression sql
 	return result.(sqlparser.Expr)
 }
 
-// rewriteColNameToArgument rewrites subquery placeholder Arguments in the
-// expression to the argument shape appropriate for their pullout type:
+// rewriteSubqueryArgsForPullout rewrites subquery placeholder Arguments in the
+// expression to the bind-variable shape produced by their pullout:
 //   - PulloutIn / PulloutNotIn → ListArg keyed by the placeholder name
-//   - PulloutExists → typed Argument keyed by the SubQuery's HasValuesName
+//   - PulloutExists → Argument keyed by the SubQuery's HasValuesName
 //     (allocated lazily on first use)
 //   - default (scalar value subquery) → typed Argument carrying the type of
 //     the inner subquery's first SELECT column
 //
 // Used when an operator is pushed from above a subquery into the outer side
-// of the subquery, so its expression now needs the bind-var-shaped form
-// instead of the placeholder it was minted with.
-//
-// The function name is historical: subquery placeholders used to be minted
-// as unqualified *ColName instances and this helper converted them to
-// *Argument. After the typed-Argument migration of replaceSubqueryNode
-// (subquery_builder.go), placeholders are always *Argument; this function
-// now converts placeholder *Argument values to the pullout-aware
-// *Argument / ListArg shape.
-func rewriteColNameToArgument(
+// of the subquery, so its expressions now need to reference the pullout's
+// emitted bind variable instead of the abstract placeholder they were
+// minted with.
+func rewriteSubqueryArgsForPullout(
 	ctx *plancontext.PlanningContext,
 	in sqlparser.Expr, // the expression to rewrite
 	se SubQueryExpression, // the subquery expression we are rewriting

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -6847,8 +6847,7 @@
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "max(0|1) AS max((select min(col) from `user` where id = 1))",
-        "ResultColumns": 1,
+        "Aggregates": "max(0) AS max((select min(col) from `user` where id = 1))",
         "Inputs": [
           {
             "OperatorType": "UncorrelatedSubquery",
@@ -6880,8 +6879,8 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select max(:__sq1 /* INT16 */), weight_string(:__sq1 /* INT16 */) from `user` where 1 != 1 group by weight_string(:__sq1 /* INT16 */)",
-                "Query": "select max(:__sq1 /* INT16 */), weight_string(:__sq1 /* INT16 */) from `user` where id = 2 group by weight_string(:__sq1 /* INT16 */)",
+                "FieldQuery": "select max(:__sq1 /* INT16 */) from `user` where 1 != 1",
+                "Query": "select max(:__sq1 /* INT16 */) from `user` where id = 2",
                 "Values": [
                   "2"
                 ],


### PR DESCRIPTION
## Description

Subquery placeholders for non-DML pullouts have historically been minted as unqualified `*sqlparser.ColName` whose `Name` doubled as the bind-variable name. The "ColName masquerading as a column" shape was a workaround that let the placeholder flow through `SemTable` column-resolution and acquire a type annotation (the `:__sq1 /* INT16 */` comment in the emitted SQL).

This PR retires that hack: placeholders are now `*sqlparser.Argument` minted with `Type` pre-set when the inner subquery's first-column type is resolvable. The semantic type pipeline already supports typed Arguments (`semantics/typer.go:48-51` enters them into `ExprTypes`; `Argument.Format` emits the `/* TYPE */` comment when `Type >= 0`), so no changes to the binder or typer are required.

When `ctx.TypeForExpr` can't resolve the inner column's type — schemaless test tables, nested placeholders, etc. — the new helper falls back to an untyped Argument. That matches today's behaviour for those cases: the *ColName* placeholder also fails to acquire a type via the binder, so the emitted SQL has bare `:__sq1` either way.

### Cleanups unlocked

With placeholders consistently being Arguments, three load-bearing *ColName* arms of expression rewriters become dead and are deleted:

- `rewriteMergedSubqueryExpr` (also retires the systay 2023.09.15 TODO calling the matching arm "not safe enough" — it was indeed a hack born of the *ColName* placeholder shape, and goes away with it)
- `settleOrderingExpressions`
- `rewriteColNameToArgument` (renamed to `rewriteSubqueryArgsForPullout` — the new name says what the function actually does now: rewrite a subquery placeholder *Argument* into the bind-variable shape produced by its pullout type)

### Plan improvement

One plantest golden regenerates as a strict improvement:

```diff
- "Aggregates": "max(0|1) AS max((select min(col) ...))"
+ "Aggregates": "max(0) AS max((select min(col) ...))"
- "FieldQuery": "select max(:__sq1 /* INT16 */), weight_string(:__sq1 /* INT16 */) from `user` where 1 != 1 group by weight_string(:__sq1 /* INT16 */)"
+ "FieldQuery": "select max(:__sq1 /* INT16 */) from `user` where 1 != 1"
```

The new typed Argument has a resolved `INT16` type, so `NeedsWeightString` correctly returns `false` (INT16 isn't text) and the planner skips an unnecessary `weight_string` column AND a redundant `GROUP BY weight_string` in both the `FieldQuery` and the live `Query`. The old plan added these because the *ColName* placeholder had no resolved type at the `NeedsWeightString` call site and the helper conservatively returned `true`. The two plans are functionally equivalent on shard execution; the new plan emits less data over the wire and does fewer comparisons in the aggregator.

### Bonus correctness fix

`queryprojection.go:715`'s `checkForInvalidGroupingExpressions` already matched `*sqlparser.Argument` with `__sq` prefix to surface "subqueries in GROUP BY" errors. Pre-this-PR the check was latently incomplete for non-DML queries because their placeholders were *ColNames*, not Arguments, so the check silently missed them. Post-this-PR every placeholder is an Argument and the check is correct for all paths.

## Related Issue(s)

None.

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches *(N/A — main only)*
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description *(N/A)*
- [x] Tests were added or are not required *(plantest stays green; one golden regenerated to reflect the plan improvement)*
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required *(N/A — internal cleanup)*

## Deployment Notes

User-visible behaviour change in one query shape: when the outer query aggregates a scalar subquery whose result is a non-text type (e.g. an `INT` column), the query Vitess sends to shards no longer adds a redundant `weight_string` column or `GROUP BY weight_string` term. The result is functionally identical; only the wire query changes.

### AI Disclosure

Most of this was written by Claude Code — I provided the direction (audit the load-bearing *ColName* branch in the merge-rewrite engine, scope the upstream fix, then ship it).