### PR TITLE
vtgate: ignore MySQL client probe query `select $$` in querylog

### DIFF
--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -42,11 +42,13 @@ var (
 	deliveredCount = stats.NewCountersWithMultiLabels(
 		"StreamlogDelivered",
 		"Stream log delivered",
-		[]string{"Log", "Subscriber"})
+		[]string{"Log", "Subscriber"},
+	)
 	deliveryDropCount = stats.NewCountersWithMultiLabels(
 		"StreamlogDeliveryDroppedMessages",
 		"Dropped messages by streamlog delivery",
-		[]string{"Log", "Subscriber"})
+		[]string{"Log", "Subscriber"},
+	)
 )
 
 const (
@@ -290,6 +292,13 @@ func (qlConfig QueryLogConfig) shouldSampleQuery() bool {
 // It also returns an EmitReason which is a comma-separated-string to indicate all the conditions triggered for log emit.
 // If both TimeThreshold and FilterTag condition are met, EmitReason will be time,filtertag
 func (qlConfig QueryLogConfig) ShouldEmitLog(sql string, rowsAffected, rowsReturned uint64, totalTime time.Duration, hasError bool) (bool, string) {
+	// MySQL 8.4+ clients send "select $$" at connection time to probe dollar-quote
+	// syntax support. This is hardcoded client behavior that cannot be disabled;
+	// suppress it to avoid log noise.
+	if strings.EqualFold(strings.TrimSpace(sql), "select $$") {
+		return false, ""
+	}
+
 	var aMatch, allMatches bool
 	var aReason string
 	reasons := []string{}

--- a/go/streamlog/streamlog_test.go
+++ b/go/streamlog/streamlog_test.go
@@ -372,6 +372,26 @@ func TestShouldEmitLog(t *testing.T) {
 			ok:         true,
 			emitReason: "error",
 		},
+		{
+			sql:        "select $$",
+			ok:         false,
+			emitReason: "",
+		},
+		{
+			sql:        "SELECT $$",
+			ok:         false,
+			emitReason: "",
+		},
+		{
+			sql:        "  select $$  ",
+			ok:         false,
+			emitReason: "",
+		},
+		{
+			sql:        "select $$ from dual",
+			ok:         true,
+			emitReason: "",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
MySQL 8.4+ clients (`mysql` CLI, Percona fork) unconditionally send `select $$` immediately after the handshake to probe whether the server supports `$$` as a quoting style. This is hardcoded in the client ([upstream commit (https://github.com/mysql/mysql-server/commit/9c7bc2973110861b731311f8b42af152f62d65af)) and cannot be disabled or suppressed by the user.

Vitess's SQL parser does not recognize `$$` as valid syntax, so every new connection from a MySQL 8.4+ client produces a parse-error entry in vtgate's query log. 

### Before
<img width="1470" height="184" alt="image" src="https://github.com/user-attachments/assets/3fae2eea-c779-4df7-9dac-475a961a168f" />

### After
<img width="1470" height="152" alt="image" src="https://github.com/user-attachments/assets/d6f87021-43eb-4f75-a31e-814a25da18ad" />


<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)
Fixes #19610 
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required