### PR TITLE
Fix row streamer heartbeat cancellation race

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -339,7 +339,7 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 		sendMu.Lock()
 		defer sendMu.Unlock()
 		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("row stream ended: %w", context.Cause(ctx))
+			return fmt.Errorf("row stream ended: %w", err)
 		}
 		return send(r)
 	}
@@ -421,9 +421,9 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 	byteCount := 0
 	logger := logutil.NewThrottledLogger(rs.vse.GetTabletInfo(), throttledLoggerInterval)
 	for {
-		if rs.ctx.Err() != nil {
+		if err := rs.ctx.Err(); err != nil {
 			log.Info("Row stream ended because of ctx.Done")
-			return fmt.Errorf("row stream ended: %v", rs.ctx.Err())
+			return fmt.Errorf("row stream ended: %w", err)
 		}
 
 		// check throttler.

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -389,7 +389,7 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 		Gtid:     gtid,
 	})
 	if err != nil {
-		return fmt.Errorf("row stream send error: %v", err)
+		return fmt.Errorf("row stream send error: %w", err)
 	}
 
 	// streamQuery sends heartbeats as long as it operates

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -335,9 +335,12 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 	defer throttleResponseRateLimiter.Stop()
 
 	var sendMu sync.Mutex
-	safeSend := func(r *binlogdatapb.VStreamRowsResponse) error {
+	safeSend := func(ctx context.Context, r *binlogdatapb.VStreamRowsResponse) error {
 		sendMu.Lock()
 		defer sendMu.Unlock()
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("row stream ended: %v", err)
+		}
 		return send(r)
 	}
 	// Let's wait until MySQL is in good shape to stream rows
@@ -380,7 +383,7 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 		charsets[i] = collations.ID(fld.Charset)
 	}
 
-	err = safeSend(&binlogdatapb.VStreamRowsResponse{
+	err = safeSend(rs.ctx, &binlogdatapb.VStreamRowsResponse{
 		Fields:   rs.plan.fields(),
 		Pkfields: pkfields,
 		Gtid:     gtid,
@@ -390,15 +393,19 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 	}
 
 	// streamQuery sends heartbeats as long as it operates
-	heartbeatTicker := time.NewTicker(rowStreamertHeartbeatInterval)
-	defer heartbeatTicker.Stop()
+	heartbeatCtx, stopHeartbeats := context.WithCancel(rs.ctx)
+	defer stopHeartbeats()
+	heartbeatInterval := rowStreamertHeartbeatInterval
 	go func() {
+		heartbeatTicker := time.NewTicker(heartbeatInterval)
+		defer heartbeatTicker.Stop()
+
 		for {
 			select {
-			case <-rs.ctx.Done():
+			case <-heartbeatCtx.Done():
 				return
 			case <-heartbeatTicker.C:
-				safeSend(&binlogdatapb.VStreamRowsResponse{Heartbeat: true})
+				_ = safeSend(heartbeatCtx, &binlogdatapb.VStreamRowsResponse{Heartbeat: true})
 			}
 		}
 	}()
@@ -422,7 +429,7 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 		// check throttler.
 		if checkResult, ok := rs.vse.throttlerClient.ThrottleCheckOKOrWaitAppName(rs.ctx, throttlerapp.RowStreamerName); !ok {
 			throttleResponseRateLimiter.Do(func() error {
-				return safeSend(&binlogdatapb.VStreamRowsResponse{Throttled: true, ThrottledReason: checkResult.Summary()})
+				return safeSend(rs.ctx, &binlogdatapb.VStreamRowsResponse{Throttled: true, ThrottledReason: checkResult.Summary()})
 			})
 			logger.Infof("Throttled streaming rows for %s", rs.sendQuery)
 			continue
@@ -468,7 +475,7 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 			rs.vse.rowStreamerNumRows.Add(int64(len(response.Rows)))
 			rs.vse.rowStreamerNumPackets.Add(int64(1))
 			startSend := time.Now()
-			err = safeSend(&response)
+			err = safeSend(rs.ctx, &response)
 			if err != nil {
 				return err
 			}
@@ -483,7 +490,7 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 		response.Lastpk = sqltypes.RowToProto3(lastpk)
 
 		rs.vse.rowStreamerNumRows.Add(int64(len(response.Rows)))
-		err = safeSend(&response)
+		err = safeSend(rs.ctx, &response)
 		if err != nil {
 			return err
 		}

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -339,7 +339,7 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 		sendMu.Lock()
 		defer sendMu.Unlock()
 		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("row stream ended: %v", err)
+			return fmt.Errorf("row stream ended: %w", context.Cause(ctx))
 		}
 		return send(r)
 	}

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
@@ -607,7 +607,7 @@ func TestStreamRowsHeartbeat(t *testing.T) {
 		"drop table t1",
 	})
 
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	var heartbeatCount int32
@@ -650,7 +650,7 @@ func TestStreamRowsHeartbeat(t *testing.T) {
 	}, &options)
 
 	// We expect context canceled error since we cancel after receiving heartbeats
-	if err != nil && err.Error() != "stream ended: context canceled" && err.Error() != "row stream ended: context canceled" {
+	if err != nil && err.Error() != "row stream ended: context canceled" {
 		t.Errorf("unexpected error: %v", err)
 	}
 

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
@@ -580,6 +580,36 @@ func TestStreamRowsCancel(t *testing.T) {
 	}
 }
 
