### PR TITLE
vtgate: use `ToBoolean()` in the `Filter` streaming path

### DIFF
--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -152,6 +152,28 @@ func TestEqualFilterOnScatter(t *testing.T) {
 	}
 }
 
+// TestNullPredicateFilterOnScatter ensures that a scatter HAVING clause whose
+// predicate evaluates to NULL for some groups does not error out the query. The
+// streaming (OLAP) path used to error on a NULL predicate result instead of
+// treating it as false, aborting the whole stream.
+func TestNullPredicateFilterOnScatter(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	mcmp.Exec("insert into aggr_test(id, val1, val2) values(1,'a',null), (2,'a',null), (3,'b',10), (4,'b',20)")
+
+	workloads := []string{"oltp", "olap"}
+	for _, workload := range workloads {
+		mcmp.Run(workload, func(mcmp *utils.MySQLCompare) {
+			utils.Exec(t, mcmp.VtConn, fmt.Sprintf("set workload = '%s'", workload))
+
+			// Group 'a' has sum(val2) = NULL, so the predicate evaluates to NULL
+			// and the group is filtered out. Group 'b' has sum(val2) = 30.
+			mcmp.AssertMatches("select val1, sum(val2) as s from aggr_test group by val1 having sum(val2) > 5 order by val1", `[[VARCHAR("b") DECIMAL(30)]]`)
+		})
+	}
+}
+
 func TestAggrOnJoin(t *testing.T) {
 	mcmp, closer := start(t)
 	defer closer()

--- a/go/vt/vtgate/engine/filter.go
+++ b/go/vt/vtgate/engine/filter.go
@@ -78,11 +78,7 @@ func (f *Filter) TryStreamExecute(ctx context.Context, vcursor VCursor, bindVars
 			if err != nil {
 				return err
 			}
-			intEvalResult, err := evalResult.Value(vcursor.ConnCollation()).ToInt64()
-			if err != nil {
-				return err
-			}
-			if intEvalResult == 1 {
+			if evalResult.ToBoolean() {
 				rows = append(rows, row)
 			}
 		}

--- a/go/vt/vtgate/engine/filter_test.go
+++ b/go/vt/vtgate/engine/filter_test.go
@@ -124,6 +124,10 @@ func TestFilterStreaming(t *testing.T) {
 		name:   "uint64_int32",
 		res:    sqltypes.MakeTestStreamingResults(sqltypes.MakeTestFields("left|right", "uint64|int32"), "0|1", "1|0", "2|3", "---", "0|1", "1|3", "5|3"),
 		expRes: `[[UINT64(1) INT32(0)] [UINT64(5) INT32(3)]]`,
+	}, {
+		name:   "null_predicate",
+		res:    sqltypes.MakeTestStreamingResults(sqltypes.MakeTestFields("left|right", "int32|int32"), "null|0", "---", "1|0"),
+		expRes: `[[INT32(1) INT32(0)]]`,
 	}}
 	for _, tc := range tcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

`Filter.TryStreamExecute` (the OLAP/streaming path) evaluated the predicate with `evalResult.Value(...).ToInt64() == 1`. That errors on a **NULL** predicate result (and on any non-integer eval result), aborting the entire stream. The non-streaming `Filter.TryExecute` in the same file already uses `evalResult.ToBoolean()`, so the two execution paths disagreed.

This is reachable on `main` today for any OLAP-workload query whose plan contains a `Filter` primitive — e.g. a scatter `HAVING` clause where the aggregate evaluates to NULL for some group.

The fix replaces the `ToInt64()`-based block with `evalResult.ToBoolean()`, making streaming identical to `TryExecute`: a NULL predicate now counts as false instead of erroring.

This change was extracted as a standalone, flag-independent bug fix from #20213 (thanks @nickvanw).

## Related Issue(s)

Fixes #20247.

Extracted from #20213.

## Backport justification

This is a correctness bug that affects production OLAP workloads on the current release branches: any streamed query whose plan contains a `Filter` primitive (e.g. a scatter `HAVING` over a nullable aggregate) errors out the whole stream the moment the predicate evaluates to NULL, even though the equivalent non-streaming query returns the correct result. The fix is small, self-contained, and aligns streaming with the already-correct `TryExecute` semantics, so it's low-risk to backport to release-23.0 and release-24.0.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Behavioral note: under streaming, predicate values other than exactly `1` (e.g. `2`) now count as true, matching the non-streaming `TryExecute` semantics. This is the intended correction, not a regression.

### AI Disclosure

This PR was written primarily by Claude Code — I provided the direction.
