### PR TITLE
[release-24.0] tests: stop passing --watch-replication-stream in tests

### DIFF
--- a/go/test/endtoend/backup/clone/main_test.go
+++ b/go/test/endtoend/backup/clone/main_test.go
@@ -52,7 +52,6 @@ var (
 		vtutils.GetFlagVariantForTests("--vreplication-retry-delay"), "1s",
 		vtutils.GetFlagVariantForTests("--degraded-threshold"), "5s",
 		vtutils.GetFlagVariantForTests("--lock-tables-timeout"), "5s",
-		vtutils.GetFlagVariantForTests("--watch-replication-stream"),
 		vtutils.GetFlagVariantForTests("--enable-replication-reporter"),
 		vtutils.GetFlagVariantForTests("--serving-state-grace-period"), "1s",
 	}

--- a/go/test/endtoend/backup/vtbackup/main_test.go
+++ b/go/test/endtoend/backup/vtbackup/main_test.go
@@ -47,7 +47,6 @@ var (
 		vtutils.GetFlagVariantForTests("--vreplication-retry-delay"), "1s",
 		vtutils.GetFlagVariantForTests("--degraded-threshold"), "5s",
 		vtutils.GetFlagVariantForTests("--lock-tables-timeout"), "5s",
-		vtutils.GetFlagVariantForTests("--watch-replication-stream"),
 		vtutils.GetFlagVariantForTests("--enable-replication-reporter"),
 		vtutils.GetFlagVariantForTests("--serving-state-grace-period"), "1s",
 	}

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -1511,7 +1511,6 @@ func getDefaultCommonArgs() []string {
 		vtutils.GetFlagVariantForTests("--vreplication-retry-delay"), "1s",
 		vtutils.GetFlagVariantForTests("--degraded-threshold"), "5s",
 		vtutils.GetFlagVariantForTests("--lock-tables-timeout"), "5s",
-		vtutils.GetFlagVariantForTests("--watch-replication-stream"),
 		vtutils.GetFlagVariantForTests("--enable-replication-reporter"),
 		vtutils.GetFlagVariantForTests("--serving-state-grace-period"), "1s",
 	}

