### PR TITLE
vttablet: wait on _vt.dt_state in WaitForPreparedTwoPCTransactions

### DIFF
--- a/go/test/endtoend/transaction/twopc/twopc_test.go
+++ b/go/test/endtoend/transaction/twopc/twopc_test.go
@@ -1434,7 +1434,7 @@ func TestSemiSyncRequiredWithTwoPC(t *testing.T) {
 	utils.Exec(t, conn, "insert into twopc_t1(id, col) values(9, 4)")
 	_, err = utils.ExecAllowError(t, conn, "commit")
 	require.Error(t, err)
-	require.ErrorContains(t, err, "two-pc is enabled, but semi-sync is not")
+	require.ErrorContains(t, err, "2pc is enabled, but not currently allowed")
 
 	_, err = clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("SetKeyspaceDurabilityPolicy", keyspaceName, "--durability-policy=semi_sync")
 	require.NoError(t, err)

--- a/go/vt/vttablet/tabletserver/controller.go
+++ b/go/vt/vttablet/tabletserver/controller.go
@@ -117,7 +117,7 @@ type Controller interface {
 	// RollbackPrepared rolls back the prepared transaction and removes the transaction log.
 	RollbackPrepared(ctx context.Context, target *querypb.Target, dtid string, originalID int64) error
 
-	// WaitForPreparedTwoPCTransactions waits for all prepared transactions to be resolved.
+	// WaitForPreparedTwoPCTransactions waits for all unresolved 2PC transactions on this tablet to be resolved.
 	WaitForPreparedTwoPCTransactions(ctx context.Context) error
 
 	// SetDemotePrimaryStalled sets the demote primary stalled field to the provided value in the state manager.

--- a/go/vt/vttablet/tabletserver/dt_executor.go
+++ b/go/vt/vttablet/tabletserver/dt_executor.go
@@ -62,7 +62,7 @@ func (dte *DTExecutor) Prepare(transactionID int64, dtid string) error {
 		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "2pc is not enabled")
 	}
 	if !dte.te.IsTwoPCAllowed() {
-		return vterrors.VT10002("two-pc is enabled, but semi-sync is not")
+		return vterrors.VT10002("2pc is enabled, but not currently allowed")
 	}
 	defer dte.te.env.Stats().QueryTimings.Record("PREPARE", time.Now())
 	dte.logStats.TransactionID = transactionID
@@ -227,6 +227,9 @@ func (dte *DTExecutor) RollbackPrepared(dtid string, originalID int64) error {
 func (dte *DTExecutor) CreateTransaction(dtid string, participants []*querypb.Target) error {
 	if !dte.te.twopcEnabled {
 		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "2pc is not enabled")
+	}
+	if !dte.te.IsTwoPCAllowed() {
+		return vterrors.VT10002("2pc is enabled, but not currently allowed")
 	}
 	defer dte.te.env.Stats().QueryTimings.Record("CREATE_TRANSACTION", time.Now())
 	return dte.inTransaction(func(conn *StatefulConnection) error {

--- a/go/vt/vttablet/tabletserver/dt_executor_test.go
+++ b/go/vt/vttablet/tabletserver/dt_executor_test.go
@@ -675,6 +675,34 @@ func TestNoTwopc(t *testing.T) {
 	}
 }
 
+func TestTwoPCNotAllowed(t *testing.T) {
+	ctx := t.Context()
+	txe, tsv, _, closer := newTestTxExecutor(t, ctx)
+	defer closer()
+
+	tsv.SetTwoPCAllowed(TwoPCAllowed_TabletControls, false)
+	require.False(t, tsv.te.IsTwoPCAllowed())
+
+	testcases := []struct {
+		desc    string
+		fun     func() error
+		wantErr string
+	}{{
+		desc:    "Prepare",
+		fun:     func() error { return txe.Prepare(1, "aa") },
+		wantErr: "VT10002: atomic distributed transaction not allowed: 2pc is enabled, but not currently allowed",
+	}, {
+		desc:    "CreateTransaction",
+		fun:     func() error { return txe.CreateTransaction("aa", nil) },
+		wantErr: "VT10002: atomic distributed transaction not allowed: 2pc is enabled, but not currently allowed",
+	}}
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.EqualError(t, tc.fun(), tc.wantErr)
+		})
+	}
+}
+
 func newTestTxExecutor(t *testing.T, ctx context.Context) (txe *DTExecutor, tsv *TabletServer, db *fakesqldb.DB, closer func()) {
 	db = setUpQueryExecutorTest(t)
 	logStats := tabletenv.NewLogStats(ctx, "TestTxExecutor", streamlog.NewQueryLogConfigForTest())

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -771,23 +771,25 @@ func (tsv *TabletServer) RollbackPrepared(ctx context.Context, target *querypb.T
 	)
 }
 
