### PR TITLE
Support VALUES ROW as a derived table

### DIFF
--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -3186,8 +3186,7 @@ func (node *ValuesStatement) GetColumns() []SelectExpr {
 	for i := range columnCount {
 		sel = append(sel, &AliasedExpr{Expr: NewColName(fmt.Sprintf("column_%d", i))})
 	}
-	_ = sel
-	panic("no columns available") // TODO: we need a better solution than a panic
+	return sel
 }
 
 func (node *ValuesStatement) SetComments(comments Comments) {}

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -420,6 +420,17 @@ func stripDownQuery(from, to sqlparser.TableStatement) {
 		stripDownQuery(node.Right, toNode.Right)
 		toNode.OrderBy = node.OrderBy
 		toNode.Limit = node.Limit
+	case *sqlparser.ValuesStatement:
+		toNode, ok := to.(*sqlparser.ValuesStatement)
+		if !ok {
+			panic(vterrors.VT13001("AST did not match"))
+		}
+		toNode.With = node.With
+		toNode.Rows = node.Rows
+		toNode.ListArg = node.ListArg
+		toNode.Comments = node.Comments
+		toNode.Order = node.Order
+		toNode.Limit = node.Limit
 	default:
 		panic(vterrors.VT13001(fmt.Sprintf("this should not happen - we have covered all implementations of SelectStatement %T", from)))
 	}
