### PR TITLE
ci: reduce Apache ZooKeeper download load in CI

### DIFF
--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -185,6 +185,8 @@ jobs:
         timeout-minutes: 5
         uses: ./.github/actions/setup-minio
 
+      # 'consul' is the only need that triggers `make tools`, which installs both Consul and ZooKeeper.
+      # There is no separate 'zookeeper' need, so 'consul' is the correct proxy for "this shard needs ZooKeeper".
       - name: Cache ZooKeeper
         if: steps.changes.outputs.end_to_end == 'true' && contains(matrix.needs, 'consul')
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -185,6 +185,13 @@ jobs:
         timeout-minutes: 5
         uses: ./.github/actions/setup-minio
 
+      - name: Cache ZooKeeper
+        if: steps.changes.outputs.end_to_end == 'true' && contains(matrix.needs, 'consul')
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: dist/vt-zookeeper-*
+          key: zookeeper-${{ hashFiles('build.env') }}
+
       - name: Install Consul and ZooKeeper
         if: steps.changes.outputs.end_to_end == 'true' && contains(matrix.needs, 'consul')
         timeout-minutes: 5

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -190,7 +190,7 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: dist/vt-zookeeper-*
-          key: zookeeper-${{ hashFiles('build.env') }}
+          key: zookeeper-${{ hashFiles('build.env', 'bootstrap.sh') }}
 
       - name: Install Consul and ZooKeeper
         if: steps.changes.outputs.end_to_end == 'true' && contains(matrix.needs, 'consul')

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -189,7 +189,7 @@ install_zookeeper() {
 	# SHA512 checksum for Zookeeper 3.9.5 from Apache archives.
 	local sha512="baa1c21dda4d57238fca751e4fa2bbf1daff9a28612b125e497dccd5c188ee6449e2f79947e474c2dd4d19992789d4d36b27b1ba2feb80c2b0c45e7df0e22aa8"
 
-	"${VTROOT}/tools/wget-retry" -q "https://archive.apache.org/dist/zookeeper/${zk}/${file}"
+	"${VTROOT}/tools/wget-retry" -q "https://dlcdn.apache.org/zookeeper/${zk}/${file}"
 	verify_sha512 "$dist/$file" "$sha512"
 	tar -xzf "$dist/$file"
 	mkdir -p "$dist"/lib

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -186,8 +186,8 @@ install_zookeeper() {
 	local zk="zookeeper-$version"
 	local file="apache-${zk}-bin.tar.gz"
 
-	# SHA512 checksum for Zookeeper 3.9.4 from Apache archives.
-	local sha512="36bffae6440ed0d71ed83a621b8c52c583860b414812197373237f0c148bd16e6b599977c90e5eb81c0fce6b82ef44aa782621535417cffc4c2a0a51a56f2cdf"
+	# SHA512 checksum for Zookeeper 3.9.5 from Apache archives.
+	local sha512="baa1c21dda4d57238fca751e4fa2bbf1daff9a28612b125e497dccd5c188ee6449e2f79947e474c2dd4d19992789d4d36b27b1ba2feb80c2b0c45e7df0e22aa8"
 
 	"${VTROOT}/tools/wget-retry" -q "https://archive.apache.org/dist/zookeeper/${zk}/${file}"
 	verify_sha512 "$dist/$file" "$sha512"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -189,6 +189,7 @@ install_zookeeper() {
 	# SHA512 checksum for Zookeeper 3.9.5 from Apache archives.
 	local sha512="baa1c21dda4d57238fca751e4fa2bbf1daff9a28612b125e497dccd5c188ee6449e2f79947e474c2dd4d19992789d4d36b27b1ba2feb80c2b0c45e7df0e22aa8"
 
+	# dlcdn.apache.org only serves current releases; older versions 404 and must be fetched from archive.apache.org instead.
 	"${VTROOT}/tools/wget-retry" -q "https://dlcdn.apache.org/zookeeper/${zk}/${file}"
 	verify_sha512 "$dist/$file" "$sha512"
 	tar -xzf "$dist/$file"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -189,8 +189,9 @@ install_zookeeper() {
 	# SHA512 checksum for Zookeeper 3.9.5 from Apache archives.
 	local sha512="baa1c21dda4d57238fca751e4fa2bbf1daff9a28612b125e497dccd5c188ee6449e2f79947e474c2dd4d19992789d4d36b27b1ba2feb80c2b0c45e7df0e22aa8"
 
-	# dlcdn.apache.org only serves current releases; older versions 404 and must be fetched from archive.apache.org instead.
-	"${VTROOT}/tools/wget-retry" -q "https://dlcdn.apache.org/zookeeper/${zk}/${file}"
+	# dlcdn.apache.org only serves current releases; fall back to archive.apache.org for older versions.
+	"${VTROOT}/tools/wget-retry" -q "https://dlcdn.apache.org/zookeeper/${zk}/${file}" || \
+		"${VTROOT}/tools/wget-retry" -q "https://archive.apache.org/dist/zookeeper/${zk}/${file}"
 	verify_sha512 "$dist/$file" "$sha512"
 	tar -xzf "$dist/$file"
 	mkdir -p "$dist"/lib

--- a/build.env
+++ b/build.env
@@ -28,7 +28,7 @@ export VTROOT="$PWD"
 export VTDATAROOT="${VTDATAROOT:-${VTROOT}/vtdataroot}"
 export PATH="$PWD/bin:$PATH"
 export PROTOC_VER=21.3
-export ZK_VER=${ZK_VERSION:-3.9.4}
+export ZK_VER=${ZK_VERSION:-3.9.5}
 export ETCD_VER=v3.6.7
 export CONSUL_VER=1.11.4
 

--- a/go/vt/zkctl/zksrv.sh
+++ b/go/vt/zkctl/zksrv.sh
@@ -21,7 +21,7 @@ logdir="$1"
 config="$2"
 pidfile="$3"
 zk_java_opts=${ZK_JAVA_OPTS:-}
-zk_ver=${ZK_VERSION:-3.9.4}
+zk_ver=${ZK_VERSION:-3.9.5}
 
 # Build classpath: use wildcard to include all JARs in the lib directory.
 # This supports both the old fatjar layout and the new binary distribution layout.
@@ -70,4 +70,5 @@ if [ "$pidfile" ]; then
 fi
 
 wait $pid
+exit_status=$?
 log "INFO exit status $pid: $exit_status"


### PR DESCRIPTION
We were getting throttled by Apache's archive servers because every CI run
re-downloaded ZooKeeper from scratch (sorry!)

## What changed

- Cache the ZooKeeper install directory in GitHub Actions, keyed on `build.env`
  (auto-invalidates on version bumps)
- Bump ZooKeeper 3.9.4 → 3.9.5
- Switch download URL from `archive.apache.org` to `dlcdn.apache.org` (Apache's
  recommended CDN for current releases)

