### PR TITLE
smartconnpool: fix MaxLifetime jitter

### DIFF
--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -526,10 +526,10 @@ func (pool *ConnPool[C]) closeOnIdleLimitReached(conn *Pooled[C]) bool {
 
 func (pool *ConnPool[D]) extendedMaxLifetime() time.Duration {
 	maxLifetime := pool.config.maxLifetime.Load()
-	if maxLifetime == 0 {
+	if maxLifetime <= 0 {
 		return 0
 	}
-	return time.Duration(maxLifetime) + time.Duration(rand.Uint32N(uint32(maxLifetime)))
+	return time.Duration(maxLifetime) + time.Duration(rand.Int64N(maxLifetime))
 }
 
 func (pool *ConnPool[C]) connReopen(ctx context.Context, dbconn *Pooled[C], now time.Duration) (err error) {

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -812,6 +812,46 @@ func TestExtendedLifetimeTimeout(t *testing.T) {
 	}
 }
 
+func TestExtendedMaxLifetimeJitter(t *testing.T) {
+	var state TestState
+	config := &Config[*TestConn]{
+		Capacity:    1,
+		MaxLifetime: 30 * time.Minute,
+		LogWait:     state.LogWait,
+	}
+
+	p := NewPool(config).Open(newConnector(&state), nil)
+	t.Cleanup(p.Close)
+
+	threshold := config.MaxLifetime + config.MaxLifetime/2
+	const maxAttempts = 64
+
+	for range maxAttempts {
+		extended := p.extendedMaxLifetime()
+		require.LessOrEqual(t, config.MaxLifetime, extended)
+		require.Greater(t, 2*config.MaxLifetime, extended)
+
+		if extended > threshold {
+			return
+		}
+	}
+
+	require.Failf(t, "jitter never reached upper half of range",
+		"no sample in %d tries exceeded %s", maxAttempts, threshold)
+}
+
+func TestExtendedMaxLifetimeNegativeDisables(t *testing.T) {
+	var state TestState
+	p := NewPool(&Config[*TestConn]{
+		Capacity:    1,
+		MaxLifetime: -1 * time.Second,
+		LogWait:     state.LogWait,
+	}).Open(newConnector(&state), nil)
+	t.Cleanup(p.Close)
+
+	require.EqualValues(t, 0, p.extendedMaxLifetime())
+}
+
 // TestMaxIdleCount tests the MaxIdleCount setting, to check if the pool closes
 // the idle connections when the number of idle connections exceeds the limit.
 func TestMaxIdleCount(t *testing.T) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Fixes two `smartconnpool` `MaxLifetime` edge cases:

* Use the full `int64` nanosecond duration when adding lifetime jitter. The old `uint32` cast truncated jitter for lifetimes above roughly 4.29s and could panic on exact multiples of 2^32 ns.
* Treat non-positive `MaxLifetime` values as disabled so a negative duration cannot produce bogus jitter through `rand.Int64N`.

This is a behavior correction: for long `MaxLifetime` values, pooled connections can now live anywhere in the intended `[MaxLifetime, 2*MaxLifetime)` range. Before this PR, those same values effectively lived in a much narrower range close to `MaxLifetime`, weakening the anti-herd protection and making connection recycling more synchronized.

## Related Issue(s)

Extracted from #20081.

## Backport Justification

This is a small, isolated `smartconnpool` correctness fix with no API changes, migrations, or deployment steps. It restores the intended `MaxLifetime` jitter behavior and avoids panic/bogus-jitter edge cases for invalid or unlucky duration values.

Backporting is useful because released branches can otherwise recycle pooled connections more synchronously than configured for common minute/hour-scale lifetimes. The practical implication is that after this fix, connections may be kept open longer than before, up to nearly `2*MaxLifetime`, but that is the documented/intended jitter window rather than a new feature.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

No deployment steps required.

### AI Disclosure

This PR was written by Codex with direction from Arthur.
