### PR TITLE
vtgate: regression tests for routing-rule + schema-tracker `t.*` expansion

### DIFF
--- a/go/test/endtoend/vtgate/schematracker/multi_ks_routing/routing_rules.json
+++ b/go/test/endtoend/vtgate/schematracker/multi_ks_routing/routing_rules.json
@@ -1,0 +1,12 @@
+{
+  "rules": [
+    {
+      "from_table": "table_a",
+      "to_tables": ["ks_a.table_a"]
+    },
+    {
+      "from_table": "table_b",
+      "to_tables": ["ks_b.table_b"]
+    }
+  ]
+}

--- a/go/test/endtoend/vtgate/schematracker/multi_ks_routing/routing_test.go
+++ b/go/test/endtoend/vtgate/schematracker/multi_ks_routing/routing_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -44,6 +45,9 @@ var (
 	//go:embed schema_b.sql
 	schemaB string
 
+	//go:embed vschema.json
+	emptyVSchema string
+
 	//go:embed routing_rules.json
 	routingRules string
 )
@@ -61,13 +65,16 @@ func TestMain(m *testing.M) {
 		}
 
 		// Two unsharded keyspaces, each with a single table on the tablet but
-		// EMPTY vschema (the schema tracker is the only source of column info).
-		ka := &cluster.Keyspace{Name: ksA, SchemaSQL: schemaA}
+		// an explicit empty vschema (the schema tracker is the only source of
+		// column info). The vschema is set explicitly rather than left to a
+		// default so the test always pins down the routing-rules-only +
+		// schema-tracker scenario regardless of vtctld defaults.
+		ka := &cluster.Keyspace{Name: ksA, SchemaSQL: schemaA, VSchema: emptyVSchema}
 		if err := clusterInstance.StartUnshardedKeyspace(*ka, 0, false, cell); err != nil {
 			fmt.Println(err)
 			return 1
 		}
