### PR TITLE
tests: give vtctl/workflow tests their own port range

### DIFF
--- a/go/testfiles/ports.go
+++ b/go/testfiles/ports.go
@@ -42,22 +42,28 @@ var (
 	GoVtTopoEtcd2topoPeerPort    = vtPortStart + 1 // etcd peer URL (plaintext)
 	GoVtTopoEtcd2topoTLSPort     = vtPortStart + 2 // etcd client URL (TLS)
 	GoVtTopoEtcd2topoTLSPeerPort = vtPortStart + 3 // etcd peer URL (TLS)
+	// Per-cell etcd pairs for TestEtcd2TopoGetTabletsPartialResults, which
+	// starts a global etcd plus one etcd per cell.
+	GoVtTopoEtcd2topoCell1Port     = vtPortStart + 4 // cell1 etcd client URL
+	GoVtTopoEtcd2topoCell1PeerPort = vtPortStart + 5 // cell1 etcd peer URL
+	GoVtTopoEtcd2topoCell2Port     = vtPortStart + 6 // cell2 etcd client URL
+	GoVtTopoEtcd2topoCell2PeerPort = vtPortStart + 7 // cell2 etcd peer URL
 
 	// Base port used by the go/vt/topo/zk2topo package tests.
 	// zkctl.StartLocalZk consumes three consecutive ports (leader, election,
-	// client) starting at this base, so vtPortStart+4..6 are reserved.
-	GoVtTopoZk2topoPort = vtPortStart + 4
+	// client) starting at this base, so vtPortStart+8..10 are reserved.
+	GoVtTopoZk2topoPort = vtPortStart + 8
 
 	// Ports used by the go/vt/topo/consultopo package tests.
-	GoVtTopoConsultopoDNSPort     = vtPortStart + 7
-	GoVtTopoConsultopoHTTPPort    = vtPortStart + 8
-	GoVtTopoConsultopoSerfLANPort = vtPortStart + 9
-	GoVtTopoConsultopoSerfWANPort = vtPortStart + 10
+	GoVtTopoConsultopoDNSPort     = vtPortStart + 11
+	GoVtTopoConsultopoHTTPPort    = vtPortStart + 12
+	GoVtTopoConsultopoSerfLANPort = vtPortStart + 13
+	GoVtTopoConsultopoSerfWANPort = vtPortStart + 14
 
 	// Ports used by the go/vt/vtctl/workflow package tests for the
 	// etcd-backed keyspace routing rules tests.
-	GoVtVtctlWorkflowPort     = vtPortStart + 11 // etcd client URL
-	GoVtVtctlWorkflowPeerPort = vtPortStart + 12 // etcd peer URL
+	GoVtVtctlWorkflowPort     = vtPortStart + 15 // etcd client URL
+	GoVtVtctlWorkflowPeerPort = vtPortStart + 16 // etcd peer URL
 )
 
 // Zookeeper server ID definitions. Unit tests may run at the

--- a/go/testfiles/ports.go
+++ b/go/testfiles/ports.go
@@ -44,6 +44,10 @@ var (
 	// GoVtTopoConsultopoPort is used by the go/vt/topo/consultopo package.
 	// Takes four ports.
 	GoVtTopoConsultopoPort = GoVtTopoZk2topoPort + 3
+
+	// GoVtVtctlWorkflowPort is used by the go/vt/vtctl/workflow package for
+	// etcd-backed keyspace routing rules tests. Takes two ports.
+	GoVtVtctlWorkflowPort = GoVtTopoConsultopoPort + 4
 )
 
 // Zookeeper server ID definitions. Unit tests may run at the

