### PR TITLE
fix(backup): Clear lastErr on repl healthy

### DIFF
--- a/go/cmd/vtbackup/cli/vtbackup.go
+++ b/go/cmd/vtbackup/cli/vtbackup.go
@@ -741,6 +741,8 @@ func catchUpReplicationForBackup(ctx context.Context, topoServer *topo.Server, m
 				log.Warn(fmt.Sprintf("Failed to restart replication: %v", err))
 			}
 		} else {
+			// Clear last error as MySQL's replication is healthy
+			lastErr.Record(nil)
 			phaseStatus.Set([]string{phaseNameCatchupReplication, phaseStatusCatchupReplicationStopped}, 0)
 		}
 	}

--- a/go/cmd/vtbackup/cli/vtbackup_test.go
+++ b/go/cmd/vtbackup/cli/vtbackup_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/replication"
+	"vitess.io/vitess/go/vt/mysqlctl"
+	"vitess.io/vitess/go/vt/topo"
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+)
+
+func TestCatchUpReplicationForBackupClearsLastErrWhenReplicationBecomesHealthy(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+
+		oldInitKeyspace := initKeyspace
+		oldInitShard := initShard
+		initKeyspace = "test_keyspace"
+		initShard = "0"
+		t.Cleanup(func() {
+			initKeyspace = oldInitKeyspace
+			initShard = oldInitShard
+		})
+
+		ts := memorytopo.NewServer(ctx, "zone1")
+		t.Cleanup(ts.Close)
+		require.NoError(t, ts.CreateKeyspace(ctx, initKeyspace, &topodatapb.Keyspace{}))
+		require.NoError(t, ts.CreateShard(ctx, initKeyspace, initShard))
+		primaryAlias := &topodatapb.TabletAlias{Cell: "zone1", Uid: 100}
+		require.NoError(t, ts.CreateTablet(ctx, &topodatapb.Tablet{
+			Alias:         primaryAlias,
+			Keyspace:      initKeyspace,
+			Shard:         initShard,
+			Hostname:      "primary.test",
+			MysqlHostname: "primary-mysql.test",
+			MysqlPort:     3306,
+			Type:          topodatapb.TabletType_PRIMARY,
+		}))
+		_, err := ts.UpdateShardFields(ctx, initKeyspace, initShard, func(si *topo.ShardInfo) error {
+			si.PrimaryAlias = primaryAlias
+			return nil
+		})
+		require.NoError(t, err)
+
+		restorePos := testCatchupPosition(1)
+		primaryPos := testCatchupPosition(3)
+		statuses := []replication.ReplicationStatus{
+			{
+				Position:    restorePos,
+				IOState:     replication.ReplicationStateConnecting,
+				LastIOError: "Replica I/O for channel '': Error reconnecting to source 'vt_test@192.0.2.10:3306'. This was attempt 1/300, with a delay of 10 seconds between attempts. Message: Can't connect to MySQL server on '192.0.2.10:3306' (111), Error_code: MY-002003",
+				SQLState:    replication.ReplicationStateRunning,
+			},
+		}
+		for range int(timeoutWaitingForReplicationStatus.Seconds()) + 1 {
+			statuses = append(statuses, replication.ReplicationStatus{
+				Position: restorePos,
+				IOState:  replication.ReplicationStateRunning,
+				SQLState: replication.ReplicationStateRunning,
+			})
+		}
+		statuses = append(
+			statuses,
+			replication.ReplicationStatus{
+				Position: primaryPos,
+				IOState:  replication.ReplicationStateRunning,
+				SQLState: replication.ReplicationStateRunning,
+			},
+			replication.ReplicationStatus{
+				Position: primaryPos,
+				IOState:  replication.ReplicationStateRunning,
+				SQLState: replication.ReplicationStateRunning,
+			},
+		)
+		mysqld := &catchupReplicationMysqlDaemon{
+			statuses: statuses,
+		}
+
+		status, err := catchUpReplicationForBackup(ctx, ts, mysqld, restorePos, primaryPos)
+
+		require.NoError(t, err)
+		assert.True(t, status.Position.Equal(primaryPos))
+		assert.Equal(t, 1, mysqld.setReplicationSourceCalls)
+		assert.Equal(t, 1, mysqld.stopReplicationCalls)
+	})
+}
+
+type catchupReplicationMysqlDaemon struct {
+	mysqlctl.MysqlDaemon
+
+	statuses                  []replication.ReplicationStatus
+	statusCalls               int
+	setReplicationSourceCalls int
+	stopReplicationCalls      int
+}
+
+func (m *catchupReplicationMysqlDaemon) ReplicationStatus(ctx context.Context) (replication.ReplicationStatus, error) {
+	status := m.statuses[m.statusCalls]
+	m.statusCalls++
+	return status, nil
+}
+
+func (m *catchupReplicationMysqlDaemon) SetReplicationSource(ctx context.Context, host string, port int32, heartbeatInterval float64, stopReplicationBefore bool, startReplicationAfter bool) error {
+	m.setReplicationSourceCalls++
+	return nil
+}
+
+func (m *catchupReplicationMysqlDaemon) StopReplication(ctx context.Context, hookExtraEnv map[string]string) error {
+	m.stopReplicationCalls++
+	return nil
+}
+
+func testCatchupPosition(pos uint64) replication.Position {
+	return replication.Position{GTIDSet: replication.FilePosGTID{File: "source-bin.000001", Pos: pos}}
+}


### PR DESCRIPTION
## Description

`vtbackup` can abort during catch-up replication even after its internal mysqld recovers from a transient replication failure.

This can happen during a failover or reparent while a backup is running. `vtbackup` sees replication become unhealthy, restarts replication against the updated source, and MySQL later reports that replication is healthy again. Despite that recovery, `vtbackup` can still abort about 60 seconds after the original error.

## Root cause

`vtbackup` tracks replication catch-up errors with a `LastError`.

When replication is unhealthy, `vtbackup` records:

```go
replication has stopped before backup could be taken. trying to restart replication.
```

The old code never cleared that recorded error once replication returned to a healthy state.

Because `LastError.ShouldRetry()` only looks at how long the recorded error has been present, a transient replication failure could still be treated as continuously failing. After `timeoutWaitingForReplicationStatus`, `vtbackup` would abort with:

```text
the same error was encountered continuously since
```

even though replication had already recovered.

## Fix

When catch-up replication status is healthy, clear the recorded `LastError` with `lastErr.Record(nil)`.

This preserves the existing timeout behavior for continuous failures, but prevents a recovered transient replication issue from poisoning the rest of the catch-up loop.

## How to reproduce

Run `vtbackup` so it restores from an existing backup and starts catch-up replication from the current primary.

While `vtbackup` is catching up, trigger a failover or reparent that temporarily breaks replication. For example:

- `vtbackup` is replicating from the current primary
- The primary becomes unavailable during a failover
- MySQL reports an error like:

```text
Replica I/O for channel '': Error reconnecting to source 'vt_repl@<ip>:3306'. This was attempt 1/300, with a delay of 10 seconds between attempts. Message: Can't connect to MySQL server on '<ip>:3306' (111), Error_code: MY-002003
```

- `vtbackup` restarts replication
- MySQL reports that the replica receiver thread connected to the new source

Without the fix, `vtbackup` can still abort roughly 60 seconds after the first replication error because the old `LastError` was never cleared.

## Test

Added `TestCatchUpReplicationForBackupClearsLastErrWhenReplicationBecomesHealthy`.

The test:

- Simulates an unhealthy replication status with the MySQL `MY-002003` reconnect error
- Returns healthy but not-yet-caught-up replication statuses long enough to cross the real 60 second `LastError` threshold
- Uses `testing/synctest` so the test exercises the real timeout behavior without waiting in wall-clock time
- Returns a caught-up replication status
- Confirms `vtbackup` completes catch-up successfully

Confirmed the test fails without the fix by hitting:

```text
the same error was encountered continuously since
```

from `LastError.ShouldRetry()`, then returning:

```text
timeout waiting for replication status after 60 seconds
```

Confirmed the test passes with the fix.

Also tested in prod-like environment by killing the primary while catching up. The backup succeeded as expected.

## Related Issue(s)

Fixes: https://github.com/vitessio/vitess/issues/20110

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

### AI Disclosure

Test and was written by Codex.
