### PR TITLE
ci: add per-step timeouts to fail fast on apt/registry hangs

### DIFF
--- a/.github/workflows/check_make_vtadmin_authz_testgen.yml
+++ b/.github/workflows/check_make_vtadmin_authz_testgen.yml
@@ -50,6 +50,7 @@ jobs:
 
     - name: Tune the OS
       if: steps.changes.outputs.vtadmin_changes == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Set up Go
@@ -61,6 +62,7 @@ jobs:
 
     - name: Get dependencies
       if: steps.changes.outputs.vtadmin_changes == 'true'
+      timeout-minutes: 5
       run: |
         sudo apt-get update
         sudo apt-get install -y make unzip g++ etcd-client etcd-server curl git wget
@@ -70,6 +72,7 @@ jobs:
 
     - name: Run make minimaltools
       if: steps.changes.outputs.vtadmin_changes == 'true'
+      timeout-minutes: 5
       run: |
         make minimaltools
 

--- a/.github/workflows/check_make_vtadmin_web_proto.yml
+++ b/.github/workflows/check_make_vtadmin_web_proto.yml
@@ -33,6 +33,7 @@ jobs:
         persist-credentials: 'false'
 
     - name: Tune the OS
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Check for changes in relevant files

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -138,20 +138,24 @@ jobs:
 
       - name: Tune the OS
         if: steps.changes.outputs.end_to_end == 'true'
+        timeout-minutes: 5
         uses: ./.github/actions/tune-os
 
       - name: Setup MySQL
         if: steps.changes.outputs.end_to_end == 'true' && !contains(matrix.needs, 'xtrabackup')
+        timeout-minutes: 8
         uses: ./.github/actions/setup-mysql
         with:
           flavor: mysql-8.4
 
       - name: Setup Percona Apt repository
         if: steps.changes.outputs.end_to_end == 'true' && contains(matrix.needs, 'xtrabackup')
+        timeout-minutes: 5
         uses: ./.github/actions/setup-percona-repo
 
       - name: Setup Percona Server and XtraBackup
         if: steps.changes.outputs.end_to_end == 'true' && contains(matrix.needs, 'xtrabackup')
+        timeout-minutes: 5
         run: |
           sudo percona-release setup pdps8.0
           sudo percona-release setup pxb-80
@@ -178,10 +182,12 @@ jobs:
 
       - name: Install Minio
         if: steps.changes.outputs.end_to_end == 'true' && contains(matrix.needs, 'minio')
+        timeout-minutes: 5
         uses: ./.github/actions/setup-minio
 
       - name: Install Consul and ZooKeeper
         if: steps.changes.outputs.end_to_end == 'true' && contains(matrix.needs, 'consul')
+        timeout-minutes: 5
         run: make BUILD_PROTOC=0 tools
 
       - name: Setup launchable dependencies

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -111,16 +111,19 @@ jobs:
 
     - name: Tune the OS
       if: steps.mode.outputs.is_full_run == 'true' || (steps.changes.outputs.changed_files == 'true' && steps.packages.outputs.packages != '')
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Setup MySQL
       if: steps.mode.outputs.is_full_run == 'true' || (steps.changes.outputs.changed_files == 'true' && steps.packages.outputs.packages != '')
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.4
 
     - name: Get dependencies
       if: steps.mode.outputs.is_full_run == 'true' || (steps.changes.outputs.changed_files == 'true' && steps.packages.outputs.packages != '')
+      timeout-minutes: 5
       run: |
         export DEBIAN_FRONTEND="noninteractive"
         sudo apt-get update
@@ -132,6 +135,7 @@ jobs:
 
     - name: Run make tools
       if: steps.mode.outputs.is_full_run == 'true' || (steps.changes.outputs.changed_files == 'true' && steps.packages.outputs.packages != '')
+      timeout-minutes: 10
       run: |
         make BUILD_JAVA=0 BUILD_PROTOC=0 tools
 

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -43,10 +43,12 @@ jobs:
           cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
       - name: Tune the OS
+        timeout-minutes: 5
         uses: ./.github/actions/tune-os
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
+        timeout-minutes: 5
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           languages: ${{ matrix.language }}
@@ -58,6 +60,7 @@ jobs:
           # queries: security-extended,security-and-quality
 
       - name: Setup MySQL
+        timeout-minutes: 8
         uses: ./.github/actions/setup-mysql
         with:
           flavor: mysql-8.4
