### PR TITLE
VTOrc: detect stalled replication on a full disk

### DIFF
--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -46,7 +46,8 @@ jobs:
             "docker_cluster",
             "5",
             "28",
-            "onlineddl_flow"
+            "onlineddl_flow",
+            "vtorc_disk_full"
           ]'
 
           # Build matrix

--- a/.github/workflows/vtorc_disk_full_e2e.yml
+++ b/.github/workflows/vtorc_disk_full_e2e.yml
@@ -79,14 +79,18 @@ jobs:
         timeout-minutes: 10
         run: |
           source build.env
-          make build
+          make NOVTADMINBUILD=1 build
 
       - name: Run replication-stalled disk-full e2e
         if: steps.changes.outputs.relevant == 'true'
         timeout-minutes: 20
         run: |
           # The test mounts a loopback ext4 filesystem and runs mkfs.ext4 on
-          # it; both require root. VT_TEST_DISK_FULL=1 is the explicit
+          # it; those steps shell out to `sudo` internally. The test process
+          # itself must run as a non-root user — Vitess binaries (vtctld,
+          # vttablet, ...) refuse to start as root with "running this as
+          # root makes no sense". The runner user has passwordless sudo on
+          # ubuntu-24.04 by default. VT_TEST_DISK_FULL=1 is the explicit
           # opt-in checked by the test's TestMain (in addition to the
           # //go:build linux gate that already prevents it from compiling on
           # macOS).
@@ -95,8 +99,6 @@ jobs:
           source build.env
           set -exo pipefail
 
-          # build.env prepended $PWD/bin to PATH; preserve via sudo -E.
-          # VT_TEST_DISK_FULL=1 is the explicit opt-in checked by the test.
-          sudo -E env VT_TEST_DISK_FULL=1 PATH="$PATH" \
+          VT_TEST_DISK_FULL=1 \
             go test -timeout 15m -count=1 -v \
             ./go/test/endtoend/vtorc/replicationstalleddiskfull/...

--- a/.github/workflows/vtorc_disk_full_e2e.yml
+++ b/.github/workflows/vtorc_disk_full_e2e.yml
@@ -1,0 +1,94 @@
+name: VTOrc Disk-Full E2E
+
+on:
+  push:
+    branches:
+      - "main"
+      - "release-[0-9]+.[0-9]"
+    tags: "**"
+  pull_request:
+    branches: "**"
+
+concurrency:
+  group: format('{0}-{1}', ${{ github.ref }}, 'VTOrc Disk-Full E2E')
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  test:
+    name: VTOrc replication-stalled disk-full
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: "false"
+
+      - name: Check for changes in relevant files
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: changes
+        with:
+          token: ""
+          filters: |
+            relevant:
+              - 'go/**/*.go'
+              - 'config/**'
+              - 'proto/*.proto'
+              - 'test/config.json'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - 'build.env'
+              - 'bootstrap.sh'
+              - '.github/workflows/vtorc_disk_full_e2e.yml'
+
+      - name: Set up Go
+        if: steps.changes.outputs.relevant == 'true'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
+
+      - name: Tune the OS
+        if: steps.changes.outputs.relevant == 'true'
+        timeout-minutes: 5
+        uses: ./.github/actions/tune-os
+
+      - name: Setup MySQL
+        if: steps.changes.outputs.relevant == 'true'
+        timeout-minutes: 8
+        uses: ./.github/actions/setup-mysql
+        with:
+          flavor: mysql-8.4
+
+      - name: Get dependencies
+        if: steps.changes.outputs.relevant == 'true'
+        timeout-minutes: 10
+        run: |
+          # e2fsprogs ships mkfs.ext4; mount/util-linux is preinstalled.
+          sudo apt-get -qq update
+          sudo apt-get -qq install -y make unzip g++ etcd-client etcd-server curl git wget xz-utils libncurses6 e2fsprogs
+          sudo service etcd stop
+          go mod download
+
+      - name: Run replication-stalled disk-full e2e
+        if: steps.changes.outputs.relevant == 'true'
+        timeout-minutes: 20
+        run: |
+          # The test mounts a loopback ext4 filesystem and runs mkfs.ext4 on
+          # it; both require root. VT_TEST_DISK_FULL=1 is the explicit
+          # opt-in checked by the test's TestMain (in addition to the
+          # //go:build linux gate that already prevents it from compiling on
+          # macOS).
+          export VTDATAROOT="/tmp/vtdataroot_diskfull"
+          mkdir -p "$VTDATAROOT"
+          source build.env
+          set -exo pipefail
+
+          # Use sudo -E to preserve env vars; pass VT_TEST_DISK_FULL=1.
+          sudo -E env VT_TEST_DISK_FULL=1 PATH="$PATH" \
+            go test -timeout 15m -count=1 -v \
+            ./go/test/endtoend/vtorc/replicationstalleddiskfull/...

--- a/.github/workflows/vtorc_disk_full_e2e.yml
+++ b/.github/workflows/vtorc_disk_full_e2e.yml
@@ -74,6 +74,13 @@ jobs:
           sudo service etcd stop
           go mod download
 
+      - name: Build Vitess binaries
+        if: steps.changes.outputs.relevant == 'true'
+        timeout-minutes: 10
+        run: |
+          source build.env
+          make build
+
       - name: Run replication-stalled disk-full e2e
         if: steps.changes.outputs.relevant == 'true'
         timeout-minutes: 20
@@ -88,7 +95,8 @@ jobs:
           source build.env
           set -exo pipefail
 
-          # Use sudo -E to preserve env vars; pass VT_TEST_DISK_FULL=1.
+          # build.env prepended $PWD/bin to PATH; preserve via sudo -E.
+          # VT_TEST_DISK_FULL=1 is the explicit opt-in checked by the test.
           sudo -E env VT_TEST_DISK_FULL=1 PATH="$PATH" \
             go test -timeout 15m -count=1 -v \
             ./go/test/endtoend/vtorc/replicationstalleddiskfull/...

--- a/go/mysql/capabilities/capability.go
+++ b/go/mysql/capabilities/capability.go
@@ -51,6 +51,7 @@ const (
 	BinaryLogStatus                                                       // Supported in 8.2.0 and above, uses SHOW BINARY LOG STATUS
 	RestrictFKOnNonStandardKey                                            // Supported in 8.4.0 and above, restricts usage of non-standard indexes for foreign keys.
 	MySQLClonePluginFlavorCapability                                      // Supported in 8.0.17 and above, MySQL CLONE plugin for physical snapshot.
+	PerformanceSchemaErrorLogTableCapability                              // Supported in 8.0.22 and above: performance_schema.error_log table.
 )
 
 type CapableOf func(capability FlavorCapability) (bool, error)
