### PR TITLE
vtgate/buffer: fix deadlock between buffering start and keyspace event delivery

### DIFF
--- a/go/vt/vtgate/buffer/buffer.go
+++ b/go/vt/vtgate/buffer/buffer.go
@@ -200,7 +200,13 @@ func (b *Buffer) WaitForFailoverEnd(ctx context.Context, keyspace, shard string,
 		requestsSkipped.Add([]string{keyspace, shard, skippedDisabled}, 1)
 		return nil, nil
 	}
-	return sb.waitForFailoverEnd(ctx, keyspace, shard, kev, err)
+	// Explicit nil guard: assigning a nil *KeyspaceEventWatcher to the
+	// interface directly would yield a non-nil interface value.
+	var marker shardMarker
+	if kev != nil {
+		marker = kev
+	}
+	return sb.waitForFailoverEnd(ctx, keyspace, shard, marker, err)
 }
 
 func (b *Buffer) HandleKeyspaceEvent(ksevent *discovery.KeyspaceEvent) {

--- a/go/vt/vtgate/buffer/deadlock_repro_test.go
+++ b/go/vt/vtgate/buffer/deadlock_repro_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buffer
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/discovery"
+	"vitess.io/vitess/go/vt/srvtopo/srvtopotest"
+	"vitess.io/vitess/go/vt/vterrors"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+)
+
+// TestStartBufferingDeadlockWithKeyspaceEvents reproduces a deadlock cycle
+// between the shard buffer and the keyspace event watcher:
+//
+//   - Thread A (vtgate request): holds shardBuffer.mu in waitForFailoverEnd ->
+//     startBufferingLocked -> kev.MarkShardNotServing, which blocks acquiring
+//     the keyspaceState.mu.
+//   - Thread X (KeyspaceEventWatcher healthcheck goroutine): holds
+//     keyspaceState.mu in onHealthCheck -> ensureConsistentLocked ->
+//     broadcast, which blocks sending to the full (cap 10) subscriber channel.
+//   - Thread C (the subscriber consumer, TabletGateway.setupBuffering's
+//     goroutine in production): blocks acquiring shardBuffer.mu in
+//     HandleKeyspaceEvent -> recordKeyspaceEvent, so it never returns to
+//     drain the subscriber channel.
+//
+// A waits on X, X waits on C, C waits on A. Each blocking step below is
+// verified via goroutine stacks before the next thread is engaged, so the
+// test deterministically wedges if the cycle exists and passes once any
+// edge of the cycle is broken.
+func TestStartBufferingDeadlockWithKeyspaceEvents(t *testing.T) {
+	const (
+		cell     = "cell1"
+		keyspace = "ks1"
+		shard    = "0"
+	)
+
+	ctx := t.Context()
+
+	srvTopo := srvtopotest.NewPassthroughSrvTopoServer()
+	srvTopo.SrvKeyspaceNames = []string{keyspace}
+	srvTopo.SrvKeyspace = &topodatapb.SrvKeyspace{
+		Partitions: []*topodatapb.SrvKeyspace_KeyspacePartition{{
+			ServedType:      topodatapb.TabletType_PRIMARY,
+			ShardReferences: []*topodatapb.ShardReference{{Name: shard}},
+		}},
+	}
+
+	fhc := discovery.NewFakeHealthCheck(make(chan *discovery.TabletHealth))
+	defer fhc.Close()
+
+	kev := discovery.NewKeyspaceEventWatcher(ctx, srvTopo, fhc, cell)
+	subscriber := kev.Subscribe()
+
+	cfg := NewDefaultConfig()
+	cfg.Enabled = true
+	cfg.Window = 1 * time.Second
+	cfg.MaxFailoverDuration = 2 * time.Second
+	// NOTE: no buf.Shutdown() — when the deadlock engages it would block on
+	// shardBuffer.mu forever and hang the test binary instead of failing.
+	buf := New(cfg)
+
+	// Prime the keyspace event watcher: a serving PRIMARY healthcheck creates
+	// the keyspaceState and shardState, makes the keyspace consistent and
+	// broadcasts one event into the subscriber channel.
+	conn := fhc.AddTestTablet(cell, "1.1.1.1", 1, keyspace, shard, topodatapb.TabletType_PRIMARY, true, 0, nil)
+	tablet := conn.Tablet()
+	fhc.Broadcast(tablet)
+	require.Eventually(t, func() bool {
+		return len(subscriber) == 1
+	}, 30*time.Second, 10*time.Millisecond, "priming keyspace event was not broadcast")
+
+	// Fill the remaining 9 slots of the cap-10 subscriber channel. In
+	// production these are events from other keyspaces backing up while the
+	// consumer goroutine is busy.
+	for range 9 {
+		subscriber <- &discovery.KeyspaceEvent{}
+	}
+
+	// Thread X: flip the primary not-serving -> serving. Processing the
+	// second healthcheck makes the keyspace consistent again, so the
+	// healthcheck goroutine broadcasts while holding keyspaceState.mu and
+	// blocks on the full subscriber channel.
+	fhc.SetServing(tablet, false)
+	fhc.Broadcast(tablet)
+	fhc.SetServing(tablet, true)
+	fhc.Broadcast(tablet)
+	waitForGoroutineIn(t, "discovery.(*KeyspaceEventWatcher).broadcast")
+
+	// Thread A: a request sees a reparent error, takes shardBuffer.mu, tries
+	// to start buffering and blocks on keyspaceState.mu inside
+	// MarkShardNotServing.
+	aDone := make(chan struct{})
+	go func() {
+		defer close(aDone)
+		reparentErr := vterrors.New(vtrpcpb.Code_CLUSTER_EVENT, ClusterEventReparentInProgress)
+		retryDone, _ := buf.WaitForFailoverEnd(ctx, keyspace, shard, kev, reparentErr)
+		if retryDone != nil {
+			retryDone()
+		}
+	}()
+	waitForGoroutineIn(t, "discovery.(*KeyspaceEventWatcher).MarkShardNotServing")
+
+	// Thread C: the subscriber consumer processes an event it received
+	// earlier (before the channel backed up) and blocks on shardBuffer.mu in
+	// recordKeyspaceEvent. Only after that would it return to draining the
+	// subscriber channel, exactly like TabletGateway's consumer goroutine.
+	go func() {
+		buf.HandleKeyspaceEvent(&discovery.KeyspaceEvent{
+			Cell:     cell,
+			Keyspace: keyspace,
+			Shards: []discovery.ShardEvent{{
+				Tablet:  tablet.Alias,
+				Target:  &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_PRIMARY},
+				Serving: true,
+			}},
+		})
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ev := <-subscriber:
+				if ev == nil {
+					return
+				}
+				buf.HandleKeyspaceEvent(ev)
+			}
+		}
+	}()
+
+	// If the cycle exists, thread A never returns: it waits on
+	// keyspaceState.mu (held by X), X waits on the subscriber channel
+	// (drained only by C), and C waits on shardBuffer.mu (held by A).
+	// Without the deadlock, C unblocks, drains the channel, X's broadcast
+	// completes and A's buffered request finishes well within the window
+	// (1s) / max failover duration (2s).
+	select {
+	case <-aDone:
+	case <-time.After(20 * time.Second):
+		stacks := allStacks()
+		require.Failf(t, "deadlock", "WaitForFailoverEnd is deadlocked: sb.mu -> kss.mu -> subscriber channel -> sb.mu\n%s", stacks)
+	}
+}
+
+// waitForGoroutineIn blocks until some goroutine has the given function on
+// its stack, i.e. it is executing or blocked inside it.
+func waitForGoroutineIn(t *testing.T, fn string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return strings.Contains(allStacks(), fn)
+	}, 30*time.Second, 10*time.Millisecond, "no goroutine reached %s", fn)
+}
+
+func allStacks() string {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	return string(buf[:n])
+}