-// hasUnresolvedTwoPCTransactions returns true if this tablet has any
-// unresolved 2PC transaction.
-func (tsv *TabletServer) hasUnresolvedTwoPCTransactions(ctx context.Context) bool {
+// hasUnresolvedTwoPCTransactions checks if this tablet has any unresolved 2PC transactions.
+func (tsv *TabletServer) hasUnresolvedTwoPCTransactions(ctx context.Context) (bool, error) {
 	if !tsv.te.preparedPool.IsEmpty() {
-		return true
+		return true, nil
 	}
-	count, err := tsv.te.twoPC.CountUnresolvedTransaction(ctx, time.Now())
+	if !tsv.te.twopcEnabled {
+		return false, nil
+	}
+	count, err := tsv.te.twoPC.CountUnresolvedTransaction(ctx, time.Now().Add(365*24*time.Hour))
 	if err != nil {
-		log.Error(fmt.Sprintf("Error reading unresolved transactions: %v", err))
-		return true
+		return true, err
 	}
-	return count > 0
+	return count > 0, nil
 }
 
 // WaitForPreparedTwoPCTransactions waits for all unresolved 2PC transactions on this tablet to be resolved.
 func (tsv *TabletServer) WaitForPreparedTwoPCTransactions(ctx context.Context) error {
-	if !tsv.hasUnresolvedTwoPCTransactions(ctx) {
+	hasUnresolved, lastErr := tsv.hasUnresolvedTwoPCTransactions(ctx)
+	if !hasUnresolved {
 		return nil
 	}
 	ticker := time.NewTicker(100 * time.Millisecond)
@@ -795,10 +797,18 @@ func (tsv *TabletServer) WaitForPreparedTwoPCTransactions(ctx context.Context) e
 	for {
 		select {
 		case <-ctx.Done():
+			if lastErr != nil {
+				log.Error(fmt.Sprintf("Error reading unresolved transactions during wait: %v", lastErr))
+			}
 			// Return an error if we run out of time.
 			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "Prepared transactions have not been resolved yet")
 		case <-ticker.C:
-			if !tsv.hasUnresolvedTwoPCTransactions(ctx) {
+			var err error
+			hasUnresolved, err = tsv.hasUnresolvedTwoPCTransactions(ctx)
+			if err != nil {
+				lastErr = err
+			}
+			if !hasUnresolved {
 				return nil
 			}
 		}

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -771,9 +771,23 @@ func (tsv *TabletServer) RollbackPrepared(ctx context.Context, target *querypb.T
 	)
 }
 
-// WaitForPreparedTwoPCTransactions waits for all the prepared transactions to complete.
+// hasUnresolvedTwoPCTransactions returns true if this tablet has any
+// unresolved 2PC transaction.
+func (tsv *TabletServer) hasUnresolvedTwoPCTransactions(ctx context.Context) bool {
+	if !tsv.te.preparedPool.IsEmpty() {
+		return true
+	}
+	count, err := tsv.te.twoPC.CountUnresolvedTransaction(ctx, time.Now())
+	if err != nil {
+		log.Error(fmt.Sprintf("Error reading unresolved transactions: %v", err))
+		return true
+	}
+	return count > 0
+}
+
+// WaitForPreparedTwoPCTransactions waits for all unresolved 2PC transactions on this tablet to be resolved.
 func (tsv *TabletServer) WaitForPreparedTwoPCTransactions(ctx context.Context) error {
-	if tsv.te.preparedPool.IsEmpty() {
+	if !tsv.hasUnresolvedTwoPCTransactions(ctx) {
 		return nil
 	}
 	ticker := time.NewTicker(100 * time.Millisecond)
@@ -784,7 +798,7 @@ func (tsv *TabletServer) WaitForPreparedTwoPCTransactions(ctx context.Context) e
 			// Return an error if we run out of time.
 			return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "Prepared transactions have not been resolved yet")
 		case <-ticker.C:
-			if tsv.te.preparedPool.IsEmpty() {
+			if !tsv.hasUnresolvedTwoPCTransactions(ctx) {
 				return nil
 			}
 		}

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -781,7 +781,7 @@ func (tsv *TabletServer) hasUnresolvedTwoPCTransactions(ctx context.Context) (bo
 	}
 	count, err := tsv.te.twoPC.CountUnresolvedTransaction(ctx, time.Now().Add(365*24*time.Hour))
 	if err != nil {
-		return true, err
+		return false, err
 	}
 	return count > 0, nil
 }
@@ -789,7 +789,7 @@ func (tsv *TabletServer) hasUnresolvedTwoPCTransactions(ctx context.Context) (bo
 // WaitForPreparedTwoPCTransactions waits for all unresolved 2PC transactions on this tablet to be resolved.
 func (tsv *TabletServer) WaitForPreparedTwoPCTransactions(ctx context.Context) error {
 	hasUnresolved, lastErr := tsv.hasUnresolvedTwoPCTransactions(ctx)
-	if !hasUnresolved {
+	if lastErr == nil && !hasUnresolved {
 		return nil
 	}
 	ticker := time.NewTicker(100 * time.Millisecond)
@@ -807,8 +807,7 @@ func (tsv *TabletServer) WaitForPreparedTwoPCTransactions(ctx context.Context) e
 			hasUnresolved, err = tsv.hasUnresolvedTwoPCTransactions(ctx)
 			if err != nil {
 				lastErr = err
-			}
-			if !hasUnresolved {
+			} else if !hasUnresolved {
 				return nil
 			}
 		}

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2603,6 +2603,63 @@ func TestWaitForPreparedTwoPCTransactionsDoesNotDrainCoordinatorDtState(t *testi
 			"with in-flight 2PC where this shard is the MM, stranding participant redo logs")
 }
 
+func TestWaitForPreparedTwoPCTransactionsTwoPCDisabled(t *testing.T) {
+	ctx := t.Context()
+	_, tsv, db := newNoTwopcExecutor(t, ctx)
+	defer db.Close()
+	defer tsv.StopService()
+
+	// 2PC disabled: WaitForPreparedTwoPCTransactions must short-circuit
+	// without issuing a count query against the unopened TwoPC read pool.
+	waitCtx, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
+	defer cancel()
+	err := tsv.WaitForPreparedTwoPCTransactions(waitCtx)
+	require.NoError(t, err,
+		"WaitForPreparedTwoPCTransactions should return immediately when 2PC is disabled, "+
+			"without querying _vt.dt_state on an unopened pool")
+}
+
+func TestWaitForPreparedTwoPCTransactionsSQLError(t *testing.T) {
+	ctx := t.Context()
+	_, tsv, db, closer := newTestTxExecutor(t, ctx)
+	defer closer()
+
+	require.True(t, tsv.te.preparedPool.IsEmpty(),
+		"prepared pool should be empty for the coordinator role")
+
+	// Inject a failure for the dt_state count query. The wait function must
+	// not silently claim drained on a query error; it should keep waiting and
+	// time out with FAILED_PRECONDITION.
+	db.RejectQueryPattern(
+		`select count\(\*\) from _vt\.dt_state where time_created.*`,
+		"simulated MySQL outage during cutover",
+	)
+
+	waitCtx, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
+	defer cancel()
+	err := tsv.WaitForPreparedTwoPCTransactions(waitCtx)
+	require.Error(t, err,
+		"WaitForPreparedTwoPCTransactions must not declare success when the count query fails")
+	require.ErrorContains(t, err, "Prepared transactions have not been resolved yet")
+}
+
+func TestHasUnresolvedTwoPCTransactionsSQLError(t *testing.T) {
+	ctx := t.Context()
+	_, tsv, db, closer := newTestTxExecutor(t, ctx)
+	defer closer()
+
+	db.RejectQueryPattern(
+		`select count\(\*\) from _vt\.dt_state where time_created.*`,
+		"simulated MySQL outage",
+	)
+
+	has, err := tsv.hasUnresolvedTwoPCTransactions(ctx)
+	require.Error(t, err)
+	require.False(t, has,
+		"on count-query failure, the predicate must return (false, err) so callers "+
+			"don't claim drained on inconclusive data")
+}
+
 func setupTabletServerTest(t testing.TB, ctx context.Context, keyspaceName string) (*fakesqldb.DB, *TabletServer) {
 	cfg := tabletenv.NewDefaultConfig()
 	return setupTabletServerTestCustom(t, ctx, cfg, keyspaceName, vtenv.NewTestEnv())

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2578,6 +2578,31 @@ func TestDatabaseNameReplaceByKeyspaceNameReserveBeginExecuteMethod(t *testing.T
 	require.NoError(t, err)
 }
 
+func TestWaitForPreparedTwoPCTransactionsDoesNotDrainCoordinatorDtState(t *testing.T) {
+	ctx := t.Context()
+	_, tsv, db, closer := newTestTxExecutor(t, ctx)
+	defer closer()
+
+	require.True(t, tsv.te.preparedPool.IsEmpty(),
+		"prepared pool should be empty for the coordinator role")
+
+	db.AddQueryPattern(
+		`select count\(\*\) from _vt\.dt_state where time_created.*`,
+		sqltypes.MakeTestResult(
+			sqltypes.MakeTestFields("count(*)", "int64"),
+			"1",
+		),
+	)
+
+	waitCtx, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
+	defer cancel()
+	err := tsv.WaitForPreparedTwoPCTransactions(waitCtx)
+	require.Error(t, err,
+		"WaitForPreparedTwoPCTransactions must not declare success while _vt.dt_state still "+
+			"has coordinator entries; otherwise SwitchWrites can disable the source primary "+
+			"with in-flight 2PC where this shard is the MM, stranding participant redo logs")
+}
+
 func setupTabletServerTest(t testing.TB, ctx context.Context, keyspaceName string) (*fakesqldb.DB, *TabletServer) {
 	cfg := tabletenv.NewDefaultConfig()
 	return setupTabletServerTestCustom(t, ctx, cfg, keyspaceName, vtenv.NewTestEnv())


### PR DESCRIPTION
## Description

This fixes a bug where a Reshard SwitchTraffic can permanently orphan participant redo logs.

It fixes it by gating `CreateTransaction` on IsTwoPCAllowed() (matching the existing Prepare gate), and also by waiting in `WaitForPreparedTwoPCTransactions` for `_vt.dt_state` to drain to empty. I'm also looking into the defense in depth changes mentioned in the bug report as a followup.

Backport request to release-23.0 and release-24.0. We are running 23.0.3 and this bug was found in that release.

## Related Issue(s)

Fixes #20002 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

  - `Reshard.SwitchTraffic` (and any caller of `tmState.prepareForDisableQueryService`)
    now blocks until `_vt.dt_state` is empty in addition to the prepared pool.
    Cutovers without in-flight 2PC are unaffected; cutovers with in-flight
    coordinator-role 2PC will wait for `TxResolver` to drive resolution. The
    existing context deadline still bounds the wait, so a stuck cutover fails with
    the same `Prepared transactions have not been resolved yet` error.

  - `DTExecutor.CreateTransaction` now returns `VT10002: atomic distributed
    transaction not allowed: 2pc is enabled, but not currently allowed` when
    `IsTwoPCAllowed()` is false (mirrors the existing `Prepare` behavior).

  - Drive-by: `Prepare`'s gate error message changed from `"two-pc is enabled, but
    semi-sync is not"` to `"2pc is enabled, but not currently allowed"`. The old
    message was misleading because `IsTwoPCAllowed()` returns false for either
    semi-sync or tablet-controls reasons.

### AI Disclosure

The main code was written primarily by me with Claude Code providing guidance to identify existing patterns and Claude Code writing the tests with some touch-ups by me. Claude Code wrote the deployment notes on this PR description.
