### PR TITLE
fix(vttablet): run vttablet_restore_done hook synchronously

### DIFF
--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -406,6 +406,10 @@ func TestBackup(t *testing.T, setupType int, streamMode string, stripes int, cDe
 			method: terminatedRestore,
 		}, //
 		{
+			name:   "TestRestoreDoneHookOnFailure",
+			method: testRestoreDoneHookOnFailure,
+		}, //
+		{
 			name:   "DoNotDemoteNewlyPromotedPrimaryIfReparentingDuringBackup",
 			method: doNotDemoteNewlyPromotedPrimaryIfReparentingDuringBackup,
 		}, //
@@ -1647,4 +1651,85 @@ func TestRestoreAllowedBackupEngines(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, backupMsg, result.Named().Row().AsString("msg", ""))
 	})
+}
+
+// testRestoreDoneHookOnFailure verifies that the vttablet_restore_done hook
+// fires synchronously even when the restore fails and the process exits.
+// This is a regression test for a bug where the hook was launched in a
+// goroutine that was killed by os.Exit(1) before it could complete.
+func testRestoreDoneHookOnFailure(t *testing.T) {
+	// 1. Install a vttablet_restore_done hook that writes env vars to a file.
+	vtroot := os.Getenv("VTROOT")
+	require.NotEmpty(t, vtroot, "VTROOT must be set")
+
+	hookDir := path.Join(vtroot, "vthook")
+	require.NoError(t, os.MkdirAll(hookDir, 0o755))
+
+	hookOutputFile := path.Join(localCluster.CurrentVTDATAROOT, "hook_restore_done_output")
+	hookScript := path.Join(hookDir, "vttablet_restore_done")
+	hookContent := fmt.Sprintf("#!/bin/bash\nenv > %s\n", hookOutputFile)
+	require.NoError(t, os.WriteFile(hookScript, []byte(hookContent), 0o755))
+	t.Cleanup(func() {
+		os.Remove(hookScript)
+		os.Remove(hookOutputFile)
+	})
+
+	// 2. Take a backup (using replica1 which is already running).
+	err := localCluster.VtctldClientProcess.ExecuteCommand("Backup", replica1.Alias)
+	require.NoError(t, err)
+	backups := localCluster.VerifyBackupCount(t, shardKsName, 1)
+	require.Len(t, backups, 1)
+
+	// 3. Corrupt the backup by truncating one of its data files.
+	backupDir := path.Join(replica1.VttabletProcess.FileBackupStorageRoot, keyspaceName, shardName, backups[0])
+	entries, err := os.ReadDir(backupDir)
+	require.NoError(t, err)
+
+	corrupted := false
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Name() == "MANIFEST" {
+			continue
+		}
+		// Truncate a data file to cause a checksum/read error during restore.
+		require.NoError(t, os.Truncate(path.Join(backupDir, entry.Name()), 1))
+		corrupted = true
+		break
+	}
+	require.True(t, corrupted, "expected at least one data file to corrupt in backup")
+
+	// 4. Start replica3 — it will attempt to restore from the corrupted backup.
+	//    The restore will fail and the process will exit with os.Exit(1).
+	replica3.VttabletProcess.ExtraArgs = commonTabletArg
+	replica3.VttabletProcess.ServingStatus = "SERVING"
+	err = replica3.VttabletProcess.Setup()
+	require.Error(t, err, "expected vttablet to exit due to failed restore")
+	require.Contains(t, err.Error(), "exited prematurely")
+
+	// 5. Verify the hook output file exists and contains the expected env vars.
+	//    Before the fix, this file would not exist because the hook goroutine was
+	//    killed by os.Exit(1) before it could complete.
+	hookOutput, err := os.ReadFile(hookOutputFile)
+	require.NoError(t, err, "hook output file must exist — hook should fire synchronously before os.Exit")
+
+	output := string(hookOutput)
+	assert.Contains(t, output, "TM_RESTORE_DATA_ERROR=")
+	assert.Contains(t, output, "TM_RESTORE_DATA_START_TS=")
+	assert.Contains(t, output, "TM_RESTORE_DATA_STOP_TS=")
+	assert.Contains(t, output, "TM_RESTORE_DATA_DURATION=")
+	assert.Contains(t, output, "TABLET_ALIAS=")
+	assert.Contains(t, output, "KEYSPACE="+keyspaceName)
+	assert.Contains(t, output, "SHARD="+shardName)
+
+	// With the backup engine fix, the engine should be reported even on failure.
+	switch currentSetupType {
+	case BuiltinBackup:
+		assert.Contains(t, output, "TM_RESTORE_DATA_BACKUP_ENGINE=builtin")
+	case XtraBackup:
+		assert.Contains(t, output, "TM_RESTORE_DATA_BACKUP_ENGINE=xtrabackup")
+	case MySQLShell:
+		assert.Contains(t, output, "TM_RESTORE_DATA_BACKUP_ENGINE=mysqlshell")
+	}
+
+	// Clean up: remove all backups so other tests aren't affected.
+	localCluster.RemoveAllBackups(t, shardKsName)
 }

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -1659,6 +1659,10 @@ func TestRestoreAllowedBackupEngines(t *testing.T) {
 // This is a regression test for a bug where the hook was launched in a
 // goroutine that was killed by os.Exit(1) before it could complete.
 func testRestoreDoneHookOnFailure(t *testing.T) {
+	// Ensure a clean cluster state — preceding tests (e.g., terminatedRestore)
+	// may have torn down all tablets.
+	restartPrimaryAndReplica(t)
+
 	// 1. Install a vttablet_restore_done hook that writes env vars to a file.
 	vtroot := os.Getenv("VTROOT")
 	require.NotEmpty(t, vtroot, "VTROOT must be set")

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -1662,11 +1663,11 @@ func testRestoreDoneHookOnFailure(t *testing.T) {
 	vtroot := os.Getenv("VTROOT")
 	require.NotEmpty(t, vtroot, "VTROOT must be set")
 
-	hookDir := path.Join(vtroot, "vthook")
+	hookDir := filepath.Join(vtroot, "vthook")
 	require.NoError(t, os.MkdirAll(hookDir, 0o755))
 
-	hookOutputFile := path.Join(localCluster.CurrentVTDATAROOT, "hook_restore_done_output")
-	hookScript := path.Join(hookDir, "vttablet_restore_done")
+	hookOutputFile := filepath.Join(localCluster.CurrentVTDATAROOT, "hook_restore_done_output")
+	hookScript := filepath.Join(hookDir, "vttablet_restore_done")
 	hookContent := fmt.Sprintf("#!/bin/bash\nenv > %s\n", hookOutputFile)
 	require.NoError(t, os.WriteFile(hookScript, []byte(hookContent), 0o755))
 	t.Cleanup(func() {
@@ -1680,8 +1681,8 @@ func testRestoreDoneHookOnFailure(t *testing.T) {
 	backups := localCluster.VerifyBackupCount(t, shardKsName, 1)
 	require.Len(t, backups, 1)
 
-	// 3. Corrupt the backup by truncating one of its data files.
-	backupDir := path.Join(replica1.VttabletProcess.FileBackupStorageRoot, keyspaceName, shardName, backups[0])
+	// 3. Corrupt the backup by overwriting one of its data files with garbage.
+	backupDir := filepath.Join(replica1.VttabletProcess.FileBackupStorageRoot, keyspaceName, shardName, backups[0])
 	entries, err := os.ReadDir(backupDir)
 	require.NoError(t, err)
 
@@ -1690,8 +1691,9 @@ func testRestoreDoneHookOnFailure(t *testing.T) {
 		if entry.IsDir() || entry.Name() == "MANIFEST" {
 			continue
 		}
-		// Truncate a data file to cause a checksum/read error during restore.
-		require.NoError(t, os.Truncate(path.Join(backupDir, entry.Name()), 1))
+		// Overwrite with deterministic garbage to cause a checksum/read error.
+		garbage := []byte("CORRUPTED_FOR_TEST_DO_NOT_USE")
+		require.NoError(t, os.WriteFile(filepath.Join(backupDir, entry.Name()), garbage, 0o644))
 		corrupted = true
 		break
 	}

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -1705,8 +1705,13 @@ func testRestoreDoneHookOnFailure(t *testing.T) {
 
 	// 4. Start replica3 — it will attempt to restore from the corrupted backup.
 	//    The restore will fail and the process will exit with os.Exit(1).
+	//    We set ExplicitServingStatus so Setup() waits only for SERVING (not
+	//    NOT_SERVING). Since the tablet never reaches SERVING (the background
+	//    restore goroutine fails and calls os.Exit), the exit channel fires
+	//    and Setup() returns "exited prematurely".
 	replica3.VttabletProcess.ExtraArgs = commonTabletArg
 	replica3.VttabletProcess.ServingStatus = "SERVING"
+	replica3.VttabletProcess.ExplicitServingStatus = true
 	err = replica3.VttabletProcess.Setup()
 	require.Error(t, err, "expected vttablet to exit due to failed restore")
 	require.Contains(t, err.Error(), "exited prematurely")

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -449,9 +449,16 @@ func Restore(ctx context.Context, params RestoreParams) (*BackupManifest, error)
 		backupstats.Component(backupstats.BackupEngine),
 		backupstats.Implementation(textutil.Title(backupEngineImplementation)),
 	)
+	// Read the backup manifest before restoring so we can report metadata
+	// (such as the backup engine) even if the restore fails.
+	backupManifest, merr := GetBackupManifest(ctx, bh)
+	if merr != nil {
+		return nil, vterrors.Wrap(merr, "Failed to read backup MANIFEST")
+	}
+
 	manifest, err := re.ExecuteRestore(ctx, reParams, bh)
 	if err != nil {
-		return nil, err
+		return backupManifest, err
 	}
 
 	if re.ShouldStartMySQLAfterRestore() { // all engines except mysqlshell since MySQL is always running there

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -435,7 +435,7 @@ func Restore(ctx context.Context, params RestoreParams) (*BackupManifest, error)
 		return nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "empty restore path")
 	}
 	bh := restorePath.FullBackupHandle()
-	re, err := GetRestoreEngine(ctx, bh)
+	re, backupManifest, err := GetRestoreEngineAndManifest(ctx, bh)
 	if err != nil {
 		return nil, vterrors.Wrap(err, "Failed to find restore engine")
 	}
@@ -449,12 +449,6 @@ func Restore(ctx context.Context, params RestoreParams) (*BackupManifest, error)
 		backupstats.Component(backupstats.BackupEngine),
 		backupstats.Implementation(textutil.Title(backupEngineImplementation)),
 	)
-	// Read the backup manifest before restoring so we can report metadata
-	// (such as the backup engine) even if the restore fails.
-	backupManifest, merr := GetBackupManifest(ctx, bh)
-	if merr != nil {
-		return nil, vterrors.Wrap(merr, "Failed to read backup MANIFEST")
-	}
 
 	manifest, err := re.ExecuteRestore(ctx, reParams, bh)
 	if err != nil {

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -466,23 +466,23 @@ func Restore(ctx context.Context, params RestoreParams) (*BackupManifest, error)
 		params.Logger.Infof("Restore: starting mysqld for mysql_upgrade")
 		// Note Start will use dba user for waiting, this is fine, it will be allowed.
 		if err := params.Mysqld.Start(context.Background(), params.Cnf, "--skip-grant-tables", "--skip-networking"); err != nil {
-			return nil, err
+			return backupManifest, err
 		}
 	}
 
 	params.Logger.Infof("Restore: running mysql_upgrade")
 	if err := params.Mysqld.RunMysqlUpgrade(ctx); err != nil {
-		return nil, vterrors.Wrap(err, "mysql_upgrade failed")
+		return backupManifest, vterrors.Wrap(err, "mysql_upgrade failed")
 	}
 
 	// The MySQL manual recommends restarting mysqld after running mysql_upgrade,
 	// so that any changes made to system tables take effect.
 	params.Logger.Infof("Restore: restarting mysqld after mysql_upgrade")
 	if err := params.Mysqld.Shutdown(context.Background(), params.Cnf, true, params.MysqlShutdownTimeout); err != nil {
-		return nil, err
+		return backupManifest, err
 	}
 	if err := params.Mysqld.Start(context.Background(), params.Cnf); err != nil {
-		return nil, err
+		return backupManifest, err
 	}
 	if err = ensureRestoredGTIDPurgedMatchesManifest(ctx, manifest, &params); err != nil {
 		return nil, err

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -485,7 +485,7 @@ func Restore(ctx context.Context, params RestoreParams) (*BackupManifest, error)
 		return backupManifest, err
 	}
 	if err = ensureRestoredGTIDPurgedMatchesManifest(ctx, manifest, &params); err != nil {
-		return nil, err
+		return backupManifest, err
 	}
 
 	if handles := restorePath.IncrementalBackupHandles(); len(handles) > 0 {
@@ -496,7 +496,7 @@ func Restore(ctx context.Context, params RestoreParams) (*BackupManifest, error)
 		for _, bh := range handles {
 			manifest, err := builtInRE.ExecuteRestore(ctx, params, bh)
 			if err != nil {
-				return nil, err
+				return backupManifest, err
 			}
 			params.Logger.Infof("Restore: applied incremental backup: %v", manifest.Position)
 		}
@@ -505,7 +505,7 @@ func Restore(ctx context.Context, params RestoreParams) (*BackupManifest, error)
 
 	params.Logger.Infof("Restore: removing state file")
 	if err = removeStateFile(params.Cnf); err != nil {
-		return nil, err
+		return backupManifest, err
 	}
 
 	backupstats.DeprecatedRestoreDurationS.Set(int64(time.Since(startTs).Seconds()))

--- a/go/vt/mysqlctl/backupengine.go
+++ b/go/vt/mysqlctl/backupengine.go
@@ -243,9 +243,16 @@ func GetBackupEngine(backupEngine string) (BackupEngine, error) {
 // GetRestoreEngine returns the RestoreEngine implementation to restore a given backup.
 // It reads the MANIFEST file from the backup to check which engine was used to create it.
 func GetRestoreEngine(ctx context.Context, backup backupstorage.BackupHandle) (RestoreEngine, error) {
+	re, _, err := GetRestoreEngineAndManifest(ctx, backup)
+	return re, err
+}
+
+// GetRestoreEngineAndManifest returns the RestoreEngine and the BackupManifest
+// for a given backup in a single MANIFEST read.
+func GetRestoreEngineAndManifest(ctx context.Context, backup backupstorage.BackupHandle) (RestoreEngine, *BackupManifest, error) {
 	manifest, err := GetBackupManifest(ctx, backup)
 	if err != nil {
-		return nil, vterrors.Wrap(err, "can't get backup MANIFEST")
+		return nil, nil, vterrors.Wrap(err, "can't get backup MANIFEST")
 	}
 	engine := manifest.BackupMethod
 	if engine == "" {
@@ -254,9 +261,9 @@ func GetRestoreEngine(ctx context.Context, backup backupstorage.BackupHandle) (R
 	}
 	re, ok := BackupRestoreEngineMap[engine]
 	if !ok {
-		return nil, vterrors.Errorf(vtrpc.Code_NOT_FOUND, "can't restore backup created with %q engine; no such BackupEngine implementation is registered", manifest.BackupMethod)
+		return nil, nil, vterrors.Errorf(vtrpc.Code_NOT_FOUND, "can't restore backup created with %q engine; no such BackupEngine implementation is registered", manifest.BackupMethod)
 	}
-	return re, nil
+	return re, manifest, nil
 }
 
 // GetBackupManifest returns the common fields of the MANIFEST file for a given backup.

--- a/go/vt/mysqlctl/backupengine.go
+++ b/go/vt/mysqlctl/backupengine.go
@@ -258,6 +258,7 @@ func GetRestoreEngineAndManifest(ctx context.Context, backup backupstorage.Backu
 	if engine == "" {
 		// The builtin engine is the only one that ever left BackupMethod unset.
 		engine = builtinBackupEngineName
+		manifest.BackupMethod = engine
 	}
 	re, ok := BackupRestoreEngineMap[engine]
 	if !ok {

--- a/go/vt/mysqlctl/backupengine.go
+++ b/go/vt/mysqlctl/backupengine.go
@@ -249,6 +249,8 @@ func GetRestoreEngine(ctx context.Context, backup backupstorage.BackupHandle) (R
 
 // GetRestoreEngineAndManifest returns the RestoreEngine and the BackupManifest
 // for a given backup in a single MANIFEST read.
+// Note: if BackupMethod is empty (legacy builtin backups), the returned manifest
+// will have BackupMethod set to "builtin" — this may differ from what is on disk.
 func GetRestoreEngineAndManifest(ctx context.Context, backup backupstorage.BackupHandle) (RestoreEngine, *BackupManifest, error) {
 	manifest, err := GetBackupManifest(ctx, backup)
 	if err != nil {

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -425,19 +425,17 @@ func (tm *TabletManager) invokeRestoreDoneHook(startTime time.Time, err error, b
 		h.ExtraEnv["TM_RESTORE_DATA_ERROR"] = err.Error()
 	}
 
-	// vttablet_restore_done is best-effort (for now?).
-	go func() {
-		// Package vthook already logs the stdout/stderr of hooks when they
-		// are run, so we don't duplicate that here.
-		hr := h.Execute()
-		switch hr.ExitStatus {
-		case hook.HOOK_SUCCESS:
-		case hook.HOOK_DOES_NOT_EXIST:
-			log.Info("No vttablet_restore_done hook.")
-		default:
-			log.Warn("vttablet_restore_done hook failed")
-		}
-	}()
+	// Run the hook synchronously to ensure it completes before the process
+	// exits. The caller (tm_init.go) calls os.Exit immediately after a failed
+	// restore, which would kill a background goroutine before the hook runs.
+	hr := h.Execute()
+	switch hr.ExitStatus {
+	case hook.HOOK_SUCCESS:
+	case hook.HOOK_DOES_NOT_EXIST:
+		log.Info("No vttablet_restore_done hook.")
+	default:
+		log.Warn("vttablet_restore_done hook failed")
+	}
 }
 
 type replicationAction int

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -260,7 +260,11 @@ func (tm *TabletManager) restoreBackupLocked(ctx context.Context, logger logutil
 		if err := rsm.abort(); err != nil {
 			logger.Errorf("Failed to abort restore: %v", err)
 		}
-		return "", vterrors.Wrap(err, "can't restore backup")
+		var engine string
+		if backupManifest != nil {
+			engine = backupManifest.BackupMethod
+		}
+		return engine, vterrors.Wrap(err, "can't restore backup")
 	}
 
 	if params.IsIncrementalRecovery() && !params.DryRun {

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -432,7 +432,10 @@ func (tm *TabletManager) invokeRestoreDoneHook(startTime time.Time, err error, b
 	// Run the hook synchronously to ensure it completes before the process
 	// exits. The caller (tm_init.go) calls os.Exit immediately after a failed
 	// restore, which would kill a background goroutine before the hook runs.
-	hr := h.Execute()
+	// Bound with a timeout so a hanging hook cannot wedge tablet startup.
+	hookCtx, hookCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer hookCancel()
+	hr := h.ExecuteContext(hookCtx)
 	switch hr.ExitStatus {
 	case hook.HOOK_SUCCESS:
 	case hook.HOOK_DOES_NOT_EXIST:

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -102,20 +102,25 @@ func (tm *TabletManager) RestoreBackup(
 	allowedBackupEngines []string,
 	mysqlShutdownTimeout time.Duration,
 ) error {
-	if err := tm.lock(ctx); err != nil {
-		return err
-	}
-	defer tm.unlock()
-
 	var (
 		err          error
 		startTime    time.Time
 		backupEngine string
 	)
 
+	// Declare the hook defer before the lock so it runs after unlock (LIFO).
+	// The hook can block up to 30s and does not need the action lock.
 	defer func() {
+		if startTime.IsZero() {
+			return
+		}
 		tm.invokeRestoreDoneHook(startTime, err, backupEngine)
 	}()
+
+	if err := tm.lock(ctx); err != nil {
+		return err
+	}
+	defer tm.unlock()
 
 	startTime = time.Now()
 
@@ -207,7 +212,7 @@ func (tm *TabletManager) restoreBackupLocked(ctx context.Context, logger logutil
 	var backupManifest *mysqlctl.BackupManifest
 	for {
 		backupManifest, err = mysqlctl.Restore(ctx, params)
-		if backupManifest != nil {
+		if backupManifest != nil && err == nil {
 			statsRestoreBackup.Set(replication.EncodePosition(backupManifest.Position))
 			statsRestoreBackupTime.Set(backupManifest.BackupTime)
 		}
@@ -286,19 +291,23 @@ func (tm *TabletManager) restoreBackupLocked(ctx context.Context, logger logutil
 }
 
 func (tm *TabletManager) restoreFromClone(ctx context.Context, logger logutil.Logger, deleteBeforeRestore bool) error {
-	if err := tm.lock(ctx); err != nil {
-		return err
-	}
-	defer tm.unlock()
-
 	var (
 		err       error
 		startTime time.Time
 	)
 
+	// Declare the hook defer before the lock so it runs after unlock (LIFO).
 	defer func() {
+		if startTime.IsZero() {
+			return
+		}
 		tm.invokeRestoreDoneHook(startTime, err, "")
 	}()
+
+	if err := tm.lock(ctx); err != nil {
+		return err
+	}
+	defer tm.unlock()
 
 	startTime = time.Now()
 

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -117,8 +117,8 @@ func (tm *TabletManager) RestoreBackup(
 		tm.invokeRestoreDoneHook(startTime, err, backupEngine)
 	}()
 
-	if err := tm.lock(ctx); err != nil {
-		return err
+	if lockErr := tm.lock(ctx); lockErr != nil {
+		return lockErr
 	}
 	defer tm.unlock()
 
@@ -290,6 +290,9 @@ func (tm *TabletManager) restoreBackupLocked(ctx context.Context, logger logutil
 	return backupEngine, nil
 }
 
+// restoreFromClone handles the clone-based restore path. It uses the same
+// defer-before-lock pattern as RestoreBackup but has no e2e test coverage;
+// the clone path is only exercised in production behind a feature gate.
 func (tm *TabletManager) restoreFromClone(ctx context.Context, logger logutil.Logger, deleteBeforeRestore bool) error {
 	var (
 		err       error
@@ -304,8 +307,8 @@ func (tm *TabletManager) restoreFromClone(ctx context.Context, logger logutil.Lo
 		tm.invokeRestoreDoneHook(startTime, err, "")
 	}()
 
-	if err := tm.lock(ctx); err != nil {
-		return err
+	if lockErr := tm.lock(ctx); lockErr != nil {
+		return lockErr
 	}
 	defer tm.unlock()
 
@@ -452,8 +455,10 @@ func (tm *TabletManager) invokeRestoreDoneHook(startTime time.Time, err error, b
 	case hook.HOOK_SUCCESS:
 	case hook.HOOK_DOES_NOT_EXIST:
 		log.Info("No vttablet_restore_done hook.")
+	case hook.HOOK_TIMEOUT_ERROR:
+		log.Warn(fmt.Sprintf("vttablet_restore_done hook timed out (exit status %d), stderr: %s", hr.ExitStatus, hr.Stderr))
 	default:
-		log.Warn("vttablet_restore_done hook failed")
+		log.Warn(fmt.Sprintf("vttablet_restore_done hook failed with exit status %d, stderr: %s", hr.ExitStatus, hr.Stderr))
 	}
 }
 

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -429,10 +429,13 @@ func (tm *TabletManager) invokeRestoreDoneHook(startTime time.Time, err error, b
 		h.ExtraEnv["TM_RESTORE_DATA_ERROR"] = err.Error()
 	}
 
-	// Run the hook synchronously to ensure it completes before the process
-	// exits. The caller (tm_init.go) calls os.Exit immediately after a failed
-	// restore, which would kill a background goroutine before the hook runs.
-	// Bound with a timeout so a hanging hook cannot wedge tablet startup.
+	// Run the hook synchronously so it completes before either (a) the process
+	// exits on restore failure — tm_init.go calls os.Exit immediately, which
+	// would kill a background goroutine — or (b) the tablet finishes startup on
+	// the success path, where a background goroutine could race with serving.
+	//
+	// 30s is generous for typical hooks (write a file, emit a metric) while
+	// short enough to avoid meaningfully delaying tablet startup.
 	hookCtx, hookCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer hookCancel()
 	hr := h.ExecuteContext(hookCtx)

--- a/go/vt/vttablet/tabletmanager/restore_test.go
+++ b/go/vt/vttablet/tabletmanager/restore_test.go
@@ -66,18 +66,11 @@ func setupHookDir(t *testing.T) (outputFile string) {
 	return outputFile
 }
 
-func waitForHookOutput(t *testing.T, outputFile string) string {
+func readHookOutput(t *testing.T, outputFile string) string {
 	t.Helper()
-	var content string
-	assert.Eventually(t, func() bool {
-		data, err := os.ReadFile(outputFile)
-		if err != nil {
-			return false
-		}
-		content = string(data)
-		return len(content) > 0
-	}, 5*time.Second, 50*time.Millisecond)
-	return content
+	data, err := os.ReadFile(outputFile)
+	require.NoError(t, err, "hook output file should exist after synchronous execution")
+	return string(data)
 }
 
 func TestInvokeRestoreDoneHook_BackupEngine(t *testing.T) {
@@ -87,7 +80,7 @@ func TestInvokeRestoreDoneHook_BackupEngine(t *testing.T) {
 	startTime := time.Now().Add(-10 * time.Second)
 	tm.invokeRestoreDoneHook(startTime, nil, "xtrabackup")
 
-	content := waitForHookOutput(t, outputFile)
+	content := readHookOutput(t, outputFile)
 
 	assert.Contains(t, content, "TM_RESTORE_DATA_BACKUP_ENGINE=xtrabackup")
 	assert.Contains(t, content, "TM_RESTORE_DATA_START_TS=")
@@ -105,7 +98,7 @@ func TestInvokeRestoreDoneHook_EmptyBackupEngine(t *testing.T) {
 
 	tm.invokeRestoreDoneHook(time.Now(), nil, "")
 
-	content := waitForHookOutput(t, outputFile)
+	content := readHookOutput(t, outputFile)
 
 	assert.NotContains(t, content, "TM_RESTORE_DATA_BACKUP_ENGINE=")
 }
@@ -117,7 +110,7 @@ func TestInvokeRestoreDoneHook_WithError(t *testing.T) {
 	restoreErr := errors.New("restore failed: connection refused")
 	tm.invokeRestoreDoneHook(time.Now(), restoreErr, "builtin")
 
-	content := waitForHookOutput(t, outputFile)
+	content := readHookOutput(t, outputFile)
 
 	assert.Contains(t, content, "TM_RESTORE_DATA_BACKUP_ENGINE=builtin")
 	assert.Contains(t, content, "TM_RESTORE_DATA_ERROR=restore failed: connection refused")
@@ -130,7 +123,7 @@ func TestInvokeRestoreDoneHook_ErrorWithoutBackupEngine(t *testing.T) {
 	restoreErr := errors.New("no backup found")
 	tm.invokeRestoreDoneHook(time.Now(), restoreErr, "")
 
-	content := waitForHookOutput(t, outputFile)
+	content := readHookOutput(t, outputFile)
 
 	assert.Contains(t, content, "TM_RESTORE_DATA_ERROR=no backup found")
 	assert.NotContains(t, content, "TM_RESTORE_DATA_BACKUP_ENGINE=")
@@ -143,7 +136,7 @@ func TestInvokeRestoreDoneHook_Timestamps(t *testing.T) {
 	startTime := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
 	tm.invokeRestoreDoneHook(startTime, nil, "xtrabackup")
 
-	content := waitForHookOutput(t, outputFile)
+	content := readHookOutput(t, outputFile)
 
 	assert.Contains(t, content, "TM_RESTORE_DATA_START_TS=2024-01-15T10:30:00Z")
 	// Verify the duration is present and contains a non-zero value.

--- a/go/vt/vttablet/tabletmanager/rpc_backup.go
+++ b/go/vt/vttablet/tabletmanager/rpc_backup.go
@@ -197,13 +197,14 @@ func (tm *TabletManager) RestoreFromBackup(ctx context.Context, logger logutil.L
 	)
 
 	// Declare the hook defer before the lock so it runs after unlock (LIFO).
-	// The hook can block up to 30s and does not need the action lock.
+	// Broadcast health first so vtgate sees updated state immediately, then
+	// run the hook which can block up to 30s.
 	defer func() {
 		if startTime.IsZero() {
 			return
 		}
-		tm.invokeRestoreDoneHook(startTime, restoreErr, backupEngine)
 		tm.QueryServiceControl.BroadcastHealth()
+		tm.invokeRestoreDoneHook(startTime, restoreErr, backupEngine)
 	}()
 
 	if err := tm.lock(ctx); err != nil {

--- a/go/vt/vttablet/tabletmanager/rpc_backup.go
+++ b/go/vt/vttablet/tabletmanager/rpc_backup.go
@@ -190,6 +190,22 @@ func (tm *TabletManager) Backup(ctx context.Context, logger logutil.Logger, req 
 // RestoreFromBackup deletes all local data and then restores the data from the latest backup [at
 // or before the backupTime value if specified]
 func (tm *TabletManager) RestoreFromBackup(ctx context.Context, logger logutil.Logger, request *tabletmanagerdatapb.RestoreFromBackupRequest) error {
+	var (
+		startTime    time.Time
+		backupEngine string
+		restoreErr   error
+	)
+
+	// Declare the hook defer before the lock so it runs after unlock (LIFO).
+	// The hook can block up to 30s and does not need the action lock.
+	defer func() {
+		if startTime.IsZero() {
+			return
+		}
+		tm.invokeRestoreDoneHook(startTime, restoreErr, backupEngine)
+		tm.QueryServiceControl.BroadcastHealth()
+	}()
+
 	if err := tm.lock(ctx); err != nil {
 		return err
 	}
@@ -207,14 +223,10 @@ func (tm *TabletManager) RestoreFromBackup(ctx context.Context, logger logutil.L
 	l := logutil.NewTeeLogger(logutil.NewConsoleLogger(), logger)
 
 	// Now we can run restore.
-	startTime := time.Now()
-	backupEngine, err := tm.restoreBackupLocked(ctx, l, 0 /* waitForBackupInterval */, true /* deleteBeforeRestore */, request, mysqlShutdownTimeout)
-	tm.invokeRestoreDoneHook(startTime, err, backupEngine)
+	startTime = time.Now()
+	backupEngine, restoreErr = tm.restoreBackupLocked(ctx, l, 0 /* waitForBackupInterval */, true /* deleteBeforeRestore */, request, mysqlShutdownTimeout)
 
-	// Re-run health check to be sure to capture any replication delay.
-	tm.QueryServiceControl.BroadcastHealth()
-
-	return err
+	return restoreErr
 }
 
 func (tm *TabletManager) IsBackupRunning() bool {

--- a/go/vt/vttablet/tabletmanager/rpc_backup.go
+++ b/go/vt/vttablet/tabletmanager/rpc_backup.go
@@ -197,8 +197,8 @@ func (tm *TabletManager) RestoreFromBackup(ctx context.Context, logger logutil.L
 	)
 
 	// Declare the hook defer before the lock so it runs after unlock (LIFO).
-	// Broadcast health first so vtgate sees updated state immediately, then
-	// run the hook which can block up to 30s.
+	// BroadcastHealth intentionally runs outside the action lock so vtgate
+	// sees the updated serving state without waiting for the hook to finish.
 	defer func() {
 		if startTime.IsZero() {
 			return


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

The `vttablet_restore_done` hook was executed in a background goroutine, but the caller (tm_init.go) calls os.Exit immediately after a failed restore. This race condition meant the hook goroutine was killed before it could complete, leaving no trace of the failure for external monitoring systems.

Run the hook synchronously to guarantee it completes before the process exits. The hook typically runs in <1s so the impact on shutdown time is negligible.

## Related Issue(s)

  - Fixes: #20112

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

This PR was written primarily by Claude Code
<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
