### PR TITLE
etcd2topo: bound lock-acquisition cleanup RPCs

### DIFF
--- a/go/vt/topo/etcd2topo/lock.go
+++ b/go/vt/topo/etcd2topo/lock.go
@@ -69,8 +69,10 @@ func (s *Server) newUniqueEphemeralKV(ctx context.Context, cli *clientv3.Client,
 			// delete the node, so we don't leave an orphan
 			// node behind for *leaseTTL time.
 
-			if _, err := cli.Delete(context.Background(), newKey); err != nil {
-				log.Error(fmt.Sprintf("cli.Delete(context.Background(), newKey) failed :%v", err))
+			deleteCtx, deleteCancel := context.WithTimeout(context.WithoutCancel(ctx), topo.RemoteOperationTimeout)
+			defer deleteCancel()
+			if _, err := cli.Delete(deleteCtx, newKey); err != nil {
+				log.Error(fmt.Sprintf("cli.Delete(%v) failed: %v", newKey, err))
 			}
 		}
 		return "", 0, convertError(err, newKey)
@@ -223,9 +225,11 @@ func (s *Server) lock(ctx context.Context, nodePath, contents string, ttl int) (
 		if err != nil {
 			// We had an error waiting on the last node.
 			// Revoke our lease, this will delete the file.
-			if _, rerr := s.cli.Revoke(context.Background(), lease.ID); rerr != nil {
+			revokeCtx, revokeCancel := context.WithTimeout(context.WithoutCancel(ctx), topo.RemoteOperationTimeout)
+			if _, rerr := s.cli.Revoke(revokeCtx, lease.ID); rerr != nil {
 				log.Warn(fmt.Sprintf("Revoke(%d) failed, may have left %v behind: %v", lease.ID, key, rerr))
 			}
+			revokeCancel()
 			return nil, err
 		}
 		if done {

--- a/go/vt/vtctl/workflow/utils_test.go
+++ b/go/vt/vtctl/workflow/utils_test.go
@@ -195,21 +195,21 @@ func testConcurrentKeyspaceRoutingRulesUpdates(t *testing.T, ctx context.Context
 				case <-shortCtx.Done():
 					return
 				default:
-					update(t, ts, id)
+					update(t, shortCtx, ts, id)
 				}
 			}
 		}(i)
 	}
 	wg.Wait()
 	log.Info("All updates completed")
-	rules, err := ts.GetKeyspaceRoutingRules(ctx)
+	verifyCtx, verifyCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer verifyCancel()
+	rules, err := ts.GetKeyspaceRoutingRules(verifyCtx)
 	require.NoError(t, err)
 	require.LessOrEqual(t, concurrency, len(rules.Rules))
 }
 
-func update(t *testing.T, ts *topo.Server, id int) {
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
+func update(t *testing.T, ctx context.Context, ts *topo.Server, id int) {
 	s := fmt.Sprintf("%d_%d", id, rand.IntN(math.MaxInt))
 	routes := make(map[string]string)
 	for _, tabletType := range tabletTypeSuffixes {
@@ -217,8 +217,14 @@ func update(t *testing.T, ts *topo.Server, id int) {
 		routes[from] = s + tabletType
 	}
 	err := updateKeyspaceRoutingRules(ctx, ts, "test", routes)
+	if ctx.Err() != nil {
+		return
+	}
 	require.NoError(t, err)
 	got, err := topotools.GetKeyspaceRoutingRules(ctx, ts)
+	if ctx.Err() != nil {
+		return
+	}
 	require.NoError(t, err)
 	for _, tabletType := range tabletTypeSuffixes {
 		from := fmt.Sprintf("from%s%s", s, tabletType)


### PR DESCRIPTION
## Description

The failure paths in the etcd2topo lock implementation use `context.Background()` for their cleanup RPCs (the `Delete` in `newUniqueEphemeralKV` and the `Revoke` in `lock()`). `context.Background()` has no deadline, so against an unresponsive etcd these cleanup calls hang indefinitely — and because the caller is waiting on them to unwind, it hangs too.

This was first surfaced as flakiness in `TestConcurrentKeyspaceRoutingRulesUpdates`: when the test's 10-second window expired, the in-flight lock RPCs returned `DeadlineExceeded` as expected, but workers that had already moved into the lock cleanup path then wedged inside `lessor.Revoke` because that call ignored the caller's context. The 100 worker goroutines never returned, `wg.Wait()` never unblocked, and the test only died via the 10-minute Go test alarm.

The fix is small: use `context.WithTimeout(context.WithoutCancel(ctx), topo.RemoteOperationTimeout)` for both cleanup RPCs. That gives cleanup a bounded deadline (the existing operator-tunable `--remote-operation-timeout`, 15s default), preserves any trace/caller-id values on the original ctx, and remains independent of the caller's own cancellation — which is the whole reason `Background()` was used in the first place.

The same hazard exists in production: any topo lock acquisition against a stalled etcd would hang the calling goroutine forever rather than failing within `--remote-operation-timeout`. Worth considering for backport.

The companion test change in `utils_test.go` makes the lock-storm test fail fast under a wedged backend instead of waiting for the framework alarm:

- thread the existing 10s `shortCtx` into the worker `update()` helper (replaces an unbounded `t.Context()`-derived one);
- bound the post-`wg.Wait()` verification `Get` with a 10s deadline so it surfaces a real error rather than hanging.

## Related Issue(s)

None — uncovered while investigating an unrelated test flake.

## Checklist

-   [ ] \"Backport to:\" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

No flags or behavior changes for healthy etcd. Under a stalled etcd, topo lock acquisitions now fail fast (within `--remote-operation-timeout`) instead of hanging the calling goroutine indefinitely. Operators relying on the previous \"wait forever\" behavior — if any — would notice a new failure mode here, but the previous behavior was effectively a deadlock.

### AI Disclosure

Most of this was written by Claude Code — I just provided direction and reviewed the approach.