### PR TITLE
[main] Copy `v24.0.0` release notes

### DIFF
--- a/changelog/24.0/24.0.0/changelog.md
+++ b/changelog/24.0/24.0.0/changelog.md
@@ -7,7 +7,8 @@
 #### Backup and Restore
  * BuiltinBackupEngine: Retry file close and fail backup when we cannot [#18848](https://github.com/vitessio/vitess/pull/18848)
  * fix(backup): propagate file hashes to manifest after retry [#19336](https://github.com/vitessio/vitess/pull/19336)
- * fix: Add super_read_only handling in init_clone [#19741](https://github.com/vitessio/vitess/pull/19741) 
+ * fix: Add super_read_only handling in init_clone [#19741](https://github.com/vitessio/vitess/pull/19741)
+ * [release-24.0] vtbackup: handle MySQL termination during CLONE restart (#19808) [#19975](https://github.com/vitessio/vitess/pull/19975) 
 #### Build/CI
  * Fix minor upgrade logic in go upgrade tool  [#19176](https://github.com/vitessio/vitess/pull/19176) 
 #### CLI
@@ -70,12 +71,19 @@
  * vtgate: Add bounds check in `visitUnion` for mismatched column counts [#19476](https://github.com/vitessio/vitess/pull/19476)
  * vtgate: set ServerStatusAutocommit in handshake status flags [#19628](https://github.com/vitessio/vitess/pull/19628)
  * VTGate: fix warming reads timeout context [#19674](https://github.com/vitessio/vitess/pull/19674)
- * planner: push DISTINCT through Window [#19694](https://github.com/vitessio/vitess/pull/19694) 
+ * planner: push DISTINCT through Window [#19694](https://github.com/vitessio/vitess/pull/19694)
+ * [release-24.0] planbuilder: fix subquery arg name collision across pullout opcodes (#19781) [#19865](https://github.com/vitessio/vitess/pull/19865)
+ * [release-24.0] proto: fix incorrect flag bits on `RAW` and `ROW_TUPLE` types (#19920) [#19950](https://github.com/vitessio/vitess/pull/19950)
+ * [release-24.0] vtgate: preserve target keyspace when routing rule rewrites table AST (#19948) [#19953](https://github.com/vitessio/vitess/pull/19953)
+ * [release-24.0] vtgate: prevent buffer restart after shutdown (#19954) [#19962](https://github.com/vitessio/vitess/pull/19962) 
 #### VTOrc
  * vtorc: add `StaleTopoPrimary` analysis and recovery [#19173](https://github.com/vitessio/vitess/pull/19173)
  * `vtorc`: detect errant GTIDs for replicas not connected to primary [#19224](https://github.com/vitessio/vitess/pull/19224)
  * vtorc: Add a timeout to `DemotePrimary` RPC [#19432](https://github.com/vitessio/vitess/pull/19432)
- * vtorc: add timeout helpers for remaining recovery topo/tmc calls [#19520](https://github.com/vitessio/vitess/pull/19520) 
+ * vtorc: add timeout helpers for remaining recovery topo/tmc calls [#19520](https://github.com/vitessio/vitess/pull/19520)
+ * [release-24.0] vtorc: fix data race in forgetAliases cache initialization (#19843) [#19847](https://github.com/vitessio/vitess/pull/19847)
+ * [release-24.0] vtorc: bound stale topo reconciliation calls (#19887) [#19900](https://github.com/vitessio/vitess/pull/19900)
+ * [release-24.0] VTOrc: Address panic uncovered by Antithesis (#19904) [#19910](https://github.com/vitessio/vitess/pull/19910) 
 #### VTTablet
  * Fix bug where query consolidator returns empty result without error when the waiter cap exceeded [#18782](https://github.com/vitessio/vitess/pull/18782)
  * repltracker: reset replica lag when we are primary [#18800](https://github.com/vitessio/vitess/pull/18800)
@@ -84,7 +92,8 @@
  * binlog_json: fix opaque value parsing to read variable-length [#19102](https://github.com/vitessio/vitess/pull/19102)
  * Bug fix: Add missing db_name filters to vreplication and vdiff queries [#19378](https://github.com/vitessio/vitess/pull/19378)
  * vttablet: handle applier metadata init failures in relay-log recovery [#19560](https://github.com/vitessio/vitess/pull/19560)
- * tabletmanager: handle nil Cnf in MysqlHostMetrics to prevent panic [#19752](https://github.com/vitessio/vitess/pull/19752) 
+ * tabletmanager: handle nil Cnf in MysqlHostMetrics to prevent panic [#19752](https://github.com/vitessio/vitess/pull/19752)
+ * [release-24.0] tabletserver: fix data race in testLogger global log function pointers (#19844) [#19856](https://github.com/vitessio/vitess/pull/19856) 
 #### schema management
  * `schemadiff`: support views with CTE [#18893](https://github.com/vitessio/vitess/pull/18893)
  * Fix `DROP CONSTRAINT` to work the same way as MySQL [#19183](https://github.com/vitessio/vitess/pull/19183)
@@ -93,7 +102,9 @@
 #### vtctl
  * vschema revert: initialize as nil so that nil checks do not pass later [#19114](https://github.com/vitessio/vitess/pull/19114)
  * vtctl: fix nil pointer dereference in SNAPSHOT keyspace creation [#19120](https://github.com/vitessio/vitess/pull/19120)
- * Restart IO threads on replicas after ERS failure [#19805](https://github.com/vitessio/vitess/pull/19805) 
+ * Restart IO threads on replicas after ERS failure [#19805](https://github.com/vitessio/vitess/pull/19805)
+ * [release-24.0] `EmergencyReparentShard`: fix nil pointer panic in errant GTID detection (#19848) [#19858](https://github.com/vitessio/vitess/pull/19858)
+ * [release-24.0] `EmergencyReparentShard`: fix cancellation in `reparentReplicas()` (#19849) [#19861](https://github.com/vitessio/vitess/pull/19861) 
 #### vtctldclient
  * Fix zero timestamp if NO_ZERO_DATE is not enabled [#19185](https://github.com/vitessio/vitess/pull/19185)
 ### CI/Build 
@@ -204,7 +215,8 @@
  * build(deps): bump google.golang.org/grpc from 1.79.2 to 1.79.3 [#19670](https://github.com/vitessio/vitess/pull/19670)
  * build(deps): bump the all group with 2 updates [#19705](https://github.com/vitessio/vitess/pull/19705)
  * Update dependabot minimum-version-age to 14 days (30 days for npm) [#19768](https://github.com/vitessio/vitess/pull/19768)
- * build(deps): bump actions/setup-go from 6.3.0 to 6.4.0 in the actions group [#19772](https://github.com/vitessio/vitess/pull/19772) 
+ * build(deps): bump actions/setup-go from 6.3.0 to 6.4.0 in the actions group [#19772](https://github.com/vitessio/vitess/pull/19772)
+ * [release-24.0] build(deps): bump the actions group with 2 updates (#19871) [#19874](https://github.com/vitessio/vitess/pull/19874) 
 #### Docker
  * Bump the all group across 4 directories with 3 updates [#19268](https://github.com/vitessio/vitess/pull/19268)
  * [main] Upgrade the Golang version to `go1.25.7` [#19306](https://github.com/vitessio/vitess/pull/19306)
@@ -216,7 +228,8 @@
  * build(deps): bump the all group across 3 directories with 3 updates [#19661](https://github.com/vitessio/vitess/pull/19661)
  * build(deps): bump golang from `96b2878` to `ce3f1c8` in /docker/lite in the all group across 1 directory [#19702](https://github.com/vitessio/vitess/pull/19702)
  * build(deps): bump the docker group across 2 directories with 3 updates [#19821](https://github.com/vitessio/vitess/pull/19821)
- * [main] Upgrade the Golang version to `go1.26.2` [#19830](https://github.com/vitessio/vitess/pull/19830) 
+ * [main] Upgrade the Golang version to `go1.26.2` [#19830](https://github.com/vitessio/vitess/pull/19830)
+ * [release-24.0] build(deps): bump the docker group across 3 directories with 2 updates (#19870) [#19943](https://github.com/vitessio/vitess/pull/19943) 
 #### Documentation
  * Add `--log-format json|text` [#19395](https://github.com/vitessio/vitess/pull/19395) 
 #### General
@@ -233,7 +246,9 @@
  * build(deps): bump the all group with 7 updates [#19659](https://github.com/vitessio/vitess/pull/19659)
  * build(deps): bump the all group with 10 updates [#19703](https://github.com/vitessio/vitess/pull/19703)
  * build(deps): bump the go group across 1 directory with 8 updates [#19763](https://github.com/vitessio/vitess/pull/19763)
- * Upgrade the Golang Dependencies [#19774](https://github.com/vitessio/vitess/pull/19774) 
+ * Upgrade the Golang Dependencies [#19774](https://github.com/vitessio/vitess/pull/19774)
+ * [release-24.0] build(deps): bump the go group with 2 updates (#19868) [#19873](https://github.com/vitessio/vitess/pull/19873)
+ * [release-24.0] Upgrade the Golang Dependencies (#19877) [#19881](https://github.com/vitessio/vitess/pull/19881) 
 #### Java
  * Bump the all group in /java with 31 updates [#19154](https://github.com/vitessio/vitess/pull/19154)
  * Bump the all group in /java with 11 updates [#19267](https://github.com/vitessio/vitess/pull/19267)
@@ -244,7 +259,8 @@
  * build(deps): bump the all group in /java with 8 updates [#19658](https://github.com/vitessio/vitess/pull/19658)
  * build(deps): bump the all group in /java with 2 updates [#19700](https://github.com/vitessio/vitess/pull/19700)
  * build(deps): bump io.netty:netty-handler from 4.2.11.Final to 4.2.12.Final in /java in the java group [#19729](https://github.com/vitessio/vitess/pull/19729)
- * [release-24.0] build(deps): bump org.apache.logging.log4j:log4j-core from 2.25.3 to 2.25.4 in /java (#19839) [#19840](https://github.com/vitessio/vitess/pull/19840) 
+ * [release-24.0] build(deps): bump org.apache.logging.log4j:log4j-core from 2.25.3 to 2.25.4 in /java (#19839) [#19840](https://github.com/vitessio/vitess/pull/19840)
+ * [release-24.0] build(deps): bump com.google.guava:guava from 33.5.0-jre to 33.6.0-jre in /java in the java group (#19867) [#19886](https://github.com/vitessio/vitess/pull/19886) 
 #### Observability
  * Bump go.opentelemetry.io/otel/sdk from 1.39.0 to 1.40.0 [#19525](https://github.com/vitessio/vitess/pull/19525)
  * build(deps): bump go.opentelemetry.io/otel/sdk from 1.42.0 to 1.43.0 [#19824](https://github.com/vitessio/vitess/pull/19824) 
@@ -381,9 +397,11 @@
  * Fire vttablet_restore_done hook from RestoreFromBackup RPC path [#19592](https://github.com/vitessio/vitess/pull/19592)
  * OnlineDDL: set `wait_timeout` on cutover connections [#19630](https://github.com/vitessio/vitess/pull/19630)
  * fix: Add sqlerror.ERRestartServerFailed to clone errors [#19759](https://github.com/vitessio/vitess/pull/19759)
- * feat: add workflow_type label to VReplication Prometheus metrics [#19786](https://github.com/vitessio/vitess/pull/19786) 
+ * feat: add workflow_type label to VReplication Prometheus metrics [#19786](https://github.com/vitessio/vitess/pull/19786)
+ * [release-24.0] vreplication: fix OOM on tables with large JSON columns (#19878) [#19892](https://github.com/vitessio/vitess/pull/19892) 
 #### vtctl
  * `EmergencyReparentShard`: require stop replication error to be from `PRIMARY` [#19515](https://github.com/vitessio/vitess/pull/19515)
+ * [release-24.0] reparentutil: fix goroutine count and improve logging (#19888) [#19922](https://github.com/vitessio/vitess/pull/19922)
 ### Feature 
 #### Backup and Restore
  * Backups: Add Support for Backup Init SQL Queries [#18883](https://github.com/vitessio/vitess/pull/18883)
@@ -455,7 +473,9 @@
  * `vtorc`: address CodeQL scanning alerts [#18753](https://github.com/vitessio/vitess/pull/18753) 
 #### VTTablet
  * `tabletmanager`: remove v22 backwards-compatibility for `vterrors` migration [#18986](https://github.com/vitessio/vitess/pull/18986)
- * connpool: use context.AfterFunc to avoid goroutine-per-query [#19654](https://github.com/vitessio/vitess/pull/19654)
+ * connpool: use context.AfterFunc to avoid goroutine-per-query [#19654](https://github.com/vitessio/vitess/pull/19654) 
+#### vtctl
+ * [release-24.0] `EmergencyReparentShard`: small observability and correctness fixes (#19851) [#19882](https://github.com/vitessio/vitess/pull/19882)
 ### Other 
 #### Documentation
  * docs: Add changelog entry for VReplication automatic tablet retry for tablet-specific errors [#19797](https://github.com/vitessio/vitess/pull/19797)
@@ -471,7 +491,8 @@
 #### Query Serving
  * planner: Stop searching for alternatives once we found a merge opportunity [#18898](https://github.com/vitessio/vitess/pull/18898)
  * sqlparser: remove strings.Clone from NewIdentifierCS [#19683](https://github.com/vitessio/vitess/pull/19683)
- * sqlparser: eagerly compute IdentifierCI.lowered at construction [#19691](https://github.com/vitessio/vitess/pull/19691) 
+ * sqlparser: eagerly compute IdentifierCI.lowered at construction [#19691](https://github.com/vitessio/vitess/pull/19691)
+ * [release-24.0] vtgate/buffer: lock-free hot-path with atomic state and sync.Map (#19827) [#19929](https://github.com/vitessio/vitess/pull/19929) 
 #### VTGate
  * vtgate: replace heap with tournament tree for k-way merging [#19398](https://github.com/vitessio/vitess/pull/19398) 
 #### VTTablet
@@ -488,7 +509,9 @@
  * docs: Add changelog entry for QueryThrottler event-driven configuration updates [#19190](https://github.com/vitessio/vitess/pull/19190)
  * [main] Copy `v23.0.2` release notes [#19355](https://github.com/vitessio/vitess/pull/19355)
  * [main] Copy `v23.0.3` release notes [#19506](https://github.com/vitessio/vitess/pull/19506)
- * [main] Copy `v22.0.4` release notes [#19511](https://github.com/vitessio/vitess/pull/19511) 
+ * [main] Copy `v22.0.4` release notes [#19511](https://github.com/vitessio/vitess/pull/19511)
+ * [release-24.0] Release of `v24.0.0-RC1` [#19852](https://github.com/vitessio/vitess/pull/19852)
+ * [release-24.0] Tweaks to v24 release summary (#19970) [#19971](https://github.com/vitessio/vitess/pull/19971) 
 #### General
  * Bump to `v24.0.0-SNAPSHOT` after the `v23.0.0-RC1` release [#18730](https://github.com/vitessio/vitess/pull/18730)
  * [main] Copy `v23.0.0-RC1` release notes [#18758](https://github.com/vitessio/vitess/pull/18758)
@@ -499,7 +522,8 @@
  * [main] Copy `v22.0.3` release notes [#19283](https://github.com/vitessio/vitess/pull/19283)
  * [main] Copy `v23.0.1` release notes [#19287](https://github.com/vitessio/vitess/pull/19287)
  * [release-24.0] Code Freeze for `v24.0.0-RC1` [#19837](https://github.com/vitessio/vitess/pull/19837)
- * Bump to `v25.0.0-SNAPSHOT` after the `v24.0.0-RC1` release [#19838](https://github.com/vitessio/vitess/pull/19838) 
+ * Bump to `v25.0.0-SNAPSHOT` after the `v24.0.0-RC1` release [#19838](https://github.com/vitessio/vitess/pull/19838)
+ * [release-24.0] Bump to `v24.0.0-SNAPSHOT` after the `v24.0.0-RC1` release [#19855](https://github.com/vitessio/vitess/pull/19855) 
 #### Query Serving
  * docs: Add changelog entry for QueryThrottler observability metrics [#19036](https://github.com/vitessio/vitess/pull/19036)
 ### Security 
@@ -524,7 +548,8 @@
  * vtadmin: upgrade vite to the latest [#18803](https://github.com/vitessio/vitess/pull/18803)
  * Bump js-yaml from 4.1.0 to 4.1.1 in /web/vtadmin [#18908](https://github.com/vitessio/vitess/pull/18908)
  * Drop dependency on `npm`, bump version of `glob`. [#18931](https://github.com/vitessio/vitess/pull/18931)
- * Potential fix for code scanning alert no. 3944: Database query built from user-controlled sources [#18941](https://github.com/vitessio/vitess/pull/18941) 
+ * Potential fix for code scanning alert no. 3944: Database query built from user-controlled sources [#18941](https://github.com/vitessio/vitess/pull/18941)
+ * [release-24.0] build(deps-dev): bump postcss from 8.5.8 to 8.5.10 in /web/vtadmin (#19960) [#19969](https://github.com/vitessio/vitess/pull/19969) 
 #### VTTablet
  * `filebackupstorage`: use `fileutil.SafePathJoin` for all path building [#19479](https://github.com/vitessio/vitess/pull/19479)
  * `vttablet`: harden `ExecuteHook` RPC and backup engine flag inputs [#19486](https://github.com/vitessio/vitess/pull/19486) 

--- a/changelog/24.0/24.0.0/release_notes.md
+++ b/changelog/24.0/24.0.0/release_notes.md
@@ -9,11 +9,11 @@
         - [Window function pushdown for sharded keyspaces](#window-function-pushdown)
         - [View Routing Rules](#view-routing-rules)
         - [Tablet targeting via USE statement](#tablet-targeting)
+        - [VTGate Binlog Streaming Support](#vtgate-binlog-dump)
+        - [Structured logging](#structured-logging)
     - **[Breaking Changes](#breaking-changes)**
         - [External Decompressor No Longer Read from Backup MANIFEST by Default](#vttablet-external-decompressor-manifest)
 - **[Minor Changes](#minor-changes)**
-    - **[Logging](#minor-changes-logging)**
-        - [Structured logging](#structured-logging)
     - **[VReplication](#minor-changes-vreplication)**
         - [`--shards` flag for MoveTables/Reshard start and stop](#vreplication-shards-flag-start-stop)
         - [Automatic tablet retry for tablet-specific errors](#vreplication-tablet-error-retry)
@@ -21,22 +21,18 @@
         - [Removed `--grpc-send-session-in-streaming` flag](#vtgate-removed-grpc-send-session-in-streaming)
         - [New default for `--legacy-replication-lag-algorithm` flag](#vtgate-new-default-legacy-replication-lag-algorithm)
         - [New "session" mode for `--vtgate-balancer-mode` flag](#vtgate-session-balancer-mode)
-        - [Binlog Streaming Support](#vtgate-binlog-dump)
     - **[Query Serving](#minor-changes-query-serving)**
         - [JSON_EXTRACT now supports dynamic path arguments](#query-serving-json-extract-dynamic-args)
     - **[VTTablet](#minor-changes-vttablet)**
         - [New Experimental flag `--init-tablet-type-lookup`](#vttablet-init-tablet-type-lookup)
         - [QueryThrottler Observability Metrics](#vttablet-querythrottler-metrics)
         - [QueryThrottler Event-Driven Configuration Updates](#vttablet-querythrottler-config-watch)
-        - [New `in_order_completion_pending_count` field in OnlineDDL outputs](#vttablet-onlineddl-in-order-completion-count)
-        - [Tablet Shutdown Tracking and Connection Validation](#vttablet-tablet-shutdown-validation)
         - [Connection Pool Waiter Cap](#vttablet-conn-pool-waiter-cap)
     - **[Tracing](#minor-changes-tracing)**
         - [OpenTelemetry tracing support](#tracing-opentelemetry)
         - [Deprecation of OpenTracing-based tracing backends](#tracing-opentracing-deprecation)
     - **[VTOrc](#minor-changes-vtorc)**
         - [New `--cell` Flag](#vtorc-cell-flag)
-        - [Improved VTOrc Discovery Logging](#vtorc-improved-discovery-logging)
         - [Ordered Recovery Execution and Semi-Sync Rollout](#vtorc-ordered-recovery-semi-sync)
         - [Deprecated VTOrc Metric Removed](#vtorc-deprecated-metric-removed)
         - [Deprecation of Snapshot Topology feature](#vtorc-snapshot-topology-deprecation)
@@ -106,6 +102,43 @@ Once set, all subsequent queries in the session route to the specified tablet un
 
 Note: A shard must be specified when using tablet targeting. Like shard targeting, this bypasses vindex-based routing, so use with care.
 
+#### <a id="vtgate-binlog-dump"/>Binlog Streaming Support</a>
+
+VTGate now supports GTID-based binlog streaming through two protocols:
+
+- **MySQL protocol**: Clients can connect using the standard MySQL `COM_BINLOG_DUMP_GTID` replication protocol command—no special VStream-aware adapters or direct MySQL access required.
+- **gRPC**: The new `BinlogDumpGTID` streaming RPC in `vtgateservice` provides native gRPC access for custom clients without the MySQL protocol dependency.
+
+Note: Only GTID-based streaming is supported. File/position-based streaming is not available through either `COM_BINLOG_DUMP` or `COM_BINLOG_DUMP_GTID` and returns an error.
+
+This feature is disabled by default. Enable it with `--enable-binlog-dump`.
+
+**New flags:**
+
+- `--enable-binlog-dump`: Enables binlog dump support. Without this flag, binlog dump requests return an error.
+- `--binlog-dump-authorized-users`: Comma-separated list of users authorized to execute binlog dump operations, or `%` to allow all users.
+
+**Requirements:**
+
+When initiating a binlog dump connection, clients must specify:
+- An empty filename
+- A file position (`filepos`) of 4
+- A GTID position
+
+For gRPC clients, specify the keyspace, shard, and optionally the tablet type or tablet alias directly in the `BinlogDumpGTIDRequest`.
+
+**Limitations:**
+
+- Each stream operates on a single tablet—no data aggregation across shards.
+- No automatic failover—if the targeted tablet becomes unavailable, the stream fails and the client must reconnect to a different tablet.
+- Not compatible with `MoveTables` or `Reshard` operations. Use the VStream API for those use cases.
+
+#### <a id="structured-logging"/>Structured logging</a>
+
+Vitess now uses structured JSON logging by default. Log output is emitted as JSON to stderr. To configure the minimum log level, pass `--log-level` (one of `debug`, `info`, `warn`, `error`; default `info`). For a human-readable format with automatic color detection, pass `--log-format=text`. To revert to the previous `glog` backend, pass `--log-structured=false`.
+
+`glog` is deprecated as of v24 and will be removed in v25.
+
 ### <a id="breaking-changes"/>Breaking Changes</a>
 
 #### <a id="vttablet-external-decompressor-manifest"/>External Decompressor No Longer Read from Backup MANIFEST by Default</a>
@@ -117,14 +150,6 @@ Starting in v24, the `MANIFEST`-based decompressor is ignored unless you explici
 See [#19460](https://github.com/vitessio/vitess/pull/19460) for details.
 
 ## <a id="minor-changes"/>Minor Changes</a>
-
-### <a id="minor-changes-logging"/>Logging</a>
-
-#### <a id="structured-logging"/>Structured logging</a>
-
-Vitess now uses structured JSON logging by default. Log output is emitted as JSON to stderr. To configure the minimum log level, pass `--log-level` (one of `debug`, `info`, `warn`, `error`; default `info`). For a human-readable format with automatic color detection, pass `--log-format=text`. To revert to the previous `glog` backend, pass `--log-structured=false`.
-
-`glog` is deprecated as of v24 and will be removed in v25.
 
 ### <a id="minor-changes-vreplication"/>VReplication</a>
 
@@ -178,44 +203,13 @@ To enable session mode, set the flag when starting VTGate:
 --vtgate-balancer-mode=session
 ```
 
-#### <a id="vtgate-binlog-dump"/>Binlog Streaming Support</a>
-
-VTGate now supports GTID-based binlog streaming through two protocols:
-
-- **MySQL protocol**: Clients can connect using the standard MySQL `COM_BINLOG_DUMP_GTID` replication command—no special VStream-aware adapters or direct MySQL access required.
-- **gRPC**: The new `BinlogDumpGTID` streaming RPC in `vtgateservice.proto` provides native gRPC access for custom clients without the MySQL protocol dependency.
-
-Note: Only GTID-based streaming is supported. File/position-based streaming is not available through either `COM_BINLOG_DUMP` or `COM_BINLOG_DUMP_GTID` and returns an error.
-
-This feature is disabled by default. Enable it with `--enable-binlog-dump`.
-
-**New flags:**
-
-- `--enable-binlog-dump`: Enables binlog dump support. Without this flag, binlog dump requests return an error.
-- `--binlog-dump-authorized-users`: Comma-separated list of users authorized to execute binlog dump operations, or `%` to allow all users.
-
-**Requirements:**
-
-When initiating a binlog dump connection, clients must specify:
-- An empty filename
-- A file position (`filepos`) of 4
-- A GTID position
-
-For gRPC clients, specify the keyspace, shard, and optionally the tablet type or tablet alias directly in the `BinlogDumpGTIDRequest`.
-
-**Limitations:**
-
-- Each stream operates on a single tablet—no data aggregation across shards.
-- No automatic failover—if the targeted tablet becomes unavailable, the stream fails and the client must reconnect to a different tablet.
-- Not compatible with `MoveTables` or `Reshard` operations. Use the VStream API for those use cases.
-
 ### <a id="minor-changes-query-serving"/>Query Serving</a>
 
 #### <a id="query-serving-json-extract-dynamic-args"/>JSON_EXTRACT now supports dynamic path arguments</a>
 
 The `JSON_EXTRACT` function now supports dynamic path arguments like bind variables or results from other function calls. Previously, `JSON_EXTRACT` only worked with static string literals for path arguments.
 
-Null handling now matches MySQL behavior. The function returns NULL when either the document or path argument is NULL.
+NULL handling now matches MySQL behavior. The function returns NULL when either the document or path argument is NULL.
 
 Static path arguments are still optimized, even when mixed with dynamic arguments, so existing queries won't see any performance regression.
 
@@ -227,7 +221,7 @@ The new experimental flag `--init-tablet-type-lookup` for VTTablet allows tablet
 
 When enabled, the tablet uses its alias to look up the tablet type from the existing topology record on restart. This allows tablets to maintain their changed roles (e.g., RDONLY/DRAINED) across restarts without manual reconfiguration. If disabled or if no topology record exists, the standard `--init-tablet-type` value will be used instead.
 
-**Note**: Vitess Operator–managed deployments generally do not keep tablet records in the topo between restarts, so this feature will not take effect in those environments.
+**Note**: Vitess Operator–managed deployments generally do not keep matching tablet records in the topo across pod replacements, so this feature will have a more limited effect in those environments.
 
 #### <a id="vttablet-querythrottler-metrics"/>QueryThrottler Observability Metrics</a>
 
@@ -237,8 +231,8 @@ Four new metrics have been added:
 
 - **QueryThrottlerRequests**: Total number of requests evaluated by the query throttler
 - **QueryThrottlerThrottled**: Number of requests that were throttled
-- **QueryThrottlerTotalLatencyNs**: Total time each request takes in query throttling, including evaluation, metric checks, and other overhead (nanoseconds)
-- **QueryThrottlerEvaluateLatencyNs**: Time taken to make the throttling decision (nanoseconds)
+- **QueryThrottlerTotalLatencyNs**: Total time each request takes in query throttling, including evaluation, metric checks, and other overhead (in nanoseconds)
+- **QueryThrottlerEvaluateLatencyNs**: Time taken to make the throttling decision (in nanoseconds)
 
 All metrics include labels for `Strategy`, `Workload`, and `Priority`. The `QueryThrottlerThrottled` metric has additional labels for `MetricName`, `MetricValue`, and `DryRun` to identify which metric triggered the throttling and whether it occurred in dry-run mode.
 
@@ -246,32 +240,17 @@ These metrics help monitor throttling patterns, identify which workloads are thr
 
 #### <a id="vttablet-querythrottler-config-watch"/>QueryThrottler Event-Driven Configuration Updates</a>
 
-QueryThrottler configuration is now stored in `SrvKeyspace` within the topology server and managed using standard topology tools. Previously, tablets polled for configuration changes every 60 seconds. Tablets now use event-driven watches (`WatchSrvKeyspace`) to receive updates immediately when throttling configuration changes. All tablets in a keyspace see configuration changes at roughly the same time, and topology server changes are versioned and auditable.
+QueryThrottler configuration is now propagated to and stored in the `SrvKeyspace` record within the topology server and managed using standard topology tools. Previously, tablets polled for configuration changes every 60 seconds. Tablets now use event-driven watches (`WatchSrvKeyspace`) to receive updates immediately when the query throttling configuration changes. All tablets in a keyspace see configuration changes at roughly the same time, and topology server changes are versioned and auditable.
 
 This change replaces the previous file-based configuration loader with a protobuf-defined configuration structure stored in the topology. The new configuration includes fields for enabling/disabling throttling, selecting the throttling strategy, and configuring strategy-specific rules.
 
-#### <a id="vttablet-onlineddl-in-order-completion-count"/>New `in_order_completion_pending_count` field in OnlineDDL outputs</a>
-
-OnlineDDL migration outputs now include a new `in_order_completion_pending_count` field. When using the `--in-order-completion` flag, this field shows how many migrations must complete before the current migration. The field is visible in `SHOW vitess_migrations` queries and `vtctldclient OnlineDDL <db> show` outputs.
-
-This provides better visibility into migration queue dependencies, making it easier to understand why a migration might be postponed. The count is automatically updated during the scheduler loop and cleared when migrations complete, fail, or are cancelled.
-
-#### <a id="vttablet-tablet-shutdown-validation"/>Tablet Shutdown Tracking and Connection Validation</a>
-
-Vitess now tracks when tablets cleanly shut down and validates tablet records before attempting connections, reducing unnecessary connection attempts and log noise.
-
-**New Field**: A new `tablet_shutdown_time` field has been added to the Tablet protobuf. This field is set to the current timestamp when a tablet cleanly shuts down and is cleared (set to `nil`) when the tablet starts. This allows other Vitess components to detect when a tablet is intentionally offline.
-
-**Connection Validation**: When a tablet record has `tablet_shutdown_time` set, Vitess components will skip connection attempts and return an error indicating the tablet is shutdown. VTOrc will now skip polling tablets that have `tablet_shutdown_time` set. For tablets that shutdown uncleanly (crashed, killed, etc.), the field remains `nil` and the pre-v24 behavior is preserved (connection attempt with error logging).
-
-**Note**: This is a best-effort mechanism. Tablets that are killed or crash may not have the opportunity to set this field, in which case components will continue to attempt connections as they did in v23 and earlier.
-
 #### <a id="vttablet-conn-pool-waiter-cap"/>Tablet Connection Pool Waiter Cap</a>
-VTTablet now allows to set a limit on the number of requests waiting to get a connection from the connection pool, for 
-the query, stream and transaction connection pools. The limits are set with the following flags:
-* `--queryserver-config-query-pool-waiter-cap`.
-* `--queryserver-config-stream-pool-waiter-cap`.
-* `--queryserver-config-txpool-waiter-cap`.
+
+VTTablet now allows users to set a limit on the number of requests waiting to get a connection from the connection pool, for 
+the query, stream, and transaction connection pools. The limits are set with the following flags:
+* `--queryserver-config-query-pool-waiter-cap`
+* `--queryserver-config-stream-pool-waiter-cap`
+* `--queryserver-config-txpool-waiter-cap`
 
 All of the above have a default value of `0`, meaning no limit, thus preserving the behavior of the previous version.
 
@@ -313,17 +292,11 @@ This enables future cross-cell problem validation, where VTOrc will be able to a
 
 **Note**: If you're running VTOrc in a multi-cell deployment, start using the `--cell` flag now to prepare for the v25 requirement.
 
-#### <a id="vtorc-improved-discovery-logging"/>Improved VTOrc Discovery Logging</a>
-
-VTOrc's `DiscoverInstance` function now includes the tablet alias in all log messages and uses the correct log level when errors occur. Previously, error messages did not indicate which tablet failed discovery, and errors were logged at INFO level instead of ERROR level.
-
-This improvement makes it easier to identify and debug issues with specific tablets when discovery operations fail.
-
 #### <a id="vtorc-ordered-recovery-semi-sync"/>Ordered Recovery Execution and Semi-Sync Rollout</a>
 
-VTOrc now executes recoveries per-shard with defined ordering, rather than per-tablet in isolation. Problems that have ordering dependencies (e.g., semi-sync configuration) are executed serially first, while independent problems are executed concurrently. This ensures that dependent recoveries happen in the correct sequence within a shard.
+VTOrc now executes recoveries per-shard with a defined ordering, rather than per-tablet in isolation. Problems that have ordering dependencies (e.g., semi-sync configuration) are executed serially first, while independent problems are executed concurrently. This ensures that dependent recoveries happen in the correct sequence within a shard.
 
-The main user-facing improvement is to semi-sync rollouts: VTOrc now ensures replicas have semi-sync enabled before updating the primary. Previously, enabling semi-sync on the primary before enough replicas were ready could stall writes while the primary waited for semi-sync acknowledgements that no replica was prepared to send.
+The main user-facing improvement is for semi-sync rollouts: VTOrc now ensures replicas have semi-sync enabled before updating the primary. Previously, enabling semi-sync on the primary before enough replicas were ready could stall writes while the primary waited for semi-sync acknowledgements that no replica was prepared to send.
 
 See [#19427](https://github.com/vitessio/vitess/pull/19427) for details.
 
@@ -378,7 +351,7 @@ A new `go_info_ext` gauge is also added with `compiler`, `GOARCH`, and `GOOS` la
 
 #### <a id="mysql-clone-support"/>MySQL CLONE Support for Replica Provisioning</a>
 
-VTTablet and VTBackup now support using MySQL's native [CLONE plugin](https://dev.mysql.com/doc/refman/8.0/en/clone-plugin.html) to provision new replicas by copying data directly from a donor tablet over the network. Physical-level data copying is significantly faster than logical backup and restore, especially for large datasets. Requires MySQL 8.0.17+ and InnoDB-only tables.
+VTTablet and VTBackup now support using MySQL's native [CLONE plugin](https://dev.mysql.com/doc/refman/en/clone-plugin.html) to provision new replicas by copying data directly from a donor tablet over the network. Physical-level data copying is significantly faster than logical backup and restore, especially for large datasets. Requires MySQL 8.0.17+ and InnoDB-only tables.
 
 **New Flags:**
 
@@ -435,7 +408,7 @@ vtbackup \
 ------------
 The entire changelog for this release can be found [here](https://github.com/vitessio/vitess/blob/main/changelog/24.0/24.0.0/changelog.md).
 
-The release includes 436 merged Pull Requests.
+The release includes 460 merged Pull Requests.
 
 Thanks to all our contributors: @ChaitanyaD48, @Devanshusharma2005, @MargaretMorehead, @anujagrawal380, @aparajon, @app/dependabot, @app/promptless, @app/vitess-bot, @arthurschreiber, @c-r-dev, @chengyuan, @connorolaya, @dasl-, @dbussink, @demmer, @derekperkins, @ejortegau, @esignorelli, @farhann-saleem, @frouioui, @ghostframe, @harshit-gangal, @jdoupe, @khkim6040, @lizztheblizz, @maksimov, @mattlord, @maxenglander, @mcpherrinm, @mcrauwel, @mhamza15, @nickvanw, @pourtorabehsan, @rjlaine, @rvrangel, @sbaker617, @shlomi-noach, @siddharth16396, @stefanb, @stutibiyani, @systay, @tanjinx, @tetsuro-ohyama, @timvaillancourt, @ttran397, @twthorn, @varundeepsaini, @vitess-bot, @yushuqin
 


### PR DESCRIPTION
This Pull Request copies the release notes found on `release-24.0` to keep release notes up-to-date after the `v24.0.0` release.

> This Pull Request is part of https://github.com/vitessio/vitess/issues/19972