### PR TITLE
ci: use HTTPS and pin SHA256 for libaio1/libtinfo5 .deb downloads

### DIFF
--- a/.github/actions/setup-mysql/action.yml
+++ b/.github/actions/setup-mysql/action.yml
@@ -24,7 +24,8 @@ runs:
 
         # We have to install this old version of libaio1. See also:
         # https://bugs.launchpad.net/ubuntu/+source/libaio/+bug/2067501
-        wget http://archive.ubuntu.com/ubuntu/pool/main/liba/libaio/libaio1_0.3.112-13build1_amd64.deb && \
+        wget https://archive.ubuntu.com/ubuntu/pool/main/liba/libaio/libaio1_0.3.112-13build1_amd64.deb && \
+          echo "2dcfe0b49d7cccfbf1bd6a3f627cf44bea9f51fb32f7e0e552a0df75698e0d27  libaio1_0.3.112-13build1_amd64.deb" | sha256sum -c - && \
           sudo dpkg -i libaio1_0.3.112-13build1_amd64.deb && \
           rm libaio1_0.3.112-13build1_amd64.deb
 
@@ -40,7 +41,8 @@ runs:
           sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
           sudo apt-get update
           # libtinfo5 is also needed for older MySQL 5.7 builds.
-          curl -L -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
+          curl -L -O https://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
+          echo "ab89265d8dd18bda6a29d7c796367d6d9f22a39a8fa83589577321e7caf3857b  libtinfo5_6.3-2ubuntu0.1_amd64.deb" | sha256sum -c -
           sudo dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb
           sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-client=5.7* mysql-community-server=5.7* mysql-server=5.7* libncurses6
         elif [[ "${{ inputs.flavor }}" == "mysql-8.0" ]]; then


### PR DESCRIPTION
## Description

Closes #20198.

The `setup-mysql` composite action downloaded the pinned `libaio1` and
`libtinfo5` `.deb` packages from `archive.ubuntu.com` over plain HTTP. The host
serves both over HTTPS, so this switches the two URLs in
`.github/actions/setup-mysql/action.yml` accordingly.

As suggested in the issue, it also pins a SHA256 for each package and verifies
it with `sha256sum -c -` right before `dpkg -i`. Both URLs reference fixed point
releases (`libaio1_0.3.112-13build1`, `libtinfo5_6.3-2ubuntu0.1`), so the
checksums are stable, and the check guards against the archive rotating the file
under us or a corrupted download. I computed them from the files served over
HTTPS:

- `libaio1_0.3.112-13build1_amd64.deb`: `2dcfe0b49d7cccfbf1bd6a3f627cf44bea9f51fb32f7e0e552a0df75698e0d27`
- `libtinfo5_6.3-2ubuntu0.1_amd64.deb`: `ab89265d8dd18bda6a29d7c796367d6d9f22a39a8fa83589577321e7caf3857b`

The step already runs under `bash -e`, so a checksum mismatch fails the job.

Only `main` is touched here. The supported release branches can follow via the
`Backport to:` labels; the EOL branches (22/21/20) need the template edit plus
regeneration and are out of scope per the issue.
