### PR TITLE
[main] Copy `v24.0.1` release notes

### DIFF
--- a/changelog/24.0/24.0.0/changelog.md
+++ b/changelog/24.0/24.0.0/changelog.md
@@ -383,7 +383,6 @@
  * `vtorc`: improve logging in `DiscoverInstance`, remove old metric [#19010](https://github.com/vitessio/vitess/pull/19010)
  * `vtorc`: add cell/location context [#19047](https://github.com/vitessio/vitess/pull/19047)
  * VTOrc: Monitor for flappy / overloaded primaries and PRS->ERS as needed [#19328](https://github.com/vitessio/vitess/pull/19328)
- * Add flag for cells to watch to VTOrc [#19354](https://github.com/vitessio/vitess/pull/19354)
  * `vtorc`: support analysis ordering, improve semi-sync rollout [#19427](https://github.com/vitessio/vitess/pull/19427)
  * `vtorc`: improvements to analysis ordering, handle semi-sync disable [#19488](https://github.com/vitessio/vitess/pull/19488)
  * vtorc: change `StaleTopoPrimary` recovery to be best-effort [#19502](https://github.com/vitessio/vitess/pull/19502)

--- a/changelog/24.0/24.0.1/changelog.md
+++ b/changelog/24.0/24.0.1/changelog.md
@@ -1,0 +1,18 @@
+# Changelog of Vitess v24.0.1
+
+### Bug fixes 
+#### VTGate
+ * [release-24.0] planner: substitute merged DML IN/NOT IN subqueries via ListArg placeholder (#19973) [#20030](https://github.com/vitessio/vitess/pull/20030) 
+#### VTOrc
+ * Revert "Add flag for cells to watch to VTOrc (#19354)" [#20023](https://github.com/vitessio/vitess/pull/20023) 
+#### VTTablet
+ * [release-24.0] `go/mysql`, `vreplication`: fix flaky unit tests with shared root cause (#19990) [#19998](https://github.com/vitessio/vitess/pull/19998)
+### Release 
+#### General
+ * [release-24.0] Code Freeze for `v24.0.1` [#20025](https://github.com/vitessio/vitess/pull/20025)
+### Testing 
+#### VTGate
+ * [release-24.0] vtgate: regression tests for routing-rule + schema-tracker `t.*` expansion (#20026) [#20028](https://github.com/vitessio/vitess/pull/20028) 
+#### vttestserver
+ * [release-24.0] vttest: avoid 10-minute hang when vtcombo exits during startup (#20041) [#20044](https://github.com/vitessio/vitess/pull/20044)
+

--- a/changelog/24.0/24.0.1/release_notes.md
+++ b/changelog/24.0/24.0.1/release_notes.md
@@ -1,0 +1,7 @@
+# Release of Vitess v24.0.1
+The entire changelog for this release can be found [here](https://github.com/vitessio/vitess/blob/main/changelog/24.0/24.0.1/changelog.md).
+
+The release includes 6 merged Pull Requests.
+
+Thanks to all our contributors: @app/vitess-bot, @mattlord
+

--- a/changelog/24.0/README.md
+++ b/changelog/24.0/README.md
@@ -1,4 +1,8 @@
 ## v24.0
+* **[24.0.1](24.0.1)**
+	* [Changelog](24.0.1/changelog.md)
+	* [Release Notes](24.0.1/release_notes.md)
+
 * **[24.0.0](24.0.0)**
 	* [Changelog](24.0.0/changelog.md)
 	* [Release Notes](24.0.0/release_notes.md)


### PR DESCRIPTION
This Pull Request copies the release notes found on `release-24.0` to keep release notes up-to-date after the `v24.0.1` release.

> This Pull Request is part of https://github.com/vitessio/vitess/issues/20024