### PR TITLE
ci: restrict reruns to pull_request workflow runs

### DIFF
--- a/.github/workflows/ci-rerun.yml
+++ b/.github/workflows/ci-rerun.yml
@@ -102,8 +102,13 @@ jobs:
                 per_page: 100,
               });
 
+              const isCurrentPullRequestRun = run =>
+                run.event === 'pull_request' &&
+                run.pull_requests?.some(pull => pull.number === pr.number);
+
               const failedRuns = runsData.workflow_runs.filter(
-                run => run.status === 'completed' &&
+                run => isCurrentPullRequestRun(run) &&
+                       run.status === 'completed' &&
                        (run.conclusion === 'failure' ||
                         run.conclusion === 'cancelled' ||
                         run.conclusion === 'startup_failure')


### PR DESCRIPTION
## Description

The scheduled CI rerun workflow selected candidate runs only by PR head SHA. That could allow a pull request to retrigger historical privileged `push` workflow runs that happened to use the same SHA.

This narrows rerun candidates in `.github/workflows/ci-rerun.yml` to completed `pull_request` workflow runs that are associated with the current PR number. It preserves the existing SHA lookup, failure and cancellation checks, max-attempts guard, and ignore-pattern logic.

## Related Issue(s)

None. Was found by Codex Security.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

No deployment notes.

### AI Disclosure

This PR was written primarily by Codex.
