### PR TITLE
planner: substitute merged DML IN/NOT IN subqueries via ListArg placeholder

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -170,6 +170,11 @@ func rewriteMergedSubqueryExpr(ctx *plancontext.PlanningContext, se SubQueryExpr
 					if expr.Name != sq.ArgName {
 						return true
 					}
+				case sqlparser.ListArg:
+					// DML IN/NOT IN subqueries use ListArg placeholders, not Argument.
+					if string(expr) != sq.ArgName {
+						return true
+					}
 				default:
 					return true
 				}

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -7212,11 +7212,11 @@
   },
   {
     "comment": "UPDATE: IN subquery in SET that merges into the outer route",
-    "query": "update user set col = (1 in (select id from user where id = 5)) where id = 5",
+    "query": "update user set col = (1 in (select id from (select * from user) as t where id = 5)) where id = 5",
     "plan": {
       "Type": "Passthrough",
       "QueryType": "UPDATE",
-      "Original": "update user set col = (1 in (select id from user where id = 5)) where id = 5",
+      "Original": "update user set col = (1 in (select id from (select * from user) as t where id = 5)) where id = 5",
       "Instructions": {
         "OperatorType": "Update",
         "Variant": "EqualUnique",
@@ -7224,7 +7224,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "update `user` set col = 1 in (select id from `user` where id = 5) where id = 5",
+        "Query": "update `user` set col = 1 in (select id from (select * from `user`) as t where id = 5) where id = 5",
         "Values": [
           "5"
         ],
@@ -7237,11 +7237,11 @@
   },
   {
     "comment": "UPDATE: NOT IN subquery in SET that merges into the outer route",
-    "query": "update user set col = (1 not in (select id from user where id = 5)) where id = 5",
+    "query": "update user set col = (1 not in (select id from (select * from user) as t where id = 5)) where id = 5",
     "plan": {
       "Type": "Passthrough",
       "QueryType": "UPDATE",
-      "Original": "update user set col = (1 not in (select id from user where id = 5)) where id = 5",
+      "Original": "update user set col = (1 not in (select id from (select * from user) as t where id = 5)) where id = 5",
       "Instructions": {
         "OperatorType": "Update",
         "Variant": "EqualUnique",
@@ -7249,7 +7249,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "Query": "update `user` set col = 1 not in (select id from `user` where id = 5) where id = 5",
+        "Query": "update `user` set col = 1 not in (select id from (select * from `user`) as t where id = 5) where id = 5",
         "Values": [
           "5"
         ],

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -7209,5 +7209,55 @@
         "user.user_extra"
       ]
     }
+  },
+  {
+    "comment": "UPDATE: IN subquery in SET that merges into the outer route",
+    "query": "update user set col = (1 in (select id from user where id = 5)) where id = 5",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "UPDATE",
+      "Original": "update user set col = (1 in (select id from user where id = 5)) where id = 5",
+      "Instructions": {
+        "OperatorType": "Update",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "update `user` set col = 1 in (select id from `user` where id = 5) where id = 5",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "UPDATE: NOT IN subquery in SET that merges into the outer route",
+    "query": "update user set col = (1 not in (select id from user where id = 5)) where id = 5",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "UPDATE",
+      "Original": "update user set col = (1 not in (select id from user where id = 5)) where id = 5",
+      "Instructions": {
+        "OperatorType": "Update",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "update `user` set col = 1 not in (select id from `user` where id = 5) where id = 5",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Description

When an `UPDATE` `SET` expression contains an `IN`/`NOT IN` subquery whose routing is compatible with the outer route, the planner merges the subquery into the outer route — but the merge-time AST rewrite only substituted back `*sqlparser.Argument` placeholders, never `sqlparser.ListArg`. DML `SET` expressions placeholder `IN`/`NOT IN` subqueries with `ListArg` (a distinct AST type), so the placeholder leaked into the emitted SQL with no `UncorrelatedSubquery` primitive above to back it. Sending such a plan to vttablet would fail with `missing bind var __sqN`.

The fix adds a `case sqlparser.ListArg` arm to the type switch in `rewriteMergedSubqueryExpr` (`go/vt/vtgate/planbuilder/operators/subquery_planning.go`) mirroring the existing `*Argument` branch — the same `cursor.Replace(sq.originalSubquery)` path then substitutes the original inline subquery, matching the shape that `DELETE … WHERE col = (1 in (select …))` already produces.

Two regression cases are added to `dml_cases.json` covering UPDATE+IN and UPDATE+NOT IN with merge-compatible routing. The existing `UPDATE: same subquery as scalar SET and IN SET` case targets `user_extra` inside a `user` update, so the routes don't merge and the bug couldn't surface there.

Adjacent rewrite paths (`Ordering.settleOrderingExpressions`, projection `pe.Original`) were intentionally left alone — `isDML=true` is only set in `update.go` for SET expressions, so a `ListArg` placeholder cannot reach those paths under any current call graph.

## Related Issue(s)

Fixes #19965

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — purely planner-level correctness fix. No previously-working query shape changes plan; the affected shape (DML SET with merge-compatible IN/NOT IN subquery) was emitting a broken plan that would have failed at vttablet, so no production deployments are exercising it today.

### AI Disclosure

Most of this was written by Claude Code — I just provided direction.