### PR TITLE
Support `VALUES ROW()` as a derived table

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -1066,6 +1066,25 @@
     }
   },
   {
+    "comment": "VALUES statement as derived table",
+    "query": "select * from (values row(1, 1), row(2, 2)) as sub",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select * from (values row(1, 1), row(2, 2)) as sub",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select column_0, column_1 from (select 1 as column_0, 1 as column_1 from dual where 1 != 1 union all select 2, 2 from dual where 1 != 1) as sub where 1 != 1",
+        "Query": "select column_0, column_1 from (select 1 as column_0, 1 as column_1 from dual union all select 2, 2 from dual) as sub"
+      }
+    }
+  },
+  {
     "comment": "derived table that contains literals merged with outer query",
     "query": "select 1 from (select 1 as x) ue left join user u on u.id = ue.x",
     "plan": {

--- a/go/vt/vtgate/semantics/derived_test.go
+++ b/go/vt/vtgate/semantics/derived_test.go
@@ -134,6 +134,23 @@ func TestScopingWDerivedTables(t *testing.T) {
 	}
 }
 
+func TestValuesStatementAsDerivedTable(t *testing.T) {
+	queries := []string{
+		"select * from (values row(1, 1)) as sub",
+		"select sub.column_0 from (values row(1, 1)) as sub",
+	}
+
+	for _, query := range queries {
+		t.Run(query, func(t *testing.T) {
+			parse, err := sqlparser.NewTestParser().Parse(query)
+			require.NoError(t, err)
+
+			_, err = Analyze(parse, "user", fakeSchemaInfo())
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestDerivedTablesOrderClause(t *testing.T) {
 	queries := []struct {
 		query                string

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -67,6 +67,12 @@ func (r *earlyRewriter) down(cursor *sqlparser.Cursor) error {
 }
 
 func (r *earlyRewriter) handleDerivedTable(dt *sqlparser.DerivedTable) error {
+	values, isValuesStatement := dt.Select.(*sqlparser.ValuesStatement)
+	if isValuesStatement {
+		dt.Select = valuesStatementToTableStatement(values)
+		return nil
+	}
+
 	sel, ok := dt.Select.(*sqlparser.Select)
 	if !ok {
 		return nil
@@ -76,6 +82,56 @@ func (r *earlyRewriter) handleDerivedTable(dt *sqlparser.DerivedTable) error {
 		sel.OrderBy = nil
 	}
 	return nil
+}
+
+// valuesStatementToTableStatement rewrites VALUES into SELECT and UNION ALL. For example:
+//
+//	VALUES ROW(1, 2), ROW(3, 4)
+//
+// becomes:
+//
+//	SELECT 1 AS column_0, 2 AS column_1 UNION ALL SELECT 3, 4
+func valuesStatementToTableStatement(values *sqlparser.ValuesStatement) sqlparser.TableStatement {
+	if len(values.Rows) == 0 {
+		return values
+	}
+
+	stmt := valuesTupleToSelect(values.Rows[0], true)
+	stmt.Comments = values.Comments
+
+	var tableStatement sqlparser.TableStatement = stmt
+	for _, row := range values.Rows[1:] {
+		tableStatement = &sqlparser.Union{
+			Left:  tableStatement,
+			Right: valuesTupleToSelect(row, false),
+		}
+	}
+
+	tableStatement.SetWith(values.With)
+	tableStatement.SetOrderBy(values.Order)
+	tableStatement.SetLimit(values.Limit)
+
+	return tableStatement
+}
+
+// valuesTupleToSelect builds one SELECT for a VALUES tuple.
+func valuesTupleToSelect(tuple sqlparser.ValTuple, includeColumnAliases bool) *sqlparser.Select {
+	expressions := make([]sqlparser.SelectExpr, 0, len(tuple))
+	for i, expr := range tuple {
+		aliasedExpr := &sqlparser.AliasedExpr{Expr: expr}
+
+		if includeColumnAliases {
+			aliasedExpr.As = sqlparser.NewIdentifierCI(fmt.Sprintf("column_%d", i))
+		}
+
+		expressions = append(expressions, aliasedExpr)
+	}
+
+	return &sqlparser.Select{
+		SelectExprs: &sqlparser.SelectExprs{
+			Exprs: expressions,
+		},
+	}
 }
 
 func (r *earlyRewriter) up(cursor *sqlparser.Cursor) error {

--- a/go/vt/vtgate/semantics/table_collector.go
+++ b/go/vt/vtgate/semantics/table_collector.go
@@ -441,7 +441,7 @@ func (tc *tableCollector) handleDerivedTable(node *sqlparser.AliasedTableExpr, t
 	case *sqlparser.Union:
 		return tc.addUnionDerivedTable(sel, node, node.Columns, node.As)
 	default:
-		return vterrors.VT13001("[BUG] %T in a derived table", sel)
+		return vterrors.VT13001(fmt.Sprintf("%T in a derived table", sel))
 	}
 }
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

A query like:

```sql
select * from (values row(1, 1)) as sub
```

currently errors with:

```
VT13001: [BUG] [BUG] %T in a derived table%!(EXTRA *sqlparser.ValuesStatement=&{<nil> [[0xc0029b22e0 0xc0029b2300]]  <nil> [] <nil>})
```

This PR rewrites `VALUES` statements into a series of `SELECT (...) UNION ALL SELECT(...)...`. For example:

```sql
select * from (values row(1, 1), row(2, 2)) as sub
```

turns into:

```sql
select * from (
    select 1 as column_0, 1 as column_1
    union all
    select 2, 2
) as sub
```

This PR also fixes the malformed error shown above.

Recommending to backport to v23 and v24, as this is a bug fix that improves MySQL compatibility.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Fixes https://github.com/vitessio/vitess/issues/20057

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->

Help from GPT 5.5.
