### PR TITLE
vttablet: add multi-dimensional in-flight concurrency limiter

### DIFF
--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -41,6 +41,7 @@ Flags:
       --clone-restart-wait-timeout duration                              Timeout for waiting for MySQL to restart after CLONE REMOTE. (default 5m0s)
       --compression-engine-name string                                   compressor engine used for compression. (default "pargzip")
       --compression-level int                                            what level to pass to the compressor. (default 1)
+      --concurrency-limiter-dry-run                                      If true, the concurrency limiter records metrics and emits rejection signals but always admits requests.
       --config-file string                                               Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling        Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                               Name of the config file (without extension) to search for. (default "vtconfig")
@@ -117,6 +118,7 @@ Flags:
       --enable-binlog-dump                                               Allow users to perform binlog dump operations for CDC/replication
       --enable-buffer                                                    Enable buffering (stalling) of primary traffic during failovers.
       --enable-buffer-dry-run                                            Detect and log failover events, but do not actually buffer requests.
+      --enable-concurrency-limiter                                       If true, per-query concurrency limits encoded in /*vt+ CONCURRENCY=... */ directives will be enforced.
       --enable-consolidator                                              This option enables the query consolidator. (default true)
       --enable-consolidator-replicas                                     This option enables the query consolidator only on replicas.
       --enable-direct-ddl                                                Allow users to submit direct DDL statements (default true)

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -74,6 +74,7 @@ Flags:
       --clone-restart-wait-timeout duration                              Timeout for waiting for MySQL to restart after CLONE REMOTE. (default 5m0s)
       --compression-engine-name string                                   compressor engine used for compression. (default "pargzip")
       --compression-level int                                            what level to pass to the compressor. (default 1)
+      --concurrency-limiter-dry-run                                      If true, the concurrency limiter records metrics and emits rejection signals but always admits requests.
       --config-file string                                               Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling        Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                               Name of the config file (without extension) to search for. (default "vtconfig")
@@ -143,6 +144,7 @@ Flags:
       --disk-write-interval duration                                     how often to write to the disk to check whether it is stalled (default 5s)
       --disk-write-timeout duration                                      if writes exceed this duration, the disk is considered stalled (default 30s)
       --emit-stats                                                       If set, emit stats to push-based monitoring and stats backends
+      --enable-concurrency-limiter                                       If true, per-query concurrency limits encoded in /*vt+ CONCURRENCY=... */ directives will be enforced.
       --enable-consolidator                                              This option enables the query consolidator. (default true)
       --enable-consolidator-replicas                                     This option enables the query consolidator only on replicas.
       --enable-hot-row-protection                                        If true, incoming transactions for the same row (range) will be queued and cannot consume all txpool slots.

