### PR TITLE
[release-22.0] CI: deflakes, fork runner fallback, codecov / milestone gating

### DIFF
--- a/.github/workflows/assign_milestone.yml
+++ b/.github/workflows/assign_milestone.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   build:
+    if: github.repository == 'vitessio/vitess'
     name: Assign Milestone
     runs-on: ubuntu-24.04
 

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -72,7 +72,7 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
 
     name: Run endtoend tests on Cluster (${{ matrix.shard }})
-    runs-on: ${{ contains(matrix.needs, 'larger-runner') && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository == 'vitessio/vitess' && contains(matrix.needs, 'larger-runner') && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -17,7 +17,7 @@ permissions: read-all
 
 jobs:
   test:
-    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'Backport')
+    if: github.repository == 'vitessio/vitess' && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'Backport'))
     name: Code Coverage
     runs-on: oracle-vm-8cpu-32gb-x86-64
 

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -17,7 +17,7 @@ jobs:
 
   build:
     name: Local example using ${{ matrix.topo }} on Ubuntu
-    runs-on: gh-hosted-runners-16cores-1-24.04
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
     strategy:
       matrix:
         topo: [etcd,zk2]

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -17,7 +17,7 @@ jobs:
 
   build:
     name: Region Sharding example using ${{ matrix.topo }} on Ubuntu
-    runs-on: gh-hosted-runners-16cores-1-24.04
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
     strategy:
       matrix:
         topo: [etcd]

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -66,7 +66,7 @@ jobs:
             race: true
 
     name: "Unit Test (${{ matrix.race && (matrix.evalengine == '1' && 'Evalengine_' || '') || (matrix.evalengine == '1' && 'evalengine_' || '') }}${{ matrix.race && 'Race' || matrix.platform }})"
-    runs-on: ${{ matrix.race && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository == 'vitessio/vitess' && matrix.race && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -18,7 +18,7 @@ jobs:
   upgrade_downgrade_test_e2e:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Backups - E2E
-    runs-on: gh-hosted-runners-16cores-1-24.04
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -19,7 +19,7 @@ jobs:
   upgrade_downgrade_test_e2e:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Backups - E2E - Next Release
-    runs-on: gh-hosted-runners-16cores-1-24.04
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -20,7 +20,7 @@ jobs:
   upgrade_downgrade_test_manual:
     timeout-minutes: 40
     name: Run Upgrade Downgrade Test - Backups - Manual
-    runs-on: gh-hosted-runners-16cores-1-24.04
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -20,7 +20,7 @@ jobs:
   upgrade_downgrade_test_manual:
     timeout-minutes: 40
     name: Run Upgrade Downgrade Test - Backups - Manual - Next Release
-    runs-on: gh-hosted-runners-16cores-1-24.04
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
+++ b/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
@@ -22,7 +22,7 @@ jobs:
   upgrade_downgrade_test:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Online DDL flow
-    runs-on: gh-hosted-runners-16cores-1-24.04
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -22,7 +22,7 @@ jobs:
   upgrade_downgrade_test:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Query Serving (Queries)
-    runs-on: gh-hosted-runners-16cores-1-24.04
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
@@ -21,7 +21,7 @@ jobs:
   upgrade_downgrade_test:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Query Serving (Queries - 2)
-    runs-on: gh-hosted-runners-16cores-1-24.04
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
@@ -22,7 +22,7 @@ jobs:
   upgrade_downgrade_test:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Query Serving (Queries - 2) Next Release
-    runs-on: gh-hosted-runners-16cores-1-24.04
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -22,7 +22,7 @@ jobs:
   upgrade_downgrade_test:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Query Serving (Queries) Next Release
-    runs-on: gh-hosted-runners-16cores-1-24.04
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -22,7 +22,7 @@ jobs:
   upgrade_downgrade_test:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Query Serving (Schema)
-    runs-on: gh-hosted-runners-16cores-1-24.04
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -22,7 +22,7 @@ jobs:
   upgrade_downgrade_test:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Query Serving (Schema) Next Release
-    runs-on: gh-hosted-runners-16cores-1-24.04
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -22,7 +22,7 @@ jobs:
   upgrade_downgrade_test:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Reparent New Vtctl
-    runs-on: gh-hosted-runners-16cores-1-24.04
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -22,7 +22,7 @@ jobs:
   upgrade_downgrade_test:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Reparent New VTTablet
-    runs-on: gh-hosted-runners-16cores-1-24.04
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -22,7 +22,7 @@ jobs:
   upgrade_downgrade_test:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Reparent Old Vtctl
-    runs-on: gh-hosted-runners-16cores-1-24.04
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -22,7 +22,7 @@ jobs:
   upgrade_downgrade_test:
     timeout-minutes: 60
     name: Run Upgrade Downgrade Test - Reparent Old VTTablet
-    runs-on: gh-hosted-runners-16cores-1-24.04
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
 
     steps:
     - name: Skip CI

--- a/.github/workflows/upgrade_downgrade_test_semi_sync.yml
+++ b/.github/workflows/upgrade_downgrade_test_semi_sync.yml
@@ -18,7 +18,7 @@ jobs:
   upgrade_downgrade_test_e2e:
     timeout-minutes: 60
     name: Run Semi Sync Upgrade Downgrade Test
-    runs-on: gh-hosted-runners-16cores-1-24.04
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'gh-hosted-runners-16cores-1-24.04' || 'ubuntu-24.04' }}
 
     steps:
       - name: Skip CI