--- a/go/testfiles/ports.go
+++ b/go/testfiles/ports.go
@@ -29,25 +29,35 @@ import (
 
 // Port definitions. Unit tests may run at the same time,
 // so they should not use the same ports.
+//
+// Each port has its own constant; do not introduce ad-hoc `port + N`
+// arithmetic at call sites or in this file. New entries must extend
+// the range without overlapping any existing constant.
 var (
 	// vtPortStart is the starting port for all tests.
 	vtPortStart = getPortStart()
 
-	// GoVtTopoEtcd2topoPort is used by the go/vt/topo/etcd2topo package.
-	// Takes two ports.
-	GoVtTopoEtcd2topoPort = vtPortStart
+	// Ports used by the go/vt/topo/etcd2topo package tests.
+	GoVtTopoEtcd2topoPort        = vtPortStart     // etcd client URL (plaintext)
+	GoVtTopoEtcd2topoPeerPort    = vtPortStart + 1 // etcd peer URL (plaintext)
+	GoVtTopoEtcd2topoTLSPort     = vtPortStart + 2 // etcd client URL (TLS)
+	GoVtTopoEtcd2topoTLSPeerPort = vtPortStart + 3 // etcd peer URL (TLS)
 
-	// GoVtTopoZk2topoPort is used by the go/vt/topo/zk2topo package.
-	// Takes three ports.
-	GoVtTopoZk2topoPort = GoVtTopoEtcd2topoPort + 2
+	// Base port used by the go/vt/topo/zk2topo package tests.
+	// zkctl.StartLocalZk consumes three consecutive ports (leader, election,
+	// client) starting at this base, so vtPortStart+4..6 are reserved.
+	GoVtTopoZk2topoPort = vtPortStart + 4
 
-	// GoVtTopoConsultopoPort is used by the go/vt/topo/consultopo package.
-	// Takes four ports.
-	GoVtTopoConsultopoPort = GoVtTopoZk2topoPort + 3
+	// Ports used by the go/vt/topo/consultopo package tests.
+	GoVtTopoConsultopoDNSPort     = vtPortStart + 7
+	GoVtTopoConsultopoHTTPPort    = vtPortStart + 8
+	GoVtTopoConsultopoSerfLANPort = vtPortStart + 9
+	GoVtTopoConsultopoSerfWANPort = vtPortStart + 10
 
-	// GoVtVtctlWorkflowPort is used by the go/vt/vtctl/workflow package for
-	// etcd-backed keyspace routing rules tests. Takes two ports.
-	GoVtVtctlWorkflowPort = GoVtTopoConsultopoPort + 4
+	// Ports used by the go/vt/vtctl/workflow package tests for the
+	// etcd-backed keyspace routing rules tests.
+	GoVtVtctlWorkflowPort     = vtPortStart + 11 // etcd client URL
+	GoVtVtctlWorkflowPeerPort = vtPortStart + 12 // etcd peer URL
 )
 
 // Zookeeper server ID definitions. Unit tests may run at the

--- a/go/vt/topo/consultopo/server_flaky_test.go
+++ b/go/vt/topo/consultopo/server_flaky_test.go
@@ -54,13 +54,12 @@ func startConsul(t *testing.T, authToken string) (*exec.Cmd, string, string) {
 	require.NoError(t, err)
 
 	// Create the JSON config, save it.
-	port := testfiles.GoVtTopoConsultopoPort
 	config := map[string]any{
 		"ports": map[string]int{
-			"dns":      port,
-			"http":     port + 1,
-			"serf_lan": port + 2,
-			"serf_wan": port + 3,
+			"dns":      testfiles.GoVtTopoConsultopoDNSPort,
+			"http":     testfiles.GoVtTopoConsultopoHTTPPort,
+			"serf_lan": testfiles.GoVtTopoConsultopoSerfLANPort,
+			"serf_wan": testfiles.GoVtTopoConsultopoSerfWANPort,
 		},
 	}
 
@@ -92,7 +91,7 @@ func startConsul(t *testing.T, authToken string) (*exec.Cmd, string, string) {
 	require.NoError(t, err)
 
 	// Create a client to connect to the created consul.
-	serverAddr := fmt.Sprintf("localhost:%v", port+1)
+	serverAddr := fmt.Sprintf("localhost:%v", testfiles.GoVtTopoConsultopoHTTPPort)
 	cfg := api.DefaultConfig()
 	cfg.Address = serverAddr
 	if authToken != "" {

--- a/go/vt/topo/etcd2topo/server_test.go
+++ b/go/vt/topo/etcd2topo/server_test.go
@@ -40,17 +40,13 @@ import (
 )
 
 // startEtcd starts an etcd subprocess, and waits for it to be ready.
-func startEtcd(t *testing.T, port int) (string, *exec.Cmd) {
+func startEtcd(t *testing.T, clientPort, peerPort int) (string, *exec.Cmd) {
 	// Create a temporary directory.
 	dataDir := t.TempDir()
 
-	// Get our two ports to listen to.
-	if port == 0 {
-		port = testfiles.GoVtTopoEtcd2topoPort
-	}
 	name := "vitess_unit_test"
-	clientAddr := fmt.Sprintf("http://localhost:%v", port)
-	peerAddr := fmt.Sprintf("http://localhost:%v", port+1)
+	clientAddr := fmt.Sprintf("http://localhost:%v", clientPort)
+	peerAddr := fmt.Sprintf("http://localhost:%v", peerPort)
 	initialCluster := fmt.Sprintf("%v=%v", name, peerAddr)
 
 	cmd := exec.Command("etcd",
@@ -207,7 +203,7 @@ func TestEtcd2TLS(t *testing.T) {
 
 func TestEtcd2Topo(t *testing.T) {
 	// Start a single etcd in the background.
-	clientAddr, _ := startEtcd(t, 0)
+	clientAddr, _ := startEtcd(t, testfiles.GoVtTopoEtcd2topoPort, testfiles.GoVtTopoEtcd2topoPeerPort)
 
 	testIndex := 0
 	newServer := func() *topo.Server {
@@ -251,16 +247,22 @@ func TestEtcd2TopoGetTabletsPartialResults(t *testing.T) {
 	root := "/vitess"
 	// Start three etcd instances in the background. One will serve the global topo data
 	// while the other two will serve the cell topo data.
-	globalClientAddr, _ := startEtcd(t, 0)
+	globalClientAddr, _ := startEtcd(t, testfiles.GoVtTopoEtcd2topoPort, testfiles.GoVtTopoEtcd2topoPeerPort)
+	cellPorts := [...]struct {
+		client, peer int
+	}{
+		{testfiles.GoVtTopoEtcd2topoCell1Port, testfiles.GoVtTopoEtcd2topoCell1PeerPort},
+		{testfiles.GoVtTopoEtcd2topoCell2Port, testfiles.GoVtTopoEtcd2topoCell2PeerPort},
+	}
+	require.Equal(t, len(cells), len(cellPorts))
 	cellClientAddrs := make([]string, len(cells))
 	cellClientCmds := make([]*exec.Cmd, len(cells))
 	cellTSs := make([]*topo.Server, len(cells))
 	for i := range cells {
-		addr, cmd := startEtcd(t, testfiles.GoVtTopoEtcd2topoPort+(i+100*i))
+		addr, cmd := startEtcd(t, cellPorts[i].client, cellPorts[i].peer)
 		cellClientAddrs[i] = addr
 		cellClientCmds[i] = cmd
 	}
-	require.Equal(t, len(cells), len(cellTSs))
 
 	// Setup the global topo server.
 	globalTS, err := topo.OpenServer("etcd2", globalClientAddr, path.Join(root, topo.GlobalCell))
@@ -351,7 +353,7 @@ func TestEtcd2TopoGetTabletsPartialResults(t *testing.T) {
 // appropriate errors instead of panicking due to nil pointer dereference.
 func TestEtcd2TopoServerClosed(t *testing.T) {
 	// Start a single etcd in the background.
-	clientAddr, _ := startEtcd(t, 0)
+	clientAddr, _ := startEtcd(t, testfiles.GoVtTopoEtcd2topoPort, testfiles.GoVtTopoEtcd2topoPeerPort)
 
 	testRoot := "/test-closed"
 

--- a/go/vt/topo/etcd2topo/server_test.go
+++ b/go/vt/topo/etcd2topo/server_test.go
@@ -104,11 +104,9 @@ func startEtcdWithTLS(t *testing.T) (string, *tlstest.ClientServerKeyPairs) {
 	// Create a temporary directory.
 	dataDir := t.TempDir()
 
-	// Get our two ports to listen to.
-	port := testfiles.GoVtTopoEtcd2topoPort
 	name := "vitess_unit_test"
-	clientAddr := fmt.Sprintf("https://localhost:%v", port+2)
-	peerAddr := fmt.Sprintf("https://localhost:%v", port+3)
+	clientAddr := fmt.Sprintf("https://localhost:%v", testfiles.GoVtTopoEtcd2topoTLSPort)
+	peerAddr := fmt.Sprintf("https://localhost:%v", testfiles.GoVtTopoEtcd2topoTLSPeerPort)
 	initialCluster := fmt.Sprintf("%v=%v", name, peerAddr)
 
 	certs := tlstest.CreateClientServerCertPairs(dataDir)

--- a/go/vt/topo/etcd2topo/watch_test.go
+++ b/go/vt/topo/etcd2topo/watch_test.go
@@ -29,6 +29,7 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"vitess.io/vitess/go/test/utils"
+	"vitess.io/vitess/go/testfiles"
 	"vitess.io/vitess/go/vt/topo"
 )
 
@@ -41,7 +42,7 @@ import (
 // behavior accidentally/uinintentionally.
 func TestWatchTopoVersion(t *testing.T) {
 	ctx := utils.LeakCheckContext(t)
-	etcdServerAddr, _ := startEtcd(t, 0)
+	etcdServerAddr, _ := startEtcd(t, testfiles.GoVtTopoEtcd2topoPort, testfiles.GoVtTopoEtcd2topoPeerPort)
 	root := "/vitess/test"
 	name := "testkey"
 	path := path.Join(root, name)

--- a/go/vt/vtctl/workflow/utils_test.go
+++ b/go/vt/vtctl/workflow/utils_test.go
@@ -232,7 +232,7 @@ func startEtcd(t *testing.T) string {
 	dataDir := t.TempDir()
 
 	// Get our two ports to listen to.
-	port := testfiles.GoVtTopoEtcd2topoPort
+	port := testfiles.GoVtVtctlWorkflowPort
 	name := "vitess_unit_test"
 	clientAddr := fmt.Sprintf("http://localhost:%v", port)
 	peerAddr := fmt.Sprintf("http://localhost:%v", port+1)

--- a/go/vt/vtctl/workflow/utils_test.go
+++ b/go/vt/vtctl/workflow/utils_test.go
@@ -231,11 +231,9 @@ func startEtcd(t *testing.T) string {
 	// Create a temporary directory.
 	dataDir := t.TempDir()
 
-	// Get our two ports to listen to.
-	port := testfiles.GoVtVtctlWorkflowPort
 	name := "vitess_unit_test"
-	clientAddr := fmt.Sprintf("http://localhost:%v", port)
-	peerAddr := fmt.Sprintf("http://localhost:%v", port+1)
+	clientAddr := fmt.Sprintf("http://localhost:%v", testfiles.GoVtVtctlWorkflowPort)
+	peerAddr := fmt.Sprintf("http://localhost:%v", testfiles.GoVtVtctlWorkflowPeerPort)
 	initialCluster := fmt.Sprintf("%v=%v", name, peerAddr)
 	cmd := exec.Command("etcd",
 		"-name", name,


### PR DESCRIPTION
## Description

The etcd-backed tests in `go/vt/vtctl/workflow` were reusing `testfiles.GoVtTopoEtcd2topoPort`, which is also claimed by the `go/vt/topo/etcd2topo` tests.

`go/testfiles/ports.go` is the centralized "no shared ports across concurrently-running packages" registry, and its comment explicitly says _"Unit tests may run at the same time, so they should not use the same ports."_ Two packages consuming `GoVtTopoEtcd2topoPort` (= 6700) violates that contract. The workflow test was added later and reused the etcd2topo port instead of registering its own.

CI runs `go test -p 4`, so the two test binaries can run concurrently. Whichever etcd subprocess loses the bind race silently keeps running with no listener (`cmd.Start()` only reports exec failure, not bind failure). When the winner's cleanup eventually kills its etcd, the other test loses its connection and hangs on the etcd v3 client's `watchGRPCStream` chan send — eventually timing out the whole package after the per-job timeout.

This change tightens the central registry so that **each reserved port has its own named constant** (no more "this base takes N ports" comments with `port + N` arithmetic at the call sites), reshuffles the existing allocations into named pairs, and adds dedicated entries for the workflow tests:

- etcd2topo plaintext: `GoVtTopoEtcd2topoPort` / `GoVtTopoEtcd2topoPeerPort`
- etcd2topo TLS: `GoVtTopoEtcd2topoTLSPort` / `GoVtTopoEtcd2topoTLSPeerPort`
- etcd2topo cell etcds for `TestEtcd2TopoGetTabletsPartialResults`: `GoVtTopoEtcd2topoCell{1,2}{Port,PeerPort}` (this test previously computed cell ports as `GoVtTopoEtcd2topoPort + (i + 100*i)`, which collided with the global etcd for `i=0` — same silent bind-loser bug, intra-package)
- zk2topo: `GoVtTopoZk2topoPort`
- consultopo: `GoVtTopoConsultopo{DNS,HTTP,SerfLAN,SerfWAN}Port`
- workflow: `GoVtVtctlWorkflowPort` / `GoVtVtctlWorkflowPeerPort`

`startEtcd` in `go/vt/topo/etcd2topo` now takes the client and peer port explicitly (mirroring `startEtcdWithTLS`) so callers stop relying on the helper to derive `peer = client + 1`.

This is a bug fix for CI flakiness — should be backported to active release branches.

## Related Issue(s)

None.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

No new test is needed — the existing `TestEtcd2Topo` and `TestConcurrentKeyspaceRoutingRulesUpdates` together exercise the cross-package failure mode, and `TestEtcd2TopoGetTabletsPartialResults` exercises the intra-package one. Verified locally with:

```
go test -p 2 -timeout 180s \
  -run "^(TestEtcd2Topo|TestConcurrentKeyspaceRoutingRulesUpdates)$" \
  ./go/vt/topo/etcd2topo/ ./go/vt/vtctl/workflow/
```

Before this change the workflow package hangs until the timeout; after, both packages pass in ~30s.

## Deployment Notes

None — this only affects unit tests.

### AI Disclosure

This PR was written primarily by Claude Code — I just provided direction.