--- a/go/test/endtoend/cellalias/cell_alias_test.go
+++ b/go/test/endtoend/cellalias/cell_alias_test.go
@@ -58,7 +58,6 @@ var (
 		utils.GetFlagVariantForTests("--vreplication-retry-delay"), "1s",
 		utils.GetFlagVariantForTests("--degraded-threshold"), "5s",
 		utils.GetFlagVariantForTests("--lock-tables-timeout"), "5s",
-		utils.GetFlagVariantForTests("--watch-replication-stream"),
 		utils.GetFlagVariantForTests("--enable-replication-reporter"),
 		utils.GetFlagVariantForTests("--serving-state-grace-period"), "1s",
 		utils.GetFlagVariantForTests("--binlog-player-protocol"), "grpc",

--- a/go/test/endtoend/onlineddl/flow/onlineddl_flow_test.go
+++ b/go/test/endtoend/onlineddl/flow/onlineddl_flow_test.go
@@ -141,7 +141,6 @@ func TestMain(m *testing.M) {
 			"--heartbeat_interval", "250ms",
 			"--heartbeat_on_demand_duration", "5s",
 			"--migration_check_interval", "2s",
-			"--watch_replication_stream",
 		}
 		clusterInstance.VtGateExtraArgs = []string{
 			"--ddl_strategy", "online",

--- a/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
+++ b/go/test/endtoend/onlineddl/revert/onlineddl_revert_test.go
@@ -160,7 +160,6 @@ func TestMain(m *testing.M) {
 			utils.GetFlagVariantForTests("--heartbeat-interval"), "250ms",
 			utils.GetFlagVariantForTests("--heartbeat-on-demand-duration"), "5s",
 			utils.GetFlagVariantForTests("--migration-check-interval"), "5s",
-			utils.GetFlagVariantForTests("--watch-replication-stream"),
 		}
 		clusterInstance.VtGateExtraArgs = []string{
 			utils.GetFlagVariantForTests("--ddl-strategy"), "online",

--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -261,7 +261,6 @@ func TestMain(m *testing.M) {
 			utils.GetFlagVariantForTests("--heartbeat-interval"), "250ms",
 			utils.GetFlagVariantForTests("--heartbeat-on-demand-duration"), "5s",
 			utils.GetFlagVariantForTests("--migration-check-interval"), "2s",
-			utils.GetFlagVariantForTests("--watch-replication-stream"),
 		}
 		clusterInstance.VtGateExtraArgs = []string{}
 

--- a/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
+++ b/go/test/endtoend/onlineddl/vrepl/onlineddl_vrepl_test.go
@@ -182,7 +182,6 @@ func TestMain(m *testing.M) {
 		clusterInstance.VtTabletExtraArgs = []string{
 			utils.GetFlagVariantForTests("--heartbeat-interval"), "250ms",
 			utils.GetFlagVariantForTests("--migration-check-interval"), "5s",
-			utils.GetFlagVariantForTests("--watch-replication-stream"),
 		}
 		clusterInstance.VtGateExtraArgs = []string{
 			utils.GetFlagVariantForTests("--ddl-strategy"), "online",

--- a/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress/onlineddl_vrepl_mini_stress_test.go
@@ -180,7 +180,6 @@ func TestMain(m *testing.M) {
 			utils.GetFlagVariantForTests("--heartbeat-interval"), "250ms",
 			utils.GetFlagVariantForTests("--heartbeat-on-demand-duration"), "5s",
 			utils.GetFlagVariantForTests("--migration-check-interval"), "5s",
-			utils.GetFlagVariantForTests("--watch-replication-stream"),
 		}
 		clusterInstance.VtGateExtraArgs = []string{
 			utils.GetFlagVariantForTests("--ddl-strategy"), "online",

--- a/go/test/endtoend/onlineddl/vrepl_stress_suite/onlineddl_vrepl_stress_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_stress_suite/onlineddl_vrepl_stress_suite_test.go
@@ -434,7 +434,6 @@ func TestMain(m *testing.M) {
 			utils.GetFlagVariantForTests("--heartbeat-on-demand-duration"), "5s",
 			utils.GetFlagVariantForTests("--migration-check-interval"), "5s",
 			"--vstream-packet-size", "4096", // Keep this value small and below 10k to ensure multilple vstream iterations
-			utils.GetFlagVariantForTests("--watch-replication-stream"),
 		}
 		clusterInstance.VtGateExtraArgs = []string{
 			utils.GetFlagVariantForTests("--ddl-strategy"), "online",

--- a/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
@@ -92,7 +92,6 @@ func TestMain(m *testing.M) {
 			"--heartbeat_interval", "250ms",
 			"--heartbeat_on_demand_duration", "5s",
 			"--migration_check_interval", "5s",
-			"--watch_replication_stream",
 		}
 
 		if err := clusterInstance.StartTopo(); err != nil {

--- a/go/test/endtoend/recovery/unshardedrecovery/recovery.go
+++ b/go/test/endtoend/recovery/unshardedrecovery/recovery.go
@@ -55,7 +55,6 @@ var (
 		"--vreplication-retry-delay", "1s",
 		vtutils.GetFlagVariantForTests("--degraded-threshold"), "5s",
 		vtutils.GetFlagVariantForTests("--lock-tables-timeout"), "5s",
-		vtutils.GetFlagVariantForTests("--watch-replication-stream"),
 		vtutils.GetFlagVariantForTests("--serving-state-grace-period"), "1s",
 	}
 	recoveryKS1  = "recovery_ks1"

--- a/go/test/endtoend/schemadiff/vrepl/schemadiff_vrepl_suite_test.go
+++ b/go/test/endtoend/schemadiff/vrepl/schemadiff_vrepl_suite_test.go
@@ -90,7 +90,6 @@ func TestMain(m *testing.M) {
 			utils.GetFlagVariantForTests("--heartbeat-interval"), "250ms",
 			utils.GetFlagVariantForTests("--heartbeat-on-demand-duration"), "5s",
 			utils.GetFlagVariantForTests("--migration-check-interval"), "5s",
-			utils.GetFlagVariantForTests("--watch-replication-stream"),
 		}
 
 		if err := clusterInstance.StartTopo(); err != nil {

--- a/go/test/endtoend/tabletmanager/main_test.go
+++ b/go/test/endtoend/tabletmanager/main_test.go
@@ -104,7 +104,6 @@ func TestMain(m *testing.M) {
 		// Set extra tablet args for lock timeout
 		clusterInstance.VtTabletExtraArgs = []string{
 			utils.GetFlagVariantForTests("--lock-tables-timeout"), "5s",
-			utils.GetFlagVariantForTests("--watch-replication-stream"),
 			utils.GetFlagVariantForTests("--heartbeat-enable"),
 			utils.GetFlagVariantForTests("--health-check-interval"), tabletHealthcheckRefreshInterval.String(),
 			utils.GetFlagVariantForTests("--unhealthy-threshold"), tabletUnhealthyThreshold.String(),

--- a/go/test/endtoend/tabletmanager/primary/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/primary/tablet_test.go
@@ -86,7 +86,6 @@ func TestMain(m *testing.M) {
 		// Set extra tablet args for lock timeout
 		clusterInstance.VtTabletExtraArgs = []string{
 			utils.GetFlagVariantForTests("--lock-tables-timeout"), "5s",
-			utils.GetFlagVariantForTests("--watch-replication-stream"),
 			utils.GetFlagVariantForTests("--enable-replication-reporter"),
 		}
 

--- a/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
+++ b/go/test/endtoend/tabletmanager/tablegc/tablegc_test.go
@@ -100,7 +100,6 @@ func TestMain(m *testing.M) {
 		// Set extra tablet args for lock timeout
 		clusterInstance.VtTabletExtraArgs = []string{
 			utils.GetFlagVariantForTests("--lock-tables-timeout"), "5s",
-			utils.GetFlagVariantForTests("--watch-replication-stream"),
 			utils.GetFlagVariantForTests("--enable-replication-reporter"),
 			utils.GetFlagVariantForTests("--heartbeat-interval"), "250ms",
 			utils.GetFlagVariantForTests("--gc-check-interval"), gcCheckInterval.String(),

--- a/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
+++ b/go/test/endtoend/tabletmanager/throttler_topo/throttler_test.go
@@ -106,7 +106,6 @@ func TestMain(m *testing.M) {
 		// Set extra tablet args for lock timeout
 		clusterInstance.VtTabletExtraArgs = []string{
 			utils.GetFlagVariantForTests("--lock-tables-timeout"), "5s",
-			utils.GetFlagVariantForTests("--watch-replication-stream"),
 			utils.GetFlagVariantForTests("--enable-replication-reporter"),
 			utils.GetFlagVariantForTests("--heartbeat-interval"), "250ms",
 			utils.GetFlagVariantForTests("--heartbeat-on-demand-duration"), onDemandHeartbeatDuration.String(),

--- a/go/test/endtoend/topoconncache/main_test.go
+++ b/go/test/endtoend/topoconncache/main_test.go
@@ -53,7 +53,6 @@ var (
 		utils.GetFlagVariantForTests("--vreplication-retry-delay"), "1s",
 		utils.GetFlagVariantForTests("--degraded-threshold"), "5s",
 		utils.GetFlagVariantForTests("--lock-tables-timeout"), "5s",
-		utils.GetFlagVariantForTests("--watch-replication-stream"),
 		utils.GetFlagVariantForTests("--enable-replication-reporter"),
 		utils.GetFlagVariantForTests("--serving-state-grace-period"), "1s",
 		utils.GetFlagVariantForTests("--binlog-player-protocol"), "grpc",

--- a/go/test/endtoend/vault/vault_test.go
+++ b/go/test/endtoend/vault/vault_test.go
@@ -59,7 +59,6 @@ var (
 		vtutils.GetFlagVariantForTests("--vreplication-retry-delay"), "1s",
 		vtutils.GetFlagVariantForTests("--degraded-threshold"), "5s",
 		vtutils.GetFlagVariantForTests("--lock-tables-timeout"), "5s",
-		vtutils.GetFlagVariantForTests("--watch-replication-stream"),
 		// Frequently reload schema, generating some tablet traffic,
 		//   so we can speed up token refresh
 		"--queryserver-config-schema-reload-time", "5s",

--- a/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
+++ b/go/test/endtoend/vtgate/foreignkey/stress/fk_stress_test.go
@@ -359,7 +359,6 @@ func TestMain(m *testing.M) {
 			vtutils.GetFlagVariantForTests("--heartbeat-interval"), "250ms",
 			vtutils.GetFlagVariantForTests("--heartbeat-on-demand-duration"), "5s",
 			vtutils.GetFlagVariantForTests("--migration-check-interval"), "3s",
-			vtutils.GetFlagVariantForTests("--watch-replication-stream"),
 		}
 		clusterInstance.VtGateExtraArgs = []string{}
 


### PR DESCRIPTION
## Description

The `--watch-replication-stream` flag has been a deprecated no-op on vttablet since #19204 (Feb 2026) — the underlying binlog watcher was deleted in that change. Schema-change tracking now flows through the reliable vstream path unconditionally.

#20048 (merged 2026-05-26) then removed the flag entirely from vttablet on `main`, along with all of `main`'s e2e references. That cleanup did not touch `release-24.0`, where ~20 e2e tests still pass the flag.

The upgrade-downgrade workflows on `release-24.0` build `vttablet-next` from `main` and run it alongside the release-24.0 binary. With the flag now gone on `main`, `vttablet-next` aborts:

```
Flag --watch_replication_stream has been deprecated, use --watch-replication-stream instead
Error: unknown flag: --watch_replication_stream
```

This actively breaks the "Online DDL flow - Upgrade Downgrade Testing" job on every PR targeting `release-24.0` (e.g. #20183). Other upgrade-downgrade workflows on `release-24.0` happen not to run packages that pass the flag — but they would break the moment one does.

This PR drops `--watch-replication-stream` from every release-24.0 e2e test that still passes it. Since the flag is a no-op on release-24.0's own vttablet too, removing it is behavior-preserving on that side, and it makes the tests forward-compatible with vttablet-next.

## Related Issue(s)

- Follow-up to #19204 (made the flag a no-op) and #20048 (removed the flag from `main`).
- Unblocks #20183 and any other PR targeting `release-24.0`.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — test-only change on `release-24.0`.

### AI Disclosure

This PR was written primarily by Claude Code — I just provided direction.