### PR TITLE
binlog: preserve leading zero on DECIMAL JSON values like 0.1

### DIFF
--- a/go/mysql/binlog/binlog_json_test.go
+++ b/go/mysql/binlog/binlog_json_test.go
@@ -239,6 +239,16 @@ func TestBinaryJSON(t *testing.T) {
 			expected: json.NewNumber("1.99", json.NumberTypeDecimal),
 		},
 		{
+			name:     `decimal "0.1" (integer part is zero)`,
+			data:     []byte{15, 246, 4, 2, 1, 0x80, 0x01},
+			expected: json.NewNumber("0.1", json.NumberTypeDecimal),
+		},
+		{
+			name:     `decimal "-0.1" (negative, integer part is zero)`,
+			data:     []byte{15, 246, 4, 2, 1, 0x7F, 0xFE},
+			expected: json.NewNumber("-0.1", json.NumberTypeDecimal),
+		},
+		{
 			name:     `bit literal 0xCAFE`,
 			data:     []byte{15, 16, 2, 202, 254},
 			expected: json.NewBit(string([]byte{202, 254})),

--- a/go/mysql/binlog/rbr.go
+++ b/go/mysql/binlog/rbr.go
@@ -624,6 +624,12 @@ func CellValue(data []byte, pos int, typ byte, metadata uint16, field *querypb.F
 				s = s[1:]
 			}
 			s = strings.TrimLeft(s, "0")
+			// Ensure at least one digit precedes the decimal point so values
+			// like 0.1 round-trip as "0.1" instead of ".1" (invalid JSON when
+			// the decimal appears inside a JSON column).
+			if strings.HasPrefix(s, ".") {
+				s = "0" + s
+			}
 			if isNegative {
 				s = "-" + s
 			}

--- a/go/mysql/binlog/rbr.go
+++ b/go/mysql/binlog/rbr.go
@@ -617,23 +617,35 @@ func CellValue(data []byte, pos int, typ byte, metadata uint16, field *querypb.F
 
 		// remove preceding 0s from the integral part, otherwise we get "000000000001.23" instead of "1.23"
 		trimPrecedingZeroes := func(b []byte) []byte {
-			s := string(b)
-			isNegative := false
-			if s[0] == '-' {
-				isNegative = true
-				s = s[1:]
+			isNegative := b[0] == '-'
+			if isNegative {
+				b = b[1:]
 			}
-			s = strings.TrimLeft(s, "0")
+			i := 0
+			for i < len(b) && b[i] == '0' {
+				i++
+			}
+			b = b[i:]
 			// Ensure at least one digit precedes the decimal point so values
 			// like 0.1 round-trip as "0.1" instead of ".1" (invalid JSON when
 			// the decimal appears inside a JSON column).
-			if strings.HasPrefix(s, ".") {
-				s = "0" + s
-			}
+			needLeadingZero := len(b) > 0 && b[0] == '.'
+
+			size := len(b)
 			if isNegative {
-				s = "-" + s
+				size++
 			}
-			return []byte(s)
+			if needLeadingZero {
+				size++
+			}
+			out := make([]byte, 0, size)
+			if isNegative {
+				out = append(out, '-')
+			}
+			if needLeadingZero {
+				out = append(out, '0')
+			}
+			return append(out, b...)
 		}
 		return sqltypes.MakeTrusted(querypb.Type_DECIMAL, trimPrecedingZeroes(txt.Bytes())), l, nil
 

--- a/go/mysql/binlog/rbr_test.go
+++ b/go/mysql/binlog/rbr_test.go
@@ -481,6 +481,30 @@ func TestCellLengthAndData(t *testing.T) {
 		out: sqltypes.MakeTrusted(querypb.Type_DECIMAL,
 			[]byte("1.10")),
 	}, {
+		typ:      TypeNewDecimal,
+		metadata: 2<<8 | 1, // DECIMAL(2,1), value 0.1
+		data:     []byte{0x80, 0x01},
+		out: sqltypes.MakeTrusted(querypb.Type_DECIMAL,
+			[]byte("0.1")),
+	}, {
+		typ:      TypeNewDecimal,
+		metadata: 2<<8 | 1, // DECIMAL(2,1), value -0.1
+		data:     []byte{0x7F, 0xFE},
+		out: sqltypes.MakeTrusted(querypb.Type_DECIMAL,
+			[]byte("-0.1")),
+	}, {
+		typ:      TypeNewDecimal,
+		metadata: 1<<8 | 1, // DECIMAL(1,1), value 0.5
+		data:     []byte{0x85},
+		out: sqltypes.MakeTrusted(querypb.Type_DECIMAL,
+			[]byte("0.5")),
+	}, {
+		typ:      TypeNewDecimal,
+		metadata: 3<<8 | 2, // DECIMAL(3,2), value 0.05
+		data:     []byte{0x80, 0x05},
+		out: sqltypes.MakeTrusted(querypb.Type_DECIMAL,
+			[]byte("0.05")),
+	}, {
 		typ:      TypeBlob,
 		metadata: 1,
 		data:     []byte{0x3, 'a', 'b', 'c'},

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -1934,7 +1934,7 @@ func TestPlayerTypes(t *testing.T) {
 		},
 	}, {
 		input:  "insert into vitess_decimal values(1, 0, 1, null, 0, 1.1, 1)",
-		output: "insert into vitess_decimal(id,d1,d2,d3,d4,d5,d6) values (1,0,1,null,.0,1.1,1.0)",
+		output: "insert into vitess_decimal(id,d1,d2,d3,d4,d5,d6) values (1,0,1,null,0.0,1.1,1.0)",
 		table:  "vitess_decimal",
 		data: [][]string{
 			{"1", "0", "1", "", "0.0", "1.1", "1.0"},


### PR DESCRIPTION
## Description

When MySQL stores a DECIMAL with a zero integer part inside a JSON column (e.g. `JSON_OBJECT('a', 0.1)`), the binlog row event encodes the value as an opaque DECIMAL. The reader's `trimPrecedingZeroes` helper in `CellValue` strips every leading zero, including the one that should sit before the decimal point, so `0.1` round-trips as `".1"`.

- On `main` (after #19878), the strict streaming JSON encoder rejects this with `unexpected character '.' in JSON` and the vreplication stream terminally fails — this is the customer-visible symptom in #20227.
- On older branches the same output is silently passed through to MySQL because `.1` happens to be a valid SQL decimal literal — silent corruption that "works."

The fix is a three-line addition inside the existing `trimPrecedingZeroes` closure in `go/mysql/binlog/rbr.go`: after `strings.TrimLeft(s, "0")`, if the result starts with `.`, prepend `"0"`. The check runs after the `-` prefix is stripped, so the negative case is handled correctly too.

The same defect exists on `release-22.0`, `release-23.0`, and `release-24.0` — verified by source inspection. The fix applies cleanly to each. Suggest considering a backport to surface the correct text JSON on those branches even though they don't carry the strict encoder from #19878.

## Related Issue(s)

Fixes #20227

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

Six new regression cases pinning the fix:

- `TestCellLengthAndData` (`rbr_test.go`): `DECIMAL(2,1) → 0.1`, `DECIMAL(2,1) → -0.1`, `DECIMAL(1,1) → 0.5`, `DECIMAL(3,2) → 0.05`.
- `TestBinaryJSON` (`binlog_json_test.go`): JSON-wrapped `0.1` and `-0.1`.

All existing decimal cases (`1.10`, `1.99`, `123456789.1234`, `1234567890.1234`, `1234567890.0001`, `-1234567890.1234`) still pass. End-to-end verification: with the patch applied, MoveTables successfully replicates a row whose JSON column holds `0.1` decimals — was failing the stream with `unexpected character '.' in JSON` before.

## Deployment Notes

No migrations or operational changes. Pure-go-code fix.

### AI Disclosure

Most of this PR was written by Claude Code — I provided direction and reviewed.