### PR TITLE
VTOrc: remove dead `LockedSemiSyncPrimary` analysis

### DIFF
--- a/go/vt/vtorc/inst/analysis.go
+++ b/go/vt/vtorc/inst/analysis.go
@@ -58,7 +58,6 @@ const (
 	AllPrimaryReplicasNotReplicating       AnalysisCode = "AllPrimaryReplicasNotReplicating"
 	AllPrimaryReplicasNotReplicatingOrDead AnalysisCode = "AllPrimaryReplicasNotReplicatingOrDead"
 	LockedSemiSyncPrimaryHypothesis        AnalysisCode = "LockedSemiSyncPrimaryHypothesis"
-	LockedSemiSyncPrimary                  AnalysisCode = "LockedSemiSyncPrimary"
 	PrimarySemiSyncBlocked                 AnalysisCode = "PrimarySemiSyncBlocked"
 	ErrantGTIDDetected                     AnalysisCode = "ErrantGTIDDetected"
 	PrimaryDiskStalled                     AnalysisCode = "PrimaryDiskStalled"

--- a/go/vt/vtorc/inst/analysis_problem.go
+++ b/go/vt/vtorc/inst/analysis_problem.go
@@ -424,25 +424,17 @@ var detectionAnalysisProblems = []*DetectionAnalysisProblem{
 		},
 	},
 
-	// Locked semi-sync primary
-	{
-		Meta: &DetectionAnalysisProblemMeta{
-			Analysis:    LockedSemiSyncPrimary,
-			Description: "Semi sync primary is locked since it doesn't get enough replica acknowledgements",
-			Priority:    detectionAnalysisPriorityMedium,
-		},
-		MatchFunc: func(a *DetectionAnalysis, ca *clusterAnalysis, primary, tablet *topodatapb.Tablet, isInvalid, isStaleBinlogCoordinates bool) bool {
-			return a.IsPrimary && a.SemiSyncPrimaryEnabled && a.SemiSyncPrimaryStatus && a.SemiSyncPrimaryWaitForReplicaCount > 0 && a.SemiSyncPrimaryClients < a.SemiSyncPrimaryWaitForReplicaCount && isStaleBinlogCoordinates
-		},
-	},
+	// Locked semi-sync primary hypothesis. Detection only; no recovery is
+	// wired. The actionable case (MySQL itself reports
+	// Rpl_semi_sync_master_blocked) is covered by PrimarySemiSyncBlocked.
 	{
 		Meta: &DetectionAnalysisProblemMeta{
 			Analysis:    LockedSemiSyncPrimaryHypothesis,
-			Description: "Semi sync primary seems to be locked, more samplings needed to validate",
+			Description: "Semi sync primary has fewer connected semi-sync clients than required",
 			Priority:    detectionAnalysisPriorityMedium,
 		},
 		MatchFunc: func(a *DetectionAnalysis, ca *clusterAnalysis, primary, tablet *topodatapb.Tablet, isInvalid, isStaleBinlogCoordinates bool) bool {
-			return a.IsPrimary && a.SemiSyncPrimaryEnabled && a.SemiSyncPrimaryStatus && a.SemiSyncPrimaryWaitForReplicaCount > 0 && a.SemiSyncPrimaryClients < a.SemiSyncPrimaryWaitForReplicaCount && !isStaleBinlogCoordinates
+			return a.IsPrimary && a.SemiSyncPrimaryEnabled && a.SemiSyncPrimaryStatus && a.SemiSyncPrimaryWaitForReplicaCount > 0 && a.SemiSyncPrimaryClients < a.SemiSyncPrimaryWaitForReplicaCount
 		},
 	},
 

