### PR TITLE
examples: preflight hostname resolution in 101_initial_cluster.sh

### DIFF
--- a/examples/local/101_initial_cluster.sh
+++ b/examples/local/101_initial_cluster.sh
@@ -19,6 +19,17 @@
 
 source ../common/env.sh
 
+# vtorc cannot reach the tablets unless $hostname resolves.
+if ! getent hosts "$hostname" >/dev/null 2>&1; then
+	cat >&2 <<EOF
+ERROR: "$hostname" does not resolve.
+
+Fix by running:
+    echo "127.0.0.1 localhost $hostname" | sudo tee -a /etc/hosts
+EOF
+	exit 1
+fi
+
 # This is done here as a means to support testing the experimental
 # custom sidecar database name work in a wide variety of scenarios
 # as the local examples are used to test many features locally.


### PR DESCRIPTION
## Description

`vtorc` cannot dial the tablets and no primary is elected if `hostname -f` doesn't resolve to anything. 

This PR adds a quick preflight check at the top of `examples/local/101_initial_cluster.sh` that uses `getent hosts "\$hostname"` to verify the hostname resolves before doing any work. If it doesn't, the script fails fast with an actionable error pointing the user at the `/etc/hosts` fix:

```
ERROR: \"User-MacBook-Pro.local\" does not resolve.

Fix by running:
    echo \"127.0.0.1 localhost User-MacBook-Pro.local\" | sudo tee -a /etc/hosts
```


## Related Issue(s)

None. Found it while bringing up the local example on a fresh macOS dev box.

## Checklist

-   [x] \"Backport to:\" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required (shell-script preflight in an example; no test surface)
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required (error message is self-documenting)

## Deployment Notes

None — touches only \`examples/local/\`.

### AI Disclosure

This PR was written primarily by Claude Code under direction.