### PR TITLE
vtgate: register routing-rule synthesized BaseTables in ks.Tables

### DIFF
--- a/go/vt/vtgate/planbuilder/issue19986_test.go
+++ b/go/vt/vtgate/planbuilder/issue19986_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/vschemawrapper"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtenv"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+)
+
+// TestIssue19986CrossKeyspaceJoinStarExpansion reproduces issue #19986:
+// `SELECT a.* FROM table_a a JOIN table_b b ON ...` over two unsharded
+// keyspaces with empty `tables: {}` in vschema and routing rules pointing
+// at the per-keyspace tables. The planner relies on the schema tracker to
+// supply columns for the routed tables.
+//
+// Before the fix in buildRoutingRule, the routing rule's BaseTable was a
+// distinct pointer from ks.Tables[name], so schema-tracker columns landed
+// on a different pointer and the routing rule kept a non-authoritative
+// placeholder. Cross-keyspace JOIN with `t.*` then failed with VT09015.
+func TestIssue19986CrossKeyspaceJoinStarExpansion(t *testing.T) {
+	parser := sqlparser.NewTestParser()
+
+	srcVSchema := &vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{
+			"main": {Sharded: false},
+			"ks_a": {Sharded: false},
+			"ks_b": {Sharded: false},
+		},
+		RoutingRules: &vschemapb.RoutingRules{
+			Rules: []*vschemapb.RoutingRule{
+				{FromTable: "table_a", ToTables: []string{"ks_a.table_a"}},
+				{FromTable: "table_b", ToTables: []string{"ks_b.table_b"}},
+			},
+		},
+	}
+
+	vschema := vindexes.BuildVSchema(srcVSchema, parser)
+
+	// Simulate the schema tracker: mutate the existing BaseTables that
+	// buildRoutingRule registered into ks.Tables. With the fix, the routing
+	// rule references the same pointer, so this propagates.
+	populate := func(ks, tbl string, cols []vindexes.Column) {
+		t.Helper()
+		bt := vschema.Keyspaces[ks].Tables[tbl]
+		require.NotNil(t, bt, "table %s.%s not registered in ks.Tables", ks, tbl)
+		bt.Columns = cols
+		bt.ColumnListAuthoritative = true
+	}
+	populate("ks_a", "table_a", []vindexes.Column{
+		{Name: sqlparser.NewIdentifierCI("id"), Type: querypb.Type_INT64},
+		{Name: sqlparser.NewIdentifierCI("fk"), Type: querypb.Type_INT64},
+		{Name: sqlparser.NewIdentifierCI("name"), Type: querypb.Type_VARCHAR},
+	})
+	populate("ks_b", "table_b", []vindexes.Column{
+		{Name: sqlparser.NewIdentifierCI("id"), Type: querypb.Type_INT64},
+		{Name: sqlparser.NewIdentifierCI("label"), Type: querypb.Type_VARCHAR},
+	})
+
+	env := vtenv.NewTestEnv()
+	vw, err := vschemawrapper.NewVschemaWrapper(env, vschema, TestBuilder)
+	require.NoError(t, err)
+
+	queries := []string{
+		"select a.* from table_a a limit 1",
+		"select b.* from table_b b limit 1",
+		"select a.id, b.label from table_a a join table_b b on a.fk = b.id",
+		"select a.* from table_a a join table_b b on a.fk = b.id",
+	}
+	for _, q := range queries {
+		t.Run(q, func(t *testing.T) {
+			_, err := TestBuilder(q, vw, vw.CurrentDb())
+			assert.NoError(t, err, "query failed: %s", q)
+		})
+	}
+}

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -1114,12 +1114,21 @@ outer:
 				}
 				continue outer
 			}
