### PR TITLE
movetables mirrortraffic: production-safe best-effort dispatch

### DIFF
--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -125,6 +125,14 @@ func (t *noopVCursor) GetQueryPriority() (int, error) {
 	panic("implement me")
 }
 
+func (t *noopVCursor) GetMirrorTrafficSemaphore() *semaphore.Weighted {
+	// Return nil so MirrorTraffic dispatch always falls through to the drop
+	// path in tests that don't explicitly exercise mirroring.
+	return nil
+}
+
+func (t *noopVCursor) RecordMirrorDropped() {}
+
 func (t *noopVCursor) CloneForReplicaWarming(ctx context.Context) VCursor {
 	panic("implement me")
 }
@@ -483,7 +491,14 @@ type loggingVCursor struct {
 	onExecuteMultiShardFn   func(context.Context, Primitive, []*srvtopo.ResolvedShard, []*querypb.BoundQuery, bool, bool)
 	onStreamExecuteMultiFn  func(context.Context, Primitive, string, []*srvtopo.ResolvedShard, []map[string]*querypb.BindVariable, bool, bool, func(*sqltypes.Result) error)
 	onRecordMirrorStatsFn   func(time.Duration, time.Duration, error)
+	onRecordMirrorDroppedFn func()
 	onResolveDestinationsFn func(context.Context)
+
+	// mirrorTrafficSemaphore is the bounded semaphore exposed to mirror code.
+	// Lazy-initialized on first access to capacity 8 so existing mirror tests
+	// dispatch normally; tests that exercise the drop path can set this
+	// field directly with a smaller (or zero) capacity.
+	mirrorTrafficSemaphore *semaphore.Weighted
 
 	metrics *Metrics
 }
