### PR TITLE
sqltypes: add `NewXFromBytes` constructors to drop `hack.String` round-trip

### DIFF
--- a/go/sqltypes/value.go
+++ b/go/sqltypes/value.go
@@ -223,14 +223,32 @@ func NewVarBinary(v string) Value {
 	return MakeTrusted(VarBinary, []byte(v))
 }
 
+// NewVarBinaryFromBytes builds a VarBinary Value, taking ownership of b
+// without copying it. The caller must not mutate b afterwards.
+func NewVarBinaryFromBytes(b []byte) Value {
+	return MakeTrusted(VarBinary, b)
+}
+
 // NewDate builds a Date value.
 func NewDate(v string) Value {
 	return MakeTrusted(Date, []byte(v))
 }
 
+// NewDateFromBytes builds a Date value, taking ownership of b without
+// copying it. The caller must not mutate b afterwards.
+func NewDateFromBytes(b []byte) Value {
+	return MakeTrusted(Date, b)
+}
+
 // NewTime builds a Time value.
 func NewTime(v string) Value {
 	return MakeTrusted(Time, []byte(v))
+}
+
+// NewTimeFromBytes builds a Time value, taking ownership of b without
+// copying it. The caller must not mutate b afterwards.
+func NewTimeFromBytes(b []byte) Value {
+	return MakeTrusted(Time, b)
 }
 
 // NewTimestamp builds a Timestamp value.
@@ -243,9 +261,21 @@ func NewDatetime(v string) Value {
 	return MakeTrusted(Datetime, []byte(v))
 }
 
+// NewDatetimeFromBytes builds a Datetime value, taking ownership of b
+// without copying it. The caller must not mutate b afterwards.
+func NewDatetimeFromBytes(b []byte) Value {
+	return MakeTrusted(Datetime, b)
+}
+
 // NewDecimal builds a Decimal value.
 func NewDecimal(v string) Value {
 	return MakeTrusted(Decimal, []byte(v))
+}
+
+// NewDecimalFromBytes builds a Decimal value, taking ownership of b without
+// copying it. The caller must not mutate b afterwards.
+func NewDecimalFromBytes(b []byte) Value {
+	return MakeTrusted(Decimal, b)
 }
 
 // NewIntegral builds an integral type from a string representation.

--- a/go/sqltypes/value_test.go
+++ b/go/sqltypes/value_test.go
@@ -215,6 +215,14 @@ func TestNew(t *testing.T) {
 	assert.ErrorContains(t, err, "invalid JSON value")
 }
 