-			// FindTable can synthesize a BaseTable for an unsharded keyspace's
-			// missing table without storing it in ks.Tables. Persist it there so
-			// that later schema-tracker updates via setColumns mutate the same
-			// pointer the routing rule references; otherwise the rule keeps a
-			// stale, non-authoritative copy and `t.*` expansion fails for
-			// cross-keyspace JOINs (issue #19986).
+			// FindTable synthesizes a placeholder BaseTable for an unsharded
+			// keyspace's missing table and does not store it in ks.Tables.
+			// The planner reads Columns / ColumnListAuthoritative off of the
+			// routing rule's pointer when expanding `t.*` for cross-keyspace
+			// JOINs, so we have to make sure the rule references whatever
+			// pointer the schema tracker's setColumns will update -- which is
+			// ks.Tables[name]. Register t there if no entry exists yet.
+			//
+			// Other call sites that go through FindTable with the same
+			// "construct unsharded if not found" path (buildMirrorRule's
+			// to-table, resolveAutoIncrement's sequence lookup, the FK parent
+			// lookup in updateTableInfo) do not currently need this: their
+			// downstream consumers only read Keyspace.Name / Name, not column
+			// metadata. If a future consumer starts depending on that, lift
+			// this into a shared helper. See issue #19986.
 			if t != nil && t.Keyspace != nil {
 				if ks := vschema.Keyspaces[t.Keyspace.Name]; ks != nil {
 					if _, exists := ks.Tables[t.Name.String()]; !exists {

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -1114,6 +1114,19 @@ outer:
 				}
 				continue outer
 			}
+			// FindTable can synthesize a BaseTable for an unsharded keyspace's
+			// missing table without storing it in ks.Tables. Persist it there so
+			// that later schema-tracker updates via setColumns mutate the same
+			// pointer the routing rule references; otherwise the rule keeps a
+			// stale, non-authoritative copy and `t.*` expansion fails for
+			// cross-keyspace JOINs (issue #19986).
+			if t != nil && t.Keyspace != nil {
+				if ks := vschema.Keyspaces[t.Keyspace.Name]; ks != nil {
+					if _, exists := ks.Tables[t.Name.String()]; !exists {
+						ks.Tables[t.Name.String()] = t
+					}
+				}
+			}
 			rr.Tables = append(rr.Tables, t)
 		}
 		vschema.RoutingRules[rule.FromTable] = rr

--- a/go/vt/vtgate/vindexes/vschema_routing_test.go
+++ b/go/vt/vtgate/vindexes/vschema_routing_test.go
@@ -637,3 +637,47 @@ func TestRoutingRuleSynthesizedTableRegisteredInKeyspace(t *testing.T) {
 	assert.True(t, rrA.Tables[0].ColumnListAuthoritative)
 	assert.Len(t, rrA.Tables[0].Columns, 1)
 }
+
+// TestRoutingRuleSynthesizedTableAddedToGlobalTables verifies that the
+// synthesized BaseTable registered in ks.Tables by buildRoutingRule (fix for
+// issue #19986) is subsequently picked up by AddAdditionalGlobalTables, making
+// the table globally routable even before the schema tracker has populated
+// column metadata. Before the fix, ks.Tables had no entry, so
+// AddAdditionalGlobalTables would not find the table.
+func TestRoutingRuleSynthesizedTableAddedToGlobalTables(t *testing.T) {
+	parser := sqlparser.NewTestParser()
+	source := &vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{
+			"ks_a": {Sharded: false},
+			"ks_b": {Sharded: false},
+		},
+		RoutingRules: &vschemapb.RoutingRules{
+			Rules: []*vschemapb.RoutingRule{
+				{FromTable: "table_a", ToTables: []string{"ks_a.table_a"}},
+			},
+		},
+	}
+
+	vs := BuildVSchema(source, parser)
+
+	// The fix must have registered the synthesized BaseTable in ks.Tables.
+	require.NotNil(t, vs.Keyspaces["ks_a"].Tables["table_a"],
+		"synthesized BaseTable must be in ks.Tables after buildRoutingRule")
+
+	// With two keyspaces and no explicit vschema entry, the table is not yet
+	// in globalTables after BuildVSchema alone (buildGlobalTables ran before
+	// buildRoutingRule synthesized the entry). FindTable with no keyspace must
+	// fail.
+	_, err := vs.FindTable("", "table_a")
+	require.Error(t, err, "table_a should not be in globalTables before AddAdditionalGlobalTables")
+
+	// Simulate what buildAndEnhanceVSchema does next: populate globalTables
+	// from ks.Tables.
+	AddAdditionalGlobalTables(source, vs)
+
+	// Now the synthesized entry must be globally routable.
+	tbl, err := vs.FindTable("", "table_a")
+	require.NoError(t, err)
+	require.NotNil(t, tbl)
+	assert.Equal(t, "ks_a", tbl.Keyspace.Name)
+}

--- a/go/vt/vtgate/vindexes/vschema_routing_test.go
+++ b/go/vt/vtgate/vindexes/vschema_routing_test.go
@@ -594,3 +594,46 @@ func TestFindRoutedViewQualifiedLookupIgnoresUnqualifiedRules(t *testing.T) {
 	require.Nil(t, routedName, "qualified lookup should not match unqualified view rule")
 	assert.Equal(t, sqlparser.String(sourceView), sqlparser.String(view))
 }
