### PR TITLE
vtorc: reset `CurrentErrantGTIDCount` gauge when errant GTIDs are resolved

### DIFF
--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -406,6 +406,7 @@ Cleanup:
 
 // detectErrantGTIDs detects the errant GTIDs on an instance.
 func detectErrantGTIDs(instance *Instance, tablet *topodatapb.Tablet) (err error) {
+	tabletAliasString := topoproto.TabletAliasString(instance.InstanceAlias)
 	// If the tablet is not replicating from anyone, then it could be the previous primary.
 	// We should check for errant GTIDs by finding the difference with the shard's current primary.
 	primaryAlias, _, err := ReadShardPrimaryInformation(tablet.Keyspace, tablet.Shard)
@@ -416,6 +417,9 @@ func detectErrantGTIDs(instance *Instance, tablet *topodatapb.Tablet) (err error
 	// Check if the current tablet is the primary. If it is, then we don't need to
 	// run errant GTID detection on it.
 	if topoproto.TabletAliasEqual(primaryAlias, instance.InstanceAlias) {
+		// A primary cannot have errant GTIDs relative to itself; clear any
+		// value left over from before this tablet was promoted.
+		currentErrantGTIDCount.Reset(tabletAliasString)
 		return nil
 	}
 
@@ -439,6 +443,7 @@ func detectErrantGTIDs(instance *Instance, tablet *topodatapb.Tablet) (err error
 		}
 	}
 
+	var errantGtidCount int64
 	if instance.ExecutedGtidSet != "" && instance.primaryExecutedGtidSet != "" {
 		// Compare primary & replica GTID sets, but ignore the sets that present the primary's UUID.
 		// This is because vtorc may pool primary and replica at an inconvenient timing,
@@ -469,10 +474,13 @@ func detectErrantGTIDs(instance *Instance, tablet *topodatapb.Tablet) (err error
 			errantGtidSet := redactedExecutedGtidSet.Difference(redactedPrimaryExecutedGtidSet)
 			if !errantGtidSet.Empty() {
 				instance.GtidErrant = errantGtidSet.String()
-				currentErrantGTIDCount.Set(topoproto.TabletAliasString(instance.InstanceAlias), errantGtidSet.Count())
+				errantGtidCount = errantGtidSet.Count()
 			}
 		}
 	}
+	// Always publish the count. Writing 0 here is what allows the gauge to
+	// recover after errant GTIDs are reconciled or a transient race clears.
+	currentErrantGTIDCount.Set(tabletAliasString, errantGtidCount)
 	return err
 }
 

--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -419,6 +419,7 @@ func detectErrantGTIDs(instance *Instance, tablet *topodatapb.Tablet) (err error
 	if topoproto.TabletAliasEqual(primaryAlias, instance.InstanceAlias) {
 		// A primary cannot have errant GTIDs relative to itself; clear any
 		// value left over from before this tablet was promoted.
+		instance.GtidErrant = ""
 		currentErrantGTIDCount.Reset(tabletAliasString)
 		return nil
 	}
@@ -478,8 +479,12 @@ func detectErrantGTIDs(instance *Instance, tablet *topodatapb.Tablet) (err error
 			}
 		}
 	}
-	// Always publish the count. Writing 0 here is what allows the gauge to
-	// recover after errant GTIDs are reconciled or a transient race clears.
+	// Always publish the result. Writing 0 / "" here is what allows the
+	// gauge and GtidErrant field to recover after errant GTIDs are
+	// reconciled or a transient race clears.
+	if errantGtidCount == 0 {
+		instance.GtidErrant = ""
+	}
 	currentErrantGTIDCount.Set(tabletAliasString, errantGtidCount)
 	return err
 }

--- a/go/vt/vtorc/inst/instance_dao_test.go
+++ b/go/vt/vtorc/inst/instance_dao_test.go
@@ -1184,10 +1184,10 @@ func TestErrantGTIDCountGaugeIsResetWhenResolved(t *testing.T) {
 	// Second poll: the errant GTID has been reconciled (e.g., via the
 	// empty-transaction injection technique on the primary), so the primary's
 	// executed GTID set now also includes the replica UUID range.
-	replicaInstance.GtidErrant = ""
 	replicaInstance.primaryExecutedGtidSet = primaryUUID + ":1-100," + replicaUUID + ":1"
 	require.NoError(t, detectErrantGTIDs(replicaInstance, replicaTablet))
-	require.Empty(t, replicaInstance.GtidErrant)
+	require.Empty(t, replicaInstance.GtidErrant,
+		"GtidErrant should be cleared on the no-errant path so callers reusing the Instance don't see stale state")
 	require.EqualValues(t, 0, currentErrantGTIDCount.Counts()[replicaAlias],
 		"gauge should be reset to 0 after errant GTIDs are resolved")
 }

--- a/go/vt/vtorc/inst/instance_dao_test.go
+++ b/go/vt/vtorc/inst/instance_dao_test.go
@@ -1131,3 +1131,63 @@ func TestPrimaryErrantGTIDs(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, "", instance.GtidErrant)
 }