+func TestNewFromBytes(t *testing.T) {
+	assert.Equal(t, NewDate("2021-02-03"), NewDateFromBytes([]byte("2021-02-03")))
+	assert.Equal(t, NewTime("12:34:56"), NewTimeFromBytes([]byte("12:34:56")))
+	assert.Equal(t, NewDatetime("2021-02-03 12:34:56"), NewDatetimeFromBytes([]byte("2021-02-03 12:34:56")))
+	assert.Equal(t, NewDecimal("3.14"), NewDecimalFromBytes([]byte("3.14")))
+	assert.Equal(t, NewVarBinary("\x00\x01"), NewVarBinaryFromBytes([]byte("\x00\x01")))
+}
+
 func TestMakeTrusted(t *testing.T) {
 	v := MakeTrusted(Null, []byte("abcd"))
 	assert.Equal(t, NULL, v)

--- a/go/vt/sqlparser/literal.go
+++ b/go/vt/sqlparser/literal.go
@@ -22,7 +22,6 @@ import (
 	"math"
 	"math/big"
 
-	"vitess.io/vitess/go/hack"
 	"vitess.io/vitess/go/mysql/datetime"
 	"vitess.io/vitess/go/mysql/decimal"
 	"vitess.io/vitess/go/mysql/fastparse"
@@ -55,7 +54,7 @@ func LiteralToValue(lit *Literal) (sqltypes.Value, error) {
 		if err != nil {
 			return sqltypes.Value{}, err
 		}
-		return sqltypes.NewDecimal(hack.String(dec.FormatMySQL(0))), nil
+		return sqltypes.NewDecimalFromBytes(dec.FormatMySQL(0)), nil
 	case StrVal:
 		return sqltypes.NewVarChar(lit.Val), nil
 	case HexNum:
@@ -85,21 +84,21 @@ func LiteralToValue(lit *Literal) (sqltypes.Value, error) {
 			return sqltypes.Value{}, fmt.Errorf("invalid time literal: %v", lit.Val)
 		}
 		buf := datetime.Date_YYYY_MM_DD.Format(datetime.DateTime{Date: d}, 0)
-		return sqltypes.NewDate(hack.String(buf)), nil
+		return sqltypes.NewDateFromBytes(buf), nil
 	case TimeVal:
 		t, l, state := datetime.ParseTime(lit.Val, -1)
 		if state != datetime.TimeOK {
 			return sqltypes.Value{}, fmt.Errorf("invalid time literal: %v", lit.Val)
 		}
 		buf := datetime.Time_hh_mm_ss.Format(datetime.DateTime{Time: t}, uint8(l))
-		return sqltypes.NewTime(hack.String(buf)), nil
+		return sqltypes.NewTimeFromBytes(buf), nil
 	case TimestampVal:
 		dt, l, ok := datetime.ParseDateTime(lit.Val, -1)
 		if !ok {
 			return sqltypes.Value{}, fmt.Errorf("invalid time literal: %v", lit.Val)
 		}
 		buf := datetime.DateTime_YYYY_MM_DD_hh_mm_ss.Format(dt, uint8(l))
-		return sqltypes.NewDatetime(hack.String(buf)), nil
+		return sqltypes.NewDatetimeFromBytes(buf), nil
 	default:
 		return sqltypes.Value{}, fmt.Errorf("unsupported literal type: %v", lit.Type)
 	}
@@ -110,7 +109,7 @@ func parseHexLiteral(val []byte) (sqltypes.Value, error) {
 	if err := hex.DecodeBytes(raw, val); err != nil {
 		return sqltypes.Value{}, err
 	}
-	return sqltypes.NewVarBinary(hack.String(raw)), nil
+	return sqltypes.NewVarBinaryFromBytes(raw), nil
 }
 
 func parseBitLiteral(val []byte) (sqltypes.Value, error) {
@@ -119,5 +118,5 @@ func parseBitLiteral(val []byte) (sqltypes.Value, error) {
 	if !ok {
 		return sqltypes.Value{}, fmt.Errorf("invalid bit literal: %v", val)
 	}
-	return sqltypes.NewVarBinary(hack.String(i.Bytes())), nil
+	return sqltypes.NewVarBinaryFromBytes(i.Bytes()), nil
 }


### PR DESCRIPTION
## Description

While looking at uses of `hack.String` in `sqlparser`, I noticed the temporal/binary literal conversions were doing a pointless round-trip: they format into a freshly-allocated `[]byte`, cast it to a `string` with `hack.String` (zero-copy, but `unsafe`), then hand it to `NewDate`/`NewTime`/`NewDatetime`/`NewDecimal`/`NewVarBinary` — each of which immediately does `[]byte(v)`, copying the bytes right back. So the `unsafe` cast bought nothing and a copy happened anyway.

This adds byte-owning constructors — `NewVarBinaryFromBytes`, `NewDateFromBytes`, `NewTimeFromBytes`, `NewDatetimeFromBytes`, `NewDecimalFromBytes` — that take ownership of a caller-owned slice via `MakeTrusted` without copying, and switches `LiteralToValue` to use them. All the producers feeding these sites (`Strftime.Format`, `Decimal.FormatMySQL`, `hex.DecodeBytes`, `big.Int.Bytes`) return freshly-allocated, exclusively-owned slices, so handing them straight to `MakeTrusted` is safe.

Net effect: each of these conversions drops from two allocations (the format buffer + the `[]byte(v)` copy) to one, and the `hack.String`/`unsafe` usage is gone from `literal.go` — faster *and* safer.

## Related Issue(s)

N/A — small self-contained cleanup.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

This PR was written primarily by Claude Code — I provided the direction and review.
