### PR TITLE
examples: inline /etc/hosts hostname check, drop getent dependency

### DIFF
--- a/examples/local/101_initial_cluster.sh
+++ b/examples/local/101_initial_cluster.sh
@@ -20,12 +20,15 @@
 source ../common/env.sh
 
 # vtorc cannot reach the tablets unless $hostname resolves.
-if ! getent hosts "$hostname" >/dev/null 2>&1; then
+# Set SKIP_HOSTNAME_CHECK=1 to bypass.
+if [[ -z ${SKIP_HOSTNAME_CHECK} ]] && ! sed 's/#.*//' /etc/hosts | grep -qw "$hostname"; then
 	cat >&2 <<EOF
-ERROR: "$hostname" does not resolve.
+ERROR: "$hostname" is not mapped in /etc/hosts.
 
 Fix by running:
     echo "127.0.0.1 localhost $hostname" | sudo tee -a /etc/hosts
+
+Or set SKIP_HOSTNAME_CHECK=1 to skip this check.
 EOF
 	exit 1
 fi


### PR DESCRIPTION
## Description

Follow-up to #20221. `getent` is not part of a stock macOS install, so the preflight added there prints `command not found` on Macs without it before showing the actual error message.

This check can be skipped by setting `SKIP_HOSTNAME_CHECK=1 ./101_initial_cluster.sh` 

## Related Issue(s)

Follow-up to #20221.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required (shell-script preflight in an example)
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — touches only `examples/local/`.

### AI Disclosure

This PR was written primarily by Claude Code under direction.