### PR TITLE
vtctl/workflow: stop reverse replication before Complete drops sources

### DIFF
--- a/go/vt/vtctl/workflow/framework_test.go
+++ b/go/vt/vtctl/workflow/framework_test.go
@@ -365,7 +365,8 @@ func (tmc *testTMClient) ReadVReplicationWorkflow(ctx context.Context, tablet *t
 		}
 	}
 	blsKs := tmc.env.sourceKeyspace
-	if strings.HasSuffix(req.Workflow, reverseSuffix) && tablet.Keyspace == tmc.env.sourceKeyspace.KeyspaceName {
+	isReverseWorkflow := strings.HasSuffix(req.Workflow, reverseSuffix)
+	if isReverseWorkflow && tablet.Keyspace == tmc.env.sourceKeyspace.KeyspaceName {
 		blsKs = tmc.env.targetKeyspace
 	} else if tmc.reverse.Load() && tablet.Keyspace == tmc.env.sourceKeyspace.KeyspaceName {
 		blsKs = tmc.env.targetKeyspace
@@ -382,7 +383,7 @@ func (tmc *testTMClient) ReadVReplicationWorkflow(ctx context.Context, tablet *t
 				},
 			},
 		}
-		if strings.HasSuffix(req.Workflow, reverseSuffix) {
+		if isReverseWorkflow {
 			stream.State = binlogdatapb.VReplicationWorkflowState_Running
 		} else if tmc.frozen.Load() {
 			stream.Message = Frozen

--- a/go/vt/vtctl/workflow/framework_test.go
+++ b/go/vt/vtctl/workflow/framework_test.go
@@ -365,7 +365,9 @@ func (tmc *testTMClient) ReadVReplicationWorkflow(ctx context.Context, tablet *t
 		}
 	}
 	blsKs := tmc.env.sourceKeyspace
-	if tmc.reverse.Load() && tablet.Keyspace == tmc.env.sourceKeyspace.KeyspaceName {
+	if strings.HasSuffix(req.Workflow, reverseSuffix) && tablet.Keyspace == tmc.env.sourceKeyspace.KeyspaceName {
+		blsKs = tmc.env.targetKeyspace
+	} else if tmc.reverse.Load() && tablet.Keyspace == tmc.env.sourceKeyspace.KeyspaceName {
 		blsKs = tmc.env.targetKeyspace
 	}
 	for i, shard := range blsKs.ShardNames {
@@ -380,7 +382,9 @@ func (tmc *testTMClient) ReadVReplicationWorkflow(ctx context.Context, tablet *t
 				},
 			},
 		}
-		if tmc.frozen.Load() {
+		if strings.HasSuffix(req.Workflow, reverseSuffix) {
+			stream.State = binlogdatapb.VReplicationWorkflowState_Running
+		} else if tmc.frozen.Load() {
 			stream.Message = Frozen
 		}
 		res.Streams = append(res.Streams, stream)

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -2514,7 +2514,7 @@ func (s *Server) dropSources(ctx context.Context, ts *trafficSwitcher, removalTy
 		}
 	}
 	if !wopts.ignoreSourceKeyspace {
-		if err := sw.stopAndDrainReverseVReplication(ctx, reverseReplicationDrainTimeout); err != nil {
+		if err := sw.stopReverseVReplication(ctx); err != nil {
 			return nil, err
 		}
 	}

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -2513,6 +2513,11 @@ func (s *Server) dropSources(ctx context.Context, ts *trafficSwitcher, removalTy
 			return nil, err
 		}
 	}
+	if !wopts.ignoreSourceKeyspace {
+		if err := sw.stopAndDrainReverseVReplication(ctx, reverseReplicationDrainTimeout); err != nil {
+			return nil, err
+		}
+	}
 	if !keepData {
 		switch ts.MigrationType() {
 		case binlogdatapb.MigrationType_TABLES:

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -199,6 +199,16 @@ func TestMoveTablesComplete(t *testing.T) {
 	defer cancel()
 
 	workflowName := "wf1"
+	stopReverseStreamQueries := []*queryResult{
+		{
+			query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=1",
+			result: &querypb.QueryResult{},
+		},
+		{
+			query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=2",
+			result: &querypb.QueryResult{},
+		},
+	}
 	table1Name := "t1"
 	table2Name := "t1_2"
 	table3Name := "t1_3"
@@ -259,25 +269,25 @@ func TestMoveTablesComplete(t *testing.T) {
 				TargetKeyspace: targetKeyspaceName,
 				Workflow:       workflowName,
 			},
-			expectedSourceQueries: []*queryResult{
-				{
+			expectedSourceQueries: append(slices.Clone(stopReverseStreamQueries),
+				&queryResult{
 					query:  fmt.Sprintf("drop table `vt_%s`.`%s`", sourceKeyspaceName, table1Name),
 					result: &querypb.QueryResult{},
 				},
-				{
+				&queryResult{
 					query:  fmt.Sprintf("drop table `vt_%s`.`%s`", sourceKeyspaceName, table2Name),
 					result: &querypb.QueryResult{},
 				},
-				{
+				&queryResult{
 					query:  fmt.Sprintf("drop table `vt_%s`.`%s`", sourceKeyspaceName, table3Name),
 					result: &querypb.QueryResult{},
 				},
-				{
+				&queryResult{
 					query: fmt.Sprintf("delete from _vt.vreplication where db_name = 'vt_%s' and workflow = '%s'",
 						sourceKeyspaceName, ReverseWorkflowName(workflowName)),
 					result: &querypb.QueryResult{},
 				},
-			},
+			),
 			expectedTargetQueries: []*queryResult{
 				{
 					query: fmt.Sprintf("delete from _vt.vreplication where db_name = 'vt_%s' and workflow = '%s'",
@@ -306,13 +316,13 @@ func TestMoveTablesComplete(t *testing.T) {
 				KeepRoutingRules: true,
 				KeepData:         new(true),
 			},
-			expectedSourceQueries: []*queryResult{
-				{
+			expectedSourceQueries: append(slices.Clone(stopReverseStreamQueries),
+				&queryResult{
 					query: fmt.Sprintf("delete from _vt.vreplication where db_name = 'vt_%s' and workflow = '%s'",
 						sourceKeyspaceName, ReverseWorkflowName(workflowName)),
 					result: &querypb.QueryResult{},
 				},
-			},
+			),
 			expectedTargetQueries: []*queryResult{
 				{
 					query: fmt.Sprintf("delete from _vt.vreplication where db_name = 'vt_%s' and workflow = '%s'",
@@ -343,25 +353,25 @@ func TestMoveTablesComplete(t *testing.T) {
 				Workflow:       workflowName,
 				RenameTables:   true,
 			},
-			expectedSourceQueries: []*queryResult{
-				{
+			expectedSourceQueries: append(slices.Clone(stopReverseStreamQueries),
+				&queryResult{
 					query:  fmt.Sprintf("rename table `vt_%s`.`%s` TO `vt_%s`.`_%s_old`", sourceKeyspaceName, table1Name, sourceKeyspaceName, table1Name),
 					result: &querypb.QueryResult{},
 				},
-				{
+				&queryResult{
 					query:  fmt.Sprintf("rename table `vt_%s`.`%s` TO `vt_%s`.`_%s_old`", sourceKeyspaceName, table2Name, sourceKeyspaceName, table2Name),
 					result: &querypb.QueryResult{},
 				},
-				{
+				&queryResult{
 					query:  fmt.Sprintf("rename table `vt_%s`.`%s` TO `vt_%s`.`_%s_old`", sourceKeyspaceName, table3Name, sourceKeyspaceName, table3Name),
 					result: &querypb.QueryResult{},
 				},
-				{
+				&queryResult{
 					query: fmt.Sprintf("delete from _vt.vreplication where db_name = 'vt_%s' and workflow = '%s'",
 						sourceKeyspaceName, ReverseWorkflowName(workflowName)),
 					result: &querypb.QueryResult{},
 				},
-			},
+			),
 			expectedTargetQueries: []*queryResult{
 				{
 					query: fmt.Sprintf("delete from _vt.vreplication where db_name = 'vt_%s' and workflow = '%s'",
@@ -372,6 +382,46 @@ func TestMoveTablesComplete(t *testing.T) {
 			want: &vtctldatapb.MoveTablesCompleteResponse{
 				Summary: fmt.Sprintf("Successfully completed the %s workflow in the %s keyspace",
 					workflowName, targetKeyspaceName),
+			},
+		},
+		{
+			name: "reverse workflow in error state",
+			sourceKeyspace: &testKeyspace{
+				KeyspaceName: sourceKeyspaceName,
+				ShardNames:   []string{"0"},
+			},
+			targetKeyspace: &testKeyspace{
+				KeyspaceName: targetKeyspaceName,
+				ShardNames:   []string{"-80", "80-"},
+			},
+			req: &vtctldatapb.MoveTablesCompleteRequest{
+				TargetKeyspace: targetKeyspaceName,
+				Workflow:       workflowName,
+			},
+			preFunc: func(t *testing.T, env *testEnv) {
+				for _, tablet := range env.tablets[sourceKeyspaceName] {
+					env.tmc.expectReadVReplicationWorkflowRequest(tablet.Alias.Uid, &readVReplicationWorkflowRequestResponse{
+						req: &tabletmanagerdatapb.ReadVReplicationWorkflowRequest{
+							Workflow: ReverseWorkflowName(workflowName),
+						},
+						res: &tabletmanagerdatapb.ReadVReplicationWorkflowResponse{
+							Workflow: ReverseWorkflowName(workflowName),
+							Streams: []*tabletmanagerdatapb.ReadVReplicationWorkflowResponse_Stream{
+								{
+									Id:    1,
+									State: binlogdatapb.VReplicationWorkflowState_Error,
+									Bls: &binlogdatapb.BinlogSource{
+										Keyspace: targetKeyspaceName,
+										Shard:    "-80",
+									},
+								},
+							},
+						},
+					})
+				}
+			},
+			wantErr: "reverse vreplication stream 1 is in error state on tablet 100",
+			postFunc: func(t *testing.T, env *testEnv) {
 			},
 		},
 		{

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -385,46 +385,6 @@ func TestMoveTablesComplete(t *testing.T) {
 			},
 		},
 		{
-			name: "reverse workflow in error state",
-			sourceKeyspace: &testKeyspace{
-				KeyspaceName: sourceKeyspaceName,
-				ShardNames:   []string{"0"},
-			},
-			targetKeyspace: &testKeyspace{
-				KeyspaceName: targetKeyspaceName,
-				ShardNames:   []string{"-80", "80-"},
-			},
-			req: &vtctldatapb.MoveTablesCompleteRequest{
-				TargetKeyspace: targetKeyspaceName,
-				Workflow:       workflowName,
-			},
-			preFunc: func(t *testing.T, env *testEnv) {
-				for _, tablet := range env.tablets[sourceKeyspaceName] {
-					env.tmc.expectReadVReplicationWorkflowRequest(tablet.Alias.Uid, &readVReplicationWorkflowRequestResponse{
-						req: &tabletmanagerdatapb.ReadVReplicationWorkflowRequest{
-							Workflow: ReverseWorkflowName(workflowName),
-						},
-						res: &tabletmanagerdatapb.ReadVReplicationWorkflowResponse{
-							Workflow: ReverseWorkflowName(workflowName),
-							Streams: []*tabletmanagerdatapb.ReadVReplicationWorkflowResponse_Stream{
-								{
-									Id:    1,
-									State: binlogdatapb.VReplicationWorkflowState_Error,
-									Bls: &binlogdatapb.BinlogSource{
-										Keyspace: targetKeyspaceName,
-										Shard:    "-80",
-									},
-								},
-							},
-						},
-					})
-				}
-			},
-			wantErr: "reverse vreplication stream 1 is in error state on cell-0000000100",
-			postFunc: func(t *testing.T, env *testEnv) {
-			},
-		},
-		{
 			name: "ignore source keyspace",
 			sourceKeyspace: &testKeyspace{
 				KeyspaceName: sourceKeyspaceName,

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -35,6 +35,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/textutil"
+	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl/tmutils"
 	"vitess.io/vitess/go/vt/topo"
@@ -261,11 +262,11 @@ func TestMoveTablesComplete(t *testing.T) {
 			},
 			expectedSourceQueries: []*queryResult{
 				{
-					query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=1",
+					query:  binlogplayer.StopVReplication(1, stoppedForComplete),
 					result: &querypb.QueryResult{},
 				},
 				{
-					query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=2",
+					query:  binlogplayer.StopVReplication(2, stoppedForComplete),
 					result: &querypb.QueryResult{},
 				},
 				{
@@ -316,11 +317,11 @@ func TestMoveTablesComplete(t *testing.T) {
 			},
 			expectedSourceQueries: []*queryResult{
 				{
-					query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=1",
+					query:  binlogplayer.StopVReplication(1, stoppedForComplete),
 					result: &querypb.QueryResult{},
 				},
 				{
-					query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=2",
+					query:  binlogplayer.StopVReplication(2, stoppedForComplete),
 					result: &querypb.QueryResult{},
 				},
 				{
@@ -361,11 +362,11 @@ func TestMoveTablesComplete(t *testing.T) {
 			},
 			expectedSourceQueries: []*queryResult{
 				{
-					query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=1",
+					query:  binlogplayer.StopVReplication(1, stoppedForComplete),
 					result: &querypb.QueryResult{},
 				},
 				{
-					query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=2",
+					query:  binlogplayer.StopVReplication(2, stoppedForComplete),
 					result: &querypb.QueryResult{},
 				},
 				{

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -268,19 +268,19 @@ func TestMoveTablesComplete(t *testing.T) {
 					query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=2",
 					result: &querypb.QueryResult{},
 				},
-				&queryResult{
+				{
 					query:  fmt.Sprintf("drop table `vt_%s`.`%s`", sourceKeyspaceName, table1Name),
 					result: &querypb.QueryResult{},
 				},
-				&queryResult{
+				{
 					query:  fmt.Sprintf("drop table `vt_%s`.`%s`", sourceKeyspaceName, table2Name),
 					result: &querypb.QueryResult{},
 				},
-				&queryResult{
+				{
 					query:  fmt.Sprintf("drop table `vt_%s`.`%s`", sourceKeyspaceName, table3Name),
 					result: &querypb.QueryResult{},
 				},
-				&queryResult{
+				{
 					query: fmt.Sprintf("delete from _vt.vreplication where db_name = 'vt_%s' and workflow = '%s'",
 						sourceKeyspaceName, ReverseWorkflowName(workflowName)),
 					result: &querypb.QueryResult{},
@@ -323,7 +323,7 @@ func TestMoveTablesComplete(t *testing.T) {
 					query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=2",
 					result: &querypb.QueryResult{},
 				},
-				&queryResult{
+				{
 					query: fmt.Sprintf("delete from _vt.vreplication where db_name = 'vt_%s' and workflow = '%s'",
 						sourceKeyspaceName, ReverseWorkflowName(workflowName)),
 					result: &querypb.QueryResult{},
@@ -368,19 +368,19 @@ func TestMoveTablesComplete(t *testing.T) {
 					query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=2",
 					result: &querypb.QueryResult{},
 				},
-				&queryResult{
+				{
 					query:  fmt.Sprintf("rename table `vt_%s`.`%s` TO `vt_%s`.`_%s_old`", sourceKeyspaceName, table1Name, sourceKeyspaceName, table1Name),
 					result: &querypb.QueryResult{},
 				},
-				&queryResult{
+				{
 					query:  fmt.Sprintf("rename table `vt_%s`.`%s` TO `vt_%s`.`_%s_old`", sourceKeyspaceName, table2Name, sourceKeyspaceName, table2Name),
 					result: &querypb.QueryResult{},
 				},
-				&queryResult{
+				{
 					query:  fmt.Sprintf("rename table `vt_%s`.`%s` TO `vt_%s`.`_%s_old`", sourceKeyspaceName, table3Name, sourceKeyspaceName, table3Name),
 					result: &querypb.QueryResult{},
 				},
-				&queryResult{
+				{
 					query: fmt.Sprintf("delete from _vt.vreplication where db_name = 'vt_%s' and workflow = '%s'",
 						sourceKeyspaceName, ReverseWorkflowName(workflowName)),
 					result: &querypb.QueryResult{},

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -199,16 +199,6 @@ func TestMoveTablesComplete(t *testing.T) {
 	defer cancel()
 
 	workflowName := "wf1"
-	stopReverseStreamQueries := []*queryResult{
-		{
-			query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=1",
-			result: &querypb.QueryResult{},
-		},
-		{
-			query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=2",
-			result: &querypb.QueryResult{},
-		},
-	}
 	table1Name := "t1"
 	table2Name := "t1_2"
 	table3Name := "t1_3"
@@ -269,7 +259,15 @@ func TestMoveTablesComplete(t *testing.T) {
 				TargetKeyspace: targetKeyspaceName,
 				Workflow:       workflowName,
 			},
-			expectedSourceQueries: append(slices.Clone(stopReverseStreamQueries),
+			expectedSourceQueries: []*queryResult{
+				{
+					query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=1",
+					result: &querypb.QueryResult{},
+				},
+				{
+					query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=2",
+					result: &querypb.QueryResult{},
+				},
 				&queryResult{
 					query:  fmt.Sprintf("drop table `vt_%s`.`%s`", sourceKeyspaceName, table1Name),
 					result: &querypb.QueryResult{},
@@ -287,7 +285,7 @@ func TestMoveTablesComplete(t *testing.T) {
 						sourceKeyspaceName, ReverseWorkflowName(workflowName)),
 					result: &querypb.QueryResult{},
 				},
-			),
+			},
 			expectedTargetQueries: []*queryResult{
 				{
 					query: fmt.Sprintf("delete from _vt.vreplication where db_name = 'vt_%s' and workflow = '%s'",
@@ -316,13 +314,21 @@ func TestMoveTablesComplete(t *testing.T) {
 				KeepRoutingRules: true,
 				KeepData:         new(true),
 			},
-			expectedSourceQueries: append(slices.Clone(stopReverseStreamQueries),
+			expectedSourceQueries: []*queryResult{
+				{
+					query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=1",
+					result: &querypb.QueryResult{},
+				},
+				{
+					query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=2",
+					result: &querypb.QueryResult{},
+				},
 				&queryResult{
 					query: fmt.Sprintf("delete from _vt.vreplication where db_name = 'vt_%s' and workflow = '%s'",
 						sourceKeyspaceName, ReverseWorkflowName(workflowName)),
 					result: &querypb.QueryResult{},
 				},
-			),
+			},
 			expectedTargetQueries: []*queryResult{
 				{
 					query: fmt.Sprintf("delete from _vt.vreplication where db_name = 'vt_%s' and workflow = '%s'",
@@ -353,7 +359,15 @@ func TestMoveTablesComplete(t *testing.T) {
 				Workflow:       workflowName,
 				RenameTables:   true,
 			},
-			expectedSourceQueries: append(slices.Clone(stopReverseStreamQueries),
+			expectedSourceQueries: []*queryResult{
+				{
+					query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=1",
+					result: &querypb.QueryResult{},
+				},
+				{
+					query:  "update _vt.vreplication set state='Stopped', message='stopped for complete' where id=2",
+					result: &querypb.QueryResult{},
+				},
 				&queryResult{
 					query:  fmt.Sprintf("rename table `vt_%s`.`%s` TO `vt_%s`.`_%s_old`", sourceKeyspaceName, table1Name, sourceKeyspaceName, table1Name),
 					result: &querypb.QueryResult{},
@@ -371,7 +385,7 @@ func TestMoveTablesComplete(t *testing.T) {
 						sourceKeyspaceName, ReverseWorkflowName(workflowName)),
 					result: &querypb.QueryResult{},
 				},
-			),
+			},
 			expectedTargetQueries: []*queryResult{
 				{
 					query: fmt.Sprintf("delete from _vt.vreplication where db_name = 'vt_%s' and workflow = '%s'",

--- a/go/vt/vtctl/workflow/server_test.go
+++ b/go/vt/vtctl/workflow/server_test.go
@@ -420,7 +420,7 @@ func TestMoveTablesComplete(t *testing.T) {
 					})
 				}
 			},
-			wantErr: "reverse vreplication stream 1 is in error state on tablet 100",
+			wantErr: "reverse vreplication stream 1 is in error state on cell-0000000100",
 			postFunc: func(t *testing.T, env *testEnv) {
 			},
 		},

--- a/go/vt/vtctl/workflow/switcher.go
+++ b/go/vt/vtctl/workflow/switcher.go
@@ -116,6 +116,10 @@ func (r *switcher) waitForCatchup(ctx context.Context, filteredReplicationWaitTi
 	return r.ts.waitForCatchup(ctx, filteredReplicationWaitTime)
 }
 
+func (r *switcher) stopAndDrainReverseVReplication(ctx context.Context, waitTime time.Duration) error {
+	return r.ts.stopAndDrainReverseVReplication(ctx, waitTime)
+}
+
 func (r *switcher) stopSourceWrites(ctx context.Context) error {
 	return r.ts.stopSourceWrites(ctx)
 }

--- a/go/vt/vtctl/workflow/switcher.go
+++ b/go/vt/vtctl/workflow/switcher.go
@@ -116,8 +116,8 @@ func (r *switcher) waitForCatchup(ctx context.Context, filteredReplicationWaitTi
 	return r.ts.waitForCatchup(ctx, filteredReplicationWaitTime)
 }
 
-func (r *switcher) stopAndDrainReverseVReplication(ctx context.Context, waitTime time.Duration) error {
-	return r.ts.stopAndDrainReverseVReplication(ctx, waitTime)
+func (r *switcher) stopReverseVReplication(ctx context.Context) error {
+	return r.ts.stopReverseVReplication(ctx)
 }
 
 func (r *switcher) stopSourceWrites(ctx context.Context) error {

--- a/go/vt/vtctl/workflow/switcher_dry_run.go
+++ b/go/vt/vtctl/workflow/switcher_dry_run.go
@@ -261,6 +261,12 @@ func (dr *switcherDryRun) waitForCatchup(ctx context.Context, filteredReplicatio
 	return nil
 }
 
+func (dr *switcherDryRun) stopAndDrainReverseVReplication(ctx context.Context, waitTime time.Duration) error {
+	dr.drLog.Logf("Stop and drain reverse vreplication workflow %s for up to %v before removing source data",
+		dr.ts.ReverseWorkflowName(), waitTime)
+	return nil
+}
+
 func (dr *switcherDryRun) stopSourceWrites(ctx context.Context) error {
 	sources := maps.Values(dr.ts.Sources())
 	// Sort the slice for deterministic output.

--- a/go/vt/vtctl/workflow/switcher_dry_run.go
+++ b/go/vt/vtctl/workflow/switcher_dry_run.go
@@ -261,9 +261,8 @@ func (dr *switcherDryRun) waitForCatchup(ctx context.Context, filteredReplicatio
 	return nil
 }
 
-func (dr *switcherDryRun) stopAndDrainReverseVReplication(ctx context.Context, waitTime time.Duration) error {
-	dr.drLog.Logf("Stop and drain reverse vreplication workflow %s for up to %v before removing source data",
-		dr.ts.ReverseWorkflowName(), waitTime)
+func (dr *switcherDryRun) stopReverseVReplication(ctx context.Context) error {
+	dr.drLog.Logf("Stop reverse vreplication workflow %s before removing source data", dr.ts.ReverseWorkflowName())
 	return nil
 }
 

--- a/go/vt/vtctl/workflow/switcher_interface.go
+++ b/go/vt/vtctl/workflow/switcher_interface.go
@@ -31,7 +31,7 @@ type iswitcher interface {
 	stopStreams(ctx context.Context, sm *StreamMigrator) ([]string, error)
 	stopSourceWrites(ctx context.Context) error
 	waitForCatchup(ctx context.Context, filteredReplicationWaitTime time.Duration) error
-	stopAndDrainReverseVReplication(ctx context.Context, waitTime time.Duration) error
+	stopReverseVReplication(ctx context.Context) error
 	migrateStreams(ctx context.Context, sm *StreamMigrator) error
 	createReverseVReplication(ctx context.Context) error
 	createJournals(ctx context.Context, sourceWorkflows []string) error

--- a/go/vt/vtctl/workflow/switcher_interface.go
+++ b/go/vt/vtctl/workflow/switcher_interface.go
@@ -31,6 +31,7 @@ type iswitcher interface {
 	stopStreams(ctx context.Context, sm *StreamMigrator) ([]string, error)
 	stopSourceWrites(ctx context.Context) error
 	waitForCatchup(ctx context.Context, filteredReplicationWaitTime time.Duration) error
+	stopAndDrainReverseVReplication(ctx context.Context, waitTime time.Duration) error
 	migrateStreams(ctx context.Context, sm *StreamMigrator) error
 	createReverseVReplication(ctx context.Context) error
 	createJournals(ctx context.Context, sourceWorkflows []string) error

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -75,10 +75,6 @@ const (
 	// operation too.
 	shardTabletRefreshTimeout = time.Duration(30 * time.Second)
 
-	// reverseReplicationDrainTimeout bounds how long Complete waits for reverse
-	// streams to catch up to the target primary position before stopping them.
-	reverseReplicationDrainTimeout = 30 * time.Second
-
 	stoppedForComplete = "stopped for complete"
 
 	// Use pt-osc's naming convention, this format also ensures vstreamer ignores such tables.
@@ -1035,22 +1031,7 @@ func (ts *trafficSwitcher) buildTenantPredicate(ctx context.Context) (*sqlparser
 	return tenantPredicate, nil
 }
 
-func (ts *trafficSwitcher) stopAndDrainReverseVReplication(ctx context.Context, waitTime time.Duration) error {
-	targetPositions := make(map[string]string)
-	if err := ts.ForAllTargets(func(target *MigrationTarget) error {
-		pos, err := ts.TabletManagerClient().PrimaryPosition(ctx, target.GetPrimary().Tablet)
-		if err != nil {
-			return err
-		}
-		targetPositions[target.GetShard().ShardName()] = pos
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, waitTime)
-	defer cancel()
-
+func (ts *trafficSwitcher) stopReverseVReplication(ctx context.Context) error {
 	return ts.ForAllSources(func(source *MigrationSource) error {
 		tabletAlias := topoproto.TabletAliasString(source.GetPrimary().GetAlias())
 		res, err := ts.ws.tmc.ReadVReplicationWorkflow(ctx, source.GetPrimary().Tablet, &tabletmanagerdatapb.ReadVReplicationWorkflowRequest{
@@ -1063,35 +1044,8 @@ func (ts *trafficSwitcher) stopAndDrainReverseVReplication(ctx context.Context, 
 			return nil
 		}
 		for _, stream := range res.Streams {
-			if stream.Bls == nil {
-				return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "reverse vreplication stream %d on %s has no binlog source",
-					stream.Id, tabletAlias)
-			}
-			targetShard := stream.Bls.Shard
-			pos, ok := targetPositions[targetShard]
-			if !ok {
-				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
-					"reverse vreplication stream %d on %s reads from unknown target shard %s",
-					stream.Id, tabletAlias, targetShard)
-			}
-			switch stream.State {
-			case binlogdatapb.VReplicationWorkflowState_Error:
-				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
-					"reverse vreplication stream %d on %s is in error state", stream.Id, tabletAlias)
-			case binlogdatapb.VReplicationWorkflowState_Copying:
-				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
-					"reverse vreplication stream %d on %s is still copying", stream.Id, tabletAlias)
-			case binlogdatapb.VReplicationWorkflowState_Stopped:
+			if stream.State == binlogdatapb.VReplicationWorkflowState_Stopped {
 				continue
-			case binlogdatapb.VReplicationWorkflowState_Running:
-				ts.Logger().Infof("Waiting for reverse stream %d on %s to catch up to target shard %s position %s",
-					stream.Id, tabletAlias, targetShard, pos)
-				if err := ts.TabletManagerClient().VReplicationWaitForPos(ctx, source.GetPrimary().Tablet, stream.Id, pos); err != nil {
-					return err
-				}
-			default:
-				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
-					"reverse vreplication stream %d on %s is in state %s", stream.Id, tabletAlias, stream.State)
 			}
 			ts.Logger().Infof("Stopping reverse stream %d on %s for complete", stream.Id, tabletAlias)
 			if _, err := ts.TabletManagerClient().VReplicationExec(ctx, source.GetPrimary().Tablet,

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -75,6 +75,12 @@ const (
 	// operation too.
 	shardTabletRefreshTimeout = time.Duration(30 * time.Second)
 
+	// reverseReplicationDrainTimeout bounds how long Complete waits for reverse
+	// streams to catch up to the target primary position before stopping them.
+	reverseReplicationDrainTimeout = 30 * time.Second
+
+	stoppedForComplete = "stopped for complete"
+
 	// Use pt-osc's naming convention, this format also ensures vstreamer ignores such tables.
 	renameTableTemplate = "_%.59s_old" // limit table name to 64 characters
 
@@ -1027,6 +1033,64 @@ func (ts *trafficSwitcher) buildTenantPredicate(ctx context.Context) (*sqlparser
 		return nil, err
 	}
 	return tenantPredicate, nil
+}
+
+func (ts *trafficSwitcher) stopAndDrainReverseVReplication(ctx context.Context, waitTime time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, waitTime)
+	defer cancel()
+
+	targetPositions := make(map[string]string)
+	if err := ts.ForAllTargets(func(target *MigrationTarget) error {
+		pos, err := ts.TabletManagerClient().PrimaryPosition(ctx, target.GetPrimary().Tablet)
+		if err != nil {
+			return err
+		}
+		targetPositions[target.GetShard().ShardName()] = pos
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return ts.ForAllSources(func(source *MigrationSource) error {
+		res, err := ts.ws.tmc.ReadVReplicationWorkflow(ctx, source.GetPrimary().Tablet, &tabletmanagerdatapb.ReadVReplicationWorkflowRequest{
+			Workflow: ts.ReverseWorkflowName(),
+		})
+		if err != nil {
+			return err
+		}
+		if res == nil || len(res.Streams) == 0 {
+			return nil
+		}
+		for _, stream := range res.Streams {
+			if stream.Bls == nil {
+				return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "reverse vreplication stream %d on %s has no binlog source",
+					stream.Id, topoproto.TabletAliasString(source.GetPrimary().GetAlias()))
+			}
+			targetShard := stream.Bls.Shard
+			pos, ok := targetPositions[targetShard]
+			if !ok {
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
+					"reverse vreplication stream %d on %s reads from unknown target shard %s",
+					stream.Id, topoproto.TabletAliasString(source.GetPrimary().GetAlias()), targetShard)
+			}
+			if stream.State == binlogdatapb.VReplicationWorkflowState_Running {
+				ts.Logger().Infof("Waiting for reverse stream %d on %s to catch up to target shard %s position %s",
+					stream.Id, topoproto.TabletAliasString(source.GetPrimary().GetAlias()), targetShard, pos)
+				if err := ts.TabletManagerClient().VReplicationWaitForPos(ctx, source.GetPrimary().Tablet, stream.Id, pos); err != nil {
+					return err
+				}
+			}
+			if stream.State != binlogdatapb.VReplicationWorkflowState_Stopped {
+				ts.Logger().Infof("Stopping reverse stream %d on %s for complete",
+					stream.Id, topoproto.TabletAliasString(source.GetPrimary().GetAlias()))
+				if _, err := ts.TabletManagerClient().VReplicationExec(ctx, source.GetPrimary().Tablet,
+					binlogplayer.StopVReplication(stream.Id, stoppedForComplete)); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
 }
 
 func (ts *trafficSwitcher) waitForCatchup(ctx context.Context, filteredReplicationWaitTime time.Duration) error {

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -1050,7 +1050,8 @@ func (ts *trafficSwitcher) stopReverseVReplication(ctx context.Context) error {
 			ts.Logger().Infof("Stopping reverse stream %d on %s for complete", stream.Id, tabletAlias)
 			if _, err := ts.TabletManagerClient().VReplicationExec(ctx, source.GetPrimary().Tablet,
 				binlogplayer.StopVReplication(stream.Id, stoppedForComplete)); err != nil {
-				return err
+				return vterrors.Wrapf(err, "stopping reverse stream %d in workflow %s on %s",
+					stream.Id, ts.ReverseWorkflowName(), tabletAlias)
 			}
 		}
 		return nil

--- a/go/vt/vtctl/workflow/traffic_switcher.go
+++ b/go/vt/vtctl/workflow/traffic_switcher.go
@@ -1036,9 +1036,6 @@ func (ts *trafficSwitcher) buildTenantPredicate(ctx context.Context) (*sqlparser
 }
 
 func (ts *trafficSwitcher) stopAndDrainReverseVReplication(ctx context.Context, waitTime time.Duration) error {
-	ctx, cancel := context.WithTimeout(ctx, waitTime)
-	defer cancel()
-
 	targetPositions := make(map[string]string)
 	if err := ts.ForAllTargets(func(target *MigrationTarget) error {
 		pos, err := ts.TabletManagerClient().PrimaryPosition(ctx, target.GetPrimary().Tablet)
@@ -1051,12 +1048,16 @@ func (ts *trafficSwitcher) stopAndDrainReverseVReplication(ctx context.Context, 
 		return err
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, waitTime)
+	defer cancel()
+
 	return ts.ForAllSources(func(source *MigrationSource) error {
+		tabletAlias := topoproto.TabletAliasString(source.GetPrimary().GetAlias())
 		res, err := ts.ws.tmc.ReadVReplicationWorkflow(ctx, source.GetPrimary().Tablet, &tabletmanagerdatapb.ReadVReplicationWorkflowRequest{
 			Workflow: ts.ReverseWorkflowName(),
 		})
 		if err != nil {
-			return err
+			return vterrors.Wrapf(err, "reading reverse workflow %s on %s", ts.ReverseWorkflowName(), tabletAlias)
 		}
 		if res == nil || len(res.Streams) == 0 {
 			return nil
@@ -1064,29 +1065,38 @@ func (ts *trafficSwitcher) stopAndDrainReverseVReplication(ctx context.Context, 
 		for _, stream := range res.Streams {
 			if stream.Bls == nil {
 				return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "reverse vreplication stream %d on %s has no binlog source",
-					stream.Id, topoproto.TabletAliasString(source.GetPrimary().GetAlias()))
+					stream.Id, tabletAlias)
 			}
 			targetShard := stream.Bls.Shard
 			pos, ok := targetPositions[targetShard]
 			if !ok {
 				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
 					"reverse vreplication stream %d on %s reads from unknown target shard %s",
-					stream.Id, topoproto.TabletAliasString(source.GetPrimary().GetAlias()), targetShard)
+					stream.Id, tabletAlias, targetShard)
 			}
-			if stream.State == binlogdatapb.VReplicationWorkflowState_Running {
+			switch stream.State {
+			case binlogdatapb.VReplicationWorkflowState_Error:
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
+					"reverse vreplication stream %d on %s is in error state", stream.Id, tabletAlias)
+			case binlogdatapb.VReplicationWorkflowState_Copying:
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
+					"reverse vreplication stream %d on %s is still copying", stream.Id, tabletAlias)
+			case binlogdatapb.VReplicationWorkflowState_Stopped:
+				continue
+			case binlogdatapb.VReplicationWorkflowState_Running:
 				ts.Logger().Infof("Waiting for reverse stream %d on %s to catch up to target shard %s position %s",
-					stream.Id, topoproto.TabletAliasString(source.GetPrimary().GetAlias()), targetShard, pos)
+					stream.Id, tabletAlias, targetShard, pos)
 				if err := ts.TabletManagerClient().VReplicationWaitForPos(ctx, source.GetPrimary().Tablet, stream.Id, pos); err != nil {
 					return err
 				}
+			default:
+				return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
+					"reverse vreplication stream %d on %s is in state %s", stream.Id, tabletAlias, stream.State)
 			}
-			if stream.State != binlogdatapb.VReplicationWorkflowState_Stopped {
-				ts.Logger().Infof("Stopping reverse stream %d on %s for complete",
-					stream.Id, topoproto.TabletAliasString(source.GetPrimary().GetAlias()))
-				if _, err := ts.TabletManagerClient().VReplicationExec(ctx, source.GetPrimary().Tablet,
-					binlogplayer.StopVReplication(stream.Id, stoppedForComplete)); err != nil {
-					return err
-				}
+			ts.Logger().Infof("Stopping reverse stream %d on %s for complete", stream.Id, tabletAlias)
+			if _, err := ts.TabletManagerClient().VReplicationExec(ctx, source.GetPrimary().Tablet,
+				binlogplayer.StopVReplication(stream.Id, stoppedForComplete)); err != nil {
+				return err
 			}
 		}
 		return nil

--- a/go/vt/vtctl/workflow/utils.go
+++ b/go/vt/vtctl/workflow/utils.go
@@ -579,6 +579,7 @@ func doValidateWorkflowHasCompleted(ctx context.Context, ts *trafficSwitcher) er
 			return nil
 		})
 	}
+	validateReverseWorkflowForComplete(ctx, ts, &wg, &rec)
 	wg.Wait()
 
 	if !ts.keepRoutingRules {
@@ -603,6 +604,39 @@ func doValidateWorkflowHasCompleted(ctx context.Context, ts *trafficSwitcher) er
 		return fmt.Errorf("%s", strings.Join(rec.ErrorStrings(), "\n"))
 	}
 	return nil
+}
+
+func validateReverseWorkflowForComplete(ctx context.Context, ts *trafficSwitcher, wg *sync.WaitGroup, rec *concurrency.AllErrorRecorder) {
+	_ = ts.ForAllSources(func(source *MigrationSource) error {
+		wg.Add(1)
+		defer wg.Done()
+		res, err := ts.ws.tmc.ReadVReplicationWorkflow(ctx, source.GetPrimary().Tablet, &tabletmanagerdatapb.ReadVReplicationWorkflowRequest{
+			Workflow: ts.ReverseWorkflowName(),
+		})
+		if err != nil {
+			rec.RecordError(err)
+			return nil
+		}
+		if res == nil || len(res.Streams) == 0 {
+			return nil
+		}
+		for _, stream := range res.Streams {
+			switch stream.State {
+			case binlogdatapb.VReplicationWorkflowState_Running,
+				binlogdatapb.VReplicationWorkflowState_Stopped:
+			case binlogdatapb.VReplicationWorkflowState_Error:
+				rec.RecordError(fmt.Errorf("reverse vreplication stream %d is in error state on tablet %d",
+					stream.Id, source.GetPrimary().Alias.Uid))
+			case binlogdatapb.VReplicationWorkflowState_Copying:
+				rec.RecordError(fmt.Errorf("reverse vreplication stream %d is still copying on tablet %d",
+					stream.Id, source.GetPrimary().Alias.Uid))
+			default:
+				rec.RecordError(fmt.Errorf("reverse vreplication stream %d is in state %s on tablet %d",
+					stream.Id, stream.State, source.GetPrimary().Alias.Uid))
+			}
+		}
+		return nil
+	})
 }
 
 // ReverseWorkflowName returns the "reversed" name of a workflow. For a

--- a/go/vt/vtctl/workflow/utils.go
+++ b/go/vt/vtctl/workflow/utils.go
@@ -548,21 +548,18 @@ func HashStreams(targetKeyspace string, targets map[string]*MigrationTarget) int
 }
 
 func doValidateWorkflowHasCompleted(ctx context.Context, ts *trafficSwitcher) error {
-	wg := sync.WaitGroup{}
 	rec := concurrency.AllErrorRecorder{}
 	if ts.MigrationType() == binlogdatapb.MigrationType_SHARDS {
-		_ = ts.ForAllSources(func(source *MigrationSource) error {
-			wg.Add(1)
+		if err := ts.ForAllSources(func(source *MigrationSource) error {
 			if source.GetShard().IsPrimaryServing {
 				rec.RecordError(fmt.Errorf("shard %s is still serving", source.GetShard().ShardName()))
 			}
-			wg.Done()
 			return nil
-		})
+		}); err != nil {
+			rec.RecordError(err)
+		}
 	} else {
-		_ = ts.ForAllTargets(func(target *MigrationTarget) error {
-			wg.Add(1)
-			defer wg.Done()
+		if err := ts.ForAllTargets(func(target *MigrationTarget) error {
 			res, err := ts.ws.tmc.ReadVReplicationWorkflow(ctx, target.GetPrimary().Tablet, &tabletmanagerdatapb.ReadVReplicationWorkflowRequest{
 				Workflow: ts.WorkflowName(),
 			})
@@ -577,10 +574,13 @@ func doValidateWorkflowHasCompleted(ctx context.Context, ts *trafficSwitcher) er
 				}
 			}
 			return nil
-		})
+		}); err != nil {
+			rec.RecordError(err)
+		}
 	}
-	validateReverseWorkflowForComplete(ctx, ts, &wg, &rec)
-	wg.Wait()
+	if err := validateReverseWorkflowForComplete(ctx, ts, &rec); err != nil {
+		rec.RecordError(err)
+	}
 
 	if !ts.keepRoutingRules {
 		// Check if table is routable.
@@ -606,10 +606,8 @@ func doValidateWorkflowHasCompleted(ctx context.Context, ts *trafficSwitcher) er
 	return nil
 }
 
-func validateReverseWorkflowForComplete(ctx context.Context, ts *trafficSwitcher, wg *sync.WaitGroup, rec *concurrency.AllErrorRecorder) {
-	_ = ts.ForAllSources(func(source *MigrationSource) error {
-		wg.Add(1)
-		defer wg.Done()
+func validateReverseWorkflowForComplete(ctx context.Context, ts *trafficSwitcher, rec *concurrency.AllErrorRecorder) error {
+	return ts.ForAllSources(func(source *MigrationSource) error {
 		res, err := ts.ws.tmc.ReadVReplicationWorkflow(ctx, source.GetPrimary().Tablet, &tabletmanagerdatapb.ReadVReplicationWorkflowRequest{
 			Workflow: ts.ReverseWorkflowName(),
 		})

--- a/go/vt/vtctl/workflow/utils.go
+++ b/go/vt/vtctl/workflow/utils.go
@@ -608,11 +608,12 @@ func doValidateWorkflowHasCompleted(ctx context.Context, ts *trafficSwitcher) er
 
 func validateReverseWorkflowForComplete(ctx context.Context, ts *trafficSwitcher, rec *concurrency.AllErrorRecorder) error {
 	return ts.ForAllSources(func(source *MigrationSource) error {
+		tabletAlias := topoproto.TabletAliasString(source.GetPrimary().GetAlias())
 		res, err := ts.ws.tmc.ReadVReplicationWorkflow(ctx, source.GetPrimary().Tablet, &tabletmanagerdatapb.ReadVReplicationWorkflowRequest{
 			Workflow: ts.ReverseWorkflowName(),
 		})
 		if err != nil {
-			rec.RecordError(err)
+			rec.RecordError(vterrors.Wrapf(err, "reading reverse workflow %s on %s", ts.ReverseWorkflowName(), tabletAlias))
 			return nil
 		}
 		if res == nil || len(res.Streams) == 0 {
@@ -623,14 +624,14 @@ func validateReverseWorkflowForComplete(ctx context.Context, ts *trafficSwitcher
 			case binlogdatapb.VReplicationWorkflowState_Running,
 				binlogdatapb.VReplicationWorkflowState_Stopped:
 			case binlogdatapb.VReplicationWorkflowState_Error:
-				rec.RecordError(fmt.Errorf("reverse vreplication stream %d is in error state on tablet %d",
-					stream.Id, source.GetPrimary().Alias.Uid))
+				rec.RecordError(fmt.Errorf("reverse vreplication stream %d is in error state on %s",
+					stream.Id, tabletAlias))
 			case binlogdatapb.VReplicationWorkflowState_Copying:
-				rec.RecordError(fmt.Errorf("reverse vreplication stream %d is still copying on tablet %d",
-					stream.Id, source.GetPrimary().Alias.Uid))
+				rec.RecordError(fmt.Errorf("reverse vreplication stream %d is still copying on %s",
+					stream.Id, tabletAlias))
 			default:
-				rec.RecordError(fmt.Errorf("reverse vreplication stream %d is in state %s on tablet %d",
-					stream.Id, stream.State, source.GetPrimary().Alias.Uid))
+				rec.RecordError(fmt.Errorf("reverse vreplication stream %d is in state %s on %s",
+					stream.Id, stream.State, tabletAlias))
 			}
 		}
 		return nil

--- a/go/vt/vtctl/workflow/utils.go
+++ b/go/vt/vtctl/workflow/utils.go
@@ -578,10 +578,6 @@ func doValidateWorkflowHasCompleted(ctx context.Context, ts *trafficSwitcher) er
 			rec.RecordError(err)
 		}
 	}
-	if err := validateReverseWorkflowForComplete(ctx, ts, &rec); err != nil {
-		rec.RecordError(err)
-	}
-
 	if !ts.keepRoutingRules {
 		// Check if table is routable.
 		if ts.MigrationType() == binlogdatapb.MigrationType_TABLES {
@@ -604,38 +600,6 @@ func doValidateWorkflowHasCompleted(ctx context.Context, ts *trafficSwitcher) er
 		return fmt.Errorf("%s", strings.Join(rec.ErrorStrings(), "\n"))
 	}
 	return nil
-}
-
-func validateReverseWorkflowForComplete(ctx context.Context, ts *trafficSwitcher, rec *concurrency.AllErrorRecorder) error {
-	return ts.ForAllSources(func(source *MigrationSource) error {
-		tabletAlias := topoproto.TabletAliasString(source.GetPrimary().GetAlias())
-		res, err := ts.ws.tmc.ReadVReplicationWorkflow(ctx, source.GetPrimary().Tablet, &tabletmanagerdatapb.ReadVReplicationWorkflowRequest{
-			Workflow: ts.ReverseWorkflowName(),
-		})
-		if err != nil {
-			rec.RecordError(vterrors.Wrapf(err, "reading reverse workflow %s on %s", ts.ReverseWorkflowName(), tabletAlias))
-			return nil
-		}
-		if res == nil || len(res.Streams) == 0 {
-			return nil
-		}
-		for _, stream := range res.Streams {
-			switch stream.State {
-			case binlogdatapb.VReplicationWorkflowState_Running,
-				binlogdatapb.VReplicationWorkflowState_Stopped:
-			case binlogdatapb.VReplicationWorkflowState_Error:
-				rec.RecordError(fmt.Errorf("reverse vreplication stream %d is in error state on %s",
-					stream.Id, tabletAlias))
-			case binlogdatapb.VReplicationWorkflowState_Copying:
-				rec.RecordError(fmt.Errorf("reverse vreplication stream %d is still copying on %s",
-					stream.Id, tabletAlias))
-			default:
-				rec.RecordError(fmt.Errorf("reverse vreplication stream %d is in state %s on %s",
-					stream.Id, stream.State, tabletAlias))
-			}
-		}
-		return nil
-	})
 }
 
 // ReverseWorkflowName returns the "reversed" name of a workflow. For a


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
MoveTables Complete could rename or drop source tables while reverse vreplication was still applying, causing permanent errno 1146 errors.
Before removing source tables (unless `--ignore-source-keyspace` is set), Complete now stops any running reverse vreplication streams on source primaries. This is a stop-only cleanup step: it does not validate reverse workflow state or wait for streams to catch up. After reverse streams are stopped, Complete proceeds with the existing source table removal/rename flow.

## Related Issue(s)
Fixes #20135

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure
Tests were written by AI

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
