### PR TITLE
vtgate: build specialized plans for prepared statements in OLAP/streaming mode

### DIFF
--- a/go/cmd/vtgateclienttest/services/callerid.go
+++ b/go/cmd/vtgateclienttest/services/callerid.go
@@ -100,11 +100,11 @@ func (c *callerIDClient) ExecuteBatch(ctx context.Context, session *vtgatepb.Ses
 	return c.fallbackClient.ExecuteBatch(ctx, session, sqlList, bindVariablesList)
 }
 
-func (c *callerIDClient) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error) {
+func (c *callerIDClient) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, prepared bool, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error) {
 	if ok, err := c.checkCallerID(ctx, sql); ok {
 		return session, err
 	}
-	return c.fallbackClient.StreamExecute(ctx, mysqlCtx, session, sql, bindVariables, callback)
+	return c.fallbackClient.StreamExecute(ctx, mysqlCtx, session, sql, bindVariables, prepared, callback)
 }
 
 // ExecuteMulti is part of the VTGateService interface
@@ -132,7 +132,7 @@ func (c *callerIDClient) StreamExecuteMulti(ctx context.Context, mysqlCtx vtgate
 	}
 	for idx, query := range queries {
 		firstPacket := true
-		session, err = c.StreamExecute(ctx, mysqlCtx, session, query, nil, func(result *sqltypes.Result) error {
+		session, err = c.StreamExecute(ctx, mysqlCtx, session, query, nil, false, func(result *sqltypes.Result) error {
 			err = callback(sqltypes.QueryResponse{QueryResult: result}, idx < len(queries)-1, firstPacket)
 			firstPacket = false
 			return err

--- a/go/cmd/vtgateclienttest/services/echo.go
+++ b/go/cmd/vtgateclienttest/services/echo.go
@@ -118,7 +118,7 @@ func (c *echoClient) Execute(
 	return c.fallbackClient.Execute(ctx, mysqlCtx, session, sql, bindVariables, prepared)
 }
 
-func (c *echoClient) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error) {
+func (c *echoClient) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, prepared bool, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error) {
 	if strings.HasPrefix(sql, EchoPrefix) {
 		callback(echoQueryResult(map[string]any{
 			"callerId": callerid.EffectiveCallerIDFromContext(ctx),
@@ -128,7 +128,7 @@ func (c *echoClient) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.M
 		}))
 		return session, nil
 	}
-	return c.fallbackClient.StreamExecute(ctx, mysqlCtx, session, sql, bindVariables, callback)
+	return c.fallbackClient.StreamExecute(ctx, mysqlCtx, session, sql, bindVariables, prepared, callback)
 }
 
 // ExecuteMulti is part of the VTGateService interface

--- a/go/cmd/vtgateclienttest/services/errors.go
+++ b/go/cmd/vtgateclienttest/services/errors.go
@@ -139,11 +139,11 @@ func (c *errorClient) ExecuteBatch(ctx context.Context, session *vtgatepb.Sessio
 	return c.fallbackClient.ExecuteBatch(ctx, session, sqlList, bindVariablesList)
 }
 
-func (c *errorClient) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error) {
+func (c *errorClient) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, prepared bool, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error) {
 	if err := requestToError(sql); err != nil {
 		return session, err
 	}
-	return c.fallbackClient.StreamExecute(ctx, mysqlCtx, session, sql, bindVariables, callback)
+	return c.fallbackClient.StreamExecute(ctx, mysqlCtx, session, sql, bindVariables, prepared, callback)
 }
 
 // ExecuteMulti is part of the VTGateService interface

--- a/go/cmd/vtgateclienttest/services/fallback.go
+++ b/go/cmd/vtgateclienttest/services/fallback.go
@@ -55,8 +55,8 @@ func (c fallbackClient) ExecuteBatch(ctx context.Context, session *vtgatepb.Sess
 	return c.fallback.ExecuteBatch(ctx, session, sqlList, bindVariablesList)
 }
 
-func (c fallbackClient) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error) {
-	return c.fallback.StreamExecute(ctx, mysqlCtx, session, sql, bindVariables, callback)
+func (c fallbackClient) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, prepared bool, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error) {
+	return c.fallback.StreamExecute(ctx, mysqlCtx, session, sql, bindVariables, prepared, callback)
 }
 
 func (c fallbackClient) ExecuteMulti(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sqlString string) (newSession *vtgatepb.Session, qrs []*sqltypes.Result, err error) {

--- a/go/cmd/vtgateclienttest/services/terminal.go
+++ b/go/cmd/vtgateclienttest/services/terminal.go
@@ -69,7 +69,7 @@ func (c *terminalClient) ExecuteBatch(ctx context.Context, session *vtgatepb.Ses
 	return session, nil, errTerminal
 }
 
-func (c *terminalClient) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error) {
+func (c *terminalClient) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, prepared bool, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error) {
 	return session, errTerminal
 }
 

--- a/go/test/endtoend/preparestmt/stmt_methods_test.go
+++ b/go/test/endtoend/preparestmt/stmt_methods_test.go
@@ -484,36 +484,73 @@ func TestInsertTest(t *testing.T) {
 	assert.Equal(t, int64(1), ra)
 }
 
+// specializedPlanQueries are prepared queries whose baseline plan is a scatter
+// (or fails outright, in the window-function case) but whose specialized plan
+// targets a single shard once the equality predicates are known to point at the
+// same shard.
+var specializedPlanQueries = []struct {
+	query string
+	args  []any
+}{{
+	query: `select 1 from t1 tbl1, t1 tbl2 where tbl1.id = ? and tbl2.id = ?`,
+	args:  []any{1, 1},
+}, {
+	query: `select 1 from t1 tbl1, t1 tbl2, t1 tbl3 where tbl1.id = ? and tbl2.id = ? and tbl3.id = ?`,
+	args:  []any{1, 1, 1},
+}, {
+	query: `select 1 from t1 tbl1, t1 tbl2, t1 tbl3, t1 tbl4 where tbl1.id = ? and tbl2.id = ? and tbl3.id = ? and tbl4.id = ?`,
+	args:  []any{1, 1, 1, 1},
+}, {
+	query: `SELECT e.id, e.name, s.age, ROW_NUMBER() OVER (PARTITION BY e.age ORDER BY s.name DESC) AS age_rank FROM t1 e, t1 s where e.id = ? and s.id = ?`,
+	args:  []any{1, 1},
+}}
+
 // TestSpecializedPlan tests the specialized plan generation for the query.
 func TestSpecializedPlan(t *testing.T) {
 	dbInfo.KeyspaceName = sks
 	dbo := Connect(t, "interpolateParams=false")
 	defer dbo.Close()
 
+	runAndValidateSpecializedPlans(t, dbo, dbo.Prepare)
+}
+
+// TestSpecializedPlanStreaming is the OLAP/streaming counterpart of
+// TestSpecializedPlan. Specialized plans are only built on the execute path, so
+// before https://github.com/vitessio/vitess/issues/19569 was fixed the
+// streaming path never built them and the window-function query failed with
+// "window functions are only supported for single-shard queries".
+func TestSpecializedPlanStreaming(t *testing.T) {
+	dbInfo.KeyspaceName = sks
+	dbo := Connect(t, "interpolateParams=false")
+	defer dbo.Close()
+
+	// Pin a single connection so the workload setting and the prepared
+	// statements share the same session.
+	conn, err := dbo.Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = conn.ExecContext(t.Context(), "set workload = olap")
+	require.NoError(t, err)
+
+	runAndValidateSpecializedPlans(t, dbo, func(query string) (*sql.Stmt, error) {
+		return conn.PrepareContext(t.Context(), query)
+	})
+}
+
+// runAndValidateSpecializedPlans prepares and executes specializedPlanQueries
+// using the supplied prepare function, asserts that the optimized branch was
+// taken for every execution, and validates the cached specialized plans.
+func runAndValidateSpecializedPlans(t *testing.T, dbo *sql.DB, prepare func(query string) (*sql.Stmt, error)) {
+	t.Helper()
+
 	oMap := getVarValue[map[string]any](t, "OptimizedQueryExecutions", clusterInstance.VtgateProcess.GetVars)
 	initExecCount := getVarValue[float64](t, "Passthrough", func() map[string]any {
 		return oMap
 	})
 
-	queries := []struct {
-		query string
-		args  []any
-	}{{
-		query: `select 1 from t1 tbl1, t1 tbl2 where tbl1.id = ? and tbl2.id = ?`,
-		args:  []any{1, 1},
-	}, {
-		query: `select 1 from t1 tbl1, t1 tbl2, t1 tbl3 where tbl1.id = ? and tbl2.id = ? and tbl3.id = ?`,
-		args:  []any{1, 1, 1},
-	}, {
-		query: `select 1 from t1 tbl1, t1 tbl2, t1 tbl3, t1 tbl4 where tbl1.id = ? and tbl2.id = ? and tbl3.id = ? and tbl4.id = ?`,
-		args:  []any{1, 1, 1, 1},
-	}, {
-		query: `SELECT e.id, e.name, s.age, ROW_NUMBER() OVER (PARTITION BY e.age ORDER BY s.name DESC) AS age_rank FROM t1 e, t1 s where e.id = ? and s.id = ?`,
-		args:  []any{1, 1},
-	}}
-
-	for _, q := range queries {
-		stmt, err := dbo.Prepare(q.query)
+	for _, q := range specializedPlanQueries {
+		stmt, err := prepare(q.query)
 		require.NoError(t, err)
 
 		for range 5 {
@@ -532,12 +569,12 @@ func TestSpecializedPlan(t *testing.T) {
 	randomExec(t, dbo)
 
 	// Validate Join Query specialized plan.
-	p := getPlanWhenReady(t, queries[0].query, 100*time.Millisecond, clusterInstance.VtgateProcess.ReadQueryPlans)
+	p := getPlanWhenReady(t, specializedPlanQueries[0].query, 100*time.Millisecond, clusterInstance.VtgateProcess.ReadQueryPlans)
 	require.NotNil(t, p, "plan not found")
 	validateJoinSpecializedPlan(t, p)
 
 	// Validate Window Function Query specialized plan with failing baseline plan.
-	p = getPlanWhenReady(t, queries[3].query, 100*time.Millisecond, clusterInstance.VtgateProcess.ReadQueryPlans)
+	p = getPlanWhenReady(t, specializedPlanQueries[3].query, 100*time.Millisecond, clusterInstance.VtgateProcess.ReadQueryPlans)
 	require.NotNil(t, p, "plan not found")
 	validateBaselineErrSpecializedPlan(t, p)
 }

--- a/go/test/endtoend/preparestmt/stmt_methods_test.go
+++ b/go/test/endtoend/preparestmt/stmt_methods_test.go
@@ -484,14 +484,16 @@ func TestInsertTest(t *testing.T) {
 	assert.Equal(t, int64(1), ra)
 }
 
+type specializedPlanQuery struct {
+	query string
+	args  []any
+}
+
 // specializedPlanQueries are prepared queries whose baseline plan is a scatter
 // (or fails outright, in the window-function case) but whose specialized plan
 // targets a single shard once the equality predicates are known to point at the
 // same shard.
-var specializedPlanQueries = []struct {
-	query string
-	args  []any
-}{{
+var specializedPlanQueries = []specializedPlanQuery{{
 	query: `select 1 from t1 tbl1, t1 tbl2 where tbl1.id = ? and tbl2.id = ?`,
 	args:  []any{1, 1},
 }, {
@@ -505,13 +507,34 @@ var specializedPlanQueries = []struct {
 	args:  []any{1, 1},
 }}
 
+// streamingSpecializedPlanQueries mirror specializedPlanQueries with distinct
+// table aliases. The plan cache is keyed by query text and does not include the
+// workload, so reusing the OLTP query strings would let the plans cached by
+// TestSpecializedPlan satisfy the OLAP lookups here — masking whether the
+// streaming path builds the specialized plan itself. Distinct aliases yield the
+// same plan shapes under different cache keys, so the streaming path is forced
+// to build them.
+var streamingSpecializedPlanQueries = []specializedPlanQuery{{
+	query: `select 1 from t1 stbl1, t1 stbl2 where stbl1.id = ? and stbl2.id = ?`,
+	args:  []any{1, 1},
+}, {
+	query: `select 1 from t1 stbl1, t1 stbl2, t1 stbl3 where stbl1.id = ? and stbl2.id = ? and stbl3.id = ?`,
+	args:  []any{1, 1, 1},
+}, {
+	query: `select 1 from t1 stbl1, t1 stbl2, t1 stbl3, t1 stbl4 where stbl1.id = ? and stbl2.id = ? and stbl3.id = ? and stbl4.id = ?`,
+	args:  []any{1, 1, 1, 1},
+}, {
+	query: `SELECT se.id, se.name, ss.age, ROW_NUMBER() OVER (PARTITION BY se.age ORDER BY ss.name DESC) AS age_rank FROM t1 se, t1 ss where se.id = ? and ss.id = ?`,
+	args:  []any{1, 1},
+}}
+
 // TestSpecializedPlan tests the specialized plan generation for the query.
 func TestSpecializedPlan(t *testing.T) {
 	dbInfo.KeyspaceName = sks
 	dbo := Connect(t, "interpolateParams=false")
 	defer dbo.Close()
 
-	runAndValidateSpecializedPlans(t, dbo, dbo.Prepare)
+	runAndValidateSpecializedPlans(t, dbo, dbo.Prepare, specializedPlanQueries)
 }
 
 // TestSpecializedPlanStreaming is the OLAP/streaming counterpart of
@@ -535,13 +558,13 @@ func TestSpecializedPlanStreaming(t *testing.T) {
 
 	runAndValidateSpecializedPlans(t, dbo, func(query string) (*sql.Stmt, error) {
 		return conn.PrepareContext(t.Context(), query)
-	})
+	}, streamingSpecializedPlanQueries)
 }
 
-// runAndValidateSpecializedPlans prepares and executes specializedPlanQueries
+// runAndValidateSpecializedPlans prepares and executes the supplied queries
 // using the supplied prepare function, asserts that the optimized branch was
 // taken for every execution, and validates the cached specialized plans.
-func runAndValidateSpecializedPlans(t *testing.T, dbo *sql.DB, prepare func(query string) (*sql.Stmt, error)) {
+func runAndValidateSpecializedPlans(t *testing.T, dbo *sql.DB, prepare func(query string) (*sql.Stmt, error), queries []specializedPlanQuery) {
 	t.Helper()
 
 	oMap := getVarValue[map[string]any](t, "OptimizedQueryExecutions", clusterInstance.VtgateProcess.GetVars)
@@ -549,7 +572,7 @@ func runAndValidateSpecializedPlans(t *testing.T, dbo *sql.DB, prepare func(quer
 		return oMap
 	})
 
-	for _, q := range specializedPlanQueries {
+	for _, q := range queries {
 		stmt, err := prepare(q.query)
 		require.NoError(t, err)
 
@@ -569,12 +592,12 @@ func runAndValidateSpecializedPlans(t *testing.T, dbo *sql.DB, prepare func(quer
 	randomExec(t, dbo)
 
 	// Validate Join Query specialized plan.
-	p := getPlanWhenReady(t, specializedPlanQueries[0].query, 100*time.Millisecond, clusterInstance.VtgateProcess.ReadQueryPlans)
+	p := getPlanWhenReady(t, queries[0].query, 100*time.Millisecond, clusterInstance.VtgateProcess.ReadQueryPlans)
 	require.NotNil(t, p, "plan not found")
 	validateJoinSpecializedPlan(t, p)
 
 	// Validate Window Function Query specialized plan with failing baseline plan.
-	p = getPlanWhenReady(t, specializedPlanQueries[3].query, 100*time.Millisecond, clusterInstance.VtgateProcess.ReadQueryPlans)
+	p = getPlanWhenReady(t, queries[3].query, 100*time.Millisecond, clusterInstance.VtgateProcess.ReadQueryPlans)
 	require.NotNil(t, p, "plan not found")
 	validateBaselineErrSpecializedPlan(t, p)
 }

--- a/go/vt/vitessdriver/fakeserver_test.go
+++ b/go/vt/vitessdriver/fakeserver_test.go
@@ -118,7 +118,7 @@ func (f *fakeVTGateService) ExecuteBatch(ctx context.Context, session *vtgatepb.
 }
 
 // StreamExecute is part of the VTGateService interface
-func (f *fakeVTGateService) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error) {
+func (f *fakeVTGateService) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, prepared bool, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error) {
 	execCase, ok := f.execMap[sql]
 	if !ok {
 		return session, fmt.Errorf("no match for: %s", sql)
@@ -207,7 +207,7 @@ func (f *fakeVTGateService) StreamExecuteMulti(ctx context.Context, mysqlCtx vtg
 	}
 	for idx, query := range queries {
 		firstPacket := true
-		session, err = f.StreamExecute(ctx, mysqlCtx, session, query, nil, func(result *sqltypes.Result) error {
+		session, err = f.StreamExecute(ctx, mysqlCtx, session, query, nil, false, func(result *sqltypes.Result) error {
 			err = callback(sqltypes.QueryResponse{QueryResult: result}, idx < len(queries)-1, firstPacket)
 			firstPacket = false
 			return err

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -320,6 +320,7 @@ func (e *Executor) StreamExecute(
 	safeSession *econtext.SafeSession,
 	sql string,
 	bindVars map[string]*querypb.BindVariable,
+	prepared bool,
 	callback func(*sqltypes.Result) error,
 ) error {
 	span, ctx := trace.NewSpan(ctx, "executor.StreamExecute")
@@ -422,7 +423,7 @@ func (e *Executor) StreamExecute(
 		return err
 	}
 
-	err = e.newExecute(ctx, mysqlCtx, safeSession, sql, bindVars, false, logStats, resultHandler, srr.storeResultStats)
+	err = e.newExecute(ctx, mysqlCtx, safeSession, sql, bindVars, prepared, logStats, resultHandler, srr.storeResultStats)
 
 	logStats.Error = err
 	saveSessionStats(safeSession, srr.stmtType, srr.rowsAffected, srr.rowsReturned, err)

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -2783,7 +2783,7 @@ func TestStreamingDML(t *testing.T) {
 	for _, tcase := range tcases {
 		sbc.Queries = nil
 		sbc.SetResults([]*sqltypes.Result{tcase.result})
-		err := executor.StreamExecute(ctx, nil, method, session, tcase.query, nil, func(result *sqltypes.Result) error {
+		err := executor.StreamExecute(ctx, nil, method, session, tcase.query, nil, false, func(result *sqltypes.Result) error {
 			qr = result
 			return nil
 		})

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -345,6 +345,7 @@ func executorStream(ctx context.Context, executor *Executor, sql string) (qr *sq
 		econtext.NewSafeSession(nil),
 		sql,
 		nil,
+		false,
 		func(qr *sqltypes.Result) error {
 			results <- qr
 			return nil

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -674,6 +674,7 @@ func TestStreamBuffering(t *testing.T) {
 		econtext.NewSafeSession(session),
 		"select id from music_user_map where id = 1",
 		nil,
+		false,
 		func(qr *sqltypes.Result) error {
 			results = append(results, qr)
 			return nil
@@ -751,6 +752,7 @@ func TestStreamLimitOffset(t *testing.T) {
 		econtext.NewSafeSession(session),
 		"select id, textcol from user order by id limit 2 offset 2",
 		nil,
+		false,
 		func(qr *sqltypes.Result) error {
 			results <- qr
 			return nil

--- a/go/vt/vtgate/executor_stream_test.go
+++ b/go/vt/vtgate/executor_stream_test.go
@@ -103,6 +103,7 @@ func executorStreamMessages(executor *Executor, sql string) (qr *sqltypes.Result
 		econtext.NewSafeSession(session),
 		sql,
 		nil,
+		false,
 		func(qr *sqltypes.Result) error {
 			results <- qr
 			return nil

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -197,7 +197,7 @@ func TestExecutorMaxMemoryRowsExceeded(t *testing.T) {
 		}
 
 		sbclookup.SetResults([]*sqltypes.Result{result})
-		err = executor.StreamExecute(ctx, nil, "TestExecutorMaxMemoryRowsExceeded", session, test.query, nil, fn)
+		err = executor.StreamExecute(ctx, nil, "TestExecutorMaxMemoryRowsExceeded", session, test.query, nil, false, fn)
 		require.NoError(t, err, "maxMemoryRows limit does not apply to StreamExecute")
 	}
 }
@@ -350,7 +350,7 @@ func TestExecutorTransactionsAutoCommitStreaming(t *testing.T) {
 	var results []*sqltypes.Result
 
 	// begin.
-	err := executor.StreamExecute(ctx, nil, "TestExecute", session, "begin", nil, func(result *sqltypes.Result) error {
+	err := executor.StreamExecute(ctx, nil, "TestExecute", session, "begin", nil, false, func(result *sqltypes.Result) error {
 		results = append(results, result)
 		return nil
 	})
@@ -2010,7 +2010,7 @@ func TestOlapSelectDatabase(t *testing.T) {
 		cbInvoked = true
 		return nil
 	}
-	err := executor.StreamExecute(t.Context(), nil, "TestExecute", econtext.NewSafeSession(session), sql, nil, cb)
+	err := executor.StreamExecute(t.Context(), nil, "TestExecute", econtext.NewSafeSession(session), sql, nil, false, cb)
 	assert.NoError(t, err)
 	assert.True(t, cbInvoked)
 }
@@ -2679,7 +2679,7 @@ func TestExecutorVExplainQueries(t *testing.T) {
 	// Test the streaming side as well
 	var results []sqltypes.Row
 	session = econtext.NewAutocommitSession(&vtgatepb.Session{})
-	err = executor.StreamExecute(ctx, nil, "TestExecutorVExplainQueries", session, "vexplain queries select * from user where name = 'apa'", nil, func(result *sqltypes.Result) error {
+	err = executor.StreamExecute(ctx, nil, "TestExecutorVExplainQueries", session, "vexplain queries select * from user where name = 'apa'", nil, false, func(result *sqltypes.Result) error {
 		results = append(results, result.Rows...)
 		return nil
 	})
@@ -2867,7 +2867,7 @@ func TestExecutorTruncateErrors(t *testing.T) {
 	_, err := executorExecSession(ctx, executor, session, "invalid statement", nil)
 	assert.EqualError(t, err, "syntax error at posi [TRUNCATED]")
 
-	err = executor.StreamExecute(ctx, nil, "TestExecute", session, "invalid statement", nil, fn)
+	err = executor.StreamExecute(ctx, nil, "TestExecute", session, "invalid statement", nil, false, fn)
 	assert.EqualError(t, err, "syntax error at posi [TRUNCATED]")
 
 	_, _, err = executor.Prepare(t.Context(), "TestExecute", session, "invalid statement")
@@ -2976,7 +2976,7 @@ func TestExecutorKillStmt(t *testing.T) {
 		})
 		t.Run("stream:"+tc.query+tc.errStr, func(t *testing.T) {
 			mysqlCtx := &fakeMysqlConnection{ErrMsg: tc.errStr}
-			err := executor.StreamExecute(t.Context(), mysqlCtx, "TestExecutorKillStmt", econtext.NewAutocommitSession(&vtgatepb.Session{}), tc.query, nil, func(result *sqltypes.Result) error {
+			err := executor.StreamExecute(t.Context(), mysqlCtx, "TestExecutorKillStmt", econtext.NewAutocommitSession(&vtgatepb.Session{}), tc.query, nil, false, func(result *sqltypes.Result) error {
 				return nil
 			})
 			if tc.errStr != "" {

--- a/go/vt/vtgate/executor_vstream_test.go
+++ b/go/vt/vtgate/executor_vstream_test.go
@@ -78,7 +78,7 @@ func TestVStreamSQLUnsharded(t *testing.T) {
 
 	results := make(chan *sqltypes.Result, 20)
 	go func() {
-		err := executor.StreamExecute(ctx, nil, "TestExecuteStream", econtext.NewAutocommitSession(&vtgatepb.Session{TargetString: KsTestUnsharded}), sql, nil, func(qr *sqltypes.Result) error {
+		err := executor.StreamExecute(ctx, nil, "TestExecuteStream", econtext.NewAutocommitSession(&vtgatepb.Session{TargetString: KsTestUnsharded}), sql, nil, false, func(qr *sqltypes.Result) error {
 			results <- qr
 			return nil
 		})

--- a/go/vt/vtgate/grpcvtgateconn/suite_test.go
+++ b/go/vt/vtgate/grpcvtgateconn/suite_test.go
@@ -172,7 +172,7 @@ func (f *fakeVTGateService) ExecuteBatch(ctx context.Context, session *vtgatepb.
 }
 
 // StreamExecute is part of the VTGateService interface
-func (f *fakeVTGateService) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error) {
+func (f *fakeVTGateService) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, prepared bool, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error) {
 	if f.panics {
 		panic(errors.New("test forced panic"))
 	}
@@ -245,7 +245,7 @@ func (f *fakeVTGateService) StreamExecuteMulti(ctx context.Context, mysqlCtx vtg
 	}
 	for idx, query := range queries {
 		firstPacket := true
-		session, err = f.StreamExecute(ctx, mysqlCtx, session, query, nil, func(result *sqltypes.Result) error {
+		session, err = f.StreamExecute(ctx, mysqlCtx, session, query, nil, false, func(result *sqltypes.Result) error {
 			err = callback(sqltypes.QueryResponse{QueryResult: result}, idx < len(queries)-1, firstPacket)
 			firstPacket = false
 			return err

--- a/go/vt/vtgate/grpcvtgateservice/server.go
+++ b/go/vt/vtgate/grpcvtgateservice/server.go
@@ -241,7 +241,8 @@ func (vtg *VTGate) StreamExecute(request *vtgatepb.StreamExecuteRequest, stream 
 		session = &vtgatepb.Session{Autocommit: true}
 	}
 
-	session, vtgErr := vtg.server.StreamExecute(ctx, nil, session, request.Query.Sql, request.Query.BindVariables, func(value *sqltypes.Result) error {
+	// The streaming gRPC API has no prepared-statement field, so prepared is always false here.
+	session, vtgErr := vtg.server.StreamExecute(ctx, nil, session, request.Query.Sql, request.Query.BindVariables, false, func(value *sqltypes.Result) error {
 		// Send is not safe to call concurrently, but vtgate
 		// guarantees that it's not.
 		return stream.Send(&vtgatepb.StreamExecuteResponse{

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -331,7 +331,7 @@ func (vh *vtgateHandler) ComQuery(c *mysql.Conn, query string, callback func(*sq
 
 	if session.Options.Workload == querypb.ExecuteOptions_OLAP {
 		streamCallback, deferredResult := deferFirstOKOnlyResult(callback)
-		session, err := vh.vtg.StreamExecute(ctx, mysqlCtx, session, query, make(map[string]*querypb.BindVariable), streamCallback)
+		session, err := vh.vtg.StreamExecute(ctx, mysqlCtx, session, query, make(map[string]*querypb.BindVariable), false, streamCallback)
 		if err != nil {
 			return sqlerror.NewSQLErrorFromError(err)
 		}
@@ -397,7 +397,7 @@ func (vh *vtgateHandler) ComQueryMulti(c *mysql.Conn, sql string, callback func(
 		} else {
 			firstPacket := true
 			var deferredResult *sqltypes.Result
-			session, err = vh.vtg.StreamExecute(ctx, mysqlCtx, session, sql, make(map[string]*querypb.BindVariable), func(result *sqltypes.Result) error {
+			session, err = vh.vtg.StreamExecute(ctx, mysqlCtx, session, sql, make(map[string]*querypb.BindVariable), false, func(result *sqltypes.Result) error {
 				if firstPacket && len(result.Fields) == 0 {
 					deferredResult = result
 					firstPacket = false
@@ -464,7 +464,7 @@ func (vh *vtgateHandler) streamExecuteMultiQuery(ctx context.Context, c *mysql.C
 				queryCtx, cancel = context.WithTimeout(ctx, mysqlQueryTimeout)
 				defer cancel()
 			}
-			session, err = vh.vtg.StreamExecute(queryCtx, mysqlCtx, session, query, make(map[string]*querypb.BindVariable), func(result *sqltypes.Result) error {
+			session, err = vh.vtg.StreamExecute(queryCtx, mysqlCtx, session, query, make(map[string]*querypb.BindVariable), false, func(result *sqltypes.Result) error {
 				if firstPacket && len(result.Fields) == 0 {
 					deferredResult = result
 					firstPacket = false
@@ -620,7 +620,7 @@ func (vh *vtgateHandler) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareDat
 
 	if session.Options.Workload == querypb.ExecuteOptions_OLAP {
 		streamCallback, deferredResult := deferFirstOKOnlyResult(callback)
-		_, err := vh.vtg.StreamExecute(ctx, mysqlCtx, session, prepare.PrepareStmt, prepare.BindVars, streamCallback)
+		_, err := vh.vtg.StreamExecute(ctx, mysqlCtx, session, prepare.PrepareStmt, prepare.BindVars, true, streamCallback)
 		if err != nil {
 			return sqlerror.NewSQLErrorFromError(err)
 		}

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -683,7 +683,7 @@ func (vtg *VTGate) ExecuteBatch(ctx context.Context, session *vtgatepb.Session, 
 
 // StreamExecute executes a streaming query.
 // Note we guarantee the callback will not be called concurrently by multiple go routines.
-func (vtg *VTGate) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error) {
+func (vtg *VTGate) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, prepared bool, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error) {
 	// In this context, we don't care if we can't fully parse destination
 	destKeyspace, destTabletType, _, _, _ := vtg.executor.ParseDestinationTarget(session.TargetString)
 	statsKey := []string{"StreamExecute", destKeyspace, topoproto.TabletTypeLString(destTabletType)}
@@ -702,6 +702,7 @@ func (vtg *VTGate) StreamExecute(ctx context.Context, mysqlCtx vtgateservice.MyS
 			safeSession,
 			sql,
 			bindVariables,
+			prepared,
 			func(reply *sqltypes.Result) error {
 				vtg.rowsReturned.Add(statsKey, int64(len(reply.Rows)))
 				vtg.rowsAffected.Add(statsKey, int64(reply.RowsAffected))
@@ -741,7 +742,7 @@ func (vtg *VTGate) StreamExecuteMulti(ctx context.Context, mysqlCtx vtgateservic
 				ctx, cancel = context.WithTimeout(ctx, mysqlQueryTimeout)
 				defer cancel()
 			}
-			session, err = vtg.StreamExecute(ctx, mysqlCtx, session, query, make(map[string]*querypb.BindVariable), func(result *sqltypes.Result) error {
+			session, err = vtg.StreamExecute(ctx, mysqlCtx, session, query, make(map[string]*querypb.BindVariable), false, func(result *sqltypes.Result) error {
 				defer func() {
 					firstPacket = false
 				}()

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -254,6 +254,7 @@ func TestVTGateStreamExecute(t *testing.T) {
 		},
 		"select id from t1",
 		nil,
+		false,
 		func(r *sqltypes.Result) error {
 			qrs = append(qrs, r)
 			return nil
@@ -300,7 +301,7 @@ func TestVTGateBindVarError(t *testing.T) {
 	}, {
 		name: "StreamExecute",
 		f: func() error {
-			_, err := vtg.StreamExecute(ctx, nil, session, "", bindVars, func(_ *sqltypes.Result) error { return nil })
+			_, err := vtg.StreamExecute(ctx, nil, session, "", bindVars, false, func(_ *sqltypes.Result) error { return nil })
 			return err
 		},
 	}}
@@ -344,6 +345,7 @@ func testErrorPropagation(t *testing.T, ctx context.Context, vtg *VTGate, sbcs [
 		session,
 		"select id from t1",
 		nil,
+		false,
 		func(r *sqltypes.Result) error {
 			return nil
 		},

--- a/go/vt/vtgate/vtgateservice/interface.go
+++ b/go/vt/vtgate/vtgateservice/interface.go
@@ -33,7 +33,7 @@ import (
 type VTGateService interface {
 	Execute(ctx context.Context, mysqlCtx MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, prepared bool) (*vtgatepb.Session, *sqltypes.Result, error)
 	ExecuteBatch(ctx context.Context, session *vtgatepb.Session, sqlList []string, bindVariablesList []map[string]*querypb.BindVariable) (*vtgatepb.Session, []sqltypes.QueryResponse, error)
-	StreamExecute(ctx context.Context, mysqlCtx MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error)
+	StreamExecute(ctx context.Context, mysqlCtx MySQLConnection, session *vtgatepb.Session, sql string, bindVariables map[string]*querypb.BindVariable, prepared bool, callback func(*sqltypes.Result) error) (*vtgatepb.Session, error)
 	// Prepare statement support
 	Prepare(ctx context.Context, session *vtgatepb.Session, sql string) (*vtgatepb.Session, []*querypb.Field, uint16, error)
 


### PR DESCRIPTION
## Description

A prepared window-function query that works in OLTP mode fails in OLAP (streaming) mode with:

```
VT12001: unsupported: window functions are only supported for single-shard queries
```

Specialized ("optimized") plans are only built on the execute path, gated on the `prepared` flag — when the baseline plan fails (e.g. a window function over a join) but the query actually targets a single shard once the bind variable values are known, the specialized plan is what makes it succeed.

The problem: `executor.StreamExecute` hard-coded `prepared=false` when calling `newExecute`, and `VTGate.StreamExecute` (and the `vtgateservice.VTGateService` interface) had no `prepared` parameter at all — unlike `Execute`, which carries it. So a prepared statement run in OLAP mode lost the `prepared=true` signal, the specialized plan was never built (`tryOptimizedPlan`/`shouldOptimizePlan` both require it), and the failing baseline plan surfaced to the client.

### How it's fixed

Thread `prepared` through the streaming path, mirroring `Execute`:

- `vtgateservice.VTGateService.StreamExecute`
- `VTGate.StreamExecute`
- `executor.StreamExecute` → `newExecute`

`true` is passed only from the `ComStmtExecute` OLAP call site; `false` everywhere else (the plain `comQuery` paths and the gRPC server).

### Why in-process only (and the alternative we didn't take)

There were two ways to carry `prepared` into the streaming path:

1. **In-process only (this PR).** Add `prepared` to the in-process `vtgateservice.VTGateService.StreamExecute` interface and thread it down to the executor. Prepared statements only ever enter via the MySQL protocol (`COM_STMT_PREPARE`/`COM_STMT_EXECUTE`), and that handler talks to the executor in-process — so this is sufficient to fix the bug, with no proto or codegen churn.

2. **Proto-level too.** Also add a `prepared` field to the `StreamExecuteRequest` protobuf (the streaming gRPC API has no such field today, while `ExecuteRequest` does). This would make the gRPC streaming API symmetric with `Execute`, but it's a larger change (proto + regeneration + client/server wiring) for **no current consumer** — no gRPC streaming client sends prepared statements. The gRPC server here simply passes `false`, which is a faithful representation of the wire API as it exists.

We went with option 1. If a gRPC streaming client ever needs to send prepared statements, the proto field can be added on top of this without rework.

## Related Issue(s)

Fixes #19569

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

`TestSpecializedPlanStreaming` was added as the OLAP counterpart of `TestSpecializedPlan`; it fails on `main` without this fix (with the VT12001 error above) and passes with it.

## Backport

This is a correctness fix and should be backported to **release-23.0** and **release-24.0**.

Both branches contain the specialized-plan (`PlanSwitcher`) machinery *and* the same `executor.StreamExecute` hard-coding of `prepared=false`, and both have a window-function-over-join query whose baseline plan fails but whose specialized single-shard plan succeeds. So on both branches a prepared window query under `workload=OLAP` returns a `VT12001` error while the identical query in OLTP mode succeeds — the same user-visible bug this PR fixes. (release-23.0 surfaces a different pre-#18903 error string — `OVER CLAUSE with sharded keyspace` — but the failure mode is identical. release-22.0 is EOL.)

The change adds a `prepared` parameter to the `vtgateservice.VTGateService.StreamExecute` Go interface. This is an **internal-only** interface (the one RPC servers call into); it is not part of the gRPC/protobuf wire API — the `StreamExecuteRequest` proto is unchanged. The in-tree blast radius is the executor, the MySQL/gRPC servers, and test fakes, all updated here. The change mirrors the existing `prepared` parameter on `Execute`, so it's low-risk to backport.

## Deployment Notes

User-visible behavioral change: prepared statements whose baseline plan fails but whose specialized single-shard plan succeeds (e.g. window functions filtered to a single shard) now work under `workload=OLAP`, matching OLTP behavior. No configuration or schema changes.

### AI Disclosure

This PR was written primarily by Claude Code — I provided direction and review.

