### PR TITLE
mysqlctl: bound deferred ReleaseGlobalReadLock cleanup in MySQL Shell backup

### DIFF
--- a/go/vt/mysqlctl/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon.go
@@ -225,6 +225,16 @@ type FakeMysqlDaemon struct {
 	// GlobalReadLock is used to test if a lock has been acquired already or not
 	GlobalReadLock bool
 
+	// ReleaseGlobalReadLockLastCtx records the context passed to the most
+	// recent call to ReleaseGlobalReadLock, so tests can assert on its
+	// deadline and inherited values.
+	ReleaseGlobalReadLockLastCtx context.Context
+
+	// ReleaseGlobalReadLockLastCtxErr records the value of ctx.Err() at the
+	// time the most recent ReleaseGlobalReadLock call was invoked, so tests
+	// can assert the context wasn't already cancelled when the call ran.
+	ReleaseGlobalReadLockLastCtxErr error
+
 	// TimeoutHook is a func that can be called at the beginning of
 	// any method to fake a timeout.
 	// All a test needs to do is make it { return context.DeadlineExceeded }.
@@ -902,6 +912,9 @@ func (fmd *FakeMysqlDaemon) AcquireGlobalReadLock(ctx context.Context) error {
 
 // ReleaseGlobalReadLock is part of the MysqlDaemon interface.
 func (fmd *FakeMysqlDaemon) ReleaseGlobalReadLock(ctx context.Context) error {
+	fmd.ReleaseGlobalReadLockLastCtx = ctx
+	fmd.ReleaseGlobalReadLockLastCtxErr = ctx.Err()
+
 	if fmd.GlobalReadLock {
 		fmd.GlobalReadLock = false
 		return nil

--- a/go/vt/mysqlctl/mysqlshellbackupengine.go
+++ b/go/vt/mysqlctl/mysqlshellbackupengine.go
@@ -118,6 +118,12 @@ type MySQLShellBackupEngine struct {
 const (
 	mysqlShellBackupEngineName = "mysqlshell"
 	mysqlShellLockMessage      = "Global read lock has been released"
+
+	// mysqlShellBackupReleaseLockTimeout bounds the deferred best-effort
+	// ReleaseGlobalReadLock cleanup so that an unresponsive MySQL cannot
+	// cause the backup goroutine to hang indefinitely while still leaving
+	// enough time for UNLOCK TABLES to complete under load.
+	mysqlShellBackupReleaseLockTimeout = 1 * time.Minute
 )
 
 func (be *MySQLShellBackupEngine) ExecuteBackup(ctx context.Context, params BackupParams, bh backupstorage.BackupHandle) (result BackupResult, finalErr error) {
@@ -172,8 +178,13 @@ func (be *MySQLShellBackupEngine) ExecuteBackup(ctx context.Context, params Back
 
 	// we need to release the global read lock in case the backup fails to start and
 	// the lock wasn't released by releaseReadLock() yet. context might be expired,
-	// so we pass a new one.
-	defer func() { _ = params.Mysqld.ReleaseGlobalReadLock(context.Background()) }()
+	// so we detach from its cancellation but still bound the cleanup with a timeout
+	// to avoid hanging indefinitely if MySQL is unresponsive.
+	defer func() {
+		releaseCtx, releaseCancel := context.WithTimeout(context.WithoutCancel(ctx), mysqlShellBackupReleaseLockTimeout)
+		defer releaseCancel()
+		_ = params.Mysqld.ReleaseGlobalReadLock(releaseCtx)
+	}()
 
 	posBeforeBackup, err := params.Mysqld.PrimaryPosition(ctx)
 	if err != nil {

--- a/go/vt/mysqlctl/mysqlshellbackupengine_test.go
+++ b/go/vt/mysqlctl/mysqlshellbackupengine_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package mysqlctl
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -456,5 +458,58 @@ func TestMySQLShellBackupEngine_ExecuteBackup_ReleaseLock(t *testing.T) {
 		_, err = be.ExecuteBackup(t.Context(), params, bh)
 		require.ErrorContains(t, err, "mysqlshell failed")
 		require.False(t, mysql.GlobalReadLock) // lock must be released.
+	})
+
+	t.Run("deferred lock release uses a bounded context detached from parent", func(t *testing.T) {
+		be := &MySQLShellBackupEngine{binaryName: path.Join(t.TempDir(), "mysqlsh.sh")}
+		mysql.GlobalReadLock = false                // clear lock status.
+		mysql.ReleaseGlobalReadLockLastCtx = nil    // clear recorded context.
+		mysql.ReleaseGlobalReadLockLastCtxErr = nil // clear recorded ctx.Err().
+		logger.Clear()
+		manifestBuffer := ioutil.NewBytesBufferWriter()
+		bs.StartBackupReturn.BackupHandle = &FakeBackupHandle{
+			Dir:           t.TempDir(),
+			AddFileReturn: FakeBackupHandleAddFileReturn{WriteCloser: manifestBuffer},
+		}
+
+		// mysqlsh exits without emitting the lock-release message so the
+		// releaseReadLock goroutine never runs and the deferred cleanup
+		// is the only path that calls ReleaseGlobalReadLock.
+		generateTestFile(t, be.binaryName, "#!/bin/bash\nexit 0")
+
+		bh, err := bs.StartBackup(t.Context(), t.TempDir(), t.Name())
+		require.NoError(t, err)
+
+		// Build a parent context with a sentinel value, then cancel it
+		// before ExecuteBackup runs. The deferred cleanup must still
+		// happen with a fresh deadline, while preserving parent values.
+		type ctxKey struct{}
+		parentCtx, parentCancel := context.WithCancel(context.WithValue(t.Context(), ctxKey{}, "parent-value"))
+		parentCancel()
+
+		_, err = be.ExecuteBackup(parentCtx, params, bh)
+		require.Error(t, err) // parent ctx was cancelled before we started.
+		require.False(t, mysql.GlobalReadLock, "lock must be released by deferred cleanup")
+
+		require.NotNil(t, mysql.ReleaseGlobalReadLockLastCtx, "deferred ReleaseGlobalReadLock must run")
+
+		// The deferred release must bound the operation with a deadline so
+		// an unresponsive MySQL cannot hang the goroutine forever.
+		deadline, hasDeadline := mysql.ReleaseGlobalReadLockLastCtx.Deadline()
+		require.True(t, hasDeadline, "deferred release context must have a deadline")
+		require.Greater(t, time.Until(deadline), time.Duration(0), "deferred release context deadline must be in the future")
+
+		// The deferred release must inherit values from the parent (i.e.
+		// use WithoutCancel rather than a brand new context.Background),
+		// otherwise tracing / caller-ID context plumbing is lost.
+		require.Equal(t, "parent-value", mysql.ReleaseGlobalReadLockLastCtx.Value(ctxKey{}),
+			"deferred release context must inherit values from parent ctx")
+
+		// At the moment the deferred release was invoked, the context must
+		// not have been cancelled — even though the parent was cancelled
+		// before ExecuteBackup ran. This is what proves the cleanup ctx is
+		// detached from the parent's cancellation.
+		require.NoError(t, mysql.ReleaseGlobalReadLockLastCtxErr,
+			"deferred release context must not be cancelled when parent is cancelled")
 	})
 }


### PR DESCRIPTION
## What's this?

The MySQL Shell backup engine acquires a global read lock at the start of
`ExecuteBackup()` so it can capture a consistent GTID set, then registers a
deferred best-effort `ReleaseGlobalReadLock()` in case the lock wasn't already
released by the `releaseReadLock()` goroutine. That deferred call was using
`context.Background()`:

```go
// we need to release the global read lock in case the backup fails to start and
// the lock wasn't released by releaseReadLock() yet. context might be expired,
// so we pass a new one.
defer func() { _ = params.Mysqld.ReleaseGlobalReadLock(context.Background()) }()
```

`ReleaseGlobalReadLock()` runs `UNLOCK TABLES` against MySQL — with an unbounded
context, an unresponsive MySQL hangs the backup goroutine indefinitely while the
global read lock keeps blocking writes on the instance.

## How it works

Replace the unbounded context with `context.WithTimeout(context.WithoutCancel(ctx), 1m)`:

```go
defer func() {
    releaseCtx, releaseCancel := context.WithTimeout(context.WithoutCancel(ctx), mysqlShellBackupReleaseLockTimeout)
    defer releaseCancel()
    _ = params.Mysqld.ReleaseGlobalReadLock(releaseCtx)
}()
```

- `WithoutCancel(ctx)` preserves the caller's context values (tracing,
  caller ID) — that's the property the original code traded away when it
  reached for a fresh, non-expired context.
- `WithTimeout(..., 1m)` bounds `UNLOCK TABLES` at a value generous enough
  for a loaded MySQL but short enough that the cleanup goroutine can no
  longer hang forever.

This matches the existing pattern already in use in `go/vt/topo/etcd2topo/lock.go`
and `go/vt/vtctl/reparentutil/emergency_reparenter.go` for the same class of
"detach from parent cancellation but still bound the cleanup" cases.

## Test

Adds `TestMySQLShellBackupEngine_ExecuteBackup_ReleaseLock/deferred_lock_release_uses_a_bounded_context_detached_from_parent`:

- Pre-cancels the parent context, then runs `ExecuteBackup`.
- Asserts the deferred release ran, the lock is released, the cleanup ctx
  has a deadline, the cleanup ctx inherits parent values (proves
  `WithoutCancel` instead of `Background`), and the cleanup ctx wasn't
  already cancelled at call time (proves detachment from parent).

Verified the new test fails on `main` (without the fix) with
`"deferred release context must have a deadline"` and passes with the fix
applied; the three existing `ReleaseLock` subtests continue to pass.

## Related

Implements the deferred-cleanup guidance from `CLAUDE.md`:

> Deferred cleanup must use bounded contexts — never `context.Background()`
> for operations that could hang indefinitely.
> Prefer `context.WithoutCancel(ctx)` over `context.Background()` when you
> need a non-cancellable context but still want to preserve context values.

## Checklist

- [x] Tests were added
- [x] Tests pass locally
- [ ] "Backport to:" labels — deferring to maintainers; this is a small, low-risk safety fix to deferred cleanup.

---

_Most of this was written by Claude Code — I just provided direction._


---
_Generated by [Claude Code](https://claude.ai/code/session_01C2hK1U1R9f3JqWKmejTqHR)_