### PR TITLE
vstream: expose a metric for throttled vstreams

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/engine.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine.go
@@ -98,7 +98,7 @@ type Engine struct {
 	rowStreamerNumPackets                  *stats.Counter
 	rowStreamerWaits                       *servenv.TimingsWrapper
 	errorCounts                            *stats.CountersWithSingleLabel
-	throttledCounts                        *stats.CountersWithSingleLabel
+	throttledCounts                        *stats.Counter
 	vstreamersCreated                      *stats.Counter
 	vstreamersEndedWithErrors              *stats.Counter
 	vstreamerFlushedBinlogs                *stats.Counter
@@ -145,7 +145,7 @@ func NewEngine(env tabletenv.Env, ts srvtopo.Server, se *schema.Engine, lagThrot
 		tableStreamerNumTables:                 env.Exporter().NewCounter("TableStreamerNumTables", "Number of tables streamed by the table streamer"),
 		vstreamersEndedWithErrors:              env.Exporter().NewCounter("VStreamersEndedWithErrors", "Count of vstreamers that ended with errors"),
 		errorCounts:                            env.Exporter().NewCountersWithSingleLabel("VStreamerErrors", "Tracks errors in vstreamer", "type", "Catchup", "Copy", "Send", "TablePlan"),
-		throttledCounts:                        env.Exporter().NewCountersWithSingleLabel("VStreamerThrottledCounts", "Number of times vstreamer was throttled by the tablet throttler", "workflow"),
+		throttledCounts:                        env.Exporter().NewCounter("VStreamerThrottledCounts", "Number of times vstreamer was throttled by the tablet throttler"),
 		vstreamerFlushedBinlogs:                env.Exporter().NewCounter("VStreamerFlushedBinlogs", "Number of times we've successfully executed a FLUSH BINARY LOGS statement when starting a vstream"),
 	}
 	env.Exporter().NewGaugeFunc("RowStreamerMaxInnoDBTrxHistLen", "", func() int64 { return env.Config().RowStreamer.MaxInnoDBTrxHistLen })

--- a/go/vt/vttablet/tabletserver/vstreamer/engine.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine.go
@@ -98,6 +98,7 @@ type Engine struct {
 	rowStreamerNumPackets                  *stats.Counter
 	rowStreamerWaits                       *servenv.TimingsWrapper
 	errorCounts                            *stats.CountersWithSingleLabel
+	throttledCounts                        *stats.CountersWithSingleLabel
 	vstreamersCreated                      *stats.Counter
 	vstreamersEndedWithErrors              *stats.Counter
 	vstreamerFlushedBinlogs                *stats.Counter
@@ -144,6 +145,7 @@ func NewEngine(env tabletenv.Env, ts srvtopo.Server, se *schema.Engine, lagThrot
 		tableStreamerNumTables:                 env.Exporter().NewCounter("TableStreamerNumTables", "Number of tables streamed by the table streamer"),
 		vstreamersEndedWithErrors:              env.Exporter().NewCounter("VStreamersEndedWithErrors", "Count of vstreamers that ended with errors"),
 		errorCounts:                            env.Exporter().NewCountersWithSingleLabel("VStreamerErrors", "Tracks errors in vstreamer", "type", "Catchup", "Copy", "Send", "TablePlan"),
+		throttledCounts:                        env.Exporter().NewCountersWithSingleLabel("VStreamerThrottledCounts", "Number of times vstreamer was throttled by the tablet throttler, labeled by workflow name", "workflow"),
 		vstreamerFlushedBinlogs:                env.Exporter().NewCounter("VStreamerFlushedBinlogs", "Number of times we've successfully executed a FLUSH BINARY LOGS statement when starting a vstream"),
 	}
 	env.Exporter().NewGaugeFunc("RowStreamerMaxInnoDBTrxHistLen", "", func() int64 { return env.Config().RowStreamer.MaxInnoDBTrxHistLen })

--- a/go/vt/vttablet/tabletserver/vstreamer/engine.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/engine.go
@@ -145,7 +145,7 @@ func NewEngine(env tabletenv.Env, ts srvtopo.Server, se *schema.Engine, lagThrot
 		tableStreamerNumTables:                 env.Exporter().NewCounter("TableStreamerNumTables", "Number of tables streamed by the table streamer"),
 		vstreamersEndedWithErrors:              env.Exporter().NewCounter("VStreamersEndedWithErrors", "Count of vstreamers that ended with errors"),
 		errorCounts:                            env.Exporter().NewCountersWithSingleLabel("VStreamerErrors", "Tracks errors in vstreamer", "type", "Catchup", "Copy", "Send", "TablePlan"),
-		throttledCounts:                        env.Exporter().NewCountersWithSingleLabel("VStreamerThrottledCounts", "Number of times vstreamer was throttled by the tablet throttler, labeled by workflow name", "workflow"),
+		throttledCounts:                        env.Exporter().NewCountersWithSingleLabel("VStreamerThrottledCounts", "Number of times vstreamer was throttled by the tablet throttler", "workflow"),
 		vstreamerFlushedBinlogs:                env.Exporter().NewCounter("VStreamerFlushedBinlogs", "Number of times we've successfully executed a FLUSH BINARY LOGS statement when starting a vstream"),
 	}
 	env.Exporter().NewGaugeFunc("RowStreamerMaxInnoDBTrxHistLen", "", func() int64 { return env.Config().RowStreamer.MaxInnoDBTrxHistLen })

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -395,9 +395,13 @@ func (vs *vstreamer) parseEvents(ctx context.Context, events <-chan mysql.Binlog
 	}
 
 	logger := logutil.NewThrottledLogger(vs.vse.GetTabletInfo(), throttledLoggerInterval)
+	wfName := ""
+	if vs.filter != nil {
+		wfName = vs.filter.WorkflowName
+	}
 	wfNameLog := ""
-	if vs.filter != nil && vs.filter.WorkflowName != "" {
-		wfNameLog = " in workflow " + vs.filter.WorkflowName
+	if wfName != "" {
+		wfNameLog = " in workflow " + wfName
 	}
 	throttlerErrs := make(chan error, 1) // How we share the error when we've been fully throttled too long
 	defer close(throttlerErrs)
@@ -413,6 +417,7 @@ func (vs *vstreamer) parseEvents(ctx context.Context, events <-chan mysql.Binlog
 				default:
 					// Do nothing special.
 				}
+				vs.vse.throttledCounts.Add(wfName, 1)
 				curtime := time.Now().Unix()
 				if !throttledTime.CompareAndSwap(0, curtime) {
 					if curtime-throttledTime.Load() > int64(fullyThrottledTimeout.Seconds()) {

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer.go
@@ -395,13 +395,9 @@ func (vs *vstreamer) parseEvents(ctx context.Context, events <-chan mysql.Binlog
 	}
 
 	logger := logutil.NewThrottledLogger(vs.vse.GetTabletInfo(), throttledLoggerInterval)
-	wfName := ""
-	if vs.filter != nil {
-		wfName = vs.filter.WorkflowName
-	}
 	wfNameLog := ""
-	if wfName != "" {
-		wfNameLog = " in workflow " + wfName
+	if vs.filter != nil && vs.filter.WorkflowName != "" {
+		wfNameLog = " in workflow " + vs.filter.WorkflowName
 	}
 	throttlerErrs := make(chan error, 1) // How we share the error when we've been fully throttled too long
 	defer close(throttlerErrs)
@@ -417,7 +413,7 @@ func (vs *vstreamer) parseEvents(ctx context.Context, events <-chan mysql.Binlog
 				default:
 					// Do nothing special.
 				}
-				vs.vse.throttledCounts.Add(wfName, 1)
+				vs.vse.throttledCounts.Add(1)
 				curtime := time.Now().Unix()
 				if !throttledTime.CompareAndSwap(0, curtime) {
 					if curtime-throttledTime.Load() > int64(fullyThrottledTimeout.Seconds()) {

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -2422,6 +2422,25 @@ func TestFullyThrottledTimeout(t *testing.T) {
 	}
 }
 
+func TestVStreamerThrottledCounts(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	const wfName = "test_vstreamer_throttled_counts"
+	filter := &binlogdatapb.Filter{
+		WorkflowName: wfName,
+		Rules:        []*binlogdatapb.Rule{{Match: "/.*/"}},
+	}
+	startingMetric := engine.throttledCounts.Counts()[wfName]
+
+	wg, _ := startFullyThrottledStream(ctx, t, filter, "", nil)
+	defer wg.Wait()
+	defer cancel()
+
+	assert.Eventually(t, func() bool {
+		return engine.throttledCounts.Counts()[wfName] > startingMetric
+	}, 30*time.Second, 50*time.Millisecond, "VStreamerThrottledCounts should increment while vstream is throttled")
+}
+
 func TestNoFutureGTID(t *testing.T) {
 	// Execute something to make sure we have ranges in GTIDs.
 	execStatements(t, []string{

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -2425,19 +2425,14 @@ func TestFullyThrottledTimeout(t *testing.T) {
 func TestVStreamerThrottledCounts(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 
-	const wfName = "test_vstreamer_throttled_counts"
-	filter := &binlogdatapb.Filter{
-		WorkflowName: wfName,
-		Rules:        []*binlogdatapb.Rule{{Match: "/.*/"}},
-	}
-	startingMetric := engine.throttledCounts.Counts()[wfName]
+	startingMetric := engine.throttledCounts.Get()
 
-	wg, _ := startFullyThrottledStream(ctx, t, filter, "", nil)
+	wg, _ := startFullyThrottledStream(ctx, t, nil, "", nil)
 	defer wg.Wait()
 	defer cancel()
 
 	assert.Eventually(t, func() bool {
-		return engine.throttledCounts.Counts()[wfName] > startingMetric
+		return engine.throttledCounts.Get() > startingMetric
 	}, 30*time.Second, 50*time.Millisecond, "VStreamerThrottledCounts should increment while vstream is throttled")
 }
 


### PR DESCRIPTION
## Description

This PR exposes a new metric: `vttablet_v_streamer_throttled_counts`. It reports how many times a tablet throttled a VStream.

VStreams used by CDC tools, and going through VTGate can get throttled for various reasons (most common one being replication lag), but we're lacking observability into how many times tablets have throttled a VStream.

For vreplication workflows, we already have metrics: `VReplicationThrottledCounts` and `VReplicationThrottledCountTotal`. But these metrics are on the target primary side. The new metric proposed by this PR is on the source tablet/vstreamer side.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required