-		kb := &cluster.Keyspace{Name: ksB, SchemaSQL: schemaB}
+		kb := &cluster.Keyspace{Name: ksB, SchemaSQL: schemaB, VSchema: emptyVSchema}
 		if err := clusterInstance.StartUnshardedKeyspace(*kb, 0, false, cell); err != nil {
 			fmt.Println(err)
 			return 1
@@ -85,6 +92,10 @@ func TestMain(m *testing.M) {
 		// vtgate runs with --schema-change-signal=true by default; the schema
 		// tracker is what populates columns for ks_a.table_a and ks_b.table_b.
 		if err := clusterInstance.StartVtgate(); err != nil {
+			fmt.Println(err)
+			return 1
+		}
+		if err := clusterInstance.WaitForVTGateAndVTTablets(time.Minute); err != nil {
 			fmt.Println(err)
 			return 1
 		}

--- a/go/test/endtoend/vtgate/schematracker/multi_ks_routing/routing_test.go
+++ b/go/test/endtoend/vtgate/schematracker/multi_ks_routing/routing_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multiksrouting
+
+import (
+	"context"
+	_ "embed"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/utils"
+)
+
+var (
+	clusterInstance *cluster.LocalProcessCluster
+	vtParams        mysql.ConnParams
+	cell            = "zone1"
+	ksA             = "ks_a"
+	ksB             = "ks_b"
+
+	//go:embed schema_a.sql
+	schemaA string
+
+	//go:embed schema_b.sql
+	schemaB string
+
+	//go:embed routing_rules.json
+	routingRules string
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	exitCode := func() int {
+		clusterInstance = cluster.NewCluster(cell, "localhost")
+		defer clusterInstance.Teardown()
+
+		if err := clusterInstance.StartTopo(); err != nil {
+			fmt.Println(err)
+			return 1
+		}
+
+		// Two unsharded keyspaces, each with a single table on the tablet but
+		// EMPTY vschema (the schema tracker is the only source of column info).
+		ka := &cluster.Keyspace{Name: ksA, SchemaSQL: schemaA}
+		if err := clusterInstance.StartUnshardedKeyspace(*ka, 0, false, cell); err != nil {
+			fmt.Println(err)
+			return 1
+		}
+		kb := &cluster.Keyspace{Name: ksB, SchemaSQL: schemaB}
+		if err := clusterInstance.StartUnshardedKeyspace(*kb, 0, false, cell); err != nil {
+			fmt.Println(err)
+			return 1
+		}
+
+		if err := clusterInstance.VtctldClientProcess.ApplyRoutingRules(routingRules); err != nil {
+			fmt.Println(err)
+			return 1
+		}
+		if err := clusterInstance.VtctldClientProcess.ExecuteCommand("RebuildVSchemaGraph"); err != nil {
+			fmt.Println(err)
+			return 1
+		}
+
+		// vtgate runs with --schema-change-signal=true by default; the schema
+		// tracker is what populates columns for ks_a.table_a and ks_b.table_b.
+		if err := clusterInstance.StartVtgate(); err != nil {
+			fmt.Println(err)
+			return 1
+		}
+
+		vtParams = mysql.ConnParams{
+			Host: clusterInstance.Hostname,
+			Port: clusterInstance.VtgateMySQLPort,
+		}
+		return m.Run()
+	}()
+	os.Exit(exitCode)
+}
+
+// TestRoutedTableColumnsAreAuthoritativeForStarExpansion exercises the case
+// where two unsharded keyspaces have empty `tables: {}` in vschema and rely
+// entirely on routing rules + the schema tracker to make their tables
+// queryable. Once the tracker has reported columns for each routed table,
+// the planner has to treat those columns as authoritative so it can expand
+// `t.*` for queries it executes at vtgate.
+//
+// We cover four query shapes:
+//   - `t.*` against each routed table (single-Route push-down),
+//   - a cross-keyspace JOIN with explicit columns (no `*` expansion),
+//   - a cross-keyspace JOIN with `t.*` qualified to one side (forces
+//     vtgate-side expansion of the qualified `*`).
+//
+// All four should plan and return the seeded rows.
+func TestRoutedTableColumnsAreAuthoritativeForStarExpansion(t *testing.T) {
+	conn, err := mysql.Connect(context.Background(), &vtParams)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Wait until the schema tracker has reported columns for both routed
+	// tables. We poll the published vschema rather than retrying the query
+	// itself so a transient `table not found` doesn't get conflated with the
+	// authoritativeness bug we're actually testing.
+	waitForColumns := func(ks, tbl string, want int) {
+		t.Helper()
+		utils.WaitForVschemaCondition(t, clusterInstance.VtgateProcess, ks,
+			func(t *testing.T, keyspace map[string]any) bool {
+				tables, ok := keyspace["tables"].(map[string]any)
+				if !ok {
+					return false
+				}
+				table, ok := tables[tbl].(map[string]any)
+				if !ok {
+					return false
+				}
+				cols, ok := table["columns"].([]any)
+				return ok && len(cols) >= want
+			}, fmt.Sprintf("%s.%s columns not yet tracked", ks, tbl))
+	}
+	waitForColumns(ksA, "table_a", 3)
+	waitForColumns(ksB, "table_b", 2)
+
+	// Seed two matching rows on each side so the JOINs actually return data
+	// and we can verify execution, not just planning.
+	utils.Exec(t, conn, "use @primary")
+	utils.Exec(t, conn, "insert into table_a (id, fk, name) values (1, 10, 'alice'), (2, 20, 'bob')")
+	utils.Exec(t, conn, "insert into table_b (id, label) values (10, 'ten'), (20, 'twenty')")
+
+	tcases := []struct {
+		name   string
+		query  string
+		expect string
+	}{{
+		name:   "star against routed unsharded table on ks_a",
+		query:  "select a.* from table_a a where a.id = 1",
+		expect: `[[INT32(1) INT32(10) VARCHAR("alice")]]`,
+	}, {
+		name:   "star against routed unsharded table on ks_b",
+		query:  "select b.* from table_b b where b.id = 10",
+		expect: `[[INT32(10) VARCHAR("ten")]]`,
+	}, {
+		name:   "cross-keyspace join, explicit columns",
+		query:  "select a.id, b.label from table_a a join table_b b on a.fk = b.id order by a.id",
+		expect: `[[INT32(1) VARCHAR("ten")] [INT32(2) VARCHAR("twenty")]]`,
+	}, {
+		// The JOIN can't be pushed to a single MySQL, so the planner has to
+		// expand `a.*` at vtgate using the columns the tracker reported for
+		// the routing rule's target table.
+		name:   "cross-keyspace join, star qualified to one side",
+		query:  "select a.* from table_a a join table_b b on a.fk = b.id order by a.id",
+		expect: `[[INT32(1) INT32(10) VARCHAR("alice")] [INT32(2) INT32(20) VARCHAR("bob")]]`,
+	}}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			qr, err := utils.ExecAllowError(t, conn, tc.query)
+			require.NoErrorf(t, err, "query failed: %s", tc.query)
+			require.Equalf(t, tc.expect, fmt.Sprintf("%v", qr.Rows), "unexpected result for %s", tc.query)
+		})
+	}
+}