@@ -79,6 +82,7 @@ jobs:
           make build
 
       - name: Perform CodeQL Analysis
+        timeout-minutes: 15
         uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
 
       - name: Slack Workflow Notification

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -35,9 +35,11 @@ jobs:
         cache: 'false'
 
     - name: Tune the OS
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Get dependencies
+      timeout-minutes: 5
       run: |
         sudo apt-get update
         sudo apt-get install -y make ruby ruby-dev

--- a/.github/workflows/docker_build_images.yml
+++ b/.github/workflows/docker_build_images.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Build and push on main
         if: startsWith(github.ref, 'refs/tags/') == false
+        timeout-minutes: 15
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -68,6 +69,7 @@ jobs:
 
       - name: Build and push on tags
         if: startsWith(github.ref, 'refs/tags/')
+        timeout-minutes: 15
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -107,6 +109,7 @@ jobs:
 
       - name: Build and push on main
         if: startsWith(github.ref, 'refs/tags/') == false
+        timeout-minutes: 15
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -132,6 +135,7 @@ jobs:
 
       - name: Build and push on tags
         if: startsWith(github.ref, 'refs/tags/')
+        timeout-minutes: 15
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -170,6 +174,7 @@ jobs:
 
       - name: Build and push on main latest tag
         if: startsWith(github.ref, 'refs/tags/') == false && matrix.debian == 'bookworm'
+        timeout-minutes: 15
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: ${{ env.DOCKER_CTX }}
@@ -181,6 +186,7 @@ jobs:
 
       - name: Build and push on main debian specific tag
         if: startsWith(github.ref, 'refs/tags/') == false
+        timeout-minutes: 15
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: ${{ env.DOCKER_CTX }}
@@ -213,6 +219,7 @@ jobs:
       # Build and Push component image to DOCKER_TAG, applies to both debian version
       - name: Build and push on tags using Debian extension
         if: startsWith(github.ref, 'refs/tags/')
+        timeout-minutes: 15
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: ${{ env.DOCKER_CTX }}
@@ -226,6 +233,7 @@ jobs:
       # It is fine to build a second time here when "matrix.debian == 'bookworm'" as we have cached the first build already
       - name: Build and push on tags without Debian extension
         if: startsWith(github.ref, 'refs/tags/') && matrix.debian == 'bookworm'
+        timeout-minutes: 15
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: ${{ env.DOCKER_CTX }}

--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -69,6 +69,7 @@ jobs:
 
       - name: Build bootstrap images
         if: steps.changes.outputs.end_to_end == 'true'
+        timeout-minutes: 15
         uses: ./.github/actions/build-bootstrap
         with:
           bootstrap-version: ${{ env.BOOTSTRAP_VERSION }}
@@ -83,9 +84,11 @@ jobs:
 
       - name: Tune the OS
         if: steps.changes.outputs.end_to_end == 'true'
+        timeout-minutes: 5
         uses: ./.github/actions/tune-os
 
       - name: Run docker tests - ${{ matrix.shard }}
         if: steps.changes.outputs.end_to_end == 'true'
+        timeout-minutes: 20
         run: |
           go run test.go -docker=true -pull=false -flavor=${{ env.BOOTSTRAP_FLAVOR }} -bootstrap-version=${{ env.BOOTSTRAP_VERSION }} --follow -shard ${{ matrix.shard }}

--- a/.github/workflows/docker_lite_build_check.yml
+++ b/.github/workflows/docker_lite_build_check.yml
@@ -57,6 +57,7 @@ jobs:
           persist-credentials: 'false'
 
       - name: Build lite image
+        timeout-minutes: 15
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -59,16 +59,19 @@ jobs:
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Setup MySQL
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.4
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         sudo apt-get update
         
@@ -81,6 +84,7 @@ jobs:
 
     - name: Run make minimaltools
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         make minimaltools
 

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -59,16 +59,19 @@ jobs:
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Setup MySQL
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.0
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         sudo apt-get update
         sudo apt-get install -y make unzip g++ etcd-client etcd-server curl git wget
@@ -79,11 +82,13 @@ jobs:
 
     - name: Run make minimaltools
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         make minimaltools
 
     - name: Build
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 10
       run: |
         NOVTADMINBUILD=1 make build
 

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -63,6 +63,7 @@ jobs:
 
     - name: Build bootstrap images
       if: steps.changes.outputs.examples == 'true'
+      timeout-minutes: 15
       uses: ./.github/actions/build-bootstrap
 
     - name: Set up Go
