### PR TITLE
vreplication: fix TestPlayerDDL flake on multi-source GTID positions

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/framework_test.go
@@ -252,6 +252,13 @@ func primaryPosition(t *testing.T) string {
 	return replication.EncodePosition(pos)
 }
 
+func primaryPositionParsed(t *testing.T) replication.Position {
+	t.Helper()
+	pos, err := env.Mysqld.PrimaryPosition(t.Context())
+	require.NoError(t, err)
+	return pos
+}
+
 func execStatements(t *testing.T, queries []string) {
 	t.Helper()
 	if err := env.Mysqld.ExecuteSuperQueryList(t.Context(), queries); err != nil {

--- a/go/vt/vttablet/tabletmanager/vreplication/queryhistory/position.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/queryhistory/position.go
@@ -7,7 +7,7 @@ import (
 	"vitess.io/vitess/go/mysql/replication"
 )
 
-var posUpdateRegex = regexp.MustCompile(`update _vt\.vreplication set pos='(MySQL56/[^']*)'`)
+var posUpdateRegex = regexp.MustCompile(`update _vt\.vreplication set pos='([^']*)'`)
 
 // PosBetween returns an ExpectationSequencerFn that appends an expectation for
 // an "update _vt.vreplication set pos=..." query whose recorded GTID position

--- a/go/vt/vttablet/tabletmanager/vreplication/queryhistory/position.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/queryhistory/position.go
@@ -1,0 +1,67 @@
+package queryhistory
+
+import (
+	"fmt"
+	"regexp"
+
+	"vitess.io/vitess/go/mysql/replication"
+)
+
+var posUpdateRegex = regexp.MustCompile(`update _vt\.vreplication set pos='(MySQL56/[^']*)'`)
+
+// PosBetween returns an ExpectationSequencerFn that appends an expectation for
+// an "update _vt.vreplication set pos=..." query whose recorded GTID position
+// lies in the inclusive range [lower, upper], immediately following the current
+// expectation in the sequence.
+//
+// It exists because a vplayer's stop position is the GTID of an event in the
+// replication stream, while the bracketing positions are read from SHOW MASTER
+// STATUS, which can advance independently due to background activity on the same
+// server. Asserting set-containment instead of exact equality tolerates that lag
+// and works for multi-source GTID sets.
+//
+//	qh.Expect("begin").
+//		Then(qh.PosBetween(before, after)).
+//		Then(qh.Immediately("/update _vt.vreplication set state='Stopped'", "commit"))
+func PosBetween(lower, upper replication.Position) ExpectationSequencerFn {
+	return func(sequencer ExpectationSequencer) ExpectationSequencer {
+		current := newSequencedExpectation(&posBetweenExpectation{lower: lower, upper: upper})
+		head := current
+		if sequencer != nil && sequencer.Current() != nil {
+			head = sequencer.Head()
+			sequencer.Current().ExpectImmediatelyBefore(current)
+		}
+		return &expectationSequencer{
+			ExpectationSequence: &expectationSequence{head},
+			current:             current,
+		}
+	}
+}
+
+type posBetweenExpectation struct {
+	lower replication.Position
+	upper replication.Position
+}
+
+func (e *posBetweenExpectation) ExpectQuery(string) {}
+
+func (e *posBetweenExpectation) MatchQuery(query string) (bool, error) {
+	matches := posUpdateRegex.FindStringSubmatch(query)
+	if matches == nil {
+		return false, nil
+	}
+	stored, err := replication.DecodePosition(matches[1])
+	if err != nil {
+		return false, err
+	}
+	return stored.AtLeast(e.lower) && e.upper.AtLeast(stored), nil
+}
+
+func (e *posBetweenExpectation) Query() string {
+	return e.String()
+}
+
+func (e *posBetweenExpectation) String() string {
+	return fmt.Sprintf("update _vt.vreplication set pos in [%s, %s]",
+		replication.EncodePosition(e.lower), replication.EncodePosition(e.upper))
+}

--- a/go/vt/vttablet/tabletmanager/vreplication/queryhistory/position_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/queryhistory/position_test.go
@@ -1,0 +1,96 @@
+package queryhistory
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/replication"
+)
+
+func TestPosBetween(t *testing.T) {
+	mustPos := func(s string) replication.Position {
+		pos, err := replication.DecodePosition(s)
+		require.NoError(t, err)
+		return pos
+	}
+	posQuery := func(gtid string) string {
+		return fmt.Sprintf("update _vt.vreplication set pos='%s', time_updated=42, transaction_timestamp=0, rows_copied=0, message='' where id=1", gtid)
+	}
+
+	const (
+		uuidA = "02cd68df-5dd8-11f1-9a8b-12c5b0c400a7"
+		uuidB = "18b5025a-cd79-f2ac-0000-000000000001"
+	)
+
+	tests := []struct {
+		name        string
+		lower       string
+		upper       string
+		query       string
+		wantMatched bool
+	}{
+		{
+			name:        "single source in range",
+			lower:       "MySQL56/" + uuidA + ":1-100",
+			upper:       "MySQL56/" + uuidA + ":1-110",
+			query:       posQuery("MySQL56/" + uuidA + ":1-105"),
+			wantMatched: true,
+		},
+		{
+			name:        "single source at lower bound",
+			lower:       "MySQL56/" + uuidA + ":1-100",
+			upper:       "MySQL56/" + uuidA + ":1-110",
+			query:       posQuery("MySQL56/" + uuidA + ":1-100"),
+			wantMatched: true,
+		},
+		{
+			name:        "single source at upper bound",
+			lower:       "MySQL56/" + uuidA + ":1-100",
+			upper:       "MySQL56/" + uuidA + ":1-110",
+			query:       posQuery("MySQL56/" + uuidA + ":1-110"),
+			wantMatched: true,
+		},
+		{
+			// The exact scenario from issue #20220: a multi-source position
+			// where the stored GTID lags the upper bound by one on the first
+			// source.
+			name:        "multi source in range",
+			lower:       "MySQL56/" + uuidA + ":1-1491," + uuidB + ":101",
+			upper:       "MySQL56/" + uuidA + ":1-1493," + uuidB + ":101",
+			query:       posQuery("MySQL56/" + uuidA + ":1-1492," + uuidB + ":101"),
+			wantMatched: true,
+		},
+		{
+			name:        "below lower bound",
+			lower:       "MySQL56/" + uuidA + ":1-100",
+			upper:       "MySQL56/" + uuidA + ":1-110",
+			query:       posQuery("MySQL56/" + uuidA + ":1-99"),
+			wantMatched: false,
+		},
+		{
+			name:        "above upper bound",
+			lower:       "MySQL56/" + uuidA + ":1-100",
+			upper:       "MySQL56/" + uuidA + ":1-110",
+			query:       posQuery("MySQL56/" + uuidA + ":1-111"),
+			wantMatched: false,
+		},
+		{
+			name:        "not a pos update query",
+			lower:       "MySQL56/" + uuidA + ":1-100",
+			upper:       "MySQL56/" + uuidA + ":1-110",
+			query:       "update _vt.vreplication set state='Stopped' where id=1",
+			wantMatched: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &posBetweenExpectation{lower: mustPos(tt.lower), upper: mustPos(tt.upper)}
+			matched, err := e.MatchQuery(tt.query)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantMatched, matched)
+		})
+	}
+}

