### PR TITLE
connpool: fix connection leak during idle connection reopen (#18967)

### DIFF
--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -429,9 +429,13 @@ func (pool *ConnPool[C]) pop(stack *connStack[C]) *Pooled[C] {
 	// to expire this connection (even if it's still visible to them), so it's
 	// safe to return it
 	for conn, ok := stack.Pop(); ok; conn, ok = stack.Pop() {
-		if conn.timeUsed.borrow() {
-			return conn
+		if !conn.timeUsed.borrow() {
+			// Ignore the connection that couldn't be borrowed;
+			// it's being closed by the idle worker and replaced by a new connection.
+			continue
 		}
+
+		return conn
 	}
 	return nil
 }
@@ -729,11 +733,23 @@ func (pool *ConnPool[C]) closeIdleResources(now time.Time) {
 		for conn := s.Peek(); conn != nil; conn = conn.next.Load() {
 			if conn.timeUsed.expired(mono, timeout) {
 				pool.Metrics.idleClosed.Add(1)
+
 				conn.Close()
+				pool.closedConn()
+
 				// Using context.Background() is fine since MySQL connection already enforces
 				// a connect timeout via the `db_connect_timeout_ms` config param.
-				if err := pool.connReopen(context.Background(), conn, mono); err != nil {
-					pool.closedConn()
+				c, err := pool.getNew(context.Background())
+				if err != nil {
+					// If we couldn't open a new connection, just continue
+					continue
+				}
+
+				// opening a new connection might have raced with other goroutines,
+				// so it's possible that we got back `nil` here
+				if c != nil {
+					// Return the new connection to the pool
+					pool.tryReturnConn(c)
 				}
 			}
 		}

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -1200,3 +1200,168 @@ func TestGetSpike(t *testing.T) {
 		close(errs)
 	}
 }
+
+// TestCloseDuringWaitForConn confirms that we do not get hung when the pool gets
+// closed while we are waiting for a connection from it.
+func TestCloseDuringWaitForConn(t *testing.T) {
+	ctx := context.Background()
+	goRoutineCnt := 50
+	getTimeout := 2000 * time.Millisecond
+
+	for range 50 {
+		hung := make(chan (struct{}), goRoutineCnt)
+		var state TestState
+		p := NewPool(&Config[*TestConn]{
+			Capacity:    1,
+			IdleTimeout: time.Second,
+			LogWait:     state.LogWait,
+		}).Open(newConnector(&state), nil)
+
+		closed := atomic.Bool{}
+		wg := sync.WaitGroup{}
+		var count atomic.Int64
+
+		fmt.Println("Starting TestCloseDuringWaitForConn")
+
+		// Spawn multiple goroutines to perform Get and Put operations, but only
+		// allow connections to be checked out until `closed` has been set to true.
+		for range goRoutineCnt {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for !closed.Load() {
+					timeout := time.After(getTimeout)
+					getCtx, getCancel := context.WithTimeout(ctx, getTimeout/3)
+					defer getCancel()
+					done := make(chan struct{})
+					go func() {
+						defer close(done)
+						r, err := p.Get(getCtx, nil)
+						if err != nil {
+							return
+						}
+						count.Add(1)
+						r.Recycle()
+					}()
+					select {
+					case <-timeout:
+						hung <- struct{}{}
+						return
+					case <-done:
+					}
+				}
+			}()
+		}
+
+		// Let the go-routines get up and running.
+		for count.Load() < 5000 {
+			time.Sleep(1 * time.Millisecond)
+		}
+
+		// Close the pool, which should allow all goroutines to finish.
+		closeCtx, closeCancel := context.WithTimeout(ctx, 1*time.Second)
+		defer closeCancel()
+		err := p.CloseWithContext(closeCtx)
+		closed.Store(true)
+		require.NoError(t, err, "Failed to close pool")
+
+		// Wait for all goroutines to finish.
+		wg.Wait()
+		select {
+		case <-hung:
+			require.FailNow(t, "Race encountered and deadlock detected")
+		default:
+		}
+
+		fmt.Println("Count of connections checked out:", count.Load())
+		// Check that the pool is closed and no connections are available.
+		require.EqualValues(t, 0, p.Capacity())
+		require.EqualValues(t, 0, p.Available())
+		require.EqualValues(t, 0, state.open.Load())
+	}
+}
+
+// TestIdleTimeoutConnectionLeak checks for leaked connections after idle timeout
+func TestIdleTimeoutConnectionLeak(t *testing.T) {
+	var state TestState
+
+	// Slow connection creation to ensure idle timeout happens during reopening
+	state.chaos.delayConnect = 300 * time.Millisecond
+
+	p := NewPool(&Config[*TestConn]{
+		Capacity:    2,
+		IdleTimeout: 50 * time.Millisecond,
+		LogWait:     state.LogWait,
+	}).Open(newConnector(&state), nil)
+
+	getCtx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+
+	// Get and return two connections
+	conn1, err := p.Get(getCtx, nil)
+	require.NoError(t, err)
+
+	conn2, err := p.Get(getCtx, nil)
+	require.NoError(t, err)
+
+	p.put(conn1)
+	p.put(conn2)
+
+	// At this point: Active=2, InUse=0, Available=2
+	require.EqualValues(t, 2, p.Active())
+	require.EqualValues(t, 0, p.InUse())
+	require.EqualValues(t, 2, p.Available())
+
+	// Wait for idle timeout to kick in and start expiring connections
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		// Check the actual number of currently open connections
+		assert.Equal(c, int64(2), state.open.Load())
+		// Check the total number of closed connections
+		assert.Equal(c, int64(1), state.close.Load())
+	}, 100*time.Millisecond, 10*time.Millisecond)
+
+	// At this point, the idle timeout worker has expired the connections
+	// and is trying to reopen them (which takes 300ms due to delayConnect)
+
+	// Try to get connections while they're being reopened
+	// This should trigger the bug where connections get discarded
+	for i := 0; i < 2; i++ {
+		getCtx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+		defer cancel()
+
+		conn, err := p.Get(getCtx, nil)
+		require.NoError(t, err)
+
+		p.put(conn)
+	}
+
+	// Wait a moment for all reopening to complete
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		// Check the actual number of currently open connections
+		require.Equal(c, int64(2), state.open.Load())
+		// Check the total number of closed connections
+		require.Equal(c, int64(2), state.close.Load())
+	}, 400*time.Millisecond, 10*time.Millisecond)
+
+	// Check the pool state
+	assert.Equal(t, int64(2), p.Active())
+	assert.Equal(t, int64(0), p.InUse())
+	assert.Equal(t, int64(2), p.Available())
+	assert.Equal(t, int64(2), p.Metrics.IdleClosed())
+
+	// Try to close the pool - if there are leaked connections, this will timeout
+	closeCtx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+
+	err = p.CloseWithContext(closeCtx)
+	require.NoError(t, err)
+
+	// Pool should be completely closed now
+	assert.Equal(t, int64(0), p.Active())
+	assert.Equal(t, int64(0), p.InUse())
+	assert.Equal(t, int64(0), p.Available())
+	assert.Equal(t, int64(2), p.Metrics.IdleClosed())
+
+	assert.Equal(t, int64(0), state.open.Load())
+	assert.Equal(t, int64(4), state.close.Load())
+}


### PR DESCRIPTION
Signed-off-by: Arthur Schreiber <arthur@planetscale.com>

# Conflicts:
#	go/pools/smartconnpool/pool_test.go

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