@@ -615,6 +630,24 @@ func (f *loggingVCursor) CloneForReplicaWarming(ctx context.Context) VCursor {
 
 func (f *loggingVCursor) WarmingReadsContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	return ctx, func() {}
+}
+
+func (f *loggingVCursor) GetMirrorTrafficSemaphore() *semaphore.Weighted {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.mirrorTrafficSemaphore == nil {
+		// Default capacity is small but enough for normal mirror tests to
+		// dispatch. Tests that exercise the drop path can set this field
+		// directly with a smaller (or zero) capacity.
+		f.mirrorTrafficSemaphore = semaphore.NewWeighted(8)
+	}
+	return f.mirrorTrafficSemaphore
+}
+
+func (f *loggingVCursor) RecordMirrorDropped() {
+	if f.onRecordMirrorDroppedFn != nil {
+		f.onRecordMirrorDroppedFn()
+	}
 }
 
 func (f *loggingVCursor) CloneForMirroring(ctx context.Context) VCursor {

--- a/go/vt/vtgate/engine/fake_vcursor_test.go
+++ b/go/vt/vtgate/engine/fake_vcursor_test.go
@@ -133,6 +133,8 @@ func (t *noopVCursor) GetMirrorTrafficSemaphore() *semaphore.Weighted {
 
 func (t *noopVCursor) RecordMirrorDropped() {}
 
+func (t *noopVCursor) RecordMirrorPanic() {}
+
 func (t *noopVCursor) CloneForReplicaWarming(ctx context.Context) VCursor {
 	panic("implement me")
 }
@@ -492,6 +494,7 @@ type loggingVCursor struct {
 	onStreamExecuteMultiFn  func(context.Context, Primitive, string, []*srvtopo.ResolvedShard, []map[string]*querypb.BindVariable, bool, bool, func(*sqltypes.Result) error)
 	onRecordMirrorStatsFn   func(time.Duration, time.Duration, error)
 	onRecordMirrorDroppedFn func()
+	onRecordMirrorPanicFn   func()
 	onResolveDestinationsFn func(context.Context)
 
 	// mirrorTrafficSemaphore is the bounded semaphore exposed to mirror code.
@@ -647,6 +650,12 @@ func (f *loggingVCursor) GetMirrorTrafficSemaphore() *semaphore.Weighted {
 func (f *loggingVCursor) RecordMirrorDropped() {
 	if f.onRecordMirrorDroppedFn != nil {
 		f.onRecordMirrorDroppedFn()
+	}
+}
+
+func (f *loggingVCursor) RecordMirrorPanic() {
+	if f.onRecordMirrorPanicFn != nil {
+		f.onRecordMirrorPanicFn()
 	}
 }
 

--- a/go/vt/vtgate/engine/mirror.go
+++ b/go/vt/vtgate/engine/mirror.go
@@ -23,11 +23,7 @@ import (
 
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
-	"vitess.io/vitess/go/vt/proto/vtrpc"
-	"vitess.io/vitess/go/vt/vterrors"
 )
-
-var errMirrorTargetQueryTookTooLong = vterrors.Errorf(vtrpc.Code_ABORTED, "Mirror target query took too long")
 
 type (
 	// percentBasedMirror represents the instructions to execute an
@@ -38,17 +34,13 @@ type (
 		primitive Primitive
 		target    Primitive
 	}
-
-	mirrorResult struct {
-		execTime time.Duration
-		err      error
-	}
 )
 
 const (
-	// maxMirrorTargetLag limits how long a mirror target may continue
-	// executing after the main primitive has finished.
-	maxMirrorTargetLag = 100 * time.Millisecond
+	// maxMirrorTargetDuration is the maximum time a mirror target query
+	// may execute before being cancelled. This is a safety bound to
+	// prevent leaked goroutines; it does not affect primary query latency.
+	maxMirrorTargetDuration = 30 * time.Second
 )
 
 var _ Primitive = (*percentBasedMirror)(nil)
@@ -71,43 +63,23 @@ func (m *percentBasedMirror) TryExecute(ctx context.Context, vcursor VCursor, bi
 		return vcursor.ExecutePrimitive(ctx, m.primitive, bindVars, wantfields)
 	}
 
-	mirrorCh := make(chan mirrorResult, 1)
-	mirrorCtx, mirrorCtxCancel := context.WithCancel(ctx)
-	defer mirrorCtxCancel()
-
-	go func() {
-		mirrorVCursor := vcursor.CloneForMirroring(mirrorCtx)
-		targetStartTime := time.Now()
-		_, targetErr := mirrorVCursor.ExecutePrimitive(mirrorCtx, m.target, bindVars, wantfields)
-		mirrorCh <- mirrorResult{
-			execTime: time.Since(targetStartTime),
-			err:      targetErr,
-		}
-	}()
-
-	var (
-		sourceExecTime, targetExecTime time.Duration
-		targetErr                      error
-	)
-
+	// Execute the primary query first so we know its exec time.
 	sourceStartTime := time.Now()
 	r, err := vcursor.ExecutePrimitive(ctx, m.primitive, bindVars, wantfields)
-	sourceExecTime = time.Since(sourceStartTime)
+	sourceExecTime := time.Since(sourceStartTime)
 
-	// Cancel the mirror context if it continues executing too long.
-	select {
-	case r := <-mirrorCh:
-		// Mirror target finished on time.
-		targetExecTime = r.execTime
-		targetErr = r.err
-	case <-time.After(maxMirrorTargetLag):
-		// Mirror target took too long.
-		mirrorCtxCancel()
-		targetExecTime = sourceExecTime + maxMirrorTargetLag
-		targetErr = errMirrorTargetQueryTookTooLong
-	}
-
-	vcursor.RecordMirrorStats(sourceExecTime, targetExecTime, targetErr)
+	// Fire mirror query in the background. Use a detached context so it
+	// is not cancelled when this function returns the primary result.
+	// The cloned VCursor has an independent SafeSession and logStats,
+	// so it is safe to use after the primary request completes.
+	mirrorCtx, mirrorCancel := context.WithTimeout(context.Background(), maxMirrorTargetDuration)
+	mirrorVCursor := vcursor.CloneForMirroring(mirrorCtx)
+	go func() {
+		defer mirrorCancel()
+		targetStartTime := time.Now()
+		_, targetErr := mirrorVCursor.ExecutePrimitive(mirrorCtx, m.target, bindVars, wantfields)
+		mirrorVCursor.RecordMirrorStats(sourceExecTime, time.Since(targetStartTime), targetErr)
+	}()
 
 	return r, err
 }
@@ -117,45 +89,22 @@ func (m *percentBasedMirror) TryStreamExecute(ctx context.Context, vcursor VCurs
 		return vcursor.StreamExecutePrimitive(ctx, m.primitive, bindVars, wantfields, callback)
 	}
 
-	mirrorCh := make(chan mirrorResult, 1)
-	mirrorCtx, mirrorCtxCancel := context.WithCancel(ctx)
-	defer mirrorCtxCancel()
+	// Execute the primary stream first so we know its exec time.
+	sourceStartTime := time.Now()
+	err := vcursor.StreamExecutePrimitive(ctx, m.primitive, bindVars, wantfields, callback)
+	sourceExecTime := time.Since(sourceStartTime)
 
+	// Fire mirror stream in the background.
+	mirrorCtx, mirrorCancel := context.WithTimeout(context.Background(), maxMirrorTargetDuration)
+	mirrorVCursor := vcursor.CloneForMirroring(mirrorCtx)
 	go func() {
-		mirrorVCursor := vcursor.CloneForMirroring(mirrorCtx)
-		mirrorStartTime := time.Now()
+		defer mirrorCancel()
+		targetStartTime := time.Now()
 		targetErr := mirrorVCursor.StreamExecutePrimitive(mirrorCtx, m.target, bindVars, wantfields, func(_ *sqltypes.Result) error {
 			return nil
 		})
-		mirrorCh <- mirrorResult{
-			execTime: time.Since(mirrorStartTime),
-			err:      targetErr,
-		}
+		mirrorVCursor.RecordMirrorStats(sourceExecTime, time.Since(targetStartTime), targetErr)
 	}()
-
-	var (
-		sourceExecTime, targetExecTime time.Duration
-		targetErr                      error
-	)
-
-	sourceStartTime := time.Now()
-	err := vcursor.StreamExecutePrimitive(ctx, m.primitive, bindVars, wantfields, callback)
-	sourceExecTime = time.Since(sourceStartTime)
-
-	// Cancel the mirror context if it continues executing too long.
-	select {
-	case r := <-mirrorCh:
-		// Mirror target finished on time.
-		targetExecTime = r.execTime
-		targetErr = r.err
-	case <-time.After(maxMirrorTargetLag):
-		// Mirror target took too long.
-		mirrorCtxCancel()
-		targetExecTime = sourceExecTime + maxMirrorTargetLag
-		targetErr = errMirrorTargetQueryTookTooLong
-	}
-
-	vcursor.RecordMirrorStats(sourceExecTime, targetExecTime, targetErr)
 
 	return err
 }

--- a/go/vt/vtgate/engine/mirror.go
+++ b/go/vt/vtgate/engine/mirror.go
@@ -93,11 +93,12 @@ func (m *percentBasedMirror) TryExecute(ctx context.Context, vcursor VCursor, bi
 		return r, err
 	}
 
-	// Slot reserved — fire the mirror in the background. Use a detached
-	// context so it is not cancelled when this function returns the primary
-	// result. The cloned VCursor has an independent SafeSession and logStats,
-	// so it is safe to use after the primary request completes.
-	mirrorCtx, mirrorCancel := context.WithTimeout(context.Background(), maxMirrorTargetDuration)
+	// Slot reserved — fire the mirror in the background. WithoutCancel
+	// detaches the mirror from caller cancellation while preserving
+	// request-scoped values (callerid, tracing) so mirrored queries remain
+	// attributable. The cloned VCursor has an independent SafeSession and
+	// logStats, so it is safe to use after the primary request completes.
+	mirrorCtx, mirrorCancel := context.WithTimeout(context.WithoutCancel(ctx), maxMirrorTargetDuration)
 	mirrorVCursor := vcursor.CloneForMirroring(mirrorCtx)
 	go func() {
 		// recover defer is registered first so it runs LAST in the LIFO
@@ -132,7 +133,7 @@ func (m *percentBasedMirror) TryStreamExecute(ctx context.Context, vcursor VCurs
 		return err
 	}
 
-	mirrorCtx, mirrorCancel := context.WithTimeout(context.Background(), maxMirrorTargetDuration)
+	mirrorCtx, mirrorCancel := context.WithTimeout(context.WithoutCancel(ctx), maxMirrorTargetDuration)
 	mirrorVCursor := vcursor.CloneForMirroring(mirrorCtx)
 	go func() {
 		defer recoverMirrorPanic(mirrorVCursor)

--- a/go/vt/vtgate/engine/mirror.go
+++ b/go/vt/vtgate/engine/mirror.go
@@ -18,12 +18,26 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"math/rand/v2"
+	"runtime/debug"
 	"time"
 
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/log"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
+
+// recoverMirrorPanic is the deferred recovery used by both mirror dispatch
+// paths. Mirror traffic is best-effort; a panic in the target query path must
+// never crash vtgate or affect the primary response. The panic is logged with
+// a stack trace and counted via the MirrorTargetPanics stat.
+func recoverMirrorPanic(vcursor VCursor) {
+	if r := recover(); r != nil {
+		log.Error(fmt.Sprintf("mirror target panic recovered: %v\n%s", r, debug.Stack()))
+		vcursor.RecordMirrorPanic()
+	}
+}
 
 type (
 	// percentBasedMirror represents the instructions to execute an
@@ -86,6 +100,10 @@ func (m *percentBasedMirror) TryExecute(ctx context.Context, vcursor VCursor, bi
 	mirrorCtx, mirrorCancel := context.WithTimeout(context.Background(), maxMirrorTargetDuration)
 	mirrorVCursor := vcursor.CloneForMirroring(mirrorCtx)
 	go func() {
+		// recover defer is registered first so it runs LAST in the LIFO
+		// chain — that way Release(1) and mirrorCancel() always run, and
+		// any panic from those (very unlikely) is also recovered.
+		defer recoverMirrorPanic(mirrorVCursor)
 		defer sem.Release(1)
 		defer mirrorCancel()
 		targetStartTime := time.Now()
@@ -117,6 +135,7 @@ func (m *percentBasedMirror) TryStreamExecute(ctx context.Context, vcursor VCurs
 	mirrorCtx, mirrorCancel := context.WithTimeout(context.Background(), maxMirrorTargetDuration)
 	mirrorVCursor := vcursor.CloneForMirroring(mirrorCtx)
 	go func() {
+		defer recoverMirrorPanic(mirrorVCursor)
 		defer sem.Release(1)
 		defer mirrorCancel()
 		targetStartTime := time.Now()

--- a/go/vt/vtgate/engine/mirror.go
+++ b/go/vt/vtgate/engine/mirror.go
@@ -68,13 +68,25 @@ func (m *percentBasedMirror) TryExecute(ctx context.Context, vcursor VCursor, bi
 	r, err := vcursor.ExecutePrimitive(ctx, m.primitive, bindVars, wantfields)
 	sourceExecTime := time.Since(sourceStartTime)
 
-	// Fire mirror query in the background. Use a detached context so it
-	// is not cancelled when this function returns the primary result.
-	// The cloned VCursor has an independent SafeSession and logStats,
+	// Reserve a slot in the mirror-traffic semaphore. If the bound is full or
+	// the semaphore is nil (mirror dispatch disabled), drop the mirror so a
+	// slow target cannot exhaust vtgate memory. The primary query result is
+	// already returned; the drop is invisible to the caller apart from the
+	// MirrorTargetDropped counter.
+	sem := vcursor.GetMirrorTrafficSemaphore()
+	if sem == nil || !sem.TryAcquire(1) {
+		vcursor.RecordMirrorDropped()
+		return r, err
+	}
+
+	// Slot reserved — fire the mirror in the background. Use a detached
+	// context so it is not cancelled when this function returns the primary
+	// result. The cloned VCursor has an independent SafeSession and logStats,
 	// so it is safe to use after the primary request completes.
 	mirrorCtx, mirrorCancel := context.WithTimeout(context.Background(), maxMirrorTargetDuration)
 	mirrorVCursor := vcursor.CloneForMirroring(mirrorCtx)
 	go func() {
+		defer sem.Release(1)
 		defer mirrorCancel()
 		targetStartTime := time.Now()
 		_, targetErr := mirrorVCursor.ExecutePrimitive(mirrorCtx, m.target, bindVars, wantfields)
@@ -94,10 +106,18 @@ func (m *percentBasedMirror) TryStreamExecute(ctx context.Context, vcursor VCurs
 	err := vcursor.StreamExecutePrimitive(ctx, m.primitive, bindVars, wantfields, callback)
 	sourceExecTime := time.Since(sourceStartTime)
 
-	// Fire mirror stream in the background.
+	// Reserve a slot in the mirror-traffic semaphore; drop on full. See
+	// TryExecute for rationale.
+	sem := vcursor.GetMirrorTrafficSemaphore()
+	if sem == nil || !sem.TryAcquire(1) {
+		vcursor.RecordMirrorDropped()
+		return err
+	}
+
 	mirrorCtx, mirrorCancel := context.WithTimeout(context.Background(), maxMirrorTargetDuration)
 	mirrorVCursor := vcursor.CloneForMirroring(mirrorCtx)
 	go func() {
+		defer sem.Release(1)
 		defer mirrorCancel()
 		targetStartTime := time.Now()
 		targetErr := mirrorVCursor.StreamExecutePrimitive(mirrorCtx, m.target, bindVars, wantfields, func(_ *sqltypes.Result) error {

--- a/go/vt/vtgate/engine/mirror_test.go
+++ b/go/vt/vtgate/engine/mirror_test.go
@@ -322,6 +322,7 @@ func TestMirror(t *testing.T) {
 		select {
 		case <-mirrorStatsDone:
 		case <-time.After(5 * time.Second):
+			require.Fail(t, "mirror goroutine did not finish recording stats")
 		}
 	})
 
@@ -557,6 +558,7 @@ func TestMirror(t *testing.T) {
 		select {
 		case <-mirrorStatsDone:
 		case <-time.After(5 * time.Second):
+			require.Fail(t, "mirror goroutine did not finish recording stats")
 		}
 	})
 }

--- a/go/vt/vtgate/engine/mirror_test.go
+++ b/go/vt/vtgate/engine/mirror_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -82,6 +81,23 @@ func TestMirror(t *testing.T) {
 	targetExecTime := atomic.Pointer[time.Duration]{}
 	targetErr := atomic.Pointer[error]{}
 
+	// mirrorStatsDone is closed when the mirror goroutine calls
+	// RecordMirrorStats. Tests that inspect mirror stats should wait
+	// on this channel before asserting.
+	mirrorStatsDone := make(chan struct{}, 1)
+
+	// Stats callback goes on mirrorVC because fire-and-forget mirrors
+	// call RecordMirrorStats on the cloned cursor, not the original.
+	mirrorVC.onRecordMirrorStatsFn = func(sourceTime time.Duration, targetTime time.Duration, err error) {
+		sourceExecTime.Store(&sourceTime)
+		targetExecTime.Store(&targetTime)
+		targetErr.Store(&err)
+		select {
+		case mirrorStatsDone <- struct{}{}:
+		default:
+		}
+	}
+
 	vc := &loggingVCursor{
 		shards: []string{"0"},
 		ksShardMap: map[string][]string{
@@ -98,11 +114,6 @@ func TestMirror(t *testing.T) {
 		},
 		onMirrorClonesFn: func(ctx context.Context) VCursor {
 			return mirrorVC
-		},
-		onRecordMirrorStatsFn: func(sourceTime time.Duration, targetTime time.Duration, err error) {
-			sourceExecTime.Store(&sourceTime)
-			targetExecTime.Store(&targetTime)
-			targetErr.Store(&err)
 		},
 	}
 
@@ -124,6 +135,14 @@ func TestMirror(t *testing.T) {
 			"ResolveDestinations ks1 [] Destinations:DestinationAllShards()",
 			"ExecuteMultiShard ks1.0: select f.bar from foo f where f.id = 1 {} false false",
 		})
+
+		// Wait for async mirror goroutine to complete.
+		select {
+		case <-mirrorStatsDone:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "mirror stats not recorded")
+		}
+
 		mirrorVC.ExpectLog(t, []string{
 			fmt.Sprintf(`ResolveDestinations ks2 [%v] Destinations:DestinationKeyspaceID(d46405367612b4b7)`, sqltypes.Int64BindVariable(1)),
 			"ExecuteMultiShard ks2.-20: select f.bar from foo f where f.id = 1 {} false false",
@@ -158,6 +177,13 @@ func TestMirror(t *testing.T) {
 			"ResolveDestinations ks1 [] Destinations:DestinationAllShards()",
 			"ExecuteMultiShard ks1.0: select f.bar from foo f where f.id = 1 {} false false",
 		})
+
+		select {
+		case <-mirrorStatsDone:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "mirror stats not recorded")
+		}
+
 		mirrorVC.ExpectLog(t, []string{
 			fmt.Sprintf(`ResolveDestinations ks2 [%v] Destinations:DestinationKeyspaceID(d46405367612b4b7)`, sqltypes.Int64BindVariable(1)),
 			"ExecuteMultiShard ks2.-20: select f.bar from foo f where f.id = 1 {} false false",
@@ -191,6 +217,13 @@ func TestMirror(t *testing.T) {
 			"ResolveDestinations ks1 [] Destinations:DestinationAllShards()",
 			"ExecuteMultiShard ks1.0: select f.bar from foo f where f.id = 1 {} false false",
 		})
+
+		select {
+		case <-mirrorStatsDone:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "mirror stats not recorded")
+		}
+
 		mirrorVC.ExpectLog(t, []string{
 			fmt.Sprintf(`ResolveDestinations ks2 [%v] Destinations:DestinationKeyspaceID(d46405367612b4b7)`, sqltypes.Int64BindVariable(1)),
 			"ExecuteMultiShard ks2.-20: select f.bar from foo f where f.id = 1 {} false false",
@@ -201,7 +234,7 @@ func TestMirror(t *testing.T) {
 		require.ErrorContains(t, *mirrorErr, "ignore me")
 	})
 
-	t.Run("TryExecute fast mirror target", func(t *testing.T) {
+	t.Run("TryExecute mirror target completes independently", func(t *testing.T) {
 		defer func() {
 			vc.Rewind()
 			vc.onExecuteMultiShardFn = nil
@@ -212,29 +245,6 @@ func TestMirror(t *testing.T) {
 			targetErr.Store(nil)
 		}()
 
-		primitiveLatency := 10 * time.Millisecond
-		vc.onExecuteMultiShardFn = func(ctx context.Context, _ Primitive, _ []*srvtopo.ResolvedShard, _ []*querypb.BoundQuery, _ bool, _ bool) {
-			time.Sleep(primitiveLatency)
-			select {
-			case <-ctx.Done():
-				require.Fail(t, "primitive context done")
-			default:
-			}
-		}
-
-		var wg sync.WaitGroup
-		defer wg.Wait()
-		mirrorVC.onExecuteMultiShardFn = func(ctx context.Context, _ Primitive, _ []*srvtopo.ResolvedShard, _ []*querypb.BoundQuery, _ bool, _ bool) {
-			wg.Add(1)
-			defer wg.Done()
-			time.Sleep(primitiveLatency / 2)
-			select {
-			case <-ctx.Done():
-				require.Fail(t, "mirror target context done")
-			default:
-			}
-		}
-
 		want := vc.results[0]
 		res, err := mirror.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, true)
 		require.Equal(t, res, want)
@@ -244,17 +254,23 @@ func TestMirror(t *testing.T) {
 			"ResolveDestinations ks1 [] Destinations:DestinationAllShards()",
 			"ExecuteMultiShard ks1.0: select f.bar from foo f where f.id = 1 {} false false",
 		})
+
+		select {
+		case <-mirrorStatsDone:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "mirror stats not recorded")
+		}
+
 		mirrorVC.ExpectLog(t, []string{
 			fmt.Sprintf(`ResolveDestinations ks2 [%v] Destinations:DestinationKeyspaceID(d46405367612b4b7)`, sqltypes.Int64BindVariable(1)),
 			"ExecuteMultiShard ks2.-20: select f.bar from foo f where f.id = 1 {} false false",
 		})
 
-		wg.Wait()
-
-		require.Greater(t, *sourceExecTime.Load(), *targetExecTime.Load())
+		require.NotNil(t, targetExecTime.Load())
+		require.Nil(t, *targetErr.Load())
 	})
 
-	t.Run("TryExecute slow mirror target", func(t *testing.T) {
+	t.Run("TryExecute slow mirror target does not block primary", func(t *testing.T) {
 		defer func() {
 			vc.Rewind()
 			vc.onExecuteMultiShardFn = nil
@@ -268,46 +284,44 @@ func TestMirror(t *testing.T) {
 		primitiveLatency := 10 * time.Millisecond
 		vc.onExecuteMultiShardFn = func(ctx context.Context, _ Primitive, _ []*srvtopo.ResolvedShard, _ []*querypb.BoundQuery, _ bool, _ bool) {
 			time.Sleep(primitiveLatency)
-			select {
-			case <-ctx.Done():
-				require.Fail(t, "primitive context done")
-			default:
-			}
 		}
 
-		var wg sync.WaitGroup
-		defer wg.Wait()
+		mirrorStarted := make(chan struct{})
+		mirrorDone := make(chan struct{})
 		mirrorVC.onExecuteMultiShardFn = func(ctx context.Context, _ Primitive, _ []*srvtopo.ResolvedShard, _ []*querypb.BoundQuery, _ bool, _ bool) {
-			wg.Add(1)
-			defer wg.Done()
-			time.Sleep(primitiveLatency + maxMirrorTargetLag + (5 * time.Millisecond))
-			select {
-			case <-ctx.Done():
-				require.NotNil(t, ctx.Err())
-				require.ErrorContains(t, ctx.Err(), "context canceled")
-			default:
-				require.Fail(t, "mirror target context not done")
-			}
+			close(mirrorStarted)
+			// Block until the test releases us — this simulates a slow
+			// mirror target that far outlasts the primary.
+			<-mirrorDone
 		}
 
+		// TryExecute should return the primary result without waiting
+		// for the slow mirror target.
+		start := time.Now()
 		want := vc.results[0]
 		res, err := mirror.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, true)
+		elapsed := time.Since(start)
 		require.Equal(t, res, want)
 		require.NoError(t, err)
 
-		vc.ExpectLog(t, []string{
-			"ResolveDestinations ks1 [] Destinations:DestinationAllShards()",
-			"ExecuteMultiShard ks1.0: select f.bar from foo f where f.id = 1 {} false false",
-		})
-		mirrorVC.ExpectLog(t, []string{
-			fmt.Sprintf(`ResolveDestinations ks2 [%v] Destinations:DestinationKeyspaceID(d46405367612b4b7)`, sqltypes.Int64BindVariable(1)),
-			"ExecuteMultiShard ks2.-20: select f.bar from foo f where f.id = 1 {} false false",
-		})
+		// Primary should return in roughly primitiveLatency, not blocked
+		// by the mirror.
+		require.Less(t, elapsed, primitiveLatency+50*time.Millisecond)
 
-		wg.Wait()
+		// Mirror goroutine should have started.
+		select {
+		case <-mirrorStarted:
+		case <-time.After(time.Second):
+			require.Fail(t, "mirror goroutine did not start")
+		}
 
-		require.Greater(t, *targetExecTime.Load(), *sourceExecTime.Load())
-		require.ErrorContains(t, *targetErr.Load(), "Mirror target query took too long")
+		// Release the mirror goroutine and wait for it to finish
+		// recording stats so it doesn't leak into the next test.
+		close(mirrorDone)
+		select {
+		case <-mirrorStatsDone:
+		case <-time.After(5 * time.Second):
+		}
 	})
 
 	t.Run("TryStreamExecute success", func(t *testing.T) {
@@ -336,6 +350,13 @@ func TestMirror(t *testing.T) {
 			"ResolveDestinations ks1 [] Destinations:DestinationAllShards()",
 			"StreamExecuteMulti select f.bar from foo f where f.id = 1 ks1.0: {} ",
 		})
+
+		select {
+		case <-mirrorStatsDone:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "mirror stats not recorded")
+		}
+
 		mirrorVC.ExpectLog(t, []string{
 			fmt.Sprintf(`ResolveDestinations ks2 [%v] Destinations:DestinationKeyspaceID(d46405367612b4b7)`, sqltypes.Int64BindVariable(1)),
 			"StreamExecuteMulti select f.bar from foo f where f.id = 1 ks2.-20: {} ",
@@ -378,6 +399,13 @@ func TestMirror(t *testing.T) {
 			"ResolveDestinations ks1 [] Destinations:DestinationAllShards()",
 			"StreamExecuteMulti select f.bar from foo f where f.id = 1 ks1.0: {} ",
 		})
+
+		select {
+		case <-mirrorStatsDone:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "mirror stats not recorded")
+		}
+
 		mirrorVC.ExpectLog(t, []string{
 			fmt.Sprintf(`ResolveDestinations ks2 [%v] Destinations:DestinationKeyspaceID(d46405367612b4b7)`, sqltypes.Int64BindVariable(1)),
 			"StreamExecuteMulti select f.bar from foo f where f.id = 1 ks2.-20: {} ",
@@ -420,6 +448,13 @@ func TestMirror(t *testing.T) {
 			"ResolveDestinations ks1 [] Destinations:DestinationAllShards()",
 			"StreamExecuteMulti select f.bar from foo f where f.id = 1 ks1.0: {} ",
 		})
+
+		select {
+		case <-mirrorStatsDone:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "mirror stats not recorded")
+		}
+
 		mirrorVC.ExpectLog(t, []string{
 			fmt.Sprintf(`ResolveDestinations ks2 [%v] Destinations:DestinationKeyspaceID(d46405367612b4b7)`, sqltypes.Int64BindVariable(1)),
 			"StreamExecuteMulti select f.bar from foo f where f.id = 1 ks2.-20: {} ",
@@ -429,39 +464,14 @@ func TestMirror(t *testing.T) {
 		require.ErrorContains(t, *targetErr.Load(), "ignore me")
 	})
 
-	t.Run("TryStreamExecute fast mirror target", func(t *testing.T) {
+	t.Run("TryStreamExecute mirror target completes independently", func(t *testing.T) {
 		defer func() {
 			vc.Rewind()
-			vc.onStreamExecuteMultiFn = nil
 			mirrorVC.Rewind()
-			mirrorVC.onStreamExecuteMultiFn = nil
 			sourceExecTime.Store(nil)
 			targetExecTime.Store(nil)
 			targetErr.Store(nil)
 		}()
-
-		primitiveLatency := 10 * time.Millisecond
-		vc.onStreamExecuteMultiFn = func(ctx context.Context, _ Primitive, _ string, _ []*srvtopo.ResolvedShard, _ []map[string]*querypb.BindVariable, _ bool, _ bool, _ func(*sqltypes.Result) error) {
-			time.Sleep(primitiveLatency)
-			select {
-			case <-ctx.Done():
-				require.Fail(t, "primitive context done")
-			default:
-			}
-		}
-
-		var wg sync.WaitGroup
-		defer wg.Wait()
-		mirrorVC.onStreamExecuteMultiFn = func(ctx context.Context, _ Primitive, _ string, _ []*srvtopo.ResolvedShard, _ []map[string]*querypb.BindVariable, _ bool, _ bool, _ func(*sqltypes.Result) error) {
-			wg.Add(1)
-			defer wg.Done()
-			time.Sleep(primitiveLatency / 2)
-			select {
-			case <-ctx.Done():
-				require.Fail(t, "mirror target context done")
-			default:
-			}
-		}
 
 		want := vc.results[0]
 		err := mirror.TryStreamExecute(
@@ -480,15 +490,23 @@ func TestMirror(t *testing.T) {
 			"ResolveDestinations ks1 [] Destinations:DestinationAllShards()",
 			"StreamExecuteMulti select f.bar from foo f where f.id = 1 ks1.0: {} ",
 		})
+
+		select {
+		case <-mirrorStatsDone:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "mirror stats not recorded")
+		}
+
 		mirrorVC.ExpectLog(t, []string{
 			fmt.Sprintf(`ResolveDestinations ks2 [%v] Destinations:DestinationKeyspaceID(d46405367612b4b7)`, sqltypes.Int64BindVariable(1)),
 			"StreamExecuteMulti select f.bar from foo f where f.id = 1 ks2.-20: {} ",
 		})
 
-		require.Greater(t, *sourceExecTime.Load(), *targetExecTime.Load())
+		require.NotNil(t, targetExecTime.Load())
+		require.Nil(t, *targetErr.Load())
 	})
 
-	t.Run("TryStreamExecute slow mirror target", func(t *testing.T) {
+	t.Run("TryStreamExecute slow mirror target does not block primary", func(t *testing.T) {
 		defer func() {
 			vc.Rewind()
 			vc.onStreamExecuteMultiFn = nil
@@ -502,26 +520,16 @@ func TestMirror(t *testing.T) {
 		primitiveLatency := 10 * time.Millisecond
 		vc.onStreamExecuteMultiFn = func(ctx context.Context, _ Primitive, _ string, _ []*srvtopo.ResolvedShard, _ []map[string]*querypb.BindVariable, _ bool, _ bool, _ func(*sqltypes.Result) error) {
 			time.Sleep(primitiveLatency)
-			select {
-			case <-ctx.Done():
-				require.Fail(t, "primitive context done")
-			default:
-			}
 		}
 
-		var wg sync.WaitGroup
-		defer wg.Wait()
+		mirrorStarted := make(chan struct{})
+		mirrorDone := make(chan struct{})
 		mirrorVC.onStreamExecuteMultiFn = func(ctx context.Context, _ Primitive, _ string, _ []*srvtopo.ResolvedShard, _ []map[string]*querypb.BindVariable, _ bool, _ bool, _ func(*sqltypes.Result) error) {
-			wg.Add(1)
-			defer wg.Done()
-			time.Sleep(primitiveLatency + maxMirrorTargetLag + (5 * time.Millisecond))
-			select {
-			case <-ctx.Done():
-			default:
-				require.Fail(t, "mirror target context not done")
-			}
+			close(mirrorStarted)
+			<-mirrorDone
 		}
 
+		start := time.Now()
 		want := vc.results[0]
 		err := mirror.TryStreamExecute(
 			context.Background(),
@@ -533,18 +541,21 @@ func TestMirror(t *testing.T) {
 				return nil
 			},
 		)
+		elapsed := time.Since(start)
 		require.NoError(t, err)
 
-		vc.ExpectLog(t, []string{
-			"ResolveDestinations ks1 [] Destinations:DestinationAllShards()",
-			"StreamExecuteMulti select f.bar from foo f where f.id = 1 ks1.0: {} ",
-		})
-		mirrorVC.ExpectLog(t, []string{
-			fmt.Sprintf(`ResolveDestinations ks2 [%v] Destinations:DestinationKeyspaceID(d46405367612b4b7)`, sqltypes.Int64BindVariable(1)),
-			"StreamExecuteMulti select f.bar from foo f where f.id = 1 ks2.-20: {} ",
-		})
+		require.Less(t, elapsed, primitiveLatency+50*time.Millisecond)
 
-		require.Greater(t, *targetExecTime.Load(), *sourceExecTime.Load())
-		require.ErrorContains(t, *targetErr.Load(), "Mirror target query took too long")
+		select {
+		case <-mirrorStarted:
+		case <-time.After(time.Second):
+			require.Fail(t, "mirror goroutine did not start")
+		}
+
+		close(mirrorDone)
+		select {
+		case <-mirrorStatsDone:
+		case <-time.After(5 * time.Second):
+		}
 	})
 }

--- a/go/vt/vtgate/engine/mirror_test.go
+++ b/go/vt/vtgate/engine/mirror_test.go
@@ -602,3 +602,61 @@ func TestMirrorDropsWhenSemaphoreFull(t *testing.T) {
 
 	require.Equal(t, int32(1), droppedCount.Load(), "drop hook should have fired exactly once")
 }
+
+// TestMirrorRecoversTargetPanic verifies that a panic in the mirror target
+// goroutine is recovered, the primary query result is unaffected, and the
+// MirrorTargetPanics counter is incremented. Mirror is best-effort: it must
+// never crash vtgate.
+func TestMirrorRecoversTargetPanic(t *testing.T) {
+	primitive := NewRoute(
+		Unsharded,
+		&vindexes.Keyspace{Name: "ks1"},
+		"select 1 from foo",
+		"select 1 from foo where 1 != 1",
+	)
+	target := NewRoute(
+		Unsharded,
+		&vindexes.Keyspace{Name: "ks2"},
+		"select 1 from foo",
+		"select 1 from foo where 1 != 1",
+	)
+	mirror := NewPercentBasedMirror(100, primitive, target)
+
+	vc := &loggingVCursor{
+		shards:  []string{"-"},
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(sqltypes.MakeTestFields("a", "varchar"), "x")},
+	}
+
+	// mirrorVC's onExecuteMultiShardFn will panic; the recover must catch it.
+	var panicCount atomic.Int32
+	panicDone := make(chan struct{}, 1)
+	mirrorVC := &loggingVCursor{
+		shards: []string{"-"},
+		ksShardMap: map[string][]string{
+			"ks2": {"-"},
+		},
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(sqltypes.MakeTestFields("a", "varchar"), "x")},
+		onExecuteMultiShardFn: func(_ context.Context, _ Primitive, _ []*srvtopo.ResolvedShard, _ []*querypb.BoundQuery, _ bool, _ bool) {
+			panic("synthetic mirror target panic")
+		},
+		onRecordMirrorPanicFn: func() {
+			panicCount.Add(1)
+			select {
+			case panicDone <- struct{}{}:
+			default:
+			}
+		},
+	}
+	vc.onMirrorClonesFn = func(_ context.Context) VCursor { return mirrorVC }
+
+	res, err := mirror.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err, "primary query must not be affected by mirror panic")
+	require.NotNil(t, res, "primary result must be returned")
+
+	select {
+	case <-panicDone:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "mirror panic recover did not fire")
+	}
+	require.Equal(t, int32(1), panicCount.Load(), "panic counter should fire exactly once")
+}

--- a/go/vt/vtgate/engine/mirror_test.go
+++ b/go/vt/vtgate/engine/mirror_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
 
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -558,4 +559,46 @@ func TestMirror(t *testing.T) {
 		case <-time.After(5 * time.Second):
 		}
 	})
+}
+
+// TestMirrorDropsWhenSemaphoreFull verifies that when the bounded mirror
+// concurrency semaphore is at capacity, new mirror queries are dropped
+// (not queued) and the drop hook fires.
+func TestMirrorDropsWhenSemaphoreFull(t *testing.T) {
+	primitive := NewRoute(
+		Unsharded,
+		&vindexes.Keyspace{Name: "ks1"},
+		"select 1 from foo",
+		"select 1 from foo where 1 != 1",
+	)
+	target := NewRoute(
+		Unsharded,
+		&vindexes.Keyspace{Name: "ks2"},
+		"select 1 from foo",
+		"select 1 from foo where 1 != 1",
+	)
+	mirror := NewPercentBasedMirror(100, primitive, target)
+
+	vc := &loggingVCursor{
+		shards:  []string{"-"},
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(sqltypes.MakeTestFields("a", "varchar"), "x")},
+	}
+
+	// Pre-acquire the only slot so the dispatch path falls through to the
+	// drop branch. Capacity 1, weight 1 already taken => TryAcquire fails.
+	sem := semaphore.NewWeighted(1)
+	require.True(t, sem.TryAcquire(1))
+	vc.mirrorTrafficSemaphore = sem
+
+	var droppedCount atomic.Int32
+	vc.onRecordMirrorDroppedFn = func() { droppedCount.Add(1) }
+	vc.onMirrorClonesFn = func(_ context.Context) VCursor {
+		t.Fatalf("mirror should not have been cloned when semaphore is full")
+		return nil
+	}
+
+	_, err := mirror.TryExecute(context.Background(), vc, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+
+	require.Equal(t, int32(1), droppedCount.Load(), "drop hook should have fired exactly once")
 }

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -152,6 +152,11 @@ type (
 		// the bounded concurrency limit was full. The primary query is unaffected.
 		RecordMirrorDropped()
 
+		// RecordMirrorPanic increments the counter for mirror queries that panicked.
+		// Called from a deferred recover in the mirror goroutine so a panic in the
+		// mirror execution path does not crash vtgate. The primary query is unaffected.
+		RecordMirrorPanic()
+
 		// CloneForMirroring clones the VCursor for re-use in mirroring queries to other keyspaces
 		CloneForMirroring(ctx context.Context) VCursor
 		//

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -144,6 +144,14 @@ type (
 		// and a cancel function that must be called when the warming query completes.
 		WarmingReadsContext(ctx context.Context) (context.Context, context.CancelFunc)
 
+		// GetMirrorTrafficSemaphore returns the weighted semaphore that bounds concurrent
+		// mirror queries. A nil value disables mirror dispatch (every TryAcquire returns false).
+		GetMirrorTrafficSemaphore() *semaphore.Weighted
+
+		// RecordMirrorDropped increments the counter for mirror queries dropped because
+		// the bounded concurrency limit was full. The primary query is unaffected.
+		RecordMirrorDropped()
+
 		// CloneForMirroring clones the VCursor for re-use in mirroring queries to other keyspaces
 		CloneForMirroring(ctx context.Context) VCursor
 		//

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -145,7 +145,8 @@ type (
 		// queryLogger is passed in for logging from this vtgate executor.
 		queryLogger *streamlog.StreamLogger[*logstats.LogStats]
 
-		warmingReadsSemaphore *semaphore.Weighted
+		warmingReadsSemaphore  *semaphore.Weighted
+		mirrorTrafficSemaphore *semaphore.Weighted
 
 		vConfig   econtext.VCursorConfig
 		ddlConfig dynamicconfig.DDL
@@ -199,10 +200,11 @@ func NewExecutor(
 		scatterConn: resolver.scatterConn,
 		txConn:      resolver.scatterConn.txConn,
 
-		schemaTracker:         schemaTracker,
-		plans:                 plans,
-		warmingReadsSemaphore: newWarmingReadsSemaphore(warmingReadsConcurrency),
-		ddlConfig:             ddlConfig,
+		schemaTracker:          schemaTracker,
+		plans:                  plans,
+		warmingReadsSemaphore:  newWarmingReadsSemaphore(warmingReadsConcurrency),
+		mirrorTrafficSemaphore: newMirrorTrafficSemaphore(mirrorTrafficConcurrency),
+		ddlConfig:              ddlConfig,
 	}
 	// setting the vcursor config.
 	e.initVConfig(warnOnShardedOnly, pv)
@@ -1567,9 +1569,10 @@ func (e *Executor) initVConfig(warnOnShardedOnly bool, pv plancontext.PlannerVer
 
 		DBDDLPlugin: dbDDLPlugin,
 
-		WarmingReadsPercent:   e.config.WarmingReadsPercent,
-		WarmingReadsTimeout:   warmingReadsQueryTimeout,
-		WarmingReadsSemaphore: e.warmingReadsSemaphore,
+		WarmingReadsPercent:    e.config.WarmingReadsPercent,
+		WarmingReadsTimeout:    warmingReadsQueryTimeout,
+		WarmingReadsSemaphore:  e.warmingReadsSemaphore,
+		MirrorTrafficSemaphore: e.mirrorTrafficSemaphore,
 	}
 }
 
@@ -1603,6 +1606,16 @@ func newWarmingReadsSemaphore(concurrency int) *semaphore.Weighted {
 		return semaphore.NewWeighted(0)
 	}
 	return semaphore.NewWeighted(int64(concurrency) * engine.WarmingReadsBaseWeight)
+}
+
+// newMirrorTrafficSemaphore returns a weighted semaphore sized to cap
+// concurrent mirror queries. Each mirror takes weight 1, so capacity equals
+// concurrency. A non-positive concurrency disables mirror dispatch.
+func newMirrorTrafficSemaphore(concurrency int) *semaphore.Weighted {
+	if concurrency <= 0 {
+		return semaphore.NewWeighted(0)
+	}
+	return semaphore.NewWeighted(int64(concurrency))
 }
 
 func countArguments(statement sqlparser.Statement) (paramsCount uint16) {

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -4559,6 +4559,50 @@ func TestNewWarmingReadsSemaphore(t *testing.T) {
 	}
 }
 
+func TestNewMirrorTrafficSemaphore(t *testing.T) {
+	tests := []struct {
+		name        string
+		concurrency int
+		wantFit     int64 // weight that should fit via TryAcquire
+		wantReject  int64 // weight that should be rejected via TryAcquire
+	}{
+		{
+			name:        "zero concurrency disables dispatch",
+			concurrency: 0,
+			wantReject:  1,
+		},
+		{
+			name:        "negative concurrency disables dispatch",
+			concurrency: -1,
+			wantReject:  1,
+		},
+		{
+			name:        "concurrency 1 fits one mirror then rejects",
+			concurrency: 1,
+			wantFit:     1,
+			wantReject:  1,
+		},
+		{
+			name:        "concurrency 256 fits 256 mirrors then rejects",
+			concurrency: 256,
+			wantFit:     256,
+			wantReject:  1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sem := newMirrorTrafficSemaphore(tc.concurrency)
+			require.NotNil(t, sem)
+			if tc.wantFit > 0 {
+				require.True(t, sem.TryAcquire(tc.wantFit), "expected TryAcquire(%d) to succeed", tc.wantFit)
+			}
+			if tc.wantReject > 0 {
+				require.False(t, sem.TryAcquire(tc.wantReject), "expected TryAcquire(%d) to fail", tc.wantReject)
+			}
+		})
+	}
+}
+
 func TestWarmingReads(t *testing.T) {
 	ctx := utils.LeakCheckContext(t)
 	executor, primary, replica := createExecutorEnvWithPrimaryReplicaConn(t, ctx, 100)

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -35,6 +35,7 @@ import (
 	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/callerid"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/key"
@@ -1709,11 +1710,28 @@ func (vc *VCursorImpl) GetForeignKeyChecksState() *bool {
 	return vc.fkChecksState
 }
 
+var (
+	mirrorSourceLatency = stats.NewTimings("MirrorSourceExecuteTime", "Time spent executing the source (primary) query for mirrored requests", "Keyspace")
+	mirrorTargetLatency = stats.NewTimings("MirrorTargetExecuteTime", "Time spent executing the mirror target query", "Keyspace")
+	mirrorTargetErrors  = stats.NewCountersWithSingleLabel("MirrorTargetErrors", "Number of mirror target query errors", "Keyspace")
+)
+
 // RecordMirrorStats is used to record stats about a mirror query.
 func (vc *VCursorImpl) RecordMirrorStats(sourceExecTime, targetExecTime time.Duration, targetErr error) {
 	vc.logStats.MirrorSourceExecuteTime = sourceExecTime
 	vc.logStats.MirrorTargetExecuteTime = targetExecTime
 	vc.logStats.MirrorTargetError = targetErr
+
+	keyspace := vc.keyspace
+	if sourceExecTime > 0 {
+		mirrorSourceLatency.Add(keyspace, sourceExecTime)
+	}
+	if targetExecTime > 0 {
+		mirrorTargetLatency.Add(keyspace, targetExecTime)
+	}
+	if targetErr != nil {
+		mirrorTargetErrors.Add(keyspace, 1)
+	}
 }
 
 func (vc *VCursorImpl) GetMarginComments() sqlparser.MarginComments {

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -100,6 +100,13 @@ type (
 		WarmingReadsPercent   int
 		WarmingReadsTimeout   time.Duration
 		WarmingReadsSemaphore *semaphore.Weighted
+
+		// MirrorTrafficSemaphore is a weighted semaphore that caps concurrent
+		// mirror queries. Each mirror takes weight 1; TryAcquire returns false
+		// when the bound is reached and the dispatch path drops the mirror so
+		// the primary path is unaffected. A nil value disables mirror dispatch
+		// (every TryAcquire returns false).
+		MirrorTrafficSemaphore *semaphore.Weighted
 	}
 
 	// vcursor_impl needs these facilities to be able to be able to execute queries for vindexes
@@ -1689,6 +1696,12 @@ func (vc *VCursorImpl) GetWarmingReadsSemaphore() *semaphore.Weighted {
 	return vc.config.WarmingReadsSemaphore
 }
 
+// GetMirrorTrafficSemaphore returns the weighted semaphore that caps
+// concurrent mirror queries. Returns nil if mirror dispatch is disabled.
+func (vc *VCursorImpl) GetMirrorTrafficSemaphore() *semaphore.Weighted {
+	return vc.config.MirrorTrafficSemaphore
+}
+
 func (vc *VCursorImpl) GetQueryPriority() (int, error) {
 	if vc.SafeSession.Options != nil && vc.SafeSession.Options.Priority != "" {
 		priority, err := strconv.Atoi(vc.SafeSession.Options.Priority)
@@ -1714,6 +1727,7 @@ var (
 	mirrorSourceLatency = stats.NewTimings("MirrorSourceExecuteTime", "Time spent executing the source (primary) query for mirrored requests", "Keyspace")
 	mirrorTargetLatency = stats.NewTimings("MirrorTargetExecuteTime", "Time spent executing the mirror target query", "Keyspace")
 	mirrorTargetErrors  = stats.NewCountersWithSingleLabel("MirrorTargetErrors", "Number of mirror target query errors", "Keyspace")
+	mirrorTargetDropped = stats.NewCountersWithSingleLabel("MirrorTargetDropped", "Number of mirror target queries dropped because the bounded concurrency limit was full", "Keyspace")
 )
 
 // RecordMirrorStats is used to record stats about a mirror query.
@@ -1732,6 +1746,12 @@ func (vc *VCursorImpl) RecordMirrorStats(sourceExecTime, targetExecTime time.Dur
 	if targetErr != nil {
 		mirrorTargetErrors.Add(keyspace, 1)
 	}
+}
+
+// RecordMirrorDropped increments the counter for mirror queries dropped due
+// to the bounded concurrency limit being full. The primary query is unaffected.
+func (vc *VCursorImpl) RecordMirrorDropped() {
+	mirrorTargetDropped.Add(vc.keyspace, 1)
 }
 
 func (vc *VCursorImpl) GetMarginComments() sqlparser.MarginComments {

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -1728,6 +1728,7 @@ var (
 	mirrorTargetLatency = stats.NewTimings("MirrorTargetExecuteTime", "Time spent executing the mirror target query", "Keyspace")
 	mirrorTargetErrors  = stats.NewCountersWithSingleLabel("MirrorTargetErrors", "Number of mirror target query errors", "Keyspace")
 	mirrorTargetDropped = stats.NewCountersWithSingleLabel("MirrorTargetDropped", "Number of mirror target queries dropped because the bounded concurrency limit was full", "Keyspace")
+	mirrorTargetPanics  = stats.NewCountersWithSingleLabel("MirrorTargetPanics", "Number of mirror target queries that panicked and were recovered", "Keyspace")
 )
 
 // RecordMirrorStats is used to record stats about a mirror query.
@@ -1752,6 +1753,14 @@ func (vc *VCursorImpl) RecordMirrorStats(sourceExecTime, targetExecTime time.Dur
 // to the bounded concurrency limit being full. The primary query is unaffected.
 func (vc *VCursorImpl) RecordMirrorDropped() {
 	mirrorTargetDropped.Add(vc.keyspace, 1)
+}
+
+// RecordMirrorPanic increments the counter for mirror queries that panicked
+// and were recovered. The primary query is unaffected; the panic is logged
+// at the call site (in the mirror goroutine's recover) along with a stack
+// trace.
+func (vc *VCursorImpl) RecordMirrorPanic() {
+	mirrorTargetPanics.Add(vc.keyspace, 1)
 }
 
 func (vc *VCursorImpl) GetMarginComments() sqlparser.MarginComments {

--- a/go/vt/vtgate/planbuilder/operators/ast_to_op.go
+++ b/go/vt/vtgate/planbuilder/operators/ast_to_op.go
@@ -19,6 +19,7 @@ package operators
 import (
 	"fmt"
 
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
@@ -54,8 +55,11 @@ func translateQueryToOpWithMirroring(ctx *plancontext.PlanningContext, stmt sqlp
 
 	if selStmt, ok := stmt.(sqlparser.SelectStatement); ok {
 		if mi := ctx.SemTable.GetMirrorInfo(); mi.Percent > 0 {
-			mirrorOp := translateQueryToOp(ctx.UseMirror(), selStmt)
-			op = NewPercentBasedMirror(mi.Percent, op, mirrorOp)
+			mirrorCtx := ctx.UseMirror()
+			mirrorOp := translateQueryToOp(mirrorCtx, selStmt)
+			if !mirrorCtx.MirrorAborted() {
+				op = NewPercentBasedMirror(mi.Percent, op, mirrorOp)
+			}
 		}
 	}
 
@@ -308,10 +312,13 @@ func getOperatorFromAliasedTableExpr(ctx *plancontext.PlanningContext, tableExpr
 					tbl = newTbl
 				case vtbl.Type == vindexes.TypeReference && vtbl.Name.String() == "dual":
 					// Dual tables do not get an entry in the mirror rules,
-					// and we don't really need to mirror them. We just want to
-					// avoid panicking.
+					// and we don't really need to mirror them.
 				default:
-					panic(vterrors.VT13001(fmt.Sprintf("unable to find mirror rule for table: %T", tbl)))
+					// Mirroring is best effort. If we can't find a mirror rule
+					// for a table, abort mirroring for this query rather than
+					// disrupting production traffic.
+					log.Warn(fmt.Sprintf("unable to find mirror rule for table %s, skipping mirror for this query", sqlparser.String(tbl)))
+					ctx.AbortMirror()
 				}
 			}
 			qt := &QueryTable{Alias: tableExpr, Table: tbl, ID: tableID, IsInfSchema: isInfSchema}

--- a/go/vt/vtgate/planbuilder/plancontext/planning_context.go
+++ b/go/vt/vtgate/planbuilder/plancontext/planning_context.go
@@ -70,6 +70,11 @@ type PlanningContext struct {
 	// isMirrored indicates that mirrored tables should be used.
 	isMirrored bool
 
+	// mirrorAborted indicates that mirror planning should be abandoned because
+	// a table was encountered without a mirror rule. This allows the planner
+	// to gracefully skip mirroring rather than failing the query.
+	mirrorAborted bool
+
 	emptyEnv    *evalengine.ExpressionEnv
 	constantCfg *evalengine.Config
 
@@ -324,6 +329,18 @@ func (ctx *PlanningContext) ContainsWindowFunc(e sqlparser.SQLNode) (hasWindow b
 
 func (ctx *PlanningContext) IsMirrored() bool {
 	return ctx.isMirrored
+}
+
+// AbortMirror signals that mirror planning should be abandoned for this query.
+// This is used when a table is encountered that has no mirror rule, to avoid
+// disrupting production traffic.
+func (ctx *PlanningContext) AbortMirror() {
+	ctx.mirrorAborted = true
+}
+
+// MirrorAborted returns true if mirror planning was aborted.
+func (ctx *PlanningContext) MirrorAborted() bool {
+	return ctx.mirrorAborted
 }
 
 type ContextCTE struct {

--- a/go/vt/vtgate/planbuilder/testdata/mirror_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/mirror_cases.json
@@ -543,5 +543,28 @@
         "unsharded_src3.t1"
       ]
     }
+  },
+  {
+    "comment": "join mirrored table with unmirrored table skips mirroring gracefully",
+    "query": "select t1.id, t5.id from unsharded_src1.t1 join unsharded_src1.t5 on t1.id = t5.id where t1.id = 1",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select t1.id, t5.id from unsharded_src1.t1 join unsharded_src1.t5 on t1.id = t5.id where t1.id = 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "unsharded_src1",
+          "Sharded": false
+        },
+        "FieldQuery": "select t1.id, t5.id from t1, t5 where 1 != 1",
+        "Query": "select t1.id, t5.id from t1, t5 where t1.id = 1 and t1.id = t5.id"
+      },
+      "TablesUsed": [
+        "unsharded_src1.t1",
+        "unsharded_src1.t5"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -180,6 +180,12 @@ var (
 	warmingReadsPercent      = 0
 	warmingReadsQueryTimeout = 5 * time.Second
 	warmingReadsConcurrency  = 500
+
+	// mirrorTrafficConcurrency caps the number of in-flight mirror queries
+	// dispatched by MirrorTraffic. Mirrors that would exceed this bound are
+	// dropped (counter MirrorTargetDropped) so a slow mirror target cannot
+	// exhaust vtgate memory and impact the primary path.
+	mirrorTrafficConcurrency = 256
 )
 
 func registerFlags(fs *pflag.FlagSet) {
@@ -219,6 +225,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&warmingReadsPercent, "warming-reads-percent", 0, "Percentage of reads on the primary to forward to replicas. Useful for keeping buffer pools warm")
 	fs.IntVar(&warmingReadsConcurrency, "warming-reads-concurrency", 500, "Number of concurrent warming reads allowed")
 	fs.DurationVar(&warmingReadsQueryTimeout, "warming-reads-query-timeout", 5*time.Second, "Timeout of warming read queries")
+	fs.IntVar(&mirrorTrafficConcurrency, "mirror-traffic-max-concurrent", mirrorTrafficConcurrency, "Maximum number of concurrent mirror queries dispatched by MirrorTraffic. Mirrors over this bound are dropped (counter: MirrorTargetDropped) so a slow target cannot exhaust vtgate memory.")
 
 	viperutil.BindFlags(fs,
 		enableOnlineDDL,


### PR DESCRIPTION
## Description

`MoveTables MirrorTraffic` is documented as best-effort target-keyspace
warming, but is not safe to enable in production today. This PR makes the
four vtgate-side changes required to turn it into a production-ready feature,
complementing #18775 (target-side `allow_reads`, already merged).

The PR is structured as four small, independently reviewable commits.

## Details

**1. `vtgate: gracefully skip mirroring when a table has no mirror rule`**

A query that joins a mirrored table with a non-mirrored table currently
panics the planner with `VT13001`. This is hit by routine joins during a
partial MoveTables (only some tables in scope). Replace the panic with
`log.Warn` + a new `PlanningContext.AbortMirror()` flag, and skip wrapping
the plan in `PercentBasedMirror` when set. Adds a planbuilder test case.

**2. `MirrorTraffic: fire-and-forget execution + per-keyspace metrics`**

Remove the response-path `select { case <-mirrorCh; case <-time.After(100ms) }`
that added blanket latency to every mirrored query. Mirror execution now runs
in a detached goroutine (`context.Background()` + `WithTimeout(30s)`) on a
cloned VCursor, with `RecordMirrorStats` called inside the goroutine. The
primary query result returns immediately.

Adds three keyspace-labeled stats:
- `MirrorSourceExecuteTime` — source query latency for mirrored requests
- `MirrorTargetExecuteTime` — mirror target query latency
- `MirrorTargetErrors` — mirror target failure count

**3. `MirrorTraffic: bounded concurrency to cap in-flight mirror queries`**

Without a bound, a slow target accumulates goroutines unbounded — each
~10–50 KB, plus a target-side connection. A weighted semaphore
(`golang.org/x/sync/semaphore`, capacity controlled by
`--mirror-traffic-max-concurrent`, default 256) is acquired before each
dispatch via `TryAcquire(1)`. On failure the mirror is dropped and
`MirrorTargetDropped` increments. This mirrors the `--warming-reads-concurrency`
pattern in `route.go` so vtgate's two best-effort-dispatch features stay
aligned.

**4. `MirrorTraffic: recover panics in the mirror goroutine`**

Mirror traffic is best-effort. A panic during target execution must never
crash vtgate. A deferred `recover()` (registered first, runs last in LIFO so
it also catches panics from `Release`/`mirrorCancel`) logs the panic with
`runtime/debug.Stack()` and increments `MirrorTargetPanics`. The primary
path is unaffected. Test exercises a target that panics on dispatch and
verifies recovery + counter increment.

## Related Issue(s)

Fixes #19976

Companion to:
- #18775 (merged) — server-side `allow_reads` for denied tables on the target
- #19809 (RFC) — tablet-level mirroring (different feature, references this work as prior art)

## Checklist

- [ ] **"Backport to:" labels.** Recommend backport to release-22.0 and release-23.0 to match #18775's backport scope; labels applied accordingly. Deferring final call to maintainers.
- [ ] **Backport justification.** If backported: the response-path block (commit 2) is a real production hazard wherever MirrorTraffic is enabled, and the panic recovery (commit 4) is a crash-safety fix. Both should be in any release that already carries #18775.
- [x] **Tests added.** New tests: `TestMirrorDropsWhenSemaphoreFull`, `TestMirrorRecoversTargetPanic`, plus a planbuilder test in `mirror_cases.json`. Existing tests refactored for the async dispatch model.
- [x] **Tests pass locally.** `go test ./go/vt/vtgate/...` clean, including engine, executorcontext, planbuilder, and the vtgate executor tests (~48s).
- [ ] **Documentation.** New flag and stats deserve a note in the next release's docs; happy to follow up if directed.

## Deployment Notes

- **One new flag**: `--mirror-traffic-max-concurrent` (default 256). Existing vtgate deployments pick up the bound automatically; raising or lowering it requires a restart.
- **Five new stats counters/timings** under `/debug/vars`, all keyed by source keyspace:
  `MirrorSourceExecuteTime`, `MirrorTargetExecuteTime`, `MirrorTargetErrors`,
  `MirrorTargetDropped`, `MirrorTargetPanics`.
- **Behavior change worth flagging**: vtgates with MirrorTraffic enabled previously added up to 100ms to mirrored query response times. After this change, mirrored queries return at primary-only latency — the intended fix, but a real change to observable behavior.
- **No proto / RPC / topology / `_vt` table changes.** Pure vtgate-internal.

### AI Disclosure

This PR was developed using Claude Code (Opus 4.6 and 4.7). Co-authorship is
recorded in commit trailers per the project convention.
