### PR TITLE
Revert preflight hostname resolution in 101_initial_cluster.sh

### DIFF
--- a/examples/local/101_initial_cluster.sh
+++ b/examples/local/101_initial_cluster.sh
@@ -19,17 +19,6 @@
 
 source ../common/env.sh
 
-# vtorc cannot reach the tablets unless $hostname resolves.
-if ! getent hosts "$hostname" >/dev/null 2>&1; then
-	cat >&2 <<EOF
-ERROR: "$hostname" does not resolve.
-
-Fix by running:
-    echo "127.0.0.1 localhost $hostname" | sudo tee -a /etc/hosts
-EOF
-	exit 1
-fi
-
 # This is done here as a means to support testing the experimental
 # custom sidecar database name work in a wide variety of scenarios
 # as the local examples are used to test many features locally.


### PR DESCRIPTION
## Description

Reverts #20221.

The preflight was framed as a macOS/`/etc/hosts` issue, but the real dependency is `$(hostname -f)` resolving at all and when it doesn't, the example already fails with reasonable errors. 

## Related Issue(s)

Reverts #20221. Closes #20222.

## Checklist
- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

  None.

### AI Disclosure

Used github revert button.