### PR TITLE
vtgate: scope schema tracker to an optional keyspace allowlist

### DIFF
--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -334,6 +334,7 @@ Flags:
       --restore-with-clone                                               (init restore parameter) will restore from a clone, requires either --clone-from-primary or --clone-from-tablet, mutually exclusive with --restore-from-backup
       --retain-online-ddl-tables duration                                How long should vttablet keep an old migrated table before purging it (default 24h0m0s)
       --sanitize-log-messages                                            Remove potentially sensitive information in tablet INFO, WARNING, and ERROR log messages such as query parameters.
+      --schema-change-keyspaces string                                   Comma-separated allowlist of keyspaces the schema tracker should follow. If empty, all keyspaces are tracked.
       --schema-change-reload-timeout duration                            query server schema change reload timeout, this is how long to wait for the signaled schema reload operation to complete before giving up (default 30s)
       --schema-change-signal                                             Enable the schema tracker; requires queryserver-config-schema-change-signal to be enabled on the underlying vttablets for this to work (default true)
       --schema-dir string                                                Schema base directory. Should contain one directory per keyspace, with a vschema.json file if necessary.

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -188,6 +188,7 @@ Flags:
       --remote-operation-timeout duration                                time to wait for a remote operation (default 15s)
       --retry-count int                                                  retry count (default 2)
       --reuse-port                                                       Enable SO_REUSEPORT when binding sockets; available on Linux 3.9+ (default false)
+      --schema-change-keyspaces string                                   Comma-separated allowlist of keyspaces the schema tracker should follow. If empty, all keyspaces are tracked.
       --schema-change-signal                                             Enable the schema tracker; requires queryserver-config-schema-change-signal to be enabled on the underlying vttablets for this to work (default true)
       --security-policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --service-map strings                                              comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice

--- a/go/vt/vtgate/schema/tracker.go
+++ b/go/vt/vtgate/schema/tracker.go
@@ -56,6 +56,15 @@ type (
 		tracked      map[keyspaceStr]*updateController
 		consumeDelay time.Duration
 
+		// trackAllKeyspaces is true when no allowlist is configured, in which
+		// case the tracker follows every keyspace it sees. When false, only
+		// keyspaces present in keyspacesToTrackSchemaFor are tracked. The
+		// allowlist exists so deployments with hundreds of keyspaces can avoid
+		// the per-keyspace startup cost of GetAllKeyspaces + LoadKeyspace,
+		// which can otherwise exceed kubelet liveness thresholds.
+		trackAllKeyspaces         bool
+		keyspacesToTrackSchemaFor map[string]bool
+
 		parser *sqlparser.Parser
 	}
 )