+
+// TestRoutingRuleSynthesizedTableRegisteredInKeyspace verifies the fix for
+// issue #19986: when a routing rule targets an unsharded keyspace's missing
+// table, FindTable synthesizes a placeholder BaseTable. buildRoutingRule must
+// register that pointer in ks.Tables so that any later mutation of the table
+// (e.g. schema-tracker setColumns) is observed by the routing rule's reference.
+func TestRoutingRuleSynthesizedTableRegisteredInKeyspace(t *testing.T) {
+	parser := sqlparser.NewTestParser()
+	source := &vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{
+			"ks_a": {Sharded: false},
+			"ks_b": {Sharded: false},
+		},
+		RoutingRules: &vschemapb.RoutingRules{
+			Rules: []*vschemapb.RoutingRule{
+				{FromTable: "table_a", ToTables: []string{"ks_a.table_a"}},
+				{FromTable: "table_b", ToTables: []string{"ks_b.table_b"}},
+			},
+		},
+	}
+
+	vs := BuildVSchema(source, parser)
+
+	rrA := vs.RoutingRules["table_a"]
+	require.NotNil(t, rrA)
+	require.Len(t, rrA.Tables, 1)
+	require.Same(t, vs.Keyspaces["ks_a"].Tables["table_a"], rrA.Tables[0],
+		"routing rule and ks.Tables should share the same BaseTable pointer")
+
+	rrB := vs.RoutingRules["table_b"]
+	require.NotNil(t, rrB)
+	require.Len(t, rrB.Tables, 1)
+	require.Same(t, vs.Keyspaces["ks_b"].Tables["table_b"], rrB.Tables[0])
+
+	// Mutating the keyspace's BaseTable in place should be reflected in the
+	// routing rule, since they reference the same pointer. This is what makes
+	// schema-tracker setColumns "just work" for routing-rule-only setups.
+	tbl := vs.Keyspaces["ks_a"].Tables["table_a"]
+	tbl.Columns = []Column{{Name: sqlparser.NewIdentifierCI("id")}}
+	tbl.ColumnListAuthoritative = true
+	assert.True(t, rrA.Tables[0].ColumnListAuthoritative)
+	assert.Len(t, rrA.Tables[0].Columns, 1)
+}

--- a/go/vt/vtgate/vschema_manager_test.go
+++ b/go/vt/vtgate/vschema_manager_test.go
@@ -1076,6 +1076,98 @@ func TestViewRoutingRulesRebuild(t *testing.T) {
 	assert.Equal(t, "v1", vs.ViewRoutingRules["source_ks.v1"].TargetViewName)
 }
 
