### PR TITLE
test: skip topo integration tests when consul or etcd is missing

### DIFF
--- a/go/vt/topo/consultopo/server_flaky_test.go
+++ b/go/vt/topo/consultopo/server_flaky_test.go
@@ -44,6 +44,12 @@ import (
 // Returns the exec.Cmd forked, the config file to remove after the test,
 // and the server address to RPC-connect to.
 func startConsul(t *testing.T, authToken string) (*exec.Cmd, string, string) {
+	t.Helper()
+
+	if _, err := exec.LookPath("consul"); err != nil {
+		t.Skipf("skipping integration test: consul binary not found: %v", err)
+	}
+
 	// Create a temporary config file, as ports cannot all be set
 	// via command line. The file name has to end with '.json' so
 	// we're not using TempFile.

--- a/go/vt/topo/etcd2topo/server_test.go
+++ b/go/vt/topo/etcd2topo/server_test.go
@@ -41,6 +41,12 @@ import (
 
 // startEtcd starts an etcd subprocess, and waits for it to be ready.
 func startEtcd(t *testing.T, clientPort, peerPort int) (string, *exec.Cmd) {
+	t.Helper()
+
+	if _, err := exec.LookPath("etcd"); err != nil {
+		t.Skipf("skipping integration test: etcd binary not found: %v", err)
+	}
+
 	// Create a temporary directory.
 	dataDir := t.TempDir()
 
@@ -97,6 +103,12 @@ func startEtcd(t *testing.T, clientPort, peerPort int) (string, *exec.Cmd) {
 
 // startEtcdWithTLS starts an etcd subprocess with TLS setup, and waits for it to be ready.
 func startEtcdWithTLS(t *testing.T) (string, *tlstest.ClientServerKeyPairs) {
+	t.Helper()
+
+	if _, err := exec.LookPath("etcd"); err != nil {
+		t.Skipf("skipping integration test: etcd binary not found: %v", err)
+	}
+
 	// Create a temporary directory.
 	dataDir := t.TempDir()
 


### PR DESCRIPTION
## Description
`go/vt/topo/consultopo` and `go/vt/topo/etcd2topo` blow up on a normal machine if `consul` or `etcd` is not on `PATH`.

This adds a `LookPath` check in the test startup helpers and skips only when the binary is missing. If the binary exists but startup is broken, the tests still fail, so the real signal stays intact.

Repro:
`go test ./go/vt/topo/consultopo -run TestConsulTopo -count=1`
`go test ./go/vt/topo/etcd2topo -run TestEtcd2Topo -count=1`

## Related Issue(s)
Closes #20216

## Checklist
- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes
None