+
+// TestErrantGTIDCountGaugeIsResetWhenResolved verifies that the per-tablet
+// CurrentErrantGTIDCount gauge is reset to 0 when errant GTIDs are reconciled
+// on a subsequent poll. Previously, the gauge was only ever written when
+// errant GTIDs were detected, so it stuck at the last positive value forever
+// (https://github.com/vitessio/vitess/issues/20258).
+func TestErrantGTIDCountGaugeIsResetWhenResolved(t *testing.T) {
+	defer func() {
+		db.ClearVTOrcDatabase()
+		currentErrantGTIDCount.ResetAll()
+	}()
+	db.ClearVTOrcDatabase()
+	currentErrantGTIDCount.ResetAll()
+
+	keyspaceName := "ks"
+	shardName := "0"
+	primaryUUID := "230ea8ea-81e3-11e4-972a-e25ec4bd140a"
+	replicaUUID := "316d193c-70e5-11e5-adb2-ecf4bb2262ff"
+
+	primaryTablet := &topodatapb.Tablet{
+		Alias:    &topodatapb.TabletAlias{Cell: "zone-1", Uid: 101},
+		Keyspace: keyspaceName,
+		Shard:    shardName,
+		Type:     topodatapb.TabletType_PRIMARY,
+	}
+	replicaTablet := &topodatapb.Tablet{
+		Alias:    &topodatapb.TabletAlias{Cell: "zone-1", Uid: 100},
+		Keyspace: keyspaceName,
+		Shard:    shardName,
+	}
+	replicaAlias := topoproto.TabletAliasString(replicaTablet.Alias)
+
+	require.NoError(t, SaveShard(topo.NewShardInfo(keyspaceName, shardName, &topodatapb.Shard{
+		PrimaryAlias: primaryTablet.Alias,
+	}, nil)))
+
+	// First poll: the replica has an errant GTID under its own UUID.
+	replicaInstance := &Instance{
+		InstanceAlias:          replicaTablet.Alias,
+		ServerUUID:             replicaUUID,
+		SourceUUID:             primaryUUID,
+		AncestryUUID:           replicaUUID + "," + primaryUUID,
+		ExecutedGtidSet:        primaryUUID + ":1-100," + replicaUUID + ":1",
+		primaryExecutedGtidSet: primaryUUID + ":1-100",
+	}
+	require.NoError(t, detectErrantGTIDs(replicaInstance, replicaTablet))
+	require.Equal(t, replicaUUID+":1", replicaInstance.GtidErrant)
+	require.EqualValues(t, 1, currentErrantGTIDCount.Counts()[replicaAlias],
+		"gauge should be 1 after a single errant GTID is detected")
+
+	// Second poll: the errant GTID has been reconciled (e.g., via the
+	// empty-transaction injection technique on the primary), so the primary's
+	// executed GTID set now also includes the replica UUID range.
+	replicaInstance.GtidErrant = ""
+	replicaInstance.primaryExecutedGtidSet = primaryUUID + ":1-100," + replicaUUID + ":1"
+	require.NoError(t, detectErrantGTIDs(replicaInstance, replicaTablet))
+	require.Empty(t, replicaInstance.GtidErrant)
+	require.EqualValues(t, 0, currentErrantGTIDCount.Counts()[replicaAlias],
+		"gauge should be reset to 0 after errant GTIDs are resolved")
+}


### PR DESCRIPTION
## Description

VTOrc's per-tablet `CurrentErrantGTIDCount` gauge (Prometheus: `vtorc_current_errant_gtid_count`) never returned to `0` after errant GTIDs were reconciled, so the metric behaved like a sticky counter even though it's typed as a gauge.

`detectErrantGTIDs` previously only wrote the gauge when it found a non-empty errant set. Once a tablet went positive it stayed positive until `ForgetInstance` — including the case where a transient polling race between primary and replica `gtid_executed` reads flagged a healthy replica for a single cycle.

The fix tracks the count in a local variable and publishes it once at the end of the function:

```go
var errantGtidCount int64
if instance.ExecutedGtidSet != "" && instance.primaryExecutedGtidSet != "" {
    // ... existing detection logic ...
    if !errantGtidSet.Empty() {
        instance.GtidErrant = errantGtidSet.String()
        errantGtidCount = errantGtidSet.Count()
    }
}
currentErrantGTIDCount.Set(tabletAliasString, errantGtidCount)
```

A successful detection finding zero errant GTIDs now overwrites the stale positive value. Error paths (topo / instance reads failing) still return early without touching the gauge — they don't have a fresh view, so preserving the previous value is correct. The "this tablet is the primary" early return also resets the gauge, covering the post-promotion case where a former replica inherits a stale positive value.

A follow-up commit also clears `instance.GtidErrant` to `""` on the no-errant paths so callers that reuse the struct cannot see a stale errant string while the gauge reports resolved (addresses Copilot review feedback).

**Behavior change worth noting:** after the fix, the gauge carries an explicit `0` entry for every non-primary tablet that has been polled successfully, where previously the label only existed for tablets that had ever been positive. Small cardinality bump bounded by `#non-primary tablets`, and it makes `> 0` alerts work cleanly without the `and on (cluster, keyspace, shard)` workaround the original issue describes.

**Verification:**

- Unit test `TestErrantGTIDCountGaugeIsResetWhenResolved` — fails on `main` (gauge stuck at `1` after reconciliation), passes with the fix.
- Live repro: `examples/local/repro_errant_gtid_sticky_gauge.sh` (attached to the issue) exits `1` / `BUG REPRODUCED` on `main`, exits `0` / `FIX APPLIED` after the fix.

This bug exists on every release since `CurrentErrantGTIDCount` was introduced in #16829 — release-21.0 through `main`. **Backport requested** to release-22 / 23 / 24.

## Related Issue(s)

Fixes #20258

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

User-visible metric change: tablets that have been polled successfully now publish an explicit `0` for `vtorc_current_errant_gtid_count` instead of having no series. Operators with alerts on `vtorc_current_errant_gtid_count > 0` will start receiving correct (transient) clear events instead of permanently sticky `1`s; the `and on (cluster, keyspace, shard)` workaround called out in #20258 is no longer required.

### AI Disclosure

This PR was written primarily by Claude Code — I just provided direction.