### PR TITLE
vttablet: stop Stream from clobbering non-keyspace field schemas

### DIFF
--- a/go/sqltypes/result.go
+++ b/go/sqltypes/result.go
@@ -94,12 +94,14 @@ func (result *Result) Repair(fields []*querypb.Field) {
 	}
 }
 
-// ReplaceKeyspace replaces all the non-empty Database identifiers in the result
-// set with the given keyspace name
-func (result *Result) ReplaceKeyspace(keyspace string) {
+// ReplaceKeyspace rewrites the Database identifier of every field whose
+// Database matches dbName (the physical MySQL database name) to the given
+// keyspace name. Fields referencing other schemas (e.g. information_schema)
+// are left intact.
+func (result *Result) ReplaceKeyspace(dbName, keyspace string) {
 	// Change database name in mysql output to the keyspace name
 	for _, f := range result.Fields {
-		if f.Database != "" {
+		if f.Database == dbName {
 			f.Database = keyspace
 		}
 	}

--- a/go/sqltypes/result_test.go
+++ b/go/sqltypes/result_test.go
@@ -355,14 +355,19 @@ func TestReplaceKeyspace(t *testing.T) {
 			Database: "vttest",
 		}, {
 			Type: VarBinary,
+		}, {
+			Type:     VarChar,
+			Database: "information_schema",
 		}},
 	}
 
-	result.ReplaceKeyspace("keyspace-name")
+	result.ReplaceKeyspace("vttest", "keyspace-name")
 	assert.Equal(t, "keyspace-name", result.Fields[0].Database)
 	assert.Equal(t, "keyspace-name", result.Fields[1].Database)
 	// Expect empty database identifiers to remain empty
 	assert.Equal(t, "", result.Fields[2].Database)
+	// Expect databases that don't match the physical db name to be left intact
+	assert.Equal(t, "information_schema", result.Fields[3].Database)
 }
 
 func TestShallowCopy(t *testing.T) {

--- a/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
+++ b/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
@@ -173,6 +173,28 @@ func TestSystemSchemaQueryWithoutQualifier(t *testing.T) {
 	require.Equal(t, qr2, qr3)
 }
 
+func TestSystemSchemaFieldDatabaseInOLAP(t *testing.T) {
+	if clusterInstance.HasPartialKeyspaces {
+		t.Skip("partial keyspace detected, skipping test")
+	}
+	mcmp, closer := start(t)
+	defer closer()
+
+	query := fmt.Sprintf("select * from information_schema.tables where table_schema = '%s' limit 1", keyspaceName)
+
+	utils.Exec(t, mcmp.VtConn, "set workload = oltp")
+	oltp := utils.Exec(t, mcmp.VtConn, query)
+
+	utils.Exec(t, mcmp.VtConn, "set workload = olap")
+	olap := utils.Exec(t, mcmp.VtConn, query)
+
+	require.Equal(t, len(oltp.Fields), len(olap.Fields))
+	for i := range oltp.Fields {
+		assert.Equal(t, oltp.Fields[i].Database, olap.Fields[i].Database,
+			"field %q Database differs between OLTP and OLAP", oltp.Fields[i].Name)
+	}
+}
+
 func TestMultipleSchemaPredicates(t *testing.T) {
 	if clusterInstance.HasPartialKeyspaces {
 		t.Skip("test can randomly select one of the shards, and the shards are in different keyspaces")

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -389,7 +389,7 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 						// being shared
 
 						if replaceKeyspace != "" {
-							result.ReplaceKeyspace(replaceKeyspace)
+							result.ReplaceKeyspace(qre.tsv.config.DB.DBName, replaceKeyspace)
 						}
 						return callback(result)
 					})
@@ -426,7 +426,7 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 		defer returnStreamResult(result)
 
 		if replaceKeyspace != "" {
-			result.ReplaceKeyspace(replaceKeyspace)
+			result.ReplaceKeyspace(qre.tsv.config.DB.DBName, replaceKeyspace)
 		}
 		return callback(result)
 	})

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -988,13 +988,7 @@ func (tsv *TabletServer) execute(ctx context.Context, target *querypb.Target, sq
 			if tsv.sm.target.Keyspace != tsv.config.DB.DBName && sqltypes.IncludeFieldsOrDefault(options) == querypb.ExecuteOptions_ALL {
 				switch qre.plan.PlanID {
 				case planbuilder.PlanSelect, planbuilder.PlanSelectImpossible:
-					dbName := tsv.config.DB.DBName
-					ksName := tsv.sm.target.Keyspace
-					for _, f := range result.Fields {
-						if f.Database == dbName {
-							f.Database = ksName
-						}
-					}
+					result.ReplaceKeyspace(tsv.config.DB.DBName, tsv.sm.target.Keyspace)
 				}
 			}
 			return nil


### PR DESCRIPTION
## Description

In streaming (OLAP) mode, the query path rewrote the `Database` of *every* field with a non-empty schema to the keyspace name, via the unconditional `Result.ReplaceKeyspace`. For `information_schema`/`mysql`/`performance_schema` queries this corrupted the field metadata — e.g. `select * from information_schema.tables` in OLAP came back with fields whose `Database` was the keyspace name instead of `information_schema`. The non-streaming (OLTP) `Execute` path already did the right thing: it only rewrote a field whose `Database` matched the physical MySQL DB name.

This makes the two paths consistent. `Result.ReplaceKeyspace` now takes the physical db name and rewrites only the fields that match it, and the inline loop in the `Execute` path is replaced with a call to the same helper.

This is the deferred half of the work started in #20215, where the new raw-streaming path already adopted the correct conditional semantics.

## Related Issue(s)

Fixes #19570

## Backport

Requesting backport to **release-23.0** and **release-24.0** (release-22.0 is EOL). Both branches still carry the unconditional `ReplaceKeyspace` rewrite, so the bug is present there.

**Why:** This is a correctness bug — in OLAP mode, field metadata for `information_schema`/`mysql`/`performance_schema` columns is relabeled with the keyspace name, which breaks schema-introspection tools and ORMs that read those schemas. The fix simply aligns the streaming path with the semantics the non-streaming `Execute` path has always used, so the risk is low and contained.

**API note:** This changes the signature of the exported `sqltypes.Result.ReplaceKeyspace` helper. The method is internal to the tablet serving path (its only callers are in `query_executor.go` and `tabletserver.go`), so direct external use is highly unlikely, but it is technically a public-API change. If we'd rather avoid any exported-API change on the release branches, the backport can instead inline the conditional at the two `Stream` call sites and leave `ReplaceKeyspace` untouched.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

User-visible correctness change: in OLAP mode, field metadata for `information_schema`/`mysql`/`performance_schema` columns is no longer relabeled with the keyspace name. Regular keyspace tables are unaffected (their physical DB name still maps to the keyspace name in both modes).

### AI Disclosure

This PR was written primarily by Claude Code — I provided direction and review.