--- a/go/test/endtoend/vtgate/schematracker/multi_ks_routing/schema_a.sql
+++ b/go/test/endtoend/vtgate/schematracker/multi_ks_routing/schema_a.sql
@@ -1,0 +1,5 @@
+CREATE TABLE table_a (
+    id INT NOT NULL PRIMARY KEY,
+    fk INT,
+    name VARCHAR(64)
+);

--- a/go/test/endtoend/vtgate/schematracker/multi_ks_routing/schema_b.sql
+++ b/go/test/endtoend/vtgate/schematracker/multi_ks_routing/schema_b.sql
@@ -1,0 +1,4 @@
+CREATE TABLE table_b (
+    id INT NOT NULL PRIMARY KEY,
+    label VARCHAR(64)
+);

--- a/go/test/endtoend/vtgate/schematracker/multi_ks_routing/vschema.json
+++ b/go/test/endtoend/vtgate/schematracker/multi_ks_routing/vschema.json
@@ -1,0 +1,4 @@
+{
+  "sharded": false,
+  "tables": {}
+}

--- a/go/vt/vtgate/planbuilder/routed_cross_keyspace_test.go
+++ b/go/vt/vtgate/planbuilder/routed_cross_keyspace_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/vschemawrapper"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtenv"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+)
+
+// TestRoutedCrossKeyspaceJoinStarExpansion exercises the planner against a
+// routing-rule-only setup: two unsharded keyspaces with empty `tables: {}`
+// in vschema, routing rules redirecting unqualified names at per-keyspace
+// tables, and authoritative columns installed afterwards (as the schema
+// tracker would in production).
+//
+// All four query shapes must plan:
+//   - `select t.*` against either routed table -- single-Route push-down.
+//   - cross-keyspace JOIN with explicit columns -- no `*` expansion needed.
+//   - cross-keyspace JOIN with `t.*` qualified to one side -- the planner
+//     expands the qualified `*` at vtgate using the routing rule's
+//     BaseTable, which has to be authoritative.
+//
+// We replicate what `vschema_manager` does in production by installing
+// authoritative BaseTables into `ks.Tables` (matching `setColumns`) and
+// calling `RebuildRoutingRules` so each rule's `Tables[0]` picks up the new
+// pointer.
+func TestRoutedCrossKeyspaceJoinStarExpansion(t *testing.T) {
+	parser := sqlparser.NewTestParser()
+
+	srcVSchema := &vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{
+			"main": {Sharded: false},
+			"ks_a": {Sharded: false},
+			"ks_b": {Sharded: false},
+		},
+		RoutingRules: &vschemapb.RoutingRules{
+			Rules: []*vschemapb.RoutingRule{
+				{FromTable: "table_a", ToTables: []string{"ks_a.table_a"}},
+				{FromTable: "table_b", ToTables: []string{"ks_b.table_b"}},
+			},
+		},
+	}
+
+	vschema := vindexes.BuildVSchema(srcVSchema, parser)
+
+	// Stand in for the schema tracker: install authoritative BaseTables in
+	// `ks.Tables`, then re-resolve routing rules so each rule's `Tables[0]`
+	// points at those entries (matching what `buildAndEnhanceVSchema` does
+	// once the tracker reports columns).
+	populate := func(ks, tbl string, cols []vindexes.Column) {
+		t.Helper()
+		ksSchema := vschema.Keyspaces[ks]
+		require.NotNil(t, ksSchema)
+		ksSchema.Tables[tbl] = &vindexes.BaseTable{
+			Name:                    sqlparser.NewIdentifierCS(tbl),
+			Keyspace:                ksSchema.Keyspace,
+			Columns:                 cols,
+			ColumnListAuthoritative: true,
+		}
+	}
+	populate("ks_a", "table_a", []vindexes.Column{
+		{Name: sqlparser.NewIdentifierCI("id"), Type: querypb.Type_INT64},
+		{Name: sqlparser.NewIdentifierCI("fk"), Type: querypb.Type_INT64},
+		{Name: sqlparser.NewIdentifierCI("name"), Type: querypb.Type_VARCHAR},
+	})
+	populate("ks_b", "table_b", []vindexes.Column{
+		{Name: sqlparser.NewIdentifierCI("id"), Type: querypb.Type_INT64},
+		{Name: sqlparser.NewIdentifierCI("label"), Type: querypb.Type_VARCHAR},
+	})
+	vindexes.RebuildRoutingRules(srcVSchema, vschema, parser)
+
+	env := vtenv.NewTestEnv()
+	vw, err := vschemawrapper.NewVschemaWrapper(env, vschema, TestBuilder)
+	require.NoError(t, err)
+
+	queries := []string{
+		"select a.* from table_a a limit 1",
+		"select b.* from table_b b limit 1",
+		"select a.id, b.label from table_a a join table_b b on a.fk = b.id",
+		"select a.* from table_a a join table_b b on a.fk = b.id",
+	}
+	for _, q := range queries {
+		t.Run(q, func(t *testing.T) {
+			_, err := TestBuilder(q, vw, vw.CurrentDb())
+			assert.NoError(t, err, "query failed: %s", q)
+		})
+	}
+}

