### PR TITLE
fix: honor vttestserver data-dir without an explicit port

### DIFF
--- a/go/cmd/vttestserver/cli/main.go
+++ b/go/cmd/vttestserver/cli/main.go
@@ -237,14 +237,10 @@ func New() (cmd *cobra.Command) {
 }
 
 func newEnv() (env *vttest.LocalTestEnv, err error) {
-	if basePort == 0 {
-		env, err = vttest.NewLocalTestEnv(0)
+	if config.DataDir == "" {
+		env, err = vttest.NewLocalTestEnv(basePort)
 	} else {
-		if config.DataDir == "" {
-			env, err = vttest.NewLocalTestEnv(basePort)
-		} else {
-			env, err = vttest.NewLocalTestEnvWithDirectory(basePort, config.DataDir)
-		}
+		env, err = vttest.NewLocalTestEnvWithDirectory(basePort, config.DataDir)
 	}
 	if err != nil {
 		return

--- a/go/cmd/vttestserver/cli/main_test.go
+++ b/go/cmd/vttestserver/cli/main_test.go
@@ -269,6 +269,27 @@ func TestGatewayInitialTabletTimeout(t *testing.T) {
 	assertGetKeyspaces(ctx, t, cluster)
 }
 
+func TestNewEnvUsesDataDirWithoutPort(t *testing.T) {
+	conf := config
+	originalBasePort := basePort
+	t.Cleanup(func() {
+		resetConfig(conf)
+		basePort = originalBasePort
+	})
+
+	dir := t.TempDir()
+	config.DataDir = dir
+	basePort = 0
+
+	env, err := newEnv()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, env.TearDown())
+	})
+
+	assert.Equal(t, dir, env.Directory())
+}
+
 func TestExternalTopoServerConsul(t *testing.T) {
 	conf := config
 	defer resetConfig(conf)
@@ -325,7 +346,8 @@ func TestMtlsAuth(t *testing.T) {
 		fmt.Sprintf("%s=%s", "--vtctld-grpc-key", clientKey),
 		fmt.Sprintf("%s=%s", "--vtctld-grpc-cert", clientCert),
 		fmt.Sprintf("%s=%s", "--vtctld-grpc-ca", caCert),
-		fmt.Sprintf("%s=%s", "--grpc-auth-mtls-allowed-substrings", "CN=ClientApp"))
+		fmt.Sprintf("%s=%s", "--grpc-auth-mtls-allowed-substrings", "CN=ClientApp"),
+	)
 	require.NoError(t, err)
 	defer func() {
 		cluster.PersistentMode = false // Cleanup the tmpdir as we're done
@@ -367,7 +389,8 @@ func TestMtlsAuthUnauthorizedFails(t *testing.T) {
 		fmt.Sprintf("%s=%s", "--vtctld-grpc-key", clientKey),
 		fmt.Sprintf("%s=%s", "--vtctld-grpc-cert", clientCert),
 		fmt.Sprintf("%s=%s", "--vtctld-grpc-ca", caCert),
-		"--grpc-auth-mtls-allowed-substrings="+"CN=ClientApp")
+		"--grpc-auth-mtls-allowed-substrings="+"CN=ClientApp",
+	)
 	defer cluster.TearDown()
 
 	require.Error(t, err)
@@ -377,8 +400,6 @@ func TestMtlsAuthUnauthorizedFails(t *testing.T) {
 func startPersistentCluster(dir string, flags ...string) (vttest.LocalCluster, error) {
 	flags = append(flags, []string{
 		"--persistent-mode",
-		// FIXME: if port is not provided, data_dir is not respected
-		fmt.Sprintf("--port=%d", randomPort()),
 		"--data-dir=" + dir,
 	}...)
 	return startCluster(flags...)


### PR DESCRIPTION
## Description

Tiny fix, kinda annoying one.

`vttestserver` ignores `--data-dir` if `--port` is left unset, so persistent mode writes into a random temp dir instead of the requested dir.

This makes `newEnv()` honor `--data-dir` first. Added a small zero-port test and removed the test workaround that forced `--port`.

Repro:
`go test ./go/cmd/vttestserver/cli -run TestNewEnvUsesDataDirWithoutPort -count=1`

Also from the issue:
`docker run -it --volume=/tmp/vt:/tmp/vt/ vitess/vttestserver:mysql57 vttestserver --data-dir /tmp/vt -alsologtostderr`

Expected: data lands in `/tmp/vt`
Current on main: it lands in a random dir under `/vt/vtdataroot`

## Related Issue(s)

Fixes #7735

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [ ] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

None
