### PR TITLE
smartconnpool: bulk sweep idle stacks

### DIFF
--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -813,8 +813,8 @@ func (pool *ConnPool[C]) closeIdleResources(now time.Time) {
 			return
 		}
 
-		// First, we reverse the popped off connections, so when we push connections back to the stack,
-		// we can go from oldest to newest.
+		// The stack is LIFO. Reverse the detached list so we inspect and return
+		// connections from oldest to newest.
 		var stackConnections int64
 		var oldestFirst *Pooled[C]
 		for conn != nil {
@@ -825,6 +825,10 @@ func (pool *ConnPool[C]) closeIdleResources(now time.Time) {
 			conn = next
 		}
 
+		// Bound closes to the detached stack, not to the whole pool or just the
+		// expired cohort. This lets ordinary cleanup drain a small expired cohort
+		// while preventing the worker from closing and reopening an entire stack at
+		// once when all idle connections aged out together.
 		maxExpiredConnections := max(stackConnections/2, 1)
 		var expiredCount int64
 		var expiredConnections *Pooled[C]

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -851,17 +851,28 @@ func (pool *ConnPool[C]) closeIdleResources(now time.Time) {
 
 		for conn := expiredConnections; conn != nil; {
 			next := conn.next.Load()
-			if pool.active.Load() >= pool.capacity.Load() {
+			if pool.close.Load() == nil || pool.active.Load() >= pool.capacity.Load() {
 				break
 			}
 
 			conn.next.Store(nil)
 			if err := pool.connReopen(context.Background(), conn, mono); err != nil {
+				if pool.close.Load() == nil || pool.capacity.Load() == 0 {
+					break
+				}
 				conn = next
 				continue
 			}
+			if pool.close.Load() == nil || pool.capacity.Load() == 0 {
+				conn.Close()
+				break
+			}
 
 			for {
+				if pool.close.Load() == nil {
+					conn.Close()
+					break
+				}
 				open := pool.active.Load()
 				if open >= pool.capacity.Load() {
 					conn.Close()

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -849,30 +849,26 @@ func (pool *ConnPool[C]) closeIdleResources(now time.Time) {
 			pool.closedConn()
 		}
 
+		poolClosed := func() bool {
+			return pool.close.Load() == nil || pool.capacity.Load() == 0
+		}
 		for conn := expiredConnections; conn != nil; {
 			next := conn.next.Load()
-			if pool.close.Load() == nil || pool.active.Load() >= pool.capacity.Load() {
+			if poolClosed() || pool.active.Load() >= pool.capacity.Load() {
 				break
 			}
 
 			conn.next.Store(nil)
 			if err := pool.connReopen(context.Background(), conn, mono); err != nil {
-				if pool.close.Load() == nil || pool.capacity.Load() == 0 {
-					break
-				}
 				conn = next
 				continue
 			}
-			if pool.close.Load() == nil || pool.capacity.Load() == 0 {
+			if poolClosed() {
 				conn.Close()
 				break
 			}
 
 			for {
-				if pool.close.Load() == nil {
-					conn.Close()
-					break
-				}
 				open := pool.active.Load()
 				if open >= pool.capacity.Load() {
 					conn.Close()

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -813,6 +813,8 @@ func (pool *ConnPool[C]) closeIdleResources(now time.Time) {
 			return
 		}
 
+		// First, we reverse the popped off connections, so when we push connections back to the stack,
+		// we can go from oldest to newest.
 		var stackConnections int64
 		var oldestFirst *Pooled[C]
 		for conn != nil {
@@ -849,12 +851,9 @@ func (pool *ConnPool[C]) closeIdleResources(now time.Time) {
 			pool.closedConn()
 		}
 
-		poolClosed := func() bool {
-			return pool.close.Load() == nil || pool.capacity.Load() == 0
-		}
 		for conn := expiredConnections; conn != nil; {
 			next := conn.next.Load()
-			if poolClosed() || pool.active.Load() >= pool.capacity.Load() {
+			if pool.close.Load() == nil || pool.active.Load() >= pool.capacity.Load() {
 				break
 			}
 
@@ -863,14 +862,10 @@ func (pool *ConnPool[C]) closeIdleResources(now time.Time) {
 				conn = next
 				continue
 			}
-			if poolClosed() {
-				conn.Close()
-				break
-			}
 
 			for {
 				open := pool.active.Load()
-				if open >= pool.capacity.Load() {
+				if pool.close.Load() == nil || open >= pool.capacity.Load() {
 					conn.Close()
 					break
 				}

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -814,14 +814,19 @@ func (pool *ConnPool[C]) closeIdleResources(now time.Time) {
 		}
 
 		var stackConnections int64
-		for stackConn := conn; stackConn != nil; stackConn = stackConn.next.Load() {
+		var oldestFirst *Pooled[C]
+		for conn != nil {
+			next := conn.next.Load()
+			conn.next.Store(oldestFirst)
+			oldestFirst = conn
 			stackConnections++
+			conn = next
 		}
 
 		maxExpiredConnections := max(stackConnections/2, 1)
 		var expiredCount int64
 		var expiredConnections *Pooled[C]
-		for conn != nil {
+		for conn := oldestFirst; conn != nil; {
 			next := conn.next.Load()
 			conn.next.Store(nil)
 

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -435,31 +435,33 @@ func (pool *ConnPool[C]) put(conn *Pooled[C]) {
 			return
 		}
 	} else {
-		conn.timeUsed.update()
-
+		now := monotonicNow()
 		lifetime := pool.extendedMaxLifetime()
-		if lifetime > 0 && conn.timeCreated.elapsed() > lifetime {
+		if lifetime > 0 && now-conn.timeCreated.get() > lifetime {
 			pool.Metrics.maxLifetimeClosed.Add(1)
 			conn.Close()
 			// Using context.Background() is fine since MySQL connection already enforces
 			// a connect timeout via the `db-connect-timeout-ms` config param.
-			if err := pool.connReopen(context.Background(), conn, conn.timeUsed.get()); err != nil {
+			if err := pool.connReopen(context.Background(), conn, now); err != nil {
 				pool.closedConn()
 				return
 			}
 		}
 	}
 
-	pool.tryReturnConn(conn)
+	pool.tryReturnConn(conn, true)
 }
 
-func (pool *ConnPool[C]) tryReturnConn(conn *Pooled[C]) bool {
+func (pool *ConnPool[C]) tryReturnConn(conn *Pooled[C], updateIdleTime bool) bool {
 	if pool.wait.tryReturnConn(conn) {
 		return true
 	}
 
 	if pool.closeOnIdleLimitReached(conn) {
 		return false
+	}
+	if updateIdleTime {
+		conn.timeUsed.update()
 	}
 	connSetting := conn.Conn.Setting()
 	if connSetting == nil {
@@ -494,13 +496,11 @@ func (pool *ConnPool[C]) pop(stack *connStack[C]) *Pooled[C] {
 
 func (pool *ConnPool[C]) tryReturnAnyConn() bool {
 	if conn := pool.pop(&pool.clean); conn != nil {
-		conn.timeUsed.update()
-		return pool.tryReturnConn(conn)
+		return pool.tryReturnConn(conn, true)
 	}
 	for u := 0; u <= stackMask; u++ {
 		if conn := pool.pop(&pool.settings[u]); conn != nil {
-			conn.timeUsed.update()
-			return pool.tryReturnConn(conn)
+			return pool.tryReturnConn(conn, true)
 		}
 	}
 	return false
@@ -808,75 +808,43 @@ func (pool *ConnPool[C]) closeIdleResources(now time.Time) {
 	mono := monotonicFromTime(now)
 
 	closeInStack := func(s *connStack[C]) {
-		conn, ok := s.Pop()
+		conn, ok := s.PopAll()
 		if !ok {
-			// Early return to skip allocating slices when the stack is empty
 			return
 		}
 
-		activeConnections := pool.Active()
+		var expiredConnections *Pooled[C]
+		for conn != nil {
+			next := conn.next.Load()
+			conn.next.Store(nil)
 
-		// Only expire up to ~half of the active connections at a time. This should
-		// prevent us from closing too many connections in one go which could lead to
-		// a lot of `.Get` calls being added to the waitlist if there's a sudden spike
-		// coming in _after_ connections were popped off the stack but _before_ being
-		// returned back to the pool. This is unlikely to happen, but better safe than sorry.
-		//
-		// We always expire at least one connection per stack per iteration to ensure
-		// that idle connections are eventually closed even in small pools.
-		//
-		// We will expire any additional connections in the next iteration of the idle closer.
-		expiredConnections := make([]*Pooled[C], 0, max(activeConnections/2, 1))
-		validConnections := make([]*Pooled[C], 0, activeConnections)
-
-		// Pop out connections from the stack until we get a `nil` connection
-		for ok {
 			if conn.timeUsed.expired(mono, timeout) {
-				expiredConnections = append(expiredConnections, conn)
-
-				if len(expiredConnections) == cap(expiredConnections) {
-					// We have collected enough connections for this iteration to expire
-					break
-				}
-			} else {
-				validConnections = append(validConnections, conn)
+				conn.next.Store(expiredConnections)
+				expiredConnections = conn
+				conn = next
+				continue
 			}
 
-			conn, ok = s.Pop()
+			pool.tryReturnConn(conn, false)
+			conn = next
 		}
 
-		// Return all the valid connections back to waiters or the stack
-		//
-		// The order here is not important - because we can't guarantee to
-		// restore the order we got the connections out of the stack anyway.
-		//
-		// If we return the connections in the order popped off the stack:
-		//   * waiters will get the newest connection first
-		//   * stack will have the oldest connections at the top of the stack.
-		//
-		// If we return the connections in reverse order:
-		//  * waiters will get the oldest connection first
-		//  * stack will have the newest connections at the top of the stack.
-		//
-		// Neither of these is better or worse than the other.
-		for _, conn := range validConnections {
-			pool.tryReturnConn(conn)
-		}
-
-		// Close all the expired connections and open new ones to replace them
-		for _, conn := range expiredConnections {
+		for conn := expiredConnections; conn != nil; conn = conn.next.Load() {
 			pool.Metrics.idleClosed.Add(1)
 
 			conn.Close()
 			pool.closedConn()
 		}
 
-		for _, conn := range expiredConnections {
+		for conn := expiredConnections; conn != nil; {
+			next := conn.next.Load()
 			if pool.active.Load() >= pool.capacity.Load() {
 				break
 			}
 
+			conn.next.Store(nil)
 			if err := pool.connReopen(context.Background(), conn, mono); err != nil {
+				conn = next
 				continue
 			}
 
@@ -887,10 +855,11 @@ func (pool *ConnPool[C]) closeIdleResources(now time.Time) {
 					break
 				}
 				if pool.active.CompareAndSwap(open, open+1) {
-					pool.tryReturnConn(conn)
+					pool.tryReturnConn(conn, false)
 					break
 				}
 			}
+			conn = next
 		}
 	}
 

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -813,12 +813,20 @@ func (pool *ConnPool[C]) closeIdleResources(now time.Time) {
 			return
 		}
 
+		var stackConnections int64
+		for stackConn := conn; stackConn != nil; stackConn = stackConn.next.Load() {
+			stackConnections++
+		}
+
+		maxExpiredConnections := max(stackConnections/2, 1)
+		var expiredCount int64
 		var expiredConnections *Pooled[C]
 		for conn != nil {
 			next := conn.next.Load()
 			conn.next.Store(nil)
 
-			if conn.timeUsed.expired(mono, timeout) {
+			if expiredCount < maxExpiredConnections && conn.timeUsed.expired(mono, timeout) {
+				expiredCount++
 				conn.next.Store(expiredConnections)
 				expiredConnections = conn
 				conn = next

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -1693,6 +1693,103 @@ func channelClosed(ch <-chan struct{}) bool {
 	}
 }
 
+func TestIdleTimeoutStopsReopeningWhenPoolCloses(t *testing.T) {
+	var state TestState
+	var reconnectAttempts atomic.Int64
+	reconnectStarted := make(chan struct{})
+	releaseReconnect := make(chan struct{})
+	releaseReconnectOnce := sync.Once{}
+	release := func() {
+		releaseReconnectOnce.Do(func() {
+			close(releaseReconnect)
+		})
+	}
+	t.Cleanup(release)
+
+	p := NewPool(&Config[*TestConn]{
+		Capacity:    4,
+		IdleTimeout: time.Millisecond,
+		LogWait:     state.LogWait,
+	})
+	p.config.connect = func(ctx context.Context) (*TestConn, error) {
+		if reconnectAttempts.Add(1) == 1 {
+			close(reconnectStarted)
+			select {
+			case <-releaseReconnect:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+
+		state.open.Add(1)
+		return &TestConn{
+			num:    state.lastID.Add(1),
+			counts: &state,
+		}, nil
+	}
+
+	closeChan := make(chan struct{})
+	p.close.Store(&closeChan)
+	p.capacity.Store(4)
+	p.idleCount.Store(4)
+	p.active.Store(4)
+
+	now := monotonicNow()
+	for range 4 {
+		conn := &Pooled[*TestConn]{
+			pool: p,
+			Conn: &TestConn{
+				num:    state.lastID.Add(1),
+				counts: &state,
+			},
+		}
+		state.open.Add(1)
+		conn.timeCreated.set(now)
+		conn.timeUsed.set(now - 2*time.Millisecond)
+		p.clean.Push(conn)
+	}
+
+	cleanupDone := make(chan struct{})
+	go func() {
+		defer close(cleanupDone)
+		p.closeIdleResources(time.Now())
+	}()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-reconnectStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	closePtr := p.close.Swap(nil)
+	require.NotNil(t, closePtr)
+	close(*closePtr)
+	release()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-cleanupDone:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	assert.EqualValues(t, 1, reconnectAttempts.Load())
+	assert.EqualValues(t, 3, state.close.Load())
+
+	if conn, ok := p.clean.PopAll(); ok {
+		for conn != nil {
+			next := conn.next.Load()
+			conn.Close()
+			conn = next
+		}
+	}
+}
+
 func TestIdleTimeoutCloseInStackDoesNotAllocate(t *testing.T) {
 	var state TestState
 	const capacity = 1000

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"runtime"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1465,9 +1467,9 @@ func TestIdleTimeoutConnectionLeak(t *testing.T) {
 	// Wait for idle timeout to kick in and start expiring connections
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		// Check the actual number of currently open connections
-		assert.Equal(c, int64(2), state.open.Load())
+		assert.Equal(c, int64(1), state.open.Load())
 		// Check the total number of closed connections
-		assert.Equal(c, int64(1), state.close.Load())
+		assert.Equal(c, int64(2), state.close.Load())
 	}, 100*time.Millisecond, 10*time.Millisecond)
 
 	// Keep this test focused on the in-flight reopen above. Further idle
@@ -1627,6 +1629,68 @@ func TestIdleTimeoutReopenDoesNotBlockGetsDespiteAvailableCapacity(t *testing.T)
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestIdleTimeoutSweepsWholeStack(t *testing.T) {
+	var state TestState
+
+	ctx := t.Context()
+	p := NewPool(&Config[*TestConn]{
+		Capacity: 4,
+		LogWait:  state.LogWait,
+	}).Open(newConnector(&state), nil)
+	defer p.Close()
+
+	var conns []*Pooled[*TestConn]
+	for range 4 {
+		conn, err := p.Get(ctx, nil)
+		require.NoError(t, err)
+		conns = append(conns, conn)
+	}
+
+	p.SetIdleTimeout(time.Millisecond)
+	for _, conn := range conns {
+		p.put(conn)
+		conn.timeUsed.set(monotonicNow() - 2*time.Millisecond)
+	}
+
+	p.closeIdleResources(time.Now())
+
+	assert.EqualValues(t, 4, p.Metrics.IdleClosed())
+	assert.EqualValues(t, 4, state.close.Load())
+	assert.EqualValues(t, 4, p.Active())
+	assert.EqualValues(t, 4, p.Available())
+}
+
+func TestIdleTimeoutCloseInStackDoesNotAllocate(t *testing.T) {
+	var state TestState
+	const capacity = 1000
+
+	ctx := t.Context()
+	p := NewPool(&Config[*TestConn]{
+		Capacity:    capacity,
+		IdleTimeout: time.Hour,
+		LogWait:     state.LogWait,
+	}).Open(newConnector(&state), nil)
+	defer p.Close()
+
+	conns := make([]*Pooled[*TestConn], 0, capacity)
+	for range capacity {
+		conn, err := p.Get(ctx, nil)
+		require.NoError(t, err)
+		conns = append(conns, conn)
+	}
+
+	for _, conn := range conns {
+		p.put(conn)
+	}
+
+	now := time.Now()
+	allocs := testing.AllocsPerRun(100, func() {
+		p.closeIdleResources(now)
+	})
+
+	assert.Zero(t, allocs)
+}
+
 func TestIdleTimeoutDoesntLeaveLingeringConnection(t *testing.T) {
 	var state TestState
 
@@ -1704,4 +1768,97 @@ func BenchmarkPoolCleanupIdleConnectionsPerformanceNoIdleConnections(b *testing.
 	for b.Loop() {
 		p.closeIdleResources(time.Now())
 	}
+}
+
+func BenchmarkPoolCleanupIdleConnectionsPerformanceHighConcurrencyNoIdleConnections(b *testing.B) {
+	var state TestState
+
+	const capacity = 1000
+
+	p := NewPool(&Config[*TestConn]{
+		Capacity:    capacity,
+		IdleTimeout: 30 * time.Second,
+	}).Open(newConnector(&state), nil)
+	defer p.Close()
+
+	connections := make([]*Pooled[*TestConn], 0, capacity)
+	for range capacity {
+		conn, err := p.Get(b.Context(), nil)
+		require.NoError(b, err)
+		connections = append(connections, conn)
+	}
+
+	for _, conn := range connections {
+		conn.Recycle()
+	}
+
+	workerCount := runtime.GOMAXPROCS(0) * 8
+	latencies := make([][]int64, workerCount)
+	var stop atomic.Bool
+	var getErrors atomic.Int64
+	var sampleBudget atomic.Int64
+	var wg sync.WaitGroup
+	sampleBudget.Store(200_000)
+	samplesPerWorker := 200_000/workerCount + 1024
+
+	for i := range workerCount {
+		wg.Go(func() {
+			localLatencies := make([]int64, 0, samplesPerWorker)
+			for !stop.Load() {
+				start := time.Now()
+				conn, err := p.Get(b.Context(), nil)
+				elapsed := time.Since(start)
+				if err != nil {
+					getErrors.Add(1)
+					continue
+				}
+
+				if sampleBudget.Add(-1) >= 0 {
+					localLatencies = append(localLatencies, elapsed.Nanoseconds())
+				}
+				conn.Recycle()
+			}
+			latencies[i] = localLatencies
+		})
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	b.ResetTimer()
+	for b.Loop() {
+		p.closeIdleResources(time.Now())
+	}
+	b.StopTimer()
+
+	stop.Store(true)
+	wg.Wait()
+
+	require.Zero(b, getErrors.Load())
+	reportGetLatencyMetrics(b, latencies)
+}
+
+func reportGetLatencyMetrics(b *testing.B, latencies [][]int64) {
+	total := 0
+	for _, localLatencies := range latencies {
+		total += len(localLatencies)
+	}
+	if total == 0 {
+		return
+	}
+
+	merged := make([]int64, 0, total)
+	for _, localLatencies := range latencies {
+		merged = append(merged, localLatencies...)
+	}
+	slices.Sort(merged)
+
+	b.ReportMetric(float64(total), "get-ops")
+	b.ReportMetric(float64(merged[percentileIndex(total, 50)]), "get-p50-ns")
+	b.ReportMetric(float64(merged[percentileIndex(total, 95)]), "get-p95-ns")
+	b.ReportMetric(float64(merged[percentileIndex(total, 99)]), "get-p99-ns")
+	b.ReportMetric(float64(merged[total-1]), "get-max-ns")
+}
+
+func percentileIndex(total int, percentile int) int {
+	return ((total - 1) * percentile) / 100
 }

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -1663,6 +1663,8 @@ func TestIdleTimeoutBoundsExpiredSweep(t *testing.T) {
 		p.put(conn)
 		conn.timeUsed.set(monotonicNow() - 2*time.Millisecond)
 	}
+	oldestClosed := idleConns[0].Conn.waitForClose()
+	newestClosed := idleConns[1].Conn.waitForClose()
 
 	p.closeIdleResources(time.Now())
 
@@ -1670,6 +1672,8 @@ func TestIdleTimeoutBoundsExpiredSweep(t *testing.T) {
 	assert.EqualValues(t, 1, state.close.Load())
 	assert.EqualValues(t, 6, p.Active())
 	assert.EqualValues(t, 2, p.Available())
+	assert.True(t, channelClosed(oldestClosed))
+	assert.False(t, channelClosed(newestClosed))
 
 	p.closeIdleResources(time.Now())
 
@@ -1677,6 +1681,16 @@ func TestIdleTimeoutBoundsExpiredSweep(t *testing.T) {
 	assert.EqualValues(t, 2, state.close.Load())
 	assert.EqualValues(t, 6, p.Active())
 	assert.EqualValues(t, 2, p.Available())
+	assert.True(t, channelClosed(newestClosed))
+}
+
+func channelClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
 }
 
 func TestIdleTimeoutCloseInStackDoesNotAllocate(t *testing.T) {

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -1467,9 +1467,9 @@ func TestIdleTimeoutConnectionLeak(t *testing.T) {
 	// Wait for idle timeout to kick in and start expiring connections
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		// Check the actual number of currently open connections
-		assert.Equal(c, int64(1), state.open.Load())
+		assert.Equal(c, int64(2), state.open.Load())
 		// Check the total number of closed connections
-		assert.Equal(c, int64(2), state.close.Load())
+		assert.Equal(c, int64(1), state.close.Load())
 	}, 100*time.Millisecond, 10*time.Millisecond)
 
 	// Keep this test focused on the in-flight reopen above. Further idle
@@ -1629,35 +1629,54 @@ func TestIdleTimeoutReopenDoesNotBlockGetsDespiteAvailableCapacity(t *testing.T)
 	}, time.Second, 10*time.Millisecond)
 }
 
-func TestIdleTimeoutSweepsWholeStack(t *testing.T) {
+func TestIdleTimeoutBoundsExpiredSweep(t *testing.T) {
 	var state TestState
 
 	ctx := t.Context()
 	p := NewPool(&Config[*TestConn]{
-		Capacity: 4,
+		Capacity: 6,
 		LogWait:  state.LogWait,
 	}).Open(newConnector(&state), nil)
-	defer p.Close()
+	var borrowedConns []*Pooled[*TestConn]
+	defer func() {
+		for _, conn := range borrowedConns {
+			p.put(conn)
+		}
+		p.Close()
+	}()
 
-	var conns []*Pooled[*TestConn]
+	var idleConns []*Pooled[*TestConn]
+	for range 2 {
+		conn, err := p.Get(ctx, nil)
+		require.NoError(t, err)
+		idleConns = append(idleConns, conn)
+	}
+
 	for range 4 {
 		conn, err := p.Get(ctx, nil)
 		require.NoError(t, err)
-		conns = append(conns, conn)
+		borrowedConns = append(borrowedConns, conn)
 	}
 
 	p.SetIdleTimeout(time.Millisecond)
-	for _, conn := range conns {
+	for _, conn := range idleConns {
 		p.put(conn)
 		conn.timeUsed.set(monotonicNow() - 2*time.Millisecond)
 	}
 
 	p.closeIdleResources(time.Now())
 
-	assert.EqualValues(t, 4, p.Metrics.IdleClosed())
-	assert.EqualValues(t, 4, state.close.Load())
-	assert.EqualValues(t, 4, p.Active())
-	assert.EqualValues(t, 4, p.Available())
+	assert.EqualValues(t, 1, p.Metrics.IdleClosed())
+	assert.EqualValues(t, 1, state.close.Load())
+	assert.EqualValues(t, 6, p.Active())
+	assert.EqualValues(t, 2, p.Available())
+
+	p.closeIdleResources(time.Now())
+
+	assert.EqualValues(t, 2, p.Metrics.IdleClosed())
+	assert.EqualValues(t, 2, state.close.Load())
+	assert.EqualValues(t, 6, p.Active())
+	assert.EqualValues(t, 2, p.Available())
 }
 
 func TestIdleTimeoutCloseInStackDoesNotAllocate(t *testing.T) {

--- a/go/pools/smartconnpool/stack.go
+++ b/go/pools/smartconnpool/stack.go
@@ -58,6 +58,20 @@ func (s *connStack[C]) Pop() (*Pooled[C], bool) {
 	}
 }
 
+func (s *connStack[C]) PopAll() (*Pooled[C], bool) {
+	for {
+		oldHead, popCount := s.top.Load()
+		if oldHead == nil {
+			return nil, false
+		}
+
+		if s.top.CompareAndSwap(oldHead, popCount, nil, popCount+1) {
+			return oldHead, true
+		}
+		runtime.Gosched()
+	}
+}
+
 func (s *connStack[C]) Peek() *Pooled[C] {
 	top, _ := s.top.Load()
 	return top

--- a/go/pools/smartconnpool/stack_test.go
+++ b/go/pools/smartconnpool/stack_test.go
@@ -24,3 +24,22 @@ func TestStackPop(t *testing.T) {
 
 	assert.Nil(t, c.next.Load())
 }
+
+func TestStackPopAll(t *testing.T) {
+	s := &connStack[testPooled]{}
+
+	first := &Pooled[testPooled]{}
+	s.Push(first)
+
+	second := &Pooled[testPooled]{}
+	s.Push(second)
+
+	c, ok := s.PopAll()
+	assert.True(t, ok)
+	assert.Same(t, second, c)
+	assert.Same(t, first, c.next.Load())
+
+	c, ok = s.Pop()
+	assert.False(t, ok)
+	assert.Nil(t, c)
+}


### PR DESCRIPTION
## Description

This changes the smartconnpool idle cleanup worker to detach an idle stack in one CAS, walk the detached list allocation-free, return non-expired connections, and then close/reopen a bounded batch of expired connections.

The detached list is reversed locally before cleanup processing, so the worker spends its expired-close budget on the most idle entries first. Non-expired entries are pushed back in oldest-to-newest order, which leaves the newest kept connection at the top of the stack again. The close budget is based on the number of entries popped from that stack, not total pool `Active()`, so a small idle stack cannot be fully drained just because other stacks or borrowed connections make the pool active count large.

This narrows the window where cleanup makes idle connections unavailable and removes the per-sweep slice allocation. It does not fully eliminate the all-expired cold-spike risk, but it keeps the expired sweep bounded per stack and makes non-expired connections visible again before any close/reopen work happens.

One subtle part of this is the `put()` / `tryReturnConn()` timestamp handling. Real borrower returns still refresh `timeUsed` before a connection goes back to an idle stack. Cleaner reinsertion does not refresh `timeUsed`; otherwise every cleanup pass would make kept idle connections look newly used and could postpone their eventual idle expiry. The `tryReturnConn(conn, updateIdleTime)` flag keeps those two paths explicit.

Benchmark comparison against current main with the same benchmark code on linux/arm64:

```bash
go test ./go/pools/smartconnpool -run "^$" -bench "BenchmarkPoolCleanupIdleConnectionsPerformance.*NoIdleConnections$" -benchtime=1000x -benchmem -count=5
```

- no concurrency: 18.78us -> 12.18us (-35.2%), 12KiB / 2 allocs -> 0 B / 0 allocs
- high concurrency: 9.861ms -> 2.783ms (-71.8%), about 12.5KiB / 2 allocs -> about 484 B / 0 allocs
- sampled Get latency in the high-concurrency synthetic benchmark was noisy and effectively unchanged: p99 241.8us -> 250.4us, not statistically significant

The 12us no-concurrency number is for the no-expired sweep path, so it does not include connection close/reopen work. The interval where the detached stack has no entries available is shorter than that full cleanup call: it starts at `PopAll()` and ends as soon as the worker starts pushing kept connections back.

## Related Issue(s)

Follow-up to #20079 and the idle cleanup review discussion there.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

No operator action required. Idle cleanup remains bounded per stack, but now uses an allocation-free detached-stack sweep and closes the most idle expired entries first.

### AI Disclosure

This PR was written with Codex under my direction.