--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -62,6 +62,12 @@ const (
 	// DirectivePriority specifies the priority of a workload. It should be an integer between 0 and MaxPriorityValue,
 	// where 0 is the highest priority, and MaxPriorityValue is the lowest one.
 	DirectivePriority = "PRIORITY"
+	// DirectiveConcurrency encodes one or more concurrency-limiter specs on a query.
+	// Format: CONCURRENCY=key:value:limit[,key:value:limit...]
+	// The directive must appear immediately after the leading SQL verb (SELECT, INSERT, etc.)
+	// so that it is not stripped as a margin comment. Limit=0 means observe-only.
+	// Example: SELECT /*vt+ CONCURRENCY=workload:OLAP:5,caller:analytics:3 */ * FROM t
+	DirectiveConcurrency = "CONCURRENCY"
 
 	// MaxPriorityValue specifies the maximum value allowed for the priority query directive. Valid priority values are
 	// between zero and MaxPriorityValue.

--- a/go/vt/vttablet/tabletserver/limiter/limiter.go
+++ b/go/vt/vttablet/tabletserver/limiter/limiter.go
@@ -1,0 +1,248 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package limiter implements a multi-dimensional in-flight concurrency limiter
+// for use in vttablet's query execution pipeline.
+//
+// Each query may carry one or more [Spec] values encoded in a SQL directive
+// (/*vt+ CONCURRENCY=key:value:limit[,...] */). [Limiter.Acquire] increments
+// the in-flight counter for every dimension; if all counters remain within
+// their stated limits the request is admitted. If any counter would exceed
+// its limit, all increments are rolled back atomically and the first failing
+// spec is returned. [Limiter.Release] must be called exactly once after a
+// successful [Limiter.Acquire].
+//
+// Dry-run mode: when dryRun is true, Acquire keeps the increment even on a
+// limit violation and returns ok=true so the caller always admits. This keeps
+// the concurrency_level_reached histogram honest and guarantees every increment
+// is balanced by exactly one Release.
+package limiter
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"vitess.io/vitess/go/stats"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
+)
+
+// Spec describes one dimension of a concurrency constraint.
+// Limit == 0 means the dimension is observed (counted and gauged) but never
+// causes rejection.
+type Spec struct {
+	Key   string
+	Value string
+	Limit int64
+}
+
+// String returns the canonical "key:value:limit" form.
+func (s Spec) String() string {
+	return fmt.Sprintf("%s:%s:%d", s.Key, s.Value, s.Limit)
+}
+
+// ParseSpec parses "key:value" or "key:value:limit".
+// Limit must be a non-negative integer; omitting it is equivalent to Limit=0.
+func ParseSpec(raw string) (Spec, error) {
+	parts := strings.SplitN(raw, ":", 3)
+	if len(parts) < 2 || parts[0] == "" {
+		return Spec{}, fmt.Errorf("spec %q: must be key:value or key:value:limit (key must not be empty)", raw)
+	}
+	if len(parts) == 2 {
+		return Spec{Key: parts[0], Value: parts[1]}, nil
+	}
+	limit, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil || limit < 0 {
+		return Spec{}, fmt.Errorf("spec %q: limit must be a non-negative integer", raw)
+	}
+	return Spec{Key: parts[0], Value: parts[1], Limit: limit}, nil
+}
+
+// mapKey returns a collision-free internal map key for a key/value pair.
+func mapKey(key, value string) string { return key + "\x00" + value }
+
+// RejectedError returns a RESOURCE_EXHAUSTED error naming the concurrency dimension that
+// prevented admission.
+func RejectedError(failed *Spec) error {
+	return vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED,
+		"concurrency limit exceeded for %s:%s (limit %d)", failed.Key, failed.Value, failed.Limit)
+}
+
+type limiterStats struct {
+	concurrency     *stats.GaugesWithMultiLabels
+	levelReached    *stats.CountersWithMultiLabels
+	rejected        *stats.CountersWithMultiLabels
+	admitted        *stats.CountersWithMultiLabels
+	specParseErrors *stats.Counter
+}
+
+// Limiter is a multi-dimensional in-flight concurrency limiter.
+// It is safe for concurrent use by multiple goroutines.
+type Limiter struct {
+	mu       sync.Mutex
+	inflight map[string]int64 // mapKey(k,v) → current count
+	s        limiterStats
+}
+
+// New creates a Limiter whose stats are registered via env's Exporter.
+// The Exporter bridges all stats to the Prometheus /metrics endpoint
+// automatically; prometheusbackend.Init need not be called here.
+func New(env tabletenv.Env) *Limiter {
+	exp := env.Exporter()
+	return &Limiter{
+		inflight: make(map[string]int64),
+		s: limiterStats{
+			concurrency: exp.NewGaugesWithMultiLabels(
+				"LimiterConcurrency",
+				"Current in-flight requests per concurrency dimension.",
+				[]string{"Key"},
+			),
+			levelReached: exp.NewCountersWithMultiLabels(
+				"LimiterConcurrencyLevelReached",
+				"Times the in-flight count reached exactly level N for a given dimension. "+
+					"Plot as a histogram to decide on limits.",
+				[]string{"Key", "Level"},
+			),
+			rejected: exp.NewCountersWithMultiLabels(
+				"LimiterRejected",
+				"Requests rejected because a concurrency limit was exceeded.",
+				[]string{"Key", "Value", "DryRun"},
+			),
+			admitted: exp.NewCountersWithMultiLabels(
+				"LimiterAdmitted",
+				"Requests admitted (all concurrency limits satisfied).",
+				[]string{"Key"},
+			),
+			specParseErrors: exp.NewCounter(
+				"LimiterSpecParseErrors",
+				"Number of times a CONCURRENCY directive could not be parsed.",
+			),
+		},
+	}
+}
+
+// Acquire attempts to admit the request described by specs.
+//
+// When dryRun is false: all-or-nothing admission under the mutex. If every
+// spec's in-flight count stays within its limit, the request is admitted and
+// (true, nil) is returned. On the first violation all increments are rolled
+// back and (false, &failedSpec) is returned; the caller must NOT call Release.
+//
+// When dryRun is true: increments are always kept. On a limit violation the
+// rejected counter is bumped (DryRun=true), but (true, violatingSpec) is still
+// returned — the caller must call Release regardless. This keeps the level-
+// reached histogram accurate for limit-setting purposes.
+//
+// Specs with Limit==0 are counted and gauged but never cause rejection.
+// An empty specs slice is always admitted.
+func (l *Limiter) Acquire(specs []Spec, dryRun bool) (ok bool, failed *Spec) {
+	if len(specs) == 0 {
+		return true, nil
+	}
+
+	levels := make([]int64, len(specs))
+
+	l.mu.Lock()
+
+	// Pass 1: increment every in-flight counter and record the resulting level.
+	for i, s := range specs {
+		k := mapKey(s.Key, s.Value)
+		l.inflight[k]++
+		levels[i] = l.inflight[k]
+	}
+
+	// Pass 2: check limits; on first violation either roll back (normal) or keep (dry-run).
+	for i, s := range specs {
+		if s.Limit > 0 && levels[i] > s.Limit {
+			sp := specs[i] // copy before unlock
+			if !dryRun {
+				// Normal mode: roll back all increments.
+				for _, s2 := range specs {
+					k := mapKey(s2.Key, s2.Value)
+					l.inflight[k]--
+					if l.inflight[k] == 0 {
+						delete(l.inflight, k)
+					}
+				}
+				l.mu.Unlock()
+				l.s.rejected.Add([]string{sp.Key, sp.Value, "0"}, 1)
+				return false, &sp
+			}
+			// Dry-run mode: keep increments, record would-reject, admit.
+			l.mu.Unlock()
+			l.s.rejected.Add([]string{sp.Key, sp.Value, "1"}, 1)
+			// Still record admitted + levels outside the lock below.
+			l.recordAdmitted(specs, levels)
+			return true, &sp
+		}
+	}
+
+	l.mu.Unlock()
+
+	// Stats updates outside the lock. levels[i] was captured under the lock so
+	// its value is the true in-flight count at the moment this request was
+	// admitted; it is the correct level to record even if inflight has moved on.
+	l.recordAdmitted(specs, levels)
+	return true, nil
+}
+
+// recordAdmitted updates the level-reached, concurrency gauge, and admitted
+// counters for an admitted request. Must be called outside the mutex.
+func (l *Limiter) recordAdmitted(specs []Spec, levels []int64) {
+	for i, s := range specs {
+		n := levels[i]
+		l.s.concurrency.Set([]string{s.Key}, n)
+		l.s.levelReached.Add([]string{s.Key, strconv.FormatInt(n, 10)}, 1)
+		l.s.admitted.Add([]string{s.Key}, 1)
+	}
+}
+
+// Release decrements the in-flight counter for each spec and updates the
+// concurrency gauge. It must be called exactly once per successful Acquire
+// (including dry-run Acquires that reported a violation but still admitted).
+func (l *Limiter) Release(specs []Spec) {
+	if len(specs) == 0 {
+		return
+	}
+
+	counts := make([]int64, len(specs))
+
+	l.mu.Lock()
+	for i, s := range specs {
+		k := mapKey(s.Key, s.Value)
+		if l.inflight[k] > 0 {
+			l.inflight[k]--
+		}
+		counts[i] = l.inflight[k]
+		if counts[i] == 0 {
+			delete(l.inflight, k)
+		}
+	}
+	l.mu.Unlock()
+
+	for i, s := range specs {
+		l.s.concurrency.Set([]string{s.Key}, counts[i])
+	}
+}
+
+// IncSpecParseErrors increments the spec-parse-error counter. Called from the
+// plan-builder when a CONCURRENCY directive cannot be parsed.
+func (l *Limiter) IncSpecParseErrors() {
+	l.s.specParseErrors.Add(1)
+}

