### PR TITLE
mysqlshellbackupengine: bound deferred `ReleaseGlobalReadLock`

### DIFF
--- a/go/vt/mysqlctl/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon.go
@@ -68,6 +68,11 @@ type FakeMysqlDaemon struct {
 	// disappear after shutting themselves down before restarting.
 	StartAfterExitTime time.Duration
 
+	// ReleaseGlobalReadLockDelay is used to simulate an unresponsive mysqld
+	// that blocks on UNLOCK TABLES. ReleaseGlobalReadLock will wait up to this
+	// delay, or until the supplied context is cancelled, whichever comes first.
+	ReleaseGlobalReadLockDelay time.Duration
+
 	// StartAfterExitError is used by StartAfterExit.
 	StartAfterExitError error
 
@@ -902,6 +907,14 @@ func (fmd *FakeMysqlDaemon) AcquireGlobalReadLock(ctx context.Context) error {
 
 // ReleaseGlobalReadLock is part of the MysqlDaemon interface.
 func (fmd *FakeMysqlDaemon) ReleaseGlobalReadLock(ctx context.Context) error {
+	if fmd.ReleaseGlobalReadLockDelay > 0 {
+		select {
+		case <-time.After(fmd.ReleaseGlobalReadLockDelay):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
 	if fmd.GlobalReadLock {
 		fmd.GlobalReadLock = false
 		return nil

--- a/go/vt/mysqlctl/mysqlshellbackupengine.go
+++ b/go/vt/mysqlctl/mysqlshellbackupengine.go
@@ -65,6 +65,12 @@ var (
 	// use when checking if we need to create the directory on the local filesystem or not.
 	knownObjectStoreParams = []string{"s3BucketName", "osBucketName", "azureContainerName"}
 
+	// releaseGlobalReadLockTimeout bounds the deferred fallback call to
+	// ReleaseGlobalReadLock so it cannot hang indefinitely on an unresponsive
+	// mysqld and leave the global read lock held — which would block all writes.
+	// Exposed as a package-level variable so tests can shorten it.
+	releaseGlobalReadLockTimeout = 10 * time.Second
+
 	ErrMySQLShellPreCheck = errors.New("ErrMySQLShellPreCheck")
 
 	// internal databases not backed up by MySQL Shell
@@ -171,9 +177,15 @@ func (be *MySQLShellBackupEngine) ExecuteBackup(ctx context.Context, params Back
 	lockAcquired := time.Now() // we will report how long we hold the lock for
 
 	// we need to release the global read lock in case the backup fails to start and
-	// the lock wasn't released by releaseReadLock() yet. context might be expired,
-	// so we pass a new one.
-	defer func() { _ = params.Mysqld.ReleaseGlobalReadLock(context.Background()) }()
+	// the lock wasn't released by releaseReadLock() yet. the caller's context may
+	// already be cancelled, so we detach from its cancellation (but preserve its
+	// values) and bound the call with a timeout — without one, an unresponsive
+	// mysqld would leave the global read lock held indefinitely.
+	defer func() {
+		releaseCtx, releaseCancel := context.WithTimeout(context.WithoutCancel(ctx), releaseGlobalReadLockTimeout)
+		defer releaseCancel()
+		_ = params.Mysqld.ReleaseGlobalReadLock(releaseCtx)
+	}()
 
 	posBeforeBackup, err := params.Mysqld.PrimaryPosition(ctx)
 	if err != nil {

--- a/go/vt/mysqlctl/mysqlshellbackupengine.go
+++ b/go/vt/mysqlctl/mysqlshellbackupengine.go
@@ -184,7 +184,14 @@ func (be *MySQLShellBackupEngine) ExecuteBackup(ctx context.Context, params Back
 	defer func() {
 		releaseCtx, releaseCancel := context.WithTimeout(context.WithoutCancel(ctx), releaseGlobalReadLockTimeout)
 		defer releaseCancel()
-		_ = params.Mysqld.ReleaseGlobalReadLock(releaseCtx)
+		if err := params.Mysqld.ReleaseGlobalReadLock(releaseCtx); err != nil &&
+			!strings.Contains(err.Error(), "no read locks acquired yet") {
+			// "no read locks acquired yet" is the expected/normal path:
+			// releaseReadLock() already released the lock during mysqlsh's run.
+			// Any other error (most importantly a context deadline) means the
+			// global read lock may still be held, so surface it to operators.
+			params.Logger.Errorf("deferred ReleaseGlobalReadLock failed; the global read lock may still be held: %v", err)
+		}
 	}()
 
 	posBeforeBackup, err := params.Mysqld.PrimaryPosition(ctx)

--- a/go/vt/mysqlctl/mysqlshellbackupengine_test.go
+++ b/go/vt/mysqlctl/mysqlshellbackupengine_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -456,5 +457,55 @@ func TestMySQLShellBackupEngine_ExecuteBackup_ReleaseLock(t *testing.T) {
 		_, err = be.ExecuteBackup(t.Context(), params, bh)
 		require.ErrorContains(t, err, "mysqlshell failed")
 		require.False(t, mysql.GlobalReadLock) // lock must be released.
+	})
+
+	t.Run("deferred lock release is bounded when mysqld hangs", func(t *testing.T) {
+		// Without a timeout on the deferred ReleaseGlobalReadLock call, an
+		// unresponsive mysqld would leave the global read lock held forever
+		// (blocking every write on the server). Simulate that hang and verify
+		// ExecuteBackup still returns, bounded by releaseGlobalReadLockTimeout.
+		be := &MySQLShellBackupEngine{binaryName: path.Join(t.TempDir(), "mysqlsh.sh")}
+		mysql.GlobalReadLock = false // clear lock status.
+		logger.Clear()
+		manifestBuffer := ioutil.NewBytesBufferWriter()
+		bs.StartBackupReturn.BackupHandle = &FakeBackupHandle{
+			Dir:           t.TempDir(),
+			AddFileReturn: FakeBackupHandleAddFileReturn{WriteCloser: manifestBuffer},
+		}
+
+		// Simulate mysqld hanging on UNLOCK TABLES for far longer than the test
+		// or the timeout. The deferred release must give up via its own timeout
+		// rather than blocking for the full delay.
+		mysql.ReleaseGlobalReadLockDelay = time.Minute
+		t.Cleanup(func() { mysql.ReleaseGlobalReadLockDelay = 0 })
+
+		originalTimeout := releaseGlobalReadLockTimeout
+		releaseGlobalReadLockTimeout = 100 * time.Millisecond
+		t.Cleanup(func() { releaseGlobalReadLockTimeout = originalTimeout })
+
+		// Backup fails so we exercise the deferred fallback release.
+		generateTestFile(t, be.binaryName, "#!/bin/bash\nexit 1")
+
+		bh, err := bs.StartBackup(t.Context(), t.TempDir(), t.Name())
+		require.NoError(t, err)
+
+		done := make(chan struct{})
+		var execErr error
+		go func() {
+			defer close(done)
+			_, execErr = be.ExecuteBackup(t.Context(), params, bh)
+		}()
+
+		require.Eventually(t, func() bool {
+			select {
+			case <-done:
+				return true
+			default:
+				return false
+			}
+		}, 10*time.Second, 20*time.Millisecond,
+			"ExecuteBackup did not return — deferred ReleaseGlobalReadLock is not bounded by a timeout")
+
+		require.ErrorContains(t, execErr, "mysqlshell failed")
 	})
 }


### PR DESCRIPTION
## What's this?

The deferred fallback release in `MySQLShellBackupEngine.ExecuteBackup` used `context.Background()` to detach from the caller's (possibly already cancelled) context. With no timeout on that fresh context, an unresponsive `mysqld` blocks the deferred `UNLOCK TABLES` forever — and the global read lock acquired earlier in the same function stays held. That blocks every write on the server until `vttablet` or `mysqld` is bounced.

This is exactly the "deferred cleanup must use bounded contexts" rule in `CLAUDE.md` — applied to the worst possible payload (a global read lock).

```go
// before — go/vt/mysqlctl/mysqlshellbackupengine.go:176
defer func() { _ = params.Mysqld.ReleaseGlobalReadLock(context.Background()) }()
```

## How it works

Switched to the existing Vitess pattern for "detach from parent ctx, but stay bounded" — `context.WithTimeout(context.WithoutCancel(ctx), …)`. The same pattern is used in `etcd2topo/lock.go:72`, `etcd2topo/lock.go:228`, and `vtctl/reparentutil/emergency_reparenter.go:180`.

```go
defer func() {
    releaseCtx, releaseCancel := context.WithTimeout(context.WithoutCancel(ctx), releaseGlobalReadLockTimeout)
    defer releaseCancel()
    _ = params.Mysqld.ReleaseGlobalReadLock(releaseCtx)
}()
```

Timeout defaults to **10s**, matching the `killConnection` precedent in the same package (`go/vt/mysqlctl/query.go:182`), which deals with the same "caller's context is already expired" scenario. Exposed as a package-level variable so tests can shorten it.

## Test

Added `ReleaseGlobalReadLockDelay` to `FakeMysqlDaemon` (mirroring the existing `StartupTime` / `ShutdownTime` / `StartAfterExitTime` knobs) so tests can simulate a hung `mysqld`. The new subtest in `TestMySQLShellBackupEngine_ExecuteBackup_ReleaseLock` injects a 1-minute hang, shortens the timeout to 100ms, runs a failing backup, and asserts `ExecuteBackup` returns within 10s.

The test fails on `main` (the `require.Eventually` polls for 10s and never sees the goroutine finish — the deferred `ReleaseGlobalReadLock` is stuck) and passes with this change.

```
--- PASS: TestMySQLShellBackupEngine_ExecuteBackup_ReleaseLock (0.14s)
    --- PASS: …/deferred_lock_release_is_bounded_when_mysqld_hangs (0.12s)
```

## Related Issue(s)

None — surfaced via an audit of `context.Background()` / `context.TODO()` usage in deferred cleanup paths.

## Checklist

- [ ] "Backport to:" labels — deferring to maintainers. The bug exists in every release that contains `mysqlshellbackupengine.go`, but it only fires under a specific failure mode (backup error path + hung mysqld). Backport is reasonable but not urgent.
- [x] Tests added — see above.
- [x] Tests pass locally — `go test ./go/vt/mysqlctl/ -run 'TestMySQLShellBackup'` clean.
- [x] No documentation change required.

## Deployment Notes

- No new flags. No config changes. No proto/RPC changes.
- Behavior change worth flagging: when `mysqld` is hung on `UNLOCK TABLES` during the backup error path, `ExecuteBackup` now returns within ~10s instead of blocking forever. The global read lock will still be held in this scenario (we couldn't release it), but the goroutine is no longer stuck — operators can act.

---

_Most of this was written by Claude Code — I just provided direction._


---
_Generated by [Claude Code](https://claude.ai/code/session_01QkoFNHmRwiYbLrUchXSVin)_