### PR TITLE
smartconnpool: don't hand returned connections to expired waiters

### DIFF
--- a/go/list/list.go
+++ b/go/list/list.go
@@ -130,9 +130,9 @@ func (l *List[T]) move(e, at *Element[T]) {
 	e.next.prev = e
 }
 
-// Remove removes e from l if e is an element of list l.
-// It returns the element value e.Value.
-// The element must not be nil.
+// Remove removes e from l. The element must not be nil and must be an
+// element of list l; Remove panics otherwise. Use RemoveIfPresent when the
+// element may have been removed already.
 func (l *List[T]) Remove(e *Element[T]) {
 	if e.list != l {
 		panic("removing from wrong List")
@@ -140,6 +140,19 @@ func (l *List[T]) Remove(e *Element[T]) {
 	// if e.list == l, l must have been initialized when e was inserted
 	// in l or l == nil (e is a zero Element) and l.remove will crash
 	l.remove(e)
+}
+
+// RemoveIfPresent removes e from l if e is currently an element of list l
+// and reports whether it did so. Unlike Remove, it is a no-op rather than a
+// panic when e is not in l, which makes membership checks O(1) for callers
+// that would otherwise have to scan the list before removing.
+// The element must not be nil.
+func (l *List[T]) RemoveIfPresent(e *Element[T]) bool {
+	if e.list != l {
+		return false
+	}
+	l.remove(e)
+	return true
 }
 
 // PushFront inserts a new element e with value v at the front of list l and returns e.

--- a/go/list/list_test.go
+++ b/go/list/list_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInitEmptyList(t *testing.T) {
@@ -132,4 +133,40 @@ func TestPushFrontValue(t *testing.T) {
 	l.PushFrontValue(a)
 	assert.Equal(t, a, l.Front())
 	assert.Equal(t, a, e.prev)
+}
+
+func TestRemoveIfPresent(t *testing.T) {
+	l := New[int]()
+	a := l.PushBack(1)
+	b := l.PushBack(2)
+
+	require.True(t, l.RemoveIfPresent(a))
+	require.Equal(t, 1, l.Len())
+	require.Equal(t, b, l.Front())
+
+	// already removed: no-op, no panic
+	require.False(t, l.RemoveIfPresent(a))
+	require.Equal(t, 1, l.Len())
+
+	// element of a different list: no-op
+	m := New[int]()
+	c := m.PushBack(3)
+	require.False(t, l.RemoveIfPresent(c))
+	require.Equal(t, 1, m.Len())
+	require.Equal(t, c, m.Front())
+
+	require.True(t, l.RemoveIfPresent(b))
+	require.Equal(t, 0, l.Len())
+	require.Nil(t, l.Front())
+}
+
+func TestRemoveIfPresentReinsert(t *testing.T) {
+	l := New[int]()
+	a := l.PushBack(1)
+
+	require.True(t, l.RemoveIfPresent(a))
+	l.PushBackValue(a)
+	require.Equal(t, 1, l.Len())
+	require.True(t, l.RemoveIfPresent(a))
+	require.Equal(t, 0, l.Len())
 }

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"vitess.io/vitess/go/vt/log"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
@@ -144,7 +145,11 @@ type ConnPool[C Connection] struct {
 	// was pushed, or -1 if no connection with a Setting has been opened in this pool
 	freshSettingsStack atomic.Int64
 	// wait is the list of clients waiting for a connection to be returned to the pool
-	wait waitlist[C]
+	// Held behind a pointer so that growing the waitlist struct cannot
+	// change ConnPool's allocation size: the 128-bit atomics in clean and
+	// settings must stay 16-byte aligned, and the Go allocator only
+	// provides that for certain object sizes (see the assert in NewPool).
+	wait *waitlist[C]
 
 	// borrowed is the number of connections that the pool has given out to clients
 	// and that haven't been returned yet
@@ -200,6 +205,15 @@ type ConnPool[C Connection] struct {
 // The pool must be ConnPool.Open before it can start giving out connections
 func NewPool[C Connection](config *Config[C]) *ConnPool[C] {
 	pool := &ConnPool[C]{}
+	// The 128-bit atomics in the connection stacks fault on amd64 and arm64
+	// unless they are 16-byte aligned. Go offers no way to demand that
+	// alignment, so it depends on the allocator's behavior for ConnPool's
+	// exact size; fail fast and loudly if a layout or toolchain change ever
+	// breaks it, instead of crashing with SIGBUS under traffic.
+	if addr := uintptr(unsafe.Pointer(&pool.clean.top)); addr%16 != 0 {
+		panic("smartconnpool: ConnPool allocation is not 16-byte aligned")
+	}
+	pool.wait = &waitlist[C]{}
 	pool.config.maxCapacity = config.Capacity
 	pool.config.maxIdleCount = config.MaxIdleCount
 	pool.config.maxLifetime.Store(config.MaxLifetime.Nanoseconds())

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"unsafe"
 
 	"vitess.io/vitess/go/vt/log"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
@@ -148,7 +147,7 @@ type ConnPool[C Connection] struct {
 	// Held behind a pointer so that growing the waitlist struct cannot
 	// change ConnPool's allocation size: the 128-bit atomics in clean and
 	// settings must stay 16-byte aligned, and the Go allocator only
-	// provides that for certain object sizes (see the assert in NewPool).
+	// provides that for certain object sizes (see the connStack docs).
 	wait *waitlist[C]
 
 	// borrowed is the number of connections that the pool has given out to clients
@@ -205,14 +204,6 @@ type ConnPool[C Connection] struct {
 // The pool must be ConnPool.Open before it can start giving out connections
 func NewPool[C Connection](config *Config[C]) *ConnPool[C] {
 	pool := &ConnPool[C]{}
-	// The 128-bit atomics in the connection stacks fault on amd64 and arm64
-	// unless they are 16-byte aligned. Go offers no way to demand that
-	// alignment, so it depends on the allocator's behavior for ConnPool's
-	// exact size; fail fast and loudly if a layout or toolchain change ever
-	// breaks it, instead of crashing with SIGBUS under traffic.
-	if addr := uintptr(unsafe.Pointer(&pool.clean.top)); addr%16 != 0 {
-		panic("smartconnpool: ConnPool allocation is not 16-byte aligned")
-	}
 	pool.wait = &waitlist[C]{}
 	pool.config.maxCapacity = config.Capacity
 	pool.config.maxIdleCount = config.MaxIdleCount

--- a/go/pools/smartconnpool/stack.go
+++ b/go/pools/smartconnpool/stack.go
@@ -24,6 +24,18 @@ import (
 
 // connStack is a lock-free stack for Connection objects. It is safe to
 // use from several goroutines.
+//
+// ALIGNMENT: the 128-bit atomic in this struct faults (SIGBUS) on amd64 and
+// arm64 unless it is 16-byte aligned. Go has no supported way to demand
+// 16-byte alignment (the maximum natural alignment is 8 bytes), so it
+// depends entirely on where the allocator places the enclosing allocation,
+// which varies with the allocation's exact size, pointer layout, and Go
+// version — e.g. allocation headers (Go 1.22+) shift some pointer-bearing
+// objects larger than 512 bytes to an odd 8-byte boundary. ConnPool
+// currently lands in a bucket where allocations are 16-byte aligned; growing
+// it can silently break that, which is why its waitlist is held behind a
+// pointer. Be careful when adding fields to ConnPool or anything embedded
+// in it.
 type connStack[C Connection] struct {
 	// top is a pointer to the top node on the stack and to an increasing
 	// counter of pop operations, to prevent A-B-A races.

--- a/go/pools/smartconnpool/stress_test.go
+++ b/go/pools/smartconnpool/stress_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
+
+	"vitess.io/vitess/go/list"
 )
 
 type StressConn struct {
@@ -1213,6 +1215,210 @@ func runStressCloseDuringTrafficCycle(t *testing.T, cycle int) {
 	}
 	require.Equalf(t, 0, leaked, "cycle %d: leaked %d connections out of %d ever opened; connectsAfterClose=%d",
 		cycle, leaked, len(allConns), connectsAfterClose.Load())
+}
+
+// TestStressExpiredWaiterBacklog reproduces a production stall: a backlog of
+// waiters whose contexts have expired but which haven't removed themselves
+// from the waitlist yet (in production: thousands of timed-out requests
+// queued on the contended waitlist mutex). Returned connections must not be
+// handed to them — each such handoff parks the connection on a dead request
+// and, at scale, drains the pool to zero useful throughput.
+//
+// The expired cohort is modeled with synthetic waitlist entries that have no
+// goroutine behind them: they can never remove themselves, and any connection
+// handed to one is silently swallowed by its buffered channel. The test
+// verifies that live waiters queued *behind* the expired backlog keep being
+// served. Each cycle is a fresh pool; the loop runs several cycles to surface
+// scheduling-dependent races.
+func TestStressExpiredWaiterBacklog(t *testing.T) {
+	const Cycles = 25
+
+	for cycle := range Cycles {
+		if !t.Run(fmt.Sprintf("cycle-%03d", cycle), func(t *testing.T) {
+			runStressExpiredWaiterBacklogCycle(t, cycle)
+		}) {
+			return
+		}
+	}
+}
+
+func runStressExpiredWaiterBacklogCycle(t *testing.T, cycle int) {
+	t.Helper()
+
+	const (
+		Capacity      = 4
+		NumPinned     = 64
+		NumLive       = 8
+		MinSuccessful = NumLive * 4
+		GetTimeout    = 5 * time.Second
+		ProgressWait  = 30 * time.Second
+		CloseTimeout  = 30 * time.Second
+		Watchdog      = 30 * time.Second
+	)
+
+	var (
+		connsMu        sync.Mutex
+		allConns       []*StressConn
+		liveWorkers    atomic.Int64
+		successfulGets atomic.Int64
+		workerErrors   atomic.Int64
+	)
+
+	connect := func(_ context.Context) (*StressConn, error) {
+		c := &StressConn{}
+		connsMu.Lock()
+		allConns = append(allConns, c)
+		connsMu.Unlock()
+		return c, nil
+	}
+	connCount := func() int {
+		connsMu.Lock()
+		defer connsMu.Unlock()
+		return len(allConns)
+	}
+
+	pool := NewPool[*StressConn](&Config[*StressConn]{
+		Capacity: Capacity,
+	}).Open(connect, nil)
+
+	// Hold every conn so all subsequent Gets queue on the waitlist.
+	var held []*Pooled[*StressConn]
+	for range Capacity {
+		conn, err := pool.Get(t.Context(), nil)
+		require.NoError(t, err)
+		held = append(held, conn)
+	}
+
+	// Pin an expired cohort at the front of the waitlist.
+	expiredCtx, cancelExpired := context.WithCancel(t.Context())
+	cancelExpired()
+
+	pinned := make([]*list.Element[waiter[*StressConn]], 0, NumPinned)
+	pool.wait.mu.Lock()
+	for range NumPinned {
+		elem := &list.Element[waiter[*StressConn]]{
+			Value: waiter[*StressConn]{
+				ctx:  expiredCtx,
+				conn: make(chan *Pooled[*StressConn], 1),
+			},
+		}
+		pool.wait.list.PushBackValue(elem)
+		pinned = append(pinned, elem)
+	}
+	pool.wait.mu.Unlock()
+
+	// drainPinned recovers conns swallowed by pinned entries so the pool can
+	// settle and close — needed when the progress assertion fails.
+	drainPinned := func() {
+		for _, elem := range pinned {
+			select {
+			case conn := <-elem.Value.conn:
+				conn.Recycle()
+			default:
+			}
+		}
+	}
+
+	var (
+		wg   errgroup.Group
+		stop atomic.Bool
+	)
+
+	for i := range NumLive {
+		tid := int32(i + 1)
+		wg.Go(func() error {
+			liveWorkers.Add(1)
+			defer liveWorkers.Add(-1)
+
+			for !stop.Load() {
+				ctx, cancel := context.WithTimeout(t.Context(), GetTimeout)
+				conn, err := pool.Get(ctx, nil)
+				cancel()
+				if err != nil {
+					workerErrors.Add(1)
+					runtime.Gosched()
+					continue
+				}
+
+				previousOwner := conn.Conn.owner.Swap(tid)
+				if previousOwner != 0 {
+					return fmt.Errorf("cycle %d: conn handed out concurrently: %d still owned it when %d acquired", cycle, previousOwner, tid)
+				}
+				runtime.Gosched()
+				previousOwner = conn.Conn.owner.Swap(0)
+				if previousOwner != tid {
+					return fmt.Errorf("cycle %d: conn owner overwritten under us: expected %d, got %d", cycle, tid, previousOwner)
+				}
+				successfulGets.Add(1)
+				conn.Recycle()
+			}
+			return nil
+		})
+	}
+
+	status := func() string {
+		return fmt.Sprintf("capacity=%d active=%d borrowed=%d open=%d isOpen=%v waiting=%d liveWorkers=%d successfulGets=%d workerErrors=%d",
+			pool.Capacity(), pool.Active(), pool.InUse(), connCount(), pool.IsOpen(), pool.wait.waiting(), liveWorkers.Load(), successfulGets.Load(), workerErrors.Load())
+	}
+
+	abort := func() {
+		stop.Store(true)
+		drainPinned()
+		for _, conn := range held {
+			conn.Recycle()
+		}
+		waitForStressTraffic(t, cycle, &wg, Watchdog, status)
+		closeCtx, cancel := context.WithTimeout(t.Context(), CloseTimeout)
+		_ = pool.CloseWithContext(closeCtx)
+		cancel()
+	}
+
+	queued := assert.Eventuallyf(t, func() bool {
+		return pool.wait.waiting() == NumPinned+NumLive
+	}, Watchdog, time.Millisecond, "cycle %d: live waiters did not queue behind the expired backlog: %s", cycle, status())
+	if !queued {
+		abort()
+		require.FailNowf(t, "live waiters did not queue behind the expired backlog", "cycle %d: %s", cycle, status())
+	}
+
+	// Release the held conns into the teeth of the expired backlog.
+	for _, conn := range held {
+		conn.Recycle()
+	}
+	held = nil
+
+	progressed := assert.Eventuallyf(t, func() bool {
+		return successfulGets.Load() >= MinSuccessful
+	}, ProgressWait, time.Millisecond, "cycle %d: live waiters starved behind the expired backlog: %s", cycle, status())
+	if !progressed {
+		abort()
+		require.FailNowf(t, "live waiters starved behind the expired backlog", "cycle %d: %s", cycle, status())
+	}
+
+	stop.Store(true)
+	waitForStressTraffic(t, cycle, &wg, Watchdog, status)
+	drainPinned()
+
+	closeCtx, cancelClose := context.WithTimeout(t.Context(), CloseTimeout)
+	closeErr := pool.CloseWithContext(closeCtx)
+	cancelClose()
+	require.NoErrorf(t, closeErr, "cycle %d: CloseWithContext failed: %s", cycle, status())
+
+	require.EqualValuesf(t, 0, pool.Active(), "cycle %d: active should be 0 after Close", cycle)
+	require.EqualValuesf(t, 0, pool.InUse(), "cycle %d: borrowed should be 0 after Close", cycle)
+
+	finalStatus := status()
+	connsMu.Lock()
+	defer connsMu.Unlock()
+
+	var leaked int
+	for _, c := range allConns {
+		if !c.IsClosed() {
+			leaked++
+		}
+	}
+	require.Equalf(t, 0, leaked, "cycle %d: leaked %d connections out of %d ever opened; %s",
+		cycle, leaked, len(allConns), finalStatus)
 }
 
 func waitForStressTraffic(t *testing.T, cycle int, wg *errgroup.Group, timeout time.Duration, status func() string) {

--- a/go/pools/smartconnpool/stress_test.go
+++ b/go/pools/smartconnpool/stress_test.go
@@ -1399,7 +1399,6 @@ func runStressWaiterTimeoutStormCycle(t *testing.T, cycle int) {
 			return nil
 		})
 	}
-	held = nil
 
 	// Recycle decrements the borrowed count before reaching for the
 	// waitlist mutex, so once InUse hits zero every returner is parked on

--- a/go/pools/smartconnpool/stress_test.go
+++ b/go/pools/smartconnpool/stress_test.go
@@ -29,8 +29,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
-
-	"vitess.io/vitess/go/list"
 )
 
 type StressConn struct {
@@ -1217,51 +1215,68 @@ func runStressCloseDuringTrafficCycle(t *testing.T, cycle int) {
 		cycle, leaked, len(allConns), connectsAfterClose.Load())
 }
 
-// TestStressExpiredWaiterBacklog reproduces a production stall: a backlog of
-// waiters whose contexts have expired but which haven't removed themselves
-// from the waitlist yet (in production: thousands of timed-out requests
-// queued on the contended waitlist mutex). Returned connections must not be
-// handed to them — each such handoff parks the connection on a dead request
-// and, at scale, drains the pool to zero useful throughput.
+// TestStressWaiterTimeoutStorm reproduces a production vttablet stall. The
+// anatomy of the incident, taken from a goroutine dump of the stalled
+// tablet:
 //
-// The expired cohort is modeled with synthetic waitlist entries that have no
-// goroutine behind them: they can never remove themselves, and any connection
-// handed to one is silently swallowed by its buffered channel. The test
-// verifies that live waiters queued *behind* the expired backlog keep being
-// served. Each cycle is a fresh pool; the loop runs several cycles to surface
-// scheduling-dependent races.
-func TestStressExpiredWaiterBacklog(t *testing.T) {
+//   - the stream pool was at capacity and a large backlog of requests was
+//     queued on the waitlist; their deadlines expired while they waited.
+//   - an expired waiter cannot leave the waitlist instantly: it must
+//     reacquire the contended waitlist mutex to remove itself, so at any
+//     given moment the list held thousands of expired-but-still-listed
+//     waiters.
+//   - every returned connection was handed to the front-most (expired)
+//     waiter; the returner then sat blocked in the unbuffered channel send
+//     until its dead target crawled through the mutex queue to perform the
+//     fallback receive. The dead request then "completed" holding a
+//     connection it could not use, failed, and recycled it to the next
+//     expired waiter.
+//   - net effect: connections churned through dead requests while live
+//     requests starved; useful throughput was zero.
+//
+// The test recreates that state with real waiters and real returners. The
+// waitlist mutex, held by the test, plays the role of the convoyed mutex:
+// the returners are parked on it first, then the queued waiters' contexts
+// are cancelled so they pile up behind. When the test releases the mutex,
+// the returners scan a waitlist full of expired-but-listed waiters — the
+// exact moment the production bug fired.
+//
+// The assertions are the customer-visible contract and do not depend on
+// timing: no request whose context has already expired may be handed a
+// connection (wastedHandoffs must stay zero), and every live request must
+// be served. Each cycle is a fresh pool; the loop runs several cycles to
+// surface scheduling-dependent races.
+func TestStressWaiterTimeoutStorm(t *testing.T) {
 	const Cycles = 25
 
 	for cycle := range Cycles {
 		if !t.Run(fmt.Sprintf("cycle-%03d", cycle), func(t *testing.T) {
-			runStressExpiredWaiterBacklogCycle(t, cycle)
+			runStressWaiterTimeoutStormCycle(t, cycle)
 		}) {
 			return
 		}
 	}
 }
 
-func runStressExpiredWaiterBacklogCycle(t *testing.T, cycle int) {
+func runStressWaiterTimeoutStormCycle(t *testing.T, cycle int) {
 	t.Helper()
 
 	const (
-		Capacity      = 4
-		NumPinned     = 64
-		NumLive       = 8
-		MinSuccessful = NumLive * 4
-		GetTimeout    = 5 * time.Second
-		ProgressWait  = 30 * time.Second
-		CloseTimeout  = 30 * time.Second
-		Watchdog      = 30 * time.Second
+		Capacity     = 4
+		NumExpired   = 64
+		NumLive      = 8
+		GetsPerLive  = 4
+		LiveTimeout  = 30 * time.Second
+		Watchdog     = 30 * time.Second
+		CloseTimeout = 30 * time.Second
 	)
 
 	var (
-		connsMu        sync.Mutex
-		allConns       []*StressConn
-		liveWorkers    atomic.Int64
-		successfulGets atomic.Int64
-		workerErrors   atomic.Int64
+		connsMu         sync.Mutex
+		allConns        []*StressConn
+		wastedHandoffs  atomic.Int64
+		expiredTimedOut atomic.Int64
+		liveSuccesses   atomic.Int64
 	)
 
 	connect := func(_ context.Context) (*StressConn, error) {
@@ -1289,55 +1304,59 @@ func runStressExpiredWaiterBacklogCycle(t *testing.T, cycle int) {
 		held = append(held, conn)
 	}
 
-	// Pin an expired cohort at the front of the waitlist.
+	var wg errgroup.Group
+
+	// The backlog: real requests whose deadline will expire while they are
+	// queued. Until the held conns are recycled nothing can be handed to
+	// them, so any successful Get here is a connection delivered to a
+	// request whose context had already expired — the production bug.
 	expiredCtx, cancelExpired := context.WithCancel(t.Context())
-	cancelExpired()
-
-	pinned := make([]*list.Element[waiter[*StressConn]], 0, NumPinned)
-	pool.wait.mu.Lock()
-	for range NumPinned {
-		elem := &list.Element[waiter[*StressConn]]{
-			Value: waiter[*StressConn]{
-				ctx:  expiredCtx,
-				conn: make(chan *Pooled[*StressConn], 1),
-			},
-		}
-		pool.wait.list.PushBackValue(elem)
-		pinned = append(pinned, elem)
-	}
-	pool.wait.mu.Unlock()
-
-	// drainPinned recovers conns swallowed by pinned entries so the pool can
-	// settle and close — needed when the progress assertion fails.
-	drainPinned := func() {
-		for _, elem := range pinned {
-			select {
-			case conn := <-elem.Value.conn:
-				conn.Recycle()
-			default:
+	defer cancelExpired()
+	for range NumExpired {
+		wg.Go(func() error {
+			conn, err := pool.Get(expiredCtx, nil)
+			if err != nil {
+				expiredTimedOut.Add(1)
+				return nil
 			}
-		}
+			if expiredCtx.Err() != nil {
+				wastedHandoffs.Add(1)
+			}
+			// The production query path fails on the dead context and
+			// recycles; do the same so the connection churns onward.
+			conn.Recycle()
+			return nil
+		})
 	}
 
-	var (
-		wg   errgroup.Group
-		stop atomic.Bool
-	)
+	status := func() string {
+		return fmt.Sprintf("capacity=%d active=%d borrowed=%d open=%d isOpen=%v waiting=%d wastedHandoffs=%d expiredTimedOut=%d liveSuccesses=%d",
+			pool.Capacity(), pool.Active(), pool.InUse(), connCount(), pool.IsOpen(), pool.wait.waiting(), wastedHandoffs.Load(), expiredTimedOut.Load(), liveSuccesses.Load())
+	}
 
+	backlogQueued := assert.Eventuallyf(t, func() bool {
+		return pool.wait.waiting() == NumExpired
+	}, Watchdog, time.Millisecond, "cycle %d: backlog did not queue: %s", cycle, status())
+	if !backlogQueued {
+		cancelExpired()
+		for _, conn := range held {
+			conn.Recycle()
+		}
+		waitForStressTraffic(t, cycle, &wg, Watchdog, status)
+		require.FailNowf(t, "backlog did not queue", "cycle %d: %s", cycle, status())
+	}
+
+	// Live traffic queued behind the backlog, with deadlines generous
+	// enough to never expire during the test.
 	for i := range NumLive {
 		tid := int32(i + 1)
 		wg.Go(func() error {
-			liveWorkers.Add(1)
-			defer liveWorkers.Add(-1)
-
-			for !stop.Load() {
-				ctx, cancel := context.WithTimeout(t.Context(), GetTimeout)
+			for range GetsPerLive {
+				ctx, cancel := context.WithTimeout(t.Context(), LiveTimeout)
 				conn, err := pool.Get(ctx, nil)
 				cancel()
 				if err != nil {
-					workerErrors.Add(1)
-					runtime.Gosched()
-					continue
+					return fmt.Errorf("cycle %d: live request starved by the expired backlog: %w", cycle, err)
 				}
 
 				previousOwner := conn.Conn.owner.Swap(tid)
@@ -1349,55 +1368,74 @@ func runStressExpiredWaiterBacklogCycle(t *testing.T, cycle int) {
 				if previousOwner != tid {
 					return fmt.Errorf("cycle %d: conn owner overwritten under us: expected %d, got %d", cycle, tid, previousOwner)
 				}
-				successfulGets.Add(1)
+				liveSuccesses.Add(1)
 				conn.Recycle()
 			}
 			return nil
 		})
 	}
 
-	status := func() string {
-		return fmt.Sprintf("capacity=%d active=%d borrowed=%d open=%d isOpen=%v waiting=%d liveWorkers=%d successfulGets=%d workerErrors=%d",
-			pool.Capacity(), pool.Active(), pool.InUse(), connCount(), pool.IsOpen(), pool.wait.waiting(), liveWorkers.Load(), successfulGets.Load(), workerErrors.Load())
-	}
-
-	abort := func() {
-		stop.Store(true)
-		drainPinned()
+	liveQueued := assert.Eventuallyf(t, func() bool {
+		return pool.wait.waiting() == NumExpired+NumLive
+	}, Watchdog, time.Millisecond, "cycle %d: live traffic did not queue behind the backlog: %s", cycle, status())
+	if !liveQueued {
+		cancelExpired()
 		for _, conn := range held {
 			conn.Recycle()
 		}
 		waitForStressTraffic(t, cycle, &wg, Watchdog, status)
-		closeCtx, cancel := context.WithTimeout(t.Context(), CloseTimeout)
-		_ = pool.CloseWithContext(closeCtx)
-		cancel()
+		require.FailNowf(t, "live traffic did not queue behind the backlog", "cycle %d: %s", cycle, status())
 	}
 
-	queued := assert.Eventuallyf(t, func() bool {
-		return pool.wait.waiting() == NumPinned+NumLive
-	}, Watchdog, time.Millisecond, "cycle %d: live waiters did not queue behind the expired backlog: %s", cycle, status())
-	if !queued {
-		abort()
-		require.FailNowf(t, "live waiters did not queue behind the expired backlog", "cycle %d: %s", cycle, status())
-	}
+	// The convoy. With the waitlist mutex held by the test, park the
+	// returners on it, then expire the entire backlog so it piles up
+	// behind them. Releasing the mutex lets the returners scan first,
+	// while every backlog waiter is still expired-but-listed.
+	pool.wait.mu.Lock()
 
-	// Release the held conns into the teeth of the expired backlog.
 	for _, conn := range held {
-		conn.Recycle()
+		wg.Go(func() error {
+			conn.Recycle()
+			return nil
+		})
 	}
 	held = nil
 
-	progressed := assert.Eventuallyf(t, func() bool {
-		return successfulGets.Load() >= MinSuccessful
-	}, ProgressWait, time.Millisecond, "cycle %d: live waiters starved behind the expired backlog: %s", cycle, status())
-	if !progressed {
-		abort()
-		require.FailNowf(t, "live waiters starved behind the expired backlog", "cycle %d: %s", cycle, status())
+	// Recycle decrements the borrowed count before reaching for the
+	// waitlist mutex, so once InUse hits zero every returner is parked on
+	// (or a few instructions away from) the mutex queue.
+	returnersParked := assert.Eventuallyf(t, func() bool {
+		return pool.InUse() == 0
+	}, Watchdog, time.Millisecond, "cycle %d: returners did not park on the waitlist mutex: %s", cycle, status())
+	if !returnersParked {
+		pool.wait.mu.Unlock()
+		cancelExpired()
+		waitForStressTraffic(t, cycle, &wg, Watchdog, status)
+		require.FailNowf(t, "returners did not park on the waitlist mutex", "cycle %d: %s", cycle, status())
+	}
+	for range 100 {
+		runtime.Gosched()
 	}
 
-	stop.Store(true)
+	cancelExpired()
+	// Give the expired waiters a moment to wake and pile up on the mutex.
+	// This only biases the interleaving towards the production one; the
+	// assertions below hold for every interleaving.
+	for range 100 {
+		runtime.Gosched()
+	}
+
+	pool.wait.mu.Unlock()
+
+	// Everything settles on its own: the backlog drains (timing out or —
+	// on broken code — receiving wasted handoffs), then the live traffic
+	// is served.
 	waitForStressTraffic(t, cycle, &wg, Watchdog, status)
-	drainPinned()
+
+	require.Zerof(t, wastedHandoffs.Load(),
+		"cycle %d: connections were handed to requests whose context had already expired: %s", cycle, status())
+	require.EqualValuesf(t, NumLive*GetsPerLive, liveSuccesses.Load(),
+		"cycle %d: live traffic was not fully served: %s", cycle, status())
 
 	closeCtx, cancelClose := context.WithTimeout(t.Context(), CloseTimeout)
 	closeErr := pool.CloseWithContext(closeCtx)

--- a/go/pools/smartconnpool/waitlist.go
+++ b/go/pools/smartconnpool/waitlist.go
@@ -91,17 +91,8 @@ func (wl *waitlist[C]) waitForConn(ctx context.Context, setting *Setting, closeC
 	select {
 	case <-closeChan:
 		// Pool was closed while we were waiting.
-		removed := false
-
 		wl.mu.Lock()
-		// Try to find and remove ourselves from the list.
-		for e := wl.list.Front(); e != nil; e = e.Next() {
-			if e == elem {
-				wl.list.Remove(elem)
-				removed = true
-				break
-			}
-		}
+		removed := wl.list.RemoveIfPresent(elem)
 		wl.mu.Unlock()
 
 		if removed {
@@ -115,17 +106,8 @@ func (wl *waitlist[C]) waitForConn(ctx context.Context, setting *Setting, closeC
 	case <-ctx.Done():
 		// Context expired. We need to try to remove ourselves from the waitlist to
 		// prevent another goroutine from trying to hand us a connection later on.
-		removed := false
-
 		wl.mu.Lock()
-		// Try to find and remove ourselves from the list.
-		for e := wl.list.Front(); e != nil; e = e.Next() {
-			if e == elem {
-				wl.list.Remove(elem)
-				removed = true
-				break
-			}
-		}
+		removed := wl.list.RemoveIfPresent(elem)
 		wl.mu.Unlock()
 
 		if removed {

--- a/go/pools/smartconnpool/waitlist.go
+++ b/go/pools/smartconnpool/waitlist.go
@@ -135,9 +135,13 @@ func (wl *waitlist[C]) maybeStarvingCount() (maybeStarving int) {
 	wl.mu.Lock()
 	defer wl.mu.Unlock()
 
-	// iterate the waitlist looking for waiters with an expired Context,
-	// or remove everything if force is true
+	// count the waiters that no returner has aged yet; they may be starving.
+	// Waiters whose context has already expired cannot use a connection and
+	// are only listed until they remove themselves, so they don't count.
 	for e := wl.list.Front(); e != nil; e = e.Next() {
+		if e.Value.ctx.Err() != nil {
+			continue
+		}
 		if e.Value.age == 0 {
 			maybeStarving++
 		}

--- a/go/pools/smartconnpool/waitlist.go
+++ b/go/pools/smartconnpool/waitlist.go
@@ -31,6 +31,10 @@ type waiter[C Connection] struct {
 	setting *Setting
 	// conn is a channel that will receive the connection when it's ready
 	conn chan *Pooled[C]
+	// ctx is the request context of the waiting client; returners sample it
+	// under the waitlist mutex to skip waiters that can no longer use a
+	// connection
+	ctx context.Context
 	// age is the amount of cycles this client has been on the waitlist
 	age uint32
 }
@@ -52,9 +56,15 @@ type waitlist[C Connection] struct {
 // forced an expiration of all waiters in the waitlist.
 func (wl *waitlist[C]) waitForConn(ctx context.Context, setting *Setting, closeChan <-chan struct{}, maxWaiters uint) (*Pooled[C], error) {
 	elem := wl.nodes.Get().(*list.Element[waiter[C]])
-	defer wl.nodes.Put(elem)
+	defer func() {
+		// Drop the references to the request-scoped ctx and setting before
+		// recycling the node, so they aren't pinned in the pool. The element
+		// is off the list by now, so no returner can observe this write.
+		elem.Value = waiter[C]{conn: elem.Value.conn}
+		wl.nodes.Put(elem)
+	}()
 
-	elem.Value = waiter[C]{conn: elem.Value.conn, setting: setting}
+	elem.Value = waiter[C]{conn: elem.Value.conn, setting: setting, ctx: ctx}
 
 	if wl.aboveWaiterCap(maxWaiters) {
 		if wl.onWaiterCapReached != nil {
@@ -154,7 +164,9 @@ func (wl *waitlist[C]) maybeStarvingCount() (maybeStarving int) {
 	return
 }
 
-// tryReturnConn tries handing over a connection to one of the waiters in the pool.
+// tryReturnConn tries handing over a connection to one of the waiters in the
+// pool. Waiters whose context has already expired are skipped; if every
+// waiter has expired, the connection is not handed over at all.
 func (wl *waitlist[D]) tryReturnConn(conn *Pooled[D]) bool {
 	// fast path: if there's nobody waiting there's nothing to do
 	if wl.list.Len() == 0 {
@@ -172,11 +184,21 @@ func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
 	)
 
 	wl.mu.Lock()
-	target = wl.list.Front()
 	// iterate through the waitlist looking for either waiters that have been
 	// here too long, or a waiter that is looking exactly for the same Setting
 	// as the one we have in our connection.
-	for e := target; e != nil; e = e.Next() {
+	for e := wl.list.Front(); e != nil; e = e.Next() {
+		// Skip waiters whose context has already expired: they cannot use the
+		// connection and will remove themselves from the waitlist. They must
+		// remain in the list — absence from the list is how a waiter knows a
+		// returner is committed to handing it a connection.
+		if e.Value.ctx.Err() != nil {
+			continue
+		}
+		if target == nil {
+			// the front-most live waiter is the fallback handover target
+			target = e
+		}
 		if e.Value.age > maxAge || e.Value.setting == connSetting {
 			target = e
 			break
@@ -194,7 +216,8 @@ func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
 	wl.mu.Unlock()
 
 	// maybe there isn't anybody to hand over the connection to, because we've
-	// raced with another client returning another connection
+	// raced with another client returning another connection, or because all
+	// the waiters in the list have an expired context
 	if target == nil {
 		return false
 	}

--- a/go/pools/smartconnpool/waitlist.go
+++ b/go/pools/smartconnpool/waitlist.go
@@ -32,7 +32,7 @@ type waiter[C Connection] struct {
 	// conn is a channel that will receive the connection when it's ready
 	conn chan *Pooled[C]
 	// ctx is the request context of the waiting client; returners sample it
-	// under the waitlist mutex to skip waiters that can no longer use a
+	// under the waitlist mutex to evict waiters that can no longer use a
 	// connection
 	ctx context.Context
 	// age is the amount of cycles this client has been on the waitlist
@@ -100,8 +100,9 @@ func (wl *waitlist[C]) waitForConn(ctx context.Context, setting *Setting, closeC
 		}
 
 		// if we weren't able to remove ourselves from the waitlist, it means
-		// another goroutine is trying to hand us a connection
-		return <-elem.Value.conn, nil
+		// a returner reached us first: it either handed us a connection or
+		// evicted us (a nil on the channel), so read the outcome.
+		return waitResult(ctx, <-elem.Value.conn)
 
 	case <-ctx.Done():
 		// Context expired. We need to try to remove ourselves from the waitlist to
@@ -115,12 +116,26 @@ func (wl *waitlist[C]) waitForConn(ctx context.Context, setting *Setting, closeC
 		}
 
 		// if we weren't able to remove ourselves from the waitlist, it means
-		// another goroutine is trying to hand us a connection
-		return <-elem.Value.conn, nil
+		// a returner reached us first: it either handed us a connection or
+		// evicted us (a nil on the channel), so read the outcome.
+		return waitResult(ctx, <-elem.Value.conn)
 
 	case conn := <-elem.Value.conn:
+		return waitResult(ctx, conn)
+	}
+}
+
+// waitResult interprets what a returner left on the waiter's channel: a real
+// connection is a successful handoff, while a nil means the returner evicted
+// the waiter because its context had expired.
+func waitResult[C Connection](ctx context.Context, conn *Pooled[C]) (*Pooled[C], error) {
+	if conn != nil {
 		return conn, nil
 	}
+	if err := context.Cause(ctx); err != nil {
+		return nil, err
+	}
+	return nil, ErrTimeout
 }
 
 func (wl *waitlist[C]) aboveWaiterCap(maxWaiters uint) bool {
@@ -137,7 +152,7 @@ func (wl *waitlist[C]) maybeStarvingCount() (maybeStarving int) {
 
 	// count the waiters that no returner has aged yet; they may be starving.
 	// Waiters whose context has already expired cannot use a connection and
-	// are only listed until they remove themselves, so they don't count.
+	// are only listed until a returner evicts them, so they don't count.
 	for e := wl.list.Front(); e != nil; e = e.Next() {
 		if e.Value.ctx.Err() != nil {
 			continue
@@ -151,7 +166,7 @@ func (wl *waitlist[C]) maybeStarvingCount() (maybeStarving int) {
 }
 
 // tryReturnConn tries handing over a connection to one of the waiters in the
-// pool. Waiters whose context has already expired are skipped; if every
+// pool. Waiters whose context has already expired are evicted; if every
 // waiter has expired, the connection is not handed over at all.
 func (wl *waitlist[D]) tryReturnConn(conn *Pooled[D]) bool {
 	// fast path: if there's nobody waiting there's nothing to do
@@ -166,6 +181,7 @@ func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
 	const maxAge = 8
 	var (
 		target      *list.Element[waiter[D]]
+		next        *list.Element[waiter[D]]
 		connSetting = conn.Conn.Setting()
 	)
 
@@ -173,12 +189,19 @@ func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
 	// iterate through the waitlist looking for either waiters that have been
 	// here too long, or a waiter that is looking exactly for the same Setting
 	// as the one we have in our connection.
-	for e := wl.list.Front(); e != nil; e = e.Next() {
-		// Skip waiters whose context has already expired: they cannot use the
-		// connection and will remove themselves from the waitlist. They must
-		// remain in the list — absence from the list is how a waiter knows a
-		// returner is committed to handing it a connection.
+	for e := wl.list.Front(); e != nil; e = next {
+		next = e.Next() // capture before any Remove unlinks e
+
+		// Evict waiters whose context has already expired: they cannot use the
+		// connection, and removing them here is what keeps the list from
+		// accumulating a dead prefix that every later return must re-scan. Wake
+		// them with a nil so they stop waiting. This send can't block while we
+		// hold the mutex: the channel is buffered and a listed waiter's buffer
+		// is always empty, since only a returner sends and only while removing
+		// the waiter from the list.
 		if e.Value.ctx.Err() != nil {
+			wl.list.Remove(e)
+			e.Value.conn <- nil
 			continue
 		}
 		if target == nil {
@@ -208,8 +231,8 @@ func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
 		return false
 	}
 
-	// if we have a target to return the connection to, simply write the connection
-	// into the waiter's channel.
+	// hand the connection to the live target. The channel is buffered, so the
+	// send completes without waiting for the waiter to be scheduled.
 	target.Value.conn <- conn
 	// Allow the goroutine waiting on the channel to start running _now_.
 	runtime.Gosched()
@@ -220,7 +243,9 @@ func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
 func (wl *waitlist[C]) init() {
 	wl.nodes.New = func() any {
 		return &list.Element[waiter[C]]{
-			Value: waiter[C]{conn: make(chan *Pooled[C])},
+			// buffered (cap 1) so returners never block handing off a
+			// connection or waking an evicted waiter
+			Value: waiter[C]{conn: make(chan *Pooled[C], 1)},
 		}
 	}
 	wl.list.Init()

--- a/go/pools/smartconnpool/waitlist_bench_test.go
+++ b/go/pools/smartconnpool/waitlist_bench_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package smartconnpool
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// BenchmarkWaitlistHandoff measures steady-state handoff throughput on the
+// common path, with no expired waiters in the list. A number of waiter
+// goroutines block in waitForConn and re-queue as soon as they are served,
+// while a single returner hands connections back via tryReturnConn. This
+// exercises the list push/remove, the per-return scan, and the channel
+// handoff that our changes touch.
+func BenchmarkWaitlistHandoff(b *testing.B) {
+	for _, waiters := range []int{1, 8, 64} {
+		b.Run(fmt.Sprintf("waiters=%d", waiters), func(b *testing.B) {
+			wl := waitlist[*TestConn]{}
+			wl.init()
+			closeChan := make(chan struct{})
+			ctx := context.Background()
+
+			// Each consumer claims one slot per waitForConn call; the claims
+			// across all consumers sum to exactly b.N, so the same number of
+			// connections the returner produces are consumed and nobody is
+			// left blocked at the end.
+			var remaining atomic.Int64
+			remaining.Store(int64(b.N))
+
+			var consumers sync.WaitGroup
+			for range waiters {
+				consumers.Go(func() {
+					for remaining.Add(-1) >= 0 {
+						wl.waitForConn(ctx, nil, closeChan, 0)
+					}
+				})
+			}
+
+			// reuse a single connection across handoffs: the waitlist only
+			// passes the pointer around, so this measures the handoff path
+			// without per-iteration allocation/GC jitter.
+			conn := &Pooled[*TestConn]{Conn: &TestConn{}}
+
+			b.ResetTimer()
+			for range b.N {
+				// retry until a waiter takes the connection, so a return that
+				// races ahead of a re-queueing waiter doesn't drop it.
+				for !wl.tryReturnConn(conn) {
+					runtime.Gosched()
+				}
+			}
+			b.StopTimer()
+
+			consumers.Wait()
+		})
+	}
+}
+
+// BenchmarkWaitlistReturnNoWaiters measures the empty-list fast path of
+// tryReturnConn, which every connection return hits when nobody is waiting.
+func BenchmarkWaitlistReturnNoWaiters(b *testing.B) {
+	wl := waitlist[*TestConn]{}
+	wl.init()
+	conn := &Pooled[*TestConn]{Conn: &TestConn{}}
+
+	b.ResetTimer()
+	for range b.N {
+		wl.tryReturnConn(conn)
+	}
+}

--- a/go/pools/smartconnpool/waitlist_evict_bench_test.go
+++ b/go/pools/smartconnpool/waitlist_evict_bench_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package smartconnpool
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"vitess.io/vitess/go/list"
+)
+
+// injectWaiter appends a synthetic waitlist entry with no goroutine behind it.
+// The conn channel is buffered so a returner evicting it (sending nil) never
+// blocks. Self-contained here so this benchmark compiles on branches that
+// predate the test-only pushWaiter helper.
+func injectWaiter(wl *waitlist[*TestConn], ctx context.Context) {
+	elem := &list.Element[waiter[*TestConn]]{
+		Value: waiter[*TestConn]{
+			ctx:  ctx,
+			conn: make(chan *Pooled[*TestConn], 1),
+		},
+	}
+	wl.mu.Lock()
+	wl.list.PushBackValue(elem)
+	wl.mu.Unlock()
+}
+
+// BenchmarkWaitlistReturnAllExpired measures repeated returns against a list
+// whose head is a prefix of expired waiters — the timeout-storm shape. With
+// skip-and-leave every return re-scans the whole prefix (O(returns*prefix));
+// with eviction the first return drains the prefix and the rest are cheap.
+func BenchmarkWaitlistReturnAllExpired(b *testing.B) {
+	const returns = 32
+	for _, prefix := range []int{256, 2048} {
+		b.Run(fmt.Sprintf("prefix=%d", prefix), func(b *testing.B) {
+			expiredCtx, cancel := context.WithCancel(context.Background())
+			cancel()
+			conn := &Pooled[*TestConn]{Conn: &TestConn{}}
+
+			for range b.N {
+				b.StopTimer()
+				wl := waitlist[*TestConn]{}
+				wl.init()
+				for range prefix {
+					injectWaiter(&wl, expiredCtx)
+				}
+				b.StartTimer()
+
+				for range returns {
+					wl.tryReturnConn(conn)
+				}
+			}
+		})
+	}
+}

--- a/go/pools/smartconnpool/waitlist_test.go
+++ b/go/pools/smartconnpool/waitlist_test.go
@@ -173,6 +173,21 @@ func TestWaitlistTryReturnConnAllWaitersExpired(t *testing.T) {
 	}
 }
 
+func TestWaitlistMaybeStarvingCountSkipsExpiredWaiters(t *testing.T) {
+	wl := waitlist[*TestConn]{}
+	wl.init()
+
+	expiredCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	pushWaiter(&wl, expiredCtx)
+	pushWaiter(&wl, t.Context())
+
+	// only the live waiter is maybe starving; the expired waiter cannot use
+	// a connection and must not cause the starving worker to hand one out
+	require.Equal(t, 1, wl.maybeStarvingCount())
+}
+
 func TestWaitlistHandoverToLiveWaiter(t *testing.T) {
 	wl := waitlist[*TestConn]{}
 	wl.init()

--- a/go/pools/smartconnpool/waitlist_test.go
+++ b/go/pools/smartconnpool/waitlist_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/list"
 )
 
 func TestWaitlistPoolCloseWithMultipleWaiters(t *testing.T) {
@@ -97,4 +99,160 @@ func TestWaitlistWaiterCap(t *testing.T) {
 	for range maxWaiters {
 		assert.NotErrorIs(t, <-errs, ErrPoolWaiterCapReached)
 	}
+}
+
+// pushWaiter injects a synthetic waitlist entry with no goroutine behind it.
+// The conn channel is buffered so a handoff to it can't block the test.
+func pushWaiter(wl *waitlist[*TestConn], ctx context.Context) *list.Element[waiter[*TestConn]] {
+	elem := &list.Element[waiter[*TestConn]]{
+		Value: waiter[*TestConn]{
+			ctx:  ctx,
+			conn: make(chan *Pooled[*TestConn], 1),
+		},
+	}
+	wl.mu.Lock()
+	wl.list.PushBackValue(elem)
+	wl.mu.Unlock()
+	return elem
+}
+
+func TestWaitlistTryReturnConnSkipsExpiredWaiters(t *testing.T) {
+	wl := waitlist[*TestConn]{}
+	wl.init()
+
+	expiredCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	expired := pushWaiter(&wl, expiredCtx)
+	live := pushWaiter(&wl, t.Context())
+
+	conn := &Pooled[*TestConn]{Conn: &TestConn{}}
+	require.True(t, wl.tryReturnConn(conn))
+
+	// the live waiter behind the expired one received the connection
+	select {
+	case got := <-live.Value.conn:
+		require.Same(t, conn, got)
+	default:
+		require.Fail(t, "live waiter did not receive the returned connection")
+	}
+
+	// the expired waiter got nothing and is still in the list:
+	// removing itself is its own responsibility
+	require.Equal(t, 1, wl.waiting())
+	select {
+	case <-expired.Value.conn:
+		require.Fail(t, "expired waiter must not receive a connection")
+	default:
+	}
+}
+
+func TestWaitlistTryReturnConnAllWaitersExpired(t *testing.T) {
+	wl := waitlist[*TestConn]{}
+	wl.init()
+
+	expiredCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	const waiterCount = 3
+	waiters := make([]*list.Element[waiter[*TestConn]], 0, waiterCount)
+	for range waiterCount {
+		waiters = append(waiters, pushWaiter(&wl, expiredCtx))
+	}
+
+	conn := &Pooled[*TestConn]{Conn: &TestConn{}}
+	require.False(t, wl.tryReturnConn(conn))
+
+	require.Equal(t, waiterCount, wl.waiting())
+	for _, w := range waiters {
+		select {
+		case <-w.Value.conn:
+			require.Fail(t, "expired waiter must not receive a connection")
+		default:
+		}
+	}
+}
+
+func TestWaitlistHandoverToLiveWaiter(t *testing.T) {
+	wl := waitlist[*TestConn]{}
+	wl.init()
+
+	poolClose := make(chan struct{})
+
+	results := make(chan *Pooled[*TestConn], 1)
+	go func() {
+		conn, err := wl.waitForConn(t.Context(), nil, poolClose, 0)
+		assert.NoError(t, err)
+		results <- conn
+	}()
+
+	require.Eventually(t, func() bool {
+		return wl.waiting() == 1
+	}, 30*time.Second, time.Millisecond)
+
+	conn := &Pooled[*TestConn]{Conn: &TestConn{}}
+	require.True(t, wl.tryReturnConn(conn))
+
+	var got *Pooled[*TestConn]
+	require.Eventually(t, func() bool {
+		select {
+		case got = <-results:
+			return true
+		default:
+			return false
+		}
+	}, 30*time.Second, time.Millisecond)
+	require.Same(t, conn, got)
+}
+
+// TestWaitlistClaimedWaiterStillReceivesAfterExpiry pins the handoff
+// protocol's claim window: a returner removes a live waiter from the list and
+// is then committed to the handoff, even if the waiter's context expires
+// before the send lands. The waiter must take the connection instead of
+// erroring out, or the returner would be stranded mid-send.
+func TestWaitlistClaimedWaiterStillReceivesAfterExpiry(t *testing.T) {
+	wl := waitlist[*TestConn]{}
+	wl.init()
+
+	poolClose := make(chan struct{})
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	type result struct {
+		conn *Pooled[*TestConn]
+		err  error
+	}
+	results := make(chan result, 1)
+	go func() {
+		conn, err := wl.waitForConn(ctx, nil, poolClose, 0)
+		results <- result{conn: conn, err: err}
+	}()
+
+	require.Eventually(t, func() bool {
+		return wl.waiting() == 1
+	}, 30*time.Second, time.Millisecond)
+
+	// Simulate a returner that claimed the waiter while it was live, racing
+	// with the context expiring before the handoff send: remove the element
+	// and cancel under the mutex, so the waiter can't self-remove first.
+	wl.mu.Lock()
+	elem := wl.list.Front()
+	wl.list.Remove(elem)
+	cancel()
+	wl.mu.Unlock()
+
+	conn := &Pooled[*TestConn]{Conn: &TestConn{}}
+	elem.Value.conn <- conn
+
+	var res result
+	require.Eventually(t, func() bool {
+		select {
+		case res = <-results:
+			return true
+		default:
+			return false
+		}
+	}, 30*time.Second, time.Millisecond)
+	require.NoError(t, res.err)
+	require.Same(t, conn, res.conn)
 }

--- a/go/pools/smartconnpool/waitlist_test.go
+++ b/go/pools/smartconnpool/waitlist_test.go
@@ -18,6 +18,7 @@ package smartconnpool
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -116,7 +117,7 @@ func pushWaiter(wl *waitlist[*TestConn], ctx context.Context) *list.Element[wait
 	return elem
 }
 
-func TestWaitlistTryReturnConnSkipsExpiredWaiters(t *testing.T) {
+func TestWaitlistTryReturnConnEvictsExpiredWaiters(t *testing.T) {
 	wl := waitlist[*TestConn]{}
 	wl.init()
 
@@ -137,13 +138,14 @@ func TestWaitlistTryReturnConnSkipsExpiredWaiters(t *testing.T) {
 		require.Fail(t, "live waiter did not receive the returned connection")
 	}
 
-	// the expired waiter got nothing and is still in the list:
-	// removing itself is its own responsibility
-	require.Equal(t, 1, wl.waiting())
+	// the expired waiter was evicted from the list and woken with a nil, so it
+	// stops waiting and returns its context error
+	require.Equal(t, 0, wl.waiting())
 	select {
-	case <-expired.Value.conn:
-		require.Fail(t, "expired waiter must not receive a connection")
+	case got := <-expired.Value.conn:
+		require.Nil(t, got, "expired waiter must be woken with a nil, not a connection")
 	default:
+		require.Fail(t, "expired waiter was not woken")
 	}
 }
 
@@ -163,12 +165,15 @@ func TestWaitlistTryReturnConnAllWaitersExpired(t *testing.T) {
 	conn := &Pooled[*TestConn]{Conn: &TestConn{}}
 	require.False(t, wl.tryReturnConn(conn))
 
-	require.Equal(t, waiterCount, wl.waiting())
+	// every waiter was expired, so the returner evicted them all (waking each
+	// with a nil) and kept the connection (nothing live to hand it to)
+	require.Equal(t, 0, wl.waiting())
 	for _, w := range waiters {
 		select {
-		case <-w.Value.conn:
-			require.Fail(t, "expired waiter must not receive a connection")
+		case got := <-w.Value.conn:
+			require.Nil(t, got, "expired waiter must be woken with a nil, not a connection")
 		default:
+			require.Fail(t, "expired waiter was not woken")
 		}
 	}
 }
@@ -270,4 +275,66 @@ func TestWaitlistClaimedWaiterStillReceivesAfterExpiry(t *testing.T) {
 	}, 30*time.Second, time.Millisecond)
 	require.NoError(t, res.err)
 	require.Same(t, conn, res.conn)
+}
+
+// TestWaitlistConvoyDrainsUnderConcurrentReturns is a bounded reproduction of
+// the production timeout-storm convoy: a large prefix of expired waiters sits
+// at the head of the waitlist while live waiters queue behind it, and several
+// returners hand connections back concurrently. The fix requires a returner to
+// evict the dead prefix as it scans, so the list drains to empty and every
+// live waiter is served. On the unpatched skip-and-leave code the expired
+// waiters are left in place, so waiting() never reaches zero and this fails.
+func TestWaitlistConvoyDrainsUnderConcurrentReturns(t *testing.T) {
+	const (
+		expiredWaiters = 4000
+		liveWaiters    = 64
+		returners      = 8
+	)
+
+	wl := waitlist[*TestConn]{}
+	wl.init()
+
+	poolClose := make(chan struct{})
+
+	// dead prefix: synthetic waiters whose context already expired, with no
+	// goroutine behind them, so they linger in the list exactly like the
+	// timed-out waiters that pile up under a real timeout storm.
+	expiredCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+	for range expiredWaiters {
+		pushWaiter(&wl, expiredCtx)
+	}
+
+	// live waiters queue behind the dead prefix
+	var served atomic.Int64
+	var waiters sync.WaitGroup
+	for range liveWaiters {
+		waiters.Go(func() {
+			conn, err := wl.waitForConn(t.Context(), nil, poolClose, 0)
+			if err == nil && conn != nil {
+				served.Add(1)
+			}
+		})
+	}
+	require.Eventually(t, func() bool {
+		return wl.waiting() == expiredWaiters+liveWaiters
+	}, 30*time.Second, time.Millisecond, "waiters did not all enqueue")
+
+	// concurrent returners hand back exactly liveWaiters connections; the first
+	// returner to win the mutex also evicts the whole dead prefix as it scans.
+	var toIssue atomic.Int64
+	toIssue.Store(liveWaiters)
+	var returnersWG sync.WaitGroup
+	for range returners {
+		returnersWG.Go(func() {
+			for toIssue.Add(-1) >= 0 {
+				wl.tryReturnConn(&Pooled[*TestConn]{Conn: &TestConn{}})
+			}
+		})
+	}
+	returnersWG.Wait()
+	waiters.Wait()
+
+	require.Equal(t, int64(liveWaiters), served.Load(), "every live waiter should receive a connection")
+	require.Equal(t, 0, wl.waiting(), "the expired prefix must be evicted, leaving an empty waitlist")
 }


### PR DESCRIPTION
## Description

A production v23 vttablet stalled completely under a timeout storm: ~18k goroutines serialized on the stream pool's waitlist mutex, with every pool connection trapped in the return path. The root cause is in the waitlist: `tryReturnConn` hands a returned connection to the front-most waiter even when that waiter's context has already expired. Each such handoff parks the connection on a dead request — the unbuffered channel send blocks until the expired waiter gets through the contended mutex — the request then fails instantly and recycles the connection to the *next* expired waiter. Useful throughput drops to zero while new requests keep joining the list.

The fix stores the request context on the waitlist entry, and `tryReturnConnSlow` evicts waiters whose context has already expired as it scans for a handoff target: it removes them from the list and wakes them with a `nil`. Disambiguation is by the value received on the channel — a real connection is a handoff, a `nil` is an eviction — so the entry's channel is buffered (cap 1) and a `waitResult` helper maps a `nil` back to the request's own context error. Because a listed waiter's buffer is always empty (only a returner sends, and only while removing the waiter from the list), both the eviction wake-up and the handoff send complete without ever blocking — including the eviction send made under the waitlist mutex. If every waiter has expired, the connection goes back onto the stack where new requests grab it directly.

An earlier revision of this PR skipped expired waiters but left them on the list, on the theory they'd remove themselves. Under a sustained timeout storm that only relocated the convoy: the expired entries pile up as a long prefix at the head of the list, and every later return re-scans that whole prefix under the mutex — the same O(n)-under-mutex stall, moved from the waiter's exit path to the returner's handoff path. A customer's closed-loop reproduction still wedged on that revision. Evicting during the scan keeps the list from accumulating a dead prefix at all.

This also removes the other half of the collapse: a timed-out waiter could only leave the waitlist by scanning the entire list under the mutex to learn whether it was still a member — O(n) per exit, ~18k entries deep in the incident. `go/list` now exposes `RemoveIfPresent`, an O(1) membership check via the owning-list pointer the list already maintains, and both `waitForConn` fallback paths use it, so the backlog drains at mutex-handoff speed instead of scan speed. `Remove` keeps its panicking must-be-present contract for the returner's claim path, where absence would mean list corruption.

One surprise along the way: the new context field grew `ConnPool` past an allocator size bucket where its 128-bit atomics lose their 16-byte alignment, which faults (SIGBUS) on arm64 and amd64. Go has no supported way to demand 16-byte alignment, so this had always worked by allocator accident. The waitlist now lives behind a pointer so its size can never change `ConnPool`'s allocation again, and the constraint is documented on `connStack` next to the atomics it affects.

Two tests guard the behavior. The first reproduces the production incident with real actors: requests whose deadlines expire while queued, live traffic queued behind them, and returners parked on the waitlist mutex (the test holds the mutex to play the role of the production convoy); on the old code it fails immediately with connections handed to dead requests, and passes deterministically with the fix. The second (`TestWaitlistConvoyDrainsUnderConcurrentReturns`) is a bounded reproduction of the relocated convoy specifically: a large expired prefix with live waiters queued behind it and several concurrent returners — it asserts the list drains to empty and every live waiter is served, and fails on the skip-and-leave revision (the expired prefix is never removed).

## Benchmarks

Added benchmarks over the `waitForConn`/`tryReturnConn` paths — `waitlist_bench_test.go` (steady-state handoff at 1/8/64 waiters, and the empty-list fast path) and `waitlist_evict_bench_test.go` (repeated returns against a list fronted by an expired prefix).

Comparing this branch against the pre-eviction revision (`benchstat`, 10 runs; the handoff was re-confirmed with the per-iteration allocation hoisted out and `GOMAXPROCS` pinned, 20 runs, to remove GC/scheduler jitter):

| Path | Before | After | Δ |
| --- | --- | --- | --- |
| Handoff (geomean, 1/8/64 waiters) | 180.5 ns | 180.6 ns | **+0.06%** (within ±1%) |
| Empty-list fast path | ~0.8 ns | ~0.8 ns | unchanged |
| Allocations (all paths) | — | — | **0 added** |
| 32 returns, 256-deep expired prefix | 66.5 µs | 5.4 µs | **−92%** |
| 32 returns, 2048-deep expired prefix | 525 µs | 48 µs | **−91%** |

The common handoff path is neutral — a buffered send to an already-parked receiver does the same direct hand-off as the unbuffered one, so buffering costs nothing here. The expired-prefix path is ~11× faster: that is the relocated convoy being removed — skip-and-leave re-scans the whole prefix on every return, eviction drains it once.

## Backport Reasoning

This fixes a tablet-wide production outage: under a timeout storm the connection pool livelocks, the tablet serves zero queries, and only a restart recovers it. There is no configuration workaround. The defective handoff logic exists unchanged on all supported release branches, and the fix is small, self-contained to `go/pools/smartconnpool` and `go/list`, and changes no public API or behavior other than no longer handing connections to requests whose context has expired. Requesting backport to `release-23.0` (version the incident occurred on) and `release-24.0`.

## Related Issue(s)

- Fixes #20310
- Related: #20187 (waitlist handling requirements for the connection-pool generation-counter redesign)

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

No deployment steps. Behavioral change: the connection pool no longer hands returned connections to requests whose context has already expired — those requests fail with the usual timeout error, and the connection goes to a live waiter or back into the pool.

### AI Disclosure

This PR was written primarily by Claude Code (analysis of the goroutine dump, the fix, the tests, and the benchmarks), with human direction and review.
