### PR TITLE
atomic2: use acquire-release ordering for the 128-bit CAS on arm64

### DIFF
--- a/go/atomic2/atomic128_arm64.s
+++ b/go/atomic2/atomic128_arm64.s
@@ -28,12 +28,12 @@ TEXT ·compareAndSwapUint128_(SB), NOSPLIT, $0-41
 	CMP R0, R6
 	CCMP EQ, R1, R7, $0
 	CSET EQ, R0
-	MOVB R0, ret+40(FP)
+	MOVB R0, swapped+40(FP)
 	RET
 
 TEXT ·loadUint128_(SB), NOSPLIT, $0-24
 	MOVD addr+0(FP), R3
 	LDAXP (R3), (R0, R1)
-	MOVD R0, val+8(FP)
-	MOVD R1, val+16(FP)
+	MOVD R0, pp+8(FP)
+	MOVD R1, uu+16(FP)
 	RET

--- a/go/atomic2/atomic128_arm64.s
+++ b/go/atomic2/atomic128_arm64.s
@@ -24,7 +24,15 @@ TEXT ·compareAndSwapUint128_(SB), NOSPLIT, $0-41
 	MOVD newu+32(FP), R3
 	MOVD R0, R6
 	MOVD R1, R7
-	CASPD (R0, R1), (R5), (R2, R3)
+	// CASPAL X0, X1, X2, X3, [X5]
+	//
+	// The acquire/release variant of CASP. The plain CASP has relaxed
+	// memory ordering: its store can become visible to other CPUs before
+	// earlier stores by this CPU (e.g. a node's fields written before the
+	// node is published via this CAS), which breaks the lock-free
+	// data structures built on top of this primitive. Go's assembler only
+	// knows the relaxed CASPD/CASPW mnemonics, so encode CASPAL directly.
+	WORD $0x4860fca2
 	CMP R0, R6
 	CCMP EQ, R1, R7, $0
 	CSET EQ, R0

--- a/go/atomic2/atomic128_arm64.s
+++ b/go/atomic2/atomic128_arm64.s
@@ -16,6 +16,21 @@
 
 #include "textflag.h"
 
+// CASPALD(s, t, n) encodes CASPAL R<s>, R<s+1>, R<t>, R<t+1>, [R<n>],
+// the acquire/release variant of the 128-bit compare-and-swap.
+//
+// Go's built-in atomics are sequentially consistent, and callers of
+// this package expect the same semantics; the Go runtime implements
+// its own Cas64 on arm64 with CASALD, the acquire/release variant of
+// the single-doubleword CAS. The plain CASP instead has relaxed
+// memory ordering: its store can become visible to other CPUs before
+// earlier stores by this CPU (e.g. a node's fields written before the
+// node is published via this CAS), which breaks the lock-free data
+// structures built on top of this primitive. Go's assembler only
+// knows the relaxed CASPD/CASPW mnemonics, so encode the instruction
+// directly. s and t must be even.
+#define CASPALD(s, t, n) WORD $(0x4860FC00 | ((s)<<16) | ((n)<<5) | (t))
+
 TEXT ·compareAndSwapUint128_(SB), NOSPLIT, $0-41
 	MOVD addr+0(FP), R5
 	MOVD oldp+8(FP), R0
@@ -24,15 +39,7 @@ TEXT ·compareAndSwapUint128_(SB), NOSPLIT, $0-41
 	MOVD newu+32(FP), R3
 	MOVD R0, R6
 	MOVD R1, R7
-	// CASPAL X0, X1, X2, X3, [X5]
-	//
-	// The acquire/release variant of CASP. The plain CASP has relaxed
-	// memory ordering: its store can become visible to other CPUs before
-	// earlier stores by this CPU (e.g. a node's fields written before the
-	// node is published via this CAS), which breaks the lock-free
-	// data structures built on top of this primitive. Go's assembler only
-	// knows the relaxed CASPD/CASPW mnemonics, so encode CASPAL directly.
-	WORD $0x4860fca2
+	CASPALD(0, 2, 5)
 	CMP R0, R6
 	CCMP EQ, R1, R7, $0
 	CSET EQ, R0


