### PR TITLE
vtorc: wait for configuration before initializing forgetAliases cache

### DIFF
--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -71,12 +71,12 @@ func init() {
 }
 
 func initializeInstanceDao() {
-	config.WaitForConfigurationToBeLoaded()
 	initForgetAliasesCache()
 }
 
 func initForgetAliasesCache() {
 	forgetAliasesOnce.Do(func() {
+		config.WaitForConfigurationToBeLoaded()
 		forgetAliases = cache.New(config.GetInstancePollTime()*3, time.Second)
 	})
 }


### PR DESCRIPTION
## Description

Follow-up to #19843. That PR replaced the busy-wait cache init with a `sync.Once`, but the `initForgetAliasesCache` body still reads `config.GetInstancePollTime()` without first waiting for configuration to be loaded.

If `InstanceIsForgotten` or `ForgetInstance` reaches the cache before `config.MarkConfigurationLoaded()` has been called, the cache is built with the *default* `instance-poll-time` and `sync.Once` then prevents it from ever being rebuilt with the configured value.

This moves the `WaitForConfigurationToBeLoaded()` call inside the `forgetAliasesOnce.Do` block so the cache is always created from the loaded configuration, regardless of which goroutine wins the race to initialize it.

Spotted by Copilot in https://github.com/vitessio/vitess/pull/19846#discussion_r3153375075.

The `go/vt/vtorc/logic` tests call `inst.InitializeForgetAliasesCache()` directly, which now waits for configuration. The `inst` package already had a test-only `init()` calling `config.MarkConfigurationLoaded()` (`instance_test.go`); this PR mirrors that in `logic` via a new `main_test.go` so the affected tests don't deadlock.

## Related Issue(s)

Follow-up to #19843.

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [ ] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

Most of this was written by Claude Code — I provided direction and review.