### PR TITLE
tabletmanager: improve logging for `DemotePrimary`

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -569,7 +569,6 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 	}
 	defer tm.unlock()
 	defer tm.QueryServiceControl.SetDemotePrimaryStalled(false)
-	log.Info("acquired action lock")
 
 	finishCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -598,7 +597,6 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 	wasPrimary := tablet.Type == topodatapb.TabletType_PRIMARY
 	wasServing := tm.QueryServiceControl.IsServing()
 
-	log.Info("reading mysql read_only state")
 	wasReadOnly, err := tm.MysqlDaemon.IsReadOnly(ctx)
 	if err != nil {
 		return nil, err
@@ -639,7 +637,6 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 		}()
 	}
 
-	log.Info("checking semi-sync status")
 	isSemiSyncBlocked, err := tm.MysqlDaemon.IsSemiSyncBlocked(ctx)
 	if err != nil {
 		return nil, err
@@ -669,7 +666,6 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 	//
 	// The demoted primary will end up with errant GTIDs, but that's unavoidable in this scenario.
 	if force && isSemiSyncBlocked {
-		log.Info("checking primary-side semi-sync state")
 		if tm.isPrimarySideSemiSyncEnabled(ctx) {
 			// Disable the primary side semi-sync to unblock the writes.
 			log.Info("disabling primary-side semi-sync to unblock stuck writes")
@@ -733,7 +729,6 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 		}
 	}()
 
-	log.Info("checking primary-side semi-sync state")
 	// If we haven't disabled the primary side semi-sync so far, do it now.
 	if tm.isPrimarySideSemiSyncEnabled(ctx) {
 		// If using semi-sync, we need to disable primary-side.
@@ -752,7 +747,6 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 	}
 
 	// Return the current replication position.
-	log.Info("reading primary status")
 	status, err := tm.MysqlDaemon.PrimaryStatus(ctx)
 	if err != nil {
 		return nil, err

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -597,6 +597,7 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 	wasPrimary := tablet.Type == topodatapb.TabletType_PRIMARY
 	wasServing := tm.QueryServiceControl.IsServing()
 
+	log.Info("reading mysql read_only state")
 	wasReadOnly, err := tm.MysqlDaemon.IsReadOnly(ctx)
 	if err != nil {
 		return nil, err
@@ -637,6 +638,7 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 		}()
 	}
 
+	log.Info("checking semi-sync status")
 	isSemiSyncBlocked, err := tm.MysqlDaemon.IsSemiSyncBlocked(ctx)
 	if err != nil {
 		return nil, err
@@ -666,6 +668,7 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 	//
 	// The demoted primary will end up with errant GTIDs, but that's unavoidable in this scenario.
 	if force && isSemiSyncBlocked {
+		log.Info("checking primary-side semi-sync state")
 		if tm.isPrimarySideSemiSyncEnabled(ctx) {
 			// Disable the primary side semi-sync to unblock the writes.
 			log.Info("disabling primary-side semi-sync to unblock stuck writes")
@@ -698,6 +701,7 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 		// all semi-sync enabled replicas.
 		//
 		// If we can't unblock within the context timeout, the `PlannedReparentShard` operation will fail.
+		log.Info("waiting for semi-sync to be unblocked")
 		err = tm.SemiSyncMonitor.WaitUntilSemiSyncUnblocked(ctx)
 		if err != nil {
 			return nil, err
@@ -729,6 +733,7 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 		}
 	}()
 
+	log.Info("checking primary-side semi-sync state")
 	// If we haven't disabled the primary side semi-sync so far, do it now.
 	if tm.isPrimarySideSemiSyncEnabled(ctx) {
 		// If using semi-sync, we need to disable primary-side.
@@ -747,6 +752,7 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 	}
 
 	// Return the current replication position.
+	log.Info("reading primary status")
 	status, err := tm.MysqlDaemon.PrimaryStatus(ctx)
 	if err != nil {
 		return nil, err

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -550,7 +550,7 @@ func (tm *TabletManager) InitReplica(ctx context.Context, parent *topodatapb.Tab
 //
 // If a step fails in the middle, it will try to undo any changes it made.
 func (tm *TabletManager) DemotePrimary(ctx context.Context, force bool) (*replicationdatapb.PrimaryStatus, error) {
-	log.Info("DemotePrimary")
+	log.Info("demoting primary", slog.Bool("force", force))
 	if err := tm.waitForGrantsToHaveApplied(ctx); err != nil {
 		return nil, err
 	}
@@ -563,11 +563,13 @@ func (tm *TabletManager) DemotePrimary(ctx context.Context, force bool) (*replic
 // If revertPartialFailure is true, and a step fails in the middle, it will try
 // to undo any changes it made.
 func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure bool, force bool) (primaryStatus *replicationdatapb.PrimaryStatus, finalErr error) {
+	log.Info("acquiring action lock")
 	if err := tm.lock(ctx); err != nil {
 		return nil, err
 	}
 	defer tm.unlock()
 	defer tm.QueryServiceControl.SetDemotePrimaryStalled(false)
+	log.Info("acquired action lock")
 
 	finishCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -595,10 +597,22 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 	tablet := tm.Tablet()
 	wasPrimary := tablet.Type == topodatapb.TabletType_PRIMARY
 	wasServing := tm.QueryServiceControl.IsServing()
+
+	log.Info("reading mysql read_only state")
 	wasReadOnly, err := tm.MysqlDaemon.IsReadOnly(ctx)
 	if err != nil {
 		return nil, err
 	}
+
+	log.Info(
+		"captured initial state",
+		slog.String("tablet", topoproto.TabletAliasString(tablet.Alias)),
+		slog.Bool("force", force),
+		slog.Bool("revert_partial_failure", revertPartialFailure),
+		slog.Bool("was_primary", wasPrimary),
+		slog.Bool("was_serving", wasServing),
+		slog.Bool("was_read_only", wasReadOnly),
+	)
 
 	// If we are a primary tablet and not yet read-only, stop accepting new
 	// queries and wait for in-flight queries to complete. If we are not primary,
@@ -617,6 +631,7 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 		}
 		defer func() {
 			if finalErr != nil && revertPartialFailure && wasServing {
+				log.Info("reverting query service to serving")
 				if err := tm.QueryServiceControl.SetServingType(tablet.Type, protoutil.TimeFromProto(tablet.PrimaryTermStartTime).UTC(), true, ""); err != nil {
 					log.Warn(fmt.Sprintf("SetServingType(serving=true) failed during revert: %v", err))
 				}
@@ -624,10 +639,17 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 		}()
 	}
 
+	log.Info("checking semi-sync status")
 	isSemiSyncBlocked, err := tm.MysqlDaemon.IsSemiSyncBlocked(ctx)
 	if err != nil {
 		return nil, err
 	}
+
+	log.Info(
+		"checked semi-sync status",
+		slog.Bool("force", force),
+		slog.Bool("is_semi_sync_blocked", isSemiSyncBlocked),
+	)
 
 	// `force` is true when `DemotePrimary` is called for `EmergencyReparentShard` or when a primary notices
 	// that a different tablet has been promoted to primary and demotes itself.
@@ -647,14 +669,16 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 	//
 	// The demoted primary will end up with errant GTIDs, but that's unavoidable in this scenario.
 	if force && isSemiSyncBlocked {
+		log.Info("checking primary-side semi-sync state")
 		if tm.isPrimarySideSemiSyncEnabled(ctx) {
 			// Disable the primary side semi-sync to unblock the writes.
+			log.Info("disabling primary-side semi-sync to unblock stuck writes")
 			if err := tm.fixSemiSync(ctx, topodatapb.TabletType_REPLICA, SemiSyncActionSet); err != nil {
 				return nil, err
 			}
 			defer func() {
 				if finalErr != nil && revertPartialFailure && wasPrimary {
-					// enable primary-side semi-sync again
+					log.Info("reverting primary-side semi-sync to enabled")
 					if err := tm.fixSemiSync(ctx, topodatapb.TabletType_PRIMARY, SemiSyncActionSet); err != nil {
 						log.Warn(fmt.Sprintf("fixSemiSync(PRIMARY) failed during revert: %v", err))
 					}
@@ -687,6 +711,7 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 	// We can now set MySQL to super_read_only mode. If we are already super_read_only because of a
 	// previous demotion, or because we are not primary anyway, this should be
 	// idempotent.
+	log.Info("enabling super_read_only")
 	if _, err := tm.MysqlDaemon.SetSuperReadOnly(ctx, true); err != nil {
 		if sqlErr, ok := errors.AsType[*sqlerror.SQLError](err); ok && sqlErr.Number() == sqlerror.ERUnknownSystemVariable {
 			log.Warn("server does not know about super_read_only, continuing anyway...")
@@ -699,21 +724,26 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 		if finalErr != nil && revertPartialFailure && !wasReadOnly {
 			// We need to redo the prepared transactions in read only mode using the dba user to ensure we don't lose them.
 			// setting read_only OFF will also set super_read_only OFF if it was set
+			log.Info("reverting read-only by redoing prepared transactions")
 			if err = tm.redoPreparedTransactionsAndSetReadWrite(ctx); err != nil {
 				log.Warn(fmt.Sprintf("RedoPreparedTransactionsAndSetReadWrite failed during revert: %v", err))
 			}
 		}
 	}()
 
+	log.Info("enabled super_read_only")
+
+	log.Info("checking primary-side semi-sync state")
 	// If we haven't disabled the primary side semi-sync so far, do it now.
 	if tm.isPrimarySideSemiSyncEnabled(ctx) {
 		// If using semi-sync, we need to disable primary-side.
+		log.Info("disabling primary-side semi-sync")
 		if err := tm.fixSemiSync(ctx, topodatapb.TabletType_REPLICA, SemiSyncActionSet); err != nil {
 			return nil, err
 		}
 		defer func() {
 			if finalErr != nil && revertPartialFailure && wasPrimary {
-				// enable primary-side semi-sync again
+				log.Info("reverting primary-side semi-sync to enabled")
 				if err := tm.fixSemiSync(ctx, topodatapb.TabletType_PRIMARY, SemiSyncActionSet); err != nil {
 					log.Warn(fmt.Sprintf("fixSemiSync(PRIMARY) failed during revert: %v", err))
 				}
@@ -722,11 +752,16 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 	}
 
 	// Return the current replication position.
+	log.Info("reading primary status")
 	status, err := tm.MysqlDaemon.PrimaryStatus(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return replication.PrimaryStatusToProto(status), nil
+
+	protoStatus := replication.PrimaryStatusToProto(status)
+	log.Info("demoted primary", slog.String("position", protoStatus.Position))
+
+	return protoStatus, nil
 }
 
 // UndoDemotePrimary reverts a previous call to DemotePrimary

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -718,6 +718,8 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 		} else {
 			return nil, err
 		}
+	} else {
+		log.Info("enabled super_read_only")
 	}
 
 	defer func() {
@@ -730,8 +732,6 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 			}
 		}
 	}()
-
-	log.Info("enabled super_read_only")
 
 	log.Info("checking primary-side semi-sync state")
 	// If we haven't disabled the primary side semi-sync so far, do it now.


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
`DemotePrimary`'s logging can sometimes make it unclear exactly what step it has potentially stalled on or took longer than normal. For example, it is not clear when setting `super_read_only` is complete, or if it has already advanced to checking semi-sync state. In addition, there are no logs to tell you which revert steps were performed.

This adds a bit more verbose logging, especially around the areas that are known to potentially stall (such as setting `super_read_only`). This can hopefully help operators better reconstruct the timeline after the fact.
## Related Issue(s)

Closes https://github.com/vitessio/vitess/issues/20050
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->

Help from Claude Opus 4.7.