### PR DESCRIPTION
## Description

The 128-bit `CompareAndSwap` in `go/atomic2` was implemented on arm64 with the plain `CASP` instruction, which has relaxed memory ordering: its store can become visible to other CPUs before earlier stores by the same CPU. The lock-free connection stack in `smartconnpool` publishes nodes with this CAS after writing the node's fields (next pointer, timestamps), so a concurrent `Pop` could observe the new stack top before those writes land and read a stale next pointer or timestamp, silently losing the rest of the stack. Leaked connections stay counted in the pool's active total forever, which starves `SetCapacity(0)` drains and stalls `Close` and the refresh worker's reopen. This is the suspected root cause of a `TestStressCloseDuringTraffic` stall observed on an arm64 unit test runner in #20282. amd64 is unaffected (`LOCK CMPXCHG16B` on a TSO machine).

This replaces `CASP` with `CASPAL`, its acquire-release variant, matching what callers expect (Go's built-in atomics are sequentially consistent) and what the Go runtime itself uses for its arm64 `Cas64` (`CASALD`). Go's assembler doesn't know the ordered pair-CAS mnemonics yet (golang/go#79929 proposes adding them), so the instruction is encoded via a documented `CASPALD(s, t, n)` macro. Hardware requirements are unchanged — both the old and new instruction need LSE (ARMv8.1).

The first commit is a small preparatory fix: it renames the FP argument references in the assembly to match the Go declarations, so `go vet`'s asmdecl check can verify the assembly against the function signatures again.

These commits were extracted from #20282 so the fix can land independently of the CI workflow changes.

### Benchmark results

Before/after on `BenchmarkPoolCleanupIdleConnectionsPerformanceHighConcurrencyNoIdleConnections` (6 runs each, sequentially, on an arm64 machine) shows no statistically significant difference on any metric:

```
                                                                         │    before    │     after             │
                                                                         │    sec/op    │    sec/op     vs base │
PoolCleanupIdleConnectionsPerformanceHighConcurrencyNoIdleConnections-14   2.067m ± 30%   1.750m ± 55%  ~ (p=0.310 n=6)

                                                                         │ get-max-sec  │  get-max-sec          │
PoolCleanupIdleConnectionsPerformanceHighConcurrencyNoIdleConnections-14   4.387m ± 39%   3.345m ± 60%  ~ (p=0.132 n=6)

                                                                         │ get-p50-sec  │  get-p50-sec          │
PoolCleanupIdleConnectionsPerformanceHighConcurrencyNoIdleConnections-14  42.00n ± 198%  62.50n ± 100%  ~ (p=0.924 n=6)

                                                                         │ get-p95-sec  │  get-p95-sec          │
PoolCleanupIdleConnectionsPerformanceHighConcurrencyNoIdleConnections-14   57.81µ ± 70%   72.67µ ± 42%  ~ (p=0.240 n=6)

                                                                         │ get-p99-sec  │  get-p99-sec          │
PoolCleanupIdleConnectionsPerformanceHighConcurrencyNoIdleConnections-14   207.1µ ± 32%   241.2µ ± 19%  ~ (p=0.180 n=6)
```

This matches expectations: with LSE atomics the dominant cost of a CAS is gaining exclusive ownership of the cache line, which is identical for `CASP` and `CASPAL` — the acquire/release bits only constrain instruction overlap on the local core.

### Backporting

No backport needed: Vitess doesn't officially support arm64 builds (yet), and amd64 is unaffected by this change.

## Related Issue(s)

- Investigated in #20282, where the new arm64 unit test runner hit the `TestStressCloseDuringTraffic` stall
- golang/go#79929 tracks adding the ordered CASP variants to the Go assembler, which would let us drop the macro encoding

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches (not needed — see Backporting above)
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description (n/a)
-   [x] Tests were added or are not required (the existing `atomic2` and `smartconnpool` tests cover this; the arm64 stress runs in #20282 exercise it under load)
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — the instruction change requires LSE (ARMv8.1) just like the old one, so there is no change in hardware requirements.

### AI Disclosure

The investigation and the fix in this PR were done by Claude Code — I provided direction and review.