--- a/go/vt/vttablet/tabletmanager/vreplication/queryhistory/position_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/queryhistory/position_test.go
@@ -63,6 +63,15 @@ func TestPosBetween(t *testing.T) {
 			wantMatched: true,
 		},
 		{
+			// The vreplication test env can run with a MariaDB GTID flavor,
+			// so the matcher must not assume a MySQL56 position prefix.
+			name:        "mariadb flavor in range",
+			lower:       "MariaDB/0-1-100",
+			upper:       "MariaDB/0-1-110",
+			query:       posQuery("MariaDB/0-1-105"),
+			wantMatched: true,
+		},
+		{
 			name:        "below lower bound",
 			lower:       "MySQL56/" + uuidA + ":1-100",
 			upper:       "MySQL56/" + uuidA + ":1-110",

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -2051,20 +2051,20 @@ func TestPlayerDDL(t *testing.T) {
 		OnDdl:    binlogdatapb.OnDDLAction_STOP,
 	}
 	cancel, id := startVReplication(t, bls, "")
-	pos0 := primaryPosition(t) // For debugging only
+	pos0 := primaryPositionParsed(t)
 	execStatements(t, []string{"alter table t1 add column val varchar(128)"})
-	pos1 := primaryPosition(t)
-	// The stop position must be the GTID of the first DDL
-	expectDBClientQueries(t, qh.Expect(
-		"begin",
-		posOrPrevRegex(pos1),
-		"/update _vt.vreplication set state='Stopped'",
-		"commit",
-	))
-	pos2b := primaryPosition(t)
+	pos1 := primaryPositionParsed(t)
+	// The stop position must be the GTID of the first DDL, which lies between
+	// the positions observed before and after the ALTER.
+	expectDBClientQueries(t, qh.Expect("begin").
+		Then(qh.PosBetween(pos0, pos1)).
+		Then(qh.Immediately(
+			"/update _vt.vreplication set state='Stopped'",
+			"commit",
+		)))
+	pos2b := primaryPositionParsed(t)
 	execStatements(t, []string{"alter table t1 drop column val"})
-	pos2 := primaryPosition(t)
-	log.Error(fmt.Sprintf("Expected log:: TestPlayerDDL Positions are: before first alter %v, after first alter %v, before second alter %v, after second alter %v", pos0, pos1, pos2b, pos2)) // For debugging only: to check what are the positions when test works and if/when it fails
+	pos2 := primaryPositionParsed(t)
 	// Restart vreplication
 	_, err := playerEngine.Exec(fmt.Sprintf(`update _vt.vreplication set state = 'Running', message='' where id=%d`, id))
 	require.NoError(t, err)
@@ -2075,10 +2075,12 @@ func TestPlayerDDL(t *testing.T) {
 		"/update _vt.vreplication set message='Picked source tablet.*",
 		"/update.*'Running'",
 		"begin",
-		fmt.Sprintf("/update.*'%s'", pos2),
-		"/update _vt.vreplication set state='Stopped'",
-		"commit",
-	))
+	).
+		Then(qh.PosBetween(pos2b, pos2)).
+		Then(qh.Immediately(
+			"/update _vt.vreplication set state='Stopped'",
+			"commit",
+		)))
 	cancel()
 	bls = &binlogdatapb.BinlogSource{
 		Keyspace: env.KeyspaceName,
@@ -2279,32 +2281,6 @@ func TestPlayerStopPos(t *testing.T) {
 		"/update.*'Running'",
 		"/update.*'Stopped'.*already reached",
 	))
