### PR TITLE
`DemotePrimary`: dump diagnostics when setting `super_read_only` times out

### DIFF
--- a/go/test/endtoend/reparent/plannedreparent/diagnostics_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/diagnostics_test.go
@@ -41,6 +41,13 @@ const (
 // TestPlannedReparentDumpsDiagnosticsWhenSuperReadOnlyStalls verifies the real PRS path logs
 // diagnostics when MySQL is blocked on the super_read_only change.
 func TestPlannedReparentDumpsDiagnosticsWhenSuperReadOnlyStalls(t *testing.T) {
+	vttabletMajorVersion, err := cluster.GetMajorVersion("vttablet")
+	require.NoError(t, err)
+
+	if vttabletMajorVersion < 25 {
+		t.Skipf("skipping diagnostic log assertion with old vttablet: vttablet major version %d", vttabletMajorVersion)
+	}
+
 	clusterInstance := utils.SetupReparentCluster(t, policy.DurabilitySemiSync)
 	defer utils.TeardownCluster(clusterInstance)
 

--- a/go/test/endtoend/reparent/plannedreparent/diagnostics_test.go
+++ b/go/test/endtoend/reparent/plannedreparent/diagnostics_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plannedreparent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	"vitess.io/vitess/go/test/endtoend/reparent/utils"
+	"vitess.io/vitess/go/vt/vtctl/reparentutil/policy"
+)
+
+const (
+	demotePrimaryDiagnosticsMarker = "timed out or canceled while enabling super_read_only during DemotePrimary, dumping MySQL diagnostics"
+	demotePrimaryDiagnosticQuery   = "collecting DemotePrimary MySQL diagnostic query"
+)
+
+// TestPlannedReparentDumpsDiagnosticsWhenSuperReadOnlyStalls verifies the real PRS path logs
+// diagnostics when MySQL is blocked on the super_read_only change.
+func TestPlannedReparentDumpsDiagnosticsWhenSuperReadOnlyStalls(t *testing.T) {
+	clusterInstance := utils.SetupReparentCluster(t, policy.DurabilitySemiSync)
+	defer utils.TeardownCluster(clusterInstance)
+
+	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
+	oldPrimary := tablets[0]
+	newPrimary := tablets[1]
+
+	lockPrimaryTestTableForWrite(t, oldPrimary)
+
+	out, err := utils.Prs(t, clusterInstance, newPrimary)
+	require.Error(t, err)
+	require.Contains(t, out, "DeadlineExceeded")
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		logContents, err := os.ReadFile(oldPrimary.VttabletProcess.ErrorLog)
+		require.NoError(c, err)
+
+		assert.Contains(c, string(logContents), demotePrimaryDiagnosticsMarker)
+		assert.Contains(c, string(logContents), demotePrimaryDiagnosticQuery)
+	}, 30*time.Second, 250*time.Millisecond)
+}
+
+// lockPrimaryTestTableForWrite holds a table lock that stalls MySQL while it
+// enables super_read_only.
+func lockPrimaryTestTableForWrite(t *testing.T, tablet *cluster.Vttablet) {
+	t.Helper()
+
+	socketPath := filepath.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("vt_%010d/mysql.sock", tablet.TabletUID))
+	connParams := mysql.ConnParams{Uname: "vt_dba", DbName: "vt_" + utils.KeyspaceName, UnixSocket: socketPath}
+	conn, err := mysql.Connect(t.Context(), &connParams)
+	require.NoError(t, err)
+
+	_, err = conn.ExecuteFetch("lock tables vt_insert_test write", 0, false)
+	require.NoError(t, err)
+
+	var once sync.Once
+	unlock := func() {
+		once.Do(func() {
+			_, _ = conn.ExecuteFetch("unlock tables", 0, false)
+			conn.Close()
+		})
+	}
+
+	t.Cleanup(unlock)
+}

