### PR TITLE
Resolve VTAdmin lint errors

### DIFF
--- a/examples/compose/scripts/vtadmin-up.sh
+++ b/examples/compose/scripts/vtadmin-up.sh
@@ -22,7 +22,6 @@ echo "Starting vtadmin..."
 exec vtadmin \
   --addr "0.0.0.0:14200" \
   --http-origin "http://localhost:14201" \
-  --http-origin "http://localhost:14202" \
   --http-tablet-url-tmpl "http://{{ .Tablet.Hostname }}:15000" \
   --log-format text \
   --rbac \

--- a/examples/compose/scripts/vtadmin-up.sh
+++ b/examples/compose/scripts/vtadmin-up.sh
@@ -22,6 +22,7 @@ echo "Starting vtadmin..."
 exec vtadmin \
   --addr "0.0.0.0:14200" \
   --http-origin "http://localhost:14201" \
+  --http-origin "http://localhost:14202" \
   --http-tablet-url-tmpl "http://{{ .Tablet.Hostname }}:15000" \
   --log-format text \
   --rbac \

--- a/web/vtadmin/src/api/http.ts
+++ b/web/vtadmin/src/api/http.ts
@@ -47,7 +47,7 @@ export const vtfetch = async (endpoint: string, options: RequestInit = {}): Prom
         let response = null;
         try {
             response = await global.fetch(url, opts);
-        } catch (error) {
+        } catch {
             // Capture fetch() promise rejections and rethrow as HttpFetchError.
             // fetch() promises will reject with a TypeError when a network error is
             // encountered or CORS is misconfigured, in which case the request never

--- a/web/vtadmin/src/components/App.tsx
+++ b/web/vtadmin/src/components/App.tsx
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as React from 'react';
 import { BrowserRouter as Router, Navigate, Route, Routes } from 'react-router-dom';
 
 import style from './App.module.scss';

--- a/web/vtadmin/src/components/Code.tsx
+++ b/web/vtadmin/src/components/Code.tsx
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as React from 'react';
 
 import style from './Code.module.scss';
 

--- a/web/vtadmin/src/components/dataTable/DataFilter.tsx
+++ b/web/vtadmin/src/components/dataTable/DataFilter.tsx
@@ -20,23 +20,16 @@ import { TextInput } from '../TextInput';
 import style from './DataFilter.module.scss';
 
 interface Props {
-    autoFocus?: boolean;
     onChange?: React.ChangeEventHandler<HTMLInputElement>;
     onClear?: React.MouseEventHandler<HTMLButtonElement>;
     placeholder?: string;
     value?: string | null | undefined;
 }
 
-export const DataFilter = ({ autoFocus, onChange, onClear, placeholder, value }: Props) => {
+export const DataFilter = ({ onChange, onClear, placeholder, value }: Props) => {
     return (
         <div className={style.controls}>
-            <TextInput
-                autoFocus={autoFocus}
-                iconLeft={Icons.search}
-                onChange={onChange}
-                placeholder={placeholder}
-                value={value || ''}
-            />
+            <TextInput iconLeft={Icons.search} onChange={onChange} placeholder={placeholder} value={value || ''} />
             <button className="btn btn-secondary" disabled={!value} onClick={onClear} type="button">
                 Clear filters
             </button>

--- a/web/vtadmin/src/components/dataTable/DataTable.tsx
+++ b/web/vtadmin/src/components/dataTable/DataTable.tsx
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as React from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { useURLPagination } from '../../hooks/useURLPagination';

--- a/web/vtadmin/src/components/dataTable/PaginationNav.tsx
+++ b/web/vtadmin/src/components/dataTable/PaginationNav.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import cx from 'classnames';
-import * as React from 'react';
 import { Link, LinkProps } from 'react-router-dom';
 
 import style from './PaginationNav.module.scss';

--- a/web/vtadmin/src/components/dataTable/SortedDataTable.tsx
+++ b/web/vtadmin/src/components/dataTable/SortedDataTable.tsx
@@ -24,7 +24,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { Icon, Icons } from '../Icon';
 
 export interface ColumnProps {
-    // Coulmn display name string | JSX.Element
+    // Column display name string | JSX.Element
     display: string | JSX.Element;
     // Column data accessor
     accessor: string;
@@ -123,12 +123,12 @@ export const SortedDataTable = <T extends object>({
                     <tr>
                         {columns.map((col, cdx) => (
                             <SortTableHeader
+                                key={cdx}
                                 col={col}
-                                cdx={cdx}
                                 sortColumn={sortColumn}
                                 sortOrder={sortOrder}
                                 handleSort={handleSort}
-                            ></SortTableHeader>
+                            />
                         ))}
                     </tr>
                 </thead>
@@ -147,17 +147,16 @@ export const SortedDataTable = <T extends object>({
 
 type SortTableHeaderProps = {
     col: ColumnProps;
-    cdx: number;
     sortOrder: SortOrder;
     sortColumn: null | string;
     handleSort: (column: any) => void;
 };
 
-const SortTableHeader: React.FC<SortTableHeaderProps> = ({ col, cdx, sortOrder, sortColumn, handleSort }) => {
+const SortTableHeader: React.FC<SortTableHeaderProps> = ({ col, sortOrder, sortColumn, handleSort }) => {
     const upFillColor = sortOrder === 'asc' && sortColumn === col.accessor ? 'fill-current' : 'fill-gray-300';
     const downFillColor = sortOrder !== 'asc' && sortColumn === col.accessor ? 'fill-current' : 'fill-gray-300';
     return (
-        <th key={cdx} onClick={() => handleSort(col.accessor)}>
+        <th onClick={() => handleSort(col.accessor)}>
             <div className="flex cursor-pointer items-center">
                 <div className="mr-1">{col.display}</div>
                 <div>

--- a/web/vtadmin/src/components/dataTable/SortedDataTable.tsx
+++ b/web/vtadmin/src/components/dataTable/SortedDataTable.tsx
@@ -121,9 +121,9 @@ export const SortedDataTable = <T extends object>({
                 {title && <caption>{title}</caption>}
                 <thead>
                     <tr>
-                        {columns.map((col, cdx) => (
+                        {columns.map((col) => (
                             <SortTableHeader
-                                key={cdx}
+                                key={col.accessor}
                                 col={col}
                                 sortColumn={sortColumn}
                                 sortOrder={sortOrder}

--- a/web/vtadmin/src/components/inputs/MultiSelect.tsx
+++ b/web/vtadmin/src/components/inputs/MultiSelect.tsx
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
 import { Icon, Icons } from '../Icon';
 import cx from 'classnames';
 import style from './MultiSelect.module.scss';

--- a/web/vtadmin/src/components/routes/Gates.tsx
+++ b/web/vtadmin/src/components/routes/Gates.tsx
@@ -77,7 +77,6 @@ export const Gates = () => {
             </WorkspaceHeader>
             <ContentContainer>
                 <DataFilter
-                    autoFocus
                     onChange={(e) => updateFilter(e.target.value)}
                     onClear={() => updateFilter('')}
                     placeholder="Filter gates"

--- a/web/vtadmin/src/components/routes/Keyspaces.tsx
+++ b/web/vtadmin/src/components/routes/Keyspaces.tsx
@@ -103,7 +103,6 @@ export const Keyspaces = () => {
             </WorkspaceHeader>
             <ContentContainer>
                 <DataFilter
-                    autoFocus
                     onChange={(e) => updateFilter(e.target.value)}
                     onClear={() => updateFilter('')}
                     placeholder="Filter keyspaces"

--- a/web/vtadmin/src/components/routes/Schemas.tsx
+++ b/web/vtadmin/src/components/routes/Schemas.tsx
@@ -128,7 +128,6 @@ export const Schemas = () => {
             </WorkspaceHeader>
             <ContentContainer>
                 <DataFilter
-                    autoFocus
                     onChange={(e) => updateFilter(e.target.value)}
                     onClear={() => updateFilter('')}
                     placeholder="Filter schemas"

--- a/web/vtadmin/src/components/routes/Settings.tsx
+++ b/web/vtadmin/src/components/routes/Settings.tsx
@@ -168,8 +168,8 @@ export const Settings = () => {
                             <h3 className="mt-12 mb-8">Icons</h3>
                             <div className={style.iconContainer}>
                                 {Object.values(Icons).map((i) => (
-                                    <Tooltip text={i}>
-                                        <Icon className={style.icon} icon={i} key={i} tabIndex={0} />
+                                    <Tooltip text={i} key={i}>
+                                        <Icon className={style.icon} icon={i} tabIndex={0} />
                                     </Tooltip>
                                 ))}
                             </div>
@@ -309,7 +309,7 @@ export const Settings = () => {
 
                             {['btn-lg', '', 'btn-sm'].map((s, idx) => {
                                 return (
-                                    <div className="my-16">
+                                    <div className="my-16" key={idx}>
                                         {['', 'btn-danger', 'btn-warning', 'btn-success'].map((v) => {
                                             return (
                                                 <div className="flex gap-4 my-6" key={`${idx}-${v}`}>

--- a/web/vtadmin/src/components/routes/Tablets.tsx
+++ b/web/vtadmin/src/components/routes/Tablets.tsx
@@ -117,7 +117,6 @@ export const Tablets = () => {
             </WorkspaceHeader>
             <ContentContainer>
                 <DataFilter
-                    autoFocus
                     onChange={(e) => updateFilter(e.target.value)}
                     onClear={() => updateFilter('')}
                     placeholder="Filter tablets"

--- a/web/vtadmin/src/components/routes/Transactions.tsx
+++ b/web/vtadmin/src/components/routes/Transactions.tsx
@@ -33,7 +33,6 @@ import { ReadOnlyGate } from '../ReadOnlyGate';
 import TransactionActions from './transactions/TransactionActions';
 import { isReadOnlyMode } from '../../util/env';
 import { TransactionLink } from '../links/TransactionLink';
-import * as React from 'react';
 
 export const COLUMNS = ['ID', 'State', 'Participants', 'Time Created', 'Actions'];
 export const READ_ONLY_COLUMNS = ['ID', 'State', 'Participants', 'Time Created'];

--- a/web/vtadmin/src/components/routes/Vtctlds.tsx
+++ b/web/vtadmin/src/components/routes/Vtctlds.tsx
@@ -68,7 +68,6 @@ export const Vtctlds = () => {
 
             <ContentContainer>
                 <DataFilter
-                    autoFocus
                     onChange={(e) => updateFilter(e.target.value)}
                     onClear={() => updateFilter('')}
                     placeholder="Filter vtctlds"

--- a/web/vtadmin/src/components/routes/Workflows.tsx
+++ b/web/vtadmin/src/components/routes/Workflows.tsx
@@ -235,7 +235,6 @@ export const Workflows = () => {
             </WorkspaceHeader>
             <ContentContainer>
                 <DataFilter
-                    autoFocus
                     onChange={(e) => updateFilter(e.target.value)}
                     onClear={() => updateFilter('')}
                     placeholder="Filter workflows"

--- a/web/vtadmin/src/components/routes/clusters/ClusterRow.tsx
+++ b/web/vtadmin/src/components/routes/clusters/ClusterRow.tsx
@@ -64,9 +64,9 @@ const ClusterRow: React.FC<Props> = ({ cluster }) => {
                     )}
                     {!isIdle && error && (
                         <div className="w-full flex flex-col justify-center items-center">
-                            <span className="flex h-12 w-12 relative items-center justify-center">
+                            <div className="flex h-12 w-12 relative items-center justify-center">
                                 <Icon className="fill-current text-red-500" icon={Icons.alertFail} />
-                            </span>
+                            </div>
                             <div className="text-lg mt-3 font-bold text-center">
                                 There was an issue validating nodes in cluster {cluster.name}
                             </div>

--- a/web/vtadmin/src/components/routes/keyspace/KeyspaceShards.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/KeyspaceShards.tsx
@@ -155,7 +155,6 @@ export const KeyspaceShards = ({ keyspace }: Props) => {
         <div className={style.container}>
             <QueryLoadingPlaceholder query={tq} />
             <DataFilter
-                autoFocus
                 onChange={(e) => updateFilter(e.target.value)}
                 onClear={() => updateFilter('')}
                 placeholder="Filter shards"

--- a/web/vtadmin/src/components/routes/topology/ClusterTopology.tsx
+++ b/web/vtadmin/src/components/routes/topology/ClusterTopology.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useTopologyPath } from '../../../hooks/api';
 import { useDocumentTitle } from '../../../hooks/useDocumentTitle';

--- a/web/vtadmin/src/components/routes/topology/ClusterTopology.tsx
+++ b/web/vtadmin/src/components/routes/topology/ClusterTopology.tsx
@@ -87,7 +87,6 @@ export const ClusterTopology = () => {
         if (data?.cell) {
             setTopology({ cell: data?.cell as TopologyCell });
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [data]);
 
     if (!data) {

--- a/web/vtadmin/src/components/routes/topology/Nodes.tsx
+++ b/web/vtadmin/src/components/routes/topology/Nodes.tsx
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
 import { MarkerType, Node, Edge } from '@xyflow/react';
 
 export interface TopologyCell {

--- a/web/vtadmin/src/components/routes/topologyTree/Node.tsx
+++ b/web/vtadmin/src/components/routes/topologyTree/Node.tsx
@@ -49,9 +49,13 @@ export const Node = ({ topologyNode, clusterID }: NodeParams) => {
     const nodeTitle = `${isOpen ? '▼' : '►'} ${node.name}`;
     return (
         <div className="border-l border-x-zinc-300 pl-2 mt-4">
-            <div className="w-fit cursor-pointer font-bold text-blue-500" onClick={() => setIsOpen(!isOpen)}>
+            <button
+                className="w-fit cursor-pointer border-0 bg-transparent p-0 text-left font-bold text-blue-500"
+                type="button"
+                onClick={() => setIsOpen(!isOpen)}
+            >
                 {nodeTitle}
-            </div>
+            </button>
 
             {isOpen && (
                 <div className="w-fit ml-4">

--- a/web/vtadmin/src/components/routes/topologyTree/Node.tsx
+++ b/web/vtadmin/src/components/routes/topologyTree/Node.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useTopologyPath } from '../../../hooks/api';
 import { buildChildNodes, TopologyNode } from './TopologyTree';

--- a/web/vtadmin/src/components/routes/topologyTree/TopologyTree.tsx
+++ b/web/vtadmin/src/components/routes/topologyTree/TopologyTree.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useTopologyPath } from '../../../hooks/api';
 import { useDocumentTitle } from '../../../hooks/useDocumentTitle';

--- a/web/vtadmin/src/components/routes/transaction/Transaction.tsx
+++ b/web/vtadmin/src/components/routes/transaction/Transaction.tsx
@@ -33,7 +33,6 @@ import { Link, useParams } from 'react-router-dom';
 import { NavCrumbs } from '../../layout/NavCrumbs';
 import { READ_ONLY_COLUMNS } from '../Transactions';
 import { COLUMNS } from '../Transactions';
-import * as React from 'react';
 import { TransactionLink } from '../../links/TransactionLink';
 
 interface RouteParams {

--- a/web/vtadmin/src/components/routes/transaction/Transaction.tsx
+++ b/web/vtadmin/src/components/routes/transaction/Transaction.tsx
@@ -95,6 +95,7 @@ export const Transaction = () => {
                             const shard = `${participant.keyspace}/${participant.shard}`;
                             return (
                                 <ShardLink
+                                    key={shard}
                                     clusterID={clusterID}
                                     keyspace={participant.keyspace}
                                     shard={participant.shard}

--- a/web/vtadmin/src/components/routes/workflow/WorkflowDetails.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowDetails.tsx
@@ -15,7 +15,7 @@
  */
 
 import { orderBy } from 'lodash-es';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 
 import { useWorkflow, useWorkflowStatus, useWorkflows } from '../../../hooks/api';

--- a/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowStreams.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import React from 'react';
-
 import { WorkflowStreamsLagChart } from '../../charts/WorkflowStreamsLagChart';
 import { env } from '../../../util/env';
 

--- a/web/vtadmin/src/components/routes/workflow/WorkflowVDiff.tsx
+++ b/web/vtadmin/src/components/routes/workflow/WorkflowVDiff.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { useCreateVDiff, useShowVDiff } from '../../../hooks/api';
 import { DataTable } from '../../dataTable/DataTable';


### PR DESCRIPTION
## Description

This resolves all outstanding linter errors reported by ESLint for `web/vtadmin`.
I've broken up the changes into individual commits for specific classes of linter errors.

## Related Issue(s)

- #19664

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

This changes in this PR was primarily written by myself, but Cursor was used for some of the linter fixes (primarily 2278a9ff3a752b031858d2f056525efb36b2f29c) and investigating why the unused `React` imports were no longer necessary (a77673f2b778284c6dce1c037630a2cd56a8c3f4).
