### PR TITLE
smartconnpool: reject SetCapacity on a closed pool + shutdown stress tests

### DIFF
--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -835,6 +835,9 @@ func (pool *ConnPool[C]) getWithSetting(ctx context.Context, setting *Setting) (
 func (pool *ConnPool[C]) SetCapacity(ctx context.Context, newcap int64) error {
 	pool.capacityMu.Lock()
 	defer pool.capacityMu.Unlock()
+	if pool.close.Load() == nil {
+		return ErrConnPoolClosed
+	}
 	return pool.setCapacity(ctx, newcap)
 }
 

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -808,6 +808,33 @@ func TestCloseWithContextDrainsAfterTimedOutSetCapacityZero(t *testing.T) {
 	conn.Recycle()
 }
 
+// TestSetCapacityRejectedOnClosedPool pins the contract that SetCapacity must
+// fail fast (rather than silently writing into pool.capacity) when the pool
+// is not open. This covers both states: never-opened and previously-opened-
+// then-closed. Without this guard, a SetCapacity call queued on capacityMu
+// during CloseWithContext can race through after Close releases the mutex
+// and bump capacity back up — leaving the pool closed with non-zero capacity.
+func TestSetCapacityRejectedOnClosedPool(t *testing.T) {
+	var state TestState
+
+	// Never-opened pool: SetCapacity must reject.
+	p := NewPool(&Config[*TestConn]{Capacity: 4})
+	err := p.SetCapacity(t.Context(), 2)
+	require.ErrorIs(t, err, ErrConnPoolClosed)
+
+	// Opened pool: SetCapacity succeeds.
+	p.Open(newConnector(&state), nil)
+	require.NoError(t, p.SetCapacity(t.Context(), 2))
+	require.EqualValues(t, 2, p.Capacity())
+
+	// Closed pool: SetCapacity must reject and must not change capacity.
+	p.Close()
+	require.False(t, p.IsOpen())
+	err = p.SetCapacity(t.Context(), 8)
+	require.ErrorIs(t, err, ErrConnPoolClosed)
+	require.EqualValues(t, 0, p.Capacity())
+}
+
 func TestConnReopen(t *testing.T) {
 	var state TestState
 

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -657,6 +657,82 @@ func TestUserClosing(t *testing.T) {
 	}
 }
 
+func TestCloseWithContextAfterIdleCleanupPopDoesNotLeak(t *testing.T) {
+	var state TestState
+
+	p := NewPool(&Config[*TestConn]{
+		Capacity: 2,
+		LogWait:  state.LogWait,
+	}).Open(newConnector(&state), nil)
+	t.Cleanup(p.Close)
+
+	held, err := p.Get(t.Context(), nil)
+	require.NoError(t, err)
+
+	idle, err := p.Get(t.Context(), nil)
+	require.NoError(t, err)
+	idle.Recycle()
+
+	cleanupConn, ok := p.clean.Pop()
+	require.True(t, ok)
+	require.NotNil(t, cleanupConn)
+
+	var waiterGotConn atomic.Bool
+	waiterDone := make(chan struct{})
+	go func() {
+		defer close(waiterDone)
+
+		conn, err := p.Get(t.Context(), nil)
+		if err == nil {
+			waiterGotConn.Store(true)
+			conn.Recycle()
+		}
+	}()
+
+	require.Eventually(t, func() bool {
+		return p.wait.waiting() == 1
+	}, 30*time.Second, time.Millisecond)
+
+	closeCtx, cancelClose := context.WithTimeout(t.Context(), 30*time.Second)
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- p.CloseWithContext(closeCtx)
+	}()
+
+	require.Eventually(t, func() bool {
+		return p.Capacity() == 0
+	}, 30*time.Second, time.Millisecond)
+
+	p.tryReturnConn(cleanupConn)
+	held.Recycle()
+
+	var closeErr error
+	require.Eventually(t, func() bool {
+		select {
+		case closeErr = <-closeDone:
+			return true
+		default:
+			return false
+		}
+	}, 30*time.Second, time.Millisecond)
+	cancelClose()
+	require.NoError(t, closeErr)
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-waiterDone:
+			return true
+		default:
+			return false
+		}
+	}, 30*time.Second, time.Millisecond)
+
+	require.False(t, waiterGotConn.Load(), "close must not hand an idle-cleanup conn to a waiter after capacity reaches 0")
+	require.EqualValues(t, 0, p.Active())
+	require.EqualValues(t, 0, p.InUse())
+	require.EqualValues(t, 0, state.open.Load())
+}
+
 func TestConnReopen(t *testing.T) {
 	var state TestState
 

--- a/go/pools/smartconnpool/stress_test.go
+++ b/go/pools/smartconnpool/stress_test.go
@@ -19,12 +19,14 @@ package smartconnpool
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
@@ -158,4 +160,383 @@ func TestStress(t *testing.T) {
 	time.Sleep(5 * time.Second)
 	stop.Store(true)
 	require.NoError(t, wg.Wait())
+}
+
+func TestStressFull(t *testing.T) {
+	const (
+		MaxCapacity      = 32
+		NumWorkers       = 16
+		CoverageTimeout  = 30 * time.Second
+		ShutdownTimeout  = 30 * time.Second
+		MinSuccessfulGet = 2000
+	)
+
+	var (
+		connsMu        sync.Mutex
+		allConns       []*StressConn
+		successfulGets atomic.Int64
+		capacitySets   atomic.Int64
+		refreshChecks  atomic.Int64
+	)
+
+	connect := func(_ context.Context) (*StressConn, error) {
+		c := &StressConn{}
+		connsMu.Lock()
+		allConns = append(allConns, c)
+		connsMu.Unlock()
+		return c, nil
+	}
+	connCount := func() int {
+		connsMu.Lock()
+		defer connsMu.Unlock()
+		return len(allConns)
+	}
+
+	refresh := func() (bool, error) {
+		return refreshChecks.Add(1)%4 == 0, nil
+	}
+
+	pool := NewPool[*StressConn](&Config[*StressConn]{
+		Capacity:        MaxCapacity,
+		IdleTimeout:     10 * time.Millisecond,
+		RefreshInterval: 25 * time.Millisecond,
+	}).Open(connect, refresh)
+
+	settings := []*Setting{
+		nil,
+		NewSetting("set a=1", "set a=0"),
+		NewSetting("set b=1", "set b=0"),
+		NewSetting("set c=1", "set c=0"),
+	}
+
+	var (
+		wg   errgroup.Group
+		stop atomic.Bool
+	)
+
+	for i := range NumWorkers {
+		worker := i
+		tid := int32(worker + 1)
+		wg.Go(func() error {
+			rng := rand.New(rand.NewPCG(uint64(worker+1), uint64(worker+101)))
+
+			for !stop.Load() {
+				ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+				conn, err := pool.Get(ctx, settings[rng.IntN(len(settings))])
+				cancel()
+				if err != nil {
+					runtime.Gosched()
+					continue
+				}
+
+				previousOwner := conn.Conn.owner.Swap(tid)
+				if previousOwner != 0 {
+					return fmt.Errorf("conn handed out concurrently: %d still owned it when %d acquired", previousOwner, tid)
+				}
+				runtime.Gosched()
+				previousOwner = conn.Conn.owner.Swap(0)
+				if previousOwner != tid {
+					return fmt.Errorf("conn owner overwritten under us: expected %d, got %d", tid, previousOwner)
+				}
+				successfulGets.Add(1)
+
+				switch rng.IntN(50) {
+				case 0:
+					conn.Conn.closed.Store(true)
+					conn.Recycle()
+				case 1:
+					conn.Conn.closed.Store(true)
+					conn.Taint()
+				default:
+					conn.Recycle()
+				}
+			}
+			return nil
+		})
+	}
+
+	wg.Go(func() error {
+		rng := rand.New(rand.NewPCG(1, 2))
+
+		for !stop.Load() {
+			ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+			_ = pool.SetCapacity(ctx, int64(rng.IntN(MaxCapacity+1)))
+			cancel()
+			capacitySets.Add(1)
+			runtime.Gosched()
+		}
+		return nil
+	})
+
+	status := func() string {
+		return fmt.Sprintf("capacity=%d active=%d borrowed=%d open=%d isOpen=%v successfulGets=%d capacitySets=%d refreshChecks=%d",
+			pool.Capacity(), pool.Active(), pool.InUse(), connCount(), pool.IsOpen(), successfulGets.Load(), capacitySets.Load(), refreshChecks.Load())
+	}
+
+	coverageReached := assert.Eventuallyf(t, func() bool {
+		return successfulGets.Load() >= MinSuccessfulGet &&
+			capacitySets.Load() >= 10 &&
+			refreshChecks.Load() >= 4
+	}, CoverageTimeout, time.Millisecond, "stress coverage was not reached: %s", status())
+
+	stop.Store(true)
+	waitForStressTraffic(t, -1, &wg, ShutdownTimeout, status)
+
+	restoreCtx, restoreCancel := context.WithTimeout(t.Context(), ShutdownTimeout)
+	restoreErr := pool.SetCapacity(restoreCtx, MaxCapacity)
+	restoreCancel()
+	require.NoError(t, restoreErr)
+
+	closeCtx, closeCancel := context.WithTimeout(t.Context(), ShutdownTimeout)
+	closeErr := pool.CloseWithContext(closeCtx)
+	closeCancel()
+	require.NoError(t, closeErr)
+
+	if !coverageReached {
+		require.FailNowf(t, "stress coverage was not reached", "%s", status())
+	}
+
+	require.EqualValues(t, 0, pool.active.Load(), "active should be 0 after Close")
+	require.EqualValues(t, 0, pool.borrowed.Load(), "borrowed should be 0 after Close")
+
+	connsMu.Lock()
+	defer connsMu.Unlock()
+
+	var leaked int
+	for _, c := range allConns {
+		if !c.IsClosed() {
+			leaked++
+		}
+	}
+	require.Equalf(t, 0, leaked, "leaked %d connections out of %d ever opened", leaked, len(allConns))
+	t.Logf("stress test exercised %d connections", len(allConns))
+}
+
+func TestStressRefreshReopenSetCapacityClose(t *testing.T) {
+	const Cycles = 50
+
+	for cycle := range Cycles {
+		if !t.Run(fmt.Sprintf("cycle-%03d", cycle), func(t *testing.T) {
+			runStressRefreshReopenSetCapacityCloseCycle(t, cycle)
+		}) {
+			return
+		}
+	}
+}
+
+func runStressRefreshReopenSetCapacityCloseCycle(t *testing.T, cycle int) {
+	t.Helper()
+
+	const (
+		MaxCapacity   = 12
+		NumWorkers    = 16
+		NumCapWorkers = 3
+		StartupWait   = 30 * time.Second
+		CloseTimeout  = 30 * time.Second
+		Watchdog      = 30 * time.Second
+	)
+
+	var (
+		connsMu            sync.Mutex
+		allConns           []*StressConn
+		liveGetWorkers     atomic.Int64
+		liveCapWorkers     atomic.Int64
+		successfulGets     atomic.Int64
+		refreshChecks      atomic.Int64
+		connectsAfterClose atomic.Int64
+		closeStarted       atomic.Bool
+		capacityInProgress atomic.Bool
+	)
+
+	connect := func(_ context.Context) (*StressConn, error) {
+		if closeStarted.Load() {
+			connectsAfterClose.Add(1)
+		}
+
+		c := &StressConn{}
+		connsMu.Lock()
+		allConns = append(allConns, c)
+		connsMu.Unlock()
+		return c, nil
+	}
+	connCount := func() int {
+		connsMu.Lock()
+		defer connsMu.Unlock()
+		return len(allConns)
+	}
+
+	refresh := func() (bool, error) {
+		refreshChecks.Add(1)
+		return true, nil
+	}
+
+	pool := NewPool[*StressConn](&Config[*StressConn]{
+		Capacity:        MaxCapacity,
+		IdleTimeout:     10 * time.Millisecond,
+		RefreshInterval: time.Millisecond,
+	}).Open(connect, refresh)
+
+	settings := []*Setting{
+		nil,
+		NewSetting("set refresh a=1", "set refresh a=0"),
+		NewSetting("set refresh b=1", "set refresh b=0"),
+		NewSetting("set refresh c=1", "set refresh c=0"),
+	}
+
+	var (
+		wg   errgroup.Group
+		stop atomic.Bool
+	)
+
+	for i := range NumWorkers {
+		worker := i
+		tid := int32(worker + 1)
+		wg.Go(func() error {
+			liveGetWorkers.Add(1)
+			defer liveGetWorkers.Add(-1)
+
+			rng := rand.New(rand.NewPCG(uint64(cycle+1), uint64(worker+201)))
+
+			for !stop.Load() {
+				ctx, cancel := context.WithTimeout(t.Context(), 150*time.Millisecond)
+				conn, err := pool.Get(ctx, settings[rng.IntN(len(settings))])
+				cancel()
+				if err != nil {
+					runtime.Gosched()
+					continue
+				}
+				if conn.Conn.IsClosed() {
+					return fmt.Errorf("cycle %d: closed conn handed out to worker %d", cycle, tid)
+				}
+
+				previousOwner := conn.Conn.owner.Swap(tid)
+				if previousOwner != 0 {
+					return fmt.Errorf("cycle %d: conn handed out concurrently: %d still owned it when %d acquired", cycle, previousOwner, tid)
+				}
+				if rng.IntN(3) == 0 {
+					runtime.Gosched()
+				}
+				previousOwner = conn.Conn.owner.Swap(0)
+				if previousOwner != tid {
+					return fmt.Errorf("cycle %d: conn owner overwritten under us: expected %d, got %d", cycle, tid, previousOwner)
+				}
+				successfulGets.Add(1)
+
+				if rng.IntN(20) == 0 {
+					conn.Conn.closed.Store(true)
+					conn.Recycle()
+					continue
+				}
+				conn.Recycle()
+			}
+			return nil
+		})
+	}
+
+	for i := range NumCapWorkers {
+		worker := i
+		wg.Go(func() error {
+			liveCapWorkers.Add(1)
+			defer liveCapWorkers.Add(-1)
+
+			rng := rand.New(rand.NewPCG(uint64(cycle+1), uint64(worker+301)))
+
+			for !stop.Load() {
+				ctx, cancel := context.WithTimeout(t.Context(), 150*time.Millisecond)
+				capacityInProgress.Store(true)
+				_ = pool.SetCapacity(ctx, int64(rng.IntN(MaxCapacity+1)))
+				capacityInProgress.Store(false)
+				cancel()
+				runtime.Gosched()
+			}
+			return nil
+		})
+	}
+
+	status := func() string {
+		return fmt.Sprintf("capacity=%d active=%d borrowed=%d open=%d isOpen=%v liveGetWorkers=%d liveCapWorkers=%d successfulGets=%d refreshChecks=%d connectsAfterClose=%d capacityInProgress=%v",
+			pool.Capacity(), pool.Active(), pool.InUse(), connCount(), pool.IsOpen(), liveGetWorkers.Load(), liveCapWorkers.Load(), successfulGets.Load(), refreshChecks.Load(), connectsAfterClose.Load(), capacityInProgress.Load())
+	}
+
+	started := assert.Eventuallyf(t, func() bool {
+		return liveGetWorkers.Load() == NumWorkers &&
+			liveCapWorkers.Load() == NumCapWorkers &&
+			successfulGets.Load() >= NumWorkers &&
+			refreshChecks.Load() > 0
+	}, StartupWait, time.Millisecond, "cycle %d: stress workers did not start: %s", cycle, status())
+	if !started {
+		stop.Store(true)
+		waitForStressTraffic(t, cycle, &wg, Watchdog, status)
+		closeCtx, closeCancel := context.WithTimeout(t.Context(), CloseTimeout)
+		_ = pool.CloseWithContext(closeCtx)
+		closeCancel()
+		require.FailNowf(t, "stress workers did not start", "cycle %d: %s", cycle, status())
+	}
+
+	closeCtx, cancelClose := context.WithTimeout(t.Context(), CloseTimeout)
+	closeDone := make(chan error, 1)
+	closeStarted.Store(true)
+	go func() {
+		closeDone <- pool.CloseWithContext(closeCtx)
+	}()
+
+	var closeErr error
+	closeReturned := assert.Eventuallyf(t, func() bool {
+		select {
+		case closeErr = <-closeDone:
+			return true
+		default:
+			return false
+		}
+	}, Watchdog, time.Millisecond, "cycle %d: CloseWithContext stalled during refresh/capacity churn: %s", cycle, status())
+	cancelClose()
+
+	stop.Store(true)
+
+	if !closeReturned {
+		require.FailNowf(t, "CloseWithContext stalled during refresh/capacity churn", "cycle %d: %s", cycle, status())
+	}
+	waitForStressTraffic(t, cycle, &wg, Watchdog, status)
+
+	require.NoErrorf(t, closeErr, "cycle %d: CloseWithContext failed during refresh/capacity churn: %s", cycle, status())
+	require.Falsef(t, pool.IsOpen(), "cycle %d: pool should be closed", cycle)
+	require.EqualValuesf(t, 0, pool.Capacity(), "cycle %d: capacity should be 0 after Close: %s", cycle, status())
+	require.EqualValuesf(t, 0, pool.Active(), "cycle %d: active should be 0 after Close: %s", cycle, status())
+	require.EqualValuesf(t, 0, pool.InUse(), "cycle %d: borrowed should be 0 after Close: %s", cycle, status())
+
+	finalStatus := status()
+	connsMu.Lock()
+	defer connsMu.Unlock()
+
+	var leaked int
+	for _, c := range allConns {
+		if !c.IsClosed() {
+			leaked++
+		}
+	}
+	require.Equalf(t, 0, leaked, "cycle %d: leaked %d connections out of %d ever opened; %s",
+		cycle, leaked, len(allConns), finalStatus)
+}
+
+func waitForStressTraffic(t *testing.T, cycle int, wg *errgroup.Group, timeout time.Duration, status func() string) {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- wg.Wait()
+	}()
+
+	var err error
+	trafficStopped := assert.Eventuallyf(t, func() bool {
+		select {
+		case err = <-done:
+			return true
+		default:
+			return false
+		}
+	}, timeout, time.Millisecond, "cycle %d: traffic workers did not stop: %s", cycle, status())
+	if !trafficStopped {
+		require.FailNowf(t, "traffic workers did not stop", "cycle %d: %s", cycle, status())
+	}
+	require.NoErrorf(t, err, "cycle %d: traffic worker failed", cycle)
 }

--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -209,11 +209,11 @@ func primeTxPoolWithConnection(t *testing.T, ctx context.Context) (*fakesqldb.DB
 	t.Helper()
 	db := fakesqldb.New(t)
 	txPool, _ := newTxPool()
+	params := dbconfigs.New(db.ConnParams())
+	txPool.Open(params, params, params)
 	// Set the capacity to 1 to ensure that the db connection is reused.
 	err := txPool.scp.conns.SetCapacity(t.Context(), 1)
 	require.NoError(t, err)
-	params := dbconfigs.New(db.ConnParams())
-	txPool.Open(params, params, params)
 
 	// Run a query to trigger a database connection. That connection will be
 	// reused by subsequent transactions.


### PR DESCRIPTION
## What's this?

Adds the remaining smartconnpool stress/regression tests from the connection pool stall / correctness audit, plus the small fix one of them surfaced.

### Fix: `SetCapacity` on a closed pool

`SetCapacity` used to accept calls on a pool whose `close` pointer was `nil`. That predicate covers two states — never-opened, and previously-opened-then-closed — and in both, the prior "successful" return was misleading:

- **Never-opened pool.** The call did write into `pool.capacity`, but `pool.open()` then unconditionally stores `config.maxCapacity` into `pool.capacity` (`pool.go:253`), so the write was always going to be overwritten the moment anyone called `Open()`. The caller's intent was never honored — it just looked like it was.
- **Previously-opened-then-closed pool.** The write also went through. With no race, it sat there until the next `Open()` clobbered it — same silent-no-op outcome. With a `SetCapacity` racing `CloseWithContext`, though, `SetCapacity` could queue on `capacityMu` behind Close's `setCapacity(ctx, 0)`, run right after Close released the mutex, and swap capacity from 0 back to N. The pool ended up `IsOpen() == false` with `Capacity() == N`, and the stale value stuck around until the next `Open()`. `TestStressRefreshReopenSetCapacityClose` surfaces this case.

Guarded `SetCapacity` with the same `close.Load() == nil` check that `reopen()` already uses, returning `ErrConnPoolClosed` when the pool is not open. Strictly an improvement: callers that previously got `nil` were either getting nothing or a poisoned read; now they get a real failure they can react to.

One test (`primeTxPoolWithConnection` in `tx_pool_test.go`) was leaning on the silent-no-op behavior pre-`Open`. It always intended capacity to be 1, but the post-`Open` overwrite meant it actually ran at the default (300). The `SetCapacity(1)` is now moved after `Open`, which is what the test always wanted.

### Tests

- `TestStressFull` — broad shutdown stress
- `TestStressRefreshReopenSetCapacityClose` — surfaces the `SetCapacity`/`Close` race fixed here
- `TestCloseWithContextAfterIdleCleanupPopDoesNotLeak` — covered by #20122's fix
- `TestSetCapacityRejectedOnClosedPool` — pins the new contract directly (pre-`Open`, open, and closed)

## Related Issue(s)

Builds on #20122 and #20157, both of which have merged.

## Backport

The same `SetCapacity` / `CloseWithContext` race window exists in `release-23.0` and `release-24.0` — the `capacityMu` ordering that lets a queued `SetCapacity` run after `Close` releases the mutex is unchanged on those branches. Both #20122 and #20157 were backported to 23.0 and 24.0; this PR is the matching fix and regression coverage, so it should follow the same path.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

`SetCapacity` now returns `ErrConnPoolClosed` instead of silently storing a value that is either later overwritten by `Open()` or left as inconsistent state on a closed pool. The only production callers are `SetPoolSize`, `SetStreamPoolSize`, and the two halves of `SetTxPoolSize` in `tabletserver.go`, all reachable only through the `/debug/env` HTTP form. That endpoint has no open-state guard and is wired up in `NewTabletServer`, so an operator hitting it while the QueryEngine pools are closed (between startup and `QueryEngine.Open`, across state transitions that close the pools, or after `Close`) previously got a misleading "Setting X to: N" success even though the write was about to be clobbered (or worse, left as stale capacity on a closed pool). After this PR they get `failed setting value for X: connection pool is closed` instead — a clear, actionable failure rather than a fake success. Steady-state `/debug/env` usage on an open tablet is unaffected.

### AI Disclosure

Tests written by GPT-5 with human direction; the `SetCapacity` guard and the test updates were written by Claude Code with direction from Arthur.