@@ -63,15 +72,19 @@ type (
 // defaultConsumeDelay is the default time, the updateController will wait before checking the schema fetch request queue.
 const defaultConsumeDelay = 1 * time.Second
 
-// NewTracker creates the tracker object.
-func NewTracker(ch chan *discovery.TabletHealth, enableViews, enableUDFs bool, parser *sqlparser.Parser) *Tracker {
+// NewTracker creates the tracker object. If keyspacesToTrackSchemaFor is empty
+// or nil, the tracker follows every keyspace; otherwise it follows only the
+// keyspaces in the map.
+func NewTracker(ch chan *discovery.TabletHealth, enableViews, enableUDFs bool, parser *sqlparser.Parser, keyspacesToTrackSchemaFor map[string]bool) *Tracker {
 	t := &Tracker{
-		ctx:          context.Background(),
-		ch:           ch,
-		tables:       &tableMap{m: make(map[keyspaceStr]map[tableNameStr]*vindexes.TableInfo)},
-		tracked:      map[keyspaceStr]*updateController{},
-		consumeDelay: defaultConsumeDelay,
-		parser:       parser,
+		ctx:                       context.Background(),
+		ch:                        ch,
+		tables:                    &tableMap{m: make(map[keyspaceStr]map[tableNameStr]*vindexes.TableInfo)},
+		tracked:                   map[keyspaceStr]*updateController{},
+		consumeDelay:              defaultConsumeDelay,
+		keyspacesToTrackSchemaFor: keyspacesToTrackSchemaFor,
+		trackAllKeyspaces:         len(keyspacesToTrackSchemaFor) == 0,
+		parser:                    parser,
 	}
 
 	if enableViews {
@@ -81,6 +94,16 @@ func NewTracker(ch chan *discovery.TabletHealth, enableViews, enableUDFs bool, p
 		t.udfs = map[keyspaceStr][]string{}
 	}
 	return t
+}
+
+// ShouldTrackKeyspace reports whether the given keyspace should be tracked
+// given the configured allowlist. Returns true when no allowlist is set
+// (the default) or when the keyspace is in the allowlist.
+func (t *Tracker) ShouldTrackKeyspace(keyspace string) bool {
+	if t.trackAllKeyspaces {
+		return true
+	}
+	return t.keyspacesToTrackSchemaFor[keyspace]
 }
 
 // LoadKeyspace loads the keyspace schema.
@@ -197,6 +220,9 @@ func (t *Tracker) Start() {
 				if th == nil {
 					// channel closed
 					return
+				}
+				if !t.ShouldTrackKeyspace(th.Target.Keyspace) {
+					continue
 				}
 				ksUpdater := t.getKeyspaceUpdateController(th)
 				ksUpdater.add(th)

--- a/go/vt/vtgate/schema/tracker_test.go
+++ b/go/vt/vtgate/schema/tracker_test.go
@@ -82,7 +82,7 @@ func TestTrackingUnHealthyTablet(t *testing.T) {
 
 	sbc := sandboxconn.NewSandboxConn(tablet)
 	ch := make(chan *discovery.TabletHealth)
-	tracker := NewTracker(ch, false, false, sqlparser.NewTestParser())
+	tracker := NewTracker(ch, false, false, sqlparser.NewTestParser(), nil)
 	tracker.consumeDelay = 1 * time.Millisecond
 	tracker.Start()
 	defer tracker.Stop()
@@ -136,6 +136,90 @@ func TestTrackingUnHealthyTablet(t *testing.T) {
 	assert.EqualValues(t, 3, sbc.GetSchemaCount.Load())
 }
 
+// TestShouldTrackKeyspace verifies the keyspace allowlist filter applied by
+// both addKeyspacesToTracker (startup loop) and Tracker.Start (channel
+// goroutine). An empty/nil allowlist tracks all keyspaces; a non-empty
+// allowlist filters strictly.
+func TestShouldTrackKeyspace(t *testing.T) {
+	ch := make(chan *discovery.TabletHealth)
+
+	all := NewTracker(ch, false, false, sqlparser.NewTestParser(), map[string]bool{})
+	assert.True(t, all.ShouldTrackKeyspace("anything"), "empty allowlist must track all keyspaces")
+	assert.True(t, all.ShouldTrackKeyspace(""), "empty allowlist must track empty keyspace name too")
+
+	allNil := NewTracker(ch, false, false, sqlparser.NewTestParser(), nil)
+	assert.True(t, allNil.ShouldTrackKeyspace("anything"), "nil allowlist must track all keyspaces")
+
+	filtered := NewTracker(ch, false, false, sqlparser.NewTestParser(), map[string]bool{"allowed": true})
+	assert.True(t, filtered.ShouldTrackKeyspace("allowed"), "listed keyspace must be tracked")
+	assert.False(t, filtered.ShouldTrackKeyspace("blocked"), "non-listed keyspace must be skipped")
+	assert.False(t, filtered.ShouldTrackKeyspace(""), "empty name must not be tracked when allowlist is set")
+}
+
+// TestTrackingFilteredByKeyspace verifies the keyspace allowlist
+// (--schema-change-keyspaces) gates which TabletHealth events the tracker
+// processes.
+func TestTrackingFilteredByKeyspace(t *testing.T) {
+	allowedTarget := &querypb.Target{
+		Keyspace:   "allowed",
+		Shard:      "-80",
+		TabletType: topodatapb.TabletType_PRIMARY,
+		Cell:       cell,
+	}
+	blockedTarget := &querypb.Target{
+		Keyspace:   "blocked",
+		Shard:      "-80",
+		TabletType: topodatapb.TabletType_PRIMARY,
+		Cell:       cell,
+	}
+	allowedTablet := &topodatapb.Tablet{
+		Keyspace: "allowed",
+		Shard:    "-80",
+		Type:     topodatapb.TabletType_PRIMARY,
+	}
+	blockedTablet := &topodatapb.Tablet{
+		Keyspace: "blocked",
+		Shard:    "-80",
+		Type:     topodatapb.TabletType_PRIMARY,
+	}
+
+	allowedConn := sandboxconn.NewSandboxConn(allowedTablet)
+	blockedConn := sandboxconn.NewSandboxConn(blockedTablet)
+	ch := make(chan *discovery.TabletHealth)
+	tracker := NewTracker(ch, false, false, sqlparser.NewTestParser(), map[string]bool{"allowed": true})
+	tracker.consumeDelay = 1 * time.Millisecond
+	tracker.Start()
+	defer tracker.Stop()
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	tracker.RegisterSignalReceiver(func() {
+		wg.Done()
+	})
+
+	// Blocked keyspace event — should be filtered out (no GetSchema, no signal).
+	ch <- &discovery.TabletHealth{
+		Conn:    blockedConn,
+		Tablet:  blockedTablet,
+		Target:  blockedTarget,
+		Serving: true,
+		Stats:   &querypb.RealtimeStats{},
+	}
+	time.Sleep(5 * time.Millisecond)
+	// Allowed keyspace event — should be processed and trigger one signal.
+	ch <- &discovery.TabletHealth{
+		Conn:    allowedConn,
+		Tablet:  allowedTablet,
+		Target:  allowedTarget,
+		Serving: true,
+		Stats:   &querypb.RealtimeStats{},
+	}
+
+	require.False(t, waitTimeout(&wg, 5*time.Second), "expected schema-update signal from allowed keyspace")
+	assert.EqualValues(t, 0, blockedConn.GetSchemaCount.Load(), "blocked keyspace must not trigger GetSchema")
+	assert.GreaterOrEqual(t, allowedConn.GetSchemaCount.Load(), int64(1), "allowed keyspace should have triggered GetSchema")
+}
+
 // TestTrackerGetKeyspaceUpdateController tests table update controller initialization.
 func TestTrackerGetKeyspaceUpdateController(t *testing.T) {
 	ks3 := &updateController{}
@@ -172,7 +256,7 @@ func TestTrackerGetKeyspaceUpdateController(t *testing.T) {
 // TestTrackerNoLock tests that processing of health check is not blocked while tracking is making GetSchema rpc calls.
 func TestTrackerNoLock(t *testing.T) {
 	ch := make(chan *discovery.TabletHealth)
-	tracker := NewTracker(ch, true, false, sqlparser.NewTestParser())
+	tracker := NewTracker(ch, true, false, sqlparser.NewTestParser(), nil)
 	tracker.consumeDelay = 1 * time.Millisecond
 	tracker.Start()
 	defer tracker.Stop()
@@ -528,7 +612,7 @@ type testCases struct {
 
 func testTracker(t *testing.T, enableUDFs bool, schemaDefResult []sandboxconn.SchemaResult, tcases []testCases) {
 	ch := make(chan *discovery.TabletHealth)
-	tracker := NewTracker(ch, true, enableUDFs, sqlparser.NewTestParser())
+	tracker := NewTracker(ch, true, enableUDFs, sqlparser.NewTestParser(), nil)
 	tracker.consumeDelay = 1 * time.Millisecond
 	tracker.Start()
 	defer tracker.Stop()

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -524,7 +524,7 @@ func parseSchemaChangeKeyspaces(raw string) (map[string]bool, error) {
 		return nil, nil
 	}
 	allowlist := map[string]bool{}
-	for _, ks := range strings.Split(raw, ",") {
+	for ks := range strings.SplitSeq(raw, ",") {
 		if ks = strings.TrimSpace(ks); ks != "" {
 			allowlist[ks] = true
 		}

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -404,14 +404,10 @@ func Init(
 	var si SchemaInfo // default nil
 	var st *vtschema.Tracker
 	if enableSchemaChangeSignal {
-		var keyspacesToTrackSchemaFor map[string]bool
-		if schemaChangeKeyspaces != "" {
-			keyspacesToTrackSchemaFor = map[string]bool{}
-			for _, ks := range strings.Split(schemaChangeKeyspaces, ",") {
-				if ks = strings.TrimSpace(ks); ks != "" {
-					keyspacesToTrackSchemaFor[ks] = true
-				}
-			}
+		keyspacesToTrackSchemaFor, err := parseSchemaChangeKeyspaces(schemaChangeKeyspaces)
+		if err != nil {
+			log.Error(fmt.Sprintf("Invalid --schema-change-keyspaces value: %v", err))
+			os.Exit(1)
 		}
 		st = vtschema.NewTracker(gw.hc.Subscribe(schemaTrackerHcName), enableViews, enableUdfs, env.Parser(), keyspacesToTrackSchemaFor)
 		addKeyspacesToTracker(ctx, srvResolver, st, gw)
@@ -516,6 +512,27 @@ func rebuildTopoGraphs(ctx context.Context, topoServer *topo.Server, cell string
 		return vterrors.Wrap(err, "vtgate Init: failed to read SrvVSchema")
 	}
 	return nil
+}
+
+// parseSchemaChangeKeyspaces parses the comma-separated value of
+// --schema-change-keyspaces into an allowlist set. A blank input returns nil
+// (meaning "track all keyspaces"). A non-blank input that contains only
+// whitespace and commas returns an error so a misconfigured flag does not
+// silently fall back to tracking every keyspace.
+func parseSchemaChangeKeyspaces(raw string) (map[string]bool, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	allowlist := map[string]bool{}
+	for _, ks := range strings.Split(raw, ",") {
+		if ks = strings.TrimSpace(ks); ks != "" {
+			allowlist[ks] = true
+		}
+	}
+	if len(allowlist) == 0 {
+		return nil, fmt.Errorf("flag is set but contains no keyspace names: %q", raw)
+	}
+	return allowlist, nil
 }
 
 func addKeyspacesToTracker(ctx context.Context, srvResolver *srvtopo.Resolver, st *vtschema.Tracker, gw *TabletGateway) {

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -164,6 +164,12 @@ var (
 	enableViews              = true
 	enableUdfs               bool
 
+	// schemaChangeKeyspaces is a comma-separated allowlist of keyspaces the
+	// schema tracker should follow. Empty (the default) tracks all keyspaces.
+	// Cells with hundreds of keyspaces can otherwise spend many minutes in
+	// addKeyspacesToTracker on startup, exceeding kubelet liveness thresholds.
+	schemaChangeKeyspaces string
+
 	// vtgate views flags
 	queryTimeout int
 
@@ -209,6 +215,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.Bool("enable-direct-ddl", enableDirectDDL.Default(), "Allow users to submit direct DDL statements")
 	fs.Bool("enable-binlog-dump", enableBinlogDump.Default(), "Allow users to perform binlog dump operations for CDC/replication")
 	utils.SetFlagBoolVar(fs, &enableSchemaChangeSignal, "schema-change-signal", enableSchemaChangeSignal, "Enable the schema tracker; requires queryserver-config-schema-change-signal to be enabled on the underlying vttablets for this to work")
+	utils.SetFlagStringVar(fs, &schemaChangeKeyspaces, "schema-change-keyspaces", schemaChangeKeyspaces, "Comma-separated allowlist of keyspaces the schema tracker should follow. If empty, all keyspaces are tracked.")
 	fs.IntVar(&queryTimeout, "query-timeout", queryTimeout, "Sets the default query timeout (in ms). Can be overridden by session variable (query_timeout) or comment directive (QUERY_TIMEOUT_MS)")
 	utils.SetFlagStringVar(fs, &queryLogToFile, "log-queries-to-file", queryLogToFile, "Enable query logging to the specified file")
 	fs.IntVar(&queryLogBufferSize, "querylog-buffer-size", queryLogBufferSize, "Maximum number of buffered query logs before throttling log output")
@@ -397,7 +404,16 @@ func Init(
 	var si SchemaInfo // default nil
 	var st *vtschema.Tracker
 	if enableSchemaChangeSignal {
-		st = vtschema.NewTracker(gw.hc.Subscribe(schemaTrackerHcName), enableViews, enableUdfs, env.Parser())
+		var keyspacesToTrackSchemaFor map[string]bool
+		if schemaChangeKeyspaces != "" {
+			keyspacesToTrackSchemaFor = map[string]bool{}
+			for _, ks := range strings.Split(schemaChangeKeyspaces, ",") {
+				if ks = strings.TrimSpace(ks); ks != "" {
+					keyspacesToTrackSchemaFor[ks] = true
+				}
+			}
+		}
+		st = vtschema.NewTracker(gw.hc.Subscribe(schemaTrackerHcName), enableViews, enableUdfs, env.Parser(), keyspacesToTrackSchemaFor)
 		addKeyspacesToTracker(ctx, srvResolver, st, gw)
 		si = st
 	}
@@ -512,6 +528,9 @@ func addKeyspacesToTracker(ctx context.Context, srvResolver *srvtopo.Resolver, s
 		log.Info("No keyspace to load")
 	}
 	for _, keyspace := range keyspaces {
+		if !st.ShouldTrackKeyspace(keyspace) {
+			continue
+		}
 		resolveAndLoadKeyspace(ctx, srvResolver, st, gw, keyspace)
 	}
 }

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -1029,3 +1029,62 @@ func TestBinlogDumpGTID(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+// TestParseSchemaChangeKeyspaces covers the parsing of the
+// --schema-change-keyspaces flag value. An unset (empty) value preserves the
+// "track all keyspaces" default by returning a nil allowlist; a populated
+// value returns an allowlist with whitespace trimmed and empty entries
+// dropped; a value that contains only whitespace and/or commas is rejected so
+// a misconfigured flag does not silently fall back to tracking everything.
+func TestParseSchemaChangeKeyspaces(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    map[string]bool
+		wantErr bool
+	}{
+		{
+			name: "empty value tracks all keyspaces",
+			raw:  "",
+			want: nil,
+		},
+		{
+			name: "single keyspace",
+			raw:  "ks1",
+			want: map[string]bool{"ks1": true},
+		},
+		{
+			name: "multiple keyspaces",
+			raw:  "ks1,ks2,ks3",
+			want: map[string]bool{"ks1": true, "ks2": true, "ks3": true},
+		},
+		{
+			name: "trims whitespace and drops empty entries between commas",
+			raw:  " ks1 , ,ks2,",
+			want: map[string]bool{"ks1": true, "ks2": true},
+		},
+		{
+			name:    "whitespace-only value is rejected",
+			raw:     "   ",
+			wantErr: true,
+		},
+		{
+			name:    "commas and whitespace only is rejected",
+			raw:     " , , ,",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseSchemaChangeKeyspaces(tc.raw)
+			if tc.wantErr {
+				require.Error(t, err, "expected an error for input %q", tc.raw)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

The vtgate schema tracker, when enabled, iterates every keyspace returned by `srvResolver.GetAllKeyspaces` on startup and calls `LoadKeyspace` per keyspace with a 5 s timeout. In cells with hundreds of keyspaces this turns startup into a multi-minute blocking loop — well past most kubelet liveness thresholds, which then crashloops the vtgate before tracking is ever ready. The same scaling issue applies to `Tracker.Start()`, which forwards every inbound `TabletHealth` event into the per-keyspace `updateController`.

This PR adds a new vtgate flag, `--schema-change-keyspaces`, taking a comma-separated allowlist of keyspaces to track. Empty (the default) preserves today's behavior — the tracker follows every keyspace it sees. When non-empty, both the startup loop in `addKeyspacesToTracker` and the channel goroutine in `Tracker.Start` skip keyspaces that aren't in the list, which lets operators of large multi-keyspace cells bound startup time to a known set of keyspaces they actually care about tracking.

The change is small (~50 lines in `vtgate.go` and `go/vt/vtgate/schema/tracker.go`) and has no behavior change for users who don't set the flag.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes https://github.com/vitessio/vitess/issues/20007

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
No migrations or special deployments required. The default empty flag maintains existing behavior so using this new feature is opt in by setting the flag on the vtgate

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->

The solution was designed by me with the code implementation primarily written by Claude
