### PR TITLE
fix(backup): Restart replication if source is stale

### DIFF
--- a/go/cmd/vtbackup/cli/vtbackup.go
+++ b/go/cmd/vtbackup/cli/vtbackup.go
@@ -691,6 +691,7 @@ func catchUpReplicationForBackup(ctx context.Context, topoServer *topo.Server, m
 		lastStatus replication.ReplicationStatus
 		status     replication.ReplicationStatus
 		statusErr  error
+		haveStatus bool
 
 		waitStartTime = time.Now()
 	)
@@ -707,7 +708,6 @@ func catchUpReplicationForBackup(ctx context.Context, topoServer *topo.Server, m
 		case <-time.After(time.Second):
 		}
 
-		lastStatus = status
 		status, statusErr = mysqld.ReplicationStatus(ctx)
 		if statusErr != nil {
 			lastErr.Record(statusErr)
@@ -723,15 +723,27 @@ func catchUpReplicationForBackup(ctx context.Context, topoServer *topo.Server, m
 			break
 		}
 
-		if !lastStatus.Position.IsZero() {
+		replicationHealthy := status.Healthy()
+		sourceExists := true
+		if haveStatus {
 			if status.Position.Equal(lastStatus.Position) {
 				phaseStatus.Set([]string{phaseNameCatchupReplication, phaseStatusCatchupReplicationStalled}, 1)
+				if replicationHealthy {
+					var err error
+					sourceExists, err = replicationSourceExists(ctx, topoServer, status)
+					if err != nil {
+						log.Warn(fmt.Sprintf("Failed to check replication source in topo: %v", err))
+						sourceExists = true
+					}
+				}
 			} else {
 				phaseStatus.Set([]string{phaseNameCatchupReplication, phaseStatusCatchupReplicationStalled}, 0)
 			}
 		}
+		lastStatus = status
+		haveStatus = true
 
-		if !status.Healthy() {
+		if !replicationHealthy || !sourceExists {
 			errStr := "Replication has stopped before backup could be taken. Trying to restart replication."
 			log.Warn(errStr)
 			lastErr.Record(errors.New(strings.ToLower(errStr)))
@@ -813,6 +825,23 @@ func startReplication(ctx context.Context, mysqld mysqlctl.MysqlDaemon, topoServ
 		return vterrors.Wrap(err, "MysqlDaemon.SetReplicationSource failed")
 	}
 	return nil
+}
+
+func replicationSourceExists(ctx context.Context, topoServer *topo.Server, status replication.ReplicationStatus) (bool, error) {
+	if status.SourceHost == "" || status.SourcePort == 0 {
+		return false, nil
+	}
+
+	tablets, err := topoServer.GetTabletMapForShard(ctx, initKeyspace, initShard)
+	if err != nil {
+		return false, err
+	}
+	for _, tablet := range tablets {
+		if tablet.MysqlHostname == status.SourceHost && tablet.MysqlPort == status.SourcePort {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func getPrimaryPosition(ctx context.Context, tmc tmclient.TabletManagerClient, ts *topo.Server) (replication.Position, error) {

--- a/go/cmd/vtbackup/cli/vtbackup_test.go
+++ b/go/cmd/vtbackup/cli/vtbackup_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/replication"
+	"vitess.io/vitess/go/vt/mysqlctl"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+)
+
+func TestCatchUpReplicationForBackupRetargetsCycledSourceIP(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	topoServer := newVtbackupTestTopo(t, []*topodatapb.Tablet{
+		newVtbackupTestTablet(100, topodatapb.TabletType_PRIMARY, "10.0.189.249", 3306),
+	}, 100)
+
+	mysqld := newStalledVtbackupTestMysqlDaemon(t, "10.0.189.245", 3306, "10.0.189.249", 3306)
+
+	status, err := catchUpReplicationForBackup(ctx, topoServer, mysqld, vtbackupTestPosition(1), vtbackupTestPosition(2))
+	require.NoError(t, err)
+	require.True(t, status.Position.AtLeast(vtbackupTestPosition(2)))
+}
+
+func TestCatchUpReplicationForBackupRetargetsMissingSourceTablet(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	topoServer := newVtbackupTestTopo(t, []*topodatapb.Tablet{
+		newVtbackupTestTablet(101, topodatapb.TabletType_PRIMARY, "new-primary", 3306),
+	}, 101)
+
+	mysqld := newStalledVtbackupTestMysqlDaemon(t, "old-primary", 3306, "new-primary", 3306)
+
+	status, err := catchUpReplicationForBackup(ctx, topoServer, mysqld, vtbackupTestPosition(1), vtbackupTestPosition(2))
+	require.NoError(t, err)
+	require.True(t, status.Position.AtLeast(vtbackupTestPosition(2)))
+}
+
+func newVtbackupTestTopo(t *testing.T, tablets []*topodatapb.Tablet, primaryUID uint32) *topo.Server {
+	oldKeyspace, oldShard := initKeyspace, initShard
+	initKeyspace, initShard = "ks", "0"
+	t.Cleanup(func() {
+		initKeyspace, initShard = oldKeyspace, oldShard
+	})
+
+	ctx := t.Context()
+	topoServer := memorytopo.NewServer(ctx, "zone1")
+	require.NoError(t, topoServer.CreateKeyspace(ctx, initKeyspace, &topodatapb.Keyspace{}))
+	require.NoError(t, topoServer.CreateShard(ctx, initKeyspace, initShard))
+	for _, tablet := range tablets {
+		require.NoError(t, topoServer.CreateTablet(ctx, tablet))
+	}
+
+	_, err := topoServer.UpdateShardFields(ctx, initKeyspace, initShard, func(si *topo.ShardInfo) error {
+		si.PrimaryAlias = &topodatapb.TabletAlias{Cell: "zone1", Uid: primaryUID}
+		return nil
+	})
+	require.NoError(t, err)
+
+	return topoServer
+}
+
+func newVtbackupTestTablet(uid uint32, tabletType topodatapb.TabletType, mysqlHostname string, mysqlPort int32) *topodatapb.Tablet {
+	return &topodatapb.Tablet{
+		Alias:         &topodatapb.TabletAlias{Cell: "zone1", Uid: uid},
+		Keyspace:      "ks",
+		Shard:         "0",
+		Type:          tabletType,
+		MysqlHostname: mysqlHostname,
+		MysqlPort:     mysqlPort,
+	}
+}
+
+func newStalledVtbackupTestMysqlDaemon(t *testing.T, currentHost string, currentPort int32, wantHost string, wantPort int32) *mysqlctl.FakeMysqlDaemon {
+	restorePos := vtbackupTestPosition(1)
+	primaryPos := vtbackupTestPosition(2)
+
+	mysqld := &mysqlctl.FakeMysqlDaemon{
+		Replicating:                   true,
+		IOThreadRunning:               true,
+		CurrentPrimaryPosition:        restorePos,
+		CurrentSourceHost:             currentHost,
+		CurrentSourcePort:             currentPort,
+		ExpectedExecuteSuperQueryList: []string{"STOP REPLICA"},
+	}
+	mysqld.SetReplicationSourceFunc = func(_ context.Context, host string, port int32, heartbeatInterval float64, stopReplicationBefore bool, startReplicationAfter bool) error {
+		require.Equal(t, wantHost, host)
+		require.Equal(t, wantPort, port)
+		require.True(t, stopReplicationBefore)
+		require.True(t, startReplicationAfter)
+
+		mysqld.CurrentSourceHost = host
+		mysqld.CurrentSourcePort = port
+		mysqld.CurrentPrimaryPosition = primaryPos
+		return nil
+	}
+
+	return mysqld
+}
+
+func vtbackupTestPosition(sequence int) replication.Position {
+	if sequence == 1 {
+		return replication.MustParsePosition(replication.Mysql56FlavorID, "16b1039f-22b6-11ed-b765-0a43f95f28a3:1")
+	}
+	return replication.MustParsePosition(replication.Mysql56FlavorID, fmt.Sprintf("16b1039f-22b6-11ed-b765-0a43f95f28a3:1-%d", sequence))
+}


### PR DESCRIPTION
## Description

`vtbackup` can get stuck during catch-up replication if its internal mysqld is still configured to replicate from a source host/port that no longer exists in topology.

This can happen during a planned reparent or rolling restart: `vtbackup` starts replicating from the old primary pod IP, the old primary pod is deleted and recreated with a new IP or replaced by a different primary, and topology is updated. The internal mysqld still has the old `SOURCE_HOST` configured.

## Root cause

`vtbackup` only refreshed replication by calling `startReplication()` when `ReplicationStatus.Healthy()` returned false.

That misses cases where MySQL reports the IO thread as `Connecting` with an empty `Last_IO_Error`. In that state, `ReplicationStatus.Healthy()` can still return true even though replication is stalled and the configured source host/port is stale.

Because the old code considered the status healthy, it never re-read topology, never issued a fresh `CHANGE REPLICATION SOURCE TO`, and eventually timed out while retrying the stale source.

## Fix

When catch-up replication is stalled but still reported as healthy, check whether the configured source host/port still exists in the shard's topology records.

If the source no longer exists, reuse the existing `startReplication()` path. That path reads the current shard primary from topology and issues a fresh `CHANGE REPLICATION SOURCE TO`.

If the topo check itself fails, log a warning and preserve the old behavior.

## How to reproduce

Run `vtbackup` so it restores from an existing backup and starts catch-up replication from the current primary.

While `vtbackup` is catching up, make the configured replication source stale. For example:

- `vtbackup` is replicating from `10.0.189.245:3306`
- A planned reparent or rolling restart removes that source from topology
- The same tablet comes back at `10.0.189.249:3306`, or a different tablet becomes the current primary
- `SHOW REPLICA STATUS` on vtbackup's internal mysqld shows no position progress, but still has an empty `Last_IO_Error`

Without the fix, `vtbackup` keeps retrying the stale source until it times out.

## Test

Added unit tests for both stale-source cases:

- `TestCatchUpReplicationForBackupRetargetsCycledSourceIP`
  - Simulates vtbackup still pointing at old source IP `10.0.189.245:3306`
  - Topology contains the same source at the new IP `10.0.189.249:3306`
  - Replication is healthy but stalled
  - Confirms vtbackup retargets replication through the existing restart path

- `TestCatchUpReplicationForBackupRetargetsMissingSourceTablet`
  - Simulates vtbackup still pointing at `old-primary:3306`
  - That source no longer exists in topology
  - Topology contains a different current primary, `new-primary:3306`
  - Replication is healthy but stalled
  - Confirms vtbackup retargets replication through the existing restart path

Confirmed both tests fail without the fix with `context deadline exceeded`, and pass with it.

## Related Issue(s)

Fixes: https://github.com/vitessio/vitess/issues/20104

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

### AI Disclosure

Test and fix were written by Codex.





