### PR TITLE
`EmergencyReparentShard`: fail-fast on suspected split-brain with operator override

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -21,6 +21,8 @@
         - [Consolidator Reject on Waiter Cap](#vttablet-consolidator-reject-on-cap)
     - **[VTTablet](#minor-changes-vttablet)**
         - [Schema engine table-count limit is now configurable](#vttablet-schema-max-table-count)
+    - **[VTCtld](#minor-changes-vtctld)**
+        - [EmergencyReparentShard fails fast on suspected split-brain](#vtctld-ers-split-brain-detection)
 
 ## <a id="major-changes"/>Major Changes</a>
 
@@ -136,3 +138,13 @@ Two changes:
 Tablets that already have more tracked schema objects than the configured limit will reload fine — only new creations are gated. Operators who need to support more tables and views should increase the flag and ensure both vttablet and mysqld have enough memory to comfortably hold the larger schema.
 
 See [#19978](https://github.com/vitessio/vitess/issues/19978) for details.
+
+### <a id="minor-changes-vtctld"/>VTCtld</a>
+
+#### <a id="vtctld-ers-split-brain-detection"/>EmergencyReparentShard fails fast on suspected split-brain</a>
+
+When the leading GTID-based candidates for `EmergencyReparentShard` have incomparable `Combined` positions (suspected split-brain), ERS now aborts upfront with a clear `FAILED_PRECONDITION` error naming the diverged tablets, rather than silently picking one side. Pre-PR ERS would pick blindly and let the losing side's unique GTIDs become errant on those tablets — a silent data-integrity incident that surfaced later via lag alerts or downstream consistency checks. See [#20199](https://github.com/vitessio/vitess/issues/20199) for the bug this addresses.
+
+A new `--allow-split-brain-promotion` flag is added to `vtctldclient EmergencyReparentShard` (and `--allow_split_brain_promotion` on the legacy `vtctl`). It is **off by default**. Operators who deliberately need to force ERS through a detected split-brain — typically because they already know which side to keep and plan to re-clone the losing side — can set it to convert the abort into a `WARN` log and proceed. The non-promoted side's unique GTIDs will become errant after promotion, so this is an explicit operator override, not a default-on safety knob.
+
+A new `EmergencyReparentSplitBrainOverrides` stat is exported for observability. It counts split-brain detections bypassed by `--allow-split-brain-promotion` per detection. It stays at zero unless an operator has deliberately invoked the escape hatch.

--- a/go/cmd/vtctldclient/command/reparents.go
+++ b/go/cmd/vtctldclient/command/reparents.go
@@ -96,6 +96,7 @@ var emergencyReparentShardOptions = struct {
 	IgnoreReplicaAliasStrList []string
 	PreventCrossCellPromotion bool
 	WaitForAllTablets         bool
+	AllowSplitBrainPromotion  bool
 }{}
 
 func commandEmergencyReparentShard(cmd *cobra.Command, args []string) error {
@@ -144,6 +145,7 @@ func commandEmergencyReparentShard(cmd *cobra.Command, args []string) error {
 		WaitReplicasTimeout:       protoutil.DurationToProto(emergencyReparentShardOptions.WaitReplicasTimeout),
 		PreventCrossCellPromotion: emergencyReparentShardOptions.PreventCrossCellPromotion,
 		WaitForAllTablets:         emergencyReparentShardOptions.WaitForAllTablets,
+		AllowSplitBrainPromotion:  emergencyReparentShardOptions.AllowSplitBrainPromotion,
 	})
 	if err != nil {
 		return err
@@ -310,6 +312,7 @@ func init() {
 	EmergencyReparentShard.Flags().BoolVar(&emergencyReparentShardOptions.PreventCrossCellPromotion, "prevent-cross-cell-promotion", false, "Only promotes a new primary from the same cell as the previous primary.")
 	EmergencyReparentShard.Flags().BoolVar(&emergencyReparentShardOptions.WaitForAllTablets, "wait-for-all-tablets", false, "Should ERS wait for all the tablets to respond. Useful when all the tablets are reachable.")
 	EmergencyReparentShard.Flags().StringSliceVarP(&emergencyReparentShardOptions.IgnoreReplicaAliasStrList, "ignore-replicas", "i", nil, "Comma-separated, repeated list of replica tablet aliases to ignore during the emergency reparent.")
+	EmergencyReparentShard.Flags().BoolVar(&emergencyReparentShardOptions.AllowSplitBrainPromotion, "allow-split-brain-promotion", false, "Allow ERS to proceed when two leading candidates have incomparable Combined GTID positions (suspected split-brain). Off by default — operator escape hatch. The non-promoted side's unique GTIDs will become errant on those tablets.")
 	Root.AddCommand(EmergencyReparentShard)
 
 	InitShardPrimary.Flags().DurationVar(&initShardPrimaryOptions.WaitReplicasTimeout, "wait-replicas-timeout", 30*time.Second, "Time to wait for replicas to catch up in reparenting.")

--- a/go/test/endtoend/reparent/emergencyreparent/ers_test.go
+++ b/go/test/endtoend/reparent/emergencyreparent/ers_test.go
@@ -29,6 +29,7 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/reparent/utils"
+	e2eutils "vitess.io/vitess/go/test/endtoend/utils"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vtctl/reparentutil/policy"
 
@@ -627,6 +628,66 @@ func TestERSFailFast(t *testing.T) {
 	case <-time.After(60 * time.Second):
 		require.Fail(t, "Emergency Reparent Shard did not fail in 60 seconds")
 	}
+}
+
+// TestERSSplitBrainDetection verifies that ERS aborts upfront with a clear
+// "suspected split-brain" error when two leading candidates have incomparable
+// Combined GTID positions. We simulate a real split-brain by detaching two
+// replicas from the primary and writing to each independently — each INSERT
+// generates a GTID under that replica's own server UUID, so neither tablet's
+// Combined set is a superset of the other's. The pairwise dominance filter
+// keeps both tablets, the uniformCombined check fires, and ERS aborts before
+// risking promotion of either diverged side.
+func TestERSSplitBrainDetection(t *testing.T) {
+	// The upfront "suspected split-brain" abort was added in v25. Older vtctld either
+	// promotes one side silently or surfaces a different error message, so this test
+	// is only meaningful against v25+.
+	e2eutils.SkipIfBinaryIsBelowVersion(t, 25, "vtctld")
+
+	clusterInstance := utils.SetupReparentCluster(t, policy.DurabilitySemiSync)
+	defer utils.TeardownCluster(clusterInstance)
+	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
+
+	ctx := t.Context()
+
+	// Baseline: confirm replication is healthy before we break it.
+	utils.ConfirmReplication(t, tablets[0], tablets[1:])
+
+	// Detach tablets[2] and tablets[3] from replication and make them writable.
+	// Each subsequent INSERT will generate a GTID under that tablet's own
+	// server UUID, producing two-sided GTID divergence (split-brain).
+	// super_read_only must be cleared explicitly: Vitess leaves demoted replicas
+	// at super_read_only=1, which blocks the direct INSERT below regardless of
+	// read_only.
+	detachAndMakeWritable := []string{
+		"STOP REPLICA",
+		"RESET REPLICA ALL",
+		"SET GLOBAL super_read_only = OFF",
+		"SET GLOBAL read_only = OFF",
+	}
+	utils.RunSQLs(ctx, t, detachAndMakeWritable, tablets[2])
+	utils.RunSQL(ctx, t,
+		"INSERT INTO vt_insert_test(id, msg) VALUES (90002, 'split-brain side A')",
+		tablets[2])
+
+	utils.RunSQLs(ctx, t, detachAndMakeWritable, tablets[3])
+	utils.RunSQL(ctx, t,
+		"INSERT INTO vt_insert_test(id, msg) VALUES (90003, 'split-brain side B')",
+		tablets[3])
+
+	// Kill the primary so ERS is needed.
+	utils.StopTablet(t, tablets[0], true)
+
+	// ERS must abort with the upfront split-brain error, not silently promote
+	// one of the diverged sides. The vtctldclient surfaces the RPC error message
+	// in stdout/stderr — assert against `out` rather than err (which is just
+	// "exit status 1" from the command process).
+	out, err := utils.Ers(clusterInstance, nil, "60s", "30s")
+	require.Error(t, err, out)
+	require.Contains(t, out, "suspected split-brain", "ERS output: %s", out)
+	// describeCombinedPositions names the offending tablets in the error.
+	require.Contains(t, out, tablets[2].Alias)
+	require.Contains(t, out, tablets[3].Alias)
 }
 
 // TestReplicationStopped checks that ERS ignores the tablets that have sql thread stopped.

--- a/go/vt/proto/vtctldata/vtctldata.pb.go
+++ b/go/vt/proto/vtctldata/vtctldata.pb.go
@@ -4340,8 +4340,13 @@ type EmergencyReparentShardRequest struct {
 	// ExpectedPrimary is the optional alias we expect to be the current primary in order for
 	// the reparent operation to succeed.
 	ExpectedPrimary *topodata.TabletAlias `protobuf:"bytes,8,opt,name=expected_primary,json=expectedPrimary,proto3" json:"expected_primary,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// AllowSplitBrainPromotion lets ERS proceed when two leading candidates have incomparable
+	// Combined GTID positions (suspected split-brain). By default ERS aborts with FAILED_PRECONDITION
+	// in that case; setting this true logs a WARN and continues, accepting that the losing side's
+	// unique GTIDs will become errant on those tablets. Intended as a deliberate operator override.
+	AllowSplitBrainPromotion bool `protobuf:"varint,9,opt,name=allow_split_brain_promotion,json=allowSplitBrainPromotion,proto3" json:"allow_split_brain_promotion,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *EmergencyReparentShardRequest) Reset() {
@@ -4428,6 +4433,13 @@ func (x *EmergencyReparentShardRequest) GetExpectedPrimary() *topodata.TabletAli
 		return x.ExpectedPrimary
 	}
 	return nil
+}
+
+func (x *EmergencyReparentShardRequest) GetAllowSplitBrainPromotion() bool {
+	if x != nil {
+		return x.AllowSplitBrainPromotion
+	}
+	return false
 }
 
 type EmergencyReparentShardResponse struct {
@@ -17843,7 +17855,7 @@ const file_vtctldata_proto_rawDesc = "" +
 	"\x14DeleteTabletsRequest\x12<\n" +
 	"\x0etablet_aliases\x18\x01 \x03(\v2\x15.topodata.TabletAliasR\rtabletAliases\x12#\n" +
 	"\rallow_primary\x18\x02 \x01(\bR\fallowPrimary\"\x17\n" +
-	"\x15DeleteTabletsResponse\"\xc3\x03\n" +
+	"\x15DeleteTabletsResponse\"\x82\x04\n" +
 	"\x1dEmergencyReparentShardRequest\x12\x1a\n" +
 	"\bkeyspace\x18\x01 \x01(\tR\bkeyspace\x12\x14\n" +
 	"\x05shard\x18\x02 \x01(\tR\x05shard\x126\n" +
@@ -17853,7 +17865,8 @@ const file_vtctldata_proto_rawDesc = "" +
 	"\x15wait_replicas_timeout\x18\x05 \x01(\v2\x10.vttime.DurationR\x13waitReplicasTimeout\x12?\n" +
 	"\x1cprevent_cross_cell_promotion\x18\x06 \x01(\bR\x19preventCrossCellPromotion\x12/\n" +
 	"\x14wait_for_all_tablets\x18\a \x01(\bR\x11waitForAllTablets\x12@\n" +
-	"\x10expected_primary\x18\b \x01(\v2\x15.topodata.TabletAliasR\x0fexpectedPrimary\"\xbc\x01\n" +
+	"\x10expected_primary\x18\b \x01(\v2\x15.topodata.TabletAliasR\x0fexpectedPrimary\x12=\n" +
+	"\x1ballow_split_brain_promotion\x18\t \x01(\bR\x18allowSplitBrainPromotion\"\xbc\x01\n" +
 	"\x1eEmergencyReparentShardResponse\x12\x1a\n" +
 	"\bkeyspace\x18\x01 \x01(\tR\bkeyspace\x12\x14\n" +
 	"\x05shard\x18\x02 \x01(\tR\x05shard\x12@\n" +

--- a/go/vt/proto/vtctldata/vtctldata_vtproto.pb.go
+++ b/go/vt/proto/vtctldata/vtctldata_vtproto.pb.go
@@ -1495,6 +1495,7 @@ func (m *EmergencyReparentShardRequest) CloneVT() *EmergencyReparentShardRequest
 	r.PreventCrossCellPromotion = m.PreventCrossCellPromotion
 	r.WaitForAllTablets = m.WaitForAllTablets
 	r.ExpectedPrimary = m.ExpectedPrimary.CloneVT()
+	r.AllowSplitBrainPromotion = m.AllowSplitBrainPromotion
 	if rhs := m.IgnoreReplicas; rhs != nil {
 		tmpContainer := make([]*topodata.TabletAlias, len(rhs))
 		for k, v := range rhs {
@@ -10528,6 +10529,16 @@ func (m *EmergencyReparentShardRequest) MarshalToSizedBufferVT(dAtA []byte) (int
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.AllowSplitBrainPromotion {
+		i--
+		if m.AllowSplitBrainPromotion {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x48
 	}
 	if m.ExpectedPrimary != nil {
 		size, err := m.ExpectedPrimary.MarshalToSizedBufferVT(dAtA[:i])
@@ -24347,6 +24358,9 @@ func (m *EmergencyReparentShardRequest) SizeVT() (n int) {
 	if m.ExpectedPrimary != nil {
 		l = m.ExpectedPrimary.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.AllowSplitBrainPromotion {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -40902,6 +40916,26 @@ func (m *EmergencyReparentShardRequest) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AllowSplitBrainPromotion", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.AllowSplitBrainPromotion = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/go/vt/vtctl/grpcvtctldserver/server.go
+++ b/go/vt/vtctl/grpcvtctldserver/server.go
@@ -1304,6 +1304,7 @@ func (s *VtctldServer) EmergencyReparentShard(ctx context.Context, req *vtctldat
 	span.Annotate("wait_replicas_timeout_sec", waitReplicasTimeout.Seconds())
 	span.Annotate("prevent_cross_cell_promotion", req.PreventCrossCellPromotion)
 	span.Annotate("wait_for_all_tablets", req.WaitForAllTablets)
+	span.Annotate("allow_split_brain_promotion", req.AllowSplitBrainPromotion)
 
 	m := sync.RWMutex{}
 	logstream := []*logutilpb.Event{}
@@ -1314,7 +1315,8 @@ func (s *VtctldServer) EmergencyReparentShard(ctx context.Context, req *vtctldat
 		logstream = append(logstream, e)
 	})
 
-	ev, err := reparentutil.NewEmergencyReparenter(s.ts, s.tmc, logger).ReparentShard(ctx,
+	ev, err := reparentutil.NewEmergencyReparenter(s.ts, s.tmc, logger).ReparentShard(
+		ctx,
 		req.Keyspace,
 		req.Shard,
 		reparentutil.EmergencyReparentOptions{
@@ -1324,6 +1326,7 @@ func (s *VtctldServer) EmergencyReparentShard(ctx context.Context, req *vtctldat
 			WaitAllTablets:            req.WaitForAllTablets,
 			PreventCrossCellPromotion: req.PreventCrossCellPromotion,
 			ExpectedPrimaryAlias:      req.ExpectedPrimary,
+			AllowSplitBrainPromotion:  req.AllowSplitBrainPromotion,
 		},
 	)
 
@@ -3315,7 +3318,8 @@ func (s *VtctldServer) PlannedReparentShard(ctx context.Context, req *vtctldatap
 		logstream = append(logstream, e)
 	})
 
-	ev, err := reparentutil.NewPlannedReparenter(s.ts, s.tmc, logger).ReparentShard(ctx,
+	ev, err := reparentutil.NewPlannedReparenter(s.ts, s.tmc, logger).ReparentShard(
+		ctx,
 		req.Keyspace,
 		req.Shard,
 		reparentutil.PlannedReparentOptions{
@@ -5496,7 +5500,8 @@ func (s *VtctldServer) ValidateVSchema(ctx context.Context, req *vtctldatapb.Val
 			r := &tabletmanagerdatapb.GetSchemaRequest{ExcludeTables: req.ExcludeTables, IncludeViews: req.IncludeViews}
 			primarySchema, err := schematools.GetSchema(ctx, s.ts, s.tmc, si.PrimaryAlias, r)
 			if err != nil {
-				errorMessage := fmt.Sprintf("GetSchema(%s, nil, %v, %v) (%v/%v) failed: %v", si.PrimaryAlias.String(),
+				errorMessage := fmt.Sprintf(
+					"GetSchema(%s, nil, %v, %v) (%v/%v) failed: %v", si.PrimaryAlias.String(),
 					excludeTables, includeViews, keyspace, shard, err,
 				)
 				shardResult.Results = append(shardResult.Results, errorMessage)

--- a/go/vt/vtctl/reparent.go
+++ b/go/vt/vtctl/reparent.go
@@ -173,6 +173,7 @@ func commandEmergencyReparentShard(ctx context.Context, wr *wrangler.Wrangler, s
 	preventCrossCellPromotion := subFlags.Bool("prevent_cross_cell_promotion", false, "only promotes a new primary from the same cell as the previous primary")
 	ignoreReplicasList := subFlags.String("ignore_replicas", "", "comma-separated list of replica tablet aliases to ignore during emergency reparent")
 	waitForAllTablets := subFlags.Bool("wait_for_all_tablets", false, "should ERS wait for all the tablets to respond. Useful when all the tablets are reachable")
+	allowSplitBrainPromotion := subFlags.Bool("allow_split_brain_promotion", false, "allow ERS to proceed when two leading candidates have incomparable Combined GTID positions (suspected split-brain). Off by default — operator escape hatch. The non-promoted side's unique GTIDs will become errant on those tablets")
 
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -206,6 +207,7 @@ func commandEmergencyReparentShard(ctx context.Context, wr *wrangler.Wrangler, s
 		WaitReplicasTimeout:       *waitReplicasTimeout,
 		IgnoreReplicas:            topoproto.ParseTabletSet(*ignoreReplicasList),
 		PreventCrossCellPromotion: *preventCrossCellPromotion,
+		AllowSplitBrainPromotion:  *allowSplitBrainPromotion,
 	})
 }
 

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -19,6 +19,7 @@ package reparentutil
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -62,6 +63,12 @@ type EmergencyReparentOptions struct {
 	WaitReplicasTimeout       time.Duration
 	PreventCrossCellPromotion bool
 	ExpectedPrimaryAlias      *topodatapb.TabletAlias
+	// AllowSplitBrainPromotion lets ERS proceed when two leading candidates have
+	// incomparable Combined GTID positions (suspected split-brain). Off by default —
+	// operator escape hatch. When set, the split-brain check logs a warning and
+	// continues instead of aborting with FAILED_PRECONDITION. The losing side's
+	// unique GTIDs will become errant on those tablets after promotion.
+	AllowSplitBrainPromotion bool
 
 	// Private options managed internally. We use value passing to avoid leaking
 	// these details back out.
@@ -70,9 +77,15 @@ type EmergencyReparentOptions struct {
 }
 
 // counters for Emergency Reparent Shard
-var ersCounter = stats.NewCountersWithMultiLabels(
-	"EmergencyReparentCounts", "Number of times Emergency Reparent Shard has been run",
-	[]string{"Keyspace", "Shard", "Result"},
+var (
+	ersCounter = stats.NewCountersWithMultiLabels(
+		"EmergencyReparentCounts", "Number of times Emergency Reparent Shard has been run",
+		[]string{"Keyspace", "Shard", "Result"},
+	)
+	ersSplitBrainOverrides = stats.NewCountersWithMultiLabels(
+		"EmergencyReparentSplitBrainOverrides", "Number of split-brain detections bypassed by AllowSplitBrainPromotion=true during EmergencyReparentShard. The non-promoted side's unique GTIDs will become errant on those tablets after promotion.",
+		[]string{"Keyspace", "Shard"},
+	)
 )
 
 // NewEmergencyReparenter returns a new EmergencyReparenter object, ready to
@@ -272,6 +285,25 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 		return vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no valid candidates for emergency reparent")
 	}
 
+	// Upfront split-brain detection for GTID-based shards: if two leading candidates
+	// have incomparable Combined positions ERS must not silently pick one — the loser's
+	// unique writes would become errant after promotion. Non-GTID flavors (FilePos,
+	// MariaDB) skip this because Combined is the executed position, so true incomparable
+	// maxima cannot arise from received-but-unapplied transactions.
+	var preErrantLeaders map[string]*RelayLogPositions
+	if isGTIDBased {
+		preErrantLeaders = leadingCandidatesByCombined(validCandidates)
+		if !uniformCombined(preErrantLeaders) {
+			if !opts.AllowSplitBrainPromotion {
+				return vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION,
+					"suspected split-brain: leading candidates have incomparable Combined GTID positions: %s — re-run with AllowSplitBrainPromotion to override (the non-promoted side's unique GTIDs will become errant)",
+					describeCombinedPositions(preErrantLeaders))
+			}
+			erp.logger.Warningf("AllowSplitBrainPromotion=true: proceeding despite incomparable Combined positions on leading candidates: %s", describeCombinedPositions(preErrantLeaders))
+			ersSplitBrainOverrides.Add([]string{keyspace, shard}, 1)
+		}
+	}
+
 	// Wait for all candidates to apply relay logs
 	if err = erp.waitForAllRelayLogsToApply(ctx, validCandidates, tabletMap, stoppedReplicationSnapshot.statusMap, opts.WaitReplicasTimeout); err != nil {
 		return err
@@ -279,9 +311,39 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 
 	// For GTID based replication, we will run errant GTID detection.
 	if isGTIDBased {
+		// Snapshot validCandidates so the safeguard below can restore the leading
+		// set if every leader is pruned by errant-GTID detection. maps.Clone defends
+		// against a future refactor that mutates the input.
+		preErrantCandidates := maps.Clone(validCandidates)
 		validCandidates, err = erp.findErrantGTIDs(ctx, validCandidates, stoppedReplicationSnapshot.statusMap, tabletMap, opts.WaitReplicasTimeout)
 		if err != nil {
 			return err
+		}
+		// Detect whether any of the pre-detection leading candidates survived errant-GTID
+		// detection. The failure mode we need to guard against is mutually-errant leaders
+		// being pruned while a lagging non-errant candidate remains — promoting the lagger
+		// would lose unique writes from both split-brain sides, which is strictly worse
+		// than the documented "pick one side; losing side becomes errant" semantics.
+		leadingSurvived := false
+		for alias := range validCandidates {
+			if _, isLeading := preErrantLeaders[alias]; isLeading {
+				leadingSurvived = true
+				break
+			}
+		}
+		if !leadingSurvived {
+			if !opts.AllowSplitBrainPromotion {
+				return vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no valid candidates for emergency reparent: all leading candidates have errant GTIDs")
+			}
+			erp.logger.Warningf("AllowSplitBrainPromotion=true: no leading candidates survived errant-GTID detection — restoring the pre-detection leading set so findMostAdvanced can pick a side without promoting a lagger")
+			ersSplitBrainOverrides.Add([]string{keyspace, shard}, 1)
+			restored := make(map[string]*RelayLogPositions, len(preErrantLeaders))
+			for alias := range preErrantLeaders {
+				if pos, ok := preErrantCandidates[alias]; ok {
+					restored[alias] = pos
+				}
+			}
+			validCandidates = restored
 		}
 		if len(validCandidates) == 0 {
 			return vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no valid candidates for emergency reparent: all candidates have errant GTIDs")

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -1870,10 +1870,11 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 			errShouldContain: "primary zone1-0000000100 is not equal to expected alias zone1-0000000101",
 		},
 		{
-			// Regression test: if every candidate has mutually errant GTIDs, findErrantGTIDs
-			// returns an empty map, which previously caused findMostAdvanced to panic with
-			// "index out of range [0] with length 0" when indexing the empty tablet slice.
-			name:                 "all candidates filtered out by errant GTID detection",
+			// Two leading candidates have incomparable Combined GTID positions (each
+			// side has unique writes under a different server UUID). ERS must abort
+			// upfront with a "suspected split-brain" error instead of silently picking
+			// one side.
+			name:                 "suspected split-brain on incomparable leading candidates",
 			durability:           policy.DurabilityNone,
 			emergencyReparentOps: EmergencyReparentOptions{},
 			tmc: &testutil.TabletManagerClient{
@@ -1941,7 +1942,7 @@ func TestEmergencyReparenter_reparentShardLocked(t *testing.T) {
 			shard:            "-",
 			cells:            []string{"zone1"},
 			shouldErr:        true,
-			errShouldContain: "no valid candidates for emergency reparent",
+			errShouldContain: "suspected split-brain: leading candidates have incomparable Combined GTID positions",
 		},
 	}
 

--- a/go/vt/vtctl/reparentutil/replication.go
+++ b/go/vt/vtctl/reparentutil/replication.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -82,6 +84,67 @@ func (rlp *RelayLogPositions) Equal(pos *RelayLogPositions) bool {
 // IsZero returns true if the RelayLogPositions is zero.
 func (rlp *RelayLogPositions) IsZero() bool {
 	return rlp.Combined.IsZero()
+}
+
+// describeCombinedPositions returns a sorted "alias=position" listing, used to make
+// split-brain abort errors actionable by naming exactly which tablets diverged.
+func describeCombinedPositions(candidates map[string]*RelayLogPositions) string {
+	parts := make([]string, 0, len(candidates))
+	for alias, pos := range candidates {
+		parts = append(parts, alias+"="+pos.Combined.String())
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ", ")
+}
+
+// uniformCombined returns true when every candidate in the map shares the same Combined
+// position. Applied to the output of leadingCandidatesByCombined, a false result means
+// the leading set has incomparable maxima — a suspected split-brain that ERS must not
+// silently resolve by short-circuiting on one side.
+func uniformCombined(candidates map[string]*RelayLogPositions) bool {
+	var ref replication.Position
+	set := false
+	for _, pos := range candidates {
+		if !set {
+			ref = pos.Combined
+			set = true
+			continue
+		}
+		if !pos.Combined.Equal(ref) {
+			return false
+		}
+	}
+	return true
+}
+
+// leadingCandidatesByCombined keeps only candidates whose Combined position is not
+// strictly dominated by another (X dominated by Y iff Y.AtLeast(X) and X != Y). Pairwise
+// comparison is required to correctly handle partially-ordered GTID sets: when two
+// candidates have disjoint UUIDs neither dominates the other, so both must be kept;
+// comparing against a single chosen max would silently drop one incomparable maximum.
+func leadingCandidatesByCombined(candidates map[string]*RelayLogPositions) map[string]*RelayLogPositions {
+	if len(candidates) == 0 {
+		return candidates
+	}
+
+	result := make(map[string]*RelayLogPositions, len(candidates))
+	for alias, pos := range candidates {
+		dominated := false
+		for otherAlias, otherPos := range candidates {
+			if otherAlias == alias {
+				continue
+			}
+			if otherPos.Combined.AtLeast(pos.Combined) && !pos.Combined.Equal(otherPos.Combined) {
+				dominated = true
+				break
+			}
+		}
+		if !dominated {
+			result[alias] = pos
+		}
+	}
+
+	return result
 }
 
 // FindPositionsOfAllCandidates will find candidates for an emergency

--- a/proto/vtctldata.proto
+++ b/proto/vtctldata.proto
@@ -756,6 +756,11 @@ message EmergencyReparentShardRequest {
   // ExpectedPrimary is the optional alias we expect to be the current primary in order for
   // the reparent operation to succeed.
   topodata.TabletAlias expected_primary = 8;
+  // AllowSplitBrainPromotion lets ERS proceed when two leading candidates have incomparable
+  // Combined GTID positions (suspected split-brain). By default ERS aborts with FAILED_PRECONDITION
+  // in that case; setting this true logs a WARN and continues, accepting that the losing side's
+  // unique GTIDs will become errant on those tablets. Intended as a deliberate operator override.
+  bool allow_split_brain_promotion = 9;
 }
 
 message EmergencyReparentShardResponse {

--- a/web/vtadmin/src/proto/vtadmin.d.ts
+++ b/web/vtadmin/src/proto/vtadmin.d.ts
@@ -60445,6 +60445,9 @@ export namespace vtctldata {
 
         /** EmergencyReparentShardRequest expected_primary */
         expected_primary?: (topodata.ITabletAlias|null);
+
+        /** EmergencyReparentShardRequest allow_split_brain_promotion */
+        allow_split_brain_promotion?: (boolean|null);
     }
 
     /** Represents an EmergencyReparentShardRequest. */
@@ -60479,6 +60482,9 @@ export namespace vtctldata {
 
         /** EmergencyReparentShardRequest expected_primary. */
         public expected_primary?: (topodata.ITabletAlias|null);
+
+        /** EmergencyReparentShardRequest allow_split_brain_promotion. */
+        public allow_split_brain_promotion: boolean;
 
         /**
          * Creates a new EmergencyReparentShardRequest instance using the specified properties.


### PR DESCRIPTION
## Description

Follow-up to #18707, separating the split-brain detection from the GTID-based lagging-tablet optimisation to make review more streamlined

Today `EmergencyReparentShard` only catches a split-brain when the **chosen** primary's position is not at-least every other valid candidate's position _(the existing `findMostAdvanced` AtLeast check)_. That's a narrow window — it fires only after the sort picks a winner. If the sort picks a "winner" whose `Combined` position is incomparable with another candidate _(the canonical split-brain shape: two sides have written under different server UUIDs)_, ERS silently promotes that side and the loser's unique GTIDs become errant. The operator sees a successful reparent followed by lag alerts or downstream consistency checks days later 😱

This PR addresses #20199 by detecting split-brain **upfront**, before promotion, naming the diverged tablets in the error so operators can see exactly which sides need reconciliation

#### What changed

1. **Pairwise-dominance filter** — added `leadingCandidatesByCombined()` in `replication.go` that keeps every candidate not strictly dominated by another. Under partially-ordered GTID sets _(disjoint UUIDs, neither side wholly contains the other)_ the leading set can have multiple members. Comparing against a single chosen max would silently drop one incomparable maximum

2. **Upfront uniformity check** — after `restrictValidCandidates()` and before relay-log-apply, compute `leadingCandidatesByCombined(validCandidates)` and check `uniformCombined()` on the result. Non-uniform = suspected split-brain → abort with `FAILED_PRECONDITION` and a `describeCombinedPositions()` listing of the diverged tablets. Gated on `isGTIDBased`: non-GTID flavours _(FilePos, MariaDB)_ have `Combined` equal to executed, so true incomparable maxima can't arise from received-but-unapplied transactions

3. **Errant-GTID restoration safeguard** — snapshot the pre-detection leading set _(via `leadingCandidatesByCombined()` before `findErrantGTIDs`)_ and check whether any leader survived errant detection. The failure mode this guards: 2 x mutually-errant leaders get pruned, leaving only a strictly-lagging non-errant candidate. Promoting that lagger would lose unique writes from **both** split-brain sides — strictly worse than the documented "pick one side; loser becomes errant" semantics. Without the safeguard, this case would still silently promote the lagger

4. **`--allow-split-brain-promotion` operator escape hatch** _(off by default)_ — converts the abort into a `WARN` log naming both diverged tablets + their positions, increments `EmergencyReparentSplitBrainOverrides`, and lets ERS proceed. The non-promoted side's unique GTIDs become errant after promotion — the flag is an explicit operator override, not a default-on safety knob. Intended for the case where the operator already knows which side to keep and plans to re-clone the loser. Available as `--allow-split-brain-promotion` _(`vtctldclient`)_ and `--allow_split_brain_promotion` _(legacy `vtctl`)_

#### Stats

1 x new stat exported for observability:

- `EmergencyReparentSplitBrainOverrides{Keyspace, Shard}` — ERS runs that proceeded despite incomparable `Combined` positions because `--allow-split-brain-promotion` was set. Always zero unless an operator has deliberately invoked the escape hatch

#### Testing

1. **`TestERSSplitBrainDetection`** _(e2e in `ers_test.go`)_ — detaches `tablets[2]` and `tablets[3]` from replication, makes them writable _(must clear `super_read_only`, which Vitess leaves at 1 on demoted replicas)_, inserts to each independently to produce two-sided GTID divergence under their own server UUIDs, kills the primary, runs ERS, and asserts the output contains `"suspected split-brain"` plus both diverged tablet aliases. Gated on `e2eutils.SkipIfBinaryIsBelowVersion(t, 25, "vtctld")` so the `Reparent Old Vtctl` upgrade-downgrade job skips it cleanly

2. **Unit test in `emergency_reparenter_test.go`** — the existing `"all candidates filtered out by errant GTID detection"` regression case is renamed and now asserts the new `"suspected split-brain: leading candidates have incomparable Combined GTID positions"` error _(the upfront check fires before errant-GTID detection on the mutually-errant tablet shape)_

## Related Issue(s)

Resolves: #20199

Related: #18707 _(the GTID-based lagging-tablet optimisation this was split out from)_

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

This is a user-visible behavioural change in `EmergencyReparentShard` for GTID-based shards. It is called out in `changelog/25.0/25.0.0/summary.md` under VTCtld. No new required flags or configuration — the one new flag is an opt-in operator escape hatch:

1. **Suspected split-brain** — when the leading GTID candidates have incomparable `Combined` positions, ERS now aborts upfront with a `FAILED_PRECONDITION` error naming the diverged tablets. This is a stricter check than pre-PR behaviour and may surface as a new failure mode on shards that previously survived a split-brain scenario by luck. The pre-PR behaviour was silent data loss + errant GTIDs on the losing side — this PR converts that invisible data-integrity incident into a visible operational one

2. **`--allow-split-brain-promotion`** _(off by default)_ — operators who deliberately need to force ERS through a detected split-brain _(eg: they know which side to keep, plan to manually re-clone the losing side after)_ can set this flag. ERS will log a `WARN` naming the diverged tablets + their positions, increment `EmergencyReparentSplitBrainOverrides`, and proceed

1 x new stat _(`EmergencyReparentSplitBrainOverrides`)_ is exported from vtctld for operators to track split-brain-override counts per keyspace/shard

### AI Disclosure

Claude Code assisted with development. Claude prepared this PR summary