@@ -111,6 +112,8 @@ func MySQLVersionHasCapability(serverVersion string, capability FlavorCapability
 		return atLeast(8, 0, 17)
 	case DisableRedoLogFlavorCapability:
 		return atLeast(8, 0, 21)
+	case PerformanceSchemaErrorLogTableCapability:
+		return atLeast(8, 0, 22)
 	case FastDropTableFlavorCapability:
 		return atLeast(8, 0, 23)
 	case InstantChangeColumnVisibilityCapability:

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -478,6 +478,13 @@ func (cluster *LocalProcessCluster) AddShard(keyspaceName string, shardName stri
 		}
 
 		tablet.MysqlctlProcess = *mysqlctlProcess
+		// Apply mysqlctl customizations before StartProcess so per-tablet
+		// settings (e.g. ExtraMyCnfPath) take effect on the spawned mysqld.
+		for _, customizer := range customizers {
+			if f, ok := customizer.(func(*MysqlctlProcess)); ok {
+				f(&tablet.MysqlctlProcess)
+			}
+		}
 		proc, err := tablet.MysqlctlProcess.StartProcess()
 		if err != nil {
 			log.Error(fmt.Sprintf("error starting mysqlctl process: %v, %v", tablet.MysqlctldProcess, err))
@@ -513,9 +520,12 @@ func (cluster *LocalProcessCluster) AddShard(keyspaceName string, shardName stri
 		shard.Vttablets = append(shard.Vttablets, tablet)
 		// Apply customizations
 		for _, customizer := range customizers {
-			if f, ok := customizer.(func(*VttabletProcess)); ok {
+			switch f := customizer.(type) {
+			case func(*VttabletProcess):
 				f(tablet.VttabletProcess)
-			} else {
+			case func(*MysqlctlProcess):
+				// Already applied above, before StartProcess.
+			default:
 				return nil, fmt.Errorf("type mismatch on customizer: %T", customizer)
 			}
 		}
@@ -599,6 +609,11 @@ func (cluster *LocalProcessCluster) StartKeyspaceLegacy(keyspace Keyspace, shard
 				return err
 			}
 			tablet.MysqlctlProcess = *mysqlctlProcess
+			for _, customizer := range customizers {
+				if f, ok := customizer.(func(*MysqlctlProcess)); ok {
+					f(&tablet.MysqlctlProcess)
+				}
+			}
 			proc, err := tablet.MysqlctlProcess.StartProcess()
 			if err != nil {
 				log.Error(fmt.Sprintf("error starting mysqlctl process: %v, %v", tablet.MysqlctldProcess, err))
@@ -628,9 +643,12 @@ func (cluster *LocalProcessCluster) StartKeyspaceLegacy(keyspace Keyspace, shard
 			shard.Vttablets = append(shard.Vttablets, tablet)
 			// Apply customizations
 			for _, customizer := range customizers {
-				if f, ok := customizer.(func(*VttabletProcess)); ok {
+				switch f := customizer.(type) {
+				case func(*VttabletProcess):
 					f(tablet.VttabletProcess)
-				} else {
+				case func(*MysqlctlProcess):
+					// Already applied above, before StartProcess.
+				default:
 					return fmt.Errorf("type mismatch on customizer: %T", customizer)
 				}
 			}

--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -48,6 +48,10 @@ type MysqlctlProcess struct {
 	ExtraArgs       []string
 	InitMysql       bool
 	SecureTransport bool
+	// ExtraMyCnfPath, when set, is appended to EXTRA_MY_CNF on the per-process
+	// env so its directives are loaded after the generated cnf and override it.
+	// Only this mysqlctl invocation sees it; other tablets' env is untouched.
+	ExtraMyCnfPath string
 }
 
 // InitDb executes mysqlctl command to add cell info
@@ -109,6 +113,7 @@ func (mysqlctl *MysqlctlProcess) startProcess(init bool) (*exec.Cmd, error) {
 	if len(mysqlctl.ExtraArgs) > 0 {
 		tmpProcess.Args = append(tmpProcess.Args, mysqlctl.ExtraArgs...)
 	}
+	var extraCnfPaths []string
 	if mysqlctl.InitMysql {
 		if mysqlctl.SecureTransport {
 			// Set up EXTRA_MY_CNF for ssl
@@ -145,7 +150,7 @@ ssl_key={{.ServerKey}}
 				return nil, err
 			}
 
-			tmpProcess.Env = append(tmpProcess.Env, "EXTRA_MY_CNF="+extraMyCNF)
+			extraCnfPaths = append(extraCnfPaths, extraMyCNF)
 			tmpProcess.Env = append(tmpProcess.Env, "VTDATAROOT="+os.Getenv("VTDATAROOT"))
 		}
 
@@ -157,6 +162,12 @@ ssl_key={{.ServerKey}}
 		}
 	} else {
 		tmpProcess.Args = append(tmpProcess.Args, "start")
+	}
+	if mysqlctl.ExtraMyCnfPath != "" {
+		extraCnfPaths = append(extraCnfPaths, mysqlctl.ExtraMyCnfPath)
+	}
+	if len(extraCnfPaths) > 0 {
+		tmpProcess.Env = append(tmpProcess.Env, "EXTRA_MY_CNF="+strings.Join(extraCnfPaths, ":"))
 	}
 	tmpProcess.Env = append(tmpProcess.Env, os.Environ()...)
 	tmpProcess.Env = append(tmpProcess.Env, DefaultVttestEnv)

--- a/go/test/endtoend/vtorc/replicationstalleddiskfull/main_test.go
+++ b/go/test/endtoend/vtorc/replicationstalleddiskfull/main_test.go
@@ -185,22 +185,23 @@ func TestMain(m *testing.M) {
 }
 
 // replicaCnf is the EXTRA_MY_CNF fragment we point the replica's mysqld at.
-// EXTRA_MY_CNF is loaded after the generated cnf so these directives win:
-// data, redo log, tmpdir, binlog and relay log all land on the small mount,
-// which is what triggers MY-012814 / MY-012820 once the disk fills.
+// EXTRA_MY_CNF is loaded after the generated cnf so these directives win.
 //
-// socket / pid-file / log-error stay at their generated $VTDATAROOT/vt_<uid>/
-// paths — mysqlctl finds the socket where it expects, error log stays
-// readable after the mount is unwound.
+// CRITICAL: only the InnoDB filesystem moves to the small mount. The relay
+// log and binlog stay at their generated $VTDATAROOT/vt_<uid>/ paths on the
+// regular disk. The whole point of the analysis is to catch the case where
+// InnoDB's filesystem hits ENOSPC while the relay log filesystem still has
+// space — InnoDB silently retries inside ha_commit_trans (Slave_*_Running
+// stay Yes) while the relay log never fails. If both filesystems are on
+// the same mount, the IO thread's relay-log write fails first with
+// ER_REPLICA_RELAY_LOG_WRITE_FAILURE → Slave_IO_Running flips to No, which
+// is the OTHER (already-detected) scenario.
 //
-// Sizing knobs (the floor; bigger if a future cnf change lands):
+// Sizing knobs:
 //   - innodb_redo_log_capacity = 8 MB (vs 100 MB default; valid on 8.0.30+,
 //     ignored on older versions)
 //   - innodb_buffer_pool_size  = 32 MB (memory only; doesn't change disk)
-//   - max_binlog_size, max_relay_log_size = 16 MB (vs 1 GB default) — keeps
-//     individual log files small so the "filling" pressure builds up evenly
-//     rather than the first relay-log file growing toward 1 GB
-//   - performance_schema = ON (required for our query)
+//   - performance_schema = ON (required for our detection query)
 func replicaCnf(dataDir, tmpDir string) string {
 	return fmt.Sprintf(`
 [mysqld]
@@ -208,15 +209,10 @@ datadir                   = %[1]s
 innodb_data_home_dir      = %[1]s
 innodb_log_group_home_dir = %[1]s
 tmpdir                    = %[2]s
-relay-log                 = %[1]s/vt-relay-bin
-relay-log-index           = %[1]s/vt-relay-bin.index
-log-bin                   = %[1]s/vt-bin
 
 innodb_redo_log_capacity = 8388608
 innodb_buffer_pool_size  = 33554432
 innodb_log_buffer_size   = 1048576
-max_binlog_size          = 16777216
-max_relay_log_size       = 16777216
 performance_schema       = ON
 `, dataDir, tmpDir)
 }

--- a/go/test/endtoend/vtorc/replicationstalleddiskfull/main_test.go
+++ b/go/test/endtoend/vtorc/replicationstalleddiskfull/main_test.go
@@ -46,16 +46,20 @@ var (
 
 // shouldSkip returns a non-empty reason string when the e2e cannot run on the
 // current host. Linux is enforced via the build tag; this checks the runtime
-// preconditions: must be root (loopback mount + mkfs require it) and must be
-// explicitly opted-in via VT_TEST_DISK_FULL=1 (a belt-and-braces guard so a
-// developer who happens to be root on Linux doesn't trigger the test by
-// accident).
+// preconditions: must NOT be root (Vitess binaries refuse to start as root)
+// but must have passwordless sudo available (loopback mount + mkfs.ext4
+// require it). Also requires VT_TEST_DISK_FULL=1 — an explicit opt-in so a
+// developer who happens to have passwordless sudo on Linux doesn't trigger
+// the test by accident.
 func shouldSkip() string {
 	if os.Getenv("VT_TEST_DISK_FULL") != "1" {
 		return "set VT_TEST_DISK_FULL=1 to run; this test mounts a loopback filesystem"
 	}
-	if os.Geteuid() != 0 {
-		return "must run as root (loopback mount + mkfs.ext4)"
+	if os.Geteuid() == 0 {
+		return "must run as a non-root user; Vitess binaries refuse to start as root"
+	}
+	if err := exec.Command("sudo", "-n", "true").Run(); err != nil {
+		return "passwordless sudo required (loopback mount + mkfs.ext4)"
 	}
 	if _, err := exec.LookPath("mkfs.ext4"); err != nil {
 		return "mkfs.ext4 not found in PATH"

--- a/go/test/endtoend/vtorc/replicationstalleddiskfull/main_test.go
+++ b/go/test/endtoend/vtorc/replicationstalleddiskfull/main_test.go
@@ -1,0 +1,218 @@
+//go:build linux
+
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replicationstalleddiskfull
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/vt/vtctl/reparentutil/policy"
+)
+
+const (
+	cellName     = "zone1"
+	hostname     = "localhost"
+	keyspaceName = "ks"
+	shardName    = "0"
+)
+
+var (
+	clusterInstance *cluster.LocalProcessCluster
+	vtorcProcess    *cluster.VTOrcProcess
+	primaryTablet   *cluster.Vttablet
+	replicaTablet   *cluster.Vttablet
+	diskMount       *mount
+)
+
+// shouldSkip returns a non-empty reason string when the e2e cannot run on the
+// current host. Linux is enforced via the build tag; this checks the runtime
+// preconditions: must be root (loopback mount + mkfs require it) and must be
+// explicitly opted-in via VT_TEST_DISK_FULL=1 (a belt-and-braces guard so a
+// developer who happens to be root on Linux doesn't trigger the test by
+// accident).
+func shouldSkip() string {
+	if os.Getenv("VT_TEST_DISK_FULL") != "1" {
+		return "set VT_TEST_DISK_FULL=1 to run; this test mounts a loopback filesystem"
+	}
+	if os.Geteuid() != 0 {
+		return "must run as root (loopback mount + mkfs.ext4)"
+	}
+	if _, err := exec.LookPath("mkfs.ext4"); err != nil {
+		return "mkfs.ext4 not found in PATH"
+	}
+	return ""
+}
+
+func TestMain(m *testing.M) {
+	if reason := shouldSkip(); reason != "" {
+		fmt.Fprintln(os.Stderr, "skipping replicationstalleddiskfull e2e:", reason)
+		os.Exit(0)
+	}
+
+	exitCode, err := func() (int, error) {
+		// Loopback mount must come up first; the replica's mysqld will
+		// initialise its data dir on it.
+		var err error
+		mountRoot, err := os.MkdirTemp("", "vtorc_diskfull_*")
+		if err != nil {
+			return 1, err
+		}
+		defer os.RemoveAll(mountRoot)
+
+		diskMount, err = newLoopbackMount(mountRoot)
+		if err != nil {
+			return 1, err
+		}
+		defer diskMount.cleanup()
+
+		replicaDataDir := filepath.Join(diskMount.mountDir, "replica_data")
+		replicaTmpDir := filepath.Join(diskMount.mountDir, "replica_tmp")
+		for _, dir := range []string{replicaDataDir, replicaTmpDir} {
+			if err := os.MkdirAll(dir, 0o777); err != nil {
+				return 1, err
+			}
+		}
+
+		cnfPath := filepath.Join(diskMount.mountDir, "replica_extra.cnf")
+		if err := os.WriteFile(cnfPath, []byte(replicaCnf(replicaDataDir, replicaTmpDir)), 0o644); err != nil {
+			return 1, err
+		}
+
+		clusterInstance = cluster.NewCluster(cellName, hostname)
+		defer clusterInstance.Teardown()
+
+		if err := clusterInstance.StartTopo(); err != nil {
+			return 1, err
+		}
+
+		// 1 primary + 1 replica.
+		primaryTablet = clusterInstance.NewVttabletInstance("replica", 100, cellName)
+		replicaTablet = clusterInstance.NewVttabletInstance("replica", 101, cellName)
+
+		keyspace := &cluster.Keyspace{Name: keyspaceName}
+		shard := &cluster.Shard{Name: shardName, Vttablets: []*cluster.Vttablet{primaryTablet, replicaTablet}}
+		if err := clusterInstance.SetupCluster(keyspace, []cluster.Shard{*shard}); err != nil {
+			return 1, err
+		}
+
+		// Inject the replica-only my.cnf overrides AFTER SetupCluster has
+		// created the MysqlctlProcess but BEFORE we start mysqld.
+		replicaTablet.MysqlctlProcess.ExtraMyCnfPath = cnfPath
+
+		// Start mysqlctl on both tablets.
+		var mysqlctlProcs []*exec.Cmd
+		for _, t := range []*cluster.Vttablet{primaryTablet, replicaTablet} {
+			proc, err := t.MysqlctlProcess.StartProcess()
+			if err != nil {
+				return 1, err
+			}
+			mysqlctlProcs = append(mysqlctlProcs, proc)
+		}
+		for _, p := range mysqlctlProcs {
+			if err := p.Wait(); err != nil {
+				return 1, fmt.Errorf("mysqlctl init failed: %w", err)
+			}
+		}
+
+		// Start vttablets.
+		for _, t := range []*cluster.Vttablet{primaryTablet, replicaTablet} {
+			t.VttabletProcess.ServingStatus = ""
+			if err := t.VttabletProcess.Setup(); err != nil {
+				return 1, err
+			}
+		}
+		for _, t := range []*cluster.Vttablet{primaryTablet, replicaTablet} {
+			if err := t.VttabletProcess.WaitForTabletStatuses([]string{"SERVING", "NOT_SERVING"}); err != nil {
+				return 1, err
+			}
+		}
+
+		out, err := clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput(
+			"SetKeyspaceDurabilityPolicy", keyspaceName, "--durability-policy="+policy.DurabilityNone)
+		if err != nil {
+			return 1, fmt.Errorf("SetKeyspaceDurabilityPolicy: %w (%s)", err, out)
+		}
+
+		// Promote primaryTablet via PRS.
+		out, err = clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput(
+			"PlannedReparentShard", keyspaceName+"/"+shardName,
+			"--new-primary", primaryTablet.Alias)
+		if err != nil {
+			return 1, fmt.Errorf("PlannedReparentShard: %w (%s)", err, out)
+		}
+
+		// Start vtorc with a fast poll cadence so we observe the analysis quickly.
+		vtorcProcess = clusterInstance.NewVTOrcProcess(cluster.VTOrcConfiguration{
+			InstancePollTime:     "1s",
+			RecoveryPollDuration: "1s",
+		}, cellName)
+		if err := vtorcProcess.Setup(); err != nil {
+			return 1, err
+		}
+		clusterInstance.VTOrcProcesses = append(clusterInstance.VTOrcProcesses, vtorcProcess)
+
+		return m.Run(), nil
+	}()
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "TestMain setup error: %v\n", err)
+	}
+	os.Exit(exitCode)
+}
+
+// replicaCnf is the EXTRA_MY_CNF fragment we point the replica's mysqld at.
+// EXTRA_MY_CNF is loaded after the generated cnf so these directives win:
+// data, redo log, tmpdir, binlog and relay log all land on the small mount,
+// which is what triggers MY-012814 / MY-012820 once the disk fills.
+//
+// socket / pid-file / log-error stay at their generated $VTDATAROOT/vt_<uid>/
+// paths — mysqlctl finds the socket where it expects, error log stays
+// readable after the mount is unwound.
+//
+// Sizing knobs (the floor; bigger if a future cnf change lands):
+//   - innodb_redo_log_capacity = 8 MB (vs 100 MB default; valid on 8.0.30+,
+//     ignored on older versions)
+//   - innodb_buffer_pool_size  = 32 MB (memory only; doesn't change disk)
+//   - max_binlog_size, max_relay_log_size = 16 MB (vs 1 GB default) — keeps
+//     individual log files small so the "filling" pressure builds up evenly
+//     rather than the first relay-log file growing toward 1 GB
+//   - performance_schema = ON (required for our query)
+func replicaCnf(dataDir, tmpDir string) string {
+	return fmt.Sprintf(`
+[mysqld]
+datadir                   = %[1]s
+innodb_data_home_dir      = %[1]s
+innodb_log_group_home_dir = %[1]s
+tmpdir                    = %[2]s
+relay-log                 = %[1]s/vt-relay-bin
+relay-log-index           = %[1]s/vt-relay-bin.index
+log-bin                   = %[1]s/vt-bin
+
+innodb_redo_log_capacity = 8388608
+innodb_buffer_pool_size  = 33554432
+innodb_log_buffer_size   = 1048576
+max_binlog_size          = 16777216
+max_relay_log_size       = 16777216
+performance_schema       = ON
+`, dataDir, tmpDir)
+}

--- a/go/test/endtoend/vtorc/replicationstalleddiskfull/mount_linux.go
+++ b/go/test/endtoend/vtorc/replicationstalleddiskfull/mount_linux.go
@@ -37,22 +37,27 @@ import (
 // and chown the mount point back to the calling user so mysqld can write
 // to it. The CI runner has passwordless `sudo` for ubuntu-24.04 by default.
 //
-// Sized deliberately tight so the test fills the disk fast in CI. Floor
-// comes from what the Vitess cnf creates on first init, with our
-// EXTRA_MY_CNF overrides applied:
+// Sized so the *first* InnoDB autoextend attempt fails. Only the InnoDB
+// filesystem lives here — relay log + binlog are on the regular disk, so
+// the floor is just InnoDB artifacts created at mysql --initialize:
 //
-//	mysql.ibd, sys schema, ibdata1                 ~50 MB
+//	mysql.ibd, sys schema                          ~35 MB
+//	ibdata1 (initial)                              ~12 MB
 //	undo_001 + undo_002                            ~32 MB
 //	innodb_redo_log_capacity (we override to 8 MB)   8 MB
-//	first binlog + relay log files (capped at 16M)  ~10 MB
-//	misc init artifacts, slow log, error log        ~10 MB
+//	doublewrite buffer + scratch                    ~8 MB
 //	──────────────────────────────────────────────
-//	floor:                                         ~110 MB
+//	floor:                                         ~95 MB
 //
-// 256 MB image → ~145 MB headroom → ~145 1-MB BLOB inserts to wedge,
-// roughly 15–25 s of insert traffic. If a future Vitess cnf change pushes
-// the floor higher and mysqld fails to start in CI, bump this to 320 MB.
-const loopbackImageSizeMB = 256
+// innodb_autoextend_increment defaults to 64 MB. When the SQL thread fills
+// the initial 12 MB ibdata1, InnoDB tries to grow it by 64 MB. With ~65 MB
+// of headroom in a 160 MB image the first autoextend attempt fails —
+// MY-012814 lands in performance_schema.error_log, and InnoDB silently
+// retries (the wedge state our analysis is designed to detect).
+//
+// Bump to 192 MB if mysql --initialize ever fails to fit on 160 MB after a
+// future Vitess cnf change.
+const loopbackImageSizeMB = 160
 
 type mount struct {
 	imagePath string

--- a/go/test/endtoend/vtorc/replicationstalleddiskfull/mount_linux.go
+++ b/go/test/endtoend/vtorc/replicationstalleddiskfull/mount_linux.go
@@ -22,12 +22,20 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"syscall"
 )
 
 // loopbackMount creates a small ext4 loopback filesystem and mounts it. It
-// returns the mount path. Caller must call cleanup(). Requires root.
+// returns the mount path. Caller must call cleanup().
+//
+// The test process itself must run as a non-root user — Vitess's `vtctld`
+// and other binaries refuse to start as root (`servenv.Init: running this
+// as root makes no sense`). We therefore drop privileges by running each
+// privileged step (`mkfs.ext4`, `mount`, `chown`, `umount`) under `sudo`,
+// and chown the mount point back to the calling user so mysqld can write
+// to it. The CI runner has passwordless `sudo` for ubuntu-24.04 by default.
 //
 // Sized deliberately tight so the test fills the disk fast in CI. Floor
 // comes from what the Vitess cnf creates on first init, with our
@@ -58,20 +66,27 @@ func newLoopbackMount(rootDir string) (*mount, error) {
 		return nil, fmt.Errorf("mkdir mount dir: %w", err)
 	}
 
+	// dd writes to a path the calling user can write to; no sudo needed.
 	if err := runCmd("dd", "if=/dev/zero", "of="+imagePath, "bs=1M",
 		fmt.Sprintf("count=%d", loopbackImageSizeMB), "status=none"); err != nil {
 		return nil, fmt.Errorf("dd: %w", err)
 	}
-	if err := runCmd("mkfs.ext4", "-F", "-q", imagePath); err != nil {
+	if err := runCmd("sudo", "mkfs.ext4", "-F", "-q", imagePath); err != nil {
 		return nil, fmt.Errorf("mkfs.ext4: %w", err)
 	}
-	if err := runCmd("mount", "-o", "loop", imagePath, mountDir); err != nil {
+	if err := runCmd("sudo", "mount", "-o", "loop", imagePath, mountDir); err != nil {
 		return nil, fmt.Errorf("mount: %w", err)
 	}
-	// MySQL needs to write here as the unprivileged tablet user; the test
-	// itself runs as root so just open it up.
-	if err := os.Chmod(mountDir, 0o777); err != nil {
-		return nil, fmt.Errorf("chmod: %w", err)
+
+	// After mount, the mount point is owned by root. Hand it back to the
+	// calling user so mysqld (running as the same user) can write to it.
+	u, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("user.Current: %w", err)
+	}
+	owner := u.Uid + ":" + u.Gid
+	if err := runCmd("sudo", "chown", "-R", owner, mountDir); err != nil {
+		return nil, fmt.Errorf("chown: %w", err)
 	}
 
 	return &mount{imagePath: imagePath, mountDir: mountDir}, nil
@@ -79,7 +94,7 @@ func newLoopbackMount(rootDir string) (*mount, error) {
 
 func (m *mount) cleanup() {
 	// Lazy unmount tolerates lingering mysqld file handles after the test.
-	_ = exec.Command("umount", "-l", m.mountDir).Run()
+	_ = exec.Command("sudo", "umount", "-l", m.mountDir).Run()
 	_ = os.Remove(m.imagePath)
 	_ = os.Remove(m.mountDir)
 }

--- a/go/test/endtoend/vtorc/replicationstalleddiskfull/mount_linux.go
+++ b/go/test/endtoend/vtorc/replicationstalleddiskfull/mount_linux.go
@@ -1,0 +1,103 @@
+//go:build linux
+
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replicationstalleddiskfull
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+)
+
+// loopbackMount creates a small ext4 loopback filesystem and mounts it. It
+// returns the mount path. Caller must call cleanup(). Requires root.
+//
+// Sized deliberately tight so the test fills the disk fast in CI. Floor
+// comes from what the Vitess cnf creates on first init, with our
+// EXTRA_MY_CNF overrides applied:
+//
+//	mysql.ibd, sys schema, ibdata1                 ~50 MB
+//	undo_001 + undo_002                            ~32 MB
+//	innodb_redo_log_capacity (we override to 8 MB)   8 MB
+//	first binlog + relay log files (capped at 16M)  ~10 MB
+//	misc init artifacts, slow log, error log        ~10 MB
+//	──────────────────────────────────────────────
+//	floor:                                         ~110 MB
+//
+// 256 MB image → ~145 MB headroom → ~145 1-MB BLOB inserts to wedge,
+// roughly 15–25 s of insert traffic. If a future Vitess cnf change pushes
+// the floor higher and mysqld fails to start in CI, bump this to 320 MB.
+const loopbackImageSizeMB = 256
+
+type mount struct {
+	imagePath string
+	mountDir  string
+}
+
+func newLoopbackMount(rootDir string) (*mount, error) {
+	imagePath := filepath.Join(rootDir, "diskfull.img")
+	mountDir := filepath.Join(rootDir, "mnt")
+	if err := os.MkdirAll(mountDir, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir mount dir: %w", err)
+	}
+
+	if err := runCmd("dd", "if=/dev/zero", "of="+imagePath, "bs=1M",
+		fmt.Sprintf("count=%d", loopbackImageSizeMB), "status=none"); err != nil {
+		return nil, fmt.Errorf("dd: %w", err)
+	}
+	if err := runCmd("mkfs.ext4", "-F", "-q", imagePath); err != nil {
+		return nil, fmt.Errorf("mkfs.ext4: %w", err)
+	}
+	if err := runCmd("mount", "-o", "loop", imagePath, mountDir); err != nil {
+		return nil, fmt.Errorf("mount: %w", err)
+	}
+	// MySQL needs to write here as the unprivileged tablet user; the test
+	// itself runs as root so just open it up.
+	if err := os.Chmod(mountDir, 0o777); err != nil {
+		return nil, fmt.Errorf("chmod: %w", err)
+	}
+
+	return &mount{imagePath: imagePath, mountDir: mountDir}, nil
+}
+
+func (m *mount) cleanup() {
+	// Lazy unmount tolerates lingering mysqld file handles after the test.
+	_ = exec.Command("umount", "-l", m.mountDir).Run()
+	_ = os.Remove(m.imagePath)
+	_ = os.Remove(m.mountDir)
+}
+
+// freeBytes returns bytes available on the mount.
+func (m *mount) freeBytes() (uint64, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(m.mountDir, &stat); err != nil {
+		return 0, err
+	}
+	return stat.Bavail * uint64(stat.Bsize), nil
+}
+
+func runCmd(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s %v: %w (%s)", name, args, err, out)
+	}
+	return nil
+}

--- a/go/test/endtoend/vtorc/replicationstalleddiskfull/replication_stalled_test.go
+++ b/go/test/endtoend/vtorc/replicationstalleddiskfull/replication_stalled_test.go
@@ -69,11 +69,26 @@ func TestReplicationStalledDiskFull(t *testing.T) {
 	insertCtx, stopInserts := context.WithCancel(context.Background())
 	defer stopInserts()
 
-	var inserts atomic.Int64
+	var (
+		inserts      atomic.Int64
+		insertErrors atomic.Int64
+		lastErr      atomic.Pointer[string]
+	)
 	go func() {
 		for insertCtx.Err() == nil {
-			_ = runSQLNoFail(insertCtx, "INSERT INTO filler (blob_col) VALUES (REPEAT('x', 1048576))",
+			err := runSQLNoFail(insertCtx,
+				"INSERT INTO filler (blob_col) VALUES (REPEAT('x', 1048576))",
 				primaryTablet, "vt_"+keyspaceName)
+			if err != nil {
+				if insertCtx.Err() != nil {
+					return // shutting down
+				}
+				insertErrors.Add(1)
+				s := err.Error()
+				lastErr.Store(&s)
+				time.Sleep(50 * time.Millisecond)
+				continue
+			}
 			inserts.Add(1)
 		}
 	}()
@@ -81,20 +96,32 @@ func TestReplicationStalledDiskFull(t *testing.T) {
 	// Poll error_log for the InnoDB disk-full codes. Up to 120s — InnoDB's
 	// dirty-page flush cadence + buffer pool size mean we may need a fair
 	// bit of cumulative writes before ibdata1 actually fails to extend.
-	require.Eventually(t, func() bool {
+	deadline := time.Now().Add(120 * time.Second)
+	gotDiskFullEntry := false
+	for time.Now().Before(deadline) {
 		errLog, err := utils.RunSQL(t, `SELECT COUNT(*) AS c FROM performance_schema.error_log
 			WHERE prio = 'Error' AND subsystem = 'InnoDB'
 			  AND error_code IN ('MY-012814', 'MY-012820')`,
 			replicaTablet, "")
-		if err != nil || len(errLog.Rows) == 0 {
-			return false
+		if err == nil && len(errLog.Rows) > 0 {
+			if count, _ := errLog.Named().Row().ToInt64("c"); count > 0 {
+				gotDiskFullEntry = true
+				break
+			}
 		}
-		count, _ := errLog.Named().Row().ToInt64("c")
-		return count > 0
-	}, 120*time.Second, 1*time.Second,
-		"replica's performance_schema.error_log never recorded MY-012814/MY-012820 (inserts so far: %d)", inserts.Load())
-
-	t.Logf("InnoDB ENOSPC observed after %d primary inserts", inserts.Load())
+		time.Sleep(2 * time.Second)
+		t.Logf("waiting for InnoDB ENOSPC: inserts=%d, insertErrors=%d, free=%s",
+			inserts.Load(), insertErrors.Load(), formatBytes(diskMount))
+	}
+	if !gotDiskFullEntry {
+		var lastErrStr string
+		if p := lastErr.Load(); p != nil {
+			lastErrStr = *p
+		}
+		t.Fatalf("performance_schema.error_log never recorded MY-012814/MY-012820: inserts=%d insertErrors=%d lastErr=%q",
+			inserts.Load(), insertErrors.Load(), lastErrStr)
+	}
+	t.Logf("InnoDB ENOSPC observed after %d primary inserts (%d errors)", inserts.Load(), insertErrors.Load())
 
 	// Confirm we hit case 2 (silent InnoDB retry, IO thread unaffected) and
 	// not case 1 (relay log filesystem fails, IO thread stops). With relay
@@ -125,6 +152,20 @@ func TestReplicationStalledDiskFull(t *testing.T) {
 		func(_ int, response string) bool {
 			return strings.Contains(response, "ReplicationStalledDiskFull")
 		})
+}
+
+// formatBytes returns a short human-readable free-space figure for the
+// loopback mount, used in periodic diagnostic logs while we wait for the
+// InnoDB ENOSPC entry.
+func formatBytes(m *mount) string {
+	if m == nil {
+		return "?"
+	}
+	free, err := m.freeBytes()
+	if err != nil {
+		return "?"
+	}
+	return fmt.Sprintf("%d KiB", free/1024)
 }
 
 // runSQLNoFail executes a query against a tablet's mysqld without using

--- a/go/test/endtoend/vtorc/replicationstalleddiskfull/replication_stalled_test.go
+++ b/go/test/endtoend/vtorc/replicationstalleddiskfull/replication_stalled_test.go
@@ -1,0 +1,123 @@
+//go:build linux
+
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replicationstalleddiskfull
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/vtorc/utils"
+)
+
+// TestReplicationStalledDiskFull asserts VTOrc surfaces the new analysis
+// when a replica's IO/SQL threads are still "Yes" but InnoDB is parked on
+// ENOSPC. The replica's mysqld is launched against a 256 MB ext4 loopback
+// mount; we then push 1 MB BLOB inserts at the primary until the replica's
+// disk is exhausted and the InnoDB applier wedges. VTOrc should detect
+// `ReplicationStalledDiskFull` for the replica only.
+func TestReplicationStalledDiskFull(t *testing.T) {
+	require.NotNil(t, primaryTablet)
+	require.NotNil(t, replicaTablet)
+	require.NotNil(t, vtorcProcess)
+
+	// Sanity check: replication is healthy before we wedge it.
+	utils.CheckReplication(t, &utils.VTOrcClusterInfo{ClusterInstance: clusterInstance},
+		primaryTablet, []*cluster.Vttablet{replicaTablet}, 30*time.Second)
+
+	// Create the filler table and push large rows until the replica's
+	// filesystem is exhausted. Each row is ~1 MiB; with ~150 MB of headroom
+	// after MySQL initialisation, ~150 inserts is more than enough.
+	_, err := utils.RunSQL(t, "CREATE TABLE filler (id INT AUTO_INCREMENT PRIMARY KEY, blob_col MEDIUMBLOB) ENGINE=InnoDB", primaryTablet, "vt_"+keyspaceName)
+	require.NoError(t, err, "create filler table")
+
+	// Insert in a tight loop until replica's mount has < 5 MB free or 90s
+	// elapses (whichever comes first).
+	deadline := time.Now().Add(90 * time.Second)
+	const lowWaterBytes = uint64(5 * 1024 * 1024)
+	for time.Now().Before(deadline) {
+		_, err := utils.RunSQL(t, "INSERT INTO filler (blob_col) VALUES (REPEAT('x', 1048576))", primaryTablet, "vt_"+keyspaceName)
+		if err != nil {
+			// Primary's own disk is fine, but in the unlikely event of an
+			// error keep the test honest by surfacing it.
+			t.Logf("INSERT failed: %v", err)
+			break
+		}
+		free, ferr := diskMount.freeBytes()
+		require.NoError(t, ferr)
+		if free < lowWaterBytes {
+			t.Logf("replica mount nearly full: %d bytes free", free)
+			break
+		}
+	}
+
+	// Confirm the replica is in the wedge state we're targeting: both
+	// threads still "Yes", and the error log shows the InnoDB disk-full
+	// codes from the issue.
+	requireReplicaWedged(t)
+
+	// Poll vtorc's analysis API until it surfaces the new code for the
+	// replica. Allow up to 60s for two discovery cycles + the analysis pass.
+	utils.MakeAPICallRetryTimeout(t, vtorcProcess,
+		"/api/replication-analysis", 60*time.Second,
+		func(_ int, response string) bool {
+			return !strings.Contains(response, "ReplicationStalledDiskFull")
+		})
+
+	// Self-healing check: drop the filler on the primary, free space on the
+	// replica's mount (the relay log shrinks once the applier catches up),
+	// and confirm the analysis clears.
+	_, err = utils.RunSQL(t, "DROP TABLE filler", primaryTablet, "vt_"+keyspaceName)
+	require.NoError(t, err)
+
+	utils.MakeAPICallRetryTimeout(t, vtorcProcess,
+		"/api/replication-analysis", 90*time.Second,
+		func(_ int, response string) bool {
+			return strings.Contains(response, "ReplicationStalledDiskFull")
+		})
+}
+
+// requireReplicaWedged asserts the replica is in the precise state our new
+// analysis is designed to detect: IO+SQL threads both running, no last error,
+// and InnoDB has logged a disk-full event.
+func requireReplicaWedged(t *testing.T) {
+	t.Helper()
+
+	// Both threads should still be running — that's the whole point.
+	res, err := utils.RunSQL(t, "SHOW REPLICA STATUS", replicaTablet, "")
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Rows, "SHOW REPLICA STATUS returned no rows")
+
+	row := res.Named().Row()
+	require.Equal(t, "Yes", row.AsString("Replica_IO_Running", ""), "Replica_IO_Running should be Yes")
+	require.Equal(t, "Yes", row.AsString("Replica_SQL_Running", ""), "Replica_SQL_Running should be Yes")
+
+	// performance_schema.error_log should have at least one of the two
+	// InnoDB disk-full codes we look for.
+	errLog, err := utils.RunSQL(t, `SELECT COUNT(*) AS c FROM performance_schema.error_log
+		WHERE prio = 'Error' AND subsystem = 'InnoDB'
+		  AND error_code IN ('MY-012814', 'MY-012820')`, replicaTablet, "")
+	require.NoError(t, err)
+	require.NotEmpty(t, errLog.Rows)
+	count, _ := errLog.Named().Row().ToInt64("c")
+	require.Greater(t, count, int64(0), "expected at least one MY-012814/MY-012820 entry in error_log")
+}

--- a/go/test/endtoend/vtorc/replicationstalleddiskfull/replication_stalled_test.go
+++ b/go/test/endtoend/vtorc/replicationstalleddiskfull/replication_stalled_test.go
@@ -19,12 +19,18 @@ limitations under the License.
 package replicationstalleddiskfull
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"path"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/vtorc/utils"
 )
@@ -32,9 +38,14 @@ import (
 // TestReplicationStalledDiskFull asserts VTOrc surfaces the new analysis
 // when a replica's IO/SQL threads are still "Yes" but InnoDB is parked on
 // ENOSPC. The replica's mysqld is launched against a 256 MB ext4 loopback
-// mount; we then push 1 MB BLOB inserts at the primary until the replica's
-// disk is exhausted and the InnoDB applier wedges. VTOrc should detect
-// `ReplicationStalledDiskFull` for the replica only.
+// mount that holds *only* the InnoDB filesystem (datadir, redo log, undo,
+// tmpdir) — relay log + binlog stay on the regular disk so the IO thread
+// keeps running while InnoDB's tablespace extends silently fail.
+//
+// The test runs inserts in a goroutine and polls performance_schema.error_log
+// for the disk-full InnoDB messages (MY-012814 / MY-012820). Once they
+// appear we assert SHOW REPLICA STATUS still reports both threads as Yes
+// (the wedge state) and then poll vtorc's analysis API for the new code.
 func TestReplicationStalledDiskFull(t *testing.T) {
 	require.NotNil(t, primaryTablet)
 	require.NotNil(t, replicaTablet)
@@ -44,36 +55,56 @@ func TestReplicationStalledDiskFull(t *testing.T) {
 	utils.CheckReplication(t, &utils.VTOrcClusterInfo{ClusterInstance: clusterInstance},
 		primaryTablet, []*cluster.Vttablet{replicaTablet}, 30*time.Second)
 
-	// Create the filler table and push large rows until the replica's
-	// filesystem is exhausted. Each row is ~1 MiB; with ~150 MB of headroom
-	// after MySQL initialisation, ~150 inserts is more than enough.
-	_, err := utils.RunSQL(t, "CREATE TABLE filler (id INT AUTO_INCREMENT PRIMARY KEY, blob_col MEDIUMBLOB) ENGINE=InnoDB", primaryTablet, "vt_"+keyspaceName)
+	_, err := utils.RunSQL(t, "CREATE TABLE filler (id INT AUTO_INCREMENT PRIMARY KEY, blob_col MEDIUMBLOB) ENGINE=InnoDB",
+		primaryTablet, "vt_"+keyspaceName)
 	require.NoError(t, err, "create filler table")
 
-	// Insert in a tight loop until replica's mount has < 5 MB free or 90s
-	// elapses (whichever comes first).
-	deadline := time.Now().Add(90 * time.Second)
-	const lowWaterBytes = uint64(5 * 1024 * 1024)
-	for time.Now().Before(deadline) {
-		_, err := utils.RunSQL(t, "INSERT INTO filler (blob_col) VALUES (REPEAT('x', 1048576))", primaryTablet, "vt_"+keyspaceName)
-		if err != nil {
-			// Primary's own disk is fine, but in the unlikely event of an
-			// error keep the test honest by surfacing it.
-			t.Logf("INSERT failed: %v", err)
-			break
-		}
-		free, ferr := diskMount.freeBytes()
-		require.NoError(t, ferr)
-		if free < lowWaterBytes {
-			t.Logf("replica mount nearly full: %d bytes free", free)
-			break
-		}
-	}
+	// Drive inserts continuously in a goroutine so InnoDB keeps pressure on
+	// the small mount even after the disk is "full". InnoDB doesn't fail
+	// fast — it retries — and we need sustained writes to provoke the
+	// MY-012814 / MY-012820 log entries our analysis keys on.
+	//
+	// runSQLNoFail is used here instead of utils.RunSQL because the latter
+	// calls require.Nil from inside, which is unsafe from a goroutine.
+	insertCtx, stopInserts := context.WithCancel(context.Background())
+	defer stopInserts()
 
-	// Confirm the replica is in the wedge state we're targeting: both
-	// threads still "Yes", and the error log shows the InnoDB disk-full
-	// codes from the issue.
-	requireReplicaWedged(t)
+	var inserts atomic.Int64
+	go func() {
+		for insertCtx.Err() == nil {
+			_ = runSQLNoFail(insertCtx, "INSERT INTO filler (blob_col) VALUES (REPEAT('x', 1048576))",
+				primaryTablet, "vt_"+keyspaceName)
+			inserts.Add(1)
+		}
+	}()
+
+	// Poll error_log for the InnoDB disk-full codes. Up to 120s — InnoDB's
+	// dirty-page flush cadence + buffer pool size mean we may need a fair
+	// bit of cumulative writes before ibdata1 actually fails to extend.
+	require.Eventually(t, func() bool {
+		errLog, err := utils.RunSQL(t, `SELECT COUNT(*) AS c FROM performance_schema.error_log
+			WHERE prio = 'Error' AND subsystem = 'InnoDB'
+			  AND error_code IN ('MY-012814', 'MY-012820')`,
+			replicaTablet, "")
+		if err != nil || len(errLog.Rows) == 0 {
+			return false
+		}
+		count, _ := errLog.Named().Row().ToInt64("c")
+		return count > 0
+	}, 120*time.Second, 1*time.Second,
+		"replica's performance_schema.error_log never recorded MY-012814/MY-012820 (inserts so far: %d)", inserts.Load())
+
+	t.Logf("InnoDB ENOSPC observed after %d primary inserts", inserts.Load())
+
+	// Confirm we hit case 2 (silent InnoDB retry, IO thread unaffected) and
+	// not case 1 (relay log filesystem fails, IO thread stops). With relay
+	// log on the regular disk this should always be case 2.
+	res, err := utils.RunSQL(t, "SHOW REPLICA STATUS", replicaTablet, "")
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Rows, "SHOW REPLICA STATUS returned no rows")
+	row := res.Named().Row()
+	require.Equal(t, "Yes", row.AsString("Replica_IO_Running", ""), "Replica_IO_Running should be Yes")
+	require.Equal(t, "Yes", row.AsString("Replica_SQL_Running", ""), "Replica_SQL_Running should be Yes")
 
 	// Poll vtorc's analysis API until it surfaces the new code for the
 	// replica. Allow up to 60s for two discovery cycles + the analysis pass.
@@ -83,9 +114,9 @@ func TestReplicationStalledDiskFull(t *testing.T) {
 			return !strings.Contains(response, "ReplicationStalledDiskFull")
 		})
 
-	// Self-healing check: drop the filler on the primary, free space on the
-	// replica's mount (the relay log shrinks once the applier catches up),
-	// and confirm the analysis clears.
+	// Self-healing check: stop inserts, drop the filler on the primary, and
+	// verify the analysis clears once InnoDB resumes commits.
+	stopInserts()
 	_, err = utils.RunSQL(t, "DROP TABLE filler", primaryTablet, "vt_"+keyspaceName)
 	require.NoError(t, err)
 
@@ -96,28 +127,25 @@ func TestReplicationStalledDiskFull(t *testing.T) {
 		})
 }
 
-// requireReplicaWedged asserts the replica is in the precise state our new
-// analysis is designed to detect: IO+SQL threads both running, no last error,
-// and InnoDB has logged a disk-full event.
-func requireReplicaWedged(t *testing.T) {
-	t.Helper()
-
-	// Both threads should still be running — that's the whole point.
-	res, err := utils.RunSQL(t, "SHOW REPLICA STATUS", replicaTablet, "")
-	require.NoError(t, err)
-	require.NotEmpty(t, res.Rows, "SHOW REPLICA STATUS returned no rows")
-
-	row := res.Named().Row()
-	require.Equal(t, "Yes", row.AsString("Replica_IO_Running", ""), "Replica_IO_Running should be Yes")
-	require.Equal(t, "Yes", row.AsString("Replica_SQL_Running", ""), "Replica_SQL_Running should be Yes")
-
-	// performance_schema.error_log should have at least one of the two
-	// InnoDB disk-full codes we look for.
-	errLog, err := utils.RunSQL(t, `SELECT COUNT(*) AS c FROM performance_schema.error_log
-		WHERE prio = 'Error' AND subsystem = 'InnoDB'
-		  AND error_code IN ('MY-012814', 'MY-012820')`, replicaTablet, "")
-	require.NoError(t, err)
-	require.NotEmpty(t, errLog.Rows)
-	count, _ := errLog.Named().Row().ToInt64("c")
-	require.Greater(t, count, int64(0), "expected at least one MY-012814/MY-012820 entry in error_log")
+// runSQLNoFail executes a query against a tablet's mysqld without using
+// require.Nil; safe to call from a goroutine. Errors are returned for the
+// caller to inspect; the insert loop above swallows them because we only
+// care that *some* inserts land, not that every one succeeds.
+func runSQLNoFail(ctx context.Context, sql string, tablet *cluster.Vttablet, db string) error {
+	params := mysql.ConnParams{
+		Uname:      "vt_dba",
+		UnixSocket: path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/mysql.sock", tablet.TabletUID)),
+	}
+	if db != "" {
+		params.DbName = db
+	}
+	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	conn, err := mysql.Connect(cctx, &params)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_, err = conn.ExecuteFetch(sql, 1000, false)
+	return err
 }

--- a/go/vt/mysqlctl/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon.go
@@ -222,6 +222,9 @@ type FakeMysqlDaemon struct {
 	// SemiSyncReplicaEnabled represents the state of rpl_semi_sync_replica_enabled.
 	SemiSyncReplicaEnabled bool
 
+	// ReplicationStalledDiskFull is the value returned by IsReplicationStalledDiskFull.
+	ReplicationStalledDiskFull bool
+
 	// GlobalReadLock is used to test if a lock has been acquired already or not
 	GlobalReadLock bool
 
@@ -865,6 +868,11 @@ func (fmd *FakeMysqlDaemon) SemiSyncReplicationStatus(ctx context.Context) (bool
 // IsSemiSyncBlocked is part of the MysqlDaemon interface.
 func (fmd *FakeMysqlDaemon) IsSemiSyncBlocked(ctx context.Context) (bool, error) {
 	return false, nil
+}
+
+// IsReplicationStalledDiskFull is part of the MysqlDaemon interface.
+func (fmd *FakeMysqlDaemon) IsReplicationStalledDiskFull(ctx context.Context) (bool, error) {
+	return fmd.ReplicationStalledDiskFull, nil
 }
 
 // GetVersionString is part of the MysqlDaemon interface.

--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -76,6 +76,7 @@ type MysqlDaemon interface {
 	SemiSyncSettings(ctx context.Context) (timeout uint64, numReplicas uint32)
 	SemiSyncReplicationStatus(ctx context.Context) (bool, error)
 	IsSemiSyncBlocked(ctx context.Context) (bool, error)
+	IsReplicationStalledDiskFull(ctx context.Context) (bool, error)
 	ResetReplicationParameters(ctx context.Context) error
 	GetBinlogInformation(ctx context.Context) (binlogFormat string, logEnabled bool, logReplicaUpdate bool, binlogRowImage string, err error)
 	GetGTIDMode(ctx context.Context) (gtidMode string, err error)

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -27,10 +27,13 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/mysql/capabilities"
 	"vitess.io/vitess/go/mysql/replication"
+	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/netutil"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/hook"
@@ -845,4 +848,70 @@ func (mysqld *Mysqld) IsSemiSyncBlocked(ctx context.Context) (bool, error) {
 	}
 	value, err := res.Rows[0][0].ToCastInt64()
 	return value != 0, err
+}
+
+// replicationStalledDiskFullQuery detects a replica that is wedged because
+// InnoDB has reported "Disk is full" (error codes MY-012814 and MY-012820)
+// after the applier's last successful commit. In that state the IO and SQL
+// threads remain "Yes" but the applier silently retries failed writes inside
+// ha_commit_trans, so SHOW REPLICA STATUS looks healthy. The query is
+// stateless and self-healing: it returns no rows once the applier resumes.
+//
+// Requires MySQL 8.0.22+ (performance_schema.error_log).
+const replicationStalledDiskFullQuery = `SELECT 1
+  FROM performance_schema.error_log el
+ WHERE el.logged    >= NOW(6) - INTERVAL 1 HOUR
+   AND el.prio       = 'Error'
+   AND el.subsystem  = 'InnoDB'
+   AND el.error_code IN ('MY-012814', 'MY-012820')
+   AND el.logged > COALESCE(
+         (SELECT MAX(LAST_APPLIED_TRANSACTION_END_APPLY_TIMESTAMP)
+            FROM performance_schema.replication_applier_status_by_worker),
+         '1970-01-01')
+ LIMIT 1`
+
+// replicationStalledDiskFullPermWarned is set the first time
+// IsReplicationStalledDiskFull observes a permission-denied error so the
+// warning is logged once per process instead of on every poll.
+var replicationStalledDiskFullPermWarned atomic.Bool
+
+// IsReplicationStalledDiskFull returns true when the replica's applier appears
+// to be wedged by a full disk (see replicationStalledDiskFullQuery). On older
+// MySQL versions or other flavors that lack performance_schema.error_log it
+// returns (false, nil). A SELECT permission denied error is logged once and
+// also reported as (false, nil) so it cannot fail FullStatus discovery.
+func (mysqld *Mysqld) IsReplicationStalledDiskFull(ctx context.Context) (bool, error) {
+	versionStr, err := mysqld.GetVersionString(ctx)
+	if err != nil {
+		return false, err
+	}
+	if _, v, perr := ParseVersionString(versionStr); perr == nil {
+		versionStr = fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+	}
+	capableOf := mysql.ServerVersionCapableOf(versionStr)
+	if capableOf == nil {
+		return false, nil
+	}
+	ok, err := capableOf(capabilities.PerformanceSchemaErrorLogTableCapability)
+	if err != nil || !ok {
+		return false, nil
+	}
+
+	conn, err := getPoolReconnect(ctx, mysqld.dbaPool)
+	if err != nil {
+		return false, err
+	}
+	defer conn.Recycle()
+
+	res, err := conn.Conn.ExecuteFetch(replicationStalledDiskFullQuery, 1, false)
+	if err != nil {
+		if sqlErr, ok := sqlerror.NewSQLErrorFromError(err).(*sqlerror.SQLError); ok && sqlErr.Num == sqlerror.ERTableAccessDenied {
+			if replicationStalledDiskFullPermWarned.CompareAndSwap(false, true) {
+				log.Warn(fmt.Sprintf("IsReplicationStalledDiskFull: SELECT denied on performance_schema.error_log; check is disabled until grants are fixed (%v)", err))
+			}
+			return false, nil
+		}
+		return false, err
+	}
+	return len(res.Rows) > 0, nil
 }

--- a/go/vt/proto/replicationdata/replicationdata.pb.go
+++ b/go/vt/proto/replicationdata/replicationdata.pb.go
@@ -539,6 +539,7 @@ type FullStatus struct {
 	DiskStalled                 bool                   `protobuf:"varint,23,opt,name=disk_stalled,json=diskStalled,proto3" json:"disk_stalled,omitempty"`
 	SemiSyncBlocked             bool                   `protobuf:"varint,24,opt,name=semi_sync_blocked,json=semiSyncBlocked,proto3" json:"semi_sync_blocked,omitempty"`
 	TabletType                  topodata.TabletType    `protobuf:"varint,25,opt,name=tablet_type,json=tabletType,proto3,enum=topodata.TabletType" json:"tablet_type,omitempty"`
+	ReplicationStalledDiskFull  bool                   `protobuf:"varint,26,opt,name=replication_stalled_disk_full,json=replicationStalledDiskFull,proto3" json:"replication_stalled_disk_full,omitempty"`
 	unknownFields               protoimpl.UnknownFields
 	sizeCache                   protoimpl.SizeCache
 }
@@ -748,6 +749,13 @@ func (x *FullStatus) GetTabletType() topodata.TabletType {
 	return topodata.TabletType(0)
 }
 
+func (x *FullStatus) GetReplicationStalledDiskFull() bool {
+	if x != nil {
+		return x.ReplicationStalledDiskFull
+	}
+	return false
+}
+
 var File_replicationdata_proto protoreflect.FileDescriptor
 
 const file_replicationdata_proto_rawDesc = "" +
@@ -798,7 +806,8 @@ const file_replicationdata_proto_rawDesc = "" +
 	"\bposition\x18\x01 \x01(\tR\bposition\x12#\n" +
 	"\rfile_position\x18\x02 \x01(\tR\ffilePosition\x12\x1f\n" +
 	"\vserver_uuid\x18\x03 \x01(\tR\n" +
-	"serverUuid\"\xce\t\n" +
+	"serverUuid\"\x91\n" +
+	"\n" +
 	"\n" +
 	"FullStatus\x12\x1b\n" +
 	"\tserver_id\x18\x01 \x01(\rR\bserverId\x12\x1f\n" +
@@ -829,7 +838,8 @@ const file_replicationdata_proto_rawDesc = "" +
 	"\fdisk_stalled\x18\x17 \x01(\bR\vdiskStalled\x12*\n" +
 	"\x11semi_sync_blocked\x18\x18 \x01(\bR\x0fsemiSyncBlocked\x125\n" +
 	"\vtablet_type\x18\x19 \x01(\x0e2\x14.topodata.TabletTypeR\n" +
-	"tabletType*;\n" +
+	"tabletType\x12A\n" +
+	"\x1dreplication_stalled_disk_full\x18\x1a \x01(\bR\x1areplicationStalledDiskFull*;\n" +
 	"\x13StopReplicationMode\x12\x12\n" +
 	"\x0eIOANDSQLTHREAD\x10\x00\x12\x10\n" +
 	"\fIOTHREADONLY\x10\x01B.Z,vitess.io/vitess/go/vt/proto/replicationdatab\x06proto3"

--- a/go/vt/proto/replicationdata/replicationdata_vtproto.pb.go
+++ b/go/vt/proto/replicationdata/replicationdata_vtproto.pb.go
@@ -150,6 +150,7 @@ func (m *FullStatus) CloneVT() *FullStatus {
 	r.DiskStalled = m.DiskStalled
 	r.SemiSyncBlocked = m.SemiSyncBlocked
 	r.TabletType = m.TabletType
+	r.ReplicationStalledDiskFull = m.ReplicationStalledDiskFull
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -607,6 +608,18 @@ func (m *FullStatus) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.ReplicationStalledDiskFull {
+		i--
+		if m.ReplicationStalledDiskFull {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xd0
 	}
 	if m.TabletType != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.TabletType))
@@ -1082,6 +1095,9 @@ func (m *FullStatus) SizeVT() (n int) {
 	}
 	if m.TabletType != 0 {
 		n += 2 + protohelpers.SizeOfVarint(uint64(m.TabletType))
+	}
+	if m.ReplicationStalledDiskFull {
+		n += 3
 	}
 	n += len(m.unknownFields)
 	return n
@@ -2798,6 +2814,26 @@ func (m *FullStatus) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 26:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReplicationStalledDiskFull", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.ReplicationStalledDiskFull = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/go/vt/vtorc/db/generate_base.go
+++ b/go/vt/vtorc/db/generate_base.go
@@ -107,6 +107,7 @@ CREATE TABLE database_instance (
 	semi_sync_primary_clients int NOT NULL DEFAULT 0,
 	semi_sync_blocked tinyint NOT NULL DEFAULT 0,
 	is_disk_stalled TINYint NOT NULL DEFAULT 0,
+	replication_stalled_disk_full TINYint NOT NULL DEFAULT 0,
 	PRIMARY KEY (alias)
 )`,
 	`

--- a/go/vt/vtorc/inst/analysis.go
+++ b/go/vt/vtorc/inst/analysis.go
@@ -62,6 +62,7 @@ const (
 	PrimarySemiSyncBlocked                 AnalysisCode = "PrimarySemiSyncBlocked"
 	ErrantGTIDDetected                     AnalysisCode = "ErrantGTIDDetected"
 	PrimaryDiskStalled                     AnalysisCode = "PrimaryDiskStalled"
+	ReplicationStalledDiskFull             AnalysisCode = "ReplicationStalledDiskFull"
 
 	// StaleTopoPrimary describes when a tablet still has the type PRIMARY in the topology when a newer primary
 	// has been elected. VTOrc should demote this primary to a replica.
@@ -151,6 +152,7 @@ type DetectionAnalysis struct {
 	MaxReplicaGTIDErrant                      string
 	IsReadOnly                                bool
 	IsDiskStalled                             bool
+	ReplicationStalledDiskFull                bool
 }
 
 // hasMinSemiSyncAckers returns true if there are a minimum number of semi-sync ackers enabled and replicating.

--- a/go/vt/vtorc/inst/analysis_dao.go
+++ b/go/vt/vtorc/inst/analysis_dao.go
@@ -273,7 +273,8 @@ func GetDetectionAnalysis(keyspace string, shard string, hints *DetectionAnalysi
 			DISTINCT case when replica_instance.log_bin
 			AND replica_instance.log_replica_updates then replica_instance.major_version else NULL end
 		) AS count_distinct_logging_major_versions,
-		primary_instance.is_disk_stalled != 0 AS is_disk_stalled
+		primary_instance.is_disk_stalled != 0 AS is_disk_stalled,
+		primary_instance.replication_stalled_disk_full != 0 AS replication_stalled_disk_full
 	FROM
 		vitess_tablet
 		JOIN vitess_keyspace ON (
@@ -399,6 +400,7 @@ func GetDetectionAnalysis(keyspace string, shard string, hints *DetectionAnalysi
 
 		a.IsReadOnly = m.GetUint("read_only") == 1
 		a.IsDiskStalled = m.GetBool("is_disk_stalled")
+		a.ReplicationStalledDiskFull = m.GetBool("replication_stalled_disk_full")
 
 		if !a.LastCheckValid {
 			analysisMessage := fmt.Sprintf("analysis: Alias: %+v, Keyspace: %+v, Shard: %+v, IsPrimary: %+v, PrimaryHealthUnhealthy: %+v, LastCheckValid: %+v, LastCheckPartialSuccess: %+v, CountReplicas: %+v, CountValidReplicas: %+v, CountValidReplicatingReplicas: %+v, CountLaggingReplicas: %+v, CountDelayedReplicas: %+v",

--- a/go/vt/vtorc/inst/analysis_dao_test.go
+++ b/go/vt/vtorc/inst/analysis_dao_test.go
@@ -34,10 +34,10 @@ import (
 // The initialSQL is a set of insert commands copied from a dump of an actual running VTOrc instances. The relevant insert commands are here.
 // This is a dump taken from a test running 4 tablets, zone1-101 is the primary, zone1-100 is a replica, zone1-112 is a rdonly and zone2-200 is a cross-cell replica.
 var initialSQL = []string{
-	`INSERT INTO database_instance VALUES('zone1-0000000112','localhost',6747,3,'zone1','2022-12-28 07:26:04','2022-12-28 07:26:04',213696377,'8.0.31','ROW',1,1,'vt-0000000112-bin.000001',15963,'localhost',6714,8,4.0,1,1,'vt-0000000101-bin.000001',15583,'vt-0000000101-bin.000001',15583,0,0,1,'','',1,'vt-0000000112-relay-bin.000002',15815,1,0,0,0,0,1,'729a4cc4-8680-11ed-a104-47706090afbd:1-54','729a5138-8680-11ed-9240-92a06c3be3c2','2022-12-28 07:26:04','',1,0,0,'Homebrew','8.0','FULL',10816929,0,0,'ON',1,'729a4cc4-8680-11ed-a104-47706090afbd','','729a4cc4-8680-11ed-a104-47706090afbd,729a5138-8680-11ed-9240-92a06c3be3c2',1,1,1000000000000000000,1,0,0,0,false,false);`,
-	`INSERT INTO database_instance VALUES('zone1-0000000100','localhost',6711,2,'zone1','2022-12-28 07:26:04','2022-12-28 07:26:04',1094500338,'8.0.31','ROW',1,1,'vt-0000000100-bin.000001',15963,'localhost',6714,8,4.0,1,1,'vt-0000000101-bin.000001',15583,'vt-0000000101-bin.000001',15583,0,0,1,'','',1,'vt-0000000100-relay-bin.000002',15815,1,0,0,0,0,1,'729a4cc4-8680-11ed-a104-47706090afbd:1-54','729a5138-8680-11ed-acf8-d6b0ef9f4eaa','2022-12-28 07:26:04','',1,0,0,'Homebrew','8.0','FULL',10103920,0,1,'ON',1,'729a4cc4-8680-11ed-a104-47706090afbd','','729a4cc4-8680-11ed-a104-47706090afbd,729a5138-8680-11ed-acf8-d6b0ef9f4eaa',1,1,1000000000000000000,1,0,1,0,false,false);`,
-	`INSERT INTO database_instance VALUES('zone1-0000000101','localhost',6714,1,'zone1','2022-12-28 07:26:04','2022-12-28 07:26:04',390954723,'8.0.31','ROW',1,1,'vt-0000000101-bin.000001',15583,'',0,0,0,0,0,'',0,'',0,NULL,NULL,0,'','',0,'',0,0,0,0,0,0,1,'729a4cc4-8680-11ed-a104-47706090afbd:1-54','729a4cc4-8680-11ed-a104-47706090afbd','2022-12-28 07:26:04','',0,0,0,'Homebrew','8.0','FULL',11366095,1,1,'ON',1,'','','729a4cc4-8680-11ed-a104-47706090afbd',-1,-1,1000000000000000000,1,1,0,2,false,false);`,
-	`INSERT INTO database_instance VALUES('zone2-0000000200','localhost',6756,2,'zone2','2022-12-28 07:26:05','2022-12-28 07:26:05',444286571,'8.0.31','ROW',1,1,'vt-0000000200-bin.000001',15963,'localhost',6714,8,4.0,1,1,'vt-0000000101-bin.000001',15583,'vt-0000000101-bin.000001',15583,0,0,1,'','',1,'vt-0000000200-relay-bin.000002',15815,1,0,0,0,0,1,'729a4cc4-8680-11ed-a104-47706090afbd:1-54','729a497c-8680-11ed-8ad4-3f51d747db75','2022-12-28 07:26:05','',1,0,0,'Homebrew','8.0','FULL',10443112,0,1,'ON',1,'729a4cc4-8680-11ed-a104-47706090afbd','','729a4cc4-8680-11ed-a104-47706090afbd,729a497c-8680-11ed-8ad4-3f51d747db75',1,1,1000000000000000000,1,0,1,0,false,false);`,
+	`INSERT INTO database_instance VALUES('zone1-0000000112','localhost',6747,3,'zone1','2022-12-28 07:26:04','2022-12-28 07:26:04',213696377,'8.0.31','ROW',1,1,'vt-0000000112-bin.000001',15963,'localhost',6714,8,4.0,1,1,'vt-0000000101-bin.000001',15583,'vt-0000000101-bin.000001',15583,0,0,1,'','',1,'vt-0000000112-relay-bin.000002',15815,1,0,0,0,0,1,'729a4cc4-8680-11ed-a104-47706090afbd:1-54','729a5138-8680-11ed-9240-92a06c3be3c2','2022-12-28 07:26:04','',1,0,0,'Homebrew','8.0','FULL',10816929,0,0,'ON',1,'729a4cc4-8680-11ed-a104-47706090afbd','','729a4cc4-8680-11ed-a104-47706090afbd,729a5138-8680-11ed-9240-92a06c3be3c2',1,1,1000000000000000000,1,0,0,0,false,false,false);`,
+	`INSERT INTO database_instance VALUES('zone1-0000000100','localhost',6711,2,'zone1','2022-12-28 07:26:04','2022-12-28 07:26:04',1094500338,'8.0.31','ROW',1,1,'vt-0000000100-bin.000001',15963,'localhost',6714,8,4.0,1,1,'vt-0000000101-bin.000001',15583,'vt-0000000101-bin.000001',15583,0,0,1,'','',1,'vt-0000000100-relay-bin.000002',15815,1,0,0,0,0,1,'729a4cc4-8680-11ed-a104-47706090afbd:1-54','729a5138-8680-11ed-acf8-d6b0ef9f4eaa','2022-12-28 07:26:04','',1,0,0,'Homebrew','8.0','FULL',10103920,0,1,'ON',1,'729a4cc4-8680-11ed-a104-47706090afbd','','729a4cc4-8680-11ed-a104-47706090afbd,729a5138-8680-11ed-acf8-d6b0ef9f4eaa',1,1,1000000000000000000,1,0,1,0,false,false,false);`,
+	`INSERT INTO database_instance VALUES('zone1-0000000101','localhost',6714,1,'zone1','2022-12-28 07:26:04','2022-12-28 07:26:04',390954723,'8.0.31','ROW',1,1,'vt-0000000101-bin.000001',15583,'',0,0,0,0,0,'',0,'',0,NULL,NULL,0,'','',0,'',0,0,0,0,0,0,1,'729a4cc4-8680-11ed-a104-47706090afbd:1-54','729a4cc4-8680-11ed-a104-47706090afbd','2022-12-28 07:26:04','',0,0,0,'Homebrew','8.0','FULL',11366095,1,1,'ON',1,'','','729a4cc4-8680-11ed-a104-47706090afbd',-1,-1,1000000000000000000,1,1,0,2,false,false,false);`,
+	`INSERT INTO database_instance VALUES('zone2-0000000200','localhost',6756,2,'zone2','2022-12-28 07:26:05','2022-12-28 07:26:05',444286571,'8.0.31','ROW',1,1,'vt-0000000200-bin.000001',15963,'localhost',6714,8,4.0,1,1,'vt-0000000101-bin.000001',15583,'vt-0000000101-bin.000001',15583,0,0,1,'','',1,'vt-0000000200-relay-bin.000002',15815,1,0,0,0,0,1,'729a4cc4-8680-11ed-a104-47706090afbd:1-54','729a497c-8680-11ed-8ad4-3f51d747db75','2022-12-28 07:26:05','',1,0,0,'Homebrew','8.0','FULL',10443112,0,1,'ON',1,'729a4cc4-8680-11ed-a104-47706090afbd','','729a4cc4-8680-11ed-a104-47706090afbd,729a497c-8680-11ed-8ad4-3f51d747db75',1,1,1000000000000000000,1,0,1,0,false,false,false);`,
 	`INSERT INTO vitess_tablet VALUES('zone1-0000000100','localhost',6711,'ks','0','zone1',2,'0001-01-01 00:00:00 +0000 UTC',X'616c6961733a7b63656c6c3a227a6f6e653122207569643a3130307d20686f73746e616d653a226c6f63616c686f73742220706f72745f6d61703a7b6b65793a2267727063222076616c75653a363731307d20706f72745f6d61703a7b6b65793a227674222076616c75653a363730397d206b657973706163653a226b73222073686172643a22302220747970653a5245504c494341206d7973716c5f686f73746e616d653a226c6f63616c686f737422206d7973716c5f706f72743a363731312064625f7365727665725f76657273696f6e3a22382e302e3331222064656661756c745f636f6e6e5f636f6c6c6174696f6e3a3435');`,
 	`INSERT INTO vitess_tablet VALUES('zone1-0000000101','localhost',6714,'ks','0','zone1',1,'2022-12-28 07:23:25.129898 +0000 UTC',X'616c6961733a7b63656c6c3a227a6f6e653122207569643a3130317d20686f73746e616d653a226c6f63616c686f73742220706f72745f6d61703a7b6b65793a2267727063222076616c75653a363731337d20706f72745f6d61703a7b6b65793a227674222076616c75653a363731327d206b657973706163653a226b73222073686172643a22302220747970653a5052494d415259206d7973716c5f686f73746e616d653a226c6f63616c686f737422206d7973716c5f706f72743a36373134207072696d6172795f7465726d5f73746172745f74696d653a7b7365636f6e64733a31363732323132323035206e616e6f7365636f6e64733a3132393839383030307d2064625f7365727665725f76657273696f6e3a22382e302e3331222064656661756c745f636f6e6e5f636f6c6c6174696f6e3a3435');`,
 	`INSERT INTO vitess_tablet VALUES('zone1-0000000112','localhost',6747,'ks','0','zone1',3,'0001-01-01 00:00:00 +0000 UTC',X'616c6961733a7b63656c6c3a227a6f6e653122207569643a3131327d20686f73746e616d653a226c6f63616c686f73742220706f72745f6d61703a7b6b65793a2267727063222076616c75653a363734367d20706f72745f6d61703a7b6b65793a227674222076616c75653a363734357d206b657973706163653a226b73222073686172643a22302220747970653a52444f4e4c59206d7973716c5f686f73746e616d653a226c6f63616c686f737422206d7973716c5f706f72743a363734372064625f7365727665725f76657273696f6e3a22382e302e3331222064656661756c745f636f6e6e5f636f6c6c6174696f6e3a3435');`,
@@ -123,6 +123,47 @@ func TestGetDetectionAnalysisDecision(t *testing.T) {
 			keyspaceWanted: "ks",
 			shardWanted:    "0",
 			codeWanted:     PrimaryDiskStalled,
+		},
+		{
+			name: "ReplicationStalledDiskFull",
+			info: []*test.InfoForRecoveryAnalysis{{
+				TabletInfo: &topodatapb.Tablet{
+					Alias:         &topodatapb.TabletAlias{Cell: "zone1", Uid: 101},
+					Hostname:      "localhost",
+					Keyspace:      "ks",
+					Shard:         "0",
+					Type:          topodatapb.TabletType_PRIMARY,
+					MysqlHostname: "localhost",
+					MysqlPort:     6708,
+				},
+				DurabilityPolicy:              policy.DurabilityNone,
+				LastCheckValid:                1,
+				CountReplicas:                 1,
+				CountValidReplicas:            1,
+				CountValidReplicatingReplicas: 1,
+				IsPrimary:                     1,
+				CurrentTabletType:             int(topodatapb.TabletType_PRIMARY),
+			}, {
+				TabletInfo: &topodatapb.Tablet{
+					Alias:         &topodatapb.TabletAlias{Cell: "zone1", Uid: 100},
+					Hostname:      "localhost",
+					Keyspace:      "ks",
+					Shard:         "0",
+					Type:          topodatapb.TabletType_REPLICA,
+					MysqlHostname: "localhost",
+					MysqlPort:     6709,
+				},
+				DurabilityPolicy: policy.DurabilityNone,
+				PrimaryTabletInfo: &topodatapb.Tablet{
+					Alias: &topodatapb.TabletAlias{Cell: "zone1", Uid: 101},
+				},
+				LastCheckValid:             1,
+				ReadOnly:                   1,
+				ReplicationStalledDiskFull: 1,
+			}},
+			keyspaceWanted: "ks",
+			shardWanted:    "0",
+			codeWanted:     ReplicationStalledDiskFull,
 		},
 		{
 			name: "PrimarySemiSyncBlocked",

--- a/go/vt/vtorc/inst/analysis_problem.go
+++ b/go/vt/vtorc/inst/analysis_problem.go
@@ -358,6 +358,16 @@ var detectionAnalysisProblems = []*DetectionAnalysisProblem{
 	},
 	{
 		Meta: &DetectionAnalysisProblemMeta{
+			Analysis:    ReplicationStalledDiskFull,
+			Description: "Replication threads are running but the applier has made no progress (disk full)",
+			Priority:    detectionAnalysisPriorityMedium,
+		},
+		MatchFunc: func(a *DetectionAnalysis, ca *clusterAnalysis, primary, tablet *topodatapb.Tablet, isInvalid, isStaleBinlogCoordinates bool) bool {
+			return topo.IsReplicaType(a.TabletType) && !a.IsPrimary && a.ReplicationStalledDiskFull
+		},
+	},
+	{
+		Meta: &DetectionAnalysisProblemMeta{
 			Analysis:    NotConnectedToPrimary,
 			Description: "Not connected to the primary",
 			Priority:    detectionAnalysisPriorityMedium,

--- a/go/vt/vtorc/inst/instance.go
+++ b/go/vt/vtorc/inst/instance.go
@@ -90,12 +90,13 @@ type Instance struct {
 	SemiSyncReplicaStatus              bool
 	SemiSyncBlocked                    bool
 
-	LastSeenTimestamp    string
-	IsLastCheckValid     bool
-	IsUpToDate           bool
-	IsRecentlyChecked    bool
-	SecondsSinceLastSeen sql.NullInt64
-	StalledDisk          bool
+	LastSeenTimestamp          string
+	IsLastCheckValid           bool
+	IsUpToDate                 bool
+	IsRecentlyChecked          bool
+	SecondsSinceLastSeen       sql.NullInt64
+	StalledDisk                bool
+	ReplicationStalledDiskFull bool
 
 	AllowTLS bool
 

--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -333,6 +333,8 @@ func ReadTopologyInstanceBufferable(tabletAlias *topodatapb.TabletAlias, latency
 		instance.HeartbeatInterval = fs.ReplicationConfiguration.HeartbeatInterval
 	}
 
+	instance.ReplicationStalledDiskFull = fs.ReplicationStalledDiskFull
+
 	instanceFound = true
 
 	// -------------------------------------------------------------------------
@@ -935,6 +937,7 @@ func mkInsertForInstances(instances []*Instance, instanceWasActuallyFound bool, 
 		"semi_sync_blocked",
 		"last_discovery_latency",
 		"is_disk_stalled",
+		"replication_stalled_disk_full",
 	}
 
 	values := make([]string, len(columns))
@@ -1015,6 +1018,7 @@ func mkInsertForInstances(instances []*Instance, instanceWasActuallyFound bool, 
 		args = append(args, instance.SemiSyncBlocked)
 		args = append(args, instance.LastDiscoveryLatency.Nanoseconds())
 		args = append(args, instance.StalledDisk)
+		args = append(args, instance.ReplicationStalledDiskFull)
 	}
 
 	sql, err := mkInsert("database_instance", columns, values, len(instances), insertIgnore)

--- a/go/vt/vtorc/inst/instance_dao_test.go
+++ b/go/vt/vtorc/inst/instance_dao_test.go
@@ -63,13 +63,13 @@ func TestMkInsertSingle(t *testing.T) {
 				version, major_version, version_comment, binlog_server, read_only, binlog_format,
 				binlog_row_image, log_bin, log_replica_updates, binary_log_file, binary_log_pos, source_host, source_port, replica_net_timeout, heartbeat_interval,
 				replica_sql_running, replica_io_running, replication_sql_thread_state, replication_io_thread_state, has_replication_filters, supports_oracle_gtid, oracle_gtid, source_uuid, ancestry_uuid, executed_gtid_set, gtid_mode, gtid_purged, gtid_errant,
-				source_log_file, read_source_log_pos, relay_source_log_file, exec_source_log_pos, relay_log_file, relay_log_pos, last_sql_error, last_io_error, replication_lag_seconds, replica_lag_seconds, sql_delay, replication_depth, is_co_primary, has_replication_credentials, allow_tls, semi_sync_enforced, semi_sync_primary_enabled, semi_sync_primary_timeout, semi_sync_primary_wait_for_replica_count, semi_sync_replica_enabled, semi_sync_primary_status, semi_sync_primary_clients, semi_sync_replica_status, semi_sync_blocked, last_discovery_latency, is_disk_stalled, last_seen)
+				source_log_file, read_source_log_pos, relay_source_log_file, exec_source_log_pos, relay_log_file, relay_log_pos, last_sql_error, last_io_error, replication_lag_seconds, replica_lag_seconds, sql_delay, replication_depth, is_co_primary, has_replication_credentials, allow_tls, semi_sync_enforced, semi_sync_primary_enabled, semi_sync_primary_timeout, semi_sync_primary_wait_for_replica_count, semi_sync_replica_enabled, semi_sync_primary_status, semi_sync_primary_clients, semi_sync_replica_status, semi_sync_blocked, last_discovery_latency, is_disk_stalled, replication_stalled_disk_full, last_seen)
 		VALUES
-				(?, ?, ?, ?, DATETIME('now'), DATETIME('now'), 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, DATETIME('now'))
+				(?, ?, ?, ?, DATETIME('now'), DATETIME('now'), 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, DATETIME('now'))
        `
 	a1 := `zone1-0000000710, i710, 3306, zone1, 1, 710, , 5.6.7, 5.6, MySQL, false, false, STATEMENT,
 	FULL, false, false, , 0, , 0, 0, 0,
-	false, false, 0, 0, false, false, false, , , , , , , , 0, mysql.000007, 10, , 0, , , {0 false}, {0 false}, 0, 0, false, false, false, false, false, 0, 0, false, false, 0, false, false, 0, false,`
+	false, false, 0, 0, false, false, false, , , , , , , , 0, mysql.000007, 10, , 0, , , {0 false}, {0 false}, 0, 0, false, false, false, false, false, 0, 0, false, false, 0, false, false, 0, false, false,`
 
 	sql1, args1, err := mkInsertForInstances(instances[:1], false, true)
 	require.NoError(t, err)
@@ -86,16 +86,16 @@ func TestMkInsertThree(t *testing.T) {
 				version, major_version, version_comment, binlog_server, read_only, binlog_format,
 				binlog_row_image, log_bin, log_replica_updates, binary_log_file, binary_log_pos, source_host, source_port, replica_net_timeout, heartbeat_interval,
 				replica_sql_running, replica_io_running, replication_sql_thread_state, replication_io_thread_state, has_replication_filters, supports_oracle_gtid, oracle_gtid, source_uuid, ancestry_uuid, executed_gtid_set, gtid_mode, gtid_purged, gtid_errant,
-				source_log_file, read_source_log_pos, relay_source_log_file, exec_source_log_pos, relay_log_file, relay_log_pos, last_sql_error, last_io_error, replication_lag_seconds, replica_lag_seconds, sql_delay, replication_depth, is_co_primary, has_replication_credentials, allow_tls, semi_sync_enforced, semi_sync_primary_enabled, semi_sync_primary_timeout, semi_sync_primary_wait_for_replica_count, semi_sync_replica_enabled, semi_sync_primary_status, semi_sync_primary_clients, semi_sync_replica_status, semi_sync_blocked, last_discovery_latency, is_disk_stalled, last_seen)
+				source_log_file, read_source_log_pos, relay_source_log_file, exec_source_log_pos, relay_log_file, relay_log_pos, last_sql_error, last_io_error, replication_lag_seconds, replica_lag_seconds, sql_delay, replication_depth, is_co_primary, has_replication_credentials, allow_tls, semi_sync_enforced, semi_sync_primary_enabled, semi_sync_primary_timeout, semi_sync_primary_wait_for_replica_count, semi_sync_replica_enabled, semi_sync_primary_status, semi_sync_primary_clients, semi_sync_replica_status, semi_sync_blocked, last_discovery_latency, is_disk_stalled, replication_stalled_disk_full, last_seen)
 		VALUES
-				(?, ?, ?, ?, DATETIME('now'), DATETIME('now'), 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, DATETIME('now')),
-				(?, ?, ?, ?, DATETIME('now'), DATETIME('now'), 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, DATETIME('now')),
-				(?, ?, ?, ?, DATETIME('now'), DATETIME('now'), 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, DATETIME('now'))
+				(?, ?, ?, ?, DATETIME('now'), DATETIME('now'), 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, DATETIME('now')),
+				(?, ?, ?, ?, DATETIME('now'), DATETIME('now'), 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, DATETIME('now')),
+				(?, ?, ?, ?, DATETIME('now'), DATETIME('now'), 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, DATETIME('now'))
        `
 	a3 := `
-		zone1-0000000710, i710, 3306, zone1, 1, 710, , 5.6.7, 5.6, MySQL, false, false, STATEMENT, FULL, false, false, , 0, , 0, 0, 0, false, false, 0, 0, false, false, false, , , , , , , , 0, mysql.000007, 10, , 0, , , {0 false}, {0 false}, 0, 0, false, false, false, false, false, 0, 0, false, false, 0, false ,false, 0, false,
-		zone1-0000000720, i720, 3306, zone1, 2, 720, , 5.6.7, 5.6, MySQL, false, false, STATEMENT, FULL, false, false, , 0, , 0, 0, 0, false, false, 0, 0, false, false, false, , , , , , , , 0, mysql.000007, 20, , 0, , , {0 false}, {0 false}, 0, 0, false, false, false, false, false, 0, 0, false, false, 0, false, false, 0, false,
-		zone1-0000000730, i730, 3306, zone1, 2, 730, , 5.6.7, 5.6, MySQL, false, false, STATEMENT, FULL, false, false, , 0, , 0, 0, 0, false, false, 0, 0, false, false, false, , , , , , , , 0, mysql.000007, 30, , 0, , , {0 false}, {0 false}, 0, 0, false, false, false, false, false, 0, 0, false, false, 0, false, false, 0, false,
+		zone1-0000000710, i710, 3306, zone1, 1, 710, , 5.6.7, 5.6, MySQL, false, false, STATEMENT, FULL, false, false, , 0, , 0, 0, 0, false, false, 0, 0, false, false, false, , , , , , , , 0, mysql.000007, 10, , 0, , , {0 false}, {0 false}, 0, 0, false, false, false, false, false, 0, 0, false, false, 0, false ,false, 0, false, false,
+		zone1-0000000720, i720, 3306, zone1, 2, 720, , 5.6.7, 5.6, MySQL, false, false, STATEMENT, FULL, false, false, , 0, , 0, 0, 0, false, false, 0, 0, false, false, false, , , , , , , , 0, mysql.000007, 20, , 0, , , {0 false}, {0 false}, 0, 0, false, false, false, false, false, 0, 0, false, false, 0, false, false, 0, false, false,
+		zone1-0000000730, i730, 3306, zone1, 2, 730, , 5.6.7, 5.6, MySQL, false, false, STATEMENT, FULL, false, false, , 0, , 0, 0, 0, false, false, 0, 0, false, false, false, , , , , , , , 0, mysql.000007, 30, , 0, , , {0 false}, {0 false}, 0, 0, false, false, false, false, false, 0, 0, false, false, 0, false, false, 0, false, false,
 		`
 
 	sql3, args3, err := mkInsertForInstances(instances[:3], true, true)

--- a/go/vt/vtorc/test/recovery_analysis.go
+++ b/go/vt/vtorc/test/recovery_analysis.go
@@ -83,6 +83,7 @@ type InfoForRecoveryAnalysis struct {
 	MaxReplicaGTIDErrant                      string
 	ReadOnly                                  uint
 	IsStalledDisk                             uint
+	ReplicationStalledDiskFull                uint
 }
 
 func (info *InfoForRecoveryAnalysis) ConvertToRowMap() sqlutils.RowMap {
@@ -151,6 +152,7 @@ func (info *InfoForRecoveryAnalysis) ConvertToRowMap() sqlutils.RowMap {
 	rowMap["current_tablet_type"] = sqlutils.CellData{String: strconv.Itoa(currentType), Valid: true}
 	rowMap["tablet_info"] = sqlutils.CellData{String: string(res), Valid: true}
 	rowMap["is_disk_stalled"] = sqlutils.CellData{String: strconv.FormatUint(uint64(info.IsStalledDisk), 10), Valid: true}
+	rowMap["replication_stalled_disk_full"] = sqlutils.CellData{String: strconv.FormatUint(uint64(info.ReplicationStalledDiskFull), 10), Valid: true}
 	return rowMap
 }
 

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -167,6 +167,16 @@ func (tm *TabletManager) FullStatus(ctx context.Context) (*replicationdatapb.Ful
 		return nil, err
 	}
 
+	// Detect a replica wedged by a full disk (IO/SQL threads "Yes" but applier
+	// is silently retrying inside ha_commit_trans). Tolerate failures: the check
+	// is best-effort and must not break FullStatus on older MySQL versions or
+	// when the dba user lacks SELECT on performance_schema.error_log.
+	replicationStalledDiskFull, err := tm.MysqlDaemon.IsReplicationStalledDiskFull(ctx)
+	if err != nil {
+		log.Warn(fmt.Sprintf("IsReplicationStalledDiskFull failed: %v", err))
+		replicationStalledDiskFull = false
+	}
+
 	return &replicationdatapb.FullStatus{
 		ServerId:                    serverID,
 		ServerUuid:                  serverUUID,
@@ -192,6 +202,7 @@ func (tm *TabletManager) FullStatus(ctx context.Context) (*replicationdatapb.Ful
 		SuperReadOnly:               superReadOnly,
 		ReplicationConfiguration:    replConfiguration,
 		TabletType:                  tm.Tablet().Type,
+		ReplicationStalledDiskFull:  replicationStalledDiskFull,
 	}, nil
 }
 

--- a/proto/replicationdata.proto
+++ b/proto/replicationdata.proto
@@ -114,4 +114,5 @@ message FullStatus {
   bool disk_stalled = 23;
   bool semi_sync_blocked = 24;
   topodata.TabletType tablet_type = 25;
+  bool replication_stalled_disk_full = 26;
 }

--- a/test/config.json
+++ b/test/config.json
@@ -2320,6 +2320,18 @@
         "memory-check"
       ]
     },
+    "vtorc_replication_stalled_disk_full": {
+      "File": "unused.go",
+      "Packages": [
+        "vitess.io/vitess/go/test/endtoend/vtorc/replicationstalleddiskfull"
+      ],
+      "Args": [],
+      "Command": [],
+      "Manual": true,
+      "Shard": "vtorc_disk_full",
+      "Tags": [],
+      "Needs": []
+    },
     "vault": {
       "File": "unused.go",
       "Packages": [

--- a/web/vtadmin/src/proto/vtadmin.d.ts
+++ b/web/vtadmin/src/proto/vtadmin.d.ts
@@ -51127,6 +51127,9 @@ export namespace replicationdata {
 
         /** FullStatus tablet_type */
         tablet_type?: (topodata.TabletType|null);
+
+        /** FullStatus replication_stalled_disk_full */
+        replication_stalled_disk_full?: (boolean|null);
     }
 
     /** Represents a FullStatus. */
@@ -51212,6 +51215,9 @@ export namespace replicationdata {
 
         /** FullStatus tablet_type. */
         public tablet_type: topodata.TabletType;
+
+        /** FullStatus replication_stalled_disk_full. */
+        public replication_stalled_disk_full: boolean;
 
         /**
          * Creates a new FullStatus instance using the specified properties.


### PR DESCRIPTION
## Description

Implements the proposal in #20056 — a new `ReplicationStalledDiskFull` analysis code that detects MySQL replicas wedged by `ENOSPC` on the InnoDB filesystem _(where `Slave_IO_Running` and `Slave_SQL_Running` stay `Yes` but the applier is parked inside `ha_commit_trans` retrying writes)_. Today VTOrc treats these replicas as healthy and they sit silent until lag-based alerts fire

Detection is the single-poll, stateless query from the issue, run on each replica via the existing `FullStatus` RPC:

```sql
SELECT 1 FROM performance_schema.error_log el
 WHERE el.logged    >= NOW(6) - INTERVAL 1 HOUR
   AND el.prio       = 'Error'
   AND el.subsystem  = 'InnoDB'
   AND el.error_code IN ('MY-012814', 'MY-012820')
   AND el.logged > COALESCE(
         (SELECT MAX(LAST_APPLIED_TRANSACTION_END_APPLY_TIMESTAMP)
            FROM performance_schema.replication_applier_status_by_worker),
         '1970-01-01')
 LIMIT 1
```

A row means: a `Disk is full` was logged after the applier's last successful commit — still wedged. Self-healing — clears the moment the applier resumes

#### What changed

1. **New `PerformanceSchemaErrorLogTableCapability`** _(MySQL/Percona 8.0.22+)_ — gates the query so MariaDB and older MySQL skip cleanly without log spam. `ER_TABLEACCESS_DENIED_ERROR` _(missing `SELECT` on `performance_schema.error_log`)_ also soft-fails with a one-shot warning so grants issues don't break `FullStatus` discovery
2. **`IsReplicationStalledDiskFull(ctx)` on `MysqlDaemon`** — runs the query and returns the bool. Wired through `FullStatus` _(new `replication_stalled_disk_full = 26` field)_ into VTOrc's existing instance-discovery path. Errors from the check are logged but don't fail `FullStatus`
3. **`ReplicationStalledDiskFull` analysis code + matcher** — fires when `topo.IsReplicaType(...) && !a.IsPrimary && a.ReplicationStalledDiskFull`. Priority `detectionAnalysisPriorityMedium`. No explicit recovery case — falls through to the default arm with `RecoverySkipNoRecoveryAction`, the same path as `InvalidReplica` and `InvalidPrimary`. Disk-full recovery is operator-driven _(free disk space)_, so VTOrc only surfaces the analysis
4. **End-to-end test** _(Linux only)_ — mounts a 256 MB ext4 loopback filesystem, points the replica's `mysqld` `datadir` / `innodb_log_group_home_dir` / `relay-log` / `log-bin` at it via `EXTRA_MY_CNF`, and asserts the analysis surfaces when 1 MB BLOB inserts from the primary fill the replica's disk. Three-layered gate: `//go:build linux` _(compile-time)_, `os.Geteuid() == 0` _(runtime root check)_, and `VT_TEST_DISK_FULL=1` _(explicit opt-in)_. Dedicated workflow `vtorc_disk_full_e2e.yml` runs it on `ubuntu-24.04` under `sudo`; the regular `cluster_endtoend.yml` excludes the new `vtorc_disk_full` shard

#### Why Linux + CI-only

The e2e creates a real ext4 loopback filesystem _(`dd` + `mkfs.ext4` + `mount -o loop`)_ — that's a Linux-only setup that also needs root. Supporting macOS would mean a second set of test logic _(`hdiutil create` / `hdiutil attach`, APFS or HFS+ instead of ext4, different unmount semantics)_ for marginal additional signal. Running on a developer's laptop is also a poor experience: it prompts for `sudo`, and a half-cleaned-up mount _(after `Ctrl-C` or a panic)_ leaves the machine in a messy state that's hard to diagnose. CI workers _(GitHub Actions `ubuntu-24.04`)_ are ephemeral, so a leftover mount doesn't matter — the runner is destroyed at the end of the job

#### E2E framework hook

The e2e needed per-tablet `mysqld` config without polluting other tablets' env. Two small additions to `go/test/endtoend/cluster/`:

- New `ExtraMyCnfPath string` field on `MysqlctlProcess` — appended to `EXTRA_MY_CNF` on the per-process exec only _(colon-joined with the existing SSL cnf if both are set)_
- The customizer type-switch in `StartShards` / `StartKeyspaceLegacy` now also handles `func(*MysqlctlProcess)`, applied before `StartProcess` so the override takes effect at `mysqld --initialize` time

Reusable for any future test needing per-tablet `mysqld` tuning. Existing tests that pass `func(*VttabletProcess)` are unaffected

#### Surfaced metrics

When the analysis fires for a replica, the standard surfacing metrics increment — same shape as the existing non-actionable codes:

- `DetectedProblems{Analysis="ReplicationStalledDiskFull", ...}` gauge → `1` while active, resets to `0` on the next pass once the row clears
- `AnalysisChangeWrite` counter on each transition
- `SkippedRecoveries{RecoveryType="", Reason="NoRecoveryAction"}` counter per recovery-dispatcher cycle

## Related Issue(s)

Resolves: https://github.com/vitessio/vitess/issues/20056

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

No new flags. The new analysis surfaces automatically on MySQL/Percona 8.0.22+ replicas; older versions and MariaDB skip the check via the capability gate. The `dba` user needs `SELECT` on `performance_schema.error_log` for the check to run — denied access is logged once and the check is disabled for the process

### AI Disclosure

Claude Code assisted with development and testing; I committed the change manually after reviewing each step. Claude prepared this PR summary