### PR TITLE
mysqlctl: propagate remote shutdown timeout

### DIFF
--- a/go/vt/mysqlctl/grpcmysqlctlclient/client.go
+++ b/go/vt/mysqlctl/grpcmysqlctlclient/client.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
+	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/vt/grpcclient"
 	"vitess.io/vitess/go/vt/mysqlctl/mysqlctlclient"
 
@@ -73,10 +74,11 @@ func (c *client) Start(ctx context.Context, mysqldArgs ...string) error {
 }
 
 // Shutdown is part of the MysqlctlClient interface.
-func (c *client) Shutdown(ctx context.Context, waitForMysqld bool) error {
+func (c *client) Shutdown(ctx context.Context, waitForMysqld bool, shutdownTimeout time.Duration) error {
 	return c.withRetry(ctx, func() error {
 		_, err := c.c.Shutdown(ctx, &mysqlctlpb.ShutdownRequest{
-			WaitForMysqld: waitForMysqld,
+			WaitForMysqld:        waitForMysqld,
+			MysqlShutdownTimeout: protoutil.DurationToProto(shutdownTimeout),
 		})
 		return err
 	})

--- a/go/vt/mysqlctl/mysqlctlclient/interface.go
+++ b/go/vt/mysqlctl/mysqlctlclient/interface.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/pflag"
 
@@ -47,7 +48,7 @@ type MysqlctlClient interface {
 	Start(ctx context.Context, mysqldArgs ...string) error
 
 	// Shutdown calls Mysqld.Shutdown remotely.
-	Shutdown(ctx context.Context, waitForMysqld bool) error
+	Shutdown(ctx context.Context, waitForMysqld bool, shutdownTimeout time.Duration) error
 
 	// RunMysqlUpgrade calls Mysqld.RunMysqlUpgrade remotely.
 	RunMysqlUpgrade(ctx context.Context) error

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -632,7 +632,7 @@ func (mysqld *Mysqld) Shutdown(ctx context.Context, cnf *Mycnf, waitForMysqld bo
 			return fmt.Errorf("can't dial mysqlctld: %v", err)
 		}
 		defer client.Close()
-		return client.Shutdown(ctx, waitForMysqld)
+		return client.Shutdown(ctx, waitForMysqld, shutdownTimeout)
 	}
 
 	// We're shutting down on purpose. We no longer want to be notified when

--- a/go/vt/mysqlctl/mysqld_test.go
+++ b/go/vt/mysqlctl/mysqld_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package mysqlctl
 
 import (
+	"context"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -25,10 +27,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
+	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"
+	_ "vitess.io/vitess/go/vt/mysqlctl/grpcmysqlctlclient"
+	mysqlctlpb "vitess.io/vitess/go/vt/proto/mysqlctl"
 )
 
 type testcase struct {
@@ -112,6 +118,70 @@ func TestParseVersionString(t *testing.T) {
 			assert.Failf(t, "ParseVersionString failed", "ParseVersionString failed for: %#v, Got: %#v, %#v Expected: %#v, %#v", testcase.versionString, v, f, testcase.version, testcase.flavor)
 		}
 	}
+}
+
+// shutdownRecordingMysqlCtlServer records remote Shutdown requests from Mysqld.
+type shutdownRecordingMysqlCtlServer struct {
+	mysqlctlpb.UnimplementedMysqlCtlServer
+
+	// shutdownRequests carries the remote shutdown request.
+	shutdownRequests chan *mysqlctlpb.ShutdownRequest
+}
+
+// Shutdown records the request and returns a successful response.
+func (s *shutdownRecordingMysqlCtlServer) Shutdown(ctx context.Context, request *mysqlctlpb.ShutdownRequest) (*mysqlctlpb.ShutdownResponse, error) {
+	s.shutdownRequests <- request
+
+	return &mysqlctlpb.ShutdownResponse{}, nil
+}
+
+// TestMysqldShutdownForwardsTimeoutToRemoteMysqlctld verifies that the remote
+// shutdown path preserves the caller's timeout.
+func TestMysqldShutdownForwardsTimeoutToRemoteMysqlctld(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	oldSocketFile := socketFile
+	t.Cleanup(func() {
+		socketFile = oldSocketFile
+	})
+
+	tempSocketFile, err := os.CreateTemp("/tmp", "mysqlctld-*.sock")
+	require.NoError(t, err)
+	require.NoError(t, tempSocketFile.Close())
+	require.NoError(t, os.Remove(tempSocketFile.Name()))
+	t.Cleanup(func() {
+		_ = os.Remove(tempSocketFile.Name())
+	})
+
+	socketPath := tempSocketFile.Name()
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
+	t.Cleanup(server.Stop)
+
+	recordingServer := &shutdownRecordingMysqlCtlServer{
+		shutdownRequests: make(chan *mysqlctlpb.ShutdownRequest, 1),
+	}
+	mysqlctlpb.RegisterMysqlCtlServer(server, recordingServer)
+
+	go func() { _ = server.Serve(listener) }()
+
+	socketFile = socketPath
+	shutdownTimeout := 43*time.Second + 125*time.Millisecond
+
+	mysqld := &Mysqld{}
+	err = mysqld.Shutdown(ctx, &Mycnf{}, true, shutdownTimeout)
+	require.NoError(t, err)
+
+	request := <-recordingServer.shutdownRequests
+	assert.True(t, request.WaitForMysqld)
+
+	gotTimeout, ok, err := protoutil.DurationFromProto(request.MysqlShutdownTimeout)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, shutdownTimeout, gotTimeout)
 }
 
 func TestRegexps(t *testing.T) {


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
Remote mysqlctl shutdown calls accepted a caller-provided timeout but dropped it when building the gRPC request, causing mysqlctld to fall back to its default shutdown timeout. This carries the timeout through the client interface and serializes it into the shutdown request.

This is a small, isolated bug fix, so I'm suggesting to backport it to v23 and v24.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Closes https://github.com/vitessio/vitess/issues/20061

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->

Help from GPT 5.5.