@@ -667,6 +678,10 @@ func buildDerived(op *Horizon, qb *queryBuilder) {
 
 	stmt := qb.stmt
 	qb.stmt = nil
+	if values, ok := op.Query.(*sqlparser.ValuesStatement); ok {
+		buildDerivedValues(op, qb, values)
+		return
+	}
 	switch sel := stmt.(type) {
 	case *sqlparser.Select:
 		buildDerivedSelect(op, qb, sel)
@@ -676,6 +691,15 @@ func buildDerived(op *Horizon, qb *queryBuilder) {
 		return
 	}
 	panic(fmt.Sprintf("unknown select statement type: %T", stmt))
+}
+
+func buildDerivedValues(op *Horizon, qb *queryBuilder, values *sqlparser.ValuesStatement) {
+	qb.addTableExpr(op.Alias, op.Alias, TableID(op), &sqlparser.DerivedTable{
+		Select: values,
+	}, nil, op.ColumnAliases)
+	for _, col := range op.Columns {
+		qb.addProjection(&sqlparser.AliasedExpr{Expr: col})
+	}
 }
 
 func buildDerivedUnion(op *Horizon, qb *queryBuilder, union *sqlparser.Union) {
@@ -714,6 +738,10 @@ func buildDerivedSelect(op *Horizon, qb *queryBuilder, sel *sqlparser.Select) {
 
 func buildHorizon(op *Horizon, qb *queryBuilder) {
 	buildQuery(op.Source, qb)
+	if values, ok := op.Query.(*sqlparser.ValuesStatement); ok {
+		qb.stmt = sqlparser.Clone(values)
+		return
+	}
 	stripDownQuery(op.Query, qb.asSelectStatement())
 }
 

--- a/go/vt/vtgate/planbuilder/operators/ast_to_op.go
+++ b/go/vt/vtgate/planbuilder/operators/ast_to_op.go
@@ -38,6 +38,8 @@ func translateQueryToOp(ctx *plancontext.PlanningContext, selStmt sqlparser.Stat
 		return createOperatorFromSelect(ctx, node)
 	case *sqlparser.Union:
 		return createOperatorFromUnion(ctx, node)
+	case *sqlparser.ValuesStatement:
+		return createOperatorFromValues(node)
 	case *sqlparser.Update:
 		return createOperatorFromUpdate(ctx, node)
 	case *sqlparser.Delete:
@@ -79,6 +81,10 @@ func createOperatorFromSelect(ctx *plancontext.PlanningContext, sel *sqlparser.S
 	op = newHorizon(op, sel)
 
 	return op
+}
+
+func createOperatorFromValues(values *sqlparser.ValuesStatement) Operator {
+	return newHorizon(createDualRoute(), values)
 }
 
 func addWherePredicates(ctx *plancontext.PlanningContext, expr sqlparser.Expr, op Operator) Operator {

--- a/go/vt/vtgate/planbuilder/operators/horizon.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon.go
@@ -87,6 +87,11 @@ func (h *Horizon) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.
 		h.Source = h.Source.AddPredicate(ctx, expr)
 		return h
 	}
+	if h.IsDerived() {
+		if _, isValues := h.Query.(*sqlparser.ValuesStatement); isValues {
+			return newFilter(h, expr)
+		}
+	}
 	tableInfo, err := ctx.SemTable.TableInfoForExpr(expr)
 	if err != nil {
 		if errors.Is(err, semantics.ErrNotSingleTable) {
@@ -159,7 +164,7 @@ func (h *Horizon) FindCol(ctx *plancontext.PlanningContext, expr sqlparser.Expr,
 		return -1
 	}
 
-	for idx, se := range getFirstSelect(h.Query).GetColumns() {
+	for idx, se := range ctx.SemTable.SelectExprs(h.Query) {
 		ae, ok := se.(*sqlparser.AliasedExpr)
 		if !ok {
 			panic(vterrors.VT09015())
@@ -184,8 +189,8 @@ func (h *Horizon) GetColumns(ctx *plancontext.PlanningContext) (exprs []*sqlpars
 	return exprs
 }
 
-func (h *Horizon) GetSelectExprs(*plancontext.PlanningContext) []sqlparser.SelectExpr {
-	return getFirstSelect(h.Query).GetColumns()
+func (h *Horizon) GetSelectExprs(ctx *plancontext.PlanningContext) []sqlparser.SelectExpr {
+	return ctx.SemTable.SelectExprs(h.Query)
 }
 
 func (h *Horizon) GetOrdering(ctx *plancontext.PlanningContext) []OrderBy {

--- a/go/vt/vtgate/planbuilder/operators/queryprojection.go
+++ b/go/vt/vtgate/planbuilder/operators/queryprojection.go
@@ -164,7 +164,7 @@ func createQPFromSelect(ctx *plancontext.PlanningContext, sel *sqlparser.Select)
 		Distinct: sel.Distinct,
 	}
 
-	qp.addSelectExpressions(ctx, sel)
+	qp.addSelectExpressions(ctx, sel.GetColumns())
 	qp.addGroupBy(ctx, sel.GroupBy)
 	qp.addOrderBy(ctx, sel.OrderBy)
 	if !qp.HasAggr && sel.Having != nil {
@@ -183,8 +183,8 @@ func createQPFromSelect(ctx *plancontext.PlanningContext, sel *sqlparser.Select)
 	return qp
 }
 
-func (qp *QueryProjection) addSelectExpressions(ctx *plancontext.PlanningContext, sel *sqlparser.Select) {
-	for _, selExp := range sel.GetColumns() {
+func (qp *QueryProjection) addSelectExpressions(ctx *plancontext.PlanningContext, columns []sqlparser.SelectExpr) {
+	for _, selExp := range columns {
 		switch selExp := selExp.(type) {
 		case *sqlparser.AliasedExpr:
 			col := SelectExpr{
@@ -215,8 +215,17 @@ func createQPFromUnion(ctx *plancontext.PlanningContext, union *sqlparser.Union)
 	qp := &QueryProjection{}
 
 	sel := getFirstSelect(union)
-	qp.addSelectExpressions(ctx, sel)
+	qp.addSelectExpressions(ctx, sel.GetColumns())
 	qp.addOrderBy(ctx, union.OrderBy)
+
+	return qp
+}
+
+func createQPFromValues(ctx *plancontext.PlanningContext, values *sqlparser.ValuesStatement) *QueryProjection {
+	qp := &QueryProjection{}
+
+	qp.addSelectExpressions(ctx, values.GetColumns())
+	qp.addOrderBy(ctx, values.Order)
 
 	return qp
 }
@@ -743,6 +752,8 @@ func CreateQPFromSelectStatement(ctx *plancontext.PlanningContext, stmt sqlparse
 		return createQPFromSelect(ctx, sel)
 	case *sqlparser.Union:
 		return createQPFromUnion(ctx, sel)
+	case *sqlparser.ValuesStatement:
+		return createQPFromValues(ctx, sel)
 	}
-	panic(vterrors.VT13001("can only create query projection from Union and Select statements"))
+	panic(vterrors.VT13001("can only create query projection from Union, Select and Values statements"))
 }

--- a/go/vt/vtgate/planbuilder/operators/subquery_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_builder.go
@@ -148,6 +148,8 @@ func (sqb *SubQueryBuilder) inspectStatement(ctx *plancontext.PlanningContext,
 		exprs1, cols1 := sqb.inspectStatement(ctx, stmt.Left)
 		exprs2, cols2 := sqb.inspectStatement(ctx, stmt.Right)
 		return append(exprs1, exprs2...), append(cols1, cols2...)
+	case *sqlparser.ValuesStatement:
+		return nil, nil
 	}
 	panic("unknown type")
 }

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -70,6 +70,8 @@ func isMergeable(ctx *plancontext.PlanningContext, query sqlparser.TableStatemen
 		return true
 	case *sqlparser.Union:
 		return isMergeable(ctx, node.Left, op) && isMergeable(ctx, node.Right, op)
+	case *sqlparser.ValuesStatement:
+		return true
 	default:
 		panic(vterrors.VT13001(fmt.Sprintf("Unknown SelectStatement type - %T", node)))
 	}

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -1598,6 +1598,82 @@
     }
   },
   {
+    "comment": "values derived table",
+    "query": "select * from (values row(1, 1)) as sub",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select * from (values row(1, 1)) as sub",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select column_0, column_1 from (values row(1, 1)) as sub where 1 != 1",
+        "Query": "select column_0, column_1 from (values row(1, 1)) as sub"
+      }
+    }
+  },
+  {
+    "comment": "values derived table with explicit column aliases",
+    "query": "select sub.c1 from (values row(1, 1)) as sub(c1, c2)",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select sub.c1 from (values row(1, 1)) as sub(c1, c2)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select sub.c1 from (values row(1, 1)) as sub(c1, c2) where 1 != 1",
+        "Query": "select sub.c1 from (values row(1, 1)) as sub(c1, c2)"
+      }
+    }
+  },
+  {
+    "comment": "filtered values derived table",
+    "query": "select * from (values row(1, 1), row(2, 2)) as sub where sub.column_0 = 1",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select * from (values row(1, 1), row(2, 2)) as sub where sub.column_0 = 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select column_0, column_1 from (values row(1, 1), row(2, 2)) as sub where 1 != 1",
+        "Query": "select column_0, column_1 from (values row(1, 1), row(2, 2)) as sub where sub.column_0 = 1"
+      }
+    }
+  },
+  {
+    "comment": "filtered values derived table with explicit column aliases",
+    "query": "select sub.c1 from (values row(1, 1), row(2, 2)) as sub(c1, c2) where sub.c1 = 1",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select sub.c1 from (values row(1, 1), row(2, 2)) as sub(c1, c2) where sub.c1 = 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select sub.c1 from (values row(1, 1), row(2, 2)) as sub(c1, c2) where 1 != 1",
+        "Query": "select sub.c1 from (values row(1, 1), row(2, 2)) as sub(c1, c2) where sub.c1 = 1"
+      }
+    }
+  },
+  {
     "comment": "derived table",
     "query": "select id from (select id, col from user where id = 5) as t",
     "plan": {

--- a/go/vt/vtgate/semantics/derived_test.go
+++ b/go/vt/vtgate/semantics/derived_test.go
@@ -107,6 +107,17 @@ func TestScopingWDerivedTables(t *testing.T) {
 			query:         "select uu.count from (select count(*) as `count` from t1) uu",
 			directDeps:    TS1,
 			recursiveDeps: TS0,
+		}, {
+			query:         "select sub.column_0 from (values row(1, 1)) as sub",
+			directDeps:    TS0,
+			recursiveDeps: NoTables,
+		}, {
+			query:         "select sub.c1 from (values row(1, 1)) as sub(c1, c2)",
+			directDeps:    TS0,
+			recursiveDeps: NoTables,
+		}, {
+			query:        "select sub.c1 from (values row(1, 1)) as sub(c1, c1)",
+			errorMessage: "Duplicate column name 'c1'",
 		},
 	}
 	for _, query := range queries {

--- a/go/vt/vtgate/semantics/semantic_table.go
+++ b/go/vt/vtgate/semantics/semantic_table.go
@@ -498,6 +498,8 @@ func (st *SemTable) SelectExprs(sel sqlparser.TableStatement) []sqlparser.Select
 	switch sel := sel.(type) {
 	case *sqlparser.Select:
 		return sel.GetColumns()
+	case *sqlparser.ValuesStatement:
+		return sel.GetColumns()
 	case *sqlparser.Union:
 		exprs, found := st.columns[sel]
 		if found {

--- a/go/vt/vtgate/semantics/table_collector.go
+++ b/go/vt/vtgate/semantics/table_collector.go
@@ -440,8 +440,10 @@ func (tc *tableCollector) handleDerivedTable(node *sqlparser.AliasedTableExpr, t
 		return tc.addSelectDerivedTable(sel, node, node.Columns, node.As)
 	case *sqlparser.Union:
 		return tc.addUnionDerivedTable(sel, node, node.Columns, node.As)
+	case *sqlparser.ValuesStatement:
+		return tc.addValuesDerivedTable(sel, node, node.Columns, node.As)
 	default:
-		return vterrors.VT13001("[BUG] %T in a derived table", sel)
+		return vterrors.VT13001(fmt.Sprintf("[BUG] %T in a derived table", sel))
 	}
 }
 
@@ -495,6 +497,51 @@ func (tc *tableCollector) addUnionDerivedTable(
 	}
 
 	tableInfo := createDerivedTableForExpressions(info.exprs, columns, tables.tables, tc.org, info.isAuthoritative, info.recursive, info.types)
+	if err := tableInfo.checkForDuplicates(); err != nil {
+		return err
+	}
+	tableInfo.ASTNode = node
+	tableInfo.tableName = alias.String()
+
+	tc.Tables = append(tc.Tables, tableInfo)
+	scope := tc.scoper.currentScope()
+	return scope.addTable(tableInfo)
+}
+
+func (tc *tableCollector) addValuesDerivedTable(
+	values *sqlparser.ValuesStatement,
+	node *sqlparser.AliasedTableExpr,
+	columns sqlparser.Columns,
+	alias sqlparser.IdentifierCS,
+) error {
+	if len(values.Rows) == 0 {
+		return vterrors.VT12001("VALUES statement without rows in derived table")
+	}
+
+	size := values.GetColumnCount()
+	deps := make([]TableSet, size)
+	typers := make([]evalengine.TypeAggregator, size)
+	collations := tc.org.collationEnv()
+
+	for _, row := range values.Rows {
+		if len(row) != size {
+			return &UnionColumnsDoNotMatchError{FirstProj: size, SecondProj: len(row)}
+		}
+		for i, expr := range row {
+			_, recursiveDeps, qt := tc.org.depsForExpr(expr)
+			deps[i] = deps[i].Merge(recursiveDeps)
+			if err := typers[i].Add(qt, collations); err != nil {
+				return err
+			}
+		}
+	}
+
+	types := make([]evalengine.Type, 0, size)
+	for _, typer := range typers {
+		types = append(types, typer.Type())
+	}
+
+	tableInfo := createDerivedTableForExpressions(values.GetColumns(), columns, nil, tc.org, true, deps, types)
 	if err := tableInfo.checkForDuplicates(); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Support `VALUES ROW(...)` as a first-class derived table in VTGate. The planned SQL preserves `VALUES` syntax while exposing default `column_N` names and explicit derived-table aliases.

## Related Issue(s)



## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

This PR was authored with assistance from GPT-5.