### PR TITLE
test: migrate go/vt/logutil tests to use testify assert/require

### DIFF
--- a/go/vt/logutil/logger_test.go
+++ b/go/vt/logutil/logger_test.go
@@ -20,6 +20,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/race"
 	logutilpb "vitess.io/vitess/go/vt/proto/logutil"
@@ -74,14 +77,12 @@ func TestLogEvent(t *testing.T) {
 	ml := NewMemoryLogger()
 	for i, testValue := range testValues {
 		LogEvent(ml, testValue.event)
-		if got, want := ml.Events[i].Value, testValue.expected; got != want {
-			t.Errorf("ml.Events[%v].Value = %q, want %q", i, got, want)
-		}
+		assert.Equal(t, testValue.expected, ml.Events[i].Value, "ml.Events[%d].Value", i)
 		// Skip the check below if go test -race is run because then the stack
 		// is shifted by one and the test would fail.
 		if !race.Enabled {
-			if got, want := ml.Events[i].File, "logger_test.go"; got != want && ml.Events[i].Level != logutilpb.Level_CONSOLE {
-				t.Errorf("ml.Events[%v].File = %q (line = %v), want %q", i, got, ml.Events[i].Line, want)
+			if ml.Events[i].Level != logutilpb.Level_CONSOLE {
+				assert.Equal(t, "logger_test.go", ml.Events[i].File, "ml.Events[%d].File", i)
 			}
 		}
 	}
@@ -90,26 +91,14 @@ func TestLogEvent(t *testing.T) {
 func TestMemoryLogger(t *testing.T) {
 	ml := NewMemoryLogger()
 	ml.Infof("test %v", 123)
-	if got, want := len(ml.Events), 1; got != want {
-		t.Fatalf("len(ml.Events) = %v, want %v", got, want)
-	}
-	if got, want := ml.Events[0].File, "logger_test.go"; got != want {
-		t.Errorf("ml.Events[0].File = %q, want %q", got, want)
-	}
+	require.Len(t, ml.Events, 1)
+	assert.Equal(t, "logger_test.go", ml.Events[0].File)
 	ml.Warningf("test %v", 456)
-	if got, want := len(ml.Events), 2; got != want {
-		t.Fatalf("len(ml.Events) = %v, want %v", got, want)
-	}
-	if got, want := ml.Events[1].File, "logger_test.go"; got != want {
-		t.Errorf("ml.Events[1].File = %q, want %q", got, want)
-	}
+	require.Len(t, ml.Events, 2)
+	assert.Equal(t, "logger_test.go", ml.Events[1].File)
 	ml.Errorf("test %v", 789)
-	if got, want := len(ml.Events), 3; got != want {
-		t.Fatalf("len(ml.Events) = %v, want %v", got, want)
-	}
-	if got, want := ml.Events[2].File, "logger_test.go"; got != want {
-		t.Errorf("ml.Events[2].File = %q, want %q", got, want)
-	}
+	require.Len(t, ml.Events, 3)
+	assert.Equal(t, "logger_test.go", ml.Events[2].File)
 }
 
 func TestTeeLogger(t *testing.T) {
@@ -131,22 +120,16 @@ func TestTeeLogger(t *testing.T) {
 	wantFile := "logger_test.go"
 
 	for i, events := range [][]*logutilpb.Event{ml1.Events, ml2.Events} {
-		if got, want := len(events), len(wantEvents); got != want {
-			t.Fatalf("[%v] len(events) = %v, want %v", i, got, want)
-		}
+		require.Len(t, events, len(wantEvents), "logger %d", i)
 		for j, got := range events {
 			want := wantEvents[j]
-			if got.Level != want.Level {
-				t.Errorf("[%v] events[%v].Level = %s, want %s", i, j, got.Level, want.Level)
-			}
-			if got.Value != want.Value {
-				t.Errorf("[%v] events[%v].Value = %q, want %q", i, j, got.Value, want.Value)
-			}
+			assert.Equal(t, want.Level, got.Level, "[%d] events[%d].Level", i, j)
+			assert.Equal(t, want.Value, got.Value, "[%d] events[%d].Value", i, j)
 			// Skip the check below if go test -race is run because then the stack
 			// is shifted by one and the test would fail.
 			if !race.Enabled {
-				if got.File != wantFile && got.Level != logutilpb.Level_CONSOLE {
-					t.Errorf("[%v] events[%v].File = %q, want %q", i, j, got.File, wantFile)
+				if got.Level != logutilpb.Level_CONSOLE {
+					assert.Equal(t, wantFile, got.File, "[%d] events[%d].File", i, j)
 				}
 			}
 		}

--- a/go/vt/logutil/logutil_test.go
+++ b/go/vt/logutil/logutil_test.go
@@ -23,6 +23,9 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParsing(t *testing.T) {
@@ -33,21 +36,15 @@ func TestParsing(t *testing.T) {
 
 	for _, filepath := range path {
 		ts, err := parseCreatedTimestamp(filepath)
-		if err != nil {
-			t.Fatalf("parse: %v", err)
-		}
-
-		if want := time.Date(2013, 8, 6, 15, 10, 0o6, 0, time.Now().Location()); ts != want {
-			t.Errorf("timestamp: want %v, got %v", want, ts)
-		}
+		require.NoError(t, err)
+		want := time.Date(2013, 8, 6, 15, 10, 0o6, 0, time.Now().Location())
+		assert.Equal(t, want, ts)
 	}
 }
 
 func TestPurgeByCtime(t *testing.T) {
 	logDir := path.Join(os.TempDir(), fmt.Sprintf("%v-%v", os.Args[0], os.Getpid()))
-	if err := os.MkdirAll(logDir, 0o777); err != nil {
-		t.Fatalf("os.MkdirAll: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(logDir, 0o777))
 	defer os.RemoveAll(logDir)
 
 	now := time.Date(2013, 8, 6, 15, 10, 0o6, 0, time.Now().Location())
@@ -59,49 +56,34 @@ func TestPurgeByCtime(t *testing.T) {
 	}
 
 	for _, file := range files {
-		if _, err := os.Create(path.Join(logDir, file)); err != nil {
-			t.Fatalf("os.Create: %v", err)
-		}
+		_, err := os.Create(path.Join(logDir, file))
+		require.NoError(t, err)
 	}
-	if err := os.Symlink(files[1], path.Join(logDir, "zkocc.INFO")); err != nil {
-		t.Fatalf("os.Symlink: %v", err)
-	}
+	require.NoError(t, os.Symlink(files[1], path.Join(logDir, "zkocc.INFO")))
 
 	purgeLogsOnce(now, logDir, "zkocc", 30*time.Minute, 0)
 
 	left, err := filepath.Glob(path.Join(logDir, "zkocc.*"))
-	if err != nil {
-		t.Fatalf("filepath.Glob: %v", err)
-	}
+	require.NoError(t, err)
 
-	if len(left) != 3 {
-		// 131006 is current
-		// 151006 is within 30 min
-		// symlink remains
-		// the rest should be removed.
-		t.Errorf("wrong number of files remain: want %v, got %v", 3, len(left))
-	}
+	// 131006 is current
+	// 151006 is within 30 min
+	// symlink remains
+	// the rest should be removed.
+	assert.Len(t, left, 3)
 }
 
 func TestPurgeByMtime(t *testing.T) {
 	logDir := path.Join(os.TempDir(), fmt.Sprintf("%v-%v", os.Args[0], os.Getpid()))
-	if err := os.MkdirAll(logDir, 0o777); err != nil {
-		t.Fatalf("os.MkdirAll: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(logDir, 0o777))
 	defer os.RemoveAll(logDir)
 	createFileWithMtime := func(filename, mtimeStr string) {
-		var err error
-		var mtime time.Time
+		mtime, err := time.Parse(time.RFC3339, mtimeStr)
+		require.NoError(t, err)
 		filepath := path.Join(logDir, filename)
-		if mtime, err = time.Parse(time.RFC3339, mtimeStr); err != nil {
-			t.Fatalf("time.Parse: %v", err)
-		}
-		if _, err = os.Create(filepath); err != nil {
-			t.Fatalf("os.Create: %v", err)
-		}
-		if err = os.Chtimes(filepath, mtime, mtime); err != nil {
-			t.Fatalf("os.Chtimes: %v", err)
-		}
+		_, err = os.Create(filepath)
+		require.NoError(t, err)
+		require.NoError(t, os.Chtimes(filepath, mtime, mtime))
 	}
 	now := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC)
 	filenameMtimeMap := map[string]string{
@@ -117,22 +99,16 @@ func TestPurgeByMtime(t *testing.T) {
 	// Create vtadam.INFO symlink to 100000. This is a contrived example in that
 	// current log (100000) is not the latest log (113000). This will not happen
 	// IRL but it helps us test edge cases of purging by mtime.
-	if err := os.Symlink("vtadam.localhost.vitess.log.INFO.20200101-100000.00000", path.Join(logDir, "vtadam.INFO")); err != nil {
-		t.Fatalf("os.Symlink: %v", err)
-	}
+	require.NoError(t, os.Symlink("vtadam.localhost.vitess.log.INFO.20200101-100000.00000", path.Join(logDir, "vtadam.INFO")))
 
 	purgeLogsOnce(now, logDir, "vtadam", 0, 1*time.Hour)
 
 	left, err := filepath.Glob(path.Join(logDir, "vtadam.*"))
-	if err != nil {
-		t.Fatalf("filepath.Glob: %v", err)
-	}
+	require.NoError(t, err)
 
-	if len(left) != 3 {
-		// 1. 113000 is within 1 hour
-		// 2. 100000 is current (vtadam.INFO)
-		// 3. vtadam.INFO symlink remains
-		// rest are removed
-		t.Errorf("wrong number of files remain: want %v, got %v", 3, len(left))
-	}
+	// 1. 113000 is within 1 hour
+	// 2. 100000 is current (vtadam.INFO)
+	// 3. vtadam.INFO symlink remains
+	// rest are removed
+	assert.Len(t, left, 3)
 }

--- a/go/vt/logutil/throttled_test.go
+++ b/go/vt/logutil/throttled_test.go
@@ -20,6 +20,8 @@ import (
 	"log/slog"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func skippedCount(tl *ThrottledLogger) int {
@@ -40,26 +42,14 @@ func TestThrottledLogger(t *testing.T) {
 	start := time.Now()
 
 	go tl.Infof("test %v", 1)
-	if got, want := <-log, "name: test 1"; got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
+	assert.Equal(t, "name: test 1", <-log)
 
 	go tl.Infof("test %v", 2)
-	if got, want := <-log, "name: skipped 1 log messages"; got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
-	if got, want := skippedCount(tl), 0; got != want {
-		t.Errorf("skippedCount is %v but was expecting %v after waiting", got, want)
-	}
-	if got := time.Since(start); got < interval {
-		t.Errorf("didn't wait long enough before logging, got %v, want >= %v", got, interval)
-	}
+	assert.Equal(t, "name: skipped 1 log messages", <-log)
+	assert.Equal(t, 0, skippedCount(tl), "skippedCount after waiting")
+	assert.GreaterOrEqual(t, time.Since(start), interval, "should have waited at least one interval")
 
 	go tl.Infof("test %v", 3)
-	if got, want := <-log, "name: test 3"; got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
-	if got, want := skippedCount(tl), 0; got != want {
-		t.Errorf("skippedCount is %v but was expecting %v", got, want)
-	}
+	assert.Equal(t, "name: test 3", <-log)
+	assert.Equal(t, 0, skippedCount(tl))
 }


### PR DESCRIPTION
Replaces raw `t.Errorf`/`t.Fatalf` calls with testify `assert`/`require`
in the three remaining test files under `go/vt/logutil/`:

- `logger_test.go` - 12 assertions converted
- `logutil_test.go` - 14 assertions converted
- `throttled_test.go` - 6 assertions converted

`console_logger_test.go` already uses testify, so this completes the
migration for the package.

`require` is used for checks that would make subsequent assertions
meaningless on failure (length checks, error checks). `assert` is
used for value comparisons that don't block further testing.

Part of #15182