### PR TITLE
CI: Deflake TestMonitorClearAllData, TestDemotePrimaryStalled, and TestMonitorWriteBlocked

### DIFF
--- a/go/vt/vttablet/tabletmanager/semisyncmonitor/monitor.go
+++ b/go/vt/vttablet/tabletmanager/semisyncmonitor/monitor.go
@@ -416,7 +416,7 @@ func (m *Monitor) clearAllData() {
 		return
 	}
 	defer conn.Recycle()
-	_, _, err = conn.Conn.ExecuteFetchMulti(m.addLockWaitTimeout(m.bindSideCarDBName(semiSyncHeartbeatClear)), 0, false)
+	err = conn.Conn.ExecuteFetchMultiDrain(m.addLockWaitTimeout(m.bindSideCarDBName(semiSyncHeartbeatClear)))
 	if err != nil {
 		m.errorCount.Add(1)
 		log.Error(fmt.Sprintf("SemiSync Monitor: failed to clear semisync_heartbeat table: %v", err))

--- a/go/vt/vttablet/tabletmanager/semisyncmonitor/monitor_test.go
+++ b/go/vt/vttablet/tabletmanager/semisyncmonitor/monitor_test.go
@@ -669,8 +669,14 @@ func TestMonitorWriteBlocked(t *testing.T) {
 	db.AddQuery("INSERT INTO _vt.semisync_heartbeat (ts) VALUES (NOW())", &sqltypes.Result{})
 	// Block the INSERT so we have a deterministic window in which write() is in
 	// progress; otherwise the goroutine can complete before the assertion below
-	// observes inProgressWriteCount > 0 on a busy CI runner.
+	// observes inProgressWriteCount > 0 on a busy CI runner. release() is
+	// idempotent and registered with t.Cleanup so a require.* failure can't
+	// leave the INSERT goroutine wedged inside BeforeFunc and deadlock
+	// db.Close() during teardown.
 	unblock := make(chan struct{})
+	var unblockOnce sync.Once
+	release := func() { unblockOnce.Do(func() { close(unblock) }) }
+	t.Cleanup(release)
 	db.SetBeforeFunc("INSERT INTO _vt.semisync_heartbeat (ts) VALUES (NOW())", func() {
 		<-unblock
 	})
@@ -691,7 +697,7 @@ func TestMonitorWriteBlocked(t *testing.T) {
 	}, 15*time.Second, time.Millisecond)
 
 	// Let the INSERT proceed and check that the write finished successfully.
-	close(unblock)
+	release()
 	require.Eventually(t, func() bool {
 		return writeFinished.Load()
 	}, 10*time.Second, 100*time.Millisecond)

--- a/go/vt/vttablet/tabletmanager/semisyncmonitor/monitor_test.go
+++ b/go/vt/vttablet/tabletmanager/semisyncmonitor/monitor_test.go
@@ -665,28 +665,33 @@ func TestMonitorWriteBlocked(t *testing.T) {
 	m.mu.Unlock()
 
 	// ExecuteFetchMulti will execute each statement separately, so we need to add SET query and INSERT query.
-	// Add them multiple times so the writes can execute.
-	for range maxWritesPermitted {
-		db.AddQuery("SET SESSION lock_wait_timeout=1", &sqltypes.Result{})
-		db.AddQuery("INSERT INTO _vt.semisync_heartbeat (ts) VALUES (NOW())", &sqltypes.Result{})
-	}
+	db.AddQuery("SET SESSION lock_wait_timeout=1", &sqltypes.Result{})
+	db.AddQuery("INSERT INTO _vt.semisync_heartbeat (ts) VALUES (NOW())", &sqltypes.Result{})
+	// Block the INSERT so we have a deterministic window in which write() is in
+	// progress; otherwise the goroutine can complete before the assertion below
+	// observes inProgressWriteCount > 0 on a busy CI runner.
+	unblock := make(chan struct{})
+	db.SetBeforeFunc("INSERT INTO _vt.semisync_heartbeat (ts) VALUES (NOW())", func() {
+		<-unblock
+	})
 
-	// Do a write, which we expect to block.
+	// Do a write, which we expect to block on the INSERT.
 	var writeFinished atomic.Bool
 	go func() {
 		m.write()
 		writeFinished.Store(true)
 	}()
 
-	// We should see the number of writers increase briefly, before it completes.
+	// We should see the number of writers increase while the INSERT is blocked.
 	require.Zero(t, m.errorCount.Get())
 	require.Eventually(t, func() bool {
 		m.mu.Lock()
 		defer m.mu.Unlock()
 		return m.inProgressWriteCount > 0
-	}, 15*time.Second, 1*time.Microsecond)
+	}, 15*time.Second, time.Millisecond)
 
-	// Check that the writes finished successfully.
+	// Let the INSERT proceed and check that the write finished successfully.
+	close(unblock)
 	require.Eventually(t, func() bool {
 		return writeFinished.Load()
 	}, 10*time.Second, 100*time.Millisecond)

--- a/go/vt/vttablet/tabletserver/state_manager_test.go
+++ b/go/vt/vttablet/tabletserver/state_manager_test.go
@@ -658,7 +658,6 @@ func TestStateManagerNotify(t *testing.T) {
 
 func TestDemotePrimaryStalled(t *testing.T) {
 	sm := newTestStateManager()
-	defer sm.StopService()
 	err := sm.SetServingType(topodatapb.TabletType_PRIMARY, testNow, StateServing, "")
 	require.NoError(t, err)
 	// Stopping the ticker so that we don't get unexpected health streams.
@@ -673,7 +672,16 @@ func TestDemotePrimaryStalled(t *testing.T) {
 		})
 		assert.Contains(t, err.Error(), "tabletserver is shutdown")
 	})