--- a/go/vt/mysqlctl/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon.go
@@ -138,6 +138,9 @@ type FakeMysqlDaemon struct {
 	// SetSuperReadOnlyError is used by SetSuperReadOnly.
 	SetSuperReadOnlyError error
 
+	// SetSuperReadOnlyFunc overrides SetSuperReadOnly when it is set.
+	SetSuperReadOnlyFunc func(ctx context.Context, on bool) (ResetSuperReadOnlyFunc, error)
+
 	// ExecuteSuperQueryListCallback is called at the start of ExecuteSuperQueryList
 	// before any queries are executed, if set.
 	ExecuteSuperQueryListCallback func()
@@ -502,9 +505,14 @@ func (fmd *FakeMysqlDaemon) SetReadOnly(ctx context.Context, on bool) error {
 
 // SetSuperReadOnly is part of the MysqlDaemon interface.
 func (fmd *FakeMysqlDaemon) SetSuperReadOnly(ctx context.Context, on bool) (ResetSuperReadOnlyFunc, error) {
+	if fmd.SetSuperReadOnlyFunc != nil {
+		return fmd.SetSuperReadOnlyFunc(ctx, on)
+	}
+
 	if fmd.SetSuperReadOnlyError != nil {
 		return nil, fmd.SetSuperReadOnlyError
 	}
+
 	prev := fmd.SuperReadOnly.Load()
 	prevReadOnly := fmd.ReadOnly
 	fmd.SuperReadOnly.Store(on)

--- a/go/vt/vttablet/tabletmanager/diagnostics.go
+++ b/go/vt/vttablet/tabletmanager/diagnostics.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletmanager
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+const (
+	// mysqlDiagnosticsTimeout is the timeout to use when running the diagnostics queries on MySQL.
+	mysqlDiagnosticsTimeout = 5 * time.Second
+
+	// defaultRedactedText is used when proper redaction fails for whatever reason. The full text is instead
+	// replaced with this value.
+	defaultRedactedText = "[REDACTED]"
+)
+
+// redactableColumns is the set of columns that may contain client SQL and should be redacted.
+var redactableColumns = map[string]struct{}{
+	"blocking_query":   {},
+	"info":             {},
+	"processlist_info": {},
+	"trx_query":        {},
+	"waiting_query":    {},
+}
+
+// diagnosticQuery describes a query to run that collects useful data about the current state of MySQL,
+// to help debug notable events, such as when setting `super_read_only=1` stalls.
+type diagnosticQuery struct {
+	// description explains what the query is reading.
+	description string
+
+	// query is the actual query to run on MySQL.
+	query string
+}
+
+// diagnosticQueries is the collection of queries to run to collect data during notable MySQL events.
+var diagnosticQueries = []diagnosticQuery{
+	{
+		description: "active MySQL sessions",
+		query: `select
+	id,
+	user,
+	host,
+	db,
+	command,
+	time,
+	state,
+	info
+from information_schema.processlist
+where command != 'Sleep' or info is not null
+order by time desc
+limit 50`,
+	},
+
+	{
+		description: "current MySQL read-only settings",
+		query: `select
+	@@global.read_only as read_only,
+	@@global.super_read_only as super_read_only`,
+	},
+
+	{
+		description: "current MySQL semi-sync counters",
+		query: `select
+	variable_name,
+	variable_value
+from performance_schema.global_status
+where variable_name like 'Rpl_semi_sync_source_%'
+	or variable_name like 'Rpl_semi_sync_master_%'
+order by variable_name`,
+	},
+
+	{
+		description: "active InnoDB transactions",
+		query: `select
+	trx_id,
+	trx_state,
+	trx_started,
+	trx_wait_started,
+	trx_mysql_thread_id,
+	trx_query
+from information_schema.innodb_trx
+order by trx_started
+limit 50`,
+	},
+
+	{
+		description: "current InnoDB row lock waits",
+		query: `select
+	waiting_trx.trx_mysql_thread_id as waiting_thread_id,
+	waiting_trx.trx_started as waiting_trx_started,
+	waiting_trx.trx_query as waiting_query,
+	blocking_trx.trx_mysql_thread_id as blocking_thread_id,
+	blocking_trx.trx_started as blocking_trx_started,
+	blocking_trx.trx_query as blocking_query
+from performance_schema.data_lock_waits lock_waits
+join information_schema.innodb_trx waiting_trx
+	on waiting_trx.trx_id = lock_waits.requesting_engine_transaction_id
+join information_schema.innodb_trx blocking_trx
+	on blocking_trx.trx_id = lock_waits.blocking_engine_transaction_id
+limit 50`,
+	},
+
+	{
+		description: "pending MySQL metadata locks",
+		query: `select
+	locks.object_type,
+	locks.object_schema,
+	locks.object_name,
+	locks.lock_type,
+	locks.lock_duration,
+	locks.lock_status,
+	threads.processlist_id,
+	threads.processlist_user,
+	threads.processlist_host,
+	threads.processlist_db,
+	threads.processlist_command,
+	threads.processlist_time,
+	threads.processlist_state,
+	threads.processlist_info
+from performance_schema.metadata_locks locks
+left join performance_schema.threads threads
+	on locks.owner_thread_id = threads.thread_id
+where locks.lock_status = 'PENDING'
+order by threads.processlist_time desc
+limit 50`,
+	},
+}
+
+// logMySQLDiagnostics logs useful MySQL diagnostics to help debug notable MySQL events.
+func (tm *TabletManager) logMySQLDiagnostics(ctx context.Context) {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), mysqlDiagnosticsTimeout)
+	defer cancel()
+
+	var parser *sqlparser.Parser
+	if tm.Env != nil {
+		parser = tm.Env.Parser()
+	}
+
+	for _, diagnosticQuery := range diagnosticQueries {
+		log.Info(
+			"collecting DemotePrimary MySQL diagnostic query",
+			slog.String("description", diagnosticQuery.description),
+			slog.String("query", diagnosticQuery.query),
+		)
+
+		result, err := tm.MysqlDaemon.FetchSuperQuery(ctx, diagnosticQuery.query)
+		if err != nil {
+			log.Warn(
+				"failed to collect DemotePrimary MySQL diagnostic query",
+				slog.String("description", diagnosticQuery.description),
+				slog.Any("error", err),
+			)
+
+			continue
+		}
+
+		rowCount := len(result.Rows)
+		if rowCount == 0 {
+			log.Info(
+				diagnosticQuery.description,
+				slog.String("description", diagnosticQuery.description),
+				slog.Int("row_count", rowCount),
+			)
+
+			continue
+		}
+
+		columnNames := make([]string, 0, len(result.Fields))
+		for fieldIndex, field := range result.Fields {
+			columnName := field.Name
+			if columnName == "" {
+				columnName = fmt.Sprintf("column_%d", fieldIndex)
+			}
+
+			columnNames = append(columnNames, columnName)
+		}
+
+		for rowIndex, row := range result.Rows {
+			diagnosticRow := make(map[string]string, len(row))
+			for valueIndex, value := range row {
+				columnName := fmt.Sprintf("column_%d", valueIndex)
+				if valueIndex < len(columnNames) {
+					columnName = columnNames[valueIndex]
+				}
+
+				diagnosticRow[columnName] = redactIfNecessary(parser, columnName, value.ToString())
+			}
+
+			log.Info(
+				diagnosticQuery.description,
+				slog.String("description", diagnosticQuery.description),
+				slog.Any("row", diagnosticRow),
+				slog.Int("row_index", rowIndex),
+				slog.Int("row_count", rowCount),
+			)
+		}
+	}
+}
+
+// redactIfNecessary redacts a column's value if it may contain client SQL.
+func redactIfNecessary(parser *sqlparser.Parser, columnName, value string) string {
+	if !isRedactableColumn(columnName) {
+		return value
+	}
+
+	return redactQueryText(parser, value)
+}
+
+// isRedactableColumn returns true if the column may contain client SQL.
+func isRedactableColumn(columnName string) bool {
+	for queryTextColumnName := range redactableColumns {
+		if strings.EqualFold(columnName, queryTextColumnName) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// redactQueryText removes literals from the query text.
+func redactQueryText(parser *sqlparser.Parser, queryText string) string {
+	if strings.TrimSpace(queryText) == "" || parser == nil {
+		return defaultRedactedText
+	}
+
+	redactedQueryText, err := parser.RedactSQLQuery(queryText)
+	if err != nil {
+		return defaultRedactedText
+	}
+
+	return redactedQueryText
+}

--- a/go/vt/vttablet/tabletmanager/diagnostics.go
+++ b/go/vt/vttablet/tabletmanager/diagnostics.go
@@ -183,6 +183,7 @@ func (tm *TabletManager) logMySQLDiagnostics(ctx context.Context) {
 			continue
 		}
 
+		// Collect the column names.
 		columnNames := make([]string, 0, len(result.Fields))
 		for fieldIndex, field := range result.Fields {
 			columnName := field.Name
@@ -193,6 +194,7 @@ func (tm *TabletManager) logMySQLDiagnostics(ctx context.Context) {
 			columnNames = append(columnNames, columnName)
 		}
 
+		// Log a line for each row returned by the query.
 		for rowIndex, row := range result.Rows {
 			diagnosticRow := make(map[string]string, len(row))
 			for valueIndex, value := range row {

--- a/go/vt/vttablet/tabletmanager/diagnostics.go
+++ b/go/vt/vttablet/tabletmanager/diagnostics.go
@@ -37,12 +37,12 @@ const (
 )
 
 // redactableColumns is the set of columns that may contain client SQL and should be redacted.
-var redactableColumns = map[string]struct{}{
-	"blocking_query":   {},
-	"info":             {},
-	"processlist_info": {},
-	"trx_query":        {},
-	"waiting_query":    {},
+var redactableColumns = []string{
+	"blocking_query",
+	"info",
+	"processlist_info",
+	"trx_query",
+	"waiting_query",
 }
 
 // diagnosticQuery describes a query to run that collects useful data about the current state of MySQL,
@@ -231,7 +231,7 @@ func redactIfNecessary(parser *sqlparser.Parser, columnName, value string) strin
 
 // isRedactableColumn returns true if the column may contain client SQL.
 func isRedactableColumn(columnName string) bool {
-	for queryTextColumnName := range redactableColumns {
+	for _, queryTextColumnName := range redactableColumns {
 		if strings.EqualFold(columnName, queryTextColumnName) {
 			return true
 		}

--- a/go/vt/vttablet/tabletmanager/diagnostics.go
+++ b/go/vt/vttablet/tabletmanager/diagnostics.go
@@ -73,14 +73,12 @@ where command != 'Sleep' or info is not null
 order by time desc
 limit 50`,
 	},
-
 	{
 		description: "current MySQL read-only settings",
 		query: `select
 	@@global.read_only as read_only,
 	@@global.super_read_only as super_read_only`,
 	},
-
 	{
 		description: "current MySQL semi-sync counters",
 		query: `select
@@ -91,7 +89,6 @@ where variable_name like 'Rpl_semi_sync_source_%'
 	or variable_name like 'Rpl_semi_sync_master_%'
 order by variable_name`,
 	},
-
 	{
 		description: "active InnoDB transactions",
 		query: `select
@@ -105,7 +102,6 @@ from information_schema.innodb_trx
 order by trx_started
 limit 50`,
 	},
-
 	{
 		description: "current InnoDB row lock waits",
 		query: `select
@@ -122,7 +118,6 @@ join information_schema.innodb_trx blocking_trx
 	on blocking_trx.trx_id = lock_waits.blocking_engine_transaction_id
 limit 50`,
 	},
-
 	{
 		description: "pending MySQL metadata locks",
 		query: `select

--- a/go/vt/vttablet/tabletmanager/diagnostics_test.go
+++ b/go/vt/vttablet/tabletmanager/diagnostics_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletmanager
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/mysqlctl"
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+)
+
+// deadlineContext is a manually expired context that reports deadline exceeded.
+type deadlineContext struct {
+	// Context provides parent values and cancellation.
+	context.Context
+
+	// done is closed when the test deadline expires.
+	done chan struct{}
+
+	// once ensures the deadline is expired at most once.
+	once sync.Once
+}
+
+// newDeadlineContext returns a manually expired deadline context.
+func newDeadlineContext(parent context.Context) *deadlineContext {
+	return &deadlineContext{
+		Context: parent,
+		done:    make(chan struct{}),
+	}
+}
+
+// Done returns a channel that closes when expire is called.
+func (c *deadlineContext) Done() <-chan struct{} {
+	return c.done
+}
+
+// Err reports deadline exceeded after expire is called.
+func (c *deadlineContext) Err() error {
+	select {
+	case <-c.done:
+		return context.DeadlineExceeded
+	default:
+		return c.Context.Err()
+	}
+}
+
+// expire marks the context as past its deadline.
+func (c *deadlineContext) expire() {
+	c.once.Do(func() {
+		close(c.done)
+	})
+}
+
+// TestDemotePrimaryDumpsMysqlDiagnosticsWhenSetSuperReadOnlyTimesOut verifies
+// that a timed out super_read_only step collects MySQL diagnostics.
+func TestDemotePrimaryDumpsMysqlDiagnosticsWhenSetSuperReadOnlyTimesOut(t *testing.T) {
+	baseCtx := t.Context()
+	ctx := newDeadlineContext(baseCtx)
+	ts := memorytopo.NewServer(baseCtx, "cell1")
+	tm := newTestTM(t, ts, 1, "ks", "0", nil)
+
+	fakeMysqlDaemon := tm.MysqlDaemon.(*mysqlctl.FakeMysqlDaemon)
+	var gotQueries []string
+	var gotQueriesMu sync.Mutex
+
+	fakeMysqlDaemon.FetchSuperQueryCallback = func(query string) (*sqltypes.Result, error) {
+		gotQueriesMu.Lock()
+		defer gotQueriesMu.Unlock()
+
+		gotQueries = append(gotQueries, query)
+
+		return sqltypes.MakeTestResult(
+			sqltypes.MakeTestFields("value", "varchar"),
+			"ok",
+		), nil
+	}
+
+	fakeMysqlDaemon.SetSuperReadOnlyFunc = func(ctx context.Context, on bool) (mysqlctl.ResetSuperReadOnlyFunc, error) {
+		ctx.(*deadlineContext).expire()
+
+		require.Eventually(t, func() bool {
+			gotQueriesMu.Lock()
+			defer gotQueriesMu.Unlock()
+
+			return len(gotQueries) == len(diagnosticQueries)
+		}, 30*time.Second, 10*time.Millisecond)
+
+		return nil, ctx.Err()
+	}
+
+	_, err := tm.demotePrimary(ctx, false /* revertPartialFailure */, false /* force */)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	gotQueriesMu.Lock()
+	defer gotQueriesMu.Unlock()
+
+	assert.Len(t, gotQueries, len(diagnosticQueries))
+}
+
+// TestDemotePrimaryDoesNotDumpMysqlDiagnosticsWhenSetSuperReadOnlyFailsWithoutTimeout
+// verifies that non-timeout failures do not trigger extra MySQL queries.
+func TestDemotePrimaryDoesNotDumpMysqlDiagnosticsWhenSetSuperReadOnlyFailsWithoutTimeout(t *testing.T) {
+	ctx := t.Context()
+	ts := memorytopo.NewServer(ctx, "cell1")
+	tm := newTestTM(t, ts, 1, "ks", "0", nil)
+
+	fakeMysqlDaemon := tm.MysqlDaemon.(*mysqlctl.FakeMysqlDaemon)
+	fakeMysqlDaemon.SetSuperReadOnlyError = errors.New("access denied")
+
+	var gotQueries []string
+	fakeMysqlDaemon.FetchSuperQueryCallback = func(query string) (*sqltypes.Result, error) {
+		gotQueries = append(gotQueries, query)
+
+		return sqltypes.MakeTestResult(sqltypes.MakeTestFields("value", "varchar"), "ok"), nil
+	}
+
+	_, err := tm.demotePrimary(ctx, false /* revertPartialFailure */, false /* force */)
+	require.ErrorContains(t, err, "access denied")
+
+	assert.Empty(t, gotQueries)
+}

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -716,10 +716,10 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 	// If setting super_read_only stalls and leads to a context cancellation, log useful MySQL diagnostics
 	// to aid in debugging why it may have taken so long.
 	//
-	// Note that this runs on both context.DeadlineExceeded and context.Canceled. The reason for this is that
-	// a client-side timeout can manifest as a server-side context.Canceled, we need to account for both. This
-	// has the unfortunate consequence that we will dump diagnostics on normal cancelations as well. The window
-	// is small though, as the cancelation would need to occur exactly during this call.
+	// Note that this runs on both context.DeadlineExceeded and context.Canceled. The reason for this is that a
+	// client-side timeout can manifest as a server-side context.Canceled, so we need to account for both. This
+	// has the unfortunate consequence that we will dump diagnostics on normal cancellations as well. The window
+	// is small though, as the cancellation would need to occur exactly during this call.
 	stop := context.AfterFunc(ctx, func() {
 		log.Error(
 			"timed out or canceled while enabling super_read_only during DemotePrimary, dumping MySQL diagnostics",

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -712,7 +712,29 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 	// previous demotion, or because we are not primary anyway, this should be
 	// idempotent.
 	log.Info("enabling super_read_only")
-	if _, err := tm.MysqlDaemon.SetSuperReadOnly(ctx, true); err != nil {
+
+	// If the context times out while enabling super_read_only, we want to print a variety of MySQL
+	// diagnostics to help us debug why it may have stalled.
+	stop := context.AfterFunc(ctx, func() {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			log.Error(
+				"timed out enabling super_read_only during DemotePrimary, dumping MySQL diagnostics",
+				slog.Any("error", ctx.Err()),
+			)
+
+			tm.logMySQLDiagnostics(ctx)
+		}
+	})
+
+	_, err = tm.MysqlDaemon.SetSuperReadOnly(ctx, true)
+
+	// If setting super_read_only succeeded, or it errored but it was not due to reaching the context
+	// deadline, prevent the above diagnostics AfterFunc from running.
+	if err == nil || !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		stop()
+	}
+
+	if err != nil {
 		if sqlErr, ok := errors.AsType[*sqlerror.SQLError](err); ok && sqlErr.Number() == sqlerror.ERUnknownSystemVariable {
 			log.Warn("server does not know about super_read_only, continuing anyway...")
 		} else {

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -713,24 +713,28 @@ func (tm *TabletManager) demotePrimary(ctx context.Context, revertPartialFailure
 	// idempotent.
 	log.Info("enabling super_read_only")
 
-	// If the context times out while enabling super_read_only, we want to print a variety of MySQL
-	// diagnostics to help us debug why it may have stalled.
+	// If setting super_read_only stalls and leads to a context cancellation, log useful MySQL diagnostics
+	// to aid in debugging why it may have taken so long.
+	//
+	// Note that this runs on both context.DeadlineExceeded and context.Canceled. The reason for this is that
+	// a client-side timeout can manifest as a server-side context.Canceled, we need to account for both. This
+	// has the unfortunate consequence that we will dump diagnostics on normal cancelations as well. The window
+	// is small though, as the cancelation would need to occur exactly during this call.
 	stop := context.AfterFunc(ctx, func() {
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			log.Error(
-				"timed out enabling super_read_only during DemotePrimary, dumping MySQL diagnostics",
-				slog.Any("error", ctx.Err()),
-			)
+		log.Error(
+			"timed out or canceled while enabling super_read_only during DemotePrimary, dumping MySQL diagnostics",
+			slog.Any("error", ctx.Err()),
+		)
 
-			tm.logMySQLDiagnostics(ctx)
-		}
+		tm.logMySQLDiagnostics(ctx)
 	})
 
 	_, err = tm.MysqlDaemon.SetSuperReadOnly(ctx, true)
 
-	// If setting super_read_only succeeded, or it errored but it was not due to reaching the context
-	// deadline, prevent the above diagnostics AfterFunc from running.
-	if err == nil || !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+	// If setting super_read_only was successful, or it errored due to an error unrelated to context
+	// cancellation/deadline, prevent the above diagnostics AfterFunc from running due to a future,
+	// unrelated context cancellation/deadline.
+	if err == nil || ctx.Err() == nil {
 		stop()
 	}
 


### PR DESCRIPTION



<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
When setting `super_read_only` during `DemotePrimary`, it can often time out, and it is not easy to debug why after the fact. This change dumps a number of useful MySQL diagnostics when this call times out to aid operators in understanding the conditions that might've caused the stall.

These logs can be expectedly noisy. For example:

```
2026-05-19 15:55:54.900 UTC INF tabletmanager/rpc_replication.go:553 demoting primary force=false
2026-05-19 15:55:54.902 UTC INF tabletmanager/rpc_replication.go:714 enabling super_read_only
2026-05-19 15:56:09.899 UTC ERR tabletmanager/rpc_replication.go:724 timed out or canceled while enabling super_read_only during DemotePrimary, dumping MySQL diagnostics error="context canceled"
2026-05-19 15:56:09.899 UTC INF tabletmanager/diagnostics.go:158 collecting DemotePrimary MySQL diagnostic query description="active MySQL sessions" query="select\n\tid,\n\tuser,\n\thost,\n\tdb,\n\tcommand,\n\ttime,\n\tstate,\n\tinfo\nfrom information_schema.processlist\nwhere command != 'Sleep' or info is not null\norder by time desc\nlimit 50"
2026-05-19 15:56:09.900 UTC ERR mysqlctl/query.go:94 ExecuteFetch(SET GLOBAL super_read_only = 'ON') failed: context canceled
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 active MySQL sessions description="active MySQL sessions" row="map[command:Daemon db: host:localhost id:5 info:[REDACTED] state:Waiting on empty queue time:51 user:event_scheduler]" row_index=0 row_count=6
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 active MySQL sessions description="active MySQL sessions" row="map[command:Binlog Dump GTID db: host:192.168.107.8:54654 id:36 info:[REDACTED] state:Source has sent all binlog to replica; waiting for more updates time:45 user:vt_repl]" row_index=1 row_count=6
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 active MySQL sessions description="active MySQL sessions" row="map[command:Query db: host:localhost id:51 info:select sleep(:redacted1 /* INT64 */) from dual state:User sleep time:21 user:root]" row_index=2 row_count=6
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 active MySQL sessions description="active MySQL sessions" row="map[command:Binlog Dump GTID db: host:192.168.107.9:57644 id:53 info:[REDACTED] state:Source has sent all binlog to replica; waiting for more updates time:15 user:vt_repl]" row_index=3 row_count=6
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 active MySQL sessions description="active MySQL sessions" row="map[command:Connect db: host:localhost id:56 info:[REDACTED] state:Receiving from client time:0 user:unauthenticated user]" row_index=4 row_count=6
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 active MySQL sessions description="active MySQL sessions" row="map[command:Query db: host:localhost id:55 info:select id, `user`, host, db, command, `time`, state, info from information_schema.`processlist` where command != :command /* VARCHAR */ or info is not null order by `time` desc limit :redacted1 /* INT64 */ state:executing time:0 user:vt_dba]" row_index=5 row_count=6
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:158 collecting DemotePrimary MySQL diagnostic query description="current MySQL read-only settings" query="select\n\t@@global.read_only as read_only,\n\t@@global.super_read_only as super_read_only"
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 current MySQL read-only settings description="current MySQL read-only settings" row="map[read_only:0 super_read_only:0]" row_index=0 row_count=1
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:158 collecting DemotePrimary MySQL diagnostic query description="current MySQL semi-sync counters" query="select\n\tvariable_name,\n\tvariable_value\nfrom performance_schema.global_status\nwhere variable_name like 'Rpl_semi_sync_source_%'\n\tor variable_name like 'Rpl_semi_sync_master_%'\norder by variable_name"
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 current MySQL semi-sync counters description="current MySQL semi-sync counters" row="map[variable_name:Rpl_semi_sync_source_clients variable_value:1]" row_index=0 row_count=14
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 current MySQL semi-sync counters description="current MySQL semi-sync counters" row="map[variable_name:Rpl_semi_sync_source_net_avg_wait_time variable_value:0]" row_index=1 row_count=14
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 current MySQL semi-sync counters description="current MySQL semi-sync counters" row="map[variable_name:Rpl_semi_sync_source_net_wait_time variable_value:0]" row_index=2 row_count=14
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 current MySQL semi-sync counters description="current MySQL semi-sync counters" row="map[variable_name:Rpl_semi_sync_source_net_waits variable_value:11]" row_index=3 row_count=14
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 current MySQL semi-sync counters description="current MySQL semi-sync counters" row="map[variable_name:Rpl_semi_sync_source_no_times variable_value:0]" row_index=4 row_count=14
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 current MySQL semi-sync counters description="current MySQL semi-sync counters" row="map[variable_name:Rpl_semi_sync_source_no_tx variable_value:0]" row_index=5 row_count=14
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 current MySQL semi-sync counters description="current MySQL semi-sync counters" row="map[variable_name:Rpl_semi_sync_source_status variable_value:ON]" row_index=6 row_count=14
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 current MySQL semi-sync counters description="current MySQL semi-sync counters" row="map[variable_name:Rpl_semi_sync_source_timefunc_failures variable_value:0]" row_index=7 row_count=14
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 current MySQL semi-sync counters description="current MySQL semi-sync counters" row="map[variable_name:Rpl_semi_sync_source_tx_avg_wait_time variable_value:3463]" row_index=8 row_count=14
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 current MySQL semi-sync counters description="current MySQL semi-sync counters" row="map[variable_name:Rpl_semi_sync_source_tx_wait_time variable_value:38103]" row_index=9 row_count=14
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 current MySQL semi-sync counters description="current MySQL semi-sync counters" row="map[variable_name:Rpl_semi_sync_source_tx_waits variable_value:11]" row_index=10 row_count=14
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 current MySQL semi-sync counters description="current MySQL semi-sync counters" row="map[variable_name:Rpl_semi_sync_source_wait_pos_backtraverse variable_value:0]" row_index=11 row_count=14
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 current MySQL semi-sync counters description="current MySQL semi-sync counters" row="map[variable_name:Rpl_semi_sync_source_wait_sessions variable_value:0]" row_index=12 row_count=14
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:209 current MySQL semi-sync counters description="current MySQL semi-sync counters" row="map[variable_name:Rpl_semi_sync_source_yes_tx variable_value:11]" row_index=13 row_count=14
2026-05-19 15:56:09.901 UTC INF tabletmanager/diagnostics.go:158 collecting DemotePrimary MySQL diagnostic query description="active InnoDB transactions" query="select\n\ttrx_id,\n\ttrx_state,\n\ttrx_started,\n\ttrx_wait_started,\n\ttrx_mysql_thread_id,\n\ttrx_query\nfrom information_schema.innodb_trx\norder by trx_started\nlimit 50"
2026-05-19 15:56:09.902 UTC INF tabletmanager/diagnostics.go:209 active InnoDB transactions description="active InnoDB transactions" row="map[trx_id:562948191114832 trx_mysql_thread_id:57 trx_query:show create table _vt.semisync_heartbeat trx_started:2026-05-19 15:56:09 trx_state:RUNNING trx_wait_started:]" row_index=0 row_count=1
2026-05-19 15:56:09.902 UTC INF tabletmanager/diagnostics.go:158 collecting DemotePrimary MySQL diagnostic query description="current InnoDB row lock waits" query="select\n\twaiting_trx.trx_mysql_thread_id as waiting_thread_id,\n\twaiting_trx.trx_started as waiting_trx_started,\n\twaiting_trx.trx_query as waiting_query,\n\tblocking_trx.trx_mysql_thread_id as blocking_thread_id,\n\tblocking_trx.trx_started as blocking_trx_started,\n\tblocking_trx.trx_query as blocking_query\nfrom performance_schema.data_lock_waits lock_waits\njoin information_schema.innodb_trx waiting_trx\n\ton waiting_trx.trx_id = lock_waits.requesting_engine_transaction_id\njoin information_schema.innodb_trx blocking_trx\n\ton blocking_trx.trx_id = lock_waits.blocking_engine_transaction_id\nlimit 50"
2026-05-19 15:56:09.902 UTC INF tabletmanager/diagnostics.go:177 current InnoDB row lock waits description="current InnoDB row lock waits" row_count=0
2026-05-19 15:56:09.902 UTC INF tabletmanager/diagnostics.go:158 collecting DemotePrimary MySQL diagnostic query description="pending MySQL metadata locks" query="select\n\tlocks.object_type,\n\tlocks.object_schema,\n\tlocks.object_name,\n\tlocks.lock_type,\n\tlocks.lock_duration,\n\tlocks.lock_status,\n\tthreads.processlist_id,\n\tthreads.processlist_user,\n\tthreads.processlist_host,\n\tthreads.processlist_db,\n\tthreads.processlist_command,\n\tthreads.processlist_time,\n\tthreads.processlist_state,\n\tthreads.processlist_info\nfrom performance_schema.metadata_locks locks\nleft join performance_schema.threads threads\n\ton locks.owner_thread_id = threads.thread_id\nwhere locks.lock_status = 'PENDING'\norder by threads.processlist_time desc\nlimit 50"
2026-05-19 15:56:09.903 UTC INF tabletmanager/diagnostics.go:177 pending MySQL metadata locks description="pending MySQL metadata locks" row_count=0
2026-05-19 15:56:09.907 UTC WRN tabletmanager/rpc_server.go:79 TabletManager.DemotePrimary()(on zone1-0000000100 from ) error: ExecuteFetch(SET GLOBAL super_read_only = 'ON') failed: context canceled
```

It's hard to know what is useful beforehand, and these only happen in a small set of failure cases, so I've chosen to collect as much information as is reasonable. We can reduce it as it gains usage in production and we better gauge what is useful and what isn't.
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Closes https://github.com/vitessio/vitess/issues/20130

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->

Help from GPT 5.5
