### PR TITLE
vttest: avoid 10-minute hang when vtcombo exits during startup

### DIFF
--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -171,6 +171,10 @@ func (vtp *VtProcess) WaitStart() (err error) {
 
 		select {
 		case err := <-vtp.exit:
+			// Drop the exec.Cmd so a subsequent WaitTerminate() does not
+			// signal a dead pid and then block forever on the already-drained
+			// exit channel.
+			vtp.proc = nil
 			return fmt.Errorf("process '%s' exited prematurely (err: %s)", vtp.Name, err)
 		default:
 			time.Sleep(300 * time.Millisecond)
@@ -178,7 +182,9 @@ func (vtp *VtProcess) WaitStart() (err error) {
 	}
 
 	vtp.proc.Process.Kill()
-	return fmt.Errorf("process '%s' timed out after 60s (err: %s)", vtp.Name, <-vtp.exit)
+	exitErr := <-vtp.exit
+	vtp.proc = nil
+	return fmt.Errorf("process '%s' timed out after 60s (err: %s)", vtp.Name, exitErr)
 }
 
 const (

--- a/go/vt/vttest/vtprocess_test.go
+++ b/go/vt/vttest/vtprocess_test.go
@@ -57,6 +57,6 @@ func TestWaitTerminateAfterPrematureExit(t *testing.T) {
 	case err := <-done:
 		require.NoError(t, err)
 	case <-time.After(2 * time.Second):
-		t.Fatal("WaitTerminate hung after a premature exit during WaitStart")
+		require.Fail(t, "WaitTerminate hung after a premature exit during WaitStart")
 	}
 }

--- a/go/vt/vttest/vtprocess_test.go
+++ b/go/vt/vttest/vtprocess_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vttest
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWaitTerminateAfterPrematureExit verifies that WaitTerminate returns
+// promptly when the underlying process has already exited during WaitStart.
+//
+// Regression test: previously, a premature exit during WaitStart drained the
+// exit channel but left vtp.proc non-nil, so WaitTerminate would send SIGTERM
+// to a dead pid, time out after 10s, and then block forever on a second read
+// from the now-empty exit channel — surfacing as a 10-minute test timeout in
+// CI whenever vtcombo failed to start (e.g. transient port collisions).
+func TestWaitTerminateAfterPrematureExit(t *testing.T) {
+	falsePath, err := exec.LookPath("false")
+	if err != nil {
+		t.Skipf("`false` command not available: %v", err)
+	}
+
+	vtp := &VtProcess{
+		Name:        "exits-immediately",
+		Binary:      falsePath,
+		BindAddress: "127.0.0.1",
+		Port:        1,
+	}
+
+	startErr := vtp.WaitStart()
+	require.ErrorContains(t, startErr, "exited prematurely")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- vtp.WaitTerminate()
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitTerminate hung after a premature exit during WaitStart")
+	}
+}


### PR DESCRIPTION
## Description

When `vtcombo` (or any process spawned via `vttest.VtProcess`) exits during `WaitStart`, a deferred `TearDown` -> `WaitTerminate` blocks forever — surfacing in CI as the test runner's 10-minute timeout.

The cause is a channel-ownership bug:

1. `WaitStart` spawns a goroutine that does `vtp.exit <- vtp.proc.Wait()` once and exits. The channel is unbuffered.
2. If the process exits before `WaitStart`'s health check passes, the loop receives that single value and returns the error — **but leaves `vtp.proc` non-nil**.
3. `TearDown` -> `WaitTerminate` then signals a dead pid, falls through the 10s SIGTERM wait (no one will ever send on the drained channel), kills the dead pid, and ends with an unconditional `<-vtp.exit` that blocks forever.

The 60s-timeout path in `WaitStart` has the same hazard.

This is the actual cause of the symptom seen in #20029's CI run (https://github.com/vitessio/vitess/actions/runs/25442858175/job/74638672137):
- `TestMtlsAuthUnauthorizedFails` ran for 8m53s before the test runner's 10m alarm fired.
- vtcombo's log shows it failed to bind to its grpc port (`bind: address already in use` — a known port-allocation TOCTOU race).
- Without this fix, *any* startup failure of vtcombo (port collision, OOM, crash, mtls misconfig, etc.) hangs the test for 10 minutes and aborts `gotestsum`'s rerun-fails.

## How it works

Nil out `vtp.proc` on both the premature-exit and 60s-timeout paths in `WaitStart` so `WaitTerminate`'s existing nil-guard short-circuits. A regression test using `/usr/bin/false` fails (via a 2s hang-detector) without the fix.

This does not address the underlying port-allocation flake, but it makes such failures surface in seconds instead of the 10-minute timeout — letting `gotestsum --rerun-fails` hide them automatically.

## Related Issue(s)

None.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

Backport justification: this affects every release branch — any vtcombo startup failure in `vttest`-based tests currently produces a 10-minute hang.

## Deployment Notes

None — affects test infrastructure only.

### AI Disclosure

Most of this was written by Claude Code — I provided direction and review.