### PR TITLE
Cleanup TODOs targeting v25 or earlier

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -34,7 +34,7 @@ The deprecated `--watch-replication-stream` VTTablet flag has been removed.
 
 **Impact**: VTTablet will fail to start if `--watch-replication-stream` is still passed.
 
-See [#20048](https://github.com/vitessio/vitess/pull/20048) for details.
+See [#20048](https://github.com/vitessio/vitess/pull/20048) for the removal and [#19204](https://github.com/vitessio/vitess/pull/19204) for the original deprecation.
 
 #### <a id="vtorc-snapshot-topology-removed"/>Snapshot Topology feature removed</a>
 
@@ -44,7 +44,7 @@ VTOrc's Snapshot Topology feature, [deprecated in v24](../../24.0/24.0.0/summary
 
 **Impact**: VTOrc will fail to start if `--snapshot-topology-interval` is still passed.
 
-See [#20048](https://github.com/vitessio/vitess/pull/20048) for details.
+See [#20048](https://github.com/vitessio/vitess/pull/20048) for the removal and [#19070](https://github.com/vitessio/vitess/pull/19070) for the original deprecation.
 
 #### <a id="vtorc-cell-required"/>VTOrc `--cell` flag is now required</a>
 
@@ -54,7 +54,7 @@ The `--cell` VTOrc flag, [introduced in v24](../../24.0/24.0.0/summary.md#vtorc-
 
 **Impact**: VTOrc will fail to start with a `FAILED_PRECONDITION` error if `--cell` is empty.
 
-See [#20048](https://github.com/vitessio/vitess/pull/20048) for details.
+See [#20048](https://github.com/vitessio/vitess/pull/20048) for the removal and [#19047](https://github.com/vitessio/vitess/pull/19047) for the original `--cell` flag introduction.
 
 ## <a id="minor-changes"/>Minor Changes</a>
 

--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -7,6 +7,9 @@
 - **[Major Changes](#major-changes)**
     - **[New Support](#new-support)**
     - **[Breaking Changes](#breaking-changes)**
+        - [`--watch-replication-stream` flag removed](#vttablet-watch-replication-stream-removed)
+        - [Snapshot Topology feature removed](#vtorc-snapshot-topology-removed)
+        - [VTOrc `--cell` flag is now required](#vtorc-cell-required)
 - **[Minor Changes](#minor-changes)**
     - **[VReplication](#minor-changes-vreplication)**
         - [Default data protection for `_reverse` workflow cancel/complete](#vreplication-reverse-workflow-data-protection)
@@ -22,6 +25,36 @@
 ### <a id="new-support"/>New Support</a>
 
 ### <a id="breaking-changes"/>Breaking Changes</a>
+
+#### <a id="vttablet-watch-replication-stream-removed"/>`--watch-replication-stream` flag removed</a>
+
+The deprecated `--watch-replication-stream` VTTablet flag has been removed.
+
+**Migration**: remove `--watch-replication-stream` from VTTablet startup arguments.
+
+**Impact**: VTTablet will fail to start if `--watch-replication-stream` is still passed.
+
+See [#20048](https://github.com/vitessio/vitess/pull/20048) for details.
+
+#### <a id="vtorc-snapshot-topology-removed"/>Snapshot Topology feature removed</a>
+
+VTOrc's Snapshot Topology feature, [deprecated in v24](../../24.0/24.0.0/summary.md#vtorc-snapshot-topology-deprecation), has been removed. This includes the `--snapshot-topology-interval` flag and the `database_instance_topology_history` table.
+
+**Migration**: remove `--snapshot-topology-interval` from VTOrc startup arguments.
+
+**Impact**: VTOrc will fail to start if `--snapshot-topology-interval` is still passed.
+
+See [#20048](https://github.com/vitessio/vitess/pull/20048) for details.
+
+#### <a id="vtorc-cell-required"/>VTOrc `--cell` flag is now required</a>
+
+The `--cell` VTOrc flag, [introduced in v24](../../24.0/24.0.0/summary.md#vtorc-cell-flag), is now required.
+
+**Migration**: ensure `--cell` is set on every VTOrc deployment.
+
+**Impact**: VTOrc will fail to start with a `FAILED_PRECONDITION` error if `--cell` is empty.
+
+See [#20048](https://github.com/vitessio/vitess/pull/20048) for details.
 
 ## <a id="minor-changes"/>Minor Changes</a>
 

--- a/config/tablet/default.yaml
+++ b/config/tablet/default.yaml
@@ -100,7 +100,6 @@ consolidator: enable|disable|notOnPrimary # enable-consolidator, enable-consolid
 passthroughDML: false                    # queryserver-config-passthrough-dmls
 streamBufferSize: 32768                  # queryserver-config-stream-buffer-size
 schemaReloadIntervalSeconds: 1800        # queryserver-config-schema-reload-time
-watchReplication: false                  # watch-replication-stream
 terseErrors: false                       # queryserver-config-terse-errors
 truncateErrorLen: 0                      # queryserver-config-truncate-error-len
 messagePostponeParallelism: 4            # queryserver-config-message-postpone-cap

--- a/doc/design-docs/TabletServerParamsAsYAML.md
+++ b/doc/design-docs/TabletServerParamsAsYAML.md
@@ -127,7 +127,6 @@ shutdownGracePeriodSeconds: 0            # transaction_shutdown_grace_period
 passthroughDML: false                    # queryserver-config-passthrough-dmls
 streamBufferSize: 32768                  # queryserver-config-stream-buffer-size
 schemaReloadIntervalSeconds: 1800        # queryserver-config-schema-reload-time
-watchReplication: false                  # watch_replication_stream
 terseErrors: false                       # queryserver-config-terse-errors
 messagePostponeParallelism: 4            # queryserver-config-message-postpone-cap
 sanitizeLogMessages: false               # sanitize_log_messages

--- a/examples/common/vtorc/config.yaml
+++ b/examples/common/vtorc/config.yaml
@@ -1,6 +1,5 @@
 instance-poll-time: 1s
 prevent-cross-cell-failover: false
-snapshot-topology-interval: 0h
 reasonable-replication-lag: 10s
 audit-to-backend: false
 audit-to-syslog: false

--- a/examples/operator/101_initial_cluster.yaml
+++ b/examples/operator/101_initial_cluster.yaml
@@ -90,6 +90,7 @@ spec:
           cpu: 100m
           memory: 128Mi
       extraFlags:
+        cell: zone1
         instance-poll-time: 1s
         log-format: text
     partitionings:

--- a/examples/operator/201_customer_tablets.yaml
+++ b/examples/operator/201_customer_tablets.yaml
@@ -86,6 +86,7 @@ spec:
           cpu: 100m
           memory: 128Mi
       extraFlags:
+        cell: zone1
         instance-poll-time: 1s
         log-format: text
     partitionings:

--- a/examples/operator/201_customer_tablets.yaml
+++ b/examples/operator/201_customer_tablets.yaml
@@ -125,6 +125,9 @@ spec:
   - name: customer
     durabilityPolicy: none
     turndownPolicy: Immediate
+    vitessOrchestrator:
+      extraFlags:
+        cell: zone1
     partitionings:
     - equal:
         parts: 1

--- a/examples/operator/302_new_shards.yaml
+++ b/examples/operator/302_new_shards.yaml
@@ -86,6 +86,7 @@ spec:
           cpu: 100m
           memory: 128Mi
       extraFlags:
+        cell: zone1
         instance-poll-time: 1s
         log-format: text
     partitionings:

--- a/examples/operator/302_new_shards.yaml
+++ b/examples/operator/302_new_shards.yaml
@@ -125,6 +125,9 @@ spec:
   - name: customer
     durabilityPolicy: none
     turndownPolicy: Immediate
+    vitessOrchestrator:
+      extraFlags:
+        cell: zone1
     partitionings:
     - equal:
         parts: 1

--- a/examples/operator/306_down_shard_0.yaml
+++ b/examples/operator/306_down_shard_0.yaml
@@ -86,6 +86,7 @@ spec:
           cpu: 100m
           memory: 128Mi
       extraFlags:
+        cell: zone1
         instance-poll-time: 1s
         log-format: text
     partitionings:

--- a/examples/operator/306_down_shard_0.yaml
+++ b/examples/operator/306_down_shard_0.yaml
@@ -125,6 +125,9 @@ spec:
   - name: customer
     durabilityPolicy: none
     turndownPolicy: Immediate
+    vitessOrchestrator:
+      extraFlags:
+        cell: zone1
     partitionings:
     - equal:
         parts: 2

--- a/examples/operator/401_scheduled_backups.yaml
+++ b/examples/operator/401_scheduled_backups.yaml
@@ -120,6 +120,7 @@ spec:
           cpu: 100m
           memory: 128Mi
       extraFlags:
+        cell: zone1
         instance-poll-time: 1s
         log-format: text
     partitionings:

--- a/examples/operator/401_scheduled_backups.yaml
+++ b/examples/operator/401_scheduled_backups.yaml
@@ -160,6 +160,9 @@ spec:
   - name: customer
     durabilityPolicy: none
     turndownPolicy: Immediate
+    vitessOrchestrator:
+      extraFlags:
+        cell: zone1
     partitionings:
     - equal:
         parts: 2

--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -25,7 +25,7 @@ Flags:
       --backend-write-concurrency int                               Maximum concurrency for writes to the backend (default 24)
       --bind-address string                                         Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --catch-sigpipe                                               catch and ignore SIGPIPE on stdout and stderr if specified
-      --cell string                                                 cell to use (required in v25+)
+      --cell string                                                 cell to use (required)
       --cells-to-watch strings                                      Comma-separated list of cells that this instance will monitor and repair. Defaults to all cells in the topology. Example: "cell1,cell2"
       --change-tablets-with-errant-gtid-to-drained                  Whether VTOrc should be changing the type of tablets with errant GTIDs to DRAINED
       --clusters-to-watch strings                                   Comma-separated list of keyspaces or keyspace/keyranges that this instance will monitor and repair. Defaults to all clusters in the topology. Example: "ks1,ks2/-80"

--- a/go/flags/endtoend/vtorc.txt
+++ b/go/flags/endtoend/vtorc.txt
@@ -74,7 +74,6 @@ Flags:
       --remote-operation-timeout duration                           time to wait for a remote operation (default 15s)
       --security-policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --shutdown-wait-time duration                                 Maximum time to wait for VTOrc to release all the locks that it is holding before shutting down on SIGTERM (default 30s)
-      --snapshot-topology-interval duration                         Timer duration on which VTOrc takes a snapshot of the current MySQL information it has in the database. Should be in multiple of hours
       --sqlite-data-file string                                     SQLite Datafile to use as VTOrc's database (default "file::memory:?mode=memory&cache=shared")
       --stats-backend string                                        The name of the registered push-based monitoring/stats backend to use
       --stats-combine-dimensions string                             List of dimensions to be combined into a single "all" value in exported stats vars

--- a/go/test/endtoend/backup/clone/main_test.go
+++ b/go/test/endtoend/backup/clone/main_test.go
@@ -51,7 +51,6 @@ var (
 		"--vreplication-retry-delay", "1s",
 		"--degraded-threshold", "5s",
 		"--lock-tables-timeout", "5s",
-		"--watch-replication-stream",
 		"--enable-replication-reporter",
 		"--serving-state-grace-period", "1s",
 	}

--- a/go/test/endtoend/backup/vtbackup/main_test.go
+++ b/go/test/endtoend/backup/vtbackup/main_test.go
@@ -46,7 +46,6 @@ var (
 		"--vreplication-retry-delay", "1s",
 		"--degraded-threshold", "5s",
 		"--lock-tables-timeout", "5s",
-		"--watch-replication-stream",
 		"--enable-replication-reporter",
 		"--serving-state-grace-period", "1s",
 	}

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -1510,7 +1510,6 @@ func getDefaultCommonArgs() []string {
 		"--vreplication-retry-delay", "1s",
 		"--degraded-threshold", "5s",
 		"--lock-tables-timeout", "5s",
-		"--watch-replication-stream",
 		"--enable-replication-reporter",
 		"--serving-state-grace-period", "1s",
 	}

--- a/go/test/endtoend/cellalias/cell_alias_test.go
+++ b/go/test/endtoend/cellalias/cell_alias_test.go
@@ -56,7 +56,6 @@ var (
 		"--vreplication-retry-delay", "1s",
 		"--degraded-threshold", "5s",
 		"--lock-tables-timeout", "5s",
-		"--watch-replication-stream",
 		"--enable-replication-reporter",
 		"--serving-state-grace-period", "1s",
 		"--binlog-player-protocol", "grpc",

--- a/go/test/endtoend/cluster/vtorc_process.go
+++ b/go/test/endtoend/cluster/vtorc_process.go
@@ -53,7 +53,6 @@ type VTOrcProcess struct {
 
 type VTOrcConfiguration struct {
 	InstancePollTime                     string `json:"instance-poll-time,omitempty"`
-	SnapshotTopologyInterval             string `json:"snapshot-topology-interval,omitempty"`
 	PreventCrossCellFailover             bool   `json:"prevent-cross-cell-failover,omitempty"`
 	ReasonableReplicationLag             string `json:"reasonable-replication-lag,omitempty"`
 	AuditToBackend                       bool   `json:"audit-to-backend,omitempty"`

--- a/go/test/endtoend/onlineddl/flow/onlineddl_flow_test.go
+++ b/go/test/endtoend/onlineddl/flow/onlineddl_flow_test.go
@@ -139,7 +139,6 @@ func TestMain(m *testing.M) {
 			"--heartbeat-interval", "250ms",
 			"--heartbeat-on-demand-duration", "5s",
 			"--migration-check-interval", "2s",
-			"--watch-replication-stream",
 		}
 		clusterInstance.VtGateExtraArgs = []string{
 			"--ddl-strategy", "online",

--- a/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
+++ b/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
@@ -159,7 +159,6 @@ func TestMain(m *testing.M) {
 			"--heartbeat-interval", "250ms",
 			"--heartbeat-on-demand-duration", "5s",
 			"--migration-check-interval", "5s",
-			"--watch-replication-stream",
 		}
 		clusterInstance.VtGateExtraArgs = []string{
 			"--ddl-strategy", "online",

--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -260,7 +260,6 @@ func TestMain(m *testing.M) {
 			"--heartbeat-interval", "250ms",
 			"--heartbeat-on-demand-duration", "5s",
 			"--migration-check-interval", "2s",
-			"--watch-replication-stream",
 		}
 		clusterInstance.VtGateExtraArgs = []string{}
 

--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -181,7 +181,6 @@ func TestMain(m *testing.M) {
 		clusterInstance.VtTabletExtraArgs = []string{
 			"--heartbeat-interval", "250ms",
 			"--migration-check-interval", "5s",
-			"--watch-replication-stream",
 		}
 		clusterInstance.VtGateExtraArgs = []string{
 			"--ddl-strategy", "online",

--- a/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
@@ -179,7 +179,6 @@ func TestMain(m *testing.M) {
 			"--heartbeat-interval", "250ms",
 			"--heartbeat-on-demand-duration", "5s",
 			"--migration-check-interval", "5s",
-			"--watch-replication-stream",
 		}
 		clusterInstance.VtGateExtraArgs = []string{
 			"--ddl-strategy", "online",

--- a/go/test/endtoend/onlineddl/vrepl_stress_suite/onlineddl_vrepl_stress_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress_suite/onlineddl_vrepl_stress_suite_test.go
@@ -433,7 +433,6 @@ func TestMain(m *testing.M) {
 			"--heartbeat-on-demand-duration", "5s",
 			"--migration-check-interval", "5s",
 			"--vstream-packet-size", "4096", // Keep this value small and below 10k to ensure multilple vstream iterations
-			"--watch-replication-stream",
 		}
 		clusterInstance.VtGateExtraArgs = []string{
 			"--ddl-strategy", "online",

--- a/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
@@ -90,7 +90,6 @@ func TestMain(m *testing.M) {
 			"--heartbeat-interval", "250ms",
 			"--heartbeat-on-demand-duration", "5s",
 			"--migration-check-interval", "5s",
-			"--watch-replication-stream",
 		}
 
 		if err := clusterInstance.StartTopo(); err != nil {

--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -54,7 +54,6 @@ var (
 		"--vreplication-retry-delay", "1s",
 		"--degraded-threshold", "5s",
 		"--lock-tables-timeout", "5s",
-		"--watch-replication-stream",
 		"--serving-state-grace-period", "1s",
 	}
 	recoveryKS1  = "recovery_ks1"

--- a/go/test/endtoend/schemadiff/vrepl/schemadiff_vrepl_suite_test.go
+++ b/go/test/endtoend/schemadiff/vrepl/schemadiff_vrepl_suite_test.go
@@ -89,7 +89,6 @@ func TestMain(m *testing.M) {
 			"--heartbeat-interval", "250ms",
 			"--heartbeat-on-demand-duration", "5s",
 			"--migration-check-interval", "5s",
-			"--watch-replication-stream",
 		}
 
 		if err := clusterInstance.StartTopo(); err != nil {

--- a/go/test/endtoend/tabletmanager/main_test.go
+++ b/go/test/endtoend/tabletmanager/main_test.go
@@ -103,7 +103,6 @@ func TestMain(m *testing.M) {
 		// Set extra tablet args for lock timeout
 		clusterInstance.VtTabletExtraArgs = []string{
 			"--lock-tables-timeout", "5s",
-			"--watch-replication-stream",
 			"--heartbeat-enable",
 			"--health-check-interval", tabletHealthcheckRefreshInterval.String(),
 			"--unhealthy-threshold", tabletUnhealthyThreshold.String(),

--- a/go/test/endtoend/tabletmanager/primary/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/primary/tablet_test.go
@@ -84,7 +84,6 @@ func TestMain(m *testing.M) {
 		// Set extra tablet args for lock timeout
 		clusterInstance.VtTabletExtraArgs = []string{
 			"--lock-tables-timeout", "5s",
-			"--watch-replication-stream",
 			"--enable-replication-reporter",
 		}
 

--- a/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
+++ b/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
@@ -99,7 +99,6 @@ func TestMain(m *testing.M) {
 		// Set extra tablet args for lock timeout
 		clusterInstance.VtTabletExtraArgs = []string{
 			"--lock-tables-timeout", "5s",
-			"--watch-replication-stream",
 			"--enable-replication-reporter",
 			"--heartbeat-interval", "250ms",
 			"--gc-check-interval", gcCheckInterval.String(),

--- a/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
@@ -105,7 +105,6 @@ func TestMain(m *testing.M) {
 		// Set extra tablet args for lock timeout
 		clusterInstance.VtTabletExtraArgs = []string{
 			"--lock-tables-timeout", "5s",
-			"--watch-replication-stream",
 			"--enable-replication-reporter",
 			"--heartbeat-interval", "250ms",
 			"--heartbeat-on-demand-duration", onDemandHeartbeatDuration.String(),

--- a/go/test/endtoend/topoconncache/main_test.go
+++ b/go/test/endtoend/topoconncache/main_test.go
@@ -54,7 +54,6 @@ var (
 		"--vreplication-retry-delay", "1s",
 		"--degraded-threshold", "5s",
 		"--lock-tables-timeout", "5s",
-		"--watch-replication-stream",
 		"--enable-replication-reporter",
 		"--serving-state-grace-period", "1s",
 		"--binlog-player-protocol", "grpc",

--- a/go/test/endtoend/vault/vault_test.go
+++ b/go/test/endtoend/vault/vault_test.go
@@ -58,7 +58,6 @@ var (
 		"--vreplication-retry-delay", "1s",
 		"--degraded-threshold", "5s",
 		"--lock-tables-timeout", "5s",
-		"--watch-replication-stream",
 		// Frequently reload schema, generating some tablet traffic,
 		//   so we can speed up token refresh
 		"--queryserver-config-schema-reload-time", "5s",

--- a/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
@@ -358,7 +358,6 @@ func TestMain(m *testing.M) {
 			"--heartbeat-interval", "250ms",
 			"--heartbeat-on-demand-duration", "5s",
 			"--migration-check-interval", "3s",
-			"--watch-replication-stream",
 		}
 		clusterInstance.VtGateExtraArgs = []string{}
 

--- a/go/test/endtoend/vtorc/api/config_test.go
+++ b/go/test/endtoend/vtorc/api/config_test.go
@@ -71,17 +71,6 @@ func TestDynamicConfigs(t *testing.T) {
 		waitForConfig(t, vtorc, `"prevent-cross-cell-failover": true`)
 	})
 
-	t.Run("SnapshotTopologyInterval", func(t *testing.T) {
-		// Get configuration and verify the output.
-		waitForConfig(t, vtorc, `"snapshot-topology-interval": 0`)
-		// Update configuration and verify the output.
-		vtorc.Config.SnapshotTopologyInterval = "10h"
-		err := vtorc.RewriteConfiguration()
-		assert.NoError(t, err)
-		// Wait until the config has been updated and seen.
-		waitForConfig(t, vtorc, `"snapshot-topology-interval": "10h"`)
-	})
-
 	t.Run("ReasonableReplicationLag", func(t *testing.T) {
 		// Get configuration and verify the output.
 		waitForConfig(t, vtorc, `"reasonable-replication-lag": 10000000000`)

--- a/go/vt/sidecardb/sidecardb.go
+++ b/go/vt/sidecardb/sidecardb.go
@@ -24,7 +24,6 @@ import (
 	"log/slog"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"sync"
 
@@ -190,15 +189,6 @@ func loadSchemaDefinitions(parser *sqlparser.Parser) {
 	}
 }
 
-// printCallerDetails is a helper for dev debugging.
-func printCallerDetails() {
-	pc, _, line, ok := runtime.Caller(2)
-	details := runtime.FuncForPC(pc)
-	if ok && details != nil {
-		log.Info(fmt.Sprintf("%s schema init called from %s:%d\n", sidecar.GetName(), details.Name(), line))
-	}
-}
-
 type schemaInit struct {
 	ctx       context.Context
 	env       *vtenv.Environment
@@ -240,7 +230,6 @@ func getDDLErrorHistory() []*ddlError {
 // Init creates or upgrades the sidecar database based on
 // the declarative schema defined for all tables.
 func Init(ctx context.Context, env *vtenv.Environment, exec Exec) error {
-	printCallerDetails() // for debug purposes only, remove in v17
 	log.Info("Starting sidecardb.Init()")
 
 	once.Do(func() {

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -31,8 +31,6 @@ import (
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/prototext"
 
 	"vitess.io/vitess/go/protoutil"
@@ -796,7 +794,8 @@ func (s *Server) LookupVindexInternalize(ctx context.Context, req *vtctldatapb.L
 		if err != nil {
 			return err
 		}
-		query, err := sqlparser.ParseAndBind(SqlUnfreezeWorkflow,
+		query, err := sqlparser.ParseAndBind(
+			SqlUnfreezeWorkflow,
 			sqltypes.StringBindVariable(tabletInfo.DbName()),
 			sqltypes.StringBindVariable(req.Name),
 		)
@@ -3798,12 +3797,6 @@ func (s *Server) validateShardsHaveVReplicationPermissions(ctx context.Context, 
 			req := &tabletmanagerdatapb.ValidateVReplicationPermissionsRequest{}
 			res, err := s.tmc.ValidateVReplicationPermissions(validateCtx, tablet.Tablet, req)
 			if err != nil {
-				// This older tablet handling can be removed in v22 or later.
-				if st, ok := status.FromError(err); ok && st.Code() == codes.Unimplemented {
-					// This is a pre v21 tablet, so don't return an error since the
-					// permissions not being there should be very rare.
-					return nil
-				}
 				return vterrors.Wrapf(err, "failed to validate required vreplication metadata permissions on tablet %s",
 					topoproto.TabletAliasString(tablet.Alias))
 			}

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -29,8 +29,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/prototext"
 
 	"vitess.io/vitess/go/ptr"
@@ -3153,13 +3151,6 @@ func TestValidateShardsHaveVReplicationPermissions(t *testing.T) {
 		response            *validateVReplicationPermissionsResponse
 		expectedErrContains string
 	}{
-		{
-			// Expect no error in this case.
-			name: "unimplemented error",
-			response: &validateVReplicationPermissionsResponse{
-				err: status.Error(codes.Unimplemented, "unimplemented test"),
-			},
-		},
 		{
 			name: "tmc error",
 			response: &validateVReplicationPermissionsResponse{

--- a/go/vt/vtorc/config/config.go
+++ b/go/vt/vtorc/config/config.go
@@ -88,15 +88,6 @@ var (
 		},
 	)
 
-	snapshotTopologyInterval = viperutil.Configure(
-		"snapshot-topology-interval",
-		viperutil.Options[time.Duration]{
-			FlagName: "snapshot-topology-interval",
-			Default:  0 * time.Hour,
-			Dynamic:  true,
-		},
-	)
-
 	reasonableReplicationLag = viperutil.Configure(
 		"reasonable-replication-lag",
 		viperutil.Options[time.Duration]{
@@ -240,10 +231,9 @@ func init() {
 // registerFlags registers the flags required by VTOrc
 func registerFlags(fs *pflag.FlagSet) {
 	fs.Int("discovery-workers", discoveryWorkers.Default(), "Number of workers used for tablet discovery")
-	fs.String("cell", cell.Default(), "cell to use (required in v25+)")
+	fs.String("cell", cell.Default(), "cell to use (required)")
 	fs.String("sqlite-data-file", sqliteDataFile.Default(), "SQLite Datafile to use as VTOrc's database")
 	fs.Duration("instance-poll-time", instancePollTime.Default(), "Timer duration on which VTOrc refreshes MySQL information")
-	fs.Duration("snapshot-topology-interval", snapshotTopologyInterval.Default(), "Timer duration on which VTOrc takes a snapshot of the current MySQL information it has in the database. Should be in multiple of hours")
 	fs.Duration("reasonable-replication-lag", reasonableReplicationLag.Default(), "Maximum replication lag on replicas which is deemed to be acceptable")
 	fs.String("audit-file-location", auditFileLocation.Default(), "File location where the audit logs are to be stored")
 	fs.Bool("audit-to-backend", auditToBackend.Default(), "Whether to store the audit log in the VTOrc database")
@@ -261,13 +251,13 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.Bool("change-tablets-with-errant-gtid-to-drained", convertTabletsWithErrantGTIDs.Default(), "Whether VTOrc should be changing the type of tablets with errant GTIDs to DRAINED")
 	fs.Bool("enable-primary-disk-stalled-recovery", enablePrimaryDiskStalledRecovery.Default(), "Whether VTOrc should detect a stalled disk on the primary and failover")
 
-	viperutil.BindFlags(fs,
+	viperutil.BindFlags(
+		fs,
 		cell,
 		instancePollTime,
 		preventCrossCellFailover,
 		discoveryWorkers,
 		sqliteDataFile,
-		snapshotTopologyInterval,
 		reasonableReplicationLag,
 		auditFileLocation,
 		auditToBackend,
@@ -324,11 +314,6 @@ func GetSQLiteDataFile() string {
 // GetReasonableReplicationLagSeconds gets the reasonable replication lag but in seconds.
 func GetReasonableReplicationLagSeconds() int64 {
 	return int64(reasonableReplicationLag.Get() / time.Second)
-}
-
-// GetSnapshotTopologyInterval is a getter function.
-func GetSnapshotTopologyInterval() time.Duration {
-	return snapshotTopologyInterval.Get()
 }
 
 // GetAuditFileLocation is a getter function.

--- a/go/vt/vtorc/db/generate_base.go
+++ b/go/vt/vtorc/db/generate_base.go
@@ -21,7 +21,6 @@ var TableNames = []string{
 	"audit",
 	"node_health",
 	"topology_recovery",
-	"database_instance_topology_history",
 	"recovery_detection",
 	"database_instance_last_analysis",
 	"database_instance_analysis_changelog",
@@ -165,25 +164,6 @@ CREATE TABLE topology_recovery (
 )`,
 	`
 CREATE INDEX start_recovery_idx_topology_recovery ON topology_recovery (start_recovery)
-	`,
-	`
-DROP TABLE IF EXISTS database_instance_topology_history
-`,
-	`
-CREATE TABLE database_instance_topology_history (
-	snapshot_unix_timestamp int NOT NULL,
-	alias varchar(256) NOT NULL,
-	hostname varchar(128) NOT NULL,
-	port smallint NOT NULL,
-	source_host varchar(128) NOT NULL,
-	source_port smallint NOT NULL,
-	keyspace varchar(128) NOT NULL,
-	shard varchar(128) NOT NULL,
-	version varchar(128) not null default '',
-	PRIMARY KEY (snapshot_unix_timestamp, alias)
-)`,
-	`
-CREATE INDEX keyspace_shard_idx_database_instance_topology_history ON database_instance_topology_history (snapshot_unix_timestamp, keyspace, shard)
 	`,
 	`
 DROP TABLE IF EXISTS recovery_detection

--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -1194,40 +1194,6 @@ func ForgetLongUnseenInstances() error {
 	return err
 }
 
-// SnapshotTopologies records topology graph for all existing topologies
-func SnapshotTopologies() error {
-	writeFunc := func() error {
-		_, err := db.ExecVTOrc(`INSERT OR IGNORE
-			INTO database_instance_topology_history (
-				snapshot_unix_timestamp,
-				alias,
-				hostname,
-				port,
-				source_host,
-				source_port,
-				keyspace,
-				shard,
-				version
-			)
-			SELECT
-				STRFTIME('%s', 'now'),
-				vitess_tablet.alias, vitess_tablet.hostname, vitess_tablet.port,
-				database_instance.source_host, database_instance.source_port,
-				vitess_tablet.keyspace, vitess_tablet.shard, database_instance.version
-			FROM
-				vitess_tablet LEFT JOIN database_instance USING (alias, hostname, port)
-			`,
-		)
-		if err != nil {
-			log.Error(err.Error())
-			return err
-		}
-
-		return nil
-	}
-	return ExecDBWriteFunc(writeFunc)
-}
-
 func ExpireStaleInstanceBinlogCoordinates() error {
 	expireSeconds := max(config.GetReasonableReplicationLagSeconds()*2, config.StaleInstanceCoordinatesExpireSeconds)
 	writeFunc := func() error {

--- a/go/vt/vtorc/inst/instance_dao_test.go
+++ b/go/vt/vtorc/inst/instance_dao_test.go
@@ -785,31 +785,6 @@ func TestForgetInstanceAndInstanceIsForgotten(t *testing.T) {
 	}
 }
 
-func TestSnapshotTopologies(t *testing.T) {
-	// Clear the database after the test. The easiest way to do that is to run all the initialization commands again.
-	defer func() {
-		db.ClearVTOrcDatabase()
-	}()
-
-	for _, query := range initialSQL {
-		_, err := db.ExecVTOrc(query)
-		require.NoError(t, err)
-	}
-
-	err := SnapshotTopologies()
-	require.NoError(t, err)
-
-	query := "select alias from database_instance_topology_history"
-	var tabletAliases []string
-	err = db.QueryVTOrc(query, nil, func(rowMap sqlutils.RowMap) error {
-		tabletAliases = append(tabletAliases, rowMap.GetString("alias"))
-		return nil
-	})
-	require.NoError(t, err)
-
-	require.Equal(t, []string{"zone1-0000000100", "zone1-0000000101", "zone1-0000000112", "zone2-0000000200"}, tabletAliases)
-}
-
 func TestGetDatabaseState(t *testing.T) {
 	// Clear the database after the test. The easiest way to do that is to run all the initialization commands again.
 	defer func() {

--- a/go/vt/vtorc/logic/vtorc.go
+++ b/go/vt/vtorc/logic/vtorc.go
@@ -272,11 +272,6 @@ func ContinuousDiscovery() {
 	recoveryTick := time.Tick(config.GetRecoveryPollDuration())
 	tabletTopoTick := OpenTabletDiscovery()
 	var recoveryEntrance atomic.Int64
-	var snapshotTopologiesTick <-chan time.Time
-	if config.GetSnapshotTopologyInterval() > 0 {
-		log.Warn("--snapshot-topology-interval is deprecated and will be removed in v25+")
-		snapshotTopologiesTick = time.Tick(config.GetSnapshotTopologyInterval())
-	}
 
 	go func() {
 		_ = initMetrics()
@@ -316,8 +311,6 @@ func ContinuousDiscovery() {
 					CheckAndRecover()
 				}()
 			}()
-		case <-snapshotTopologiesTick:
-			go inst.SnapshotTopologies() //nolint:errcheck
 		case <-tabletTopoTick:
 			ctx, cancel := context.WithTimeout(context.Background(), config.GetTopoInformationRefreshDuration())
 			if err := refreshAllInformation(ctx); err != nil {

--- a/go/vt/vtorc/server/discovery.go
+++ b/go/vt/vtorc/server/discovery.go
@@ -31,9 +31,7 @@ import (
 // validateCell checks that the provided cell exists.
 func validateCell(cell string) error {
 	if cell == "" {
-		// TODO: remove warning in v25+, make flag required.
-		log.Warn("WARNING: --cell will become a required vtorc flag in v25 and up")
-		return nil
+		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "--cell is required")
 	}
 
 	// TODO: pass a single *topo.Server into VTOrc down from StartVTOrcDiscovery().

--- a/go/vt/vttablet/grpctmclient/client.go
+++ b/go/vt/vttablet/grpctmclient/client.go
@@ -164,13 +164,7 @@ func NewClient() *Client {
 // validateTablet confirms the tablet record contains the necessary fields
 // for talking gRPC.
 func validateTablet(tablet *topodatapb.Tablet) error {
-	// v24+ adds a TabletShutdownTime field that is set to "now" on clean shutdown.
 	if tablet.TabletShutdownTime != nil {
-		return vterrors.New(vtrpcpb.Code_UNAVAILABLE, "tablet is shutdown")
-	}
-
-	// <= v23 compatibility to similuate missing TabletShutdownTime field. Remove in v25.
-	if tablet.Hostname == "" && tablet.MysqlHostname == "" && tablet.PortMap == nil && tablet.Type != topodatapb.TabletType_UNKNOWN {
 		return vterrors.New(vtrpcpb.Code_UNAVAILABLE, "tablet is shutdown")
 	}
 

--- a/go/vt/vttablet/grpctmclient/client_test.go
+++ b/go/vt/vttablet/grpctmclient/client_test.go
@@ -227,18 +227,6 @@ func TestValidateTablet(t *testing.T) {
 		require.ErrorContains(t, validateTablet(tablet), "tablet is shutdown")
 	})
 
-	// TODO: remove in v25
-	t.Run("is shutdown pre-v24", func(t *testing.T) {
-		tablet := &topodatapb.Tablet{
-			Type:               topodatapb.TabletType_REPLICA,
-			Hostname:           "",
-			MysqlHostname:      "",
-			PortMap:            nil,
-			TabletShutdownTime: nil,
-		}
-		require.ErrorContains(t, validateTablet(tablet), "tablet is shutdown")
-	})
-
 	t.Run("invalid - empty Hostname", func(t *testing.T) {
 		tablet := &topodatapb.Tablet{
 			Hostname: "",

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication.go
@@ -606,7 +606,11 @@ func (tm *TabletManager) UpdateVReplicationWorkflow(ctx context.Context, req *ta
 			return nil, err
 		}
 		if req.State != nil {
-			state = binlogdatapb.VReplicationWorkflowState_name[int32(*req.State)]
+			var ok bool
+			state, ok = binlogdatapb.VReplicationWorkflowState_name[int32(*req.State)]
+			if !ok {
+				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid state value: %v", req.GetState())
+			}
 		}
 		if state == binlogdatapb.VReplicationWorkflowState_Running.String() {
 			// `Workflow Start` sets the new state to Running. However, if stream is still copying tables, we should set

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication.go
@@ -598,6 +598,9 @@ func (tm *TabletManager) UpdateVReplicationWorkflow(ctx context.Context, req *ta
 			return nil, err
 		}
 		if req.OnDdl != nil {
+			if _, ok := binlogdatapb.OnDDLAction_name[int32(*req.OnDdl)]; !ok {
+				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid OnDdl value: %v", req.GetOnDdl())
+			}
 			bls.OnDdl = *req.OnDdl
 		}
 		bls.Filter.Rules = append(bls.Filter.Rules, req.FilterRules...)

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication.go
@@ -145,7 +145,8 @@ func (tm *TabletManager) CreateVReplicationWorkflow(ctx context.Context, req *ta
 			"deferSecondaryKeys": sqltypes.BoolBindVariable(req.DeferSecondaryKeys),
 			"options":            sqltypes.StringBindVariable(req.Options),
 		}
-		parsed := sqlparser.BuildParsedQuery(sqlCreateVReplicationWorkflow, sidecar.GetIdentifier(),
+		parsed := sqlparser.BuildParsedQuery(
+			sqlCreateVReplicationWorkflow, sidecar.GetIdentifier(),
 			":workflow", ":source", ":cells", ":tabletTypes", ":state", ":dbname", ":workflowType", ":workflowSubType",
 			":deferSecondaryKeys", ":options",
 		)
@@ -596,9 +597,7 @@ func (tm *TabletManager) UpdateVReplicationWorkflow(ctx context.Context, req *ta
 		if err = prototext.Unmarshal(source, bls); err != nil {
 			return nil, err
 		}
-		// We also need to check for a SimulatedNull here to support older clients and
-		// smooth upgrades. All non-slice simulated NULL checks can be removed in v22+.
-		if req.OnDdl != nil && *req.OnDdl != binlogdatapb.OnDDLAction(textutil.SimulatedNullInt) {
+		if req.OnDdl != nil {
 			bls.OnDdl = *req.OnDdl
 		}
 		bls.Filter.Rules = append(bls.Filter.Rules, req.FilterRules...)
@@ -606,9 +605,7 @@ func (tm *TabletManager) UpdateVReplicationWorkflow(ctx context.Context, req *ta
 		if err != nil {
 			return nil, err
 		}
-		// We also need to check for a SimulatedNull here to support older clients and
-		// smooth upgrades. All non-slice simulated NULL checks can be removed in v22+.
-		if req.State != nil && *req.State != binlogdatapb.VReplicationWorkflowState(textutil.SimulatedNullInt) {
+		if req.State != nil {
 			state = binlogdatapb.VReplicationWorkflowState_name[int32(*req.State)]
 		}
 		if state == binlogdatapb.VReplicationWorkflowState_Running.String() {
@@ -756,7 +753,8 @@ func (tm *TabletManager) getMaxSequenceValue(ctx context.Context, sm *tabletmana
 				"the database (%s), table (%s), and column (%s) names must be non-empty escaped values", sm.UsingTableDbNameEscaped, sm.UsingTableNameEscaped, sm.UsingColEscaped)
 		}
 	}
-	query := sqlparser.BuildParsedQuery(sqlGetMaxSequenceVal,
+	query := sqlparser.BuildParsedQuery(
+		sqlGetMaxSequenceVal,
 		sm.UsingColEscaped,
 		sm.UsingTableDbNameEscaped,
 		sm.UsingTableNameEscaped,
@@ -796,7 +794,8 @@ func (tm *TabletManager) UpdateSequenceTables(ctx context.Context, req *tabletma
 	if err != nil {
 		return nil, vterrors.Errorf(
 			vtrpcpb.Code_INTERNAL, "failed to reset sequences on %q: %v",
-			tm.DBConfigs.DBName, err)
+			tm.DBConfigs.DBName, err,
+		)
 	}
 	return &tabletmanagerdatapb.UpdateSequenceTablesResponse{}, nil
 }
@@ -817,7 +816,8 @@ func (tm *TabletManager) updateSequenceValue(ctx context.Context, seq *tabletman
 			seq.BackingTableName, err)
 	}
 	log.Info(fmt.Sprintf("Updating sequence %s.%s to %d", seq.BackingTableDbName, seq.BackingTableName, nextVal))
-	initQuery := sqlparser.BuildParsedQuery(sqlInitSequenceTable,
+	initQuery := sqlparser.BuildParsedQuery(
+		sqlInitSequenceTable,
 		backingTableDbNameEscaped,
 		backingTableNameEscaped,
 		nextVal,
@@ -856,7 +856,8 @@ func (tm *TabletManager) updateSequenceValue(ctx context.Context, seq *tabletman
 
 	return vterrors.Errorf(
 		vtrpcpb.Code_INTERNAL, "failed to initialize the backing sequence table %s.%s after retries. Last error: %v",
-		backingTableDbNameEscaped, backingTableNameEscaped, err)
+		backingTableDbNameEscaped, backingTableNameEscaped, err,
+	)
 }
 
 func (tm *TabletManager) createSequenceTable(ctx context.Context, tableName string) error {
@@ -882,7 +883,8 @@ func (tm *TabletManager) createSequenceTable(ctx context.Context, tableName stri
 // instead of querying mysql.user table directly as that requires permissions on the mysql.user table.
 // Leaving this here for now in case we want to revert back.
 func (tm *TabletManager) ValidateVReplicationPermissionsOld(ctx context.Context, req *tabletmanagerdatapb.ValidateVReplicationPermissionsRequest) (*tabletmanagerdatapb.ValidateVReplicationPermissionsResponse, error) {
-	query, err := sqlparser.ParseAndBind(sqlValidateVReplicationPermissions,
+	query, err := sqlparser.ParseAndBind(
+		sqlValidateVReplicationPermissions,
 		sqltypes.StringBindVariable(tm.DBConfigs.Filtered.User),
 		sqltypes.StringBindVariable(sidecar.GetName()),
 		sqltypes.StringBindVariable(sidecar.GetName()),
@@ -1101,9 +1103,7 @@ func (tm *TabletManager) buildUpdateVReplicationWorkflowsQuery(req *tabletmanage
 	predicates := strings.Builder{}
 
 	// First add the SET clauses.
-	// We also need to check for a SimulatedNull here to support older clients and
-	// smooth upgrades. All non-slice simulated NULL checks can be removed in v22+.
-	if req.State != nil && *req.State != binlogdatapb.VReplicationWorkflowState(textutil.SimulatedNullInt) {
+	if req.State != nil {
 		state, ok := binlogdatapb.VReplicationWorkflowState_name[int32(req.GetState())]
 		if !ok {
 			return "", vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid state value: %v", req.GetState())
@@ -1111,18 +1111,14 @@ func (tm *TabletManager) buildUpdateVReplicationWorkflowsQuery(req *tabletmanage
 		sets.WriteString(" state = ")
 		sets.WriteString(sqltypes.EncodeStringSQL(state))
 	}
-	// We also need to check for a SimulatedNull here to support older clients and
-	// smooth upgrades. All non-slice simulated NULL checks can be removed in v22+.
-	if req.Message != nil && *req.Message != sqltypes.Null.String() {
+	if req.Message != nil {
 		if sets.Len() > 0 {
 			sets.WriteByte(',')
 		}
 		sets.WriteString(" message = ")
 		sets.WriteString(sqltypes.EncodeStringSQL(req.GetMessage()))
 	}
-	// We also need to check for a SimulatedNull here to support older clients and
-	// smooth upgrades. All non-slice simulated NULL checks can be removed in v22+.
-	if req.StopPosition != nil && *req.StopPosition != sqltypes.Null.String() {
+	if req.StopPosition != nil {
 		if sets.Len() > 0 {
 			sets.WriteByte(',')
 		}

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
@@ -931,12 +931,15 @@ func TestUpdateVReplicationWorkflow(t *testing.T) {
 	notCopying := sqltypes.MakeTestResult(copyStatusFields)
 	copying := sqltypes.MakeTestResult(copyStatusFields, "1")
 
+	invalidState := binlogdatapb.VReplicationWorkflowState(9999)
+
 	tests := []struct {
 		name                     string
 		request                  *tabletmanagerdatapb.UpdateVReplicationWorkflowRequest
 		query                    string
 		isCopying                bool
 		initiallyNonEmptyMessage bool
+		wantErr                  string
 	}{
 		{
 			name: "update cells",
@@ -1064,6 +1067,16 @@ func TestUpdateVReplicationWorkflow(t *testing.T) {
 			query: fmt.Sprintf(`update _vt.vreplication set state = 'Running', source = 'keyspace:"%s" shard:"%s" filter:{rules:{match:"corder" filter:"select * from corder"} rules:{match:"customer" filter:"select * from customer"}}', cell = '%s', tablet_types = '', message = '', options = json_set(options, '$.config', json_object(), '$.config."password"', 'secret', '$.config."user"', 'admin') where id in (%d)`,
 				keyspace, shard, "zone2", vreplID),
 		},
+		{
+			name: "invalid state value",
+			request: &tabletmanagerdatapb.UpdateVReplicationWorkflowRequest{
+				Workflow:    workflow,
+				State:       &invalidState,
+				Cells:       textutil.SimulatedNullStringSlice,
+				TabletTypes: textutil.SimulatedNullTabletTypeSlice,
+			},
+			wantErr: fmt.Sprintf("invalid state value: %d", invalidState),
+		},
 	}
 
 	for _, tt := range tests {
@@ -1079,7 +1092,9 @@ func TestUpdateVReplicationWorkflow(t *testing.T) {
 			}()
 
 			require.NotNil(t, tt.request, "No request provided")
-			require.NotEqual(t, "", tt.query, "No expected query provided")
+			if tt.wantErr == "" {
+				require.NotEqual(t, "", tt.query, "No expected query provided")
+			}
 
 			// These are the same for each RPC call.
 			tenv.tmc.tablets[tabletUID].vrdbClient.ExpectRequest("use "+sidecar.GetIdentifier(), &sqltypes.Result{}, nil)
@@ -1088,23 +1103,29 @@ func TestUpdateVReplicationWorkflow(t *testing.T) {
 			} else {
 				tenv.tmc.tablets[tabletUID].vrdbClient.ExpectRequest(selectQuery, selectRes, nil)
 			}
-			if tt.request.State == nil || *tt.request.State == binlogdatapb.VReplicationWorkflowState_Running {
-				tenv.tmc.tablets[tabletUID].vrdbClient.ExpectRequest("use "+sidecar.GetIdentifier(), &sqltypes.Result{}, nil)
-				if tt.isCopying {
-					tenv.tmc.tablets[tabletUID].vrdbClient.ExpectRequest(getCopyStateQuery, copying, nil)
-				} else {
-					tenv.tmc.tablets[tabletUID].vrdbClient.ExpectRequest(getCopyStateQuery, notCopying, nil)
+			if tt.wantErr == "" {
+				if tt.request.State == nil || *tt.request.State == binlogdatapb.VReplicationWorkflowState_Running {
+					tenv.tmc.tablets[tabletUID].vrdbClient.ExpectRequest("use "+sidecar.GetIdentifier(), &sqltypes.Result{}, nil)
+					if tt.isCopying {
+						tenv.tmc.tablets[tabletUID].vrdbClient.ExpectRequest(getCopyStateQuery, copying, nil)
+					} else {
+						tenv.tmc.tablets[tabletUID].vrdbClient.ExpectRequest(getCopyStateQuery, notCopying, nil)
+					}
 				}
+				// This is our expected query, which will also short circuit
+				// the test with an error as at this point we've tested what
+				// we wanted to test.
+				tenv.tmc.tablets[tabletUID].vrdbClient.ExpectRequest("use "+sidecar.GetIdentifier(), &sqltypes.Result{}, nil)
+				tenv.tmc.tablets[tabletUID].vrdbClient.ExpectRequest(idQuery, idRes, nil)
+				tenv.tmc.tablets[tabletUID].vrdbClient.ExpectRequest(tt.query, &sqltypes.Result{RowsAffected: 1}, errShortCircuit)
 			}
-			// This is our expected query, which will also short circuit
-			// the test with an error as at this point we've tested what
-			// we wanted to test.
-			tenv.tmc.tablets[tabletUID].vrdbClient.ExpectRequest("use "+sidecar.GetIdentifier(), &sqltypes.Result{}, nil)
-			tenv.tmc.tablets[tabletUID].vrdbClient.ExpectRequest(idQuery, idRes, nil)
-			tenv.tmc.tablets[tabletUID].vrdbClient.ExpectRequest(tt.query, &sqltypes.Result{RowsAffected: 1}, errShortCircuit)
 			_, err = tenv.tmc.tablets[tabletUID].tm.UpdateVReplicationWorkflow(ctx, tt.request)
 			tenv.tmc.tablets[tabletUID].vrdbClient.Wait()
-			require.ErrorIs(t, err, errShortCircuit)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.ErrorIs(t, err, errShortCircuit)
+			}
 		})
 	}
 }

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -162,8 +162,6 @@ func registerTabletEnvFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&currentConfig.TerseErrors, "queryserver-config-terse-errors", defaultConfig.TerseErrors, "prevent bind vars from escaping in client error messages")
 	fs.IntVar(&currentConfig.TruncateErrorLen, "queryserver-config-truncate-error-len", defaultConfig.TruncateErrorLen, "truncate errors sent to client if they are longer than this value (0 means do not truncate)")
 	fs.BoolVar(&currentConfig.AnnotateQueries, "queryserver-config-annotate-queries", defaultConfig.AnnotateQueries, "prefix queries to MySQL backend with comment indicating vtgate principal (user) and target tablet type")
-	utils.SetFlagBoolVar(fs, &currentConfig.WatchReplication, "watch-replication-stream", false, "(Deprecated and ignored) When enabled, vttablet will stream the MySQL replication stream from the local server, and use it to update schema when it sees a DDL.")
-	_ = fs.MarkDeprecated("watch-replication-stream", "please use --track-schema-versions instead, --watch-replication-stream is ignored and will be removed in v25")
 	utils.SetFlagBoolVar(fs, &currentConfig.TrackSchemaVersions, "track-schema-versions", false, "When enabled, vttablet will store versions of schemas at each position that a DDL is applied and allow retrieval of the schema corresponding to a position")
 	fs.Int64Var(&currentConfig.SchemaVersionMaxAgeSeconds, "schema-version-max-age-seconds", 0, "max age of schema version records to kept in memory by the vreplication historian")
 
@@ -349,7 +347,6 @@ type TabletConfig struct {
 	QueryCacheDoorkeeper        bool          `json:"queryCacheDoorkeeper,omitempty"`
 	SchemaReloadInterval        time.Duration `json:"schemaReloadIntervalSeconds,omitempty"`
 	SchemaChangeReloadTimeout   time.Duration `json:"schemaChangeReloadTimeout,omitempty"`
-	WatchReplication            bool          `json:"watchReplication,omitempty"` // Ignored and unused, remove in v25
 	TrackSchemaVersions         bool          `json:"trackSchemaVersions,omitempty"`
 	SchemaVersionMaxAgeSeconds  int64         `json:"schemaVersionMaxAgeSeconds,omitempty"`
 	TerseErrors                 bool          `json:"terseErrors,omitempty"`

--- a/test/antithesis/compose/vtorc-up.sh
+++ b/test/antithesis/compose/vtorc-up.sh
@@ -20,10 +20,12 @@ SOURCE_DB=${SOURCE_DB:-0}
 WEB_PORT=${WEB_PORT:-"8080"}
 VTORC_CONFIG=${VTORC_CONFIG:-/vt/vtorc/config.json}
 TOPOLOGY_FLAGS=${TOPOLOGY_FLAGS:-""}
+CELL=${CELL:-"test"}
 
 source_db=$SOURCE_DB
 web_port=$WEB_PORT
 config=$VTORC_CONFIG
+cell=$CELL
 # Copy config directory
 cp -R /script/vtorc /vt
 # Update credentials
@@ -44,5 +46,6 @@ read -r -a topo_args <<< "$TOPOLOGY_FLAGS"
 exec /vt/bin/vtorc \
 "${topo_args[@]}" \
 --logtostderr=true \
+--cell "$cell" \
 --port "$web_port" \
 --config-file "$config"


### PR DESCRIPTION
## Description

Cleans up 10 x `TODO`/deprecation items in `go/` that target a Vitess version of v25 or earlier. We're now building v25, so old compat shims, debug helpers and deprecated flags are eligible for removal

#### What was removed

1. **`grpctmclient` v23 compat shim** in `validateTablet()` _(simulated a missing `TabletShutdownTime` field via a `Hostname`/`MysqlHostname`/`PortMap`-nil heuristic)_ + the paired test case

2. **`--watch-replication-stream` flag** and the `WatchReplication` field in `tabletenv/config.go`. References cleaned up across 18 x e2e test files and `config/tablet/default.yaml`

3. **`--snapshot-topology-interval` flag** and the entire snapshot-topology feature in VTOrc — flag/getter, tick branch, `SnapshotTopologies()` and its test, the `database_instance_topology_history` SQLite table, e2e config field + sub-test, plus references in `examples/common/vtorc/config.yaml` and `flags/endtoend/vtorc.txt`

4. **VTOrc `--cell` is now required** — `validateCell()` previously logged a warning and continued; it now returns a `FAILED_PRECONDITION` error if `--cell` is empty

5. **5 x `SimulatedNull` non-slice checks in `rpc_vreplication.go`** _(`OnDdl`, `State` ×2, `Message`, `StopPosition`)_. The comments target "v22+" so they're overdue

6. **Pre-v21 `codes.Unimplemented` branch** in `validateShardsHaveVReplicationPermissions()` _(`go/vt/vtctl/workflow/server.go`)_ + updated unit test, dropped now-unused `codes`/`status` imports

7. **`printCallerDetails()` debug helper** in `go/vt/sidecardb/sidecardb.go` _(was tagged `remove in v17` 😅)_

The `go/vt/sidecardb/doc.go` note about removing `IF NOT EXISTS` from the 21 x sidecar schema `CREATE TABLE` statements is deferred — that's a real schema change with upgrade implications and deserves its own issue/PR

## Related Issue(s)

Resolves: #20047

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

3 x user-visible behaviour changes that need release-note callouts:
1. `--watch-replication-stream` removed — startup will fail if still passed _(the flag has been deprecated and ignored for a while)_
2. `--snapshot-topology-interval` removed and the snapshot-topology feature entirely deleted, including the `database_instance_topology_history` SQLite table
3. VTOrc `--cell` is now required — previously a warning, now a hard `FAILED_PRECONDITION` error if missing

### AI Disclosure

This PR was written primarily by Claude Code — I provided direction on scope and reviewed. Claude also prepared this PR summary