### PR TITLE
VStream: Disable query timeouts for VTGate vstreams

### DIFF
--- a/go/test/endtoend/vreplication/vstream_test.go
+++ b/go/test/endtoend/vreplication/vstream_test.go
@@ -21,7 +21,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"path"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -209,6 +212,24 @@ func TestVStreamWithTablesToSkipCopyFlag(t *testing.T) {
 	// subtract 10 from the total rows found in the 3 tables.
 	wantTotalRows := insertedRows1 + insertedRows2 + insertedRows3 - 10
 	assert.Equal(t, wantTotalRows, numRowEvents)
+
+	// Confirm that the copy phase queries used by the VStream did NOT include the MAX_EXECUTION_TIME
+	// query hint. Adding the hint forces unnecessary copy resume cycles for VStream clients that may
+	// not support resume well, or at all (see issue #20039).
+	logFiles := path.Join(vc.ClusterConfig.tmpDir, "*-vttablet-stderr.txt")
+	totalCmd := fmt.Sprintf("grep -h 'Streaming rows for query:' %s | wc -l", logFiles)
+	totalOut, err := exec.Command("bash", "-c", totalCmd).Output()
+	require.NoError(t, err)
+	totalCount, err := strconv.Atoi(strings.TrimSpace(string(totalOut)))
+	require.NoError(t, err)
+	require.Greater(t, totalCount, 0, "expected at least one rowstreamer 'Streaming rows for query:' log line during copy phase")
+
+	withHintCmd := fmt.Sprintf("grep -h 'Streaming rows for query:' %s | grep -c MAX_EXECUTION_TIME || true", logFiles)
+	withHintOut, err := exec.Command("bash", "-c", withHintCmd).Output()
+	require.NoError(t, err)
+	withHintCount, err := strconv.Atoi(strings.TrimSpace(string(withHintOut)))
+	require.NoError(t, err)
+	require.Zero(t, withHintCount, "expected no VStream copy/sync queries to include MAX_EXECUTION_TIME hint")
 }
 
 // TestVStreamLaggingDDLRowEvents confirms that when the schema historian is enabled via the --track-schema-versions flag, we don't

--- a/go/vt/vtgate/vstream_manager.go
+++ b/go/vt/vtgate/vstream_manager.go
@@ -750,6 +750,10 @@ func (vs *vstream) streamFromTablet(ctx context.Context, sgtid *binlogdatapb.Sha
 				TablesToCopy: vs.flags.GetTablesToCopy(),
 			}
 		}
+		// Don't add query timeouts to the VStream queries used during a table copy/sync as it can unnecessarily
+		// cause copy resume cycles and in doing so adding additional operational complexity, chance for failure
+		// (not all clients support copy resume well if at all), and extended copy/sync execution time.
+		options.NoTimeouts = true
 
 		// Safe to access sgtid.Gtid here (because it can't change until streaming begins).
 		req := &binlogdatapb.VStreamRequest{

--- a/go/vt/vtgate/vstream_manager_test.go
+++ b/go/vt/vtgate/vstream_manager_test.go
@@ -297,6 +297,14 @@ func TestVStreamEvents(t *testing.T) {
 	require.ErrorIs(t, vterrors.UnwrapAll(err), context.Canceled)
 
 	require.ElementsMatch(t, []*binlogdatapb.VStreamResponse{want1, want2}, receivedEvents)
+
+	// Confirm that the VStream request sent to the tablet had NoTimeouts=true so that the
+	// MAX_EXECUTION_TIME query hint is not added to copy/sync queries (see issue #20039).
+	require.NotEmpty(t, sbc0.VStreamRequests)
+	for _, req := range sbc0.VStreamRequests {
+		require.NotNil(t, req.Options)
+		require.True(t, req.Options.NoTimeouts, "expected VStream request Options.NoTimeouts to be true")
+	}
 }
 
 func BenchmarkVStreamEvents(b *testing.B) {

--- a/go/vt/vttablet/sandboxconn/sandboxconn.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn.go
@@ -116,6 +116,9 @@ type SandboxConn struct {
 	VStreamErrors     []error
 	VStreamCh         chan *binlogdatapb.VEvent
 	VStreamEventDelay time.Duration // Any sleep that should be introduced before each event is streamed
+	// VStreamRequests records every VStreamRequest received by VStream so tests can inspect
+	// what was sent to the tablet (e.g. Options.NoTimeouts).
+	VStreamRequests []*binlogdatapb.VStreamRequest
 
 	// BinlogDump expectations.
 	BinlogDumpResponses []*binlogdatapb.BinlogDumpResponse
@@ -602,6 +605,7 @@ func (sbc *SandboxConn) AddVStreamEvents(events []*binlogdatapb.VEvent, err erro
 
 // VStream is part of the QueryService interface.
 func (sbc *SandboxConn) VStream(ctx context.Context, request *binlogdatapb.VStreamRequest, send func([]*binlogdatapb.VEvent) error) error {
+	sbc.VStreamRequests = append(sbc.VStreamRequests, request)
 	if sbc.StartPos != "" && sbc.StartPos != request.Position {
 		log.Error(fmt.Sprintf("startPos(%v): %v, want %v", request.Target, request.Position, sbc.StartPos))
 		return fmt.Errorf("startPos(%v): %v, want %v", request.Target, request.Position, sbc.StartPos)

--- a/go/vt/vttablet/tabletserver/vstreamer/copy.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/copy.go
@@ -75,7 +75,7 @@ func (uvs *uvstreamer) catchup(ctx context.Context) error {
 	go func() {
 		uvs.stopPos = replication.Position{} // reset stopPos which was potentially set during fastforward
 		startPos := replication.EncodePosition(uvs.pos)
-		vs := uvs.newStartupVStreamer(ctx, startPos, "", uvs.send2, "catchup", nil)
+		vs := uvs.newStartupVStreamer(ctx, startPos, "", uvs.send2, "catchup", uvs.options)
 		uvs.setVs(vs)
 		errch <- vs.Stream()
 		uvs.setVs(nil)
@@ -307,7 +307,7 @@ func (uvs *uvstreamer) copyTable(ctx context.Context, tableName string) error {
 		uvs.setCopyState(tableName, qrLastPK)
 		log.V(2).Info(fmt.Sprintf("NewLastPK: %v", qrLastPK))
 		return nil
-	}, nil)
+	}, uvs.options)
 	if err != nil {
 		uvs.vse.errorCounts.Add("StreamRows", 1)
 		return err
@@ -334,7 +334,7 @@ func (uvs *uvstreamer) fastForward(stopPos string) error {
 	}()
 	log.Info(fmt.Sprintf("starting fastForward from %s upto pos %s", replication.EncodePosition(uvs.pos), stopPos))
 	uvs.stopPos, _ = replication.DecodePosition(stopPos)
-	vs := uvs.newStartupVStreamer(uvs.ctx, replication.EncodePosition(uvs.pos), "", uvs.send2, "fastforward", nil)
+	vs := uvs.newStartupVStreamer(uvs.ctx, replication.EncodePosition(uvs.pos), "", uvs.send2, "fastforward", uvs.options)
 	uvs.setVs(vs)
 	return vs.Stream()
 }


### PR DESCRIPTION
## Description

This disables any explicit query timeouts for queries used during VTGate VStream copy/sync operations.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/20039

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

### AI Disclosure

I worked with Claude and Opus 4.7 on this.