### PR TITLE
CI: switch setup-mysql .deb downloads to HTTPS and add SHA256 verification

### DIFF
--- a/.github/actions/setup-mysql/action.yml
+++ b/.github/actions/setup-mysql/action.yml
@@ -49,7 +49,8 @@ runs:
             --retry 3 \
             --retry-delay 2 && \
             echo "ab89265d8dd18bda6a29d7c796367d6d9f22a39a8fa83589577321e7caf3857b  libtinfo5_6.3-2ubuntu0.1_amd64.deb" | sha256sum --check && \
-            sudo dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb
+            sudo dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb && \
+            rm libtinfo5_6.3-2ubuntu0.1_amd64.deb
           sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-client=5.7* mysql-community-server=5.7* mysql-server=5.7* libncurses6
         elif [[ "${{ inputs.flavor }}" == "mysql-8.0" ]]; then
           echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections

--- a/.github/actions/setup-mysql/action.yml
+++ b/.github/actions/setup-mysql/action.yml
@@ -24,10 +24,14 @@ runs:
 
         # We have to install this old version of libaio1. See also:
         # https://bugs.launchpad.net/ubuntu/+source/libaio/+bug/2067501
-        wget https://archive.ubuntu.com/ubuntu/pool/main/liba/libaio/libaio1_0.3.112-13build1_amd64.deb && \
-          echo "2dcfe0b49d7cccfbf1bd6a3f627cf44bea9f51fb32f7e0e552a0df75698e0d27  libaio1_0.3.112-13build1_amd64.deb" | sha256sum --check && \
-          sudo dpkg -i libaio1_0.3.112-13build1_amd64.deb && \
-          rm libaio1_0.3.112-13build1_amd64.deb
+        wget \
+          --tries=3 \
+          --waitretry=2 \
+          --timeout=30 \
+          https://archive.ubuntu.com/ubuntu/pool/main/liba/libaio/libaio1_0.3.112-13build1_amd64.deb && \
+        echo "2dcfe0b49d7cccfbf1bd6a3f627cf44bea9f51fb32f7e0e552a0df75698e0d27  libaio1_0.3.112-13build1_amd64.deb" | sha256sum --check && \
+        sudo dpkg -i libaio1_0.3.112-13build1_amd64.deb && \
+        rm libaio1_0.3.112-13build1_amd64.deb
 
         # Get key to latest MySQL repo
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A8D3785C
@@ -41,9 +45,11 @@ runs:
           sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
           sudo apt-get update
           # libtinfo5 is also needed for older MySQL 5.7 builds.
-          curl -L -O https://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb && \
-            echo "ab89265d8dd18bda6a29d7c796367d6d9f22a39a8fa83589577321e7caf3857b  libtinfo5_6.3-2ubuntu0.1_amd64.deb" | sha256sum --check
-          sudo dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb
+          curl -fsSL -O https://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb \
+            --retry 3 \
+            --retry-delay 2 && \
+            echo "ab89265d8dd18bda6a29d7c796367d6d9f22a39a8fa83589577321e7caf3857b  libtinfo5_6.3-2ubuntu0.1_amd64.deb" | sha256sum --check && \
+            sudo dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb
           sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-client=5.7* mysql-community-server=5.7* mysql-server=5.7* libncurses6
         elif [[ "${{ inputs.flavor }}" == "mysql-8.0" ]]; then
           echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections

--- a/.github/actions/setup-mysql/action.yml
+++ b/.github/actions/setup-mysql/action.yml
@@ -24,7 +24,8 @@ runs:
 
         # We have to install this old version of libaio1. See also:
         # https://bugs.launchpad.net/ubuntu/+source/libaio/+bug/2067501
-        wget http://archive.ubuntu.com/ubuntu/pool/main/liba/libaio/libaio1_0.3.112-13build1_amd64.deb && \
+        wget https://archive.ubuntu.com/ubuntu/pool/main/liba/libaio/libaio1_0.3.112-13build1_amd64.deb && \
+          echo "2dcfe0b49d7cccfbf1bd6a3f627cf44bea9f51fb32f7e0e552a0df75698e0d27  libaio1_0.3.112-13build1_amd64.deb" | sha256sum --check && \
           sudo dpkg -i libaio1_0.3.112-13build1_amd64.deb && \
           rm libaio1_0.3.112-13build1_amd64.deb
 
@@ -40,7 +41,8 @@ runs:
           sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
           sudo apt-get update
           # libtinfo5 is also needed for older MySQL 5.7 builds.
-          curl -L -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
+          curl -L -O https://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb && \
+            echo "ab89265d8dd18bda6a29d7c796367d6d9f22a39a8fa83589577321e7caf3857b  libtinfo5_6.3-2ubuntu0.1_amd64.deb" | sha256sum --check
           sudo dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb
           sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-client=5.7* mysql-community-server=5.7* mysql-server=5.7* libncurses6
         elif [[ "${{ inputs.flavor }}" == "mysql-8.0" ]]; then


### PR DESCRIPTION
<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
The `setup-mysql` action was downloading `libaio1` and `libtinfo5` over plain HTTP. Switched both URLs to HTTPS and added SHA256 checksum verification before `dpkg -i` so the build fails fast if the downloaded file doesn't match the expected hash.

## Changes
  - `libaio1` download: `http://` → `https://`, added `sha256sum --check`
  - `libtinfo5` download: `http://` → `https://`, added `sha256sum --check`

SHA256 hashes were computed from the files served over HTTPS by `archive.ubuntu.com`.

## Related Issue(s)
Fixes #20198 

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
