### PR TITLE
tabletserver: support DML on the StreamExecute path

### DIFF
--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -312,6 +312,22 @@ func TestInsertStmtInOLAP(t *testing.T) {
 	utils.AssertMatches(t, conn, `select id1 from t1 order by id1`, `[[INT64(1)] [INT64(2)] [INT64(3)] [INT64(4)] [INT64(5)]]`)
 }
 
+// TestShardTargetedDMLInOLAP covers https://github.com/vitessio/vitess/issues/19561.
+// When a session targets a specific shard, DML is planned as a Send primitive whose
+// streaming path (used in OLAP mode) issues a StreamExecute RPC to the tablet. DML
+// must succeed on that path and run in an implicit transaction, just like the
+// non-streaming path.
+func TestShardTargetedDMLInOLAP(t *testing.T) {
+	conn, closer := start(t)
+	defer closer()
+
+	utils.Exec(t, conn, `set workload='olap'`)
+	utils.Exec(t, conn, "use `ks:-80`")
+	qr := utils.Exec(t, conn, `insert into t1(id1, id2) values (1, 1)`)
+	require.EqualValues(t, 1, qr.RowsAffected)
+	utils.AssertMatches(t, conn, `select id1, id2 from t1`, `[[INT64(1) INT64(1)]]`)
+}
+
 func TestCreateIndex(t *testing.T) {
 	conn, closer := start(t)
 	defer closer()

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -320,7 +320,7 @@ func TestInsertStmtInOLAP(t *testing.T) {
 // non-streaming path.
 func TestShardTargetedDMLInOLAP(t *testing.T) {
 	conn, closer := start(t)
-	defer closer()
+	t.Cleanup(closer)
 
 	utils.Exec(t, conn, `set workload='olap'`)
 	utils.Exec(t, conn, "use `ks:-80`")
@@ -336,7 +336,7 @@ func TestShardTargetedDMLInOLAP(t *testing.T) {
 // QueryRowsAffected, leaving these DMLs invisible to per-table tablet metrics.
 func TestShardTargetedDMLInOLAPRecordsTabletStats(t *testing.T) {
 	conn, closer := start(t)
-	defer closer()
+	t.Cleanup(closer)
 
 	// The DML below is shard-targeted to -80, so it runs on that shard's primary.
 	primary := shardPrimaryTablet(t, "-80")
@@ -359,7 +359,7 @@ func TestShardTargetedDMLInOLAPRecordsTabletStats(t *testing.T) {
 // error to the client but incremented no QueryErrorCounts.
 func TestShardTargetedFailedDMLInOLAPRecordsErrorStats(t *testing.T) {
 	conn, closer := start(t)
-	defer closer()
+	t.Cleanup(closer)
 
 	// The DML below is shard-targeted to -80, so it runs on that shard's primary.
 	primary := shardPrimaryTablet(t, "-80")

--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -27,6 +27,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/sqlerror"
+	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/utils"
 )
 
@@ -326,6 +327,80 @@ func TestShardTargetedDMLInOLAP(t *testing.T) {
 	qr := utils.Exec(t, conn, `insert into t1(id1, id2) values (1, 1)`)
 	require.EqualValues(t, 1, qr.RowsAffected)
 	utils.AssertMatches(t, conn, `select id1, id2 from t1`, `[[INT64(1) INT64(1)]]`)
+}
+
+// TestShardTargetedDMLInOLAPRecordsTabletStats verifies that DML executed on the
+// streaming path (StreamExecute, used for shard-targeted DML in OLAP mode) records
+// the same per-table query stats on the tablet as the non-streaming Execute path.
+// Before the fix, streamed DML returned the correct result but recorded no
+// QueryRowsAffected, leaving these DMLs invisible to per-table tablet metrics.
+func TestShardTargetedDMLInOLAPRecordsTabletStats(t *testing.T) {
+	conn, closer := start(t)
+	defer closer()
+
+	// The DML below is shard-targeted to -80, so it runs on that shard's primary.
+	primary := shardPrimaryTablet(t, "-80")
+	const statKey = "t1.Insert"
+	rowsAffectedBefore := tabletQueryStat(t, primary, "QueryRowsAffected", statKey)
+
+	utils.Exec(t, conn, `set workload='olap'`)
+	utils.Exec(t, conn, "use `ks:-80`")
+	qr := utils.Exec(t, conn, `insert into t1(id1, id2) values (1, 1)`)
+	require.EqualValues(t, 1, qr.RowsAffected)
+
+	rowsAffectedAfter := tabletQueryStat(t, primary, "QueryRowsAffected", statKey)
+	require.Equal(t, rowsAffectedBefore+1, rowsAffectedAfter,
+		"streamed DML must record QueryRowsAffected on the tablet like the non-streaming path")
+}
+
+// TestShardTargetedFailedDMLInOLAPRecordsErrorStats verifies that a DML that fails
+// on the streaming path records error stats on the tablet, just like the
+// non-streaming Execute path. Before the fix, a failed streamed DML returned the
+// error to the client but incremented no QueryErrorCounts.
+func TestShardTargetedFailedDMLInOLAPRecordsErrorStats(t *testing.T) {
+	conn, closer := start(t)
+	defer closer()
+
+	// The DML below is shard-targeted to -80, so it runs on that shard's primary.
+	primary := shardPrimaryTablet(t, "-80")
+	const statKey = "t1.Insert"
+	errCountBefore := tabletQueryStat(t, primary, "QueryErrorCounts", statKey)
+
+	utils.Exec(t, conn, `set workload='olap'`)
+	utils.Exec(t, conn, "use `ks:-80`")
+	// The first insert succeeds; the duplicate primary key makes the second fail
+	// on the tablet, exercising streamDML's error path.
+	utils.Exec(t, conn, `insert into t1(id1, id2) values (1, 1)`)
+	_, err := utils.ExecAllowError(t, conn, `insert into t1(id1, id2) values (1, 1)`)
+	require.ErrorContains(t, err, "errno 1062")
+
+	errCountAfter := tabletQueryStat(t, primary, "QueryErrorCounts", statKey)
+	require.Equal(t, errCountBefore+1, errCountAfter,
+		"failed streamed DML must record QueryErrorCounts on the tablet like the non-streaming path")
+}
+
+func shardPrimaryTablet(t *testing.T, shardName string) *cluster.Vttablet {
+	t.Helper()
+	for _, shard := range clusterInstance.Keyspaces[0].Shards {
+		if shard.Name == shardName {
+			primary := shard.FindPrimaryTablet()
+			require.NotNilf(t, primary, "no primary tablet for shard %q", shardName)
+			return primary
+		}
+	}
+	require.Failf(t, "shard not found", "no shard %q in keyspace %s", shardName, KeyspaceName)
+	return nil
+}
+
+func tabletQueryStat(t *testing.T, tablet *cluster.Vttablet, varName, key string) float64 {
+	t.Helper()
+	vars := tablet.VttabletProcess.GetVars()
+	counter, ok := vars[varName].(map[string]any)
+	if !ok {
+		return 0
+	}
+	val, _ := counter[key].(float64)
+	return val
 }
 
 func TestCreateIndex(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -266,21 +266,28 @@ func Build(env *vtenv.Environment, statement sqlparser.Statement, tables map[str
 
 // BuildStreaming builds a streaming plan based on the schema.
 func BuildStreaming(statement sqlparser.Statement, tables map[string]*schema.Table) (*Plan, error) {
-	plan := &Plan{
-		PlanID:    PlanSelectStream,
-		FullQuery: GenerateFullQuery(statement),
-	}
-
+	var plan *Plan
 	var err error
 	switch stmt := statement.(type) {
 	case *sqlparser.Select:
+		plan = &Plan{
+			PlanID:    PlanSelectStream,
+			FullQuery: GenerateFullQuery(statement),
+		}
 		if hasLockFunc(stmt) {
 			plan.NeedsReservedConn = true
 		}
 		plan.Table = lookupTables(stmt.From, tables)
 	case *sqlparser.Show, *sqlparser.Union, *sqlparser.CallProc, sqlparser.Explain:
+		plan = &Plan{
+			PlanID:    PlanSelectStream,
+			FullQuery: GenerateFullQuery(statement),
+		}
 	case *sqlparser.Analyze:
-		plan.PlanID = PlanOtherRead
+		plan = &Plan{
+			PlanID:    PlanOtherRead,
+			FullQuery: GenerateFullQuery(statement),
+		}
 	case *sqlparser.Insert:
 		plan, err = analyzeInsert(stmt, tables)
 	case *sqlparser.Update:

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -267,11 +267,11 @@ func Build(env *vtenv.Environment, statement sqlparser.Statement, tables map[str
 // BuildStreaming builds a streaming plan based on the schema.
 func BuildStreaming(statement sqlparser.Statement, tables map[string]*schema.Table) (*Plan, error) {
 	plan := &Plan{
-		PlanID:      PlanSelectStream,
-		FullQuery:   GenerateFullQuery(statement),
-		Permissions: BuildPermissions(statement),
+		PlanID:    PlanSelectStream,
+		FullQuery: GenerateFullQuery(statement),
 	}
 
+	var err error
 	switch stmt := statement.(type) {
 	case *sqlparser.Select:
 		if hasLockFunc(stmt) {
@@ -281,10 +281,20 @@ func BuildStreaming(statement sqlparser.Statement, tables map[string]*schema.Tab
 	case *sqlparser.Show, *sqlparser.Union, *sqlparser.CallProc, sqlparser.Explain:
 	case *sqlparser.Analyze:
 		plan.PlanID = PlanOtherRead
+	case *sqlparser.Insert:
+		plan, err = analyzeInsert(stmt, tables)
+	case *sqlparser.Update:
+		plan, err = analyzeUpdate(stmt, tables)
+	case *sqlparser.Delete:
+		plan, err = analyzeDelete(stmt, tables)
 	default:
 		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "%s not allowed for streaming", sqlparser.ASTToStatementType(statement))
 	}
+	if err != nil {
+		return nil, err
+	}
 	plan.AllTables = lookupAllTables(statement, tables)
+	plan.Permissions = BuildPermissions(statement)
 	return plan, nil
 }
 

--- a/go/vt/vttablet/tabletserver/planbuilder/testdata/stream_cases.txt
+++ b/go/vt/vttablet/tabletserver/planbuilder/testdata/stream_cases.txt
@@ -66,9 +66,48 @@
   "FullQuery": "explain foo"
 }
 
-# dml
+# dml update
 "update a set b = 1"
-"UPDATE not allowed for streaming"
+{
+  "PlanID": "UpdateLimit",
+  "TableName": "a",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 1
+    }
+  ],
+  "FullQuery": "update a set b = 1 limit :#maxLimit"
+}
+
+# dml insert
+"insert into a(foo) values (1)"
+{
+  "PlanID": "Insert",
+  "TableName": "a",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 1
+    }
+  ],
+  "FullQuery": "insert into a(foo) values (1)"
+}
+
+# dml delete
+"delete from a where foo = 1"
+{
+  "PlanID": "DeleteLimit",
+  "TableName": "a",
+  "Permissions": [
+    {
+      "TableName": "a",
+      "Role": 1
+    }
+  ],
+  "FullQuery": "delete from a where foo = 1 limit :#maxLimit",
+  "WhereClause": " where foo = 1"
+}
 
 # syntax error
 "syntax error"

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -432,7 +432,7 @@ func (qe *QueryEngine) getStreamPlan(curSchema *currentSchema, sql string) (*Tab
 	}
 
 	plan := &TabletPlan{Plan: splan, Original: sql}
-	plan.Rules = qe.queryRuleSources.FilterByPlan(sql, plan.PlanID, plan.TableName().String())
+	plan.Rules = qe.queryRuleSources.FilterByPlan(sql, plan.PlanID, plan.TableNames()...)
 	plan.buildAuthorized()
 
 	if sqlparser.CachePlan(statement) {

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -46,6 +46,7 @@ import (
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/tableacl"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/planbuilder"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/rules"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/schema/schematest"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
@@ -279,6 +280,60 @@ func TestStreamQueryPlanCache(t *testing.T) {
 	require.NotNil(t, firstPlan, "plan should not be nil")
 	assertPlanCacheSize(t, qe, 1)
 	qe.ClearQueryPlanCache()
+}
+
+// TestGetStreamPlanFiltersRulesByAllTables ensures the streaming plan path
+// filters query rules using every table the statement touches, matching the
+// non-streaming path. A multi-table DML/SELECT has plan.Table == nil, so
+// filtering by the single TableName() would silently skip table-scoped rules.
+func TestGetStreamPlanFiltersRulesByAllTables(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+	schematest.AddDefaultQueries(db)
+
+	qe := newTestQueryEngine(10*time.Second, true, newDBConfigs(db))
+	qe.se.Open()
+	qe.Open()
+	defer qe.Close()
+
+	// A rule scoped to the second table of a multi-table statement. plan.Table
+	// is nil for multi-table queries, so a single-table-name filter would drop
+	// it.
+	const sourceName = "test stream rules"
+	qr := rules.NewQueryRule("deny test_table_02", "deny_t2", rules.QRFailRetry)
+	qr.AddTableCond("test_table_02")
+	qrs := rules.New()
+	qrs.Add(qr)
+	qe.queryRuleSources.UnRegisterSource(sourceName)
+	qe.queryRuleSources.RegisterSource(sourceName)
+	defer qe.queryRuleSources.UnRegisterSource(sourceName)
+	require.NoError(t, qe.queryRuleSources.SetRules(sourceName, qrs))
+
+	// getStreamPlan is exercised directly with a populated schema so the
+	// planbuilder resolves the referenced tables (the schema engine in this
+	// test harness does not populate the table map).
+	curSchema := &currentSchema{
+		tables: map[string]*schema.Table{
+			"test_table_01": {Name: sqlparser.NewIdentifierCS("test_table_01")},
+			"test_table_02": {Name: sqlparser.NewIdentifierCS("test_table_02")},
+		},
+	}
+
+	testcases := []struct {
+		name string
+		sql  string
+	}{
+		{"multi-table DML", "update test_table_01, test_table_02 set test_table_01.pk = 1"},
+		{"multi-table select", "select test_table_01.pk from test_table_01 join test_table_02 on test_table_01.pk = test_table_02.pk"},
+	}
+	for _, tcase := range testcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			plan, err := qe.getStreamPlan(curSchema, tcase.sql)
+			require.NoError(t, err)
+			require.Nil(t, plan.Table, "expected a multi-table plan with no single table")
+			require.NotNil(t, plan.Rules.Find("deny_t2"), "table-scoped query rule must apply to multi-table streamed query")
+		})
+	}
 }
 
 func TestNoStreamQueryPlanCache(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -464,6 +464,8 @@ func (qre *QueryExecutor) streamDML(callback StreamCallback) (err error) {
 	defer func(start time.Time) {
 		duration := time.Since(start)
 		mysqlTime := qre.logStats.MysqlResponseTime
+		// Plans without a single table (e.g. multi-table statements) have an
+		// empty TableName; bucket their stats under "Join", like Execute.
 		tableName := qre.plan.TableName().String()
 		if tableName == "" {
 			tableName = "Join"

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -475,6 +475,8 @@ func (qre *QueryExecutor) streamDML(callback StreamCallback) error {
 	if err != nil {
 		return err
 	}
+	qre.logStats.RowsAffected = int(reply.RowsAffected)
+	qre.logStats.Rows = reply.Rows
 	return callback(reply)
 }
 

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -349,6 +349,14 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 		qre.recordUserQuery("Stream", int64(time.Since(start)))
 	}(time.Now())
 
+	// DML on the streaming path runs checkPermissions and the request throttler
+	// inside streamDML, so its stats defer is registered before those checks and
+	// records per-table error stats for their rejections too, matching Execute.
+	switch qre.plan.PlanID {
+	case p.PlanInsert, p.PlanUpdate, p.PlanDelete, p.PlanUpdateLimit, p.PlanDeleteLimit:
+		return qre.streamDML(callback)
+	}
+
 	if err := qre.checkPermissions(); err != nil {
 		return err
 	}
@@ -358,8 +366,6 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 	}
 
 	switch qre.plan.PlanID {
-	case p.PlanInsert, p.PlanUpdate, p.PlanDelete, p.PlanUpdateLimit, p.PlanDeleteLimit:
-		return qre.streamDML(callback)
 	case p.PlanSelectStream:
 		if qre.bindVars[sqltypes.BvReplaceSchemaName] != nil {
 			qre.bindVars[sqltypes.BvSchemaName] = sqltypes.StringBindVariable(qre.tsv.config.DB.DBName)
@@ -468,6 +474,14 @@ func (qre *QueryExecutor) streamDML(callback StreamCallback) (err error) {
 		qre.logStats.Rows = reply.Rows
 		qre.tsv.Stats().ResultHistogram.Add(int64(len(reply.Rows)))
 	}(time.Now())
+
+	if err = qre.checkPermissions(); err != nil {
+		return err
+	}
+
+	if err = qre.tsv.queryThrottler.Throttle(qre.ctx, qre.targetTabletType, qre.plan.FullQuery, qre.connID, qre.options); err != nil {
+		return err
+	}
 
 	switch {
 	case qre.connID != 0:

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -448,6 +448,14 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 func (qre *QueryExecutor) streamDML(callback StreamCallback) (err error) {
 	var reply *sqltypes.Result
 
+	// Apply the query timeout to autocommit DML, just like Execute does for a
+	// query without a transaction.
+	if qre.connID == 0 {
+		var cancel context.CancelFunc
+		qre.ctx, cancel = withTimeout(qre.ctx, qre.tsv.loadQueryTimeoutWithTxAndOptions(0, qre.options), qre.options)
+		defer cancel()
+	}
+
 	// Record the per-table and per-plan query stats, just like Execute's deferred
 	// block. Stream's own defer already records QueryTimings, QueryTimingsByTabletType
 	// and the user-query stats, so here we only add the stats the streaming path would

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -439,11 +439,36 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 // same transactional machinery as Execute (an implicit autocommit transaction
 // when none exists, or the active transaction when one does) and the result is
 // delivered through the streaming callback.
-func (qre *QueryExecutor) streamDML(callback StreamCallback) error {
-	var (
-		reply *sqltypes.Result
-		err   error
-	)
+func (qre *QueryExecutor) streamDML(callback StreamCallback) (err error) {
+	var reply *sqltypes.Result
+
+	// Record the per-table and per-plan query stats, just like Execute's deferred
+	// block. Stream's own defer already records QueryTimings, QueryTimingsByTabletType
+	// and the user-query stats, so here we only add the stats the streaming path would
+	// otherwise miss for DML: the QueryEngine/plan counters (including error counts on
+	// the failure path), the query-log fields and the result histogram.
+	defer func(start time.Time) {
+		duration := time.Since(start)
+		mysqlTime := qre.logStats.MysqlResponseTime
+		tableName := qre.plan.TableName().String()
+		if tableName == "" {
+			tableName = "Join"
+		}
+		errCode := vterrors.Code(err).String()
+
+		if reply == nil {
+			qre.tsv.qe.AddStats(qre.plan, tableName, qre.options.GetWorkloadName(), qre.targetTabletType, 1, duration, mysqlTime, 0, 0, 1, errCode)
+			qre.plan.AddStats(1, duration, mysqlTime, 0, 0, 1)
+			return
+		}
+
+		qre.tsv.qe.AddStats(qre.plan, tableName, qre.options.GetWorkloadName(), qre.targetTabletType, 1, duration, mysqlTime, int64(reply.RowsAffected), int64(len(reply.Rows)), 0, errCode)
+		qre.plan.AddStats(1, duration, mysqlTime, reply.RowsAffected, uint64(len(reply.Rows)), 0)
+		qre.logStats.RowsAffected = int(reply.RowsAffected)
+		qre.logStats.Rows = reply.Rows
+		qre.tsv.Stats().ResultHistogram.Add(int64(len(reply.Rows)))
+	}(time.Now())
+
 	switch {
 	case qre.connID != 0:
 		// Run the DML on the existing transaction or reserved connection, just
@@ -456,7 +481,8 @@ func (qre *QueryExecutor) streamDML(callback StreamCallback) error {
 		}
 		defer conn.Unlock()
 		if qre.setting != nil {
-			applied, err := conn.ApplySetting(qre.ctx, qre.setting)
+			var applied bool
+			applied, err = conn.ApplySetting(qre.ctx, qre.setting)
 			if err != nil {
 				return vterrors.Wrap(err, "failed to execute system setting on the connection")
 			}
@@ -475,9 +501,8 @@ func (qre *QueryExecutor) streamDML(callback StreamCallback) error {
 	if err != nil {
 		return err
 	}
-	qre.logStats.RowsAffected = int(reply.RowsAffected)
-	qre.logStats.Rows = reply.Rows
-	return callback(reply)
+	err = callback(reply)
+	return err
 }
 
 // MessageStream streams messages from a message table.

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -358,6 +358,8 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 	}
 
 	switch qre.plan.PlanID {
+	case p.PlanInsert, p.PlanUpdate, p.PlanDelete, p.PlanUpdateLimit, p.PlanDeleteLimit:
+		return qre.streamDML(callback)
 	case p.PlanSelectStream:
 		if qre.bindVars[sqltypes.BvReplaceSchemaName] != nil {
 			qre.bindVars[sqltypes.BvSchemaName] = sqltypes.StringBindVariable(qre.tsv.config.DB.DBName)
@@ -430,6 +432,50 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 		}
 		return callback(result)
 	})
+}
+
+// streamDML executes a DML statement on the streaming path. A DML produces a
+// single rows-affected result with no rows to stream, so it runs through the
+// same transactional machinery as Execute (an implicit autocommit transaction
+// when none exists, or the active transaction when one does) and the result is
+// delivered through the streaming callback.
+func (qre *QueryExecutor) streamDML(callback StreamCallback) error {
+	var (
+		reply *sqltypes.Result
+		err   error
+	)
+	switch {
+	case qre.connID != 0:
+		// Run the DML on the existing transaction or reserved connection, just
+		// like Execute's connID != 0 branch (e.g. a DML following Begin via
+		// BeginStreamExecute).
+		var conn *StatefulConnection
+		conn, err = qre.tsv.te.txPool.GetAndLock(qre.connID, "for query")
+		if err != nil {
+			return err
+		}
+		defer conn.Unlock()
+		if qre.setting != nil {
+			applied, err := conn.ApplySetting(qre.ctx, qre.setting)
+			if err != nil {
+				return vterrors.Wrap(err, "failed to execute system setting on the connection")
+			}
+			// If we have applied the settings on the connection, then we should record the query detail.
+			// This is required for redoing the transaction in case of a failure.
+			if applied {
+				conn.TxProperties().RecordQueryDetail(qre.setting.ApplyQuery(), nil)
+			}
+		}
+		reply, err = qre.txConnExec(conn)
+	case qre.plan.PlanID == p.PlanUpdateLimit || qre.plan.PlanID == p.PlanDeleteLimit:
+		reply, err = qre.execAsTransaction(qre.txConnExec)
+	default:
+		reply, err = qre.execAutocommit(qre.txConnExec)
+	}
+	if err != nil {
+		return err
+	}
+	return callback(reply)
 }
 
 // MessageStream streams messages from a message table.

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1609,6 +1609,41 @@ func TestQueryExecutorStreamDMLErrorStatsOnPermissionDenied(t *testing.T) {
 		"streamed DML rejected by checkPermissions must record per-table error stats like Execute")
 }
 
+// TestQueryExecutorStreamDMLAppliesQueryTimeout verifies that autocommit DML on
+// the streaming path runs under the query timeout, like the non-streaming
+// Execute path. StreamExecute leaves the request timeout unset when there is no
+// transaction (transactionID == 0), so without applying it for DML a stuck
+// INSERT/UPDATE/DELETE would run without a query deadline.
+func TestQueryExecutorStreamDMLAppliesQueryTimeout(t *testing.T) {
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+
+	query := "insert into test_table(a) values(1)"
+	db.AddQuery("insert into test_table(a) values (1)", &sqltypes.Result{RowsAffected: 1})
+
+	ctx := t.Context()
+	tsv := newTestTabletServer(ctx, noFlags, db)
+	defer tsv.StopService()
+
+	qre := newTestQueryExecutorStreaming(ctx, tsv, query, 0)
+	require.Equal(t, planbuilder.PlanInsert, qre.plan.PlanID)
+
+	// Precondition: the executor context starts without a deadline. The unit test
+	// bypasses StreamExecute, which is where a transaction's timeout is set.
+	_, ok := qre.ctx.Deadline()
+	require.False(t, ok)
+
+	err := qre.Stream(func(*sqltypes.Result) error { return nil })
+	require.NoError(t, err)
+
+	// streamDML must have bounded the autocommit DML with the query timeout,
+	// mirroring Execute's loadQueryTimeoutWithTxAndOptions(0, options).
+	deadline, ok := qre.ctx.Deadline()
+	require.True(t, ok, "autocommit streamed DML must run under the query timeout, like Execute")
+	assert.LessOrEqual(t, time.Until(deadline), tsv.loadQueryTimeout(),
+		"the deadline must come from the query timeout")
+}
+
 func TestQueryExecutorShouldConsolidate(t *testing.T) {
 	testCases := []struct {
 		// whether or not the consolidator is enabled by default on the tablet

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1561,6 +1561,54 @@ func TestQueryExecutorStreamDML(t *testing.T) {
 	}
 }
 
+// TestQueryExecutorStreamDMLErrorStatsOnPermissionDenied verifies that a streamed
+// DML rejected by checkPermissions (a QRFail query rule) still records per-table
+// error stats, matching the non-streaming Execute path. The permission and request
+// throttler checks run early, before the DML reaches the database, so streamDML's
+// stats defer must be registered ahead of them to record these rejections.
+func TestQueryExecutorStreamDMLErrorStatsOnPermissionDenied(t *testing.T) {
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+
+	query := "insert into test_table(a) values(1)"
+
+	bannedAddr := "127.0.0.1"
+	bannedUser := "u2"
+
+	denyRule := rules.NewQueryRule("disable insert", "disable insert", rules.QRFail)
+	denyRule.SetIPCond(bannedAddr)
+	denyRule.SetUserCond(bannedUser)
+	denyRule.AddPlanCond(planbuilder.PlanInsert)
+	denyRule.AddTableCond("test_table")
+
+	rulesName := "denyListStreamDMLQRFail"
+	qrs := rules.New()
+	qrs.Add(denyRule)
+
+	callInfo := &fakecallinfo.FakeCallInfo{
+		Remote: bannedAddr,
+		User:   bannedUser,
+	}
+	ctx := callinfo.NewContext(t.Context(), callInfo)
+	tsv := newTestTabletServer(ctx, noFlags, db)
+	defer tsv.StopService()
+	tsv.qe.queryRuleSources.UnRegisterSource(rulesName)
+	tsv.qe.queryRuleSources.RegisterSource(rulesName)
+	defer tsv.qe.queryRuleSources.UnRegisterSource(rulesName)
+	require.NoError(t, tsv.qe.queryRuleSources.SetRules(rulesName, qrs))
+
+	qre := newTestQueryExecutorStreaming(ctx, tsv, query, 0)
+	require.Equal(t, planbuilder.PlanInsert, qre.plan.PlanID)
+
+	errCountBefore := tsv.qe.queryErrorCounts.Counts()["test_table.Insert"]
+	err := qre.Stream(func(*sqltypes.Result) error { return nil })
+	require.Equal(t, vtrpcpb.Code_INVALID_ARGUMENT, vterrors.Code(err))
+
+	errCountAfter := tsv.qe.queryErrorCounts.Counts()["test_table.Insert"]
+	assert.Equal(t, errCountBefore+1, errCountAfter,
+		"streamed DML rejected by checkPermissions must record per-table error stats like Execute")
+}
+
 func TestQueryExecutorShouldConsolidate(t *testing.T) {
 	testCases := []struct {
 		// whether or not the consolidator is enabled by default on the tablet

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1538,6 +1538,9 @@ func TestQueryExecutorStreamDML(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.Equal(t, dmlResult, got)
+			// The streamed DML result must be reflected in the query log,
+			// just like the non-streaming Execute path.
+			assert.Equal(t, int(dmlResult.RowsAffected), qre.logStats.RowsAffected)
 
 			// Inside an existing transaction: the DML must run on that
 			// connection, like Execute's connID != 0 branch.

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1526,8 +1526,7 @@ func TestQueryExecutorStreamDML(t *testing.T) {
 			tsv := newTestTabletServer(ctx, noFlags, db)
 			defer tsv.StopService()
 
-			// Outside a transaction: Stream must start an implicit transaction
-			// for the DML (the gap described in #19564).
+			// Run the DML outside a transaction (autocommit).
 			qre := newTestQueryExecutorStreaming(ctx, tsv, tcase.input, 0)
 			require.Equal(t, tcase.planWant, qre.plan.PlanID)
 
@@ -1542,8 +1541,7 @@ func TestQueryExecutorStreamDML(t *testing.T) {
 			// just like the non-streaming Execute path.
 			assert.Equal(t, int(dmlResult.RowsAffected), qre.logStats.RowsAffected)
 
-			// Inside an existing transaction: the DML must run on that
-			// connection, like Execute's connID != 0 branch.
+			// Run the DML inside an existing transaction.
 			target := tsv.sm.Target()
 			state, err := tsv.Begin(ctx, nil, target, nil)
 			require.NoError(t, err)

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1486,6 +1486,78 @@ func TestReplaceSchemaName(t *testing.T) {
 	}
 }
 
+// TestQueryExecutorStreamDML verifies that DML executed on the streaming path
+// (StreamExecute) runs through the same transactional machinery as Execute and
+// delivers its single result through the callback. Before the fix for #19561
+// and #19564, BuildStreaming rejected DML outright and Stream had no DML
+// handling, so DML in OLAP mode could not start an implicit transaction.
+func TestQueryExecutorStreamDML(t *testing.T) {
+	dmlResult := &sqltypes.Result{RowsAffected: 1}
+
+	testcases := []struct {
+		input     string
+		dbQuery   string
+		planWant  planbuilder.PlanType
+		inTxQuery string
+	}{
+		{
+			input:    "insert into test_table(a) values(1)",
+			dbQuery:  "insert into test_table(a) values (1)",
+			planWant: planbuilder.PlanInsert,
+		},
+		{
+			input:    "update test_table set a=1",
+			dbQuery:  "update test_table set a = 1 limit 10001",
+			planWant: planbuilder.PlanUpdateLimit,
+		},
+		{
+			input:    "delete from test_table where pk = 1",
+			dbQuery:  "delete from test_table where pk = 1 limit 10001",
+			planWant: planbuilder.PlanDeleteLimit,
+		},
+	}
+
+	for _, tcase := range testcases {
+		t.Run(tcase.input, func(t *testing.T) {
+			db := setUpQueryExecutorTest(t)
+			defer db.Close()
+			db.AddQuery(tcase.dbQuery, dmlResult)
+			ctx := t.Context()
+			tsv := newTestTabletServer(ctx, noFlags, db)
+			defer tsv.StopService()
+
+			// Outside a transaction: Stream must start an implicit transaction
+			// for the DML (the gap described in #19564).
+			qre := newTestQueryExecutorStreaming(ctx, tsv, tcase.input, 0)
+			require.Equal(t, tcase.planWant, qre.plan.PlanID)
+
+			var got *sqltypes.Result
+			err := qre.Stream(func(result *sqltypes.Result) error {
+				got = result
+				return nil
+			})
+			require.NoError(t, err)
+			require.Equal(t, dmlResult, got)
+
+			// Inside an existing transaction: the DML must run on that
+			// connection, like Execute's connID != 0 branch.
+			target := tsv.sm.Target()
+			state, err := tsv.Begin(ctx, nil, target, nil)
+			require.NoError(t, err)
+			defer tsv.Commit(ctx, target, state.TransactionID)
+
+			qre = newTestQueryExecutorStreaming(ctx, tsv, tcase.input, state.TransactionID)
+			got = nil
+			err = qre.Stream(func(result *sqltypes.Result) error {
+				got = result
+				return nil
+			})
+			require.NoError(t, err)
+			require.Equal(t, dmlResult, got)
+		})
+	}
+}
+
 func TestQueryExecutorShouldConsolidate(t *testing.T) {
 	testCases := []struct {
 		// whether or not the consolidator is enabled by default on the tablet

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1119,6 +1119,17 @@ func (tsv *TabletServer) BeginStreamExecute(
 	options *querypb.ExecuteOptions,
 	callback func(*sqltypes.Result) error,
 ) (queryservice.TransactionState, error) {
+	// Disable hot row protection in case of reserve connection.
+	if tsv.enableHotRowProtection && reservedID == 0 {
+		txDone, err := tsv.beginWaitForSameRangeTransactions(ctx, target, options, sql, bindVariables)
+		if err != nil {
+			return queryservice.TransactionState{}, err
+		}
+		if txDone != nil {
+			defer txDone()
+		}
+	}
+
 	state, err := tsv.begin(ctx, target, postBeginQueries, reservedID, nil, options)
 	if err != nil {
 		return state, err

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -1155,6 +1155,103 @@ func TestSerializeTransactionsSameRow(t *testing.T) {
 	require.Truef(t, ok && got == want, "only tx2 should have been serialized: ok? %v got: %v want: %v", ok, got, want)
 }
 
+func TestSerializeTransactionsSameRow_StreamExecute(t *testing.T) {
+	ctx := t.Context()
+	// Same scenario as TestSerializeTransactionsSameRow, but the transactions
+	// run through BeginStreamExecute (the OLAP/streaming entry point) instead of
+	// BeginExecute. Hot row protection must serialize them identically: tx1 and
+	// tx2 target the same row, so tx2 cannot start until tx1's query finishes,
+	// while tx3 (a different row) runs concurrently.
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.HotRowProtection.Mode = tabletenv.Enable
+	cfg.HotRowProtection.MaxConcurrency = 1
+	// Reduce the txpool to 2 because we should never consume more than two slots.
+	cfg.TxPool.Size = 2
+	db, tsv := setupTabletServerTestCustom(t, ctx, cfg, "", vtenv.NewTestEnv())
+	defer tsv.StopService()
+	defer db.Close()
+
+	target := querypb.Target{TabletType: topodatapb.TabletType_PRIMARY}
+	countStart := tsv.stats.WaitTimings.Counts()["TabletServerTest.TxSerializer"]
+
+	// Fake data.
+	q1 := "update test_table set name_string = 'tx1' where pk = :pk and `name` = :name"
+	q2 := "update test_table set name_string = 'tx2' where pk = :pk and `name` = :name"
+	q3 := "update test_table set name_string = 'tx3' where pk = :pk and `name` = :name"
+	// Every request needs their own bind variables to avoid data races.
+	bvTx1 := map[string]*querypb.BindVariable{
+		"pk":   sqltypes.Int64BindVariable(1),
+		"name": sqltypes.Int64BindVariable(1),
+	}
+	bvTx2 := map[string]*querypb.BindVariable{
+		"pk":   sqltypes.Int64BindVariable(1),
+		"name": sqltypes.Int64BindVariable(1),
+	}
+	bvTx3 := map[string]*querypb.BindVariable{
+		"pk":   sqltypes.Int64BindVariable(2),
+		"name": sqltypes.Int64BindVariable(1),
+	}
+
+	noop := func(*sqltypes.Result) error { return nil }
+
+	// Make sure that tx2 and tx3 start only after tx1 is running its Execute().
+	tx1Started := make(chan struct{})
+	// Make sure that tx3 could finish while tx2 could not.
+	tx3Finished := make(chan struct{})
+
+	db.SetBeforeFunc("update test_table set name_string = 'tx1' where pk = 1 and `name` = 1 limit 10001",
+		func() {
+			close(tx1Started)
+			if !assert.NoError(t, waitForTxSerializationPendingQueries(tsv, "test_table where pk = 1 and `name` = 1", 2)) {
+				return
+			}
+		})
+
+	// Run all three transactions.
+	wg := sync.WaitGroup{}
+
+	// tx1.
+	wg.Go(func() {
+		state1, err := tsv.BeginStreamExecute(ctx, nil, &target, nil, q1, bvTx1, 0, nil, noop)
+		assert.NoErrorf(t, err, "failed to execute query: %s: %s", q1, err)
+		if _, err := tsv.Commit(ctx, &target, state1.TransactionID); err != nil {
+			assert.NoError(t, err)
+		}
+	})
+
+	// tx2.
+	wg.Go(func() {
+		<-tx1Started
+		state2, err := tsv.BeginStreamExecute(ctx, nil, &target, nil, q2, bvTx2, 0, nil, noop)
+		assert.NoErrorf(t, err, "failed to execute query: %s: %s", q2, err)
+		// TODO(mberlin): This should actually be in the BeforeFunc() of tx1 but
+		// then the test is hanging. It looks like the MySQL C client library cannot
+		// open a second connection while the request of the first connection is
+		// still pending.
+		<-tx3Finished
+		if _, err := tsv.Commit(ctx, &target, state2.TransactionID); err != nil {
+			assert.NoError(t, err)
+		}
+	})
+
+	// tx3.
+	wg.Go(func() {
+		<-tx1Started
+		state3, err := tsv.BeginStreamExecute(ctx, nil, &target, nil, q3, bvTx3, 0, nil, noop)
+		assert.NoErrorf(t, err, "failed to execute query: %s: %s", q3, err)
+		if _, err := tsv.Commit(ctx, &target, state3.TransactionID); err != nil {
+			assert.NoError(t, err)
+		}
+		close(tx3Finished)
+	})
+
+	wg.Wait()
+
+	got, ok := tsv.stats.WaitTimings.Counts()["TabletServerTest.TxSerializer"]
+	want := countStart + 1
+	require.Truef(t, ok && got == want, "only tx2 should have been serialized: ok? %v got: %v want: %v", ok, got, want)
+}
+
 func TestDMLQueryWithoutWhereClause(t *testing.T) {
 	ctx := t.Context()
 	cfg := tabletenv.NewDefaultConfig()


### PR DESCRIPTION
## Description

DML planned in vtgate as a `Send` primitive — which happens for shard-targeted sessions (e.g. `USE ks:-80`) and `LOAD` — is dispatched to the tablet via the **`StreamExecute` RPC** when the session is in OLAP mode (`Send.TryStreamExecute` → `StreamExecuteMulti`). Two tablet-side gaps made that path fail for DML:

- `planbuilder.BuildStreaming` rejected every DML statement with `"INSERT not allowed for streaming"`.
- `QueryExecutor.Stream` had no DML handling at all, so even with a plan it would never start the implicit transaction that `Execute` starts for DML under `autocommit=0`.

This PR closes both gaps for INSERT/UPDATE/DELETE:

- **`BuildStreaming`** now reuses the existing `analyzeInsert`/`analyzeUpdate`/`analyzeDelete`, so streaming DML plans are identical to the non-streaming ones (including the row-limited `UpdateLimit`/`DeleteLimit` variants that cap rows affected via `max_result_size`).
- **`QueryExecutor.Stream`** dispatches DML plans to a new `streamDML` helper that mirrors `Execute`'s transaction handling — an implicit autocommit transaction when none exists, or the active transaction when one does (e.g. after `BeginStreamExecute`) — and delivers the single rows-affected result through the streaming callback.
- **`BeginStreamExecute`** now also applies hot row protection (txserializer), mirroring `BeginExecute`, so streamed DML in a transaction is serialized against same-row writes just like the non-streaming path. (Autocommit DML is unchanged — `Execute` doesn't serialize it either.)
- **`streamDML`** records the same per-table / per-plan tablet stats that `Execute` does — `QueryCounts`, `QueryRowsAffected`, the error counters (incl. `QueryErrorCounts`/`QueryErrorCountsWithCode` on the failure path), the per-plan counters and the result histogram. It's scoped to only the stats `Stream`'s own deferred block doesn't already record, so it doesn't double-count `QueryTimings`/`QueryTimingsByTabletType`/`recordUserQuery`. Without this, a DML run via `StreamExecute` was invisible to per-table tablet metrics, whereas the identical DML via `Execute` was not.

A DML produces only a rows-affected result with no rows to stream, so there's no streaming benefit here; the point is correctness (it should not error) and moving toward unifying the `Execute`/`StreamExecute` paths. Vindex-routed DML (the `Insert`/`Update`/`Delete` primitives) still delegates to `Execute` and is unchanged — making those genuinely stream is a planned follow-up.

Out of scope:
- DDL, SET, migrations, and `LOAD` on the streaming path remain rejected.
- The same stats gap for *completed streaming SELECTs* (`PlanSelectStream` records no `QueryCounts`/`QueryRowsReturned`/error counters) is pre-existing and unchanged here — it's the larger, long-standing item tracked in #3861. Recording it correctly needs accumulation across the per-chunk callbacks (and care around the stream consolidator), unlike the single-result DML case.

## Related Issue(s)

- Fixes #19561
- Fixes #19564
- Fixes #20267 — `streamDML` now records the same per-table / rows-affected (and error) stats as `Execute`

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

User-visible behavioral change: DML in a shard-targeted OLAP session (and other `Send`-routed DML) now succeeds instead of failing with `"INSERT not allowed for streaming"`. The client still receives the correct `RowsAffected`, and the DML is now reflected in the tablet's per-table query stats like the non-streaming path.

### AI Disclosure

This PR was written primarily by Claude Code; I provided direction and review.