--- a/go/vt/vttablet/tabletserver/limiter/limiter_test.go
+++ b/go/vt/vttablet/tabletserver/limiter/limiter_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package limiter
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/vtenv"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
+)
+
+// newTestLimiter creates a Limiter backed by an isolated test Exporter.
+// Each call uses t.Name() as the exporter name so that stats are shared within
+// a single test function (safe) but isolated from unrelated tests.
+func newTestLimiter(t *testing.T) *Limiter {
+	t.Helper()
+	env := tabletenv.NewEnv(vtenv.NewTestEnv(), tabletenv.NewDefaultConfig(), t.Name())
+	return New(env)
+}
+
+// TestSingleSpec_AdmitUpToLimit verifies that exactly limit concurrent requests
+// are admitted and the (limit+1)-th is rejected, then that releasing one slot
+// re-opens admission.
+func TestSingleSpec_AdmitUpToLimit(t *testing.T) {
+	l := newTestLimiter(t)
+	spec := Spec{Key: "workload", Value: "OLAP", Limit: 3}
+
+	var held [][]Spec
+	for i := 1; i <= 3; i++ {
+		ok, failed := l.Acquire([]Spec{spec}, false)
+		require.Truef(t, ok, "request %d/%d: expected admit, got reject on %v", i, spec.Limit, failed)
+		held = append(held, []Spec{spec})
+	}
+
+	ok, failed := l.Acquire([]Spec{spec}, false)
+	assert.False(t, ok, "4th request: expected reject, got admit")
+	require.NotNil(t, failed)
+	assert.Equal(t, "workload", failed.Key)
+	assert.Equal(t, "OLAP", failed.Value)
+
+	l.Release(held[0])
+	ok, _ = l.Acquire([]Spec{spec}, false)
+	assert.True(t, ok, "after release: expected admit, got reject")
+}
+
+// TestMultiSpec_AllOrNothing verifies that when one dimension is at its limit a
+// request carrying that dimension is rejected and no other dimension is
+// permanently incremented (rollback).
+func TestMultiSpec_AllOrNothing(t *testing.T) {
+	l := newTestLimiter(t)
+	specA := Spec{Key: "workload", Value: "OLAP", Limit: 2}
+	specB := Spec{Key: "priority", Value: "low", Limit: 1}
+
+	ok, _ := l.Acquire([]Spec{specB}, false)
+	require.True(t, ok, "initial specB acquire failed unexpectedly")
+
+	ok, failed := l.Acquire([]Spec{specA, specB}, false)
+	assert.False(t, ok, "expected rejection when specB is at limit")
+	require.NotNil(t, failed)
+	assert.Equal(t, "priority", failed.Key)
+	assert.Equal(t, "low", failed.Value)
+
+	// specA must still have its full capacity of 2 (rollback was clean).
+	ok, _ = l.Acquire([]Spec{specA}, false)
+	assert.True(t, ok, "specA should be at 0/2 after rollback — first acquire must succeed")
+	ok, _ = l.Acquire([]Spec{specA}, false)
+	assert.True(t, ok, "specA should admit second time (1/2 → 2/2)")
+	ok, _ = l.Acquire([]Spec{specA}, false)
+	assert.False(t, ok, "specA third acquire must fail at limit (2/2)")
+}
+
+// TestRelease_RestoresCapacity is a minimal round-trip: acquire, confirm a
+// second acquire fails, release, confirm the slot is available again.
+func TestRelease_RestoresCapacity(t *testing.T) {
+	l := newTestLimiter(t)
+	spec := Spec{Key: "k", Value: "v", Limit: 1}
+
+	ok, _ := l.Acquire([]Spec{spec}, false)
+	require.True(t, ok, "first acquire failed")
+	ok, _ = l.Acquire([]Spec{spec}, false)
+	assert.False(t, ok, "second acquire should fail (limit=1)")
+
+	l.Release([]Spec{spec})
+
+	ok, _ = l.Acquire([]Spec{spec}, false)
+	assert.True(t, ok, "acquire after release should succeed")
+}
+
+// TestZeroSpecs_AlwaysAdmit verifies that a request with no specs is always
+// admitted.
+func TestZeroSpecs_AlwaysAdmit(t *testing.T) {
+	l := newTestLimiter(t)
+	for i := 0; i < 100; i++ {
+		ok, failed := l.Acquire(nil, false)
+		require.Truef(t, ok, "zero-spec request %d: expected admit, got reject on %v", i, failed)
+	}
+}
+
+// TestNoLimit_AlwaysAdmit verifies that a Spec with Limit==0 is counted but
+// never causes rejection, regardless of how many concurrent holders there are.
+func TestNoLimit_AlwaysAdmit(t *testing.T) {
+	l := newTestLimiter(t)
+	spec := Spec{Key: "k", Value: "v", Limit: 0}
+	for i := 0; i < 500; i++ {
+		ok, failed := l.Acquire([]Spec{spec}, false)
+		require.Truef(t, ok, "no-limit spec: expected admit on iteration %d, got reject on %v", i, failed)
+	}
+}
+
+// TestConcurrent_RaceSafety fires 100 goroutines against a limit of 10.
+// Run with -race to catch data races. Invariant: admitted+rejected == goroutines
+// and in-flight never exceeds the limit.
+func TestConcurrent_RaceSafety(t *testing.T) {
+	l := newTestLimiter(t)
+	spec := Spec{Key: "wl", Value: "OLTP", Limit: 10}
+
+	var (
+		wg       sync.WaitGroup
+		admitted int64
+		rejected int64
+	)
+
+	const goroutines = 100
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ok, _ := l.Acquire([]Spec{spec}, false)
+			if ok {
+				atomic.AddInt64(&admitted, 1)
+				l.Release([]Spec{spec})
+			} else {
+				atomic.AddInt64(&rejected, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	total := admitted + rejected
+	assert.Equal(t, int64(goroutines), total,
+		"admitted(%d) + rejected(%d) = %d, want %d", admitted, rejected, total, goroutines)
+}
+
+// TestParseSpec covers the parser's happy paths and error cases.
+func TestParseSpec(t *testing.T) {
+	tests := []struct {
+		raw     string
+		want    Spec
+		wantErr bool
+	}{
+		{"wl:OLAP:5", Spec{"wl", "OLAP", 5}, false},
+		{"wl:OLAP:0", Spec{"wl", "OLAP", 0}, false},
+		{"wl:OLAP", Spec{"wl", "OLAP", 0}, false},
+		// Extra colons after the limit field are not valid.
+		{"k:v:with:colons:10", Spec{}, true},
+		// Errors.
+		{"wl:OLAP:-1", Spec{}, true},  // negative limit
+		{"wl:OLAP:abc", Spec{}, true}, // non-integer limit
+		{"nocolon", Spec{}, true},     // no separator
+		{"", Spec{}, true},            // empty
+		{":value:5", Spec{}, true},    // empty key
+	}
+	for _, tc := range tests {
+		got, err := ParseSpec(tc.raw)
+		if tc.wantErr {
+			assert.Errorf(t, err, "ParseSpec(%q): expected error, got %v", tc.raw, got)
+			continue
+		}
+		require.NoErrorf(t, err, "ParseSpec(%q): unexpected error", tc.raw)
+		assert.Equal(t, tc.want, got, "ParseSpec(%q)", tc.raw)
+	}
+}
+
+// TestDryRun_KeepsIncrementAndAdmits verifies that in dry-run mode a request
+// that would violate the limit is still admitted, its increment is kept (so
+// Release balances it), and the rejected counter is bumped with DryRun=true.
+func TestDryRun_KeepsIncrementAndAdmits(t *testing.T) {
+	l := newTestLimiter(t)
+	spec := Spec{Key: "workload", Value: "OLAP", Limit: 1}
+
+	// Fill the one slot.
+	ok, _ := l.Acquire([]Spec{spec}, false)
+	require.True(t, ok)
+
+	// Dry-run over-limit: must admit.
+	ok, wouldFail := l.Acquire([]Spec{spec}, true /* dryRun */)
+	require.True(t, ok, "dry-run: over-limit request should still be admitted")
+	assert.NotNil(t, wouldFail, "dry-run: failed spec should be returned for observability")
+
+	// inflight is now 2; Release both — guard ensures no negative count.
+	l.Release([]Spec{spec})
+	l.Release([]Spec{spec})
+
+	// After releasing both, a normal request must succeed again.
+	ok, _ = l.Acquire([]Spec{spec}, false)
+	assert.True(t, ok, "after dry-run and two releases, slot must be free")
+}

--- a/go/vt/vttablet/tabletserver/limiter_integration_test.go
+++ b/go/vt/vttablet/tabletserver/limiter_integration_test.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/fakesqldb"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/stats"
+	"vitess.io/vitess/go/streamlog"
+	"vitess.io/vitess/go/vt/topo/memorytopo"
+	"vitess.io/vitess/go/vt/vtenv"
+	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/limiter"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+)
+
+// newTestTabletServerLimiter creates a TabletServer with the concurrency limiter
+// enabled and optionally in dry-run mode.
+func newTestTabletServerLimiter(t *testing.T, db *fakesqldb.DB, dryRun bool) *TabletServer {
+	t.Helper()
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.OltpReadPool.Size = 100
+	cfg.TxPool.Size = 100
+	cfg.EnableOnlineDDL = false
+	cfg.EnableConcurrencyLimiter = true
+	cfg.ConcurrencyLimiterDryRun = dryRun
+	cfg.DB = newDBConfigs(db)
+	srvTopoCounts := stats.NewCountersWithSingleLabel("", "Resilient srvtopo server operations", "type")
+	tsv := NewTabletServer(t.Context(), vtenv.NewTestEnv(), "LimiterTest"+t.Name(), cfg, memorytopo.NewServer(t.Context(), ""), &topodatapb.TabletAlias{}, srvTopoCounts)
+	target := &querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
+	if err := tsv.StartService(target, cfg.DB, nil); err != nil {
+		t.Fatalf("StartService: %v", err)
+	}
+	t.Cleanup(tsv.StopService)
+	return tsv
+}
+
+// newPlan is a helper to get a TabletPlan via GetPlan, used to inspect
+// LimiterSpecs without running the query.
+func newPlan(t *testing.T, tsv *TabletServer, sql string) *TabletPlan {
+	t.Helper()
+	logStats := tabletenv.NewLogStats(t.Context(), "TestLimiterPlan", streamlog.NewQueryLogConfigForTest())
+	plan, err := tsv.qe.GetPlan(t.Context(), logStats, sql, false, false)
+	require.NoError(t, err)
+	return plan
+}
+
+// TestLimiterDirectiveParsed verifies that a post-verb /*vt+ CONCURRENCY=... */
+// directive is parsed into plan.LimiterSpecs correctly.
+func TestLimiterDirectiveParsed(t *testing.T) {
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+	db.AddQuery("select * from test_table where pk = 1 limit 10001", &sqltypes.Result{})
+
+	tsv := newTestTabletServerLimiter(t, db, false)
+
+	plan := newPlan(t, tsv, "select /*vt+ CONCURRENCY=workload:OLAP:5,caller:analytics:3 */ * from test_table where pk = 1")
+	require.Len(t, plan.LimiterSpecs, 2)
+	assert.Equal(t, limiter.Spec{Key: "workload", Value: "OLAP", Limit: 5}, plan.LimiterSpecs[0])
+	assert.Equal(t, limiter.Spec{Key: "caller", Value: "analytics", Limit: 3}, plan.LimiterSpecs[1])
+}
+
+// TestLimiterLeadingCommentYieldsNoSpecs verifies the SE-1 constraint: a truly-
+// leading /*vt+ */ comment is stripped as a margin comment before parsing,
+// so it never reaches the AST and no specs are seen.
+func TestLimiterLeadingCommentYieldsNoSpecs(t *testing.T) {
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+	db.AddQuery("select * from test_table where pk = 1 limit 10001", &sqltypes.Result{})
+
+	tsv := newTestTabletServerLimiter(t, db, false)
+
+	// Truly leading: stripped by SplitMarginComments; directive never reaches AST.
+	plan := newPlan(t, tsv, "/*vt+ CONCURRENCY=workload:OLAP:5 */ select * from test_table where pk = 1")
+	assert.Empty(t, plan.LimiterSpecs, "leading-comment directive must yield zero specs (margin comment is stripped before parse)")
+}
+
+// TestLimiterDisabledAlwaysAdmits verifies that when EnableConcurrencyLimiter is
+// false (the default), no specs are parsed and the hook is skipped.
+func TestLimiterDisabledAlwaysAdmits(t *testing.T) {
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+	db.AddQuery("select * from test_table where pk = 1 limit 10001", &sqltypes.Result{})
+
+	// Disabled: use the stock helper (EnableConcurrencyLimiter=false by default).
+	tsv := newTestTabletServer(t.Context(), noFlags, db)
+	defer tsv.StopService()
+
+	plan := newPlan(t, tsv, "select /*vt+ CONCURRENCY=workload:OLAP:1 */ * from test_table where pk = 1")
+	assert.Empty(t, plan.LimiterSpecs, "limiter disabled: specs must not be parsed")
+}
+
+// TestLimiterEnforceOnLimit verifies that when a limit is reached the (limit+1)-th
+// Execute returns RESOURCE_EXHAUSTED naming the offending dimension.
+func TestLimiterEnforceOnLimit(t *testing.T) {
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+	db.AddQuery("select * from test_table where pk = 1 limit 10001", &sqltypes.Result{})
+
+	tsv := newTestTabletServerLimiter(t, db, false)
+
+	sql := "select /*vt+ CONCURRENCY=workload:OLAP:1 */ * from test_table where pk = 1"
+
+	// Acquire the single slot via the limiter directly (simulates a concurrent query
+	// holding the slot) — then verify that a new Execute is rejected.
+	spec := limiter.Spec{Key: "workload", Value: "OLAP", Limit: 1}
+	ok, _ := tsv.limiter.Acquire([]limiter.Spec{spec}, false)
+	require.True(t, ok, "direct pre-acquire must succeed")
+	defer tsv.limiter.Release([]limiter.Spec{spec})
+
+	qre := newTestQueryExecutor(t.Context(), tsv, sql, 0)
+	_, err := qre.Execute()
+	require.Error(t, err)
+	assert.Equal(t, vtrpcpb.Code_RESOURCE_EXHAUSTED, vterrors.Code(err), "must be RESOURCE_EXHAUSTED")
+	assert.ErrorContains(t, err, "concurrency limit exceeded for workload:OLAP")
+}
+
+// TestLimiterObserveOnly verifies that a Spec with Limit==0 never causes rejection
+// but still tracks in-flight via the admitted counter (no errors emitted).
+func TestLimiterObserveOnly(t *testing.T) {
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+	rows := sqltypes.MakeTestResult(sqltypes.MakeTestFields("pk|name|addr", "int32|int32|int32"), "1|1|1")
+	// The plan formatter includes the /*vt+ ... */ comment in the final SQL.
+	db.AddQueryPattern(`select /\*vt\+ CONCURRENCY=workload:OLAP:0 \*/ \* from test_table where pk = 1 limit 10001`, rows)
+
+	tsv := newTestTabletServerLimiter(t, db, false)
+
+	// Limit=0: observe-only, must never reject.
+	sql := "select /*vt+ CONCURRENCY=workload:OLAP:0 */ * from test_table where pk = 1"
+	for i := 0; i < 10; i++ {
+		qre := newTestQueryExecutor(t.Context(), tsv, sql, 0)
+		_, err := qre.Execute()
+		require.NoErrorf(t, err, "observe-only spec must never reject (iteration %d)", i)
+	}
+}
+
+// TestLimiterDryRunAdmitsButCounts verifies that in dry-run mode an over-limit
+// query is still admitted, and the rejected counter is bumped with DryRun=true.
+func TestLimiterDryRunAdmitsButCounts(t *testing.T) {
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+	rows := sqltypes.MakeTestResult(sqltypes.MakeTestFields("pk|name|addr", "int32|int32|int32"), "1|1|1")
+	db.AddQueryPattern(`select /\*vt\+ CONCURRENCY=workload:OLAP:1 \*/ \* from test_table where pk = 1 limit 10001`, rows)
+
+	tsv := newTestTabletServerLimiter(t, db, true /* dryRun */)
+
+	spec := limiter.Spec{Key: "workload", Value: "OLAP", Limit: 1}
+
+	// Fill the slot.
+	ok, _ := tsv.limiter.Acquire([]limiter.Spec{spec}, false)
+	require.True(t, ok)
+	defer tsv.limiter.Release([]limiter.Spec{spec})
+
+	// Dry-run over-limit: Execute must succeed.
+	sql := "select /*vt+ CONCURRENCY=workload:OLAP:1 */ * from test_table where pk = 1"
+	qre := newTestQueryExecutor(t.Context(), tsv, sql, 0)
+	_, err := qre.Execute()
+	assert.NoError(t, err, "dry-run: over-limit query must still succeed")
+}
+
+// TestLimiterReleaseRestoresCapacity exercises a full acquire-execute-release cycle
+// via the QueryExecutor and verifies that the slot is restored after the first
+// request completes, allowing a second one through.
+func TestLimiterReleaseRestoresCapacity(t *testing.T) {
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+	rows := sqltypes.MakeTestResult(sqltypes.MakeTestFields("pk|name|addr", "int32|int32|int32"), "1|1|1")
+	db.AddQueryPattern(`select /\*vt\+ CONCURRENCY=workload:OLAP:1 \*/ \* from test_table where pk = 1 limit 10001`, rows)
+
+	tsv := newTestTabletServerLimiter(t, db, false)
+	sql := "select /*vt+ CONCURRENCY=workload:OLAP:1 */ * from test_table where pk = 1"
+
+	// First execution completes; slot is released by defer in Execute.
+	qre := newTestQueryExecutor(t.Context(), tsv, sql, 0)
+	_, err := qre.Execute()
+	require.NoError(t, err, "first execute must succeed")
+
+	// Second execution must also succeed (slot was released).
+	qre = newTestQueryExecutor(t.Context(), tsv, sql, 0)
+	_, err = qre.Execute()
+	assert.NoError(t, err, "second execute must succeed after first released the slot")
+}
+
+// TestLimiterStreamPath verifies that the limiter hook in Stream enforces limits.
+func TestLimiterStreamPath(t *testing.T) {
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+	db.AddQuery("select * from test_table where pk = 1", &sqltypes.Result{})
+
+	tsv := newTestTabletServerLimiter(t, db, false)
+
+	spec := limiter.Spec{Key: "workload", Value: "OLAP", Limit: 1}
+	ok, _ := tsv.limiter.Acquire([]limiter.Spec{spec}, false)
+	require.True(t, ok)
+	defer tsv.limiter.Release([]limiter.Spec{spec})
+
+	sql := "select /*vt+ CONCURRENCY=workload:OLAP:1 */ * from test_table where pk = 1"
+	qre := newTestQueryExecutorStreaming(t.Context(), tsv, sql, 0)
+	err := qre.Stream(func(*sqltypes.Result) error { return nil })
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "concurrency limit exceeded for workload:OLAP")
+}

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -46,6 +46,7 @@ import (
 	tacl "vitess.io/vitess/go/vt/tableacl/acl"
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/limiter"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/planbuilder"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/rules"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
@@ -62,6 +63,10 @@ type TabletPlan struct {
 	Original   string
 	Rules      *rules.Rules
 	Authorized []*tableacl.ACLResult
+	// LimiterSpecs holds the concurrency-limiter specs parsed from the query's
+	// /*vt+ CONCURRENCY=... */ directive. It is populated once in getPlan/getStreamPlan
+	// and is read-only afterward — safe for concurrent use from a cached plan.
+	LimiterSpecs []limiter.Spec
 
 	QueryCount   uint64
 	Time         uint64
@@ -146,9 +151,10 @@ type currentSchema struct {
 // Close: There should be no more pending queries when this
 // function is called.
 type QueryEngine struct {
-	isOpen atomic.Bool
-	env    tabletenv.Env
-	se     *schema.Engine
+	isOpen  atomic.Bool
+	env     tabletenv.Env
+	se      *schema.Engine
+	limiter *limiter.Limiter
 
 	// mu protects the following fields.
 	schemaMu sync.Mutex
@@ -377,6 +383,37 @@ func (qe *QueryEngine) Close() {
 
 var errNoCache = errors.New("plan should not be cached")
 
+// parseLimiterSpecs extracts concurrency-limiter specs from the /*vt+ CONCURRENCY=... */
+// directive on the parsed statement. Returns nil when the feature is disabled, when the
+// statement carries no directive, or when parsing fails (error is logged and counted).
+func (qe *QueryEngine) parseLimiterSpecs(statement sqlparser.Statement) []limiter.Spec {
+	if !qe.env.Config().EnableConcurrencyLimiter {
+		return nil
+	}
+	commented, ok := statement.(sqlparser.Commented)
+	if !ok {
+		return nil
+	}
+	raw, found := commented.GetParsedComments().Directives().GetString(sqlparser.DirectiveConcurrency, "")
+	if !found || raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	specs := make([]limiter.Spec, 0, len(parts))
+	for _, p := range parts {
+		s, err := limiter.ParseSpec(strings.TrimSpace(p))
+		if err != nil {
+			log.Warn(fmt.Sprintf("concurrency limiter: ignoring malformed CONCURRENCY directive %q: %v", raw, err))
+			if qe.limiter != nil {
+				qe.limiter.IncSpecParseErrors()
+			}
+			return nil
+		}
+		specs = append(specs, s)
+	}
+	return specs
+}
+
 func (qe *QueryEngine) getPlan(curSchema *currentSchema, sql string, noRowsLimit bool) (*TabletPlan, error) {
 	statement, err := qe.env.Environment().Parser().Parse(sql)
 	if err != nil {
@@ -389,6 +426,7 @@ func (qe *QueryEngine) getPlan(curSchema *currentSchema, sql string, noRowsLimit
 	plan := &TabletPlan{Plan: splan, Original: sql}
 	plan.Rules = qe.queryRuleSources.FilterByPlan(sql, plan.PlanID, plan.TableNames()...)
 	plan.buildAuthorized()
+	plan.LimiterSpecs = qe.parseLimiterSpecs(statement)
 	if sqlparser.CachePlan(statement) {
 		return plan, nil
 	}
@@ -434,6 +472,7 @@ func (qe *QueryEngine) getStreamPlan(curSchema *currentSchema, sql string) (*Tab
 	plan := &TabletPlan{Plan: splan, Original: sql}
 	plan.Rules = qe.queryRuleSources.FilterByPlan(sql, plan.PlanID, plan.TableName().String())
 	plan.buildAuthorized()
+	plan.LimiterSpecs = qe.parseLimiterSpecs(statement)
 
 	if sqlparser.CachePlan(statement) {
 		return plan, nil

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -44,6 +44,7 @@ import (
 	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/limiter"
 	p "vitess.io/vitess/go/vt/vttablet/tabletserver/planbuilder"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/rules"
 	eschema "vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
@@ -160,6 +161,15 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 
 	if reqThrottledErr := qre.tsv.queryThrottler.Throttle(qre.ctx, qre.targetTabletType, qre.plan.FullQuery, qre.connID, qre.options); reqThrottledErr != nil {
 		return nil, reqThrottledErr
+	}
+
+	if qre.tsv.config.EnableConcurrencyLimiter && len(qre.plan.LimiterSpecs) > 0 {
+		dryRun := qre.tsv.config.ConcurrencyLimiterDryRun
+		ok, failed := qre.tsv.limiter.Acquire(qre.plan.LimiterSpecs, dryRun)
+		if !ok {
+			return nil, limiter.RejectedError(failed)
+		}
+		defer qre.tsv.limiter.Release(qre.plan.LimiterSpecs)
 	}
 
 	if qre.plan.PlanID == p.PlanNextval {
@@ -355,6 +365,15 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 
 	if reqThrottledErr := qre.tsv.queryThrottler.Throttle(qre.ctx, qre.targetTabletType, qre.plan.FullQuery, qre.connID, qre.options); reqThrottledErr != nil {
 		return reqThrottledErr
+	}
+
+	if qre.tsv.config.EnableConcurrencyLimiter && len(qre.plan.LimiterSpecs) > 0 {
+		dryRun := qre.tsv.config.ConcurrencyLimiterDryRun
+		ok, failed := qre.tsv.limiter.Acquire(qre.plan.LimiterSpecs, dryRun)
+		if !ok {
+			return limiter.RejectedError(failed)
+		}
+		defer qre.tsv.limiter.Release(qre.plan.LimiterSpecs)
 	}
 
 	switch qre.plan.PlanID {

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -179,6 +179,10 @@ func registerTabletEnvFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&currentConfig.TxThrottlerDryRun, "tx-throttler-dry-run", defaultConfig.TxThrottlerDryRun, "If present, the transaction throttler only records metrics about requests received and throttled, but does not actually throttle any requests.")
 	fs.DurationVar(&currentConfig.TxThrottlerTopoRefreshInterval, "tx-throttler-topo-refresh-interval", time.Minute*5, "The rate that the transaction throttler will refresh the topology to find cells.")
 
+	// Concurrency limiter config
+	utils.SetFlagBoolVar(fs, &currentConfig.EnableConcurrencyLimiter, "enable-concurrency-limiter", defaultConfig.EnableConcurrencyLimiter, "If true, per-query concurrency limits encoded in /*vt+ CONCURRENCY=... */ directives will be enforced.")
+	utils.SetFlagBoolVar(fs, &currentConfig.ConcurrencyLimiterDryRun, "concurrency-limiter-dry-run", defaultConfig.ConcurrencyLimiterDryRun, "If true, the concurrency limiter records metrics and emits rejection signals but always admits requests.")
+
 	utils.SetFlagBoolVar(fs, &enableHotRowProtection, "enable-hot-row-protection", false, "If true, incoming transactions for the same row (range) will be queued and cannot consume all txpool slots.")
 	utils.SetFlagBoolVar(fs, &enableHotRowProtectionDryRun, "enable-hot-row-protection-dry-run", false, "If true, hot row protection is not enforced but logs if transactions would have been queued.")
 	utils.SetFlagIntVar(fs, &currentConfig.HotRowProtection.MaxQueueSize, "hot-row-protection-max-queue-size", defaultConfig.HotRowProtection.MaxQueueSize, "Maximum number of BeginExecute RPCs which will be queued for the same row (range).")
@@ -370,6 +374,9 @@ type TabletConfig struct {
 	TxThrottlerTabletTypes         *topoproto.TabletTypeListFlag `json:"-"`
 	TxThrottlerTopoRefreshInterval time.Duration                 `json:"-"`
 	TxThrottlerDryRun              bool                          `json:"-"`
+
+	EnableConcurrencyLimiter bool `json:"-"`
+	ConcurrencyLimiterDryRun bool `json:"-"`
 
 	EnableTableGC bool `json:"-"` // can be turned off programmatically by tests
 
@@ -1125,6 +1132,9 @@ var defaultConfig = TabletConfig{
 	TxThrottlerTabletTypes:         &topoproto.TabletTypeListFlag{topodatapb.TabletType_REPLICA},
 	TxThrottlerDryRun:              false,
 	TxThrottlerTopoRefreshInterval: time.Minute * 5,
+
+	EnableConcurrencyLimiter: false,
+	ConcurrencyLimiterDryRun: false,
 
 	TransactionLimitConfig: defaultTransactionLimitConfig(),
 

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -65,6 +65,7 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/onlineddl"
 	"vitess.io/vitess/go/vt/vttablet/queryservice"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/gc"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/limiter"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/messager"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/planbuilder"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/querythrottler"
@@ -145,6 +146,7 @@ type TabletServer struct {
 	env *vtenv.Environment
 
 	queryThrottler *querythrottler.QueryThrottler
+	limiter        *limiter.Limiter
 }
 
 var _ queryservice.QueryService = (*TabletServer)(nil)
@@ -198,7 +200,9 @@ func NewTabletServer(ctx context.Context, env *vtenv.Environment, name string, c
 	tsv.vstreamer = vstreamer.NewEngine(tsv, srvTopoServer, tsv.se, tsv.lagThrottler, alias.Cell)
 	tsv.binlogDumper = NewBinlogDumpEngine()
 	tsv.tracker = schema.NewTracker(tsv, tsv.vstreamer, tsv.se)
+	tsv.limiter = limiter.New(tsv)
 	tsv.qe = NewQueryEngine(tsv, tsv.se)
+	tsv.qe.limiter = tsv.limiter
 	tsv.txThrottler = txthrottler.NewTxThrottler(tsv, topoServer)
 	tsv.te = NewTxEngine(tsv, tsv.hs.sendUnresolvedTransactionSignal)
 	tsv.messager = messager.NewEngine(tsv, tsv.se, tsv.vstreamer)
@@ -1163,7 +1167,8 @@ func (tsv *TabletServer) beginWaitForSameRangeTransactions(ctx context.Context, 
 			}
 
 			return waitErr
-		})
+		},
+	)
 	return txDone, err
 }
 


### PR DESCRIPTION
## What's this?

Adds a per-query admission controller to vttablet. Concurrent in-flight limits are
encoded as SQL comment directives that travel with the query:

```sql
SELECT /*vt+ CONCURRENCY=workload:OLAP:5,caller:analytics:3 */ * FROM t
```

Each Spec{Key, Value, Limit} is acquired atomically (all-or-nothing under a single
mutex) before a query executes and released on completion. Limit=0 is observe-only --
the LimiterConcurrencyLevelReached counter histogram lets operators pick limits from
real traffic before enabling enforcement.

## How it works

- New package go/vt/vttablet/tabletserver/limiter -- ported from an internal prototype, with per-instance stats via env.Exporter() (auto-bridges to Prometheus).
- Hook placement -- query_executor.go Execute and Stream, immediately after queryThrottler.Throttle, covering all query traffic including transactional DML.
- LimiterSpecs is parsed once in getPlan/getStreamPlan and cached on TabletPlan; no per-request parsing overhead.
- Disabled by default (--enable-concurrency-limiter=false). Dry-run mode (--concurrency-limiter-dry-run) always admits but keeps the histogram honest.
- Rejected requests return RESOURCE_EXHAUSTED naming the offending dimension.

## Caveats

- LimiterConcurrency gauge is keyed by Key only; two values under one key race (last-writer-wins). LimiterConcurrencyLevelReached is the authoritative tuning signal.
- A truly-leading vt+ comment (before the verb) is stripped as a margin comment before parsing -- specs will be nil. Pinned with a test.
- vtgate directive passthrough not yet verified end-to-end.

---
_Most of this was written by Claude Code -- I provided direction._