--- a/.github/workflows/vtop_example.yml
+++ b/.github/workflows/vtop_example.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: VTop Example
-    runs-on: oracle-vm-8cpu-32gb-x86-64
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'oracle-vm-8cpu-32gb-x86-64' || 'ubuntu-24.04' }}
 
     steps:
       - name: Skip CI

--- a/go/mysql/auth_server_static_test.go
+++ b/go/mysql/auth_server_static_test.go
@@ -180,10 +180,7 @@ func hupTest(t *testing.T, aStatic *AuthServerStatic, tmpFile *os.File, oldStr, 
 	syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
 
 	// wait for signal handler
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		require.Nil(c, aStatic.getEntries()[oldStr], "Should not have old %s after config reload", oldStr)
-		require.Equal(c, newStr, aStatic.getEntries()[newStr][0].Password, "%s's Password should be '%s'", newStr, newStr)
-	}, 30*time.Second, 10*time.Millisecond, "config should be reloaded with new file after rotation")
+	waitForReload(t, aStatic, oldStr, newStr)
 }
 
 func hupTestWithRotation(t *testing.T, aStatic *AuthServerStatic, tmpFile *os.File, oldStr, newStr string) {
@@ -192,9 +189,27 @@ func hupTestWithRotation(t *testing.T, aStatic *AuthServerStatic, tmpFile *os.Fi
 		t.Fatalf("couldn't overwrite temp file: %v", err)
 	}
 
+	waitForReload(t, aStatic, oldStr, newStr)
+}
+
+// waitForReload polls aStatic until the auth file reload has dropped oldStr
+// and installed newStr.
+//
+// We use `assert.X(c, ...)` (not `require.X`) inside the callback because
+// testify v1.9 on this branch implements `CollectT.FailNow` as
+// `panic("Assertion failed")`, and `EventuallyWithT` doesn't recover from
+// that — a failed poll would crash the test instead of being retried. We
+// also gate the `[0]` indexing on `NotEmpty` for the same reason: a panic
+// inside the callback (e.g. `nil[0]`) escapes the goroutine.
+func waitForReload(t *testing.T, aStatic *AuthServerStatic, oldStr, newStr string) {
+	t.Helper()
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		require.Nil(c, aStatic.getEntries()[oldStr], "Should not have old %s after config reload", oldStr)
-		require.Equal(c, newStr, aStatic.getEntries()[newStr][0].Password, "%s's Password should be '%s'", newStr, newStr)
+		assert.Nil(c, aStatic.getEntries()[oldStr], "Should not have old %s after config reload", oldStr)
+		entries := aStatic.getEntries()[newStr]
+		if !assert.NotEmpty(c, entries, "Should have new %s entries after config reload", newStr) {
+			return
+		}
+		assert.Equal(c, newStr, entries[0].Password, "%s's Password should be '%s'", newStr, newStr)
 	}, 30*time.Second, 10*time.Millisecond, "config should be reloaded with new file after rotation")
 }
 

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -1024,7 +1024,17 @@ func TestTLSRequired(t *testing.T) {
 	params.SslCert = path.Join(root, "revoked-client-cert.pem")
 	params.SslKey = path.Join(root, "revoked-client-key.pem")
 	conn, err = connectWithGoneServerHandling()
-	require.ErrorContains(t, err, "remote error: tls: bad certificate")
+	// On a happy day the client reads the server's TLS `bad_certificate`
+	// alert; on a less happy day the server's TCP close races ahead of the
+	// alert and the client sees `connection reset by peer` / `broken pipe`.
+	// Either outcome means the revoked cert was rejected, which is what the
+	// test cares about — so accept both.
+	errStr := err.Error()
+	require.True(t,
+		strings.Contains(errStr, "remote error: tls: bad certificate") ||
+			strings.Contains(errStr, "connection reset by peer") ||
+			strings.Contains(errStr, "broken pipe"),
+		"expected revoked-cert connection to be rejected, got: %v", err)
 	if conn != nil {
 		conn.Close()
 	}

--- a/go/vt/vtgate/schema/tracker_test.go
+++ b/go/vt/vtgate/schema/tracker_test.go
@@ -194,7 +194,7 @@ func TestTrackerNoLock(t *testing.T) {
 	for i := 0; i < 500000; i++ {
 		select {
 		case ch <- th:
-		case <-time.After(10 * time.Millisecond):
+		case <-time.After(50 * time.Millisecond):
 			t.Fatalf("failed to send health check to tracker")
 		}
 	}


### PR DESCRIPTION
## Description

`release-22.0` is long EOL and not supported. However, some users still run it internally, or have to run it for a short window as part of an upgrade path to a supported Vitess version. Those users sometimes need to backport fixes from newer branches into their own forks, and right now that's painful: CI on the `release-22.0` branch is broken in several ways for any repo that isn't `vitessio/vitess` (custom runners that forks can't schedule on, a Code Coverage job that goes red without an upload token, an Assign Milestone job that fails because the fork has no matching milestones, plus a couple of flaky tests).

This PR bundles the CI-only fixes needed to get `release-22.0` green again so those backports can land. No production code is changed — everything is `.github/`, test helpers, or test code.

To be clear: merging this is **not** a change in support status. `release-22.0` remains EOL. This is a courtesy to make life easier for users still on the branch by accident or by upgrade-path necessity.

The same set of fixes was opened against `release-20.0` in #20195 and `release-21.0` in #20196.

### Fork-runner / infra fallbacks

- **f434887e1** `ci: fall back to ubuntu-24.04 outside vitessio/vitess` — forks can't schedule on `gh-hosted-runners-16cores-1-24.04`; gate runner selection on `github.repository` (folded into the existing `matrix.needs`/`matrix.race` ternaries where they already chose between the larger runner and `ubuntu-24.04`).
- **e1a544147** `ci: fall back to ubuntu-24.04 for vtop_example outside vitessio/vitess` — `vtop_example.yml` hardcoded `oracle-vm-8cpu-32gb-x86-64`; apply the same `github.repository` ternary. Won't necessarily pass on `ubuntu-24.04` (minikube + vtop is tight on 4 cores), but failing at runtime with a log is more useful than never scheduling.

### Code Coverage gating

- **493869ecb** `ci: gate Code Coverage on github.repository` — `fail_ci_if_error: true` + no `CODECOV_TOKEN` on forks meant the job always went red. AND `github.repository == 'vitessio/vitess'` into the existing job-level `if`; the `Backport`-label exclusion is preserved for upstream runs.

### Milestone job gating

- **cc3a0cb41** `ci: gate Assign Milestone on github.repository` — `assign_milestone.yml` runs on `pull_request_target: [opened]` and tries to assign a milestone that doesn't exist on the fork, so every fork PR fails this job. Job-level `if: github.repository == 'vitessio/vitess'` skips it cleanly.

### Test deflakes (backports / cherry-picks)

- **0cffe8696** `go/mysql: relax TestTLSRequired revoked-cert assertion` — accept `connection reset by peer` / `broken pipe` alongside `bad certificate`; all three mean the revoked cert was rejected.
- **487d728a8** `go/mysql: stop TestStaticConfigHUP panicking inside EventuallyWithT` — follow-up to upstream's cherry-pick of #19388: this branch is pinned to testify v1.10.0, where `CollectT.FailNow` panics and `EventuallyWithT` doesn't recover. Use `assert.X(c, ...)` instead of `require.X(c, ...)`.
- **e91953f51** `go/vt/vtgate/schema: bump TestTrackerNoLock channel-send timeout` — backport of the `tracker_test.go` slice of #18317 (10ms → 50ms).

## Related Issue(s)

None — these are CI-only stabilization fixes.

## Checklist

-   [ ] \"Backport to:\" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — CI-only changes.