--- a/go/vt/vtgate/vschema_manager_test.go
+++ b/go/vt/vtgate/vschema_manager_test.go
@@ -1112,18 +1112,27 @@ func TestRoutingRulesAuthoritativeAfterSchemaTracker(t *testing.T) {
 		},
 	}
 
+	checkRule := func(t *testing.T, rr *vindexes.RoutingRule, wantAuthoritative bool, wantCols []vindexes.Column, label string) {
+		t.Helper()
+		require.NotNil(t, rr, label)
+		require.Len(t, rr.Tables, 1, label)
+		tbl := rr.Tables[0]
+		assert.Equal(t, wantAuthoritative, tbl.ColumnListAuthoritative, "%s authoritative state", label)
+		if !wantAuthoritative {
+			// When the rule is non-authoritative the routing rule's BaseTable is
+			// still a placeholder; columns aren't expected.
+			return
+		}
+		require.Len(t, tbl.Columns, len(wantCols), "%s column count", label)
+		for i, want := range wantCols {
+			assert.Equal(t, want.Name.String(), tbl.Columns[i].Name.String(),
+				"%s column[%d] name", label, i)
+		}
+	}
 	check := func(t *testing.T, vs *vindexes.VSchema, wantAColAuthoritative, wantBColAuthoritative bool) {
 		t.Helper()
-		rrA := vs.RoutingRules["table_a"]
-		require.NotNil(t, rrA)
-		require.Len(t, rrA.Tables, 1)
-		assert.Equal(t, wantAColAuthoritative, rrA.Tables[0].ColumnListAuthoritative,
-			"routing rule for table_a authoritative state")
-		rrB := vs.RoutingRules["table_b"]
-		require.NotNil(t, rrB)
-		require.Len(t, rrB.Tables, 1)
-		assert.Equal(t, wantBColAuthoritative, rrB.Tables[0].ColumnListAuthoritative,
-			"routing rule for table_b authoritative state")
+		checkRule(t, vs.RoutingRules["table_a"], wantAColAuthoritative, colsA, "routing rule for table_a")
+		checkRule(t, vs.RoutingRules["table_b"], wantBColAuthoritative, colsB, "routing rule for table_b")
 	}
 
 	t.Run("tracker populated when VSchemaUpdate fires", func(t *testing.T) {

--- a/go/vt/vtgate/vschema_manager_test.go
+++ b/go/vt/vtgate/vschema_manager_test.go
@@ -1076,6 +1076,106 @@ func TestViewRoutingRulesRebuild(t *testing.T) {
 	assert.Equal(t, "v1", vs.ViewRoutingRules["source_ks.v1"].TargetViewName)
 }
 
+// TestRoutingRulesAuthoritativeAfterSchemaTracker pins down the invariant
+// the planner relies on for routing-rule-only setups: once the schema
+// tracker has reported columns for a routed table, the routing rule's
+// BaseTable has `ColumnListAuthoritative=true` and carries the tracked
+// columns, so the planner can expand `t.*` against it. Two shapes:
+//
+//   - tracker has data for every keyspace at `VSchemaUpdate` time: every
+//     rule is authoritative right after the first build.
+//   - tracker is initially empty and fills in keyspace-by-keyspace across
+//     successive `Rebuild` calls: each rule flips to authoritative the
+//     first time the rebuild sees columns for its target keyspace, and
+//     rules whose target keyspace is still untracked remain non-
+//     authoritative.
+func TestRoutingRulesAuthoritativeAfterSchemaTracker(t *testing.T) {
+	colsA := []vindexes.Column{
+		{Name: sqlparser.NewIdentifierCI("id"), Type: querypb.Type_INT64},
+		{Name: sqlparser.NewIdentifierCI("fk"), Type: querypb.Type_INT64},
+	}
+	colsB := []vindexes.Column{
+		{Name: sqlparser.NewIdentifierCI("id"), Type: querypb.Type_INT64},
+		{Name: sqlparser.NewIdentifierCI("label"), Type: querypb.Type_VARCHAR},
+	}
+
+	srvVSchema := &vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{
+			"ks_a": {Sharded: false},
+			"ks_b": {Sharded: false},
+		},
+		RoutingRules: &vschemapb.RoutingRules{
+			Rules: []*vschemapb.RoutingRule{
+				{FromTable: "table_a", ToTables: []string{"ks_a.table_a"}},
+				{FromTable: "table_b", ToTables: []string{"ks_b.table_b"}},
+			},
+		},
+	}
+
+	check := func(t *testing.T, vs *vindexes.VSchema, wantAColAuthoritative, wantBColAuthoritative bool) {
+		t.Helper()
+		rrA := vs.RoutingRules["table_a"]
+		require.NotNil(t, rrA)
+		require.Len(t, rrA.Tables, 1)
+		assert.Equal(t, wantAColAuthoritative, rrA.Tables[0].ColumnListAuthoritative,
+			"routing rule for table_a authoritative state")
+		rrB := vs.RoutingRules["table_b"]
+		require.NotNil(t, rrB)
+		require.Len(t, rrB.Tables, 1)
+		assert.Equal(t, wantBColAuthoritative, rrB.Tables[0].ColumnListAuthoritative,
+			"routing rule for table_b authoritative state")
+	}
+
+	t.Run("tracker populated when VSchemaUpdate fires", func(t *testing.T) {
+		vm := &VSchemaManager{}
+		var vs *vindexes.VSchema
+		vm.subscriber = func(vschema *vindexes.VSchema, _ *VSchemaStats) {
+			vs = vschema
+			vs.ResetCreated()
+		}
+		vm.schema = &fakeSchema{
+			tables: map[string]map[string]*vindexes.TableInfo{
+				"ks_a": {"table_a": {Columns: colsA}},
+				"ks_b": {"table_b": {Columns: colsB}},
+			},
+		}
+
+		vm.VSchemaUpdate(srvVSchema, nil)
+		check(t, vs, true, true)
+	})
+
+	t.Run("tracker populates one keyspace late via Rebuild", func(t *testing.T) {
+		vm := &VSchemaManager{}
+		var vs *vindexes.VSchema
+		vm.subscriber = func(vschema *vindexes.VSchema, _ *VSchemaStats) {
+			vs = vschema
+			vs.ResetCreated()
+		}
+
+		// Tracker is empty when SrvVSchema first arrives (e.g. tablets not
+		// yet healthy at startup). Both routing rules synthesize placeholder
+		// BaseTables; neither is authoritative.
+		tracker := &fakeSchema{}
+		vm.schema = tracker
+		vm.VSchemaUpdate(srvVSchema, nil)
+		check(t, vs, false, false)
+
+		// Tracker subsequently picks up ks_a only; ks_b stays unknown.
+		tracker.tables = map[string]map[string]*vindexes.TableInfo{
+			"ks_a": {"table_a": {Columns: colsA}},
+		}
+		vm.Rebuild()
+		check(t, vs, true, false)
+
+		// Then ks_b is also tracked.
+		tracker.tables["ks_b"] = map[string]*vindexes.TableInfo{
+			"table_b": {Columns: colsB},
+		}
+		vm.Rebuild()
+		check(t, vs, true, true)
+	})
+}
+
 // testView creates a simple view selecting from the given table.
 func testView(tableName string) *sqlparser.Select {
 	return &sqlparser.Select{

--- a/test/config.json
+++ b/test/config.json
@@ -1315,6 +1315,18 @@
       "Tags": [],
       "Needs": []
     },
+    "vtgate_schematracker_multi_ks_routing": {
+      "File": "unused.go",
+      "Packages": [
+        "vitess.io/vitess/go/test/endtoend/vtgate/schematracker/multi_ks_routing"
+      ],
+      "Args": [],
+      "Command": [],
+      "Manual": false,
+      "Shard": "vtgate_schema_tracker",
+      "Tags": [],
+      "Needs": []
+    },
     "vtgate_mysql84": {
       "File": "unused.go",
       "Packages": [


### PR DESCRIPTION
## Description

Adds three layers of test coverage that pin down the contract behind issue #19986: for an empty-vschema + routing-rules + schema-tracker setup, the planner can expand `t.*` against routed tables (including in cross-keyspace JOINs that vtgate has to plan itself).

The behavior these tests cover already works on `main` thanks to the `RebuildRoutingRules` call added in #19104. This PR just locks it in so a future change in this area gets caught early. The same fix is being backported to `release-23.0` separately in #20014.

### What's covered

- **vindexes-level / vschema_manager-level** (`TestRoutingRulesAuthoritativeAfterSchemaTracker` in `vschema_manager_test.go`): once the tracker reports columns for a routed table, the routing rule's `Tables[0]` carries those columns and `ColumnListAuthoritative=true`. Two subtests cover "tracker has data when `VSchemaUpdate` fires" and "tracker fills in keyspace-by-keyspace across `Rebuild` calls".
- **planbuilder-level** (`routed_cross_keyspace_test.go`): cross-keyspace JOINs with `t.*` qualified to one side plan against a vschema where authoritative `BaseTables` were installed in `ks.Tables` after build (mimicking what `vschema_manager` does after `setColumns`).
- **end-to-end** (`schematracker/multi_ks_routing/`): real cluster with two unsharded keyspaces (empty `tables: {}`), routing rules redirecting unqualified names at the per-keyspace tables, default schema tracker. Runs four query shapes — `t.*` against each routed table, cross-keyspace JOIN with explicit columns, cross-keyspace JOIN with `t.*` qualified to one side — and verifies the results.

The e2e test is wired into the existing `vtgate_schema_tracker` CI shard via `test/config.json`.

## Related Issue(s)

Refs #19986

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Tests-only change.

### AI Disclosure

Most of the test code and PR description were written by Claude Code under my direction.
