### PR TITLE
mysqlctl: prevent test hang on missing remote shutdown RPC

### DIFF
--- a/go/vt/mysqlctl/mysqld_test.go
+++ b/go/vt/mysqlctl/mysqld_test.go
@@ -175,7 +175,12 @@ func TestMysqldShutdownForwardsTimeoutToRemoteMysqlctld(t *testing.T) {
 	err = mysqld.Shutdown(ctx, &Mycnf{}, true, shutdownTimeout)
 	require.NoError(t, err)
 
-	request := <-recordingServer.shutdownRequests
+	var request *mysqlctlpb.ShutdownRequest
+	select {
+	case request = <-recordingServer.shutdownRequests:
+	case <-ctx.Done():
+		require.Failf(t, "timed out waiting for remote shutdown request", "context error: %v", ctx.Err())
+	}
 	assert.True(t, request.WaitForMysqld)
 
 	gotTimeout, ok, err := protoutil.DurationFromProto(request.MysqlShutdownTimeout)


### PR DESCRIPTION
## Description

`TestMysqldShutdownForwardsTimeoutToRemoteMysqlctld` reads the recorded shutdown request from `recordingServer.shutdownRequests` with no cancellation or timeout. If a regression leaves the remote shutdown path returning `nil` without actually invoking the RPC, the test stalls until an external CI timeout fires.

This wraps the receive in a `select` that also watches `ctx.Done()` (the test already creates a 5s context), so a missing RPC fails the test fast with a clear message instead of hanging.

This bug exists on `main` as well as on the in-flight backports to `release-23.0` (#20074) and `release-24.0` (#20075), so this PR carries backport labels for both branches.

## Related Issue(s)

Spotted in review of the `release-24.0` backport: https://github.com/vitessio/vitess/pull/20075#discussion_r3220003678

Original PR that introduced the test: #20059

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — test-only change.

### AI Disclosure

Written by Claude Code with my direction.