-}
-
-func posOrPrevRegex(pos string) string {
-	positions := []string{pos}
-	if prev, ok := decrementPosition(pos); ok {
-		positions = append(positions, prev)
-		if prev2, ok := decrementPosition(prev); ok {
-			positions = append(positions, prev2)
-		}
-	}
-	for i := range positions {
-		positions[i] = regexp.QuoteMeta(positions[i])
-	}
-	return fmt.Sprintf("/update _vt.vreplication set pos='(%s)'", strings.Join(positions, "|"))
-}
-
-func decrementPosition(pos string) (string, bool) {
-	idx := strings.LastIndex(pos, "-")
-	if idx == -1 || idx+1 >= len(pos) {
-		return "", false
-	}
-	val, err := strconv.Atoi(pos[idx+1:])
-	if err != nil || val <= 0 {
-		return "", false
-	}
-	return pos[:idx+1] + strconv.Itoa(val-1), true
 }
 
 func TestPlayerStopAtOther(t *testing.T) {


### PR DESCRIPTION
## Description

Tests in `vplayer_flaky_test.go` that assert the vplayer's stop position — `TestPlayerDDL` chief among them — flake when the underlying mysqld reports a GTID set with more than one source UUID.

The expected stop position is computed by reading `SHOW MASTER STATUS` right after an `ALTER`, but the position the vplayer actually records is the GTID of the DDL event in the replication stream. `gtid_executed` can advance independently between the two (background MySQL bookkeeping, sidecar `_vt` writes), so the read position ends up one or more GTIDs ahead of where the vplayer stops.

The `posOrPrevRegex`/`decrementPosition` helpers (added in #19204) were meant to absorb that one-GTID lag, but they only work for single-source positions. On a multi-source set like `MySQL56/02cd68df-…:1-1493,18b5025a-…:101`, `strings.LastIndex(pos, "-")` lands inside the *second* UUID, `decrementPosition` silently bails, and the assertion flakes. Once it fails, the shared `globalDBQueries` channel desyncs and ~20 later tests in the same file fail as collateral.

This replaces the exact-GTID assertion with a `qh.PosBetween` matcher that accepts any recorded position within the inclusive `[before, after]` range, using GTID set containment (`replication.Position.AtLeast`). That's the test's real invariant, it's robust to background commits, and it works for multi-source sets — so `posOrPrevRegex` and `decrementPosition` are removed entirely. The same matcher is applied to the second stop-position assertion in `TestPlayerDDL`, which had the same race via a different mechanism.

The matcher lives in the `queryhistory` package as `qh.PosBetween`, returning an `ExpectationSequencerFn` that is composed into the expectation sequence with `.Then(...)`. This keeps the DSL's existing string-only signatures untouched.

## Related Issue(s)

Fixes #20220

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

This is a test-only change, so it's a safe backport. Both supported release branches carry a flaky version of this test: `release-24.0` has the same multi-source bug, and `release-23.0` is even more brittle (it asserts an exact position with no tolerance at all, so it races on both single- and multi-source positions). Backporting stabilizes CI on both. The cherry-picks will need manual conflict resolution since the surrounding test code differs between branches.

## Deployment Notes

None — test-only change, no production code is affected.

### AI Disclosure

This PR was written primarily by Claude Code; I provided direction and review.