--- a/go/vt/vtorc/logic/topology_recovery.go
+++ b/go/vt/vtorc/logic/topology_recovery.go
@@ -50,18 +50,17 @@ import (
 )
 
 const (
-	CheckAndRecoverGenericProblemRecoveryName        string = "CheckAndRecoverGenericProblem"
-	RestartArbitraryDirectReplicaRecoveryName        string = "RestartArbitraryDirectReplica"
-	RestartAllDirectReplicasRecoveryName             string = "RestartAllDirectReplicas"
-	RecoverDeadPrimaryRecoveryName                   string = "RecoverDeadPrimary"
-	RecoverIncapacitatedPrimaryRecoveryName          string = "RecoverIncapacitatedPrimary"
-	RecoverPrimaryTabletDeletedRecoveryName          string = "RecoverPrimaryTabletDeleted"
-	RecoverPrimaryHasPrimaryRecoveryName             string = "RecoverPrimaryHasPrimary"
-	CheckAndRecoverLockedSemiSyncPrimaryRecoveryName string = "CheckAndRecoverLockedSemiSyncPrimary"
-	ElectNewPrimaryRecoveryName                      string = "ElectNewPrimary"
-	FixPrimaryRecoveryName                           string = "FixPrimary"
-	FixReplicaRecoveryName                           string = "FixReplica"
-	RecoverErrantGTIDDetectedName                    string = "RecoverErrantGTIDDetected"
+	CheckAndRecoverGenericProblemRecoveryName string = "CheckAndRecoverGenericProblem"
+	RestartArbitraryDirectReplicaRecoveryName string = "RestartArbitraryDirectReplica"
+	RestartAllDirectReplicasRecoveryName      string = "RestartAllDirectReplicas"
+	RecoverDeadPrimaryRecoveryName            string = "RecoverDeadPrimary"
+	RecoverIncapacitatedPrimaryRecoveryName   string = "RecoverIncapacitatedPrimary"
+	RecoverPrimaryTabletDeletedRecoveryName   string = "RecoverPrimaryTabletDeleted"
+	RecoverPrimaryHasPrimaryRecoveryName      string = "RecoverPrimaryHasPrimary"
+	ElectNewPrimaryRecoveryName               string = "ElectNewPrimary"
+	FixPrimaryRecoveryName                    string = "FixPrimary"
+	FixReplicaRecoveryName                    string = "FixReplica"
+	RecoverErrantGTIDDetectedName             string = "RecoverErrantGTIDDetected"
 
 	// ReconcileStaleTopoPrimaryRecoveryName is a recovery for tablets that have a stale type of PRIMARY
 	// in the topology but a newer primary has been elected.
@@ -154,7 +153,6 @@ const (
 	recoverIncapacitatedPrimaryFunc
 	recoverPrimaryTabletDeletedFunc
 	recoverPrimaryHasPrimaryFunc
-	recoverLockedSemiSyncPrimaryFunc
 	electNewPrimaryFunc
 	fixPrimaryFunc
 	fixReplicaFunc
@@ -470,12 +468,6 @@ func postErsCompletion(topologyRecovery *TopologyRecovery, analysisEntry *inst.D
 }
 
 // checkAndRecoverGenericProblem is a general-purpose recovery function
-func checkAndRecoverLockedSemiSyncPrimary(ctx context.Context, analysisEntry *inst.DetectionAnalysis, logger *log.PrefixedLogger) (recoveryAttempted bool, topologyRecovery *TopologyRecovery, err error) {
-	logger.Warn("No actions in checkAndRecoverLockedSemiSyncPrimary")
-	return false, nil, nil
-}
-
-// checkAndRecoverGenericProblem is a general-purpose recovery function
 func checkAndRecoverGenericProblem(ctx context.Context, analysisEntry *inst.DetectionAnalysis, logger *log.PrefixedLogger) (bool, *TopologyRecovery, error) {
 	logger.Warn("No actions in checkAndRecoverGenericProblem")
 	return false, nil, nil
@@ -685,8 +677,6 @@ func getCheckAndRecoverFunctionCode(analysisEntry *inst.DetectionAnalysis) (reco
 		recoveryFunc = recoverErrantGTIDDetectedFunc
 	case inst.PrimaryHasPrimary:
 		recoveryFunc = recoverPrimaryHasPrimaryFunc
-	case inst.LockedSemiSyncPrimary:
-		recoveryFunc = recoverLockedSemiSyncPrimaryFunc
 	case inst.ClusterHasNoPrimary:
 		recoveryFunc = electNewPrimaryFunc
 	case inst.PrimaryIsReadOnly, inst.PrimarySemiSyncMustBeSet, inst.PrimarySemiSyncMustNotBeSet, inst.PrimaryCurrentTypeMismatch:
@@ -740,8 +730,6 @@ func hasActionableRecovery(recoveryFunctionCode recoveryFunction) bool {
 		return true
 	case recoverPrimaryHasPrimaryFunc:
 		return true
-	case recoverLockedSemiSyncPrimaryFunc:
-		return true
 	case electNewPrimaryFunc:
 		return true
 	case fixPrimaryFunc:
@@ -778,8 +766,6 @@ func getCheckAndRecoverFunction(recoveryFunctionCode recoveryFunction) (
 		return recoverPrimaryTabletDeleted
 	case recoverPrimaryHasPrimaryFunc:
 		return recoverPrimaryHasPrimary
-	case recoverLockedSemiSyncPrimaryFunc:
-		return checkAndRecoverLockedSemiSyncPrimary
 	case electNewPrimaryFunc:
 		return electNewPrimary
 	case fixPrimaryFunc:
@@ -815,8 +801,6 @@ func getRecoverFunctionName(recoveryFunctionCode recoveryFunction) string {
 		return RecoverPrimaryTabletDeletedRecoveryName
 	case recoverPrimaryHasPrimaryFunc:
 		return RecoverPrimaryHasPrimaryRecoveryName
-	case recoverLockedSemiSyncPrimaryFunc:
-		return CheckAndRecoverLockedSemiSyncPrimaryRecoveryName
 	case electNewPrimaryFunc:
 		return ElectNewPrimaryRecoveryName
 	case fixPrimaryFunc:

--- a/go/vt/vtorc/logic/topology_recovery_test.go
+++ b/go/vt/vtorc/logic/topology_recovery_test.go
@@ -106,10 +106,6 @@ func TestAnalysisEntriesHaveSameRecovery(t *testing.T) {
 			newAnalysisCode:  inst.PrimaryHasPrimary,
 			shouldBeEqual:    false,
 		}, {
-			prevAnalysisCode: inst.LockedSemiSyncPrimary,
-			newAnalysisCode:  inst.PrimaryHasPrimary,
-			shouldBeEqual:    false,
-		}, {
 			prevAnalysisCode: inst.PrimaryIsReadOnly,
 			newAnalysisCode:  inst.PrimarySemiSyncMustNotBeSet,
 			shouldBeEqual:    true,


### PR DESCRIPTION
## Description

Removes the `LockedSemiSyncPrimary` analyser, which has been dead code since [#15580](https://github.com/vitessio/vitess/pull/15580) (March 2024) deleted the only caller of `RecordStaleInstanceBinlogCoordinates` - the old func responsible for updating the values for `isStaleBinlogCoordinates` 😢

Two layered reasons it's dead:

1. The matcher gate `... && isStaleBinlogCoordinates` is permanently `false` in production because nothing writes to `database_instance_stale_binlog_coordinates` anymore (#15580 deleted `runEmergentOperations` which called `emergentlyRecordStaleBinlogCoordinates`; [#15595](https://github.com/vitessio/vitess/pull/15595) then followed up by removing the now-orphaned `RecordStaleInstanceBinlogCoordinates` function itself), so the `LEFT JOIN` in `analysis_dao.go` always returns NULL and `is_stale_binlog_coordinates` is always 0
2. The recovery function `checkAndRecoverLockedSemiSyncPrimary` is literally `logger.Warn("No actions in checkAndRecoverLockedSemiSyncPrimary"); return false, nil, nil` — even if the analyser were to match, no recovery action would happen

The actionable case (`mysqld` itself reports `Rpl_semi_sync_master_blocked`) is covered by `PrimarySemiSyncBlocked`, which routes through `recoverDeadPrimaryFunc` and does run ERS — that's the analyser actually doing the work in production today

#### What's kept

`LockedSemiSyncPrimaryHypothesis` stays — it's the only analyser covering "fewer connected semi-sync clients than required" (`SemiSyncPrimaryClients < SemiSyncPrimaryWaitForReplicaCount`), a condition `PrimarySemiSyncBlocked` doesn't match because it gates on `CountSemiSyncReplicasEnabled >= SemiSyncPrimaryWaitForReplicaCount`

The `&& !isStaleBinlogCoordinates` gate is dropped from Hypothesis as part of this PR — its only purpose was the two-step Hypothesis→strong promotion pattern that no longer exists. Leaving it would silently silence Hypothesis if the stale-binlog write path is ever restored

#### Removed

- `LockedSemiSyncPrimary` analysis code constant (`inst/analysis.go`)
- The matcher entry in `detectionAnalysisProblems` (`inst/analysis_problem.go`)
- `checkAndRecoverLockedSemiSyncPrimary` no-op recovery function (`logic/topology_recovery.go`)
- `recoverLockedSemiSyncPrimaryFunc` `recoveryFunction` enum member
- `CheckAndRecoverLockedSemiSyncPrimaryRecoveryName` constant
- Four switch arms wiring the above
- One test-case input in `TestAnalysisEntriesHaveSameRecovery` that referenced the removed code

## Related Issue(s)

Resolves: #20219
Related: #20169 — that PR's review discussion is what surfaced the dead-code situation

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Three operator-visible surface changes that come with this removal:

- **Metrics:** the metric label `"CheckAndRecoverLockedSemiSyncPrimary"` (on `recoveriesAttemptedCounter`, `recoveriesSkippedCounter`, etc.) will no longer receive updates. Dashboards / alerts filtering on this label name will go silent
- **Audit / `recovery_detection` / `topology_recovery` rows:** existing rows with `analysis='LockedSemiSyncPrimary'` persist; no new rows will be written. Tooling that filters/searches by this code should be updated
- **`LockedSemiSyncPrimaryHypothesis` description:** changed from _"Semi sync primary seems to be locked, more samplings needed to validate"_ to _"Semi sync primary has fewer connected semi-sync clients than required"_ — the new text accurately describes the matcher condition now that there's no two-step promotion pattern

No behaviour change in current production: the strong analyser hasn't fired in 2 years, and the Hypothesis gate has been always-true (so dropping it changes nothing today)

### AI Disclosure

Claude Code assisted with development and testing. Claude prepared this PR summary