### PR TITLE
vtgate: fix vstream StopOnReshard hang on reshard convergence

### DIFF
--- a/go/vt/vtgate/vstream_manager.go
+++ b/go/vt/vtgate/vstream_manager.go
@@ -419,7 +419,8 @@ func (vs *vstream) stream(ctx context.Context) error {
 		}()
 	}
 
-	vs.wg.Go(func() {
+	var sendWg sync.WaitGroup
+	sendWg.Go(func() {
 		// sendEvents returns either if the given context has been canceled or if
 		// an error is returned from the callback. If the callback returns an error,
 		// we need to cancel the context to stop the other stream goroutines
@@ -435,6 +436,8 @@ func (vs *vstream) stream(ctx context.Context) error {
 		vs.startOneStream(ctx, sgtid)
 	}
 	vs.wg.Wait()
+	close(vs.eventCh)
+	sendWg.Wait()
 
 	return vs.getError()
 }
@@ -474,7 +477,10 @@ func (vs *vstream) sendEvents(ctx context.Context) {
 				vs.setError(ctx.Err(), "context ended while sending events")
 			})
 			return
-		case evs := <-vs.eventCh:
+		case evs, ok := <-vs.eventCh:
+			if !ok {
+				return
+			}
 			if err := send(evs); err != nil {
 				log.Info(fmt.Sprintf("Error in vstream send events to client: %v", err))
 				vs.once.Do(func() {

--- a/go/vt/vtgate/vstream_manager.go
+++ b/go/vt/vtgate/vstream_manager.go
@@ -479,6 +479,8 @@ func (vs *vstream) sendEvents(ctx context.Context) {
 			return
 		case evs, ok := <-vs.eventCh:
 			if !ok {
+				// The channel is closed once all shard streams have ended, so
+				// there are no more events to send.
 				return
 			}
 			if err := send(evs); err != nil {

--- a/go/vt/vtgate/vstream_manager_test.go
+++ b/go/vt/vtgate/vstream_manager_test.go
@@ -1404,6 +1404,81 @@ func TestVStreamJournalManyToOne(t *testing.T) {
 	require.EqualExportedValues(t, want1, receivedResponses[2])
 }
 
+func TestVStreamStopOnReshardEndsWhenParticipantsConverge(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+
+		ks := "TestVStream"
+		cell := "aa"
+		_ = createSandbox(ks)
+		hc := discovery.NewFakeHealthCheck(nil)
+		st := getSandboxTopo(ctx, cell, ks, []string{"-80", "80-"})
+		vsm := newTestVStreamManager(ctx, hc, st, cell)
+		sbc0 := hc.AddTestTablet(cell, "1.1.1.1", 1001, ks, "-80", topodatapb.TabletType_PRIMARY, true, 1, nil)
+		addTabletToSandboxTopo(t, ctx, st, ks, "-80", sbc0.Tablet())
+		sbc1 := hc.AddTestTablet(cell, "1.1.1.1", 1002, ks, "80-", topodatapb.TabletType_PRIMARY, true, 1, nil)
+		addTabletToSandboxTopo(t, ctx, st, ks, "80-", sbc1.Tablet())
+
+		journal := &binlogdatapb.Journal{
+			Id:            1,
+			MigrationType: binlogdatapb.MigrationType_SHARDS,
+			ShardGtids: []*binlogdatapb.ShardGtid{{
+				Keyspace: ks,
+				Shard:    "-40",
+				Gtid:     "pos40",
+			}, {
+				Keyspace: ks,
+				Shard:    "40-80",
+				Gtid:     "pos4080",
+			}, {
+				Keyspace: ks,
+				Shard:    "80-",
+				Gtid:     "pos80",
+			}},
+			Participants: []*binlogdatapb.KeyspaceShard{{
+				Keyspace: ks,
+				Shard:    "-80",
+			}, {
+				Keyspace: ks,
+				Shard:    "80-",
+			}},
+		}
+		journalEvents := []*binlogdatapb.VEvent{
+			{Type: binlogdatapb.VEventType_BEGIN},
+			{Type: binlogdatapb.VEventType_JOURNAL, Journal: journal},
+			{Type: binlogdatapb.VEventType_GTID, Gtid: "gtid"},
+			{Type: binlogdatapb.VEventType_COMMIT},
+		}
+		sbc0.AddVStreamEvents(journalEvents, nil)
+		sbc1.AddVStreamEvents(journalEvents, nil)
+
+		vgtid := &binlogdatapb.VGtid{
+			ShardGtids: []*binlogdatapb.ShardGtid{{
+				Keyspace: ks,
+				Shard:    "-80",
+				Gtid:     "pos80",
+			}, {
+				Keyspace: ks,
+				Shard:    "80-",
+				Gtid:     "pos80",
+			}},
+		}
+
+		var journalCount int
+		err := vsm.VStream(ctx, topodatapb.TabletType_PRIMARY, vgtid, nil, &vtgatepb.VStreamFlags{StopOnReshard: true}, func(events []*binlogdatapb.VEvent) error {
+			for _, ev := range events {
+				if ev.Type == binlogdatapb.VEventType_JOURNAL {
+					journalCount++
+				}
+			}
+			return nil
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, 2, journalCount)
+	})
+}
+
 func TestVStreamJournalNoMatch(t *testing.T) {
 	ctx := t.Context()
 

--- a/test/config.json
+++ b/test/config.json
@@ -2181,7 +2181,7 @@
       ],
       "Args": [
         "-run",
-        "TestMultiVStreamsKeyspaceReshard",
+        "TestMultiVStreamsKeyspace",
         "-timeout",
         "15m"
       ],


### PR DESCRIPTION
## Description

When a `VStream` is started with `StopOnReshard`, the per-shard stream goroutines and the send goroutine (which drains `vs.eventCh` into the client callback) all shared the same `vs.wg` `WaitGroup`.

On reshard convergence, every participant shard goroutine returns cleanly (`io.EOF` → `nil`), so `vs.cancel()` is never called (it only fires on error). The send goroutine then blocks forever on `<-vs.eventCh`, and `vs.wg.Wait()` hangs. The stream never ends cleanly:

- on `main`/`release-24.0` it stalls until the 10-minute liveness timeout fails the stream with `UNAVAILABLE`;
- on `release-23.0` (no liveness timer) it never returns at all — a permanent hang / goroutine leak.

### How it's fixed

The send goroutine is moved to its own `WaitGroup`. After all shard streams finish (`vs.wg.Wait()`), we `close(vs.eventCh)` to signal the send goroutine to drain and return, then `sendWg.Wait()`. `sendEvents` now returns when the channel is closed. `close` is safe because every writer to `eventCh` lives in `vs.wg` and has exited by then.

### Why it went uncaught

The only e2e test that asserts a `StopOnReshard` stream ends cleanly (`TestMultiVStreamsKeyspaceStopOnReshard`, `require.True(streamStopped)`) **never ran in CI**: the `vstream` shard's `-run TestMultiVStreamsKeyspaceReshard` regex is not a substring of `TestMultiVStreamsKeyspace`**`StopOn`**`Reshard`. This PR broadens that one regex to `TestMultiVStreamsKeyspace` so both reshard tests run. The wider audit of orphaned e2e tests is tracked in #20261.

Verified locally:

| | `main` (buggy) | with fix |
|---|---|---|
| `synctest` unit test | fails (virtual clock hits the liveness error) | pass (0.02s) |
| e2e `TestMultiVStreamsKeyspaceStopOnReshard` | FAIL after 658s (`UNAVAILABLE`) | PASS in 67s |
| `TestVStream*` `-race` | — | pass |

## Related Issue(s)

Extracted from #20213, which bundled this fix with an opt-in MySQL-streaming feature; splitting it out per the breakdown in that PR so it can land (and backport) on its own.

Related to #20261 (orphaned e2e tests / proposed CI guard).

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

**Backport justification:** This is a correctness/availability fix for a real hang in the `StopOnReshard` vstream path. It affects `release-23.0` (permanent hang) and `release-24.0` (10-minute stall ending in `UNAVAILABLE`), so it should be backported to both.

## Deployment Notes

User-visible behavior change: a `StopOnReshard` `VStream` now ends cleanly (with `io.EOF`) once the reshard participants converge, instead of stalling until the liveness timeout (or indefinitely on 23.0).

### AI Disclosure

This PR was written primarily by Claude Code; I provided direction and review.