--- a/go/vt/vtgate/buffer/shard_buffer.go
+++ b/go/vt/vtgate/buffer/shard_buffer.go
@@ -81,6 +81,19 @@ type entry struct {
 	bufferCancel func()
 }
 
+// shardMarker is the part of discovery.KeyspaceEventWatcher needed to start
+// a buffering cycle. It is an interface so that tests can control when the
+// call blocks and what it returns.
+//
+// MarkShardNotServing acquires the keyspace event watcher's locks, and the
+// watcher's event delivery in turn blocks on shardBuffer.mu (via
+// Buffer.HandleKeyspaceEvent). It must therefore NEVER be called while
+// holding shardBuffer.mu: doing so deadlocks vtgate (see
+// TestStartBufferingDeadlockWithKeyspaceEvents).
+type shardMarker interface {
+	MarkShardNotServing(ctx context.Context, keyspace, shard string, isReparentErr bool) bool
+}
+
 // shardBuffer buffers requests during a failover for a particular shard.
 // The object will be reused across failovers. If no failover is currently in
 // progress, the state is "IDLE".
@@ -109,6 +122,12 @@ type shardBuffer struct {
 
 	// mu guards the mutable fields below (queue, timers, timestamps).
 	mu sync.RWMutex
+	// generation is incremented for every buffering cycle that is started.
+	// It lets the goroutine which started a cycle (and released mu while
+	// calling shardMarker.MarkShardNotServing) detect whether the BUFFERING
+	// state it observes after re-locking still belongs to its own cycle or
+	// to a successor cycle.
+	generation uint64
 	// queue is the list of buffered requests (ordered by arrival).
 	queue []*entry
 	// lastStart is the last time we saw the start of a failover.
@@ -153,7 +172,7 @@ func (sb *shardBuffer) disabled() bool {
 	return sb.mode == bufferModeDisabled
 }
 
-func (sb *shardBuffer) waitForFailoverEnd(ctx context.Context, keyspace, shard string, kev *discovery.KeyspaceEventWatcher, err error) (RetryDoneFunc, error) {
+func (sb *shardBuffer) waitForFailoverEnd(ctx context.Context, keyspace, shard string, marker shardMarker, err error) (RetryDoneFunc, error) {
 	// We assume if err != nil then it's always caused by a failover.
 	// Other errors must be filtered at higher layers.
 	failoverDetected := err != nil
@@ -229,10 +248,49 @@ func (sb *shardBuffer) waitForFailoverEnd(ctx context.Context, keyspace, shard s
 			return nil, nil
 		}
 
-		// Try to start buffering. If we're unsuccessful, then we exit early.
-		if !sb.startBufferingLocked(ctx, kev, err) {
+		// Reserve the buffering cycle BEFORE telling the keyspace event
+		// watcher: stop events arriving while we mark the shard as not
+		// serving must hit an active state machine instead of being lost
+		// against the IDLE state.
+		sb.startBufferingLocked(err)
+
+		if marker != nil {
+			gen := sb.generation
+			prevLastEnd := sb.lastEnd
+			// Mark the shard as not serving WITHOUT holding sb.mu — see the
+			// shardMarker doc comment for why holding it deadlocks.
 			sb.mu.Unlock()
-			return nil, nil
+			marked := marker.MarkShardNotServing(ctx, keyspace, shard, isErrorDueToReparenting(err))
+			sb.mu.Lock()
+			if !marked {
+				// We failed to mark the shard as not serving. Do not buffer the request.
+				// This can happen if the keyspace has been deleted or if the keyspace event
+				// watcher hasn't yet seen the shard. The keyspace event watcher might not stop
+				// buffering for this request at all until it times out. It's better to not
+				// buffer this request.
+				// Roll back the cycle we started, unless it was already stopped (by a
+				// keyspace event, shutdown, or the max-duration timeout) or superseded
+				// by a newer cycle — those stops are genuine and must stand.
+				if sb.generation == gen && bufferState(sb.state.Load()) == stateBuffering {
+					sb.stopBufferingLocked(stopMarkFailed, "failed to mark the shard as not serving in the keyspace event watcher")
+					// A mark failure is not a failover end: it must not suppress the
+					// next buffering attempt via --buffer-min-time-between-failovers
+					// (e.g. on a cold-start vtgate whose watcher lags behind).
+					sb.lastEnd = prevLastEnd
+				}
+				sb.mu.Unlock()
+				return nil, nil
+			}
+			// The cycle may have been stopped while we were marking. This must be
+			// an exact state check, not shouldBufferLocked: if the cycle stopped
+			// AND fully drained, the state is IDLE again and shouldBufferLocked
+			// would let us enqueue into an empty queue with a nil timeoutThread.
+			// A BUFFERING state is safe to enqueue into even if it belongs to a
+			// successor cycle.
+			if sb.buf.stopped.Load() || bufferState(sb.state.Load()) != stateBuffering {
+				sb.mu.Unlock()
+				return nil, nil
+			}
 		}
 	}
 
@@ -291,21 +349,13 @@ func (sb *shardBuffer) shouldBufferLocked(failoverDetected bool) bool {
 	panic("BUG: All possible states must be covered by the switch expression above.")
 }
 
-func (sb *shardBuffer) startBufferingLocked(ctx context.Context, kev *discovery.KeyspaceEventWatcher, err error) bool {
-	if kev != nil {
-		if !kev.MarkShardNotServing(ctx, sb.keyspace, sb.shard, isErrorDueToReparenting(err)) {
-			// We failed to mark the shard as not serving. Do not buffer the request.
-			// This can happen if the keyspace has been deleted or if the keyspace even watcher
-			// hasn't yet seen the shard. Keyspace event watcher might not stop buffering for this
-			// request at all until it times out. It's better to not buffer this request.
-			return false
-		}
-	}
+func (sb *shardBuffer) startBufferingLocked(err error) {
 	// Reset monitoring data from previous failover.
 	lastRequestsInFlightMax.Set(sb.statsKey, 0)
 	lastRequestsDryRunMax.Set(sb.statsKey, 0)
 	failoverDurationSumMs.Reset(sb.statsKey)
 
+	sb.generation++
 	sb.lastStart = sb.timeNow()
 	sb.logErrorIfStateNotLocked(stateIdle)
 	sb.state.Store(int32(stateBuffering))
@@ -324,7 +374,6 @@ func (sb *shardBuffer) startBufferingLocked(ctx context.Context, kev *discovery.
 		sb.buf.config.Size,
 		sb.buf.config.MaxFailoverDuration,
 		errorsanitizer.NormalizeError(err.Error())))
-	return true
 }
 
 // logErrorIfStateNotLocked logs an error if the current state is not "state".

--- a/go/vt/vtgate/buffer/shard_buffer_mark_test.go
+++ b/go/vt/vtgate/buffer/shard_buffer_mark_test.go
@@ -1,0 +1,442 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buffer
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/discovery"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+)
+
+// The tests in this file pin down the behavior of waitForFailoverEnd while
+// shardBuffer.mu is released around shardMarker.MarkShardNotServing (the
+// "mark window"). The buffering cycle is reserved (IDLE -> BUFFERING) before
+// the mark so that stop events arriving during the window are applied by the
+// normal state machine instead of being lost against the IDLE state.
+
+// fakeShardMarker implements shardMarker with controllable blocking and
+// result, so tests can deterministically interleave other actors with the
+// mark window.
+type fakeShardMarker struct {
+	result bool
+	// entered, if non-nil, receives one message per MarkShardNotServing call
+	// as soon as the call begins.
+	entered chan struct{}
+	// release, if non-nil, blocks every MarkShardNotServing call until it is
+	// closed.
+	release chan struct{}
+	calls   atomic.Int32
+}
+
+func (m *fakeShardMarker) MarkShardNotServing(ctx context.Context, keyspace, shard string, isReparentErr bool) bool {
+	m.calls.Add(1)
+	if m.entered != nil {
+		m.entered <- struct{}{}
+	}
+	if m.release != nil {
+		<-m.release
+	}
+	return m.result
+}
+
+type failoverEndResult struct {
+	retryDone RetryDoneFunc
+	err       error
+}
+
+// issueMarkedRequest runs waitForFailoverEnd with the given marker in a
+// goroutine and returns a channel carrying its result.
+func issueMarkedRequest(ctx context.Context, sb *shardBuffer, ks, sh string, marker shardMarker) chan failoverEndResult {
+	resultCh := make(chan failoverEndResult, 1)
+	go func() {
+		retryDone, err := sb.waitForFailoverEnd(ctx, ks, sh, marker, failoverErr)
+		resultCh <- failoverEndResult{retryDone: retryDone, err: err}
+	}()
+	return resultCh
+}
+
+func waitResult(t *testing.T, resultCh chan failoverEndResult) failoverEndResult {
+	t.Helper()
+	select {
+	case r := <-resultCh:
+		return r
+	case <-time.After(30 * time.Second):
+		require.FailNow(t, "waitForFailoverEnd did not return")
+		return failoverEndResult{}
+	}
+}
+
+// servingKeyspaceEvent returns a resolution event which stops buffering for
+// the given shard.
+func servingKeyspaceEvent(ks, sh string) *discovery.KeyspaceEvent {
+	return &discovery.KeyspaceEvent{
+		Keyspace: ks,
+		Shards: []discovery.ShardEvent{{
+			Tablet:  &topodatapb.TabletAlias{Cell: "cell1", Uid: 100},
+			Target:  &querypb.Target{Keyspace: ks, Shard: sh, TabletType: topodatapb.TabletType_PRIMARY},
+			Serving: true,
+		}},
+	}
+}
+
+func waitForShardBufferState(t *testing.T, sb *shardBuffer, want bufferState) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return sb.testGetState() == want
+	}, 30*time.Second, time.Millisecond, "shardBuffer did not reach state %v", want)
+}
+
+// TestMarkWindow_StopAndDrainCompleteDuringMark covers the review blocker of
+// the fix design: while a request is parked in MarkShardNotServing, the
+// cycle it reserved is stopped by a keyspace event AND fully drained, so the
+// state is IDLE (with a nil timeoutThread) by the time the request re-locks.
+// The request must pass through without buffering. A state re-check via
+// shouldBufferLocked instead of an exact BUFFERING test would enqueue into
+// the drained queue and panic on the nil timeoutThread.
+func TestMarkWindow_StopAndDrainCompleteDuringMark(t *testing.T) {
+	resetVariables()
+	const ks, sh = "markstop_ks", "0"
+
+	cfg := NewDefaultConfig()
+	cfg.Enabled = true
+	buf := New(cfg)
+	defer buf.Shutdown()
+	sb := buf.getOrCreateBuffer(ks, sh)
+
+	marker := &fakeShardMarker{result: true, entered: make(chan struct{}), release: make(chan struct{})}
+	resultCh := issueMarkedRequest(t.Context(), sb, ks, sh, marker)
+
+	// The request reserved the cycle and is parked in the marker.
+	<-marker.entered
+	require.Equal(t, stateBuffering, sb.testGetState())
+
+	// Stop the cycle and wait for the (empty) drain to complete.
+	buf.HandleKeyspaceEvent(servingKeyspaceEvent(ks, sh))
+	waitForShardBufferState(t, sb, stateIdle)
+
+	close(marker.release)
+	result := waitResult(t, resultCh)
+	require.NoError(t, result.err)
+	require.Nil(t, result.retryDone, "request must not be buffered after its cycle ended during the mark window")
+	require.Equal(t, stateIdle, sb.testGetState())
+	require.Equal(t, int64(1), stops.Counts()[ks+"."+sh+"."+string(stopFailoverEndDetected)])
+}
+
+// TestMarkWindow_RelockDuringDraining covers the request re-locking while
+// the stopped cycle is still draining (kept open by another buffered
+// request): it must pass through, not enqueue.
+func TestMarkWindow_RelockDuringDraining(t *testing.T) {
+	resetVariables()
+	const ks, sh = "markdrain_ks", "0"
+
+	cfg := NewDefaultConfig()
+	cfg.Enabled = true
+	buf := New(cfg)
+	defer buf.Shutdown()
+	sb := buf.getOrCreateBuffer(ks, sh)
+
+	marker1 := &fakeShardMarker{result: true, entered: make(chan struct{}), release: make(chan struct{})}
+	result1Ch := issueMarkedRequest(t.Context(), sb, ks, sh, marker1)
+	<-marker1.entered
+
+	// A second request arrives while the state is BUFFERING: it enqueues via
+	// the regular path and must not consult its own marker (no marker herd).
+	marker2 := &fakeShardMarker{result: false}
+	result2Ch := issueMarkedRequest(t.Context(), sb, ks, sh, marker2)
+	require.Eventually(t, func() bool { return sb.testGetSize() == 1 }, 30*time.Second, time.Millisecond)
+	require.Equal(t, int32(0), marker2.calls.Load(), "request arriving during BUFFERING must not call MarkShardNotServing")
+
+	// Stop the cycle. The drain unblocks request 2 but then waits for its
+	// retryDone, keeping the state in DRAINING.
+	buf.HandleKeyspaceEvent(servingKeyspaceEvent(ks, sh))
+	result2 := waitResult(t, result2Ch)
+	require.NoError(t, result2.err)
+	require.NotNil(t, result2.retryDone)
+	require.Equal(t, stateDraining, sb.testGetState())
+
+	// Request 1 resumes from the marker while the state is DRAINING: it must
+	// pass through.
+	close(marker1.release)
+	result1 := waitResult(t, result1Ch)
+	require.NoError(t, result1.err)
+	require.Nil(t, result1.retryDone)
+	require.Equal(t, stateDraining, sb.testGetState())
+
+	result2.retryDone()
+	waitForShardBufferState(t, sb, stateIdle)
+	require.Equal(t, int64(1), requestsBuffered.Counts()[ks+"."+sh])
+	require.Equal(t, int64(1), requestsDrained.Counts()[ks+"."+sh])
+}
+
+// TestMarkWindow_MarkFailureRollsBack covers the mark returning false with
+// the reserved cycle still live: the cycle is rolled back (stop reason
+// MarkNotServingFailed) and lastEnd is restored so the rollback does not
+// suppress the next buffering attempt via --buffer-min-time-between-failovers.
+func TestMarkWindow_MarkFailureRollsBack(t *testing.T) {
+	resetVariables()
+	const ks, sh = "markfail_ks", "0"
+
+	cfg := NewDefaultConfig()
+	cfg.Enabled = true
+	buf := New(cfg)
+	defer buf.Shutdown()
+	sb := buf.getOrCreateBuffer(ks, sh)
+
+	marker := &fakeShardMarker{result: false}
+	result := waitResult(t, issueMarkedRequest(t.Context(), sb, ks, sh, marker))
+	require.NoError(t, result.err)
+	require.Nil(t, result.retryDone)
+
+	waitForShardBufferState(t, sb, stateIdle)
+	require.Equal(t, int64(1), starts.Counts()[ks+"."+sh])
+	require.Equal(t, int64(1), stops.Counts()[ks+"."+sh+"."+string(stopMarkFailed)])
+
+	// lastEnd was restored: a new failover error must start buffering
+	// immediately instead of being skipped as "last failover too recent".
+	marker2 := &fakeShardMarker{result: true}
+	result2Ch := issueMarkedRequest(t.Context(), sb, ks, sh, marker2)
+	require.Eventually(t, func() bool { return sb.testGetSize() == 1 }, 30*time.Second, time.Millisecond)
+	require.Equal(t, stateBuffering, sb.testGetState())
+	require.Equal(t, int64(0), requestsSkipped.Counts()[ks+"."+sh+"."+string(skippedLastFailoverTooRecent)])
+
+	buf.HandleKeyspaceEvent(servingKeyspaceEvent(ks, sh))
+	result2 := waitResult(t, result2Ch)
+	require.NoError(t, result2.err)
+	require.NotNil(t, result2.retryDone)
+	result2.retryDone()
+	waitForShardBufferState(t, sb, stateIdle)
+}
+
+// TestMarkWindow_MarkFailureAfterRealStop covers the mark returning false
+// after the cycle was already stopped by a keyspace event: the rollback is
+// skipped (no double stop) and the genuine stop's lastEnd stands, so the
+// next buffering attempt IS suppressed as too recent.
+func TestMarkWindow_MarkFailureAfterRealStop(t *testing.T) {
+	resetVariables()
+	const ks, sh = "markfailstop_ks", "0"
+
+	cfg := NewDefaultConfig()
+	cfg.Enabled = true
+	buf := New(cfg)
+	defer buf.Shutdown()
+	sb := buf.getOrCreateBuffer(ks, sh)
+
+	marker := &fakeShardMarker{result: false, entered: make(chan struct{}), release: make(chan struct{})}
+	resultCh := issueMarkedRequest(t.Context(), sb, ks, sh, marker)
+	<-marker.entered
+
+	buf.HandleKeyspaceEvent(servingKeyspaceEvent(ks, sh))
+	waitForShardBufferState(t, sb, stateIdle)
+
+	close(marker.release)
+	result := waitResult(t, resultCh)
+	require.NoError(t, result.err)
+	require.Nil(t, result.retryDone)
+	require.Equal(t, int64(1), stops.Counts()[ks+"."+sh+"."+string(stopFailoverEndDetected)])
+	require.Equal(t, int64(0), stops.Counts()[ks+"."+sh+"."+string(stopMarkFailed)], "rollback must not fire after a genuine stop")
+
+	// The event's lastEnd stands: the next attempt is skipped as too recent.
+	marker2 := &fakeShardMarker{result: true}
+	result2 := waitResult(t, issueMarkedRequest(t.Context(), sb, ks, sh, marker2))
+	require.NoError(t, result2.err)
+	require.Nil(t, result2.retryDone)
+	require.Equal(t, int32(0), marker2.calls.Load())
+	require.Equal(t, int64(1), requestsSkipped.Counts()[ks+"."+sh+"."+string(skippedLastFailoverTooRecent)])
+}
+
+// TestMarkWindow_GenerationGuardProtectsSuccessorCycle covers a mark failure
+// resuming after the original cycle was stopped AND a successor cycle has
+// already started: the rollback must not stop the successor cycle.
+func TestMarkWindow_GenerationGuardProtectsSuccessorCycle(t *testing.T) {
+	resetVariables()
+	const ks, sh = "markgen_ks", "0"
+
+	var nowMu sync.Mutex
+	now := time.Now()
+	cfg := NewDefaultConfig()
+	cfg.Enabled = true
+	cfg.now = func() time.Time {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		return now
+	}
+	advance := func(d time.Duration) {
+		nowMu.Lock()
+		defer nowMu.Unlock()
+		now = now.Add(d)
+	}
+
+	buf := New(cfg)
+	defer buf.Shutdown()
+	sb := buf.getOrCreateBuffer(ks, sh)
+
+	// Cycle 1: parked in its marker, then stopped by a keyspace event.
+	marker1 := &fakeShardMarker{result: false, entered: make(chan struct{}), release: make(chan struct{})}
+	result1Ch := issueMarkedRequest(t.Context(), sb, ks, sh, marker1)
+	<-marker1.entered
+	buf.HandleKeyspaceEvent(servingKeyspaceEvent(ks, sh))
+	waitForShardBufferState(t, sb, stateIdle)
+
+	// Move past --buffer-min-time-between-failovers so a successor cycle can
+	// start, and start it.
+	advance(cfg.MinTimeBetweenFailovers + time.Second)
+	marker2 := &fakeShardMarker{result: true}
+	result2Ch := issueMarkedRequest(t.Context(), sb, ks, sh, marker2)
+	require.Eventually(t, func() bool { return sb.testGetSize() == 1 }, 30*time.Second, time.Millisecond)
+	require.Equal(t, stateBuffering, sb.testGetState())
+
+	// Cycle 1's mark fails now: the generation guard must leave the
+	// successor cycle untouched.
+	close(marker1.release)
+	result1 := waitResult(t, result1Ch)
+	require.NoError(t, result1.err)
+	require.Nil(t, result1.retryDone)
+	require.Equal(t, stateBuffering, sb.testGetState(), "mark failure of a stale cycle must not stop the successor cycle")
+	require.Equal(t, 1, sb.testGetSize())
+	require.Equal(t, int64(0), stops.Counts()[ks+"."+sh+"."+string(stopMarkFailed)])
+
+	buf.HandleKeyspaceEvent(servingKeyspaceEvent(ks, sh))
+	result2 := waitResult(t, result2Ch)
+	require.NoError(t, result2.err)
+	require.NotNil(t, result2.retryDone)
+	result2.retryDone()
+	waitForShardBufferState(t, sb, stateIdle)
+}
+
+// TestMarkWindow_ConcurrentRequestsEnqueueDuringMark covers requests arriving
+// during the mark window: they enqueue into the reserved cycle (without
+// calling their own marker) and the marking request enqueues as well after a
+// successful mark.
+func TestMarkWindow_ConcurrentRequestsEnqueueDuringMark(t *testing.T) {
+	resetVariables()
+	const ks, sh = "markconc_ks", "0"
+
+	cfg := NewDefaultConfig()
+	cfg.Enabled = true
+	buf := New(cfg)
+	defer buf.Shutdown()
+	sb := buf.getOrCreateBuffer(ks, sh)
+
+	marker1 := &fakeShardMarker{result: true, entered: make(chan struct{}), release: make(chan struct{})}
+	result1Ch := issueMarkedRequest(t.Context(), sb, ks, sh, marker1)
+	<-marker1.entered
+
+	marker2 := &fakeShardMarker{result: false}
+	result2Ch := issueMarkedRequest(t.Context(), sb, ks, sh, marker2)
+	require.Eventually(t, func() bool { return sb.testGetSize() == 1 }, 30*time.Second, time.Millisecond)
+	require.Equal(t, int32(0), marker2.calls.Load(), "request arriving during BUFFERING must not call MarkShardNotServing")
+
+	close(marker1.release)
+	require.Eventually(t, func() bool { return sb.testGetSize() == 2 }, 30*time.Second, time.Millisecond)
+	require.Equal(t, int32(1), marker1.calls.Load())
+
+	// End the failover: both requests are drained sequentially in queue
+	// order — request 2 enqueued first (while request 1 was parked in the
+	// marker), and the drain waits for each retryDone before proceeding.
+	buf.HandleKeyspaceEvent(servingKeyspaceEvent(ks, sh))
+	for _, ch := range []chan failoverEndResult{result2Ch, result1Ch} {
+		result := waitResult(t, ch)
+		require.NoError(t, result.err)
+		require.NotNil(t, result.retryDone)
+		result.retryDone()
+	}
+	waitForShardBufferState(t, sb, stateIdle)
+	require.Equal(t, int64(2), requestsBuffered.Counts()[ks+"."+sh])
+	require.Equal(t, int64(2), requestsDrained.Counts()[ks+"."+sh])
+	require.Equal(t, int64(1), starts.Counts()[ks+"."+sh])
+}
+
+// TestMarkWindow_ShutdownCompletesDuringMark covers Buffer.Shutdown() running
+// to completion while a request is parked in the marker: Shutdown does not
+// wait for that request (it is not tracked in sb.wg), so the request resumes
+// after Shutdown returned and must not buffer or restart a cycle.
+func TestMarkWindow_ShutdownCompletesDuringMark(t *testing.T) {
+	resetVariables()
+	const ks, sh = "markshutdown_ks", "0"
+
+	cfg := NewDefaultConfig()
+	cfg.Enabled = true
+	buf := New(cfg)
+	sb := buf.getOrCreateBuffer(ks, sh)
+
+	marker := &fakeShardMarker{result: true, entered: make(chan struct{}), release: make(chan struct{})}
+	resultCh := issueMarkedRequest(t.Context(), sb, ks, sh, marker)
+	<-marker.entered
+	require.Equal(t, stateBuffering, sb.testGetState())
+
+	// Shutdown stops the reserved cycle and returns while the request is
+	// still parked in the marker.
+	buf.Shutdown()
+	require.Equal(t, stateIdle, sb.testGetState(), "Shutdown must stop and drain the reserved cycle")
+
+	close(marker.release)
+	result := waitResult(t, resultCh)
+	require.NoError(t, result.err)
+	require.Nil(t, result.retryDone)
+	require.Equal(t, stateIdle, sb.testGetState(), "no buffering may start after Shutdown returned")
+	require.Equal(t, int64(1), stops.Counts()[ks+"."+sh+"."+string(stopShutdown)])
+}
+
+// TestMarkWindow_TimeoutDuringMark covers the mark blocking longer than
+// --buffer-max-failover-duration: the timeout thread stops the cycle. When
+// the mark then fails, the rollback is skipped and the timeout stop's
+// lastEnd stands (the cycle genuinely ran and timed out), so the next
+// buffering attempt is suppressed as too recent.
+func TestMarkWindow_TimeoutDuringMark(t *testing.T) {
+	resetVariables()
+	const ks, sh = "marktimeout_ks", "0"
+
+	cfg := NewDefaultConfig()
+	cfg.Enabled = true
+	cfg.Window = 50 * time.Millisecond
+	cfg.MaxFailoverDuration = 100 * time.Millisecond
+	buf := New(cfg)
+	defer buf.Shutdown()
+	sb := buf.getOrCreateBuffer(ks, sh)
+
+	marker := &fakeShardMarker{result: false, entered: make(chan struct{}), release: make(chan struct{})}
+	resultCh := issueMarkedRequest(t.Context(), sb, ks, sh, marker)
+	<-marker.entered
+
+	// The timeout thread stops the cycle while the mark is still pending.
+	waitForShardBufferState(t, sb, stateIdle)
+	require.Equal(t, int64(1), stops.Counts()[ks+"."+sh+"."+string(stopMaxFailoverDurationExceeded)])
+
+	close(marker.release)
+	result := waitResult(t, resultCh)
+	require.NoError(t, result.err)
+	require.Nil(t, result.retryDone)
+	require.Equal(t, int64(0), stops.Counts()[ks+"."+sh+"."+string(stopMarkFailed)], "rollback must not fire after the timeout stop")
+
+	// The timeout stop was genuine: its lastEnd stands and suppresses the
+	// next attempt.
+	marker2 := &fakeShardMarker{result: true}
+	result2 := waitResult(t, issueMarkedRequest(t.Context(), sb, ks, sh, marker2))
+	require.NoError(t, result2.err)
+	require.Nil(t, result2.retryDone)
+	require.Equal(t, int32(0), marker2.calls.Load())
+	require.Equal(t, int64(1), requestsSkipped.Counts()[ks+"."+sh+"."+string(skippedLastFailoverTooRecent)])
+}

