### PR TITLE
test/endtoend/cluster: fix typos in process helper comments

### DIFF
--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -429,7 +429,7 @@ func (topo *TopoProcess) ManageTopoDir(command string, directory string) (err er
 	}
 }
 
-// TopoProcessInstance returns a TopoProcess handle for a etcd sevice,
+// TopoProcessInstance returns a TopoProcess handle for an etcd service,
 // configured with the given Config.
 // The process must be manually started by calling setup()
 func TopoProcessInstance(port int, peerPort int, hostname string, flavor string, name string) *TopoProcess {

--- a/go/test/endtoend/cluster/vtadmin_process.go
+++ b/go/test/endtoend/cluster/vtadmin_process.go
@@ -52,7 +52,7 @@ type VtAdminProcess struct {
 	exit           chan error
 }
 
-// Setup starts orc process with required arguements
+// Setup starts orc process with required arguments
 func (vp *VtAdminProcess) Setup() (err error) {
 	// create the configuration file
 	timeNow := time.Now().UnixNano()

--- a/go/test/endtoend/cluster/vtbackup_process.go
+++ b/go/test/endtoend/cluster/vtbackup_process.go
@@ -54,7 +54,7 @@ type VtbackupProcess struct {
 	exit chan error
 }
 
-// Setup starts vtbackup process with required arguements
+// Setup starts vtbackup process with required arguments
 func (vtbackup *VtbackupProcess) Setup() (err error) {
 	flags := map[string]string{
 		"--topo-implementation":        vtbackup.TopoImplementation,

--- a/go/test/endtoend/cluster/vtctld_process.go
+++ b/go/test/endtoend/cluster/vtctld_process.go
@@ -48,7 +48,7 @@ type VtctldProcess struct {
 	exit chan error
 }
 
-// Setup starts vtctld process with required arguements
+// Setup starts vtctld process with required arguments
 func (vtctld *VtctldProcess) Setup(cell string, extraArgs ...string) (err error) {
 	_ = createDirectory(vtctld.LogDir, 0o700)
 	_ = createDirectory(path.Join(vtctld.Directory, "backups"), 0o700)

--- a/go/test/endtoend/cluster/vtgate_process.go
+++ b/go/test/endtoend/cluster/vtgate_process.go
@@ -147,7 +147,7 @@ func (vtgate *VtgateProcess) MakeAPICallRetry(t *testing.T, url string) {
 
 const defaultVtGatePlannerVersion = planbuilder.Gen4
 
-// Setup starts Vtgate process with required arguements
+// Setup starts Vtgate process with required arguments
 func (vtgate *VtgateProcess) Setup() (err error) {
 	args := []string{
 		"--topo-implementation", vtgate.TopoImplementation,

--- a/go/test/endtoend/cluster/vtorc_process.go
+++ b/go/test/endtoend/cluster/vtorc_process.go
@@ -84,7 +84,7 @@ func (orc *VTOrcProcess) RewriteConfiguration() error {
 	return os.WriteFile(orc.ConfigPath, []byte(orc.Config.ToJSONString()), 0o644)
 }
 
-// Setup starts orc process with required arguements
+// Setup starts orc process with required arguments
 func (orc *VTOrcProcess) Setup() (err error) {
 	// validate cell
 	if orc.Cell == "" {
@@ -142,7 +142,7 @@ func (orc *VTOrcProcess) Setup() (err error) {
 
 	if !orc.NoOverride {
 		orc.proc.Args = append(orc.proc.Args,
-			// This parameter is overriden from the config file. This verifies that we indeed use the flag value over the config file.
+			// This parameter is overridden from the config file. This verifies that we indeed use the flag value over the config file.
 			"--instance-poll-time", "1s",
 			// Faster topo information refresh speeds up the tests. This doesn't add any significant load either.
 			"--topo-information-refresh-duration", "3s",

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -91,7 +91,7 @@ type VttabletProcess struct {
 	exit chan error
 }
 
-// Setup starts vttablet process with required arguements
+// Setup starts vttablet process with required arguments
 func (vttablet *VttabletProcess) Setup() (err error) {
 	vttablet.proc = exec.Command(
 		vttablet.Binary,


### PR DESCRIPTION
## Description

Fix small typos in doc/inline comments of e2e cluster process helpers.
Comment-only change; no behavior impact. Found via `misspell` scan.

## Related Issue(s)

Fixes #20123

## Checklist

- [x] Tests were added or are not required (comment-only change)
- [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

This PR was authored primarily by Claude Code (Anthropic) with my direction and review.
