### PR TITLE
tabletserver: escape reflected form values in twopcz handler

### DIFF
--- a/go/vt/vttablet/tabletserver/twopcz.go
+++ b/go/vt/vttablet/tabletserver/twopcz.go
@@ -19,6 +19,7 @@ package tabletserver
 import (
 	"encoding/json"
 	"fmt"
+	"html"
 	"net/http"
 
 	"github.com/google/safehtml/template"
@@ -182,7 +183,7 @@ func twopczHandler(txe *DTExecutor, w http.ResponseWriter, r *http.Request) {
 	w.Write(gridTable)
 	w.Write([]byte("<h2>WARNING: Actions on this page can jeopardize data integrity.</h2>\n"))
 	if msg != "" {
-		fmt.Fprintln(w, msg)
+		fmt.Fprintln(w, html.EscapeString(msg))
 	}
 
 	w.Write(startTable)

--- a/go/vt/vttablet/tabletserver/twopcz_test.go
+++ b/go/vt/vttablet/tabletserver/twopcz_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletserver
+
+import (
+	"html"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+)
+
+// TestTwopczHandlerEscapesActionMessage checks that the twopcz page HTML-escapes
+// the reflected Action/dtid form values so a crafted request cannot inject markup
+// into the rendered response.
+func TestTwopczHandlerEscapesActionMessage(t *testing.T) {
+	ctx := t.Context()
+	txe, _, db, closer := newTestTxExecutor(t, ctx)
+	defer closer()
+
+	db.AddQueryPattern(`select t\.dtid, t\.state, t\.time_created, s\.statement.*`, &sqltypes.Result{})
+	db.AddQueryPattern(`select t\.dtid, t\.state, t\.time_created, p\.keyspace, p\.shard.*`, &sqltypes.Result{})
+
+	payload := "<script>alert(1)</script>"
+	form := url.Values{}
+	form.Set("Action", payload)
+	form.Set("dtid", "zz")
+
+	resp := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/twopcz?"+form.Encode(), nil)
+	require.NoError(t, err)
+
+	twopczHandler(txe, resp, req)
+
+	body := resp.Body.String()
+	assert.NotContains(t, body, payload)
+	assert.Contains(t, body, html.EscapeString(payload))
+}


### PR DESCRIPTION
## Description

The `twopczHandler` in `tabletserver` builds a status message from the raw `Action` and `dtid` request form values and writes it into the HTML response via `fmt.Fprintln` without escaping. A request such as `/twopcz?Action=<script>alert(1)</script>&dtid=zz` is reflected straight back into the rendered page. The response sets no `Content-Type`, so the browser sniffs it as HTML (the page starts with `<!DOCTYPE html>`), which makes this a reflected XSS on the twopcz debug page.

The fix wraps the message in `html.EscapeString` before it is written, matching the escaping already applied to the same kind of reflected message in the vttablet and vtgate `debugenv` handlers. After the change the crafted value renders as inert text (`&lt;script&gt;alert(1)&lt;/script&gt;`) instead of live markup.

A handler test drives the real `DTExecutor` harness, issues a request with a crafted `Action`, and asserts the payload is HTML-escaped in the response body. It fails on the current code and passes with the fix.

This is a small, self-contained correctness fix and is a reasonable backport candidate for active release branches.

## Related Issue(s)

No separate tracking issue was filed for this one; it is a self-contained security fix for the twopcz debug endpoint. Happy to open an issue to track it if you'd prefer.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

No new flags, schema, or configuration changes. The only behavioral change is that the reflected `Action`/`dtid` values on the twopcz debug page are now HTML-escaped before rendering. This is a user-visible correctness fix on a debug endpoint, so it likely warrants the `release notes (needs details)` label.

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