+	// Order matters: StopService cancels the streamer's context, which lets
+	// Stream return so wg.Wait can complete. Defers run LIFO.
 	defer wg.Wait()
+	defer sm.StopService()
+
+	// register() pushes the current state onto the channel as soon as the
+	// streaming client subscribes, and that value is racy with respect to
+	// SetServingType's async Broadcast trigger. Drain it so the assertions
+	// below only inspect states produced by our explicit Broadcast calls.
+	<-ch
 
 	// Send a broadcast message and check we have no error there.
 	sm.Broadcast()
@@ -688,9 +696,6 @@ func TestDemotePrimaryStalled(t *testing.T) {
 	// Verify that we can't start a new request once we have a demote primary stalled.
 	err = sm.StartRequest(context.Background(), &querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}, false)
 	require.ErrorContains(t, err, "operation not allowed in state NOT_SERVING")
-
-	// Stop the state manager.
-	sm.StopService()
 }
 
 func TestRefreshReplHealthLocked(t *testing.T) {


### PR DESCRIPTION
## Description

Three unit tests were intermittently failing on CI with high parallelism
(`VT_GO_PARALLEL_VALUE=$(nproc)`):

- `TestMonitorClearAllData`
- `TestDemotePrimaryStalled`
- `TestMonitorWriteBlocked`

One of the three is fixed by a real production change; the other two are
test-only races.

## What's changed

### `go/vt/vttablet/tabletmanager/semisyncmonitor/monitor.go` (production)

`clearAllData` issued
`"SET SESSION lock_wait_timeout=5;TRUNCATE TABLE _vt.semisync_heartbeat"`
as a multi-statement, but called `ExecuteFetchMulti(..., 0, false)` while
discarding the `more` return value. That only reads the FIRST result —
the second OK packet was left unread on the pooled connection, where the
next user of that connection would read it as the response to a different
query.

Switch to `ExecuteFetchMultiDrain`, matching the existing write path on
line 379:

```diff
-       _, _, err = conn.Conn.ExecuteFetchMulti(m.addLockWaitTimeout(m.bindSideCarDBName(semiSyncHeartbeatClear)), 0, false)
+       err = conn.Conn.ExecuteFetchMultiDrain(m.addLockWaitTimeout(m.bindSideCarDBName(semiSyncHeartbeatClear)))
```

This is a production fix. The test flake (`TestMonitorClearAllData`
failing with `"... does not contain "truncate table _vt.semisync_heartbeat""`)
is a side effect of the same bug: under CPU contention, the server's
`handleComQuery` goroutine could be descheduled between the two queries,
the 100 ms buffered-writer flush timer fires and ships the SET's response
early, the client's `ExecuteFetchMulti` returns, and the test reads
`db.QueryLog()` before the server has logged the TRUNCATE. Draining
forces the client to wait for both responses, which forces the server to
finish processing both queries first.

### `go/vt/vttablet/tabletserver/state_manager_test.go`

`TestDemotePrimaryStalled` had two interrelated bugs:

1. **Race against `register()`.** `health_streamer.register()` pushes
   `hs.state.CloneVT()` onto the client channel the moment a stream
   subscribes. The state's initial `HealthError = "tabletserver
   uninitialized"` is only cleared by a `Broadcast()`. The test relied on
   its own explicit `Broadcast()` running before the streaming goroutine
   reached `register()`, but on faster CI the streaming goroutine often
   wins and the first `<-ch` reads the uninit state — failing
   `require.Empty(...)`.

2. **Defer ordering deadlock.** `defer wg.Wait()` was queued before
   `defer sm.StopService()`. On `t.FailNow`, defers unwind LIFO:
   `wg.Wait()` ran first and blocked waiting for `Stream()` to return,
   but `Stream()` only returns once `StopService()` cancels the
   streamer's context. Result: deadlock until the package's 10-minute
   timeout, which also took down the rest of the `tabletserver` package
   run.

The fix:

- Drain the initial registration state (`<-ch`) once before any
  assertion. The drained value's content is racy and we don't care about
  it; subsequent reads then only reflect states produced by our own
  explicit `Broadcast()` calls.
- Swap the defer order so `sm.StopService()` runs before `wg.Wait()` on
  cleanup, ensuring `Stream()` can return even on test failure.
- Remove the now-redundant trailing `sm.StopService()` and the leading
  `defer sm.StopService()` (replaced by the new defer pair).

### `go/vt/vttablet/tabletmanager/semisyncmonitor/monitor_test.go`

`TestMonitorWriteBlocked` called `m.write()` in a goroutine and then
polled for the transient `m.inProgressWriteCount > 0` state. Under
fakesqldb the write path
(`incrementWriteCount → ExecuteFetchMultiDrain → decrementWriteCount`)
completes in sub-millisecond time, so on a CI runner under load the
polling goroutine could be descheduled for the entire write lifetime and
never observe the count being non-zero. The test name says "WriteBlocked"
but nothing was actually blocking the write.

The fix uses fakesqldb's `SetBeforeFunc` to gate the INSERT on a channel,
so the write goroutine actually blocks while the test observes the
in-progress state, then closes the channel to let the write complete:

```go
unblock := make(chan struct{})
db.SetBeforeFunc("INSERT INTO _vt.semisync_heartbeat (ts) VALUES (NOW())", func() {
    <-unblock
})
go func() { m.write(); writeFinished.Store(true) }()
require.Eventually(t, func() bool {
    m.mu.Lock()
    defer m.mu.Unlock()
    return m.inProgressWriteCount > 0
}, 15*time.Second, time.Millisecond)
close(unblock)
```

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/20017

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

### AI Disclosure

I worked with Claude and Opus-4.7 on this.