### PR TITLE
smartconnpool: keep refresh worker running after reopen

### DIFF
--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -259,7 +259,6 @@ func (pool *ConnPool[C]) open() {
 			}
 			if refresh {
 				go pool.reopen()
-				return false
 			}
 			return true
 		})

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -258,7 +258,7 @@ func (pool *ConnPool[C]) open() {
 				log.Error(fmt.Sprint(err))
 			}
 			if refresh {
-				go pool.reopen()
+				pool.reopen()
 			}
 			return true
 		})

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -576,6 +576,47 @@ func TestRefreshWorkerContinuesAfterTriggeredReopen(t *testing.T) {
 	}, 30*time.Second, 50*time.Millisecond)
 }
 
+func TestRefreshWorkerDoesNotQueueReopens(t *testing.T) {
+	old := PoolCloseTimeout
+	PoolCloseTimeout = 500 * time.Millisecond
+	t.Cleanup(func() { PoolCloseTimeout = old })
+
+	var state TestState
+	var refreshCount atomic.Int32
+
+	p := NewPool(&Config[*TestConn]{
+		Capacity:        1,
+		RefreshInterval: 20 * time.Millisecond,
+	}).Open(newConnector(&state), func() (bool, error) {
+		refreshCount.Add(1)
+		return true, nil
+	})
+	t.Cleanup(p.Close)
+
+	held, err := p.Get(t.Context(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if held != nil {
+			held.Recycle()
+		}
+	})
+
+	require.Eventually(t, func() bool {
+		return refreshCount.Load() == 1
+	}, 5*time.Second, time.Millisecond)
+
+	require.Never(t, func() bool {
+		return refreshCount.Load() > 1
+	}, 100*time.Millisecond, 5*time.Millisecond)
+
+	held.Recycle()
+	held = nil
+
+	require.Eventually(t, func() bool {
+		return refreshCount.Load() >= 2
+	}, 5*time.Second, 5*time.Millisecond)
+}
+
 func TestUserClosing(t *testing.T) {
 	var state TestState
 

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -504,6 +504,7 @@ func TestReopen(t *testing.T) {
 		refreshed.Store(true)
 		return true, nil
 	})
+	t.Cleanup(p.Close)
 
 	var resources [10]*Pooled[*TestConn]
 	for i := range 5 {
@@ -555,6 +556,24 @@ func TestReopen(t *testing.T) {
 	assert.Equal(t, expected, stats)
 	assert.EqualValues(t, 5, state.lastID.Load())
 	assert.EqualValues(t, 0, state.open.Load())
+}
+
+func TestRefreshWorkerContinuesAfterTriggeredReopen(t *testing.T) {
+	var state TestState
+	var refreshCount atomic.Int32
+
+	p := NewPool(&Config[*TestConn]{
+		Capacity:        2,
+		RefreshInterval: 50 * time.Millisecond,
+	}).Open(newConnector(&state), func() (bool, error) {
+		count := refreshCount.Add(1)
+		return count == 1, nil
+	})
+	t.Cleanup(p.Close)
+
+	require.Eventually(t, func() bool {
+		return refreshCount.Load() >= 3
+	}, 30*time.Second, 50*time.Millisecond)
 }
 
 func TestUserClosing(t *testing.T) {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Keeps the `smartconnpool` refresh worker running after the refresh callback triggers a reopen.

Before this PR, the worker returned `false` after starting `reopen()`, which permanently stopped the refresh loop. That meant the first DNS or endpoint-change refresh could be handled, but later refresh events were never observed for the lifetime of the pool.

This PR runs `reopen()` synchronously inside the refresh worker and then returns `true`. That keeps the worker alive while also applying backpressure: if a reopen takes longer than `RefreshInterval`, later ticks do not queue additional reopen goroutines behind `capacityMu`.

This is a behavior correction: after a refresh-triggered reopen, the pool continues checking the refresh callback on the configured interval and can react to subsequent refresh events without requiring the pool to be restarted.

## Related Issue(s)

Extracted from #20081.

## Backport Justification

This is a small, isolated `smartconnpool` correctness fix with no API changes, migrations, or deployment steps. It restores the intended repeated refresh behavior for long-lived pools and avoids queuing redundant reopen goroutines when reopen runs longer than the refresh interval.

Backporting is useful because released branches can otherwise stop observing refresh events after the first triggered reopen. For deployments that rely on refresh checks to retire stale connections after DNS or endpoint changes, that can leave later changes unnoticed until the pool is recreated.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

No deployment steps required.

### AI Disclosure

This PR was written by Codex with direction from Arthur.
