### PR TITLE
ci: add arm64 unit test jobs and run all flavors on Oracle VM runners

### DIFF
--- a/.github/actions/setup-mysql/action.yml
+++ b/.github/actions/setup-mysql/action.yml
@@ -22,40 +22,51 @@ runs:
         sudo rm -rf /var/lib/mysql
         sudo rm -rf /etc/mysql
 
-        # We have to install this old version of libaio1. See also:
-        # https://bugs.launchpad.net/ubuntu/+source/libaio/+bug/2067501
-        wget http://archive.ubuntu.com/ubuntu/pool/main/liba/libaio/libaio1_0.3.112-13build1_amd64.deb && \
-          sudo dpkg -i libaio1_0.3.112-13build1_amd64.deb && \
-          rm libaio1_0.3.112-13build1_amd64.deb
-
-        # Get key to latest MySQL repo
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A8D3785C
-        wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.35-1_all.deb
-
-        if [[ "${{ inputs.flavor }}" == "mysql-5.7" ]]; then
-          # Bionic packages are still compatible for Jammy since there's no MySQL 5.7
-          # packages for Jammy.
-          echo mysql-apt-config mysql-apt-config/repo-codename select bionic | sudo debconf-set-selections
-          echo mysql-apt-config mysql-apt-config/select-server select mysql-5.7 | sudo debconf-set-selections
-          sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
-          sudo apt-get update
-          # libtinfo5 is also needed for older MySQL 5.7 builds.
-          curl -L -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
-          sudo dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb
-          sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-client=5.7* mysql-community-server=5.7* mysql-server=5.7* libncurses6
-        elif [[ "${{ inputs.flavor }}" == "mysql-8.0" ]]; then
-          echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
-          sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
-          sudo apt-get update
-          sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
-        elif [[ "${{ inputs.flavor }}" == "mysql-8.4" ]]; then
-          echo mysql-apt-config mysql-apt-config/select-server select mysql-8.4-lts | sudo debconf-set-selections
-          sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
-          sudo apt-get update
+        if [[ "$(dpkg --print-architecture)" == "arm64" ]]; then
+          # Oracle's apt repo only publishes amd64 packages for Ubuntu, so on
+          # arm64 we install MySQL from the Ubuntu archive instead, which only
+          # ships MySQL 8.0.
+          if [[ "${{ inputs.flavor }}" != "mysql-8.0" ]]; then
+            echo "Unsupported MySQL flavor on arm64: ${{ inputs.flavor }}"
+            exit 1
+          fi
           sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
         else
-          echo "Unsupported MySQL flavor: ${{ inputs.flavor }}"
-          exit 1
+          # We have to install this old version of libaio1. See also:
+          # https://bugs.launchpad.net/ubuntu/+source/libaio/+bug/2067501
+          wget http://archive.ubuntu.com/ubuntu/pool/main/liba/libaio/libaio1_0.3.112-13build1_amd64.deb && \
+            sudo dpkg -i libaio1_0.3.112-13build1_amd64.deb && \
+            rm libaio1_0.3.112-13build1_amd64.deb
+
+          # Get key to latest MySQL repo
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A8D3785C
+          wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.35-1_all.deb
+
+          if [[ "${{ inputs.flavor }}" == "mysql-5.7" ]]; then
+            # Bionic packages are still compatible for Jammy since there's no MySQL 5.7
+            # packages for Jammy.
+            echo mysql-apt-config mysql-apt-config/repo-codename select bionic | sudo debconf-set-selections
+            echo mysql-apt-config mysql-apt-config/select-server select mysql-5.7 | sudo debconf-set-selections
+            sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
+            sudo apt-get update
+            # libtinfo5 is also needed for older MySQL 5.7 builds.
+            curl -L -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
+            sudo dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb
+            sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-client=5.7* mysql-community-server=5.7* mysql-server=5.7* libncurses6
+          elif [[ "${{ inputs.flavor }}" == "mysql-8.0" ]]; then
+            echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
+            sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
+            sudo apt-get update
+            sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
+          elif [[ "${{ inputs.flavor }}" == "mysql-8.4" ]]; then
+            echo mysql-apt-config mysql-apt-config/select-server select mysql-8.4-lts | sudo debconf-set-selections
+            sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
+            sudo apt-get update
+            sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
+          else
+            echo "Unsupported MySQL flavor: ${{ inputs.flavor }}"
+            exit 1
+          fi
         fi
 
         sudo service mysql stop

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -57,6 +57,18 @@ jobs:
             evalengine: "1"
             flavor: mysql-8.4
 
+          # arm64 tests (mysql80 only — Oracle's apt repo has no arm64
+          # packages and Ubuntu's archive only ships MySQL 8.0 on arm64)
+          - platform: mysql80
+            evalengine: "0"
+            flavor: mysql-8.0
+            arch: arm64
+
+          - platform: mysql80
+            evalengine: "1"
+            flavor: mysql-8.0
+            arch: arm64
+
           # Race tests (mysql80 only)
           - platform: mysql80
             evalengine: "0"
@@ -69,8 +81,8 @@ jobs:
             flavor: mysql-8.0
             race: true
 
-    name: "Unit Test (${{ matrix.race && (matrix.evalengine == '1' && 'Evalengine_' || '') || (matrix.evalengine == '1' && 'evalengine_' || '') }}${{ matrix.race && 'Race' || matrix.platform }})"
-    runs-on: ${{ matrix.race && github.repository == 'vitessio/vitess' && 'oracle-vm-16cpu-64gb-x86-64' || 'ubuntu-24.04' }}
+    name: "Unit Test (${{ matrix.race && (matrix.evalengine == '1' && 'Evalengine_' || '') || (matrix.evalengine == '1' && 'evalengine_' || '') }}${{ matrix.race && 'Race' || matrix.platform }}${{ matrix.arch && format('_{0}', matrix.arch) || '' }})"
+    runs-on: ${{ github.repository == 'vitessio/vitess' && (matrix.arch == 'arm64' && 'oracle-vm-16cpu-64gb-arm64' || 'oracle-vm-16cpu-64gb-x86-64') || (matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04') }}
 
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
## Description

This adds arm64 coverage to the unit test workflow and moves all unit test flavors onto the 16-CPU Oracle VM runners when running inside `vitessio/vitess`.

Two new matrix entries run the mysql80 unit tests (with and without the evalengine) on arm64. Oracle's apt repo only publishes amd64 packages for Ubuntu, so on arm64 the `setup-mysql` action now installs MySQL 8.0 from the Ubuntu archive instead — that's also why arm64 coverage is limited to mysql80 for now (no 5.7 or 8.4 packages exist for arm64; adding 8.4 would need Oracle's generic aarch64 tarballs).

Once we've got this up and running, I think it might make sense to investigate installing MySQL via the aarch64 tarballs on ARM64 instead to also get MySQL 8.4 unit tests running against ARM64.

Previously only the race jobs ran on `oracle-vm-16cpu-64gb-x86-64`. Now all jobs use the Oracle VMs in-repo, picking `-x86-64` or `-arm64` based on the matrix arch. Forks keep using the GitHub-hosted `ubuntu-24.04` / `ubuntu-24.04-arm` runners.

## Related Issue(s)

N/A

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

N/A — CI-only change.

### AI Disclosure

This PR was written by Claude Code, with direction and review from me.