### PR TITLE
binlog: trim leading zeroes for DECIMALs the 0.1 fix missed

### DIFF
--- a/go/mysql/binlog/binlog_json_test.go
+++ b/go/mysql/binlog/binlog_json_test.go
@@ -249,6 +249,16 @@ func TestBinaryJSON(t *testing.T) {
 			expected: json.NewNumber("-0.1", json.NumberTypeDecimal),
 		},
 		{
+			name:     `decimal "0.000000001" (scale is a multiple of 9, integer part is zero)`,
+			data:     []byte{15, 246, 7, 10, 9, 0x80, 0x00, 0x00, 0x00, 0x01},
+			expected: json.NewNumber("0.000000001", json.NumberTypeDecimal),
+		},
+		{
+			name:     `decimal "-0.000000001" (negative, scale is a multiple of 9, integer part is zero)`,
+			data:     []byte{15, 246, 7, 10, 9, 0x7F, 0xFF, 0xFF, 0xFF, 0xFE},
+			expected: json.NewNumber("-0.000000001", json.NumberTypeDecimal),
+		},
+		{
 			name:     `bit literal 0xCAFE`,
 			data:     []byte{15, 16, 2, 202, 254},
 			expected: json.NewBit(string([]byte{202, 254})),

--- a/go/mysql/binlog/rbr.go
+++ b/go/mysql/binlog/rbr.go
@@ -573,8 +573,6 @@ func CellValue(data []byte, pos int, typ byte, metadata uint16, field *querypb.F
 		switch dig2bytes[frac0x] {
 		case 0:
 			// Nothing to do
-			return sqltypes.MakeTrusted(querypb.Type_DECIMAL,
-				txt.Bytes()), l, nil
 		case 1:
 			// one byte, 1 or 2 digits
 			val = uint32(d[pos])

--- a/go/mysql/binlog/rbr.go
+++ b/go/mysql/binlog/rbr.go
@@ -547,6 +547,40 @@ func CellValue(data []byte, pos int, typ byte, metadata uint16, field *querypb.F
 			pos += 4
 		}
 
+		// remove preceding 0s from the integral part, otherwise we get "000000000001.23" instead of "1.23"
+		trimPrecedingZeroes := func(b []byte) []byte {
+			isNegative := b[0] == '-'
+			if isNegative {
+				b = b[1:]
+			}
+			i := 0
+			for i < len(b) && b[i] == '0' {
+				i++
+			}
+			b = b[i:]
+			// Ensure at least one digit precedes the decimal point so values
+			// like 0.1 round-trip as "0.1" instead of ".1" (invalid JSON when
+			// the decimal appears inside a JSON column), and so a fully zero
+			// integral part collapses to "0" rather than "" or a run of zeroes.
+			needLeadingZero := len(b) == 0 || b[0] == '.'
+
+			size := len(b)
+			if isNegative {
+				size++
+			}
+			if needLeadingZero {
+				size++
+			}
+			out := make([]byte, 0, size)
+			if isNegative {
+				out = append(out, '-')
+			}
+			if needLeadingZero {
+				out = append(out, '0')
+			}
+			return append(out, b...)
+		}
+
 		// now see if we have a fraction
 		if scale == 0 {
 			// When the field is a DECIMAL using a scale of 0, e.g.
@@ -558,7 +592,7 @@ func CellValue(data []byte, pos int, typ byte, metadata uint16, field *querypb.F
 			}
 
 			return sqltypes.MakeTrusted(querypb.Type_DECIMAL,
-				txt.Bytes()), l, nil
+				trimPrecedingZeroes(txt.Bytes())), l, nil
 		}
 		txt.WriteByte('.')
 
@@ -613,38 +647,6 @@ func CellValue(data []byte, pos int, typ byte, metadata uint16, field *querypb.F
 			}
 		}
 
-		// remove preceding 0s from the integral part, otherwise we get "000000000001.23" instead of "1.23"
-		trimPrecedingZeroes := func(b []byte) []byte {
-			isNegative := b[0] == '-'
-			if isNegative {
-				b = b[1:]
-			}
-			i := 0
-			for i < len(b) && b[i] == '0' {
-				i++
-			}
-			b = b[i:]
-			// Ensure at least one digit precedes the decimal point so values
-			// like 0.1 round-trip as "0.1" instead of ".1" (invalid JSON when
-			// the decimal appears inside a JSON column).
-			needLeadingZero := len(b) > 0 && b[0] == '.'
-
-			size := len(b)
-			if isNegative {
-				size++
-			}
-			if needLeadingZero {
-				size++
-			}
-			out := make([]byte, 0, size)
-			if isNegative {
-				out = append(out, '-')
-			}
-			if needLeadingZero {
-				out = append(out, '0')
-			}
-			return append(out, b...)
-		}
 		return sqltypes.MakeTrusted(querypb.Type_DECIMAL, trimPrecedingZeroes(txt.Bytes())), l, nil
 
 	case TypeEnum:

--- a/go/mysql/binlog/rbr_test.go
+++ b/go/mysql/binlog/rbr_test.go
@@ -505,6 +505,24 @@ func TestCellLengthAndData(t *testing.T) {
 		out: sqltypes.MakeTrusted(querypb.Type_DECIMAL,
 			[]byte("0.05")),
 	}, {
+		typ:      TypeNewDecimal,
+		metadata: 10<<8 | 9, // DECIMAL(10,9), scale is a multiple of 9, value 0.000000001
+		data:     []byte{0x80, 0x00, 0x00, 0x00, 0x01},
+		out: sqltypes.MakeTrusted(querypb.Type_DECIMAL,
+			[]byte("0.000000001")),
+	}, {
+		typ:      TypeNewDecimal,
+		metadata: 10<<8 | 9, // DECIMAL(10,9), scale is a multiple of 9, value -0.000000001
+		data:     []byte{0x7F, 0xFF, 0xFF, 0xFF, 0xFE},
+		out: sqltypes.MakeTrusted(querypb.Type_DECIMAL,
+			[]byte("-0.000000001")),
+	}, {
+		typ:      TypeNewDecimal,
+		metadata: 18<<8 | 9, // DECIMAL(18,9), full integral group of zeroes, value 0.123456789
+		data:     []byte{0x80, 0x00, 0x00, 0x00, 0x07, 0x5B, 0xCD, 0x15},
+		out: sqltypes.MakeTrusted(querypb.Type_DECIMAL,
+			[]byte("0.123456789")),
+	}, {
 		typ:      TypeBlob,
 		metadata: 1,
 		data:     []byte{0x3, 'a', 'b', 'c'},

--- a/go/mysql/binlog/rbr_test.go
+++ b/go/mysql/binlog/rbr_test.go
@@ -523,6 +523,18 @@ func TestCellLengthAndData(t *testing.T) {
 		out: sqltypes.MakeTrusted(querypb.Type_DECIMAL,
 			[]byte("0.123456789")),
 	}, {
+		typ:      TypeNewDecimal,
+		metadata: 20 << 8, // DECIMAL(20,0), scale zero, full integral group of zeroes, value 1
+		data:     []byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+		out: sqltypes.MakeTrusted(querypb.Type_DECIMAL,
+			[]byte("1")),
+	}, {
+		typ:      TypeNewDecimal,
+		metadata: 20 << 8, // DECIMAL(20,0), scale zero, all-zero integral part, value 0
+		data:     []byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+		out: sqltypes.MakeTrusted(querypb.Type_DECIMAL,
+			[]byte("0")),
+	}, {
 		typ:      TypeBlob,
 		metadata: 1,
 		data:     []byte{0x3, 'a', 'b', 'c'},


### PR DESCRIPTION
## Description

Follow-up to #20228, which fixed `trimPrecedingZeroes` in `go/mysql/binlog/rbr.go` so that a DECIMAL with a zero integer part (e.g. `0.1`) round-trips as `"0.1"` instead of the invalid-JSON `".1"`. That fix only covered the final return path, so two related cases still slipped through:

- **Scale is a positive multiple of 9** (`DECIMAL(*,9)`, `DECIMAL(*,18)`, …). When `frac0x == 0`, the partial-fraction `switch` returned early and bypassed `trimPrecedingZeroes` entirely, so `0.000000001` still decoded as `".000000001"` (and a full integral zero-group like `DECIMAL(18,9)` `0.123456789` kept its leading zeroes). This was caught by Copilot's review on the original PR.
- **Scale is 0** (`DECIMAL(p,0)`). This path also returned without trimming, so a value spanning a full 9-digit group kept its leading zeroes — e.g. `DECIMAL(20,0)` value `1` decoded as `"000000000000000001"`, and `0` as a run of zeroes.

The fix hoists the `trimPrecedingZeroes` closure above the `scale == 0` check, routes both early-return paths through it, and lets it collapse a fully zero integral part to `"0"`. All `scale >= 0` decimals now go through the same trimming logic.

Each new test case was confirmed to fail on the pre-fix code and pass with the fix.

## Related Issue(s)

Follow-up to #20228 (fixes #20227)

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

Backport justification: same class of correctness bug in the same code path as #20228, which was backported to release-23.0 and release-24.0.

## Deployment Notes

None.

### AI Disclosure

This PR was written by Claude Code — I just provided direction and review.