+func TestStreamRowsSendError(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	execStatements(t, []string{
+		"create table t1(id int, val varbinary(128), primary key(id))",
+		"insert into t1 values (1, 'aaa')",
+	})
+	defer execStatements(t, []string{
+		"drop table t1",
+	})
+
+	var options binlogdatapb.VStreamOptions
+	options.ConfigOverrides = make(map[string]string)
+
+	// Support both formats for backwards compatibility
+	// TODO(v25): Remove underscore versions
+	utils.SetFlagVariantsForTests(options.ConfigOverrides, "vstream-dynamic-packet-size", "false")
+	utils.SetFlagVariantsForTests(options.ConfigOverrides, "vstream-packet-size", "10")
+
+	sendErr := errors.New("send failed")
+	err := engine.StreamRows(t.Context(), "select * from t1", nil, func(rows *binlogdatapb.VStreamRowsResponse) error {
+		return sendErr
+	}, &options)
+	if !errors.Is(err, sendErr) {
+		t.Errorf("err: %v, want %v", err, sendErr)
+	}
+}
+
 func TestStreamRowsHeartbeat(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
@@ -575,8 +575,8 @@ func TestStreamRowsCancel(t *testing.T) {
 		cancel()
 		return nil
 	}, &options)
-	if got, want := err.Error(), "row stream ended: context canceled"; got != want {
-		t.Errorf("err: %v, want %s", err, want)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err: %v, want context.Canceled", err)
 	}
 }
 
@@ -650,7 +650,7 @@ func TestStreamRowsHeartbeat(t *testing.T) {
 	}, &options)
 
 	// We expect context canceled error since we cancel after receiving heartbeats
-	if err != nil && err.Error() != "row stream ended: context canceled" {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		t.Errorf("unexpected error: %v", err)
 	}
 

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
@@ -607,26 +607,41 @@ func TestStreamRowsHeartbeat(t *testing.T) {
 		"drop table t1",
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	var heartbeatCount int32
+	var streamCanceled int32
+	var rowsAfterCancel int32
+	var heartbeatsAfterCancel int32
 	dataReceived := false
 
 	var options binlogdatapb.VStreamOptions
 	options.ConfigOverrides = make(map[string]string)
-	options.ConfigOverrides["vstream_dynamic_packet_size"] = "false"
-	options.ConfigOverrides["vstream_packet_size"] = "10"
+
+	// Support both formats for backwards compatibility
+	// TODO(v25): Remove underscore versions
+	utils.SetFlagVariantsForTests(options.ConfigOverrides, "vstream-dynamic-packet-size", "false")
+	utils.SetFlagVariantsForTests(options.ConfigOverrides, "vstream-packet-size", "1")
 
 	err := engine.StreamRows(ctx, "select * from t1", nil, func(rows *binlogdatapb.VStreamRowsResponse) error {
 		if rows.Heartbeat {
+			if atomic.LoadInt32(&streamCanceled) != 0 {
+				atomic.AddInt32(&heartbeatsAfterCancel, 1)
+				return nil
+			}
 			atomic.AddInt32(&heartbeatCount, 1)
 			// After receiving at least 3 heartbeats, we can be confident the fix is working
 			if atomic.LoadInt32(&heartbeatCount) >= 3 {
+				atomic.StoreInt32(&streamCanceled, 1)
 				cancel()
 				return nil
 			}
 		} else if len(rows.Rows) > 0 {
+			if atomic.LoadInt32(&streamCanceled) != 0 {
+				atomic.AddInt32(&rowsAfterCancel, 1)
+				return nil
+			}
 			dataReceived = true
 		}
 		// Add a small delay to allow heartbeats to be sent
@@ -635,7 +650,7 @@ func TestStreamRowsHeartbeat(t *testing.T) {
 	}, &options)
 
 	// We expect context canceled error since we cancel after receiving heartbeats
-	if err != nil && err.Error() != "stream ended: context canceled" {
+	if err != nil && err.Error() != "stream ended: context canceled" && err.Error() != "row stream ended: context canceled" {
 		t.Errorf("unexpected error: %v", err)
 	}
 
@@ -650,6 +665,10 @@ func TestStreamRowsHeartbeat(t *testing.T) {
 	if atomic.LoadInt32(&heartbeatCount) < 3 {
 		t.Errorf("expected at least 3 heartbeats, got %d. This indicates the heartbeat goroutine is not running continuously", heartbeatCount)
 	}
+
+	require.Never(t, func() bool {
+		return atomic.LoadInt32(&rowsAfterCancel) != 0 || atomic.LoadInt32(&heartbeatsAfterCancel) != 0
+	}, 50*time.Millisecond, time.Millisecond, "expected context cancellation to stop row and heartbeat callbacks")
 }
 
 func checkStream(t *testing.T, query string, lastpk []sqltypes.Value, wantQuery string, wantStream []string, options *binlogdatapb.VStreamOptions) {


### PR DESCRIPTION
## Description

This fixes a race in row streaming heartbeats where a heartbeat callback could be queued behind another send and still run after the row stream had been canceled or returned.

The heartbeat goroutine now uses a stream-scoped context and creates/stops its ticker inside the goroutine. `safeSend` also checks the context after acquiring the send mutex, so queued row or heartbeat sends do not invoke the callback after cancellation.

## Related Issue(s)

Found during a CI run of #19963.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

Local test runs:

- `go test -race -count=10 -run '^TestStreamRowsHeartbeat$' vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer`
- `go test -race -count=1 vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer`

CI is pending on this draft PR.

## Deployment Notes

No deployment notes.

### AI Disclosure

This PR was written with Codex.
