### PR TITLE
`ci`: remove unnecessary `libaio` workaround from `setup-mysql` action

### DIFF
--- a/.github/actions/setup-mysql/action.yml
+++ b/.github/actions/setup-mysql/action.yml
@@ -22,12 +22,6 @@ runs:
         sudo rm -rf /var/lib/mysql
         sudo rm -rf /etc/mysql
 
-        # We have to install this old version of libaio1. See also:
-        # https://bugs.launchpad.net/ubuntu/+source/libaio/+bug/2067501
-        wget http://archive.ubuntu.com/ubuntu/pool/main/liba/libaio/libaio1_0.3.112-13build1_amd64.deb && \
-          sudo dpkg -i libaio1_0.3.112-13build1_amd64.deb && \
-          rm libaio1_0.3.112-13build1_amd64.deb
-
         # Get key to latest MySQL repo
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A8D3785C
         wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.35-1_all.deb

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -123,6 +123,7 @@ jobs:
               - 'tools/**'
               - 'config/**'
               - 'bootstrap.sh'
+              - '.github/actions/setup-mysql/**'
               - '.github/workflows/cluster_endtoend.yml'
 
       - name: Set up Go

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -50,6 +50,7 @@ jobs:
         token: ''
         filters: |
           changed_files:
+            - '.github/actions/setup-mysql/**'
             - .github/workflows/codecov.yml
             - 'go/**'
             - go.mod

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -48,6 +48,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/actions/setup-mysql/**'
             - '.github/workflows/e2e_race.yml'
 
     - name: Set up Go

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -48,6 +48,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/actions/setup-mysql/**'
             - '.github/workflows/endtoend.yml'
 
     - name: Set up Go

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -108,6 +108,7 @@ jobs:
               - 'tools/**'
               - 'config/**'
               - 'bootstrap.sh'
+              - '.github/actions/setup-mysql/**'
               - '.github/workflows/unit_test.yml'
 
       - name: Set up Go

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -65,6 +65,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/actions/setup-mysql/**'
             - '.github/workflows/upgrade_downgrade_test_backups_e2e.yml'
 
     - name: Tune the OS

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -67,6 +67,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/actions/setup-mysql/**'
             - '.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml'
 
     - name: Tune the OS

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -61,6 +61,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/actions/setup-mysql/**'
             - '.github/workflows/upgrade_downgrade_test_backups_manual.yml'
             - 'examples/**'
 

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -62,6 +62,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/actions/setup-mysql/**'
             - '.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml'
             - 'examples/**'
 

--- a/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
+++ b/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
@@ -62,6 +62,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/actions/setup-mysql/**'
             - '.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml'
 
     - name: Set output with latest release branch

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -69,6 +69,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/actions/setup-mysql/**'
             - '.github/workflows/upgrade_downgrade_test_query_serving_queries.yml'
 
     - name: Tune the OS

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
@@ -61,6 +61,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/actions/setup-mysql/**'
             - '.github/workflows/upgrade_downgrade_test_query_serving_queries.yml'
 
     - name: Set output with latest release branch

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
@@ -70,6 +70,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/actions/setup-mysql/**'
             - '.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml'
 
     - name: Tune the OS

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -70,6 +70,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/actions/setup-mysql/**'
             - '.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml'
 
     - name: Tune the OS

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -69,6 +69,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/actions/setup-mysql/**'
             - '.github/workflows/upgrade_downgrade_test_query_serving_schema.yml'
 
     - name: Tune the OS

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -70,6 +70,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/actions/setup-mysql/**'
             - '.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml'
 
     - name: Tune the OS

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -70,6 +70,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/actions/setup-mysql/**'
             - '.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml'
 
     - name: Tune the OS

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -70,6 +70,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/actions/setup-mysql/**'
             - '.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml'
 
     - name: Tune the OS

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -69,6 +69,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/actions/setup-mysql/**'
             - '.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml'
 
     - name: Tune the OS

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -69,6 +69,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/actions/setup-mysql/**'
             - '.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml'
 
     - name: Tune the OS

--- a/.github/workflows/vitess_tester_vtgate.yml
+++ b/.github/workflows/vitess_tester_vtgate.yml
@@ -61,6 +61,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
+            - '.github/actions/setup-mysql/**'
             - '.github/workflows/vitess_tester_vtgate.yml'
 
     - name: Set up Go

--- a/.github/workflows/vtop_example.yml
+++ b/.github/workflows/vtop_example.yml
@@ -56,6 +56,7 @@ jobs:
               - 'bootstrap.sh'
               - 'examples/**'
               - 'test/**'
+              - '.github/actions/setup-mysql/**'
               - '.github/workflows/vtop_example.yml'
 
       - name: Set up Go


### PR DESCRIPTION
## Description

Removes the `libaio1` workaround in `.github/actions/setup-mysql/action.yml` that downloads an older `.deb` directly from `http://archive.ubuntu.com` via `wget` + `dpkg -i`, bypassing `apt`

The workaround was added because Ubuntu 24.04 renamed the `libaio` SONAME from `libaio.so.1` to `libaio.so.1t64` _(64-bit `time_t` transition)_, and MySQL's generic binaries are linked against the old SONAME. But `archive.ubuntu.com` is flaky and has been failing CI runs for reasons unrelated to the code being tested

InnoDB defaults to `innodb_use_native_aio=ON` but auto-detects at startup — when `libaio.so.1` isn't available, it logs a warning and falls back to simulated AIO. For CI test workloads there's no meaningful performance difference, so we can safely drop the install

If we find this has a negative impact on CI, we can revert

#### Also: paths-filters were silently skipping every test job

While reviewing the first commit's CI output, none of the 22 x workflows that consume `setup-mysql` were actually running their tests on this PR — every job short-circuited at the `dorny/paths-filter` step and reported success without starting `mysqld`. Confirmed across `Unit Test (mysql80)`, `Unit Test (Race)`, `VTop Example`, `vtorc`, `xb_backup`, and `vtgate_general_heavy` — only the setup/checkout/cleanup steps executed

The cause: none of the consuming workflows _(`cluster_endtoend.yml`, `unit_test.yml`, `codecov.yml`, `e2e_race.yml`, `endtoend.yml`, `vitess_tester_vtgate.yml`, `vtop_example.yml`, and the 15 x `upgrade_downgrade_*` workflows)_ list `.github/actions/setup-mysql/**` in their `paths-filter`. Edits to the shared action don't trigger any test that depends on it

The second commit adds `'.github/actions/setup-mysql/**'` to each affected filter so this PR's CI _(and any future change to `setup-mysql`)_ actually exercises the test matrix. `codeql_analysis.yml` is unaffected — it has no `paths-filter` and runs unconditionally on `push` and on schedule

## Related Issue(s)

Resolves: https://github.com/vitessio/vitess/issues/19912

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

N/A — CI-only change

### AI Disclosure

Claude Code assisted with development and testing; I reviewed and pushed each commit manually. Claude prepared this PR summary