### PR TITLE
onlineddl: e2e test for `REVERT VITESS_MIGRATION` completing on both shards

### DIFF
--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -857,6 +857,35 @@ func TestVreplSchemaChanges(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Revert a migration completed on both shards", func(t *testing.T) {
+		var uuid string
+		t.Run("run migration, expect completion on both shards", func(t *testing.T) {
+			uuid = testOnlineDDLStatement(t, alterTableTrivialStatement, "vitess", providedUUID, providedMigrationContext, "vtgate", "test_val", "", false)
+			onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
+		})
+		var revertUUID string
+		t.Run("issue revert migration", func(t *testing.T) {
+			revertQuery := fmt.Sprintf("revert vitess_migration '%s'", uuid)
+			output, err := clusterInstance.VtctldClientProcess.ApplySchemaWithOutput(keyspaceName, revertQuery, cluster.ApplySchemaParams{DDLStrategy: "vitess"})
+			require.NoError(t, err)
+			revertUUID = strings.TrimSpace(output)
+			assert.NotEmpty(t, revertUUID)
+		})
+		t.Run("revert completes on both shards", func(t *testing.T) {
+			status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, revertUUID, normalMigrationWait, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
+			fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
+			onlineddl.CheckMigrationStatus(t, &vtParams, shards, revertUUID, schema.OnlineDDLStatusComplete)
+		})
+		t.Run("validate both shards show complete in SHOW VITESS_MIGRATIONS", func(t *testing.T) {
+			rs := onlineddl.ReadMigrations(t, &vtParams, revertUUID)
+			require.NotNil(t, rs)
+			require.Equal(t, 2, len(rs.Rows))
+			for _, row := range rs.Named().Rows {
+				status := row["migration_status"].ToString()
+				assert.Equal(t, string(schema.OnlineDDLStatusComplete), status, "shard %s", row["shard"].ToString())
+			}
+		})
+	})
 	t.Run("summary: validate sequential migration IDs", func(t *testing.T) {
 		onlineddl.ValidateSequentialMigrationIDs(t, &vtParams, shards)
 	})


### PR DESCRIPTION
This PR adds a test to a behavior we know is correct, and is true in general for all `ApplySchema` operation, but just making it very explicit now.

Adds a follow-up sub-test to `TestVreplSchemaChanges` (the only e2e suite that runs on a 2-shard cluster) covering the happy path for revert: a migration completes on both shards, a `REVERT VITESS_MIGRATION` is issued via vtctldclient, and the revert completes successfully on both shards.

The existing sibling test ("Revert a migration completed on one shard and cancelled on another") covers the failure case where revert is impossible on one shard. This PR adds the complementary success case.

## Verification

- `WaitForMigrationStatus` uses the full `shards` slice — the wait only returns when both shards reach terminal status
- `ReadMigrations` asserts exactly 2 rows, both `complete`, with the shard name surfaced in any failure message

