### PR TITLE
servenv: constant-time password compare in static grpc auth plugin

### DIFF
--- a/go/vt/servenv/grpc_server_auth_static.go
+++ b/go/vt/servenv/grpc_server_auth_static.go
@@ -18,6 +18,7 @@ package servenv
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -75,7 +76,7 @@ func (sa *StaticAuthPlugin) Authenticate(ctx context.Context, fullMethod string)
 		username := md["username"][0]
 		password := md["password"][0]
 		for _, authEntry := range sa.entries {
-			if username == authEntry.Username && password == authEntry.Password {
+			if username == authEntry.Username && subtle.ConstantTimeCompare([]byte(password), []byte(authEntry.Password)) == 1 {
 				return newStaticAuthContext(ctx, username), nil
 			}
 		}


### PR DESCRIPTION
## Description

The gRPC `StaticAuthPlugin.Authenticate` compared the caller-supplied password against the configured password with Go's `==` operator. String `==` short-circuits at the first differing byte, so the response time reveals how many leading bytes matched. `Authenticate` is registered as the unary/stream gRPC auth interceptor and runs on every incoming request, and the username/password are taken straight from the request metadata (`md["username"][0]` / `md["password"][0]`), so the values are attacker-controlled and the timing oracle is reachable by an unauthenticated network client.

This switches the password comparison to `subtle.ConstantTimeCompare`, which takes the same time regardless of where the first mismatch falls. It mirrors the constant-time check already used for the static MySQL auth server in `go/mysql/auth_server_static.go`. Valid and invalid credentials are still accepted/rejected exactly as before; only the comparison timing changes.

Small, self-contained fix and a reasonable backport candidate.

## Related Issue(s)

None. Small self-contained security fix with no separate tracking issue.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

No deterministic test is included: a functional accept/reject test passes identically with and without the fix, and a timing-based test is inherently flaky on shared CI runners, so it would not reliably guard the change.

## Deployment Notes

None. No schema changes, no flags, no migrations. Authentication behavior is unchanged for valid and invalid credentials.

### AI Disclosure

Written by hand, modeled on the existing `subtle.ConstantTimeCompare` check in `go/mysql/auth_server_static.go`.
