### PR TITLE
smartconnpool: avoid close deadlock with refresh reopen

### DIFF
--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -295,10 +295,10 @@ func (pool *ConnPool[C]) Close() {
 // pool closing operation
 func (pool *ConnPool[C]) CloseWithContext(ctx context.Context) error {
 	pool.capacityMu.Lock()
-	defer pool.capacityMu.Unlock()
 
-	if pool.close.Load() == nil || pool.capacity.Load() == 0 {
+	if pool.close.Load() == nil {
 		// already closed
+		pool.capacityMu.Unlock()
 		return nil
 	}
 
@@ -310,6 +310,7 @@ func (pool *ConnPool[C]) CloseWithContext(ctx context.Context) error {
 	closeChan := *pool.close.Swap(nil)
 	close(closeChan)
 
+	pool.capacityMu.Unlock()
 	pool.workers.Wait()
 	return err
 }
@@ -317,6 +318,10 @@ func (pool *ConnPool[C]) CloseWithContext(ctx context.Context) error {
 func (pool *ConnPool[C]) reopen() {
 	pool.capacityMu.Lock()
 	defer pool.capacityMu.Unlock()
+
+	if pool.close.Load() == nil {
+		return
+	}
 
 	capacity := pool.capacity.Load()
 	if capacity == 0 {
@@ -752,6 +757,9 @@ func (pool *ConnPool[C]) getWithSetting(ctx context.Context, setting *Setting) (
 func (pool *ConnPool[C]) SetCapacity(ctx context.Context, newcap int64) error {
 	pool.capacityMu.Lock()
 	defer pool.capacityMu.Unlock()
+	if pool.close.Load() == nil {
+		return ErrConnPoolClosed
+	}
 	return pool.setCapacity(ctx, newcap)
 }
 

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -416,6 +416,9 @@ func (pool *ConnPool[C]) Get(ctx context.Context, setting *Setting) (*Pooled[C],
 	if ctx.Err() != nil {
 		return nil, ErrCtxTimeout
 	}
+	if pool.close.Load() == nil {
+		return nil, ErrConnPoolClosed
+	}
 	if pool.capacity.Load() == 0 {
 		return nil, ErrConnPoolClosed
 	}
@@ -432,6 +435,10 @@ func (pool *ConnPool[C]) put(conn *Pooled[C]) {
 
 	if conn == nil {
 		var err error
+		if pool.close.Load() == nil {
+			pool.closedConn()
+			return
+		}
 		// Using context.Background() is fine since MySQL connection already enforces
 		// a connect timeout via the `db-connect-timeout-ms` config param.
 		conn, err = pool.connNew(context.Background())
@@ -459,6 +466,12 @@ func (pool *ConnPool[C]) put(conn *Pooled[C]) {
 }
 
 func (pool *ConnPool[C]) tryReturnConn(conn *Pooled[C]) bool {
+	if pool.close.Load() == nil {
+		conn.Close()
+		pool.closedConn()
+		return false
+	}
+
 	if pool.wait.tryReturnConn(conn) {
 		return true
 	}
@@ -593,6 +606,10 @@ func (pool *ConnPool[C]) closedConn() {
 
 func (pool *ConnPool[C]) getNew(ctx context.Context) (*Pooled[C], error) {
 	for {
+		if pool.close.Load() == nil {
+			return nil, ErrConnPoolClosed
+		}
+
 		open := pool.active.Load()
 		if open >= pool.capacity.Load() {
 			return nil, nil
@@ -603,6 +620,11 @@ func (pool *ConnPool[C]) getNew(ctx context.Context) (*Pooled[C], error) {
 			if err != nil {
 				pool.closedConn()
 				return nil, err
+			}
+			if pool.close.Load() == nil {
+				conn.Close()
+				pool.closedConn()
+				return nil, ErrConnPoolClosed
 			}
 			return conn, nil
 		}
@@ -757,9 +779,6 @@ func (pool *ConnPool[C]) getWithSetting(ctx context.Context, setting *Setting) (
 func (pool *ConnPool[C]) SetCapacity(ctx context.Context, newcap int64) error {
 	pool.capacityMu.Lock()
 	defer pool.capacityMu.Unlock()
-	if pool.close.Load() == nil {
-		return ErrConnPoolClosed
-	}
 	return pool.setCapacity(ctx, newcap)
 }
 

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -790,7 +790,12 @@ func (pool *ConnPool[C]) setCapacity(ctx context.Context, newcap int64) error {
 	}
 
 	oldcap := pool.capacity.Swap(newcap)
-	if oldcap == newcap {
+	// Skip the drain only when capacity is unchanged AND we're already at or
+	// below the target. Otherwise we may have been left with active > newcap
+	// by a prior call that timed out (e.g. SetCapacity(0) racing with held
+	// conns), and CloseWithContext relies on a follow-up call here to finish
+	// draining.
+	if oldcap == newcap && pool.active.Load() <= newcap {
 		return nil
 	}
 	// update the idle count to match the new capacity if necessary

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -682,24 +682,6 @@ func TestCloseWithContextAfterSetCapacityZeroClosesPool(t *testing.T) {
 	require.False(t, p.IsOpen())
 }
 
-func TestSetCapacityAfterCloseDoesNotReopenPool(t *testing.T) {
-	var state TestState
-
-	p := NewPool(&Config[*TestConn]{
-		Capacity: 1,
-		LogWait:  state.LogWait,
-	}).Open(newConnector(&state), nil)
-
-	ctx := t.Context()
-	require.NoError(t, p.CloseWithContext(ctx))
-
-	err := p.SetCapacity(ctx, 1)
-	require.ErrorIs(t, err, ErrConnPoolClosed)
-	require.False(t, p.IsOpen())
-	require.EqualValues(t, 0, p.Capacity())
-	require.EqualValues(t, 0, p.Active())
-}
-
 func TestConnReopen(t *testing.T) {
 	var state TestState
 

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -682,6 +682,53 @@ func TestCloseWithContextAfterSetCapacityZeroClosesPool(t *testing.T) {
 	require.False(t, p.IsOpen())
 }
 
+// TestCloseWithContextDrainsAfterTimedOutSetCapacityZero guards against an
+// early return in setCapacity that previously caused CloseWithContext to
+// return nil despite active conns being out, when a prior SetCapacity(0)
+// had timed out with conns still borrowed. The path is:
+//
+//   - SetCapacity(0) times out: capacity is swapped to 0 first, then the
+//     drain loop hits the deadline and returns an error.
+//   - The next CloseWithContext calls setCapacity(0) again. With the bug,
+//     oldcap == newcap == 0 short-circuited the drain loop and Close
+//     returned nil even though pool.active was still > 0.
+//
+// CloseWithContext must instead attempt to drain and surface a timeout
+// when borrowed conns aren't returned.
+func TestCloseWithContextDrainsAfterTimedOutSetCapacityZero(t *testing.T) {
+	var state TestState
+
+	p := NewPool(&Config[*TestConn]{
+		Capacity: 2,
+		LogWait:  state.LogWait,
+	}).Open(newConnector(&state), nil)
+
+	t.Cleanup(func() {
+		if closeChan := p.close.Swap(nil); closeChan != nil {
+			close(*closeChan)
+			p.workers.Wait()
+		}
+	})
+
+	conn, err := p.Get(t.Context(), nil)
+	require.NoError(t, err)
+
+	// SetCapacity(0) must time out: a conn is still borrowed.
+	cancelledCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+	require.Error(t, p.SetCapacity(cancelledCtx, 0))
+	require.EqualValues(t, 0, p.Capacity())
+	require.GreaterOrEqual(t, p.Active(), int64(1))
+
+	// CloseWithContext must still attempt to drain — without the fix it
+	// returns nil immediately because setCapacity short-circuits on
+	// oldcap == newcap.
+	require.Error(t, p.CloseWithContext(cancelledCtx))
+
+	// Release the held conn so it is properly closed during teardown.
+	conn.Recycle()
+}
+
 func TestConnReopen(t *testing.T) {
 	var state TestState
 

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -657,6 +657,49 @@ func TestUserClosing(t *testing.T) {
 	}
 }
 
+func TestCloseWithContextAfterSetCapacityZeroClosesPool(t *testing.T) {
+	var state TestState
+
+	p := NewPool(&Config[*TestConn]{
+		Capacity: 1,
+		LogWait:  state.LogWait,
+	}).Open(newConnector(&state), nil)
+
+	t.Cleanup(func() {
+		if closeChan := p.close.Swap(nil); closeChan != nil {
+			close(*closeChan)
+			p.workers.Wait()
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	require.NoError(t, p.SetCapacity(ctx, 0))
+	require.True(t, p.IsOpen())
+
+	require.NoError(t, p.CloseWithContext(ctx))
+	require.False(t, p.IsOpen())
+}
+
+func TestSetCapacityAfterCloseDoesNotReopenPool(t *testing.T) {
+	var state TestState
+
+	p := NewPool(&Config[*TestConn]{
+		Capacity: 1,
+		LogWait:  state.LogWait,
+	}).Open(newConnector(&state), nil)
+
+	ctx := t.Context()
+	require.NoError(t, p.CloseWithContext(ctx))
+
+	err := p.SetCapacity(ctx, 1)
+	require.ErrorIs(t, err, ErrConnPoolClosed)
+	require.False(t, p.IsOpen())
+	require.EqualValues(t, 0, p.Capacity())
+	require.EqualValues(t, 0, p.Active())
+}
+
 func TestConnReopen(t *testing.T) {
 	var state TestState
 

--- a/go/pools/smartconnpool/stress_test.go
+++ b/go/pools/smartconnpool/stress_test.go
@@ -162,6 +162,18 @@ func TestStress(t *testing.T) {
 	require.NoError(t, wg.Wait())
 }
 
+// TestStressCloseDuringTraffic exercises CloseWithContext racing against
+// active workload: NumWorkers goroutines churn conns (Get / Recycle, plus
+// occasional Taint), a separate goroutine repeatedly resizes the pool via
+// SetCapacity, and then Close is invoked. The test verifies that:
+//
+//   - Close returns (does not deadlock),
+//   - no closed conn is handed to a worker,
+//   - no conn opened by the pool is leaked,
+//   - active / inUse settle to zero.
+//
+// Each cycle is a fresh pool; the loop runs many cycles to surface
+// scheduling-dependent races.
 func TestStressCloseDuringTraffic(t *testing.T) {
 	const Cycles = 100
 
@@ -182,7 +194,7 @@ func runStressCloseDuringTrafficCycle(t *testing.T, cycle int) {
 		NumWorkers    = 24
 		WarmupTimeout = 30 * time.Second
 		CloseTimeout  = 30 * time.Second
-		WatchdogDelay = 30 * time.Second
+		Watchdog      = 30 * time.Second
 	)
 
 	var (
@@ -236,13 +248,12 @@ func runStressCloseDuringTrafficCycle(t *testing.T, cycle int) {
 	)
 
 	for i := range NumWorkers {
-		worker := i
-		tid := int32(worker + 1)
+		tid := int32(i + 1)
 		wg.Go(func() error {
 			liveGetWorkers.Add(1)
 			defer liveGetWorkers.Add(-1)
 
-			rng := rand.New(rand.NewPCG(uint64(cycle+1), uint64(worker+1)))
+			rng := rand.New(rand.NewPCG(uint64(cycle+1), uint64(i+1)))
 
 			for !stop.Load() {
 				ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
@@ -303,15 +314,27 @@ func runStressCloseDuringTrafficCycle(t *testing.T, cycle int) {
 			pool.Capacity(), pool.Active(), pool.InUse(), connCount(), pool.IsOpen(), liveGetWorkers.Load(), capacityInProgress.Load(), connectsAfterClose.Load())
 	}
 
+	// abort tears down on a watchdog trip. If closeCancel is non-nil a close
+	// goroutine is already running and we unblock it via cancellation;
+	// otherwise we drive a fresh CloseWithContext.
+	abort := func(closeCancel context.CancelFunc) {
+		if closeCancel != nil {
+			closeCancel()
+		}
+		stop.Store(true)
+		if closeCancel == nil {
+			ctx, cancel := context.WithTimeout(t.Context(), Watchdog)
+			_ = pool.CloseWithContext(ctx)
+			cancel()
+		}
+		waitForStressTraffic(t, cycle, &wg, Watchdog, status)
+	}
+
 	trafficStarted := assert.Eventuallyf(t, func() bool {
 		return liveGetWorkers.Load() == NumWorkers && successfulGets.Load() >= NumWorkers
 	}, WarmupTimeout, time.Millisecond, "cycle %d: traffic did not start: %s", cycle, status())
 	if !trafficStarted {
-		stop.Store(true)
-		ctx, cancel := context.WithTimeout(t.Context(), CloseTimeout)
-		_ = pool.CloseWithContext(ctx)
-		cancel()
-		waitForStressTraffic(t, cycle, &wg, WatchdogDelay, status)
+		abort(nil)
 		require.FailNowf(t, "traffic did not start", "cycle %d: %s", cycle, status())
 	}
 
@@ -330,17 +353,15 @@ func runStressCloseDuringTrafficCycle(t *testing.T, cycle int) {
 		default:
 			return false
 		}
-	}, WatchdogDelay, time.Millisecond, "cycle %d: CloseWithContext stalled: %s", cycle, status())
+	}, Watchdog, time.Millisecond, "cycle %d: CloseWithContext stalled: %s", cycle, status())
 	if !closeReturned {
-		cancelClose()
-		stop.Store(true)
-		waitForStressTraffic(t, cycle, &wg, WatchdogDelay, status)
+		abort(cancelClose)
 		require.FailNowf(t, "CloseWithContext stalled", "cycle %d: %s", cycle, status())
 	}
 	cancelClose()
 
 	stop.Store(true)
-	waitForStressTraffic(t, cycle, &wg, WatchdogDelay, status)
+	waitForStressTraffic(t, cycle, &wg, Watchdog, status)
 
 	require.NoErrorf(t, closeErr, "cycle %d: CloseWithContext failed", cycle)
 	require.Falsef(t, pool.IsOpen(), "cycle %d: pool should be closed", cycle)

--- a/go/pools/smartconnpool/stress_test.go
+++ b/go/pools/smartconnpool/stress_test.go
@@ -19,12 +19,14 @@ package smartconnpool
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
@@ -158,4 +160,226 @@ func TestStress(t *testing.T) {
 	time.Sleep(5 * time.Second)
 	stop.Store(true)
 	require.NoError(t, wg.Wait())
+}
+
+func TestStressCloseDuringTraffic(t *testing.T) {
+	const Cycles = 100
+
+	for cycle := range Cycles {
+		if !t.Run(fmt.Sprintf("cycle-%03d", cycle), func(t *testing.T) {
+			runStressCloseDuringTrafficCycle(t, cycle)
+		}) {
+			return
+		}
+	}
+}
+
+func runStressCloseDuringTrafficCycle(t *testing.T, cycle int) {
+	t.Helper()
+
+	const (
+		MaxCapacity   = 16
+		NumWorkers    = 24
+		WarmupTimeout = 30 * time.Second
+		CloseTimeout  = 30 * time.Second
+		WatchdogDelay = 30 * time.Second
+	)
+
+	var (
+		connsMu            sync.Mutex
+		allConns           []*StressConn
+		closeStarted       atomic.Bool
+		liveGetWorkers     atomic.Int64
+		successfulGets     atomic.Int64
+		connectsAfterClose atomic.Int64
+		capacityInProgress atomic.Bool
+	)
+
+	connect := func(_ context.Context) (*StressConn, error) {
+		if closeStarted.Load() {
+			connectsAfterClose.Add(1)
+		}
+
+		c := &StressConn{}
+		connsMu.Lock()
+		allConns = append(allConns, c)
+		connsMu.Unlock()
+		return c, nil
+	}
+	connCount := func() int {
+		connsMu.Lock()
+		defer connsMu.Unlock()
+		return len(allConns)
+	}
+
+	var refreshCount atomic.Int32
+	refresh := func() (bool, error) {
+		return refreshCount.Add(1)%2 == 0, nil
+	}
+
+	pool := NewPool[*StressConn](&Config[*StressConn]{
+		Capacity:        MaxCapacity,
+		IdleTimeout:     10 * time.Millisecond,
+		RefreshInterval: 2 * time.Millisecond,
+	}).Open(connect, refresh)
+
+	settings := []*Setting{
+		nil,
+		NewSetting("set a=1", "set a=0"),
+		NewSetting("set b=1", "set b=0"),
+		NewSetting("set c=1", "set c=0"),
+	}
+
+	var (
+		wg   errgroup.Group
+		stop atomic.Bool
+	)
+
+	for i := range NumWorkers {
+		worker := i
+		tid := int32(worker + 1)
+		wg.Go(func() error {
+			liveGetWorkers.Add(1)
+			defer liveGetWorkers.Add(-1)
+
+			rng := rand.New(rand.NewPCG(uint64(cycle+1), uint64(worker+1)))
+
+			for !stop.Load() {
+				ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+				conn, err := pool.Get(ctx, settings[rng.IntN(len(settings))])
+				cancel()
+				if err != nil {
+					runtime.Gosched()
+					continue
+				}
+				if conn.Conn.IsClosed() {
+					return fmt.Errorf("cycle %d: closed conn handed out to worker %d", cycle, tid)
+				}
+				successfulGets.Add(1)
+
+				previousOwner := conn.Conn.owner.Swap(tid)
+				if previousOwner != 0 {
+					return fmt.Errorf("cycle %d: conn handed out concurrently: %d still owned it when %d acquired", cycle, previousOwner, tid)
+				}
+				if rng.IntN(4) == 0 {
+					runtime.Gosched()
+				}
+				previousOwner = conn.Conn.owner.Swap(0)
+				if previousOwner != tid {
+					return fmt.Errorf("cycle %d: conn owner overwritten under us: expected %d, got %d", cycle, tid, previousOwner)
+				}
+
+				switch rng.IntN(50) {
+				case 0:
+					conn.Conn.closed.Store(true)
+					conn.Recycle()
+				case 1:
+					conn.Conn.closed.Store(true)
+					conn.Taint()
+				default:
+					conn.Recycle()
+				}
+			}
+			return nil
+		})
+	}
+
+	wg.Go(func() error {
+		rng := rand.New(rand.NewPCG(uint64(cycle+1), uint64(NumWorkers+1)))
+
+		for !stop.Load() {
+			ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+			capacityInProgress.Store(true)
+			_ = pool.SetCapacity(ctx, int64(rng.IntN(MaxCapacity+1)))
+			capacityInProgress.Store(false)
+			cancel()
+			time.Sleep(time.Duration(rng.IntN(5)) * time.Millisecond)
+		}
+		return nil
+	})
+
+	status := func() string {
+		return fmt.Sprintf("capacity=%d active=%d borrowed=%d open=%d isOpen=%v liveGetWorkers=%d capacityInProgress=%v connectsAfterClose=%d",
+			pool.Capacity(), pool.Active(), pool.InUse(), connCount(), pool.IsOpen(), liveGetWorkers.Load(), capacityInProgress.Load(), connectsAfterClose.Load())
+	}
+
+	trafficStarted := assert.Eventuallyf(t, func() bool {
+		return liveGetWorkers.Load() == NumWorkers && successfulGets.Load() >= NumWorkers
+	}, WarmupTimeout, time.Millisecond, "cycle %d: traffic did not start: %s", cycle, status())
+	if !trafficStarted {
+		stop.Store(true)
+		ctx, cancel := context.WithTimeout(t.Context(), CloseTimeout)
+		_ = pool.CloseWithContext(ctx)
+		cancel()
+		waitForStressTraffic(t, cycle, &wg, WatchdogDelay, status)
+		require.FailNowf(t, "traffic did not start", "cycle %d: %s", cycle, status())
+	}
+
+	closeCtx, cancelClose := context.WithTimeout(t.Context(), CloseTimeout)
+	closeDone := make(chan error, 1)
+	closeStarted.Store(true)
+	go func() {
+		closeDone <- pool.CloseWithContext(closeCtx)
+	}()
+
+	var closeErr error
+	closeReturned := assert.Eventuallyf(t, func() bool {
+		select {
+		case closeErr = <-closeDone:
+			return true
+		default:
+			return false
+		}
+	}, WatchdogDelay, time.Millisecond, "cycle %d: CloseWithContext stalled: %s", cycle, status())
+	if !closeReturned {
+		cancelClose()
+		stop.Store(true)
+		waitForStressTraffic(t, cycle, &wg, WatchdogDelay, status)
+		require.FailNowf(t, "CloseWithContext stalled", "cycle %d: %s", cycle, status())
+	}
+	cancelClose()
+
+	stop.Store(true)
+	waitForStressTraffic(t, cycle, &wg, WatchdogDelay, status)
+
+	require.NoErrorf(t, closeErr, "cycle %d: CloseWithContext failed", cycle)
+	require.Falsef(t, pool.IsOpen(), "cycle %d: pool should be closed", cycle)
+	require.EqualValuesf(t, 0, pool.Capacity(), "cycle %d: capacity should be 0 after Close", cycle)
+	require.EqualValuesf(t, 0, pool.Active(), "cycle %d: active should be 0 after Close", cycle)
+	require.EqualValuesf(t, 0, pool.InUse(), "cycle %d: borrowed should be 0 after Close", cycle)
+
+	connsMu.Lock()
+	defer connsMu.Unlock()
+
+	var leaked int
+	for _, c := range allConns {
+		if !c.IsClosed() {
+			leaked++
+		}
+	}
+	require.Equalf(t, 0, leaked, "cycle %d: leaked %d connections out of %d ever opened; connectsAfterClose=%d",
+		cycle, leaked, len(allConns), connectsAfterClose.Load())
+}
+
+func waitForStressTraffic(t *testing.T, cycle int, wg *errgroup.Group, timeout time.Duration, status func() string) {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- wg.Wait()
+	}()
+
+	var err error
+	trafficStopped := assert.Eventuallyf(t, func() bool {
+		select {
+		case err = <-done:
+			return true
+		default:
+			return false
+		}
+	}, timeout, time.Millisecond, "cycle %d: traffic workers did not stop: %s", cycle, status())
+	if !trafficStopped {
+		require.FailNowf(t, "traffic workers did not stop", "cycle %d: %s", cycle, status())
+	}
+	require.NoErrorf(t, err, "cycle %d: traffic worker failed", cycle)
 }

--- a/go/pools/smartconnpool/stress_test.go
+++ b/go/pools/smartconnpool/stress_test.go
@@ -290,7 +290,7 @@ func runStressCloseDuringTrafficCycle(t *testing.T, cycle int) {
 		for !stop.Load() {
 			ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
 			capacityInProgress.Store(true)
-			_ = pool.SetCapacity(ctx, int64(rng.IntN(MaxCapacity+1)))
+			_ = pool.SetCapacity(ctx, int64(rng.IntN(MaxCapacity)+1))
 			capacityInProgress.Store(false)
 			cancel()
 			time.Sleep(time.Duration(rng.IntN(5)) * time.Millisecond)
@@ -344,7 +344,6 @@ func runStressCloseDuringTrafficCycle(t *testing.T, cycle int) {
 
 	require.NoErrorf(t, closeErr, "cycle %d: CloseWithContext failed", cycle)
 	require.Falsef(t, pool.IsOpen(), "cycle %d: pool should be closed", cycle)
-	require.EqualValuesf(t, 0, pool.Capacity(), "cycle %d: capacity should be 0 after Close", cycle)
 	require.EqualValuesf(t, 0, pool.Active(), "cycle %d: active should be 0 after Close", cycle)
 	require.EqualValuesf(t, 0, pool.InUse(), "cycle %d: borrowed should be 0 after Close", cycle)
 


### PR DESCRIPTION
## Description

Fixes a close-time deadlock in `smartconnpool` where `CloseWithContext` could wait for background workers while still holding `capacityMu`. A refresh worker already inside `reopen()` could then block on that same mutex, leaving close stuck.

This also keeps closed/open state separate from capacity changes in the affected paths. `SetCapacity` can still update desired capacity, but `Get`, `getNew`, `put(nil)`, and returned idle connections now check whether the pool is closed before opening or retaining connections. The stress test avoids using `SetCapacity(0)` as a synthetic close signal so it exercises real `CloseWithContext` behavior.

## Related Issue(s)

Related to #20122.

Backport justification: this fixes a rare `smartconnpool` shutdown deadlock when `CloseWithContext` races with refresh-driven `reopen()`. The race can stall pool shutdown in production, and the fix is contained to connection-pool close/open state handling.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

Local test runs:

- `go test -count=1 -run '^(TestTxPoolBeginWithPoolConnectionError_Errno2006_Transient)$' -timeout 180s ./go/vt/vttablet/tabletserver`
- `go test -count=1 ./go/pools/smartconnpool`
- `go test -count=1 -race -run '^(TestCloseWithContextAfterSetCapacityZeroClosesPool|TestStressCloseDuringTraffic)$' -timeout 240s ./go/pools/smartconnpool`
- `go test -count=1 -race -run '^(TestTxPoolBeginWithPoolConnectionError_Errno2006_Transient)$' -timeout 180s ./go/vt/vttablet/tabletserver`

## Deployment Notes

No deployment steps required.

### AI Disclosure

This PR was written with AI assistance from Codex, with direction and review from Arthur.