+// TestRoutingRulesAuthoritativeAfterSchemaTracker covers issue #19986:
+// when both keyspaces have empty vschema and rely on routing rules + the
+// schema tracker, the routing rule's BaseTable must end up authoritative
+// after the tracker populates columns. Otherwise cross-keyspace JOINs with
+// `t.*` fail with VT09015.
+func TestRoutingRulesAuthoritativeAfterSchemaTracker(t *testing.T) {
+	colsA := []vindexes.Column{
+		{Name: sqlparser.NewIdentifierCI("id"), Type: querypb.Type_INT64},
+		{Name: sqlparser.NewIdentifierCI("fk"), Type: querypb.Type_INT64},
+	}
+	colsB := []vindexes.Column{
+		{Name: sqlparser.NewIdentifierCI("id"), Type: querypb.Type_INT64},
+		{Name: sqlparser.NewIdentifierCI("label"), Type: querypb.Type_VARCHAR},
+	}
+
+	srvVSchema := &vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{
+			"ks_a": {Sharded: false},
+			"ks_b": {Sharded: false},
+		},
+		RoutingRules: &vschemapb.RoutingRules{
+			Rules: []*vschemapb.RoutingRule{
+				{FromTable: "table_a", ToTables: []string{"ks_a.table_a"}},
+				{FromTable: "table_b", ToTables: []string{"ks_b.table_b"}},
+			},
+		},
+	}
+
+	check := func(t *testing.T, vs *vindexes.VSchema, wantAColAuthoritative, wantBColAuthoritative bool) {
+		t.Helper()
+		rrA := vs.RoutingRules["table_a"]
+		require.NotNil(t, rrA)
+		require.Len(t, rrA.Tables, 1)
+		assert.Equal(t, wantAColAuthoritative, rrA.Tables[0].ColumnListAuthoritative,
+			"routing rule for table_a authoritative state")
+		rrB := vs.RoutingRules["table_b"]
+		require.NotNil(t, rrB)
+		require.Len(t, rrB.Tables, 1)
+		assert.Equal(t, wantBColAuthoritative, rrB.Tables[0].ColumnListAuthoritative,
+			"routing rule for table_b authoritative state")
+	}
+
+	t.Run("tracker populated when VSchemaUpdate fires", func(t *testing.T) {
+		vm := &VSchemaManager{}
+		var vs *vindexes.VSchema
+		vm.subscriber = func(vschema *vindexes.VSchema, _ *VSchemaStats) {
+			vs = vschema
+			vs.ResetCreated()
+		}
+		vm.schema = &fakeSchema{
+			tables: map[string]map[string]*vindexes.TableInfo{
+				"ks_a": {"table_a": {Columns: colsA}},
+				"ks_b": {"table_b": {Columns: colsB}},
+			},
+		}
+
+		vm.VSchemaUpdate(srvVSchema, nil)
+		check(t, vs, true, true)
+	})
+
+	t.Run("tracker populates one keyspace late via Rebuild", func(t *testing.T) {
+		vm := &VSchemaManager{}
+		var vs *vindexes.VSchema
+		vm.subscriber = func(vschema *vindexes.VSchema, _ *VSchemaStats) {
+			vs = vschema
+			vs.ResetCreated()
+		}
+
+		// Tracker is empty when SrvVSchema first arrives (e.g. tablets not
+		// yet healthy at startup). Both routing rules synthesize placeholder
+		// BaseTables; neither is authoritative.
+		tracker := &fakeSchema{}
+		vm.schema = tracker
+		vm.VSchemaUpdate(srvVSchema, nil)
+		check(t, vs, false, false)
+
+		// Tracker subsequently picks up ks_a only; ks_b stays unknown.
+		tracker.tables = map[string]map[string]*vindexes.TableInfo{
+			"ks_a": {"table_a": {Columns: colsA}},
+		}
+		vm.Rebuild()
+		check(t, vs, true, false)
+
+		// Then ks_b is also tracked.
+		tracker.tables["ks_b"] = map[string]*vindexes.TableInfo{
+			"table_b": {Columns: colsB},
+		}
+		vm.Rebuild()
+		check(t, vs, true, true)
+	})
+}
+
 // testView creates a simple view selecting from the given table.
 func testView(tableName string) *sqlparser.Select {
 	return &sqlparser.Select{


### PR DESCRIPTION
## Description

Fixes a bug where `select t.* from . t join . u on ...` fails with `VT09015: schema tracking required` when both keyspaces have empty `tables: {}` in their vschema and rely on routing rules + the schema tracker.

The fix is in `buildRoutingRule`: when `vschema.FindTable` synthesizes a placeholder `BaseTable` for an unsharded keyspace's missing table (because the user's vschema is empty), register that pointer in `ks.Tables[name]`. That way there is exactly one `BaseTable` per `(keyspace, table)`, and the schema tracker's `setColumns` mutates the same pointer the routing rule references — so column updates are observed regardless of when/whether `RebuildRoutingRules` re-runs.

Without this fix, `setColumns` was creating a separate authoritative `BaseTable` and the routing rule kept the original non-authoritative placeholder. `RebuildRoutingRules` is supposed to fix it up, but it leaves things stale in cases where the tracker hasn't populated the keyspace yet, or returns transiently empty during a reload. Standalone `t.*` keeps working because that query gets pushed wholesale to MySQL; only the cross-keyspace JOIN exposes the issue, since the planner has to expand `*` at vtgate.

I think this is worth back-porting to the active release branches.

## Related Issue(s)

Fixes #19986

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

No flags, schema, or topology changes.

There are two related behavior changes:

**1. Routing rule's `BaseTable` is now registered in `KeyspaceSchema.Tables`.**
Previously, when a routing rule targeted a table not explicitly listed in a keyspace's vschema, `buildRoutingRule` synthesized a placeholder `BaseTable` but did not store it anywhere in `ks.Tables`. Now it does. This is what the fix actually corrects — it ensures the schema tracker and the routing rule share a single pointer, so column updates are visible to the planner.

**2. Synthesized tables become globally routable earlier in startup.**
As a consequence of (1), `AddAdditionalGlobalTables` (called in `buildAndEnhanceVSchema`) now finds the synthesized entry in `ks.Tables` and adds it to `globalTables`. Before this fix, the entry wasn't there yet at that point, so `AddAdditionalGlobalTables` would not add it — the table was only reachable via the routing rule lookup path. After the fix, the table is reachable via both paths.

For unsharded keyspaces without `require_explicit_routing`, the routing behavior is unchanged in practice: `FindRoutedTable` checks routing rules before falling back to `globalTables`, so the routing rule still wins. The only observable difference is that the table now appears in `globalTables` from the moment routing rules are built, rather than only after the schema tracker has populated column metadata. `TestRoutingRuleSynthesizedTableAddedToGlobalTables` covers this case.

### AI Disclosure

Most of the diagnosis, fix, tests, and PR description were written by Claude Code under my direction.