### PR TITLE
vstreamer: make `TestSpec.Close()` nil-safe

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/helper_event_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/helper_event_test.go
@@ -334,15 +334,6 @@ func (ts *TestSpec) Close() {
 	execStatement(ts.t, dropStatement)
 }
 
-// TestSpecCloseWithoutSchema verifies that Close() is safe to call when the
-// schema was never populated. Tests defer Close() before calling Init(), so a
-// panic inside Init() (for example when MySQL fails to start) runs Close() with
-// a nil schema; it must not panic and mask the original failure.
-func TestSpecCloseWithoutSchema(t *testing.T) {
-	ts := &TestSpec{t: t}
-	require.NotPanics(t, ts.Close)
-}
-
 func (ts *TestSpec) getBindVarsForInsert(stmt sqlparser.Statement) (string, map[string]string) {
 	bv := make(map[string]string)
 	ins := stmt.(*sqlparser.Insert)

--- a/go/vt/vttablet/tabletserver/vstreamer/helper_event_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/helper_event_test.go
@@ -327,8 +327,20 @@ func (ts *TestSpec) Init() {
 
 // Close() should be called (via defer) at the end of the test to clean up the tables created in the test.
 func (ts *TestSpec) Close() {
+	if ts.schema == nil {
+		return
+	}
 	dropStatement := "drop table if exists " + strings.Join(ts.schema.TableNames(), ", ")
 	execStatement(ts.t, dropStatement)
+}
+
+// TestSpecCloseWithoutSchema verifies that Close() is safe to call when the
+// schema was never populated. Tests defer Close() before calling Init(), so a
+// panic inside Init() (for example when MySQL fails to start) runs Close() with
+// a nil schema; it must not panic and mask the original failure.
+func TestSpecCloseWithoutSchema(t *testing.T) {
+	ts := &TestSpec{t: t}
+	require.NotPanics(t, ts.Close)
 }
 
 func (ts *TestSpec) getBindVarsForInsert(stmt sqlparser.Statement) (string, map[string]string) {


### PR DESCRIPTION
## Description

The `vstreamer` test helper `TestSpec.Close()` dereferenced `ts.schema` unconditionally. Tests register the cleanup before initialization:

```go
defer ts.Close()
ts.Init()
```

So when `Init()` panics early — e.g. it failed at `engine.watcherOnce.Do(engine.setWatch)`, before `ts.schema` is assigned, which happens when MySQL fails to start on a resource-starved CI runner (`mysqld` gets OOM-killed: `signal: killed`) — the deferred `Close()` runs with a nil `*schemadiff.Schema` and panics again on `ts.schema.TableNames()`.

That second panic turns a recoverable test failure into a hard crash of the whole package test binary, which `gotestsum` reports as:

```
ERROR rerun aborted because previous run had a suspected panic and some test may not have run
```

i.e. the panic also defeats the automatic rerun that would otherwise isolate/retry the flaky test.

The fix returns early from `Close()` when the schema was never populated (there are no tables to drop in that case). I also added a small regression test, `TestSpecCloseWithoutSchema`, which panics on `main` and passes with the fix.

This does **not** fix the underlying infra flakiness (mysqld being OOM-killed); it stops that flake from escalating into a package-wide abort so the existing rerun logic can do its job.

## Related Issue(s)

Observed in CI on a `Unit Test (Race)` run (`TestSetAndEnum` / `TestNoBlob` in `go/vt/vttablet/tabletserver/vstreamer`).

## Backport justification

This is a test-only robustness fix. The same unguarded `Close()` exists on `release-23.0` and `release-24.0`, where the same CI flake can escalate into a package-wide panic and an aborted rerun. Backporting keeps those branches' CI from hard-failing on transient resource starvation. Test-only, so there is no runtime risk.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — test-only change.

### AI Disclosure

This PR was written primarily by Claude Code — I provided the direction.