--- a/go/vt/vtgate/buffer/variables.go
+++ b/go/vt/vtgate/buffer/variables.go
@@ -105,7 +105,7 @@ var (
 // stopReason is used in "stopsByReason" as "Reason" label.
 type stopReason string
 
-var stopReasons = []stopReason{stopShardMissing, stopFailoverEndDetected, stopMaxFailoverDurationExceeded, stopShutdown}
+var stopReasons = []stopReason{stopShardMissing, stopFailoverEndDetected, stopMaxFailoverDurationExceeded, stopShutdown, stopMoveTablesSwitchingTraffic, stopMarkFailed}
 
 const (
 	stopShardMissing                stopReason = "ReshardingComplete"
@@ -113,6 +113,11 @@ const (
 	stopMaxFailoverDurationExceeded stopReason = "MaxDurationExceeded"
 	stopShutdown                    stopReason = "Shutdown"
 	stopMoveTablesSwitchingTraffic  stopReason = "MoveTablesSwitchedTraffic"
+	// stopMarkFailed means a buffering cycle was rolled back right after it
+	// started because the shard could not be marked as not serving in the
+	// keyspace event watcher (e.g. the keyspace was deleted or the watcher
+	// has not seen the shard yet).
+	stopMarkFailed stopReason = "MarkNotServingFailed"
 
 	stopMoveTablesSwitchingTrafficMessage = "MoveTables has switched writes"
 	stopFailoverEndDetectedMessage        = "a primary promotion has been detected"


### PR DESCRIPTION
## Description

vtgate can deadlock — permanently, until restarted — when a request tries to start buffering at the same moment the keyspace event watcher is processing health events. Three goroutines form a lock cycle:

1. A request thread holds `shardBuffer.mu` and calls `kev.MarkShardNotServing()`, which blocks acquiring the keyspace event watcher's `keyspaceState.mu` (and transiently holds `kew.mu`).
2. The watcher's healthcheck goroutine holds `keyspaceState.mu` in `onHealthCheck → ensureConsistentLocked → broadcast`, blocked on a send to the (cap 10) subscriber channel because it's full.
3. The subscriber — TabletGateway's buffering event consumer — is blocked on `shardBuffer.mu` in `HandleKeyspaceEvent → recordKeyspaceEvent`, so it never drains the channel.

Once engaged it never resolves: every escape path (max-failover-duration timeout, client context cancellation via `remove()`, `Shutdown()`) also needs `shardBuffer.mu`, and since the watcher's run loop is wedged, health event processing for **all** keyspaces stops — `ShouldStartBufferingForTarget` and `TargetIsBeingResharded` hang too.

### How this can be hit in production

You need buffering enabled and two things to coincide:

- **A backed-up subscriber channel.** Keyspace events are emitted whenever a keyspace *resolves* an availability event, and the channel is shared across all keyspaces. Ten undelivered events can accumulate during an event-dense window: a multi-keyspace resharding cutover, MoveTables traffic switches, rolling planned reparents across many shards/keyspaces, or repeated consistency flips while a cluster is unstable — any of these while the consumer is briefly busy or blocked.
- **A buffering start racing a health event for the same keyspace.** A request that just saw a failover error (`CLUSTER_EVENT`) tries to start buffering in the few microseconds while the watcher's goroutine holds that keyspace's lock and is blocked broadcasting.

Individually each window is tiny, but failovers are exactly when both conditions cluster: high error rates drive many buffering attempts per second while the watcher is processing a burst of health transitions. It's a classic "rare per-event, plausible at scale during the worst possible moment" race — and the failure mode is a full vtgate buffering/health-event wedge, not a transient error.

### The fix

The root cause is calling into the keyspace event watcher while holding `shardBuffer.mu`. Now `waitForFailoverEnd`:

1. **Reserves the buffering cycle first** (IDLE → BUFFERING, timeout thread armed) under `shardBuffer.mu` — so any stop event arriving while the mark is in flight hits an active state machine and is applied normally instead of being lost against IDLE,
2. releases the lock and calls `MarkShardNotServing` **without holding it**,
3. re-locks and re-validates: a failed mark rolls the cycle back (guarded by a new generation counter so it can't stop a successor cycle, and with `lastEnd` restored so a failed mark doesn't trip `--buffer-min-time-between-failovers`); a successful mark only enqueues if the state is still exactly BUFFERING.

Only the cycle-starting goroutine calls the marker — requests arriving during the window just enqueue. The hot path (idle, no failover) is untouched; benchmarks are unchanged.

There's a new `BufferStops` reason `MarkNotServingFailed` for rolled-back cycles, and the pre-existing `MoveTablesSwitchedTraffic` stop reason is now registered in `stopReasons` so its metric label gets initialized to 0 like the others.

### Testing

- `TestStartBufferingDeadlockWithKeyspaceEvents` reproduces the deadlock deterministically with the real keyspace event watcher: it stages each leg of the cycle (verified via goroutine stacks) before engaging the next. On `main` it wedges every run; with the fix it passes in milliseconds.
- Eight new unit tests cover the mark window via a fake marker that can park mid-call: stop+drain completing during the mark (enqueueing then would panic on a nil timeout thread — verified the test catches it), re-lock during DRAINING, mark-failure rollback, mark-failure after a genuine stop, the generation guard, concurrent enqueues during the window, `Shutdown()` completing while parked, and the mark outliving max-failover-duration.
- **No e2e test**: reproducing this end-to-end isn't practical. It needs four independent microsecond-scale timing windows to coincide and there are no external knobs to widen any of them (the channel capacity is hardcoded, lock hold times are nanoseconds). An e2e attempt would be an hours-long PRS/MoveTables stress loop whose failure mode is "vtgate hung" — slow, flaky, and weaker evidence than the unit-level repro, which proves the cycle by construction from the real components.

### Backport justification

This is a deadlock that wedges all of vtgate's buffering and keyspace event processing with no recovery short of a restart. The bug exists on all supported release branches; the fix is contained to the buffer package with no API or flag changes.

## Related Issue(s)

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

No flag or API changes. One new metrics label (`BufferStops` reason `MarkNotServingFailed`); the `MoveTablesSwitchedTraffic` reason label is now pre-initialized to 0.

### AI Disclosure

This PR — the analysis, the deadlock reproduction, the fix, and the tests — was written by Claude Code, with direction and design review by me (the design went through two adversarial review rounds before implementation).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)