@@ -74,20 +75,24 @@ jobs:
 
     - name: Tune the OS
       if: steps.changes.outputs.examples == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Get dependencies
       if: steps.changes.outputs.examples == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
     - name: Run make minimaltools
       if: steps.changes.outputs.examples == 'true'
+      timeout-minutes: 5
       run: |
         make minimaltools
 
     - name: Build
       if: steps.changes.outputs.examples == 'true'
+      timeout-minutes: 10
       run: |
         make build
 

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -63,6 +63,7 @@ jobs:
 
     - name: Build bootstrap images
       if: steps.changes.outputs.examples == 'true'
+      timeout-minutes: 15
       uses: ./.github/actions/build-bootstrap
 
     - name: Set up Go
@@ -74,20 +75,24 @@ jobs:
 
     - name: Tune the OS
       if: steps.changes.outputs.examples == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Get dependencies
       if: steps.changes.outputs.examples == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
     - name: Run make minimaltools
       if: steps.changes.outputs.examples == 'true'
+      timeout-minutes: 5
       run: |
         make minimaltools
 
     - name: Build
       if: steps.changes.outputs.examples == 'true'
+      timeout-minutes: 10
       run: |
         make build
 

--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -35,6 +35,7 @@ jobs:
           persist-credentials: 'false'
 
       - name: Run FOSSA scan and upload build data
+        timeout-minutes: 5
         uses: fossa-contrib/fossa-action@3d2ef181b1820d6dcd1972f86a767d18167fa19b # v3.0.1
         with:
           # This is a push-only API token: https://github.com/fossa-contrib/fossa-action#push-only-api-token
@@ -129,10 +130,12 @@ jobs:
 
       - name: Tune the OS
         if: steps.changes.outputs.go_files == 'true'
+        timeout-minutes: 5
         uses: ./.github/actions/tune-os
 
       - name: Get dependencies
         if: (steps.changes.outputs.parser_changes == 'true' || steps.changes.outputs.go_files == 'true')
+        timeout-minutes: 5
         run: |
           sudo apt-get update
           sudo apt-get install -y make unzip g++ etcd-client etcd-server curl git wget
@@ -141,6 +144,7 @@ jobs:
 
       - name: Run make minimaltools
         if: (steps.changes.outputs.parser_changes == 'true' || steps.changes.outputs.go_files == 'true')
+        timeout-minutes: 5
         run: |
           make minimaltools
 
@@ -193,6 +197,7 @@ jobs:
 
       - name: Run golangci-lint
         if: steps.changes.outputs.go_files == 'true'
+        timeout-minutes: 15
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.0.0
         with:
           args: --timeout 10m

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -123,16 +123,19 @@ jobs:
 
       - name: Tune the OS
         if: steps.changes.outputs.unit_tests == 'true'
+        timeout-minutes: 5
         uses: ./.github/actions/tune-os
 
       - name: Setup MySQL
         if: steps.changes.outputs.unit_tests == 'true'
+        timeout-minutes: 8
         uses: ./.github/actions/setup-mysql
         with:
           flavor: ${{ matrix.flavor }}
 
       - name: Get dependencies
         if: steps.changes.outputs.unit_tests == 'true'
+        timeout-minutes: 5
         run: |
           export DEBIAN_FRONTEND="noninteractive"
           sudo apt-get install -y make unzip g++ curl git wget ${{ matrix.java && 'ant default-jre-headless' || '' }}
@@ -142,6 +145,7 @@ jobs:
 
       - name: Run make tools
         if: steps.changes.outputs.unit_tests == 'true'
+        timeout-minutes: 10
         run: |
           make BUILD_JAVA=${{ matrix.java && '1' || '0' }} BUILD_PROTOC=0 tools
 

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -69,6 +69,7 @@ jobs:
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Set up python
@@ -77,12 +78,14 @@ jobs:
 
     - name: Setup MySQL
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.4
 
     - name: Setup Percona Apt repository
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/setup-percona-repo
 
     - name: Get base dependencies
@@ -119,6 +122,7 @@ jobs:
 
     - name: Get dependencies for the last release
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
@@ -148,6 +152,7 @@ jobs:
 
     - name: Get dependencies for this commit
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -71,6 +71,7 @@ jobs:
 
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Set up python
@@ -79,12 +80,14 @@ jobs:
 
     - name: Setup MySQL
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.4
 
     - name: Setup Percona Apt repository
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/setup-percona-repo
 
     - name: Get base dependencies
@@ -120,6 +123,7 @@ jobs:
 
     - name: Get dependencies for the next release
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
@@ -149,6 +153,7 @@ jobs:
 
     - name: Get dependencies for this commit
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -75,6 +75,7 @@ jobs:
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Set up python
@@ -83,12 +84,14 @@ jobs:
 
     - name: Setup MySQL
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.4
 
     - name: Setup Percona Apt repository
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/setup-percona-repo
 
     - name: Get base dependencies
@@ -124,6 +127,7 @@ jobs:
 
     - name: Get dependencies for the last release
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
@@ -153,11 +157,13 @@ jobs:
 
     - name: Get dependencies for this commit
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
     - name: Run make minimaltools
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         make minimaltools
 

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -75,6 +75,7 @@ jobs:
 
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Set up python
@@ -83,12 +84,14 @@ jobs:
 
     - name: Setup MySQL
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.4
 
     - name: Setup Percona Apt repository
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/setup-percona-repo
 
     - name: Get base dependencies
@@ -124,6 +127,7 @@ jobs:
 
     - name: Get dependencies for the next release
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
@@ -153,11 +157,13 @@ jobs:
 
     - name: Get dependencies for this commit
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
     - name: Run make minimaltools
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         make minimaltools
 

--- a/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
+++ b/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
@@ -82,6 +82,7 @@ jobs:
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Set up python
@@ -90,6 +91,7 @@ jobs:
 
     - name: Setup MySQL
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.4
@@ -122,6 +124,7 @@ jobs:
 
     - name: Get dependencies for the last release
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
@@ -153,6 +156,7 @@ jobs:
 
     - name: Get dependencies for the next release
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
@@ -183,6 +187,7 @@ jobs:
 
     - name: Get dependencies for this commit
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -73,6 +73,7 @@ jobs:
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Set up python
@@ -81,6 +82,7 @@ jobs:
 
     - name: Setup MySQL
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.4
@@ -99,6 +101,7 @@ jobs:
     # Build current commit's binaries
     - name: Get dependencies for this commit
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
@@ -129,6 +132,7 @@ jobs:
 
     - name: Get dependencies for the last release
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
@@ -73,6 +73,7 @@ jobs:
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Set up python
@@ -81,6 +82,7 @@ jobs:
 
     - name: Setup MySQL
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.4
@@ -99,6 +101,7 @@ jobs:
     # Build current commit's binaries
     - name: Get dependencies for this commit
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
@@ -129,6 +132,7 @@ jobs:
 
     - name: Get dependencies for the last release
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
@@ -74,6 +74,7 @@ jobs:
 
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Set up python
@@ -82,6 +83,7 @@ jobs:
 
     - name: Setup MySQL
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.4
@@ -114,6 +116,7 @@ jobs:
 
     - name: Get dependencies for the next release
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
@@ -143,6 +146,7 @@ jobs:
 
     - name: Get dependencies for this commit
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -74,6 +74,7 @@ jobs:
 
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Set up python
@@ -82,6 +83,7 @@ jobs:
 
     - name: Setup MySQL
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.4
@@ -114,6 +116,7 @@ jobs:
 
     - name: Get dependencies for the next release
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
@@ -143,6 +146,7 @@ jobs:
 
     - name: Get dependencies for this commit
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -73,6 +73,7 @@ jobs:
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Set up python
@@ -81,6 +82,7 @@ jobs:
 
     - name: Setup MySQL
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.4
@@ -113,6 +115,7 @@ jobs:
 
     - name: Get dependencies for the last release
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
@@ -142,6 +145,7 @@ jobs:
 
     - name: Get dependencies for this commit
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -74,6 +74,7 @@ jobs:
 
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Set up python
@@ -82,6 +83,7 @@ jobs:
 
     - name: Setup MySQL
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.4
@@ -114,6 +116,7 @@ jobs:
 
     - name: Get dependencies for the next release
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
@@ -143,6 +146,7 @@ jobs:
 
     - name: Get dependencies for this commit
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -74,6 +74,7 @@ jobs:
 
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Set up python
@@ -82,6 +83,7 @@ jobs:
 
     - name: Setup MySQL
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.4
@@ -114,6 +116,7 @@ jobs:
 
     - name: Get dependencies for the next release
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
@@ -143,6 +146,7 @@ jobs:
 
     - name: Get dependencies for this commit
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -74,6 +74,7 @@ jobs:
 
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Set up python
@@ -82,12 +83,14 @@ jobs:
 
     - name: Setup MySQL
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.4
 
     - name: Setup Percona Apt repository
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/setup-percona-repo
 
     - name: Get base dependencies
@@ -123,6 +126,7 @@ jobs:
 
     - name: Get dependencies for the next release
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
@@ -152,6 +156,7 @@ jobs:
 
     - name: Get dependencies for this commit
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -73,6 +73,7 @@ jobs:
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Set up python
@@ -81,6 +82,7 @@ jobs:
 
     - name: Setup MySQL
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.4
@@ -113,6 +115,7 @@ jobs:
 
     - name: Get dependencies for the last release
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
@@ -142,6 +145,7 @@ jobs:
 
     - name: Get dependencies for this commit
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -73,6 +73,7 @@ jobs:
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Set up python
@@ -81,6 +82,7 @@ jobs:
 
     - name: Setup MySQL
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.4
@@ -113,6 +115,7 @@ jobs:
 
     - name: Get dependencies for the last release
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 
@@ -142,6 +145,7 @@ jobs:
 
     - name: Get dependencies for this commit
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         go mod download
 

--- a/.github/workflows/vitess_tester_vtgate.yml
+++ b/.github/workflows/vitess_tester_vtgate.yml
@@ -76,16 +76,19 @@ jobs:
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       uses: ./.github/actions/tune-os
 
     - name: Setup MySQL
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 8
       uses: ./.github/actions/setup-mysql
       with:
         flavor: mysql-8.4
 
     - name: Get dependencies
       if: steps.changes.outputs.end_to_end == 'true'
+      timeout-minutes: 5
       run: |
         sudo apt-get -qq update
 

--- a/.github/workflows/vtadmin_web_build.yml
+++ b/.github/workflows/vtadmin_web_build.yml
@@ -40,6 +40,7 @@ jobs:
           persist-credentials: 'false'
 
       - name: Tune the OS
+        timeout-minutes: 5
         uses: ./.github/actions/tune-os
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -48,6 +49,7 @@ jobs:
           node-version: '22.13.1'
 
       - name: Install dependencies
+        timeout-minutes: 5
         run: cd ./web/vtadmin && npm ci
 
       - name: Build front-end

--- a/.github/workflows/vtadmin_web_lint.yml
+++ b/.github/workflows/vtadmin_web_lint.yml
@@ -40,6 +40,7 @@ jobs:
           persist-credentials: 'false'
 
       - name: Tune the OS
+        timeout-minutes: 5
         uses: ./.github/actions/tune-os
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -48,6 +49,7 @@ jobs:
           node-version: '22.13.1'
 
       - name: Install dependencies
+        timeout-minutes: 5
         run: cd ./web/vtadmin && npm ci
 
       # Using "if: always()" means each step will run, even if a previous

--- a/.github/workflows/vtadmin_web_unit_tests.yml
+++ b/.github/workflows/vtadmin_web_unit_tests.yml
@@ -35,6 +35,7 @@ jobs:
           persist-credentials: 'false'
 
       - name: Tune the OS
+        timeout-minutes: 5
         uses: ./.github/actions/tune-os
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -43,6 +44,7 @@ jobs:
           node-version: '22.13.1'
 
       - name: Install dependencies
+        timeout-minutes: 5
         run: cd ./web/vtadmin && npm ci
 
       - name: Run unit tests

--- a/.github/workflows/vtop_example.yml
+++ b/.github/workflows/vtop_example.yml
@@ -67,16 +67,19 @@ jobs:
 
       - name: Tune the OS
         if: steps.changes.outputs.end_to_end == 'true'
+        timeout-minutes: 5
         uses: ./.github/actions/tune-os
 
       - name: Setup MySQL
         if: steps.changes.outputs.end_to_end == 'true'
+        timeout-minutes: 8
         uses: ./.github/actions/setup-mysql
         with:
           flavor: mysql-8.4
 
       - name: Get dependencies
         if: steps.changes.outputs.end_to_end == 'true'
+        timeout-minutes: 5
         run: |
           # Install everything we need, and configure
           sudo apt-get install -y make
@@ -85,11 +88,13 @@ jobs:
       # needed for vtctldclient
       - name: Build vitess
         if: steps.changes.outputs.end_to_end == 'true'
+        timeout-minutes: 10
         run: |
           make build
 
       - name: Install kubectl & kind
         if: steps.changes.outputs.end_to_end == 'true'
+        timeout-minutes: 5
         run: |
           make install_kubectl_kind
 


### PR DESCRIPTION
## Description

GitHub Actions jobs have been hanging for up to the full 60-minute job timeout on steps that should take seconds, driven by ongoing instability on Ubuntu's apt mirrors. This PR adds step-level `timeout-minutes` caps so a stuck apt mirror, docker registry, or external service surfaces as a fast, actionable failure instead of a 60-minute black hole.

### How the timeouts were chosen

Pulled step durations from the last ~8 successful `main` runs of every workflow with apt or network-bound steps (~30 workflows, ~1100 jobs). Worst-case durations observed in *passing* runs:

| step | p50 | p90 | max |
| --- | --: | --: | --: |
| Setup MySQL | 29s | 54s | **2738s** (~45 min) |
| Tune the OS (composite, runs `apt-get install eatmydata`) | 12s | 25s | **945s** |
| Get base dependencies | 8s | 97s | **471s** |
| Get dependencies | 21s | 28s | 193s |
| Run make tools | 5s | 80s | 134s |
| Build bootstrap images | 138s | 167s | 198s |
| Build lite image | 222s | 229s | 232s |
| Build and push on main | 264s | 278s | 328s |
| Perform CodeQL Analysis | 133s | 284s | 293s |
| Run golangci-lint | 325s | 333s | 333s |

The Setup MySQL outlier confirms the previously mentioned pain: this is a step that p90-completes in under a minute, but has been observed eating 45 minutes of an hour-long job budget — and *still* finishing successfully on retry. The hung variant of the same step runs out the whole job clock.

Caps were chosen well above observed p90, leaving healthy runs untouched, while well below the 60-minute job-level cap.

### Caps applied

| Group | Steps | `timeout-minutes` |
| --- | --- | --: |
| Composite: setup-mysql | (every invocation) | 8 |
| Composite: tune-os | (every invocation) | 5 |
| Composite: setup-percona-repo / setup-minio | (every invocation) | 5 |
| Composite: build-bootstrap | (every invocation) | 15 |
| apt-driven inline steps | Get dependencies / Get base dependencies / Get dependencies for the {last release, this commit, next release} / Setup Percona Server and XtraBackup / Install Consul and ZooKeeper / Install kubectl & kind / Install dependencies (npm ci) | 5 |
| Build / tooling | Run make minimaltools / Build / Build vitess | 5–10 |
| Build / tooling (heavier) | Run make tools / Building binaries | 10–15 |
| External services | Run FOSSA scan and upload build data | 5 |
| Linters / analyzers | Initialize CodeQL / Run golangci-lint / Perform CodeQL Analysis | 5–15 |
| Docker build/push | Build lite image / Build and push on main / Build and push on main latest tag / Build and push on main debian specific tag / Build and push on tags / Build and push on tags using Debian extension / Build and push on tags without Debian extension | 15 |
| Test runners | Run docker tests - `\${{ matrix.shard }}` | 20 |

Existing `timeout-minutes` values are **not modified** — this change only adds caps to steps that had none. Existing job-level timeouts are also unchanged. The two highest-value additions, by frequency × hang-surface, are the **Setup MySQL (8 min)** and **Tune the OS (5 min)** caps; both currently uncapped and reachable from nearly every workflow.

The diff is mechanical — 35 files, +142 lines, all of the form:

```diff
       - name: Setup MySQL
         if: steps.changes.outputs.end_to_end == 'true'
+        timeout-minutes: 8
         uses: ./.github/actions/setup-mysql
```

## Related Issue(s)

<!-- Add issue link here if there is one tracking the apt-mirror flakiness. -->

## Checklist

-   [ ] \"Backport to:\" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required (workflow-config-only change)
-   [x] Did the new or modified tests pass consistently locally and on CI? (each YAML parses cleanly; the actual behavior change will be visible on this PR's own CI run)
-   [x] Documentation was added or is not required

## Deployment Notes

No runtime impact — this only affects CI execution. Once merged, future hung apt/registry steps will fail their job after the chosen cap (5–20 min) instead of running out the full 60-minute budget. If a healthy step starts hitting one of the new caps, the cap can be raised in a follow-up; the data above gives the headroom we have to work with.

### AI Disclosure

This PR was researched and authored primarily by Claude Code — I provided direction and reviewed the data analysis and chosen timeout values before merging.