### PR TITLE
ci: bump codecov-action to v6.0.2 to fix GPG verification failure

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -156,7 +156,7 @@ jobs:
 
     - name: Upload coverage reports
       if: steps.mode.outputs.is_full_run == 'true' || (steps.changes.outputs.changed_files == 'true' && steps.packages.outputs.packages != '')
-      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
       with:
         files: coverage.out
         fail_ci_if_error: true


### PR DESCRIPTION
## Description

Our Codecov upload step (`.github/workflows/codecov.yml`) is failing because the Codecov team lost access to their original Keybase account (`codecovsecurity`) and migrated to a new one (`codecovsecops`), deliberately disabling the old account. Older versions of `codecov-action` verify the uploader binary's GPG signature against the old account, so the verification now fails — and since we run with `fail_ci_if_error: true`, this breaks CI. See codecov/codecov-action#1956.

This bumps the pinned action to `v6.0.2` (commit `fb8b3582c8e4def4969c97caa2f19720cb33a72f`), which references the new Keybase account. Main had since moved to `v6.0.1` via a dependabot bump (#20242), but that version predates the fix, so the effective change here is `v6.0.1 → v6.0.2`. The `v7.0.0` tag points at the same commit, so this is the minimal change.

### Backport justification

The codecov workflow is failing on `release-23.0` and `release-24.0` for the same reason — both run with `fail_ci_if_error: true` and pin pre-fix versions of the action. Note for the `release-23.0` backport: that branch pins `v5.5.2`, which is on the v5 line, so it should be bumped to `v5.5.5` (commit `0fb7174895f61a3b6b78fc075e0cd60383518dac`) rather than jumping a major version — the automated cherry-pick will conflict and needs manual resolution.

## Related Issue(s)

Fixes #20269

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

N/A — CI-only change.

### AI Disclosure

This PR was written by Claude Code — I just provided direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)