### PR TITLE
fix: remove redundant error arg from vterrors.Wrapf calls

### DIFF
--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -70,7 +70,8 @@ type EmergencyReparentOptions struct {
 }
 
 // counters for Emergency Reparent Shard
-var ersCounter = stats.NewCountersWithMultiLabels("EmergencyReparentCounts", "Number of times Emergency Reparent Shard has been run",
+var ersCounter = stats.NewCountersWithMultiLabels(
+	"EmergencyReparentCounts", "Number of times Emergency Reparent Shard has been run",
 	[]string{"Keyspace", "Shard", "Result"},
 )
 
@@ -201,7 +202,8 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 	ev.ShardInfo = *shardInfo
 
 	if opts.ExpectedPrimaryAlias != nil && !topoproto.TabletAliasEqual(opts.ExpectedPrimaryAlias, shardInfo.PrimaryAlias) {
-		return vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "primary %s is not equal to expected alias %s",
+		return vterrors.Errorf(
+			vtrpc.Code_FAILED_PRECONDITION, "primary %s is not equal to expected alias %s",
 			topoproto.TabletAliasString(shardInfo.PrimaryAlias),
 			topoproto.TabletAliasString(opts.ExpectedPrimaryAlias),
 		)
@@ -233,7 +235,7 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 	event.DispatchUpdate(ev, "reading all tablets")
 	tabletMap, err = erp.ts.GetTabletMapForShard(ctx, keyspace, shard)
 	if err != nil {
-		return vterrors.Wrapf(err, "failed to get tablet map for %v/%v: %v", keyspace, shard, err)
+		return vterrors.Wrapf(err, "failed to get tablet map for %v/%v", keyspace, shard)
 	}
 
 	// Stop replication on all the tablets and build their status map
@@ -249,7 +251,7 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 	}
 
 	if err != nil {
-		return vterrors.Wrapf(err, "failed to stop replication and build status maps: %v", err)
+		return vterrors.Wrapf(err, "failed to stop replication and build status maps")
 	}
 
 	// check that we still have the shard lock. If we don't then we can terminate at this point
@@ -476,7 +478,7 @@ func (erp *EmergencyReparenter) waitForAllRelayLogsToApply(
 	rec := errgroup.Wait(groupCancel, errCh)
 
 	if len(rec.Errors) != 0 {
-		return vterrors.Wrapf(rec.Error(), "could not apply all relay logs within the provided waitReplicasTimeout (%s): %v", waitReplicasTimeout, rec.Error())
+		return vterrors.Wrapf(rec.Error(), "could not apply all relay logs within the provided waitReplicasTimeout (%s)", waitReplicasTimeout)
 	}
 
 	return nil
@@ -639,12 +641,12 @@ func (erp *EmergencyReparenter) reparentReplicas(
 				position, err = erp.tmc.PromoteReplica(primaryCtx, tablet, policy.SemiSyncAckers(opts.durability, tablet) > 0)
 			}
 			if err != nil {
-				return vterrors.Wrapf(err, "primary-elect tablet %v failed to be upgraded to primary: %v", alias, err)
+				return vterrors.Wrapf(err, "primary-elect tablet %v failed to be upgraded to primary", alias)
 			}
 			erp.logger.Infof("populating reparent journal on new primary %v", alias)
 			err = erp.tmc.PopulateReparentJournal(primaryCtx, tablet, now, opts.lockAction, tablet.Alias, position)
 			if err != nil {
-				return vterrors.Wrapf(err, "failed to PopulateReparentJournal on primary: %v", err)
+				return vterrors.Wrapf(err, "failed to PopulateReparentJournal on primary")
 			}
 		}
 		return nil
@@ -658,7 +660,7 @@ func (erp *EmergencyReparenter) reparentReplicas(
 		if status, ok := statusMap[alias]; ok {
 			fs, err := ReplicaWasRunning(status)
 			if err != nil {
-				err = vterrors.Wrapf(err, "tablet %v could not determine StopReplicationStatus: %v", alias, err)
+				err = vterrors.Wrapf(err, "tablet %v could not determine StopReplicationStatus", alias)
 				rec.RecordError(err)
 
 				return
@@ -669,7 +671,7 @@ func (erp *EmergencyReparenter) reparentReplicas(
 
 		err := erp.tmc.SetReplicationSource(replCtx, ti.Tablet, newPrimaryTablet.Alias, 0, "", forceStart, policy.IsReplicaSemiSync(opts.durability, newPrimaryTablet, ti.Tablet), 0)
 		if err != nil {
-			err = vterrors.Wrapf(err, "tablet %v SetReplicationSource failed: %v", alias, err)
+			err = vterrors.Wrapf(err, "tablet %v SetReplicationSource failed", alias)
 			rec.RecordError(err)
 
 			return
@@ -747,7 +749,7 @@ func (erp *EmergencyReparenter) reparentReplicas(
 			// Technically, rec.Errors should never be greater than numReplicas,
 			// but it's better to err on the side of caution here, but also
 			// we're going to be explicit that this is doubly unexpected.
-			return nil, vterrors.Wrapf(rec.Error(), "received more errors (= %d) than replicas (= %d), which should be impossible: %v", errCount, numReplicas, rec.Error())
+			return nil, vterrors.Wrapf(rec.Error(), "received more errors (= %d) than replicas (= %d), which should be impossible", errCount, numReplicas)
 		case errCount == numReplicas:
 			if len(tabletMap) <= 2 {
 				// If there are at most 2 tablets in the tablet map, we shouldn't be failing the promotion if the replica fails to SetReplicationSource.
@@ -755,7 +757,7 @@ func (erp *EmergencyReparenter) reparentReplicas(
 				erp.logger.Warningf("Failed to set the MySQL replication source during ERS but because there is only one other tablet we assume it is the one that had failed and will progress with the reparent. Error: %v", rec.Error())
 				return nil, nil
 			}
-			return nil, vterrors.Wrapf(rec.Error(), "%d replica(s) failed: %v", numReplicas, rec.Error())
+			return nil, vterrors.Wrapf(rec.Error(), "%d replica(s) failed", numReplicas)
 		default:
 			return replicasStartedReplication, nil
 		}
@@ -1043,7 +1045,7 @@ func (erp *EmergencyReparenter) gatherReparenJournalInfo(
 	rec := errgroup.Wait(groupCancel, errCh)
 
 	if len(rec.Errors) != 0 {
-		return nil, vterrors.Wrapf(rec.Error(), "could not read reparent journal information within the provided waitReplicasTimeout (%s): %v", waitReplicasTimeout, rec.Error())
+		return nil, vterrors.Wrapf(rec.Error(), "could not read reparent journal information within the provided waitReplicasTimeout (%s)", waitReplicasTimeout)
 	}
 
 	return reparentJournalLen, nil

--- a/go/vt/vtctl/reparentutil/replication.go
+++ b/go/vt/vtctl/reparentutil/replication.go
@@ -147,7 +147,7 @@ func FindPositionsOfAllCandidates(
 	for alias, primaryStatus := range primaryStatusMap {
 		executedPosition, err := replication.DecodePosition(primaryStatus.Position)
 		if err != nil {
-			return nil, false, vterrors.Wrapf(err, "could not decode a primary status executed position for tablet %v: %v", alias, err)
+			return nil, false, vterrors.Wrapf(err, "could not decode a primary status executed position for tablet %v", alias)
 		}
 
 		positionMap[alias] = &RelayLogPositions{Combined: executedPosition}
@@ -323,10 +323,9 @@ func stopReplicationAndBuildStatusMaps(
 
 				primaryStatus, err = tmc.DemotePrimary(groupCtx, tabletInfo.Tablet, true /* force */)
 				if err != nil {
-					msg := "replica %v thinks it's primary but we failed to demote it: %v"
-					err = vterrors.Wrapf(err, msg, alias, err)
+					err = vterrors.Wrapf(err, "replica %v thinks it's primary but we failed to demote it", alias)
 
-					logger.Warningf(msg, alias, err)
+					logger.Warningf("replica %v thinks it's primary but we failed to demote it: %v", alias, err)
 					return
 				}
 
@@ -336,7 +335,7 @@ func stopReplicationAndBuildStatusMaps(
 				m.Unlock()
 			} else {
 				logger.Warningf("failed to get replication status from %v: %v", alias, err)
-				err = vterrors.Wrapf(err, "error when getting replication status for alias %v: %v", alias, err)
+				err = vterrors.Wrapf(err, "error when getting replication status for alias %v", alias)
 			}
 		} else {
 			isTakingBackup := false
@@ -429,7 +428,7 @@ func stopReplicationAndBuildStatusMaps(
 	// check that the tablets we were able to reach are sufficient for us to guarantee that no new write will be accepted by any tablet
 	revokeSuccessful := haveRevoked(durability, res.reachableTablets, allTablets)
 	if !revokeSuccessful {
-		return res, vterrors.Wrapf(errRecorder.Error(), "could not reach sufficient tablets to guarantee safety: %v", errRecorder.Error())
+		return res, vterrors.Wrapf(errRecorder.Error(), "could not reach sufficient tablets to guarantee safety")
 	}
 
 	return res, nil

--- a/go/vt/vtctl/reparentutil/replication_test.go
+++ b/go/vt/vtctl/reparentutil/replication_test.go
@@ -19,6 +19,7 @@ package reparentutil
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -204,6 +205,34 @@ func TestFindPositionsOfAllCandidates(t *testing.T) {
 			assert.ElementsMatch(t, tt.expected, keys)
 		})
 	}
+}
+
+// TestFindPositionsOfAllCandidates_ErrorNotDuplicated verifies that when
+// FindPositionsOfAllCandidates wraps an error the underlying cause message is
+// not repeated twice in the output. vterrors.Wrapf already appends the cause
+// via "wrapper: cause", so including the cause in the format string would
+// duplicate it.
+func TestFindPositionsOfAllCandidates_ErrorNotDuplicated(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := FindPositionsOfAllCandidates(
+		map[string]*replicationdatapb.StopReplicationStatus{
+			"r1": {After: &replicationdatapb.Status{
+				SourceUuid:       "3E11FA47-71CA-11E1-9E33-C80AA9429562",
+				RelayLogPosition: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5",
+			}},
+		},
+		map[string]*replicationdatapb.PrimaryStatus{
+			"p1": {Position: "InvalidFlavor/1234"},
+		},
+	)
+	require.Error(t, err)
+
+	cause := vterrors.Cause(err)
+	require.NotNil(t, cause)
+	causeMsg := cause.Error()
+	assert.Equal(t, 1, strings.Count(err.Error(), causeMsg),
+		"cause message must appear exactly once in the wrapped error")
 }
 
 // stopReplicationAndBuildStatusMapsTestTMClient implements

--- a/go/vt/vtctl/schematools/schematools.go
+++ b/go/vt/vtctl/schematools/schematools.go
@@ -41,7 +41,7 @@ func GetSchema(ctx context.Context, ts *topo.Server, tmc tmclient.TabletManagerC
 
 	sd, err := tmc.GetSchema(ctx, ti.Tablet, request)
 	if err != nil {
-		return nil, vterrors.Wrapf(err, "GetSchema(%v, %v) failed: %v", ti.Tablet, request, err)
+		return nil, vterrors.Wrapf(err, "GetSchema(%v, %v) failed", ti.Tablet, request)
 	}
 
 	return sd, nil

--- a/go/vt/vttablet/tabletserver/throttle/throttler.go
+++ b/go/vt/vttablet/tabletserver/throttle/throttler.go
@@ -818,7 +818,8 @@ func (throttler *Throttler) Operate(ctx context.Context, wg *sync.WaitGroup) {
 							primaryStimulatorRateLimiter.Do(
 								func() error {
 									return throttler.stimulatePrimaryThrottler(ctx, tmClient)
-								})
+								},
+							)
 						}
 					}
 				}
@@ -895,7 +896,7 @@ func (throttler *Throttler) generateTabletProbeFunction(scope base.Scope, probe 
 		req := &tabletmanagerdatapb.CheckThrottlerRequest{} // We leave AppName empty; it will default to VitessName anyway, and we can save some proto space
 		resp, err := tmClient.CheckThrottler(ctx, probe.Tablet, req)
 		if err != nil {
-			err = vterrors.Wrapf(err, "gRPC error accessing tablet %v. Err=%s", probe.Alias, err.Error())
+			err = vterrors.Wrapf(err, "gRPC error accessing tablet %v", probe.Alias)
 			return metricsWithError(err)
 		}
 		throttleMetric.Value = resp.Value


### PR DESCRIPTION
## Description

`vterrors.Wrapf` already appends the cause message via `wrapping.Error()`:

```go
func (w *wrapping) Error() string { return w.msg + ": " + w.cause.Error() }
```

But 16 call sites across reparentutil, schematools and throttle were also passing the error into the format string, so the cause message ends up duplicated:

```
"failed to get tablet map for ks/shard: Code: INTERNAL\nsome error\n: some error"
```

Fix: drop the redundant `%v` / `%s` + error arg from those Wrapf calls. The cause is still included - just once, the way the library intended.

To reproduce, run the new test on main before this fix:

```
go test ./go/vt/vtctl/reparentutil/ -run TestFindPositionsOfAllCandidates_ErrorNotDuplicated
```

It fails with `expected: 1, actual: 2` (cause message count).

## Related Issue(s)

n/a

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

No behavioral change, error messages just stop repeating themselves.

### AI Disclosure

N/A