### PR TITLE
`go/mysql`, `vreplication`: fix flaky unit tests with shared root cause

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"net"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -211,22 +210,6 @@ type Listener struct {
 	// shutdown indicates that Shutdown method was called.
 	shutdown atomic.Bool
 
-	// mu guards closed and conns, and is the synchronization point for
-	// handlerWG.Add: callers that increment the WaitGroup must do so under mu
-	// while !closed, so that Close can safely wait without racing with Add.
-	mu sync.Mutex
-
-	// closed is true after Close or Shutdown has closed the underlying listener.
-	closed bool
-
-	// conns tracks active server-side connections so that Close can force-close
-	// them and unblock handler goroutines parked in (*Conn).readHeaderFrom.
-	conns map[uint32]net.Conn
-
-	// handlerWG tracks handler goroutines spawned by Accept so that Close can
-	// wait for them to exit.
-	handlerWG sync.WaitGroup
-
 	// RequireSecureTransport configures the server to reject connections from insecure clients
 	RequireSecureTransport bool
 
@@ -346,7 +329,6 @@ func NewListenerWithConfig(cfg ListenerConfig) (*Listener, error) {
 		multiQuery:          cfg.MultiQuery,
 		truncateErrLen:      cfg.Handler.Env().TruncateErrLen(),
 		charset:             cfg.Handler.Env().CollationEnv().DefaultConnectionCharset(),
-		conns:               make(map[uint32]net.Conn),
 	}, nil
 }
 
@@ -369,32 +351,13 @@ func (l *Listener) Accept() {
 
 		acceptTime := time.Now()
 
-		// Reserve a WaitGroup slot and register the conn under l.mu so Close
-		// (which sets closed=true under the same lock before calling Wait) can
-		// neither race with Add(1) nor miss this conn for force-close.
-		l.mu.Lock()
-		if l.closed {
-			l.mu.Unlock()
-			conn.Close()
-			return
-		}
 		connectionID := l.connectionID
 		l.connectionID++
-		l.handlerWG.Add(1)
-		l.conns[connectionID] = conn
-		l.mu.Unlock()
 
 		connCount.Add(1)
 		connAccept.Add(1)
 
 		go func() {
-			defer l.handlerWG.Done()
-			defer func() {
-				l.mu.Lock()
-				delete(l.conns, connectionID)
-				l.mu.Unlock()
-			}()
-
 			if l.PreHandleFunc != nil {
 				conn, err = l.PreHandleFunc(ctx, conn, connectionID)
 				if err != nil {
@@ -607,41 +570,16 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 	}
 }
 
-// Close stops the listener, force-closes any active server-side connections,
-// and waits for all in-flight handler goroutines to exit. It is idempotent and
-// safe to call after Shutdown.
+// Close stops the listener, which prevents accept of any new connections. Existing connections won't be closed.
 func (l *Listener) Close() {
-	l.mu.Lock()
-	if !l.closed {
-		l.closed = true
-		l.listener.Close()
-	}
-	snapshot := make([]net.Conn, 0, len(l.conns))
-	for _, c := range l.conns {
-		snapshot = append(snapshot, c)
-	}
-	l.conns = nil
-	l.mu.Unlock()
-
-	for _, c := range snapshot {
-		_ = c.Close()
-	}
-	l.handlerWG.Wait()
+	l.listener.Close()
 }
 
-// Shutdown closes the listener (preventing new connections) and fails any Ping
-// requests from existing connections, but leaves established connections open
-// so clients can observe the graceful "Server shutdown in progress" reply and
-// reconnect elsewhere. Callers that need to wait for handler goroutines to
-// drain — and force-close stragglers — should follow with Close.
+// Shutdown closes listener and fails any Ping requests from existing connections.
+// This can be used for graceful shutdown, to let clients know that they should reconnect to another server.
 func (l *Listener) Shutdown() {
 	if l.shutdown.CompareAndSwap(false, true) {
-		l.mu.Lock()
-		if !l.closed {
-			l.closed = true
-			l.listener.Close()
-		}
-		l.mu.Unlock()
+		l.Close()
 	}
 }
 

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -210,6 +211,22 @@ type Listener struct {
 	// shutdown indicates that Shutdown method was called.
 	shutdown atomic.Bool
 
+	// mu guards closed and conns, and is the synchronization point for
+	// handlerWG.Add: callers that increment the WaitGroup must do so under mu
+	// while !closed, so that Close can safely wait without racing with Add.
+	mu sync.Mutex
+
+	// closed is true after Close or Shutdown has closed the underlying listener.
+	closed bool
+
+	// conns tracks active server-side connections so that Close can force-close
+	// them and unblock handler goroutines parked in (*Conn).readHeaderFrom.
+	conns map[uint32]net.Conn
+
+	// handlerWG tracks handler goroutines spawned by Accept so that Close can
+	// wait for them to exit.
+	handlerWG sync.WaitGroup
+
 	// RequireSecureTransport configures the server to reject connections from insecure clients
 	RequireSecureTransport bool
 
@@ -329,6 +346,7 @@ func NewListenerWithConfig(cfg ListenerConfig) (*Listener, error) {
 		multiQuery:          cfg.MultiQuery,
 		truncateErrLen:      cfg.Handler.Env().TruncateErrLen(),
 		charset:             cfg.Handler.Env().CollationEnv().DefaultConnectionCharset(),
+		conns:               make(map[uint32]net.Conn),
 	}, nil
 }
 
@@ -351,13 +369,32 @@ func (l *Listener) Accept() {
 
 		acceptTime := time.Now()
 
+		// Reserve a WaitGroup slot and register the conn under l.mu so Close
+		// (which sets closed=true under the same lock before calling Wait) can
+		// neither race with Add(1) nor miss this conn for force-close.
+		l.mu.Lock()
+		if l.closed {
+			l.mu.Unlock()
+			conn.Close()
+			return
+		}
 		connectionID := l.connectionID
 		l.connectionID++
+		l.handlerWG.Add(1)
+		l.conns[connectionID] = conn
+		l.mu.Unlock()
 
 		connCount.Add(1)
 		connAccept.Add(1)
 
 		go func() {
+			defer l.handlerWG.Done()
+			defer func() {
+				l.mu.Lock()
+				delete(l.conns, connectionID)
+				l.mu.Unlock()
+			}()
+
 			if l.PreHandleFunc != nil {
 				conn, err = l.PreHandleFunc(ctx, conn, connectionID)
 				if err != nil {
@@ -570,16 +607,41 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 	}
 }
 
-// Close stops the listener, which prevents accept of any new connections. Existing connections won't be closed.
+// Close stops the listener, force-closes any active server-side connections,
+// and waits for all in-flight handler goroutines to exit. It is idempotent and
+// safe to call after Shutdown.
 func (l *Listener) Close() {
-	l.listener.Close()
+	l.mu.Lock()
+	if !l.closed {
+		l.closed = true
+		l.listener.Close()
+	}
+	snapshot := make([]net.Conn, 0, len(l.conns))
+	for _, c := range l.conns {
+		snapshot = append(snapshot, c)
+	}
+	l.conns = nil
+	l.mu.Unlock()
+
+	for _, c := range snapshot {
+		_ = c.Close()
+	}
+	l.handlerWG.Wait()
 }
 
-// Shutdown closes listener and fails any Ping requests from existing connections.
-// This can be used for graceful shutdown, to let clients know that they should reconnect to another server.
+// Shutdown closes the listener (preventing new connections) and fails any Ping
+// requests from existing connections, but leaves established connections open
+// so clients can observe the graceful "Server shutdown in progress" reply and
+// reconnect elsewhere. Callers that need to wait for handler goroutines to
+// drain — and force-close stragglers — should follow with Close.
 func (l *Listener) Shutdown() {
 	if l.shutdown.CompareAndSwap(false, true) {
-		l.Close()
+		l.mu.Lock()
+		if !l.closed {
+			l.closed = true
+			l.listener.Close()
+		}
+		l.mu.Unlock()
 	}
 }
 

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -1534,6 +1534,41 @@ func TestListenerShutdown(t *testing.T) {
 	require.Equal(t, "Server shutdown in progress", sqlErr.Message)
 }
 
+// TestListenerCloseWaitsForHandlers verifies that Close force-closes active
+// server-side connections and waits for handler goroutines to exit. Without
+// the WaitGroup + active-conn tracking, handlers parked in
+// (*Conn).readHeaderFrom outlive Close and trip LeakCheckContext on faster
+// CI runners (issue #19989).
+func TestListenerCloseWaitsForHandlers(t *testing.T) {
+	ctx := utils.LeakCheckContext(t)
+	th := &testHandler{}
+
+	l, err := NewListener("tcp", "127.0.0.1:", NewAuthServerNone(), th, 0, 0, false, false, 0, 0, false)
+	require.NoError(t, err)
+
+	go l.Accept()
+
+	host, port := getHostPort(t, l.Addr())
+	params := &ConnParams{Host: host, Port: port}
+
+	// Establish a real MySQL connection but never send a command, so the
+	// server-side handler parks in handleNextCommand -> readHeaderFrom.
+	c, err := Connect(ctx, params)
+	require.NoError(t, err)
+	defer c.Close()
+
+	done := make(chan struct{})
+	go func() {
+		l.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("Listener.Close did not return within 30s; handler goroutine still parked")
+	}
+}
+
 func TestParseConnAttrs(t *testing.T) {
 	expected := map[string]string{
 		"_client_version": "8.0.11",

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -1514,6 +1514,7 @@ func TestListenerShutdown(t *testing.T) {
 
 	conn, err := Connect(ctx, params)
 	require.NoError(t, err)
+	defer conn.Close()
 
 	err = conn.Ping()
 	require.NoError(t, err)
@@ -1532,41 +1533,6 @@ func TestListenerShutdown(t *testing.T) {
 	require.Equal(t, sqlerror.ERServerShutdown, sqlErr.Number())
 	require.Equal(t, sqlerror.SSNetError, sqlErr.SQLState())
 	require.Equal(t, "Server shutdown in progress", sqlErr.Message)
-}
-
-// TestListenerCloseWaitsForHandlers verifies that Close force-closes active
-// server-side connections and waits for handler goroutines to exit. Without
-// the WaitGroup + active-conn tracking, handlers parked in
-// (*Conn).readHeaderFrom outlive Close and trip LeakCheckContext on faster
-// CI runners (issue #19989).
-func TestListenerCloseWaitsForHandlers(t *testing.T) {
-	ctx := utils.LeakCheckContext(t)
-	th := &testHandler{}
-
-	l, err := NewListener("tcp", "127.0.0.1:", NewAuthServerNone(), th, 0, 0, false, false, 0, 0, false)
-	require.NoError(t, err)
-
-	go l.Accept()
-
-	host, port := getHostPort(t, l.Addr())
-	params := &ConnParams{Host: host, Port: port}
-
-	// Establish a real MySQL connection but never send a command, so the
-	// server-side handler parks in handleNextCommand -> readHeaderFrom.
-	c, err := Connect(ctx, params)
-	require.NoError(t, err)
-	defer c.Close()
-
-	done := make(chan struct{})
-	go func() {
-		l.Close()
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(30 * time.Second):
-		t.Fatal("Listener.Close did not return within 30s; handler goroutine still parked")
-	}
 }
 
 func TestParseConnAttrs(t *testing.T) {

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -58,6 +58,13 @@ var (
 	// vreplicationMinimumHeartbeatUpdateInterval overrides vreplicationHeartbeatUpdateInterval if the latter is higher than this
 	// to ensure that it satisfies liveness criteria implicitly expected by internal processes like Online DDL
 	vreplicationMinimumHeartbeatUpdateInterval = 60
+
+	// buildColInfoMapMaxAttempts and buildColInfoMapInitialDelay bound the
+	// retry of the information_schema.columns query when MySQL has just
+	// created a table but has not yet populated its column metadata
+	// (issue #19989).
+	buildColInfoMapMaxAttempts  = 5
+	buildColInfoMapInitialDelay = 100 * time.Millisecond
 )
 
 const (
@@ -378,12 +385,9 @@ func (vr *vreplicator) buildColInfoMap(ctx context.Context) (map[string][]*Colum
 	colInfoMap := make(map[string][]*ColumnInfo)
 	for _, td := range schema.TableDefinitions {
 		query := fmt.Sprintf(queryTemplate, encodeString(vr.dbClient.DBName()), encodeString(td.Name))
-		qr, err := vr.mysqld.FetchSuperQuery(ctx, query)
+		qr, err := vr.fetchInfoSchemaColumns(ctx, query, td.Name)
 		if err != nil {
 			return nil, err
-		}
-		if len(qr.Rows) == 0 {
-			return nil, errors.New("no data returned from information_schema.columns")
 		}
 
 		var pks []string
@@ -454,6 +458,35 @@ func (vr *vreplicator) buildColInfoMap(ctx context.Context) (map[string][]*Colum
 		colInfoMap[td.Name] = colInfo
 	}
 	return colInfoMap, nil
+}
+
+// fetchInfoSchemaColumns runs the information_schema.columns query with
+// bounded exponential backoff for the documented MySQL race where a newly
+// created table appears in information_schema.tables before its column
+// metadata is queryable (issue #19989). A real query error short-circuits
+// the retry; only an empty result triggers a backoff.
+func (vr *vreplicator) fetchInfoSchemaColumns(ctx context.Context, query, tableName string) (*sqltypes.Result, error) {
+	delay := buildColInfoMapInitialDelay
+	for attempt := 1; ; attempt++ {
+		qr, err := vr.mysqld.FetchSuperQuery(ctx, query)
+		if err != nil {
+			return nil, err
+		}
+		if len(qr.Rows) > 0 {
+			return qr, nil
+		}
+		if attempt >= buildColInfoMapMaxAttempts {
+			return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL,
+				"no data returned from information_schema.columns for table %s after %d attempts",
+				tableName, buildColInfoMapMaxAttempts)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(delay):
+		}
+		delay *= 2
+	}
 }
 
 // Same as readSettings, but stores some of the results on this vr.

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
@@ -19,10 +19,12 @@ package vreplication
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 	"unicode"
@@ -78,6 +80,80 @@ func TestMaxQuerySize(t *testing.T) {
 		vr := makeVR(dbClient, 4096)
 		assert.Equal(t, int64(4032), vr.maxQuerySize(vr.dbClient))
 		assert.Nil(t, vr.dbClient.queries)
+	})
+}
+
+// fakeFetchSuperQueryMysqld is a minimal MysqlDaemon test double that delegates
+// FetchSuperQuery to a callback. Only the methods exercised by tests are valid;
+// any other call will panic on the embedded nil interface.
+type fakeFetchSuperQueryMysqld struct {
+	mysqlctl.MysqlDaemon
+	callback func(query string) (*sqltypes.Result, error)
+}
+
+func (f *fakeFetchSuperQueryMysqld) FetchSuperQuery(ctx context.Context, query string) (*sqltypes.Result, error) {
+	return f.callback(query)
+}
+
+func TestFetchInfoSchemaColumnsRetry(t *testing.T) {
+	// Speed up retries for the test.
+	savedDelay := buildColInfoMapInitialDelay
+	buildColInfoMapInitialDelay = time.Millisecond
+	t.Cleanup(func() { buildColInfoMapInitialDelay = savedDelay })
+
+	cols := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"character_set_name|collation_name|column_name|data_type|column_type|extra",
+			"varchar|varchar|varchar|varchar|varchar|varchar",
+		),
+		"utf8mb4|utf8mb4_general_ci|id|int|int(11)|",
+	)
+
+	t.Run("returns rows once they appear after empty attempts", func(t *testing.T) {
+		var calls atomic.Int32
+		fmd := &fakeFetchSuperQueryMysqld{
+			callback: func(query string) (*sqltypes.Result, error) {
+				if calls.Add(1) < 3 {
+					return &sqltypes.Result{}, nil
+				}
+				return cols, nil
+			},
+		}
+		vr := &vreplicator{mysqld: fmd, WorkflowName: "wf1"}
+		qr, err := vr.fetchInfoSchemaColumns(t.Context(), "select 1", "t1")
+		require.NoError(t, err)
+		require.Len(t, qr.Rows, 1)
+		require.EqualValues(t, 3, calls.Load())
+	})
+
+	t.Run("returns bounded error after max attempts", func(t *testing.T) {
+		var calls atomic.Int32
+		fmd := &fakeFetchSuperQueryMysqld{
+			callback: func(query string) (*sqltypes.Result, error) {
+				calls.Add(1)
+				return &sqltypes.Result{}, nil
+			},
+		}
+		vr := &vreplicator{mysqld: fmd, WorkflowName: "wf1"}
+		_, err := vr.fetchInfoSchemaColumns(t.Context(), "select 1", "missingTable")
+		require.ErrorContains(t, err, "missingTable")
+		require.ErrorContains(t, err, fmt.Sprintf("%d attempts", buildColInfoMapMaxAttempts))
+		require.EqualValues(t, buildColInfoMapMaxAttempts, calls.Load())
+	})
+
+	t.Run("query error short-circuits retry", func(t *testing.T) {
+		var calls atomic.Int32
+		wantErr := errors.New("boom")
+		fmd := &fakeFetchSuperQueryMysqld{
+			callback: func(query string) (*sqltypes.Result, error) {
+				calls.Add(1)
+				return nil, wantErr
+			},
+		}
+		vr := &vreplicator{mysqld: fmd, WorkflowName: "wf1"}
+		_, err := vr.fetchInfoSchemaColumns(t.Context(), "select 1", "t1")
+		require.ErrorIs(t, err, wantErr)
+		require.EqualValues(t, 1, calls.Load())
 	})
 }
 


### PR DESCRIPTION
## Description

Targeted fix for the 2 x flakes documented in #19989. Both reproduce more often on faster, lower-jitter CI runners

#### Flake 1 — `go/mysql.TestListenerShutdown` and `TestServerFlush`

`TestListenerShutdown` connected a client and never closed it. After `l.Shutdown()`, the client's `Ping` returned `"Server shutdown in progress"` _(the polite reply)_, but the server-side handler stayed parked in `(*Conn).readHeaderFrom` waiting for the next command. The deferred `cleanupListener` only closed the listener — not the client conn — so `LeakCheckContext` caught the parked goroutine. `TestServerFlush` flaked the same way because the leaked goroutine carried over between consecutive tests _(same goroutine ID)_

The fix is a single-line `defer conn.Close()` in `TestListenerShutdown` so the server-side handler unblocks on EOF before `LeakCheckContext` runs. `Listener` itself is untouched

_Earlier in this PR I had a much larger fix that added handler-goroutine tracking and made `Close()` force-close active conns — Copilot flagged that as breaking `vtgate`'s `mysqlDrainOnTerm` path, which relies on `Close()` leaving existing connections open so its drain loop can wait for clients to disconnect themselves. Reverted in favour of the minimal test-only fix_

#### Flake 2 — `vplayer_flaky_test.go` cascade _(also a small production correctness fix)_

~17 tests fail in one run with `no data returned from information_schema.columns`. The MySQL race is already documented in the test file _(line 2032)_ — tables show up in `information_schema.tables` before column metadata is queryable, and the dummy `INSERT` mitigation isn't enough on faster runners

`vreplicator.buildColInfoMap` was erroring hard on `len(qr.Rows) == 0`. New `fetchInfoSchemaColumns` helper retries with bounded exponential backoff _(5 x attempts, 100ms → 1.6s, ~3s worst case)_, honors `ctx`, short-circuits on real query errors

`buildColInfoMap` is on the production vreplication startup path — called by every running workflow on every `vttablet` via `(*vreplicator).replicate()`. So the same race that flakes the unit tests can fire on a `vttablet` running on faster hardware: the workflow would have errored hard and been marked failed; with this change it retries and recovers. Small but real correctness improvement on top of the test-stability fix

#### Out of scope _(intentional)_

- `PreHandleFunc` error path not closing `conn` in `Listener.handle` — pre-existing resource leak unrelated to the goroutine leak this PR fixes
- `infoSchemaMysqld.FetchSuperQuery` falling through to real `mysqld` on mock miss — the issue tagged this `(Optional)`; the `buildColInfoMap` retry alone resolves the cascade

Happy to follow up on either in a separate PR

## Related Issue(s)

Resolves: #19989

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI? _(20 x passes for the previously flaky `go/mysql` tests; full vreplication suite passes)_
- [x] Documentation was added or is not required

## Deployment Notes

`Listener` semantics unchanged. `vreplicator.buildColInfoMap` now retries up to 5 x on empty `information_schema.columns` results _(~3s worst case before failing)_ instead of erroring on first attempt — workflow startup that previously failed against the documented MySQL race will now succeed transparently. No new flags or configuration

### AI Disclosure

This PR was written primarily by Claude Code — I provided direction, scope discipline, and review. Claude prepared this PR summary