### PR TITLE
smartconnpool: consolidate shutdown signaling on lifetime context

### DIFF
--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -159,14 +159,15 @@ type ConnPool[C Connection] struct {
 
 	// workers is a waitgroup for all the currently running worker goroutines
 	workers    sync.WaitGroup
-	close      atomic.Pointer[chan struct{}]
 	capacityMu sync.Mutex
 
 	// lifetime holds a context that is cancelled when the pool starts
-	// closing. Code paths that call into user-supplied callbacks (e.g. the
-	// connect Connector) pass it through so that calls in flight at shutdown
-	// unblock instead of blocking on the backend's connect timeout. Held
-	// behind a pointer to keep ConnPool's heap footprint stable.
+	// closing. It is the single source of truth for "is the pool open":
+	// a non-nil value means open, and the ctx is cancelled at the start of
+	// Close so that workers, queued waiters, and user-supplied callbacks
+	// (e.g. the Connector) all unblock immediately rather than waiting on
+	// the backend's connect timeout. Held behind a pointer to keep
+	// ConnPool's heap footprint stable.
 	lifetime atomic.Pointer[lifetime]
 
 	config struct {
@@ -218,7 +219,7 @@ func NewPool[C Connection](config *Config[C]) *ConnPool[C] {
 	return pool
 }
 
-func (pool *ConnPool[C]) runWorker(close <-chan struct{}, interval time.Duration, worker func(now time.Time) bool) {
+func (pool *ConnPool[C]) runWorker(ctx context.Context, interval time.Duration, worker func(now time.Time) bool) {
 	pool.workers.Add(1)
 
 	go func() {
@@ -233,7 +234,7 @@ func (pool *ConnPool[C]) runWorker(close <-chan struct{}, interval time.Duration
 				if !worker(now) {
 					return
 				}
-			case <-close:
+			case <-ctx.Done():
 				return
 			}
 		}
@@ -241,21 +242,19 @@ func (pool *ConnPool[C]) runWorker(close <-chan struct{}, interval time.Duration
 }
 
 func (pool *ConnPool[C]) open() {
-	closeChan := make(chan struct{})
-	if !pool.close.CompareAndSwap(nil, &closeChan) {
+	ctx, cancel := context.WithCancel(context.Background())
+	if !pool.lifetime.CompareAndSwap(nil, &lifetime{ctx: ctx, cancel: cancel}) {
 		// already open
+		cancel()
 		return
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	pool.lifetime.Store(&lifetime{ctx: ctx, cancel: cancel})
 
 	pool.capacity.Store(pool.config.maxCapacity)
 	pool.setIdleCount()
 
 	// The expire worker takes care of removing from the waiter list any clients whose
 	// context has been cancelled.
-	pool.runWorker(closeChan, 100*time.Millisecond, func(_ time.Time) bool {
+	pool.runWorker(ctx, 100*time.Millisecond, func(_ time.Time) bool {
 		maybeStarving := pool.wait.maybeStarvingCount()
 
 		// Do not allow connections to starve; if there's waiters in the queue
@@ -269,7 +268,7 @@ func (pool *ConnPool[C]) open() {
 	idleTimeout := pool.IdleTimeout()
 	if idleTimeout != 0 {
 		// The idle worker takes care of closing connections that have been idle too long
-		pool.runWorker(closeChan, idleTimeout/10, func(now time.Time) bool {
+		pool.runWorker(ctx, idleTimeout/10, func(now time.Time) bool {
 			pool.closeIdleResources(now)
 			return true
 		})
@@ -280,7 +279,7 @@ func (pool *ConnPool[C]) open() {
 		// The refresh worker periodically checks the refresh callback in this pool
 		// to decide whether all the connections in the pool need to be cycled
 		// (this usually only happens when there's a global DNS change).
-		pool.runWorker(closeChan, refreshInterval, func(_ time.Time) bool {
+		pool.runWorker(ctx, refreshInterval, func(_ time.Time) bool {
 			refresh, err := pool.config.refresh()
 			if err != nil {
 				log.Error(fmt.Sprint(err))
@@ -296,7 +295,7 @@ func (pool *ConnPool[C]) open() {
 // Open starts the background workers that manage the pool and gets it ready
 // to start serving out connections.
 func (pool *ConnPool[C]) Open(connect Connector[C], refresh RefreshCheck) *ConnPool[C] {
-	if pool.close.Load() != nil {
+	if pool.lifetime.Load() != nil {
 		// already open
 		return pool
 	}
@@ -324,28 +323,23 @@ func (pool *ConnPool[C]) Close() {
 func (pool *ConnPool[C]) CloseWithContext(ctx context.Context) error {
 	pool.capacityMu.Lock()
 
-	if pool.close.Load() == nil {
+	// Cancel the pool's lifetime context before we start draining: any user
+	// connect callback currently blocked behind it (e.g. the idle worker
+	// reopening an expired connection) unblocks immediately, workers exit,
+	// and queued waiters in wait.waitForConn return ErrConnPoolClosed
+	// without having to wait for the drain to finish.
+	lt := pool.lifetime.Swap(nil)
+	if lt == nil {
 		// already closed
 		pool.capacityMu.Unlock()
 		return nil
 	}
-
-	// Cancel the pool's lifetime context before we start draining: any user
-	// connect callback currently blocked behind it (e.g. the idle worker
-	// reopening an expired connection) needs to unblock now so that
-	// setCapacity can observe active dropping to zero and so that
-	// workers.Wait below isn't held up by a hung connect.
-	if lt := pool.lifetime.Swap(nil); lt != nil {
-		lt.cancel()
-	}
+	lt.cancel()
 
 	// close all the connections in the pool; if we time out while waiting for
 	// users to return our connections, we still want to finish the shutdown
 	// for the pool
 	err := pool.setCapacity(ctx, 0)
-
-	closeChan := *pool.close.Swap(nil)
-	close(closeChan)
 
 	pool.capacityMu.Unlock()
 	pool.workers.Wait()
@@ -356,7 +350,7 @@ func (pool *ConnPool[C]) reopen() {
 	pool.capacityMu.Lock()
 	defer pool.capacityMu.Unlock()
 
-	if pool.close.Load() == nil {
+	if pool.lifetime.Load() == nil {
 		return
 	}
 
@@ -382,7 +376,7 @@ func (pool *ConnPool[C]) reopen() {
 
 // IsOpen returns whether the pool is open
 func (pool *ConnPool[C]) IsOpen() bool {
-	return pool.close.Load() != nil
+	return pool.lifetime.Load() != nil
 }
 
 // Capacity returns the maximum amount of connections that this pool can maintain open
@@ -453,7 +447,7 @@ func (pool *ConnPool[C]) Get(ctx context.Context, setting *Setting) (*Pooled[C],
 	if ctx.Err() != nil {
 		return nil, ErrCtxTimeout
 	}
-	if pool.close.Load() == nil {
+	if pool.lifetime.Load() == nil {
 		return nil, ErrConnPoolClosed
 	}
 	if pool.capacity.Load() == 0 {
@@ -662,7 +656,7 @@ func (pool *ConnPool[C]) connectCtx() context.Context {
 
 func (pool *ConnPool[C]) getNew(ctx context.Context) (*Pooled[C], error) {
 	for {
-		if pool.close.Load() == nil {
+		if pool.lifetime.Load() == nil {
 			return nil, ErrConnPoolClosed
 		}
 
@@ -677,7 +671,7 @@ func (pool *ConnPool[C]) getNew(ctx context.Context) (*Pooled[C], error) {
 				pool.closedConn()
 				return nil, err
 			}
-			if pool.close.Load() == nil {
+			if pool.lifetime.Load() == nil {
 				conn.Close()
 				pool.closedConn()
 				return nil, ErrConnPoolClosed
@@ -711,14 +705,14 @@ func (pool *ConnPool[C]) get(ctx context.Context) (*Pooled[C], error) {
 	if conn == nil {
 		start := time.Now()
 
-		closeChan := pool.close.Load()
-		if closeChan == nil {
+		lt := pool.lifetime.Load()
+		if lt == nil {
 			return nil, ErrConnPoolClosed
 		}
 
-		conn, err = pool.wait.waitForConn(ctx, nil, *closeChan, pool.config.maxWaiters)
+		conn, err = pool.wait.waitForConn(ctx, nil, lt.ctx, pool.config.maxWaiters)
 		if err != nil {
-			if errors.Is(err, ErrPoolWaiterCapReached) {
+			if errors.Is(err, ErrPoolWaiterCapReached) || errors.Is(err, ErrConnPoolClosed) {
 				return nil, err
 			}
 			return nil, ErrTimeout
@@ -777,14 +771,14 @@ func (pool *ConnPool[C]) getWithSetting(ctx context.Context, setting *Setting) (
 	if conn == nil {
 		start := time.Now()
 
-		closeChan := pool.close.Load()
-		if closeChan == nil {
+		lt := pool.lifetime.Load()
+		if lt == nil {
 			return nil, ErrConnPoolClosed
 		}
 
-		conn, err = pool.wait.waitForConn(ctx, setting, *closeChan, pool.config.maxWaiters)
+		conn, err = pool.wait.waitForConn(ctx, setting, lt.ctx, pool.config.maxWaiters)
 		if err != nil {
-			if errors.Is(err, ErrPoolWaiterCapReached) {
+			if errors.Is(err, ErrPoolWaiterCapReached) || errors.Is(err, ErrConnPoolClosed) {
 				return nil, err
 			}
 			return nil, ErrTimeout
@@ -835,7 +829,7 @@ func (pool *ConnPool[C]) getWithSetting(ctx context.Context, setting *Setting) (
 func (pool *ConnPool[C]) SetCapacity(ctx context.Context, newcap int64) error {
 	pool.capacityMu.Lock()
 	defer pool.capacityMu.Unlock()
-	if pool.close.Load() == nil {
+	if pool.lifetime.Load() == nil {
 		return ErrConnPoolClosed
 	}
 	return pool.setCapacity(ctx, newcap)
@@ -954,7 +948,7 @@ func (pool *ConnPool[C]) closeIdleResources(now time.Time) {
 		// silently migrating to clean.
 		for conn := expiredConnections; conn != nil; {
 			next := conn.next.Load()
-			if pool.close.Load() == nil || pool.active.Load() >= pool.capacity.Load() {
+			if pool.lifetime.Load() == nil || pool.active.Load() >= pool.capacity.Load() {
 				break
 			}
 
@@ -966,7 +960,7 @@ func (pool *ConnPool[C]) closeIdleResources(now time.Time) {
 
 			for {
 				open := pool.active.Load()
-				if pool.close.Load() == nil || open >= pool.capacity.Load() {
+				if pool.lifetime.Load() == nil || open >= pool.capacity.Load() {
 					conn.Close()
 					break
 				}

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -495,12 +495,18 @@ func (pool *ConnPool[C]) put(conn *Pooled[C]) {
 }
 
 func (pool *ConnPool[C]) tryReturnConn(conn *Pooled[C], updateIdleTime bool) bool {
-	// If the pool has more conns out than its configured capacity, close
-	// this one eagerly instead of handing it off to a waiter or pushing it
-	// onto a stack. Otherwise a setCapacity reducing capacity keeps cycling
-	// connections from Recycle to waiter and the drain loop never observes
-	// a non-empty stack — including the capacity=0 case during Close.
-	if pool.active.Load() > pool.capacity.Load() {
+	// Close eagerly instead of handing this conn off or pushing it to a
+	// stack when either:
+	//   - the pool is shutting down (lifetime cancelled): otherwise a
+	//     Recycle in the brief window between CloseWithContext cancelling
+	//     lifetime and setCapacity swapping capacity to 0 could be handed
+	//     to a waiter that has not yet woken from lifetimeCtx.Done(),
+	//     defeating the "waiters unblock at drain start" guarantee; or
+	//   - the pool has more conns out than its configured capacity:
+	//     otherwise a setCapacity reducing capacity keeps cycling conns
+	//     from Recycle to waiter and the drain loop never observes a
+	//     non-empty stack — including the capacity=0 case during Close.
+	if pool.lifetime.Load() == nil || pool.active.Load() > pool.capacity.Load() {
 		conn.Close()
 		pool.closedConn()
 		return false

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -745,8 +745,8 @@ func TestCloseWithContextAfterSetCapacityZeroClosesPool(t *testing.T) {
 	}).Open(newConnector(&state), nil)
 
 	t.Cleanup(func() {
-		if closeChan := p.close.Swap(nil); closeChan != nil {
-			close(*closeChan)
+		if lt := p.lifetime.Swap(nil); lt != nil {
+			lt.cancel()
 			p.workers.Wait()
 		}
 	})
@@ -783,8 +783,8 @@ func TestCloseWithContextDrainsAfterTimedOutSetCapacityZero(t *testing.T) {
 	}).Open(newConnector(&state), nil)
 
 	t.Cleanup(func() {
-		if closeChan := p.close.Swap(nil); closeChan != nil {
-			close(*closeChan)
+		if lt := p.lifetime.Swap(nil); lt != nil {
+			lt.cancel()
 			p.workers.Wait()
 		}
 	})
@@ -1904,8 +1904,6 @@ func TestIdleTimeoutStopsReopeningWhenPoolCloses(t *testing.T) {
 		}, nil
 	}
 
-	closeChan := make(chan struct{})
-	p.close.Store(&closeChan)
 	lifetimeCtx, lifetimeCancel := context.WithCancel(context.Background())
 	t.Cleanup(lifetimeCancel)
 	p.lifetime.Store(&lifetime{ctx: lifetimeCtx, cancel: lifetimeCancel})
@@ -1943,9 +1941,9 @@ func TestIdleTimeoutStopsReopeningWhenPoolCloses(t *testing.T) {
 		}
 	}, time.Second, 10*time.Millisecond)
 
-	closePtr := p.close.Swap(nil)
-	require.NotNil(t, closePtr)
-	close(*closePtr)
+	lt := p.lifetime.Swap(nil)
+	require.NotNil(t, lt)
+	lt.cancel()
 	release()
 
 	require.Eventually(t, func() bool {
@@ -1958,7 +1956,10 @@ func TestIdleTimeoutStopsReopeningWhenPoolCloses(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 
 	assert.EqualValues(t, 1, reconnectAttempts.Load())
-	assert.EqualValues(t, 3, state.close.Load())
+	// 2 expired conns were closed by closeIdleResources; the in-flight
+	// reopen sees the cancelled lifetime ctx and returns ctx.Err() without
+	// ever producing a fresh conn, so no third close happens.
+	assert.EqualValues(t, 2, state.close.Load())
 
 	if conn, ok := p.clean.PopAll(); ok {
 		for conn != nil {
@@ -2105,6 +2106,102 @@ func TestCloseDoesNotHandOffToWaiters(t *testing.T) {
 	require.EqualValues(t, 0, state.open.Load(),
 		"recycled conn must be closed when capacity is 0, not pushed back to a stack")
 	require.EqualValues(t, 0, p.Active())
+}
+
+// TestIsOpenIsFalseDuringDrain pins the contract that the pool is reported
+// as closed as soon as CloseWithContext is called, not after the drain
+// completes. A single conn is held by the test so the drain cannot complete
+// until the conn is recycled; IsOpen must already report false while we're
+// still inside the drain.
+func TestIsOpenIsFalseDuringDrain(t *testing.T) {
+	var state TestState
+	p := NewPool(&Config[*TestConn]{
+		Capacity: 1,
+	}).Open(newConnector(&state), nil)
+	t.Cleanup(p.Close)
+
+	ctx := t.Context()
+
+	c, err := p.Get(ctx, nil)
+	require.NoError(t, err)
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		closeDone <- p.CloseWithContext(closeCtx)
+	}()
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.False(c, p.IsOpen(), "IsOpen must report false once Close starts")
+	}, time.Second, time.Millisecond)
+
+	// Sanity: drain is still in flight because we haven't recycled the conn.
+	require.EqualValues(t, 1, p.Active(),
+		"drain should not have completed yet; the held conn is still active")
+
+	c.Recycle()
+
+	select {
+	case err = <-closeDone:
+	case <-time.After(30 * time.Second):
+		require.Fail(t, "Close did not complete in time")
+	}
+	require.NoError(t, err)
+}
+
+// TestWaiterUnblocksAtDrainStart pins the contract that a goroutine queued
+// in waitForConn is released with ErrConnPoolClosed as soon as Close starts,
+// without waiting for the drain to finish. A held conn keeps the drain
+// running indefinitely; the waiter must error out before we recycle.
+func TestWaiterUnblocksAtDrainStart(t *testing.T) {
+	var state TestState
+	p := NewPool(&Config[*TestConn]{
+		Capacity: 1,
+	}).Open(newConnector(&state), nil)
+	t.Cleanup(p.Close)
+
+	ctx := t.Context()
+
+	c, err := p.Get(ctx, nil)
+	require.NoError(t, err)
+
+	waiterErr := make(chan error, 1)
+	go func() {
+		_, err := p.Get(ctx, nil)
+		waiterErr <- err
+	}()
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.EqualValues(c, 1, p.wait.waiting())
+	}, time.Second, time.Millisecond)
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		closeDone <- p.CloseWithContext(closeCtx)
+	}()
+
+	select {
+	case err = <-waiterErr:
+	case <-time.After(time.Second):
+		require.Fail(t, "waiter did not unblock at drain start (still queued during drain)")
+	}
+	require.ErrorIs(t, err, ErrConnPoolClosed)
+
+	// Sanity: drain is still in flight because we haven't recycled the conn.
+	require.EqualValues(t, 1, p.Active(),
+		"drain should not have completed yet; the held conn is still active")
+
+	c.Recycle()
+
+	select {
+	case err = <-closeDone:
+	case <-time.After(30 * time.Second):
+		require.Fail(t, "Close did not complete in time")
+	}
+	require.NoError(t, err)
 }
 
 // TestSetCapacityReductionDrainsWithWaiters verifies that SetCapacity reducing

--- a/go/pools/smartconnpool/pool_test.go
+++ b/go/pools/smartconnpool/pool_test.go
@@ -2204,6 +2204,65 @@ func TestWaiterUnblocksAtDrainStart(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestRecycleAfterLifetimeCancelClosesEagerly pins the contract that
+// tryReturnConn closes a Recycled conn instead of handing it off once the
+// pool's lifetime context has been cancelled — even before setCapacity has
+// driven capacity to 0. Without this gate, a Recycle in the brief window
+// between CloseWithContext cancelling lifetime and setCapacity swapping
+// capacity to 0 could be handed to a queued waiter that had not yet woken
+// from lifetimeCtx.Done(), defeating the "waiters unblock at drain start"
+// guarantee.
+func TestRecycleAfterLifetimeCancelClosesEagerly(t *testing.T) {
+	var state TestState
+	p := NewPool(&Config[*TestConn]{
+		Capacity: 1,
+	}).Open(newConnector(&state), nil)
+
+	ctx := t.Context()
+
+	c, err := p.Get(ctx, nil)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, state.open.Load())
+
+	waiterErr := make(chan error, 1)
+	go func() {
+		_, err := p.Get(ctx, nil)
+		waiterErr <- err
+	}()
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.EqualValues(c, 1, p.wait.waiting())
+	}, time.Second, time.Millisecond)
+
+	// Simulate the state CloseWithContext leaves the pool in between
+	// `lt.cancel()` and `setCapacity(ctx, 0)`: lifetime is nil/cancelled,
+	// but capacity has not yet been driven to 0.
+	lt := p.lifetime.Swap(nil)
+	require.NotNil(t, lt)
+	lt.cancel()
+	t.Cleanup(p.workers.Wait)
+
+	// The waiter should unblock with ErrConnPoolClosed because the lifetime
+	// context was cancelled.
+	select {
+	case err = <-waiterErr:
+	case <-time.After(time.Second):
+		require.Fail(t, "waiter did not unblock after lifetime cancel")
+	}
+	require.ErrorIs(t, err, ErrConnPoolClosed)
+
+	// Recycling now must eagerly close the conn rather than push it onto a
+	// stack — capacity is still > 0 and active is not > capacity, so the
+	// active>capacity gate alone would not catch this.
+	require.EqualValues(t, 1, p.Capacity(),
+		"sanity: capacity must still be > 0 to exercise the lifetime gate")
+	c.Recycle()
+
+	require.EqualValues(t, 1, state.close.Load(),
+		"recycled conn must be closed once lifetime is cancelled, not pushed to a stack")
+	require.EqualValues(t, 0, p.Active())
+}
+
 // TestSetCapacityReductionDrainsWithWaiters verifies that SetCapacity reducing
 // capacity from N to M (0 < M < N) completes promptly while waiters are
 // queued for conns. tryReturnConn must eagerly close conns whenever

--- a/go/pools/smartconnpool/waitlist.go
+++ b/go/pools/smartconnpool/waitlist.go
@@ -44,13 +44,15 @@ type waitlist[C Connection] struct {
 }
 
 // waitForConn blocks until a connection with the given Setting is returned by another client,
-// or until the given context expires.
+// or until the given context expires. lifetimeCtx is the pool's lifetime
+// context; it is cancelled when the pool starts closing so queued waiters
+// can fail fast with ErrConnPoolClosed instead of waiting for the drain.
 // If maxWaiters is > 0 and the waitlist already has that many waiters, it returns
 // ErrPoolWaiterCapReached immediately without blocking.
 // The returned connection may _not_ have the requested Setting. This function can
 // also return a `nil` connection even if our context has expired, if the pool has
 // forced an expiration of all waiters in the waitlist.
-func (wl *waitlist[C]) waitForConn(ctx context.Context, setting *Setting, closeChan <-chan struct{}, maxWaiters uint) (*Pooled[C], error) {
+func (wl *waitlist[C]) waitForConn(ctx context.Context, setting *Setting, lifetimeCtx context.Context, maxWaiters uint) (*Pooled[C], error) {
 	elem := wl.nodes.Get().(*list.Element[waiter[C]])
 	defer wl.nodes.Put(elem)
 
@@ -79,7 +81,7 @@ func (wl *waitlist[C]) waitForConn(ctx context.Context, setting *Setting, closeC
 	wl.mu.Unlock()
 
 	select {
-	case <-closeChan:
+	case <-lifetimeCtx.Done():
 		// Pool was closed while we were waiting.
 		removed := false
 

--- a/go/pools/smartconnpool/waitlist_test.go
+++ b/go/pools/smartconnpool/waitlist_test.go
@@ -33,21 +33,22 @@ func TestWaitlistPoolCloseWithMultipleWaiters(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 	defer cancel()
 
-	poolClose := make(chan struct{})
+	lifetimeCtx, lifetimeCancel := context.WithCancel(t.Context())
+	defer lifetimeCancel()
 
 	waiterCount := 2
 	expireCount := atomic.Int32{}
 
 	for range waiterCount {
 		go func() {
-			_, err := wait.waitForConn(ctx, nil, poolClose, 0)
+			_, err := wait.waitForConn(ctx, nil, lifetimeCtx, 0)
 			if err != nil {
 				expireCount.Add(1)
 			}
 		}()
 	}
 
-	close(poolClose)
+	lifetimeCancel()
 
 	// Wait for the context to expire
 	<-ctx.Done()
@@ -72,14 +73,15 @@ func TestWaitlistWaiterCap(t *testing.T) {
 	wl := waitlist[*TestConn]{}
 	wl.init()
 
-	poolClose := make(chan struct{})
+	lifetimeCtx, lifetimeCancel := context.WithCancel(t.Context())
+	defer lifetimeCancel()
 
 	const maxWaiters = 3
 
 	errs := make(chan error, maxWaiters)
 	for i := 1; i <= maxWaiters; i++ {
 		go func() {
-			_, err := wl.waitForConn(t.Context(), nil, poolClose, maxWaiters)
+			_, err := wl.waitForConn(t.Context(), nil, lifetimeCtx, maxWaiters)
 			errs <- err
 		}()
 
@@ -88,11 +90,11 @@ func TestWaitlistWaiterCap(t *testing.T) {
 		}, time.Second, 5*time.Millisecond)
 	}
 
-	_, err := wl.waitForConn(t.Context(), nil, poolClose, maxWaiters)
+	_, err := wl.waitForConn(t.Context(), nil, lifetimeCtx, maxWaiters)
 	assert.ErrorIs(t, err, ErrPoolWaiterCapReached)
 	assert.Equal(t, maxWaiters, wl.waiting())
 
-	close(poolClose)
+	lifetimeCancel()
 
 	for range maxWaiters {
 		assert.NotErrorIs(t, <-errs, ErrPoolWaiterCapReached)


### PR DESCRIPTION
## Description

The smartconnpool tracked "is the pool open" with two atomic pointers: a `close` channel pointer and a `lifetime` context pointer. The two had distinct timing — `lifetime.cancel()` fired at the start of `Close`, but `close(closeChan)` only fired after the drain completed. As a result, queued `Get` waiters and background workers were kept alive throughout the drain, even though there was nothing useful left for them to do.

This PR drops the `close` field entirely and uses the lifetime context's `Done()` as the single shutdown signal. `runWorker` and `wait.waitForConn` now take a `context.Context` instead of a `<-chan struct{}`, which is also more idiomatic Go.

### Observable behavior changes

- `IsOpen()` returns false as soon as `CloseWithContext` is entered, not after the drain completes. The only external caller in the repo (`semisyncmonitor.go:167`) is a startup probe and is unaffected.
- Queued `Get` waiters return `ErrConnPoolClosed` at drain start rather than being parked until the drain finishes. They were unservicable during the drain anyway because `tryReturnConn` closes any Recycled conn while `active > capacity`.
- The `closeIdleResources` reopen loop's in-flight `connect` call is cancelled at drain start, so it returns `ctx.Err()` instead of running to completion and producing a fresh conn that has to be discarded immediately.

Both behavior shifts are pinned by new tests: `TestIsOpenIsFalseDuringDrain` and `TestWaiterUnblocksAtDrainStart`.

## Related Issue(s)

Stacked on top of #20122 (smartconnpool shutdown fixes). The diff against `main` will narrow naturally once #20122 merges and this PR is retargeted.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

No user-facing config change. The minor behavior shifts on `IsOpen()` timing and waiter wake-up are described above; neither is reachable through any current external caller as a correctness-affecting change.

### AI Disclosure

This PR was authored primarily by Claude Code — I provided direction and reviewed the design.