### PR TITLE
vtgate healthcheck: drop stale updates from a replaced tablet's canceled checkConn

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -199,6 +199,11 @@ type (
 	tabletAliasString       string
 )
 
+// aliasKey returns the map key used to index a tablet by its alias.
+func aliasKey(alias *topodata.TabletAlias) tabletAliasString {
+	return tabletAliasString(topoproto.TabletAliasString(alias))
+}
+
 // HealthCheck declares what the TabletGateway needs from the HealthCheck
 type HealthCheck interface {
 	// AddTablet adds the tablet.
@@ -475,7 +480,7 @@ func (hc *HealthCheckImpl) deleteTablet(tablet *topodata.Tablet) {
 	hc.mu.Lock()
 	defer hc.mu.Unlock()
 
-	tabletAlias := tabletAliasString(topoproto.TabletAliasString(tablet.Alias))
+	tabletAlias := aliasKey(tablet.Alias)
 	defer func() {
 		// We want to be sure the tablet is gone from the secondary
 		// maps even if it's already gone from the authoritative map.
@@ -500,7 +505,7 @@ func (hc *HealthCheckImpl) deleteTablet(tablet *topodata.Tablet) {
 					// clear the healthy list for the primary.
 					//
 					// See the logic in `updateHealth` for more details.
-					alias := tabletAliasString(topoproto.TabletAliasString(healthy[0].Tablet.Alias))
+					alias := aliasKey(healthy[0].Tablet.Alias)
 					if alias == tabletAlias {
 						hc.healthy[key] = []*TabletHealth{}
 					}
@@ -528,7 +533,7 @@ func (hc *HealthCheckImpl) updateHealth(thc *tabletHealthCheck, prevTarget *quer
 	hc.mu.Lock()
 	defer hc.mu.Unlock()
 
-	tabletAlias := tabletAliasString(topoproto.TabletAliasString(thc.Tablet.Alias))
+	tabletAlias := aliasKey(thc.Tablet.Alias)
 	// let's be sure that this tablet hasn't been deleted from the authoritative map
 	// so that we're not racing to update it and in effect re-adding a copy of the
 	// tablet record that was deleted. Also verify that the update was issued by the
@@ -605,7 +610,7 @@ func (hc *HealthCheckImpl) updateHealth(thc *tabletHealthCheck, prevTarget *quer
 	case isPrimary && !up:
 		if healthy, ok := hc.healthy[targetKey]; ok && len(healthy) > 0 {
 			// isPrimary is true here therefore we should only have 1 tablet in healthy
-			alias := tabletAliasString(topoproto.TabletAliasString(healthy[0].Tablet.Alias))
+			alias := aliasKey(healthy[0].Tablet.Alias)
 			// Clear healthy list for primary if the existing tablet is down
 			if alias == tabletAlias {
 				hc.healthy[targetKey] = []*TabletHealth{}
@@ -883,7 +888,7 @@ func (hc *HealthCheckImpl) GetTabletHealthByAlias(alias *topodata.TabletAlias) (
 	hc.mu.Lock()
 	defer hc.mu.Unlock()
 
-	if hd, ok := hc.healthByAlias[tabletAliasString(topoproto.TabletAliasString(alias))]; ok {
+	if hd, ok := hc.healthByAlias[aliasKey(alias)]; ok {
 		return hd.SimpleCopy(), nil
 	}
 	return nil, fmt.Errorf("could not find tablet: %s", alias.String())
@@ -896,7 +901,7 @@ func (hc *HealthCheckImpl) GetTabletHealth(kst KeyspaceShardTabletType, alias *t
 	defer hc.mu.Unlock()
 
 	if hd, ok := hc.healthData[kst]; ok {
-		if th, ok := hd[tabletAliasString(topoproto.TabletAliasString(alias))]; ok {
+		if th, ok := hd[aliasKey(alias)]; ok {
 			return th, nil
 		}
 	}
@@ -908,7 +913,7 @@ func (hc *HealthCheckImpl) GetTabletHealth(kst KeyspaceShardTabletType, alias *t
 func (hc *HealthCheckImpl) registeredHealthCheck(alias *topodata.TabletAlias) *tabletHealthCheck {
 	hc.mu.Lock()
 	defer hc.mu.Unlock()
-	return hc.healthByAlias[tabletAliasString(topoproto.TabletAliasString(alias))]
+	return hc.healthByAlias[aliasKey(alias)]
 }
 
 // TabletConnection returns the Connection to a given tablet.

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -524,23 +524,12 @@ func (hc *HealthCheckImpl) deleteTablet(tablet *topodata.Tablet) {
 }
 
 func (hc *HealthCheckImpl) updateHealth(thc *tabletHealthCheck, prevTarget *query.Target, trivialUpdate bool, up bool) {
-	// hc.healthByAlias is authoritative, it should be updated
 	tabletAlias := tabletAliasString(topoproto.TabletAliasString(thc.Tablet.Alias))
-	// let's be sure that this tablet hasn't been deleted from the authoritative map
-	// so that we're not racing to update it and in effect re-adding a copy of the
-	// tablet record that was deleted. Also verify that the update was issued by the
-	// tabletHealthCheck currently registered for this alias. After a ReplaceTablet,
-	// the canceled checkConn goroutine of the replaced tablet can still deliver one
-	// final update, which must not overwrite the state reported by its replacement.
-	if !hc.isRegisteredHealthCheck(tabletAlias, thc) {
-		hc.logger().Infof("Tablet %v has been deleted or replaced, skipping health update", thc.Tablet)
-		return
-	}
-
 	th := thc.SimpleCopy()
 
 	hc.mu.Lock()
 	defer hc.mu.Unlock()
+	// Verify that this update came from the tabletHealthCheck currently registered for this alias.
 	if !hc.isRegisteredHealthCheckLocked(tabletAlias, thc) {
 		hc.logger().Infof("Tablet %v has been deleted or replaced, skipping health update", thc.Tablet)
 		return
@@ -906,13 +895,6 @@ func (hc *HealthCheckImpl) GetTabletHealth(kst KeyspaceShardTabletType, alias *t
 		}
 	}
 	return nil, fmt.Errorf("could not find tablet: %s", alias.String())
-}
-
-// isRegisteredHealthCheck reports whether thc is the current healthcheck for tabletAlias.
-func (hc *HealthCheckImpl) isRegisteredHealthCheck(tabletAlias tabletAliasString, thc *tabletHealthCheck) bool {
-	hc.mu.Lock()
-	defer hc.mu.Unlock()
-	return hc.isRegisteredHealthCheckLocked(tabletAlias, thc)
 }
 
 // isRegisteredHealthCheckLocked reports whether thc is the current healthcheck for tabletAlias.

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -199,11 +199,6 @@ type (
 	tabletAliasString       string
 )
 
-// aliasKey returns the map key used to index a tablet by its alias.
-func aliasKey(alias *topodata.TabletAlias) tabletAliasString {
-	return tabletAliasString(topoproto.TabletAliasString(alias))
-}
-
 // HealthCheck declares what the TabletGateway needs from the HealthCheck
 type HealthCheck interface {
 	// AddTablet adds the tablet.
@@ -480,7 +475,7 @@ func (hc *HealthCheckImpl) deleteTablet(tablet *topodata.Tablet) {
 	hc.mu.Lock()
 	defer hc.mu.Unlock()
 
-	tabletAlias := aliasKey(tablet.Alias)
+	tabletAlias := tabletAliasString(topoproto.TabletAliasString(tablet.Alias))
 	defer func() {
 		// We want to be sure the tablet is gone from the secondary
 		// maps even if it's already gone from the authoritative map.
@@ -505,7 +500,7 @@ func (hc *HealthCheckImpl) deleteTablet(tablet *topodata.Tablet) {
 					// clear the healthy list for the primary.
 					//
 					// See the logic in `updateHealth` for more details.
-					alias := aliasKey(healthy[0].Tablet.Alias)
+					alias := tabletAliasString(topoproto.TabletAliasString(healthy[0].Tablet.Alias))
 					if alias == tabletAlias {
 						hc.healthy[key] = []*TabletHealth{}
 					}
@@ -533,7 +528,7 @@ func (hc *HealthCheckImpl) updateHealth(thc *tabletHealthCheck, prevTarget *quer
 	hc.mu.Lock()
 	defer hc.mu.Unlock()
 
-	tabletAlias := aliasKey(thc.Tablet.Alias)
+	tabletAlias := tabletAliasString(topoproto.TabletAliasString(thc.Tablet.Alias))
 	// let's be sure that this tablet hasn't been deleted from the authoritative map
 	// so that we're not racing to update it and in effect re-adding a copy of the
 	// tablet record that was deleted. Also verify that the update was issued by the
@@ -610,7 +605,7 @@ func (hc *HealthCheckImpl) updateHealth(thc *tabletHealthCheck, prevTarget *quer
 	case isPrimary && !up:
 		if healthy, ok := hc.healthy[targetKey]; ok && len(healthy) > 0 {
 			// isPrimary is true here therefore we should only have 1 tablet in healthy
-			alias := aliasKey(healthy[0].Tablet.Alias)
+			alias := tabletAliasString(topoproto.TabletAliasString(healthy[0].Tablet.Alias))
 			// Clear healthy list for primary if the existing tablet is down
 			if alias == tabletAlias {
 				hc.healthy[targetKey] = []*TabletHealth{}
@@ -888,7 +883,7 @@ func (hc *HealthCheckImpl) GetTabletHealthByAlias(alias *topodata.TabletAlias) (
 	hc.mu.Lock()
 	defer hc.mu.Unlock()
 
-	if hd, ok := hc.healthByAlias[aliasKey(alias)]; ok {
+	if hd, ok := hc.healthByAlias[tabletAliasString(topoproto.TabletAliasString(alias))]; ok {
 		return hd.SimpleCopy(), nil
 	}
 	return nil, fmt.Errorf("could not find tablet: %s", alias.String())
@@ -901,7 +896,7 @@ func (hc *HealthCheckImpl) GetTabletHealth(kst KeyspaceShardTabletType, alias *t
 	defer hc.mu.Unlock()
 
 	if hd, ok := hc.healthData[kst]; ok {
-		if th, ok := hd[aliasKey(alias)]; ok {
+		if th, ok := hd[tabletAliasString(topoproto.TabletAliasString(alias))]; ok {
 			return th, nil
 		}
 	}
@@ -913,7 +908,7 @@ func (hc *HealthCheckImpl) GetTabletHealth(kst KeyspaceShardTabletType, alias *t
 func (hc *HealthCheckImpl) registeredHealthCheck(alias *topodata.TabletAlias) *tabletHealthCheck {
 	hc.mu.Lock()
 	defer hc.mu.Unlock()
-	return hc.healthByAlias[aliasKey(alias)]
+	return hc.healthByAlias[tabletAliasString(topoproto.TabletAliasString(alias))]
 }
 
 // TabletConnection returns the Connection to a given tablet.

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -903,11 +903,17 @@ func (hc *HealthCheckImpl) GetTabletHealth(kst KeyspaceShardTabletType, alias *t
 	return nil, fmt.Errorf("could not find tablet: %s", alias.String())
 }
 
+// registeredHealthCheck returns the tabletHealthCheck currently registered
+// for the given alias, or nil if there is none.
+func (hc *HealthCheckImpl) registeredHealthCheck(alias *topodata.TabletAlias) *tabletHealthCheck {
+	hc.mu.Lock()
+	defer hc.mu.Unlock()
+	return hc.healthByAlias[tabletAliasString(topoproto.TabletAliasString(alias))]
+}
+
 // TabletConnection returns the Connection to a given tablet.
 func (hc *HealthCheckImpl) TabletConnection(ctx context.Context, alias *topodata.TabletAlias, target *query.Target) (queryservice.QueryService, error) {
-	hc.mu.Lock()
-	thc := hc.healthByAlias[tabletAliasString(topoproto.TabletAliasString(alias))]
-	hc.mu.Unlock()
+	thc := hc.registeredHealthCheck(alias)
 	if thc == nil || thc.Conn == nil {
 		return nil, vterrors.Errorf(vtrpc.Code_NOT_FOUND, "tablet: %v is either down or nonexistent", alias)
 	}

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -525,9 +525,6 @@ func (hc *HealthCheckImpl) deleteTablet(tablet *topodata.Tablet) {
 
 func (hc *HealthCheckImpl) updateHealth(thc *tabletHealthCheck, prevTarget *query.Target, trivialUpdate bool, up bool) {
 	// hc.healthByAlias is authoritative, it should be updated
-	hc.mu.Lock()
-	defer hc.mu.Unlock()
-
 	tabletAlias := tabletAliasString(topoproto.TabletAliasString(thc.Tablet.Alias))
 	// let's be sure that this tablet hasn't been deleted from the authoritative map
 	// so that we're not racing to update it and in effect re-adding a copy of the
@@ -535,12 +532,20 @@ func (hc *HealthCheckImpl) updateHealth(thc *tabletHealthCheck, prevTarget *quer
 	// tabletHealthCheck currently registered for this alias. After a ReplaceTablet,
 	// the canceled checkConn goroutine of the replaced tablet can still deliver one
 	// final update, which must not overwrite the state reported by its replacement.
-	if registered, ok := hc.healthByAlias[tabletAlias]; !ok || registered != thc {
+	if !hc.isRegisteredHealthCheck(tabletAlias, thc) {
 		hc.logger().Infof("Tablet %v has been deleted or replaced, skipping health update", thc.Tablet)
 		return
 	}
 
 	th := thc.SimpleCopy()
+
+	hc.mu.Lock()
+	defer hc.mu.Unlock()
+	if !hc.isRegisteredHealthCheckLocked(tabletAlias, thc) {
+		hc.logger().Infof("Tablet %v has been deleted or replaced, skipping health update", thc.Tablet)
+		return
+	}
+
 	targetKey := KeyFromTarget(th.Target)
 	targetChanged := prevTarget.TabletType != th.Target.TabletType || prevTarget.Keyspace != th.Target.Keyspace || prevTarget.Shard != th.Target.Shard
 	if targetChanged {
@@ -901,6 +906,20 @@ func (hc *HealthCheckImpl) GetTabletHealth(kst KeyspaceShardTabletType, alias *t
 		}
 	}
 	return nil, fmt.Errorf("could not find tablet: %s", alias.String())
+}
+
+// isRegisteredHealthCheck reports whether thc is the current healthcheck for tabletAlias.
+func (hc *HealthCheckImpl) isRegisteredHealthCheck(tabletAlias tabletAliasString, thc *tabletHealthCheck) bool {
+	hc.mu.Lock()
+	defer hc.mu.Unlock()
+	return hc.isRegisteredHealthCheckLocked(tabletAlias, thc)
+}
+
+// isRegisteredHealthCheckLocked reports whether thc is the current healthcheck for tabletAlias.
+// hc.mu must be locked before calling it.
+func (hc *HealthCheckImpl) isRegisteredHealthCheckLocked(tabletAlias tabletAliasString, thc *tabletHealthCheck) bool {
+	registered, ok := hc.healthByAlias[tabletAlias]
+	return ok && registered == thc
 }
 
 // registeredHealthCheck returns the tabletHealthCheck currently registered

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -523,12 +523,12 @@ func (hc *HealthCheckImpl) deleteTablet(tablet *topodata.Tablet) {
 	delete(hc.healthByAlias, tabletAlias)
 }
 
-func (hc *HealthCheckImpl) updateHealth(thc *tabletHealthCheck, th *TabletHealth, prevTarget *query.Target, trivialUpdate bool, up bool) {
+func (hc *HealthCheckImpl) updateHealth(thc *tabletHealthCheck, prevTarget *query.Target, trivialUpdate bool, up bool) {
 	// hc.healthByAlias is authoritative, it should be updated
 	hc.mu.Lock()
 	defer hc.mu.Unlock()
 
-	tabletAlias := tabletAliasString(topoproto.TabletAliasString(th.Tablet.Alias))
+	tabletAlias := tabletAliasString(topoproto.TabletAliasString(thc.Tablet.Alias))
 	// let's be sure that this tablet hasn't been deleted from the authoritative map
 	// so that we're not racing to update it and in effect re-adding a copy of the
 	// tablet record that was deleted. Also verify that the update was issued by the
@@ -536,10 +536,11 @@ func (hc *HealthCheckImpl) updateHealth(thc *tabletHealthCheck, th *TabletHealth
 	// the canceled checkConn goroutine of the replaced tablet can still deliver one
 	// final update, which must not overwrite the state reported by its replacement.
 	if registered, ok := hc.healthByAlias[tabletAlias]; !ok || registered != thc {
-		hc.logger().Infof("Tablet %v has been deleted or replaced, skipping health update", th.Tablet)
+		hc.logger().Infof("Tablet %v has been deleted or replaced, skipping health update", thc.Tablet)
 		return
 	}
 
+	th := thc.SimpleCopy()
 	targetKey := KeyFromTarget(th.Target)
 	targetChanged := prevTarget.TabletType != th.Target.TabletType || prevTarget.Keyspace != th.Target.Keyspace || prevTarget.Shard != th.Target.Shard
 	if targetChanged {

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -523,7 +523,7 @@ func (hc *HealthCheckImpl) deleteTablet(tablet *topodata.Tablet) {
 	delete(hc.healthByAlias, tabletAlias)
 }
 
-func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, prevTarget *query.Target, trivialUpdate bool, up bool) {
+func (hc *HealthCheckImpl) updateHealth(thc *tabletHealthCheck, th *TabletHealth, prevTarget *query.Target, trivialUpdate bool, up bool) {
 	// hc.healthByAlias is authoritative, it should be updated
 	hc.mu.Lock()
 	defer hc.mu.Unlock()
@@ -531,9 +531,12 @@ func (hc *HealthCheckImpl) updateHealth(th *TabletHealth, prevTarget *query.Targ
 	tabletAlias := tabletAliasString(topoproto.TabletAliasString(th.Tablet.Alias))
 	// let's be sure that this tablet hasn't been deleted from the authoritative map
 	// so that we're not racing to update it and in effect re-adding a copy of the
-	// tablet record that was deleted
-	if _, ok := hc.healthByAlias[tabletAlias]; !ok {
-		hc.logger().Infof("Tablet %v has been deleted, skipping health update", th.Tablet)
+	// tablet record that was deleted. Also verify that the update was issued by the
+	// tabletHealthCheck currently registered for this alias. After a ReplaceTablet,
+	// the canceled checkConn goroutine of the replaced tablet can still deliver one
+	// final update, which must not overwrite the state reported by its replacement.
+	if registered, ok := hc.healthByAlias[tabletAlias]; !ok || registered != thc {
+		hc.logger().Infof("Tablet %v has been deleted or replaced, skipping health update", th.Tablet)
 		return
 	}
 

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/safehtml/template"
@@ -49,7 +50,7 @@ import (
 )
 
 var (
-	connMap   map[string]*fakeConn
+	connMap   map[string]queryservice.QueryService
 	connMapMu sync.Mutex
 )
 
@@ -61,7 +62,7 @@ func testChecksum(t *testing.T, want, got int64) {
 func init() {
 	tabletconn.RegisterDialer("fake_gateway", tabletDialer)
 	tabletconntest.SetProtocol("go.vt.discovery.healthcheck_test", "fake_gateway")
-	connMap = make(map[string]*fakeConn)
+	connMap = make(map[string]queryservice.QueryService)
 	refreshInterval = time.Minute
 }
 
@@ -855,6 +856,136 @@ func TestRemoveTablet(t *testing.T) {
 	assert.Empty(t, a, "wrong result, expected empty list")
 }
 
+// TestStaleUpdateFromCanceledCheckConn is a regression test for a race
+// between ReplaceTablet and the replaced tablet's checkConn goroutine.
+//
+// When the topology watcher observes that a tablet's address changed (same
+// alias, new host or port map), it calls ReplaceTablet, which cancels the
+// old tabletHealthCheck and registers a new one under the same alias. The
+// old checkConn goroutine reacts to the cancellation from inside stream()
+// and issues one final updateHealth(Serving: false) from its error path
+// without re-checking its own context. Because updateHealth only verifies
+// that the alias still exists in healthByAlias — not that the update came
+// from the currently registered tabletHealthCheck — that stale update can be
+// applied after the replacement connection has already reported
+// Serving: true:
+//
+//  1. ReplaceTablet cancels the old checkConn and registers a new
+//     tabletHealthCheck for the same alias.
+//  2. The new connection receives Serving: true; the tablet is added to the
+//     healthy list.
+//  3. The old goroutine's final updateHealth(Serving: false) lands, removing
+//     the tablet from the healthy list and poisoning healthData.
+//  4. Every subsequent response on the new connection is a trivialUpdate
+//     (the new tabletHealthCheck's own Serving field is still true), so
+//     recomputeHealthy never runs again: healthData shows a healthy, serving
+//     tablet with a live stream while the healthy (routing) list permanently
+//     omits it. The tablet receives zero traffic until an unrelated
+//     non-trivial event in the same keyspace/shard/type triggers a
+//     recompute.
+//
+// Step 3's timing is scheduler-dependent (the dying goroutine can be delayed
+// between its stream returning and acquiring hc.mu), so the old connection's
+// stream is gated: the canceled checkConn goroutine stays parked inside
+// stream() until the test releases it, and synctest.Wait() guarantees each
+// step is fully applied before the next.
+func TestStaleUpdateFromCanceledCheckConn(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+		ts := memorytopo.NewServer(ctx, "cell")
+		defer ts.Close()
+		hc := createTestHc(ctx, ts)
+		defer hc.Close()
+
+		target := &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA}
+
+		// The tablet before the restart, with its stream gated on cancellation.
+		oldTablet := createTestTablet(0, "cell", "a")
+		oldTablet.Type = topodatapb.TabletType_REPLICA
+		oldInput := make(chan *querypb.StreamHealthResponse)
+		oldConn := &staleStreamConn{
+			fakeConn: createFakeConn(oldTablet, oldInput),
+			release:  make(chan struct{}),
+		}
+		connMapMu.Lock()
+		connMap[TabletToMapKey(oldTablet)] = oldConn
+		connMapMu.Unlock()
+
+		// The same tablet after the restart: same alias, new ports.
+		newTablet := createTestTablet(0, "cell", "a")
+		newTablet.Type = topodatapb.TabletType_REPLICA
+		newTablet.PortMap["vt"] = 5
+		newTablet.PortMap["grpc"] = 6
+		newInput := make(chan *querypb.StreamHealthResponse)
+		createFakeConn(newTablet, newInput)
+
+		shr := &querypb.StreamHealthResponse{
+			TabletAlias:   oldTablet.Alias,
+			Target:        target,
+			Serving:       true,
+			RealtimeStats: &querypb.RealtimeStats{ReplicationLagSeconds: 1, CpuUsage: 0.2},
+		}
+
+		hc.AddTablet(oldTablet)
+		oldInput <- shr
+		synctest.Wait()
+		require.Len(t, hc.GetHealthyTabletStats(target), 1, "tablet should be healthy before the restart")
+
+		// The topology watcher notices the restarted tablet and replaces it.
+		// The old checkConn goroutine is canceled but stays parked inside its
+		// stream, before it runs its error path.
+		hc.ReplaceTablet(oldTablet, newTablet)
+
+		// The new connection reports Serving: true; the tablet becomes healthy.
+		newInput <- shr
+		synctest.Wait()
+		require.Len(t, hc.GetHealthyTabletStats(target), 1, "tablet should be healthy again after the replace")
+
+		// Release the canceled goroutine. Its stream now returns an error and
+		// the checkConn error path issues the final stale
+		// updateHealth(Serving: false) — after the replacement connection has
+		// already reported healthy.
+		close(oldConn.release)
+		synctest.Wait()
+
+		// The tablet keeps reporting good health on the new connection: a
+		// trivialUpdate, like the steady-state updates of a healthy replica.
+		newInput <- shr
+		synctest.Wait()
+
+		// The healthcheck cache (healthData) shows a serving tablet with a
+		// live stream, so the healthy (routing) list must include it as well.
+		healthy := hc.GetHealthyTabletStats(target)
+		require.Len(t, healthy, 1,
+			"tablet is serving and streaming health but missing from the healthy list: stale update from the canceled checkConn poisoned the healthy list")
+		assert.True(t, healthy[0].Serving)
+	})
+}
+
+// staleStreamConn wraps fakeConn so that a canceled stream parks until
+// release is closed and then fails like a canceled gRPC stream, modeling the
+// window between a checkConn goroutine's cancellation and its final
+// updateHealth.
+type staleStreamConn struct {
+	*fakeConn
+	release chan struct{}
+}
+
+// StreamHealth implements queryservice.QueryService.
+func (c *staleStreamConn) StreamHealth(ctx context.Context, callback func(shr *querypb.StreamHealthResponse) error) error {
+	for {
+		select {
+		case shr := <-c.hcChan:
+			if err := callback(shr); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			<-c.release
+			return ctx.Err()
+		}
+	}
+}
+
 // When an external primary failover is performed,
 // the demoted primary will advertise itself as a `PRIMARY`
 // tablet until it recognizes that it was demoted,
@@ -1268,13 +1399,18 @@ func TestLoadTabletsTrigger(t *testing.T) {
 	}
 	hc.AddTablet(tablet1)
 
+	hc.mu.Lock()
+	thc := hc.healthByAlias[tabletAliasString(topoproto.TabletAliasString(tablet1.Alias))]
+	hc.mu.Unlock()
+	require.NotNil(t, thc)
+
 	numTriggers := 10
 	for range numTriggers {
 		// Since the previous target was a primary, and there are no other
 		// primary tablets for the given keyspace shard, we will see the healtcheck
 		// send on the loadTablets trigger. We just want to verify the information
 		// there is correct.
-		hc.updateHealth(th, prevTarget, false, false)
+		hc.updateHealth(thc, th, prevTarget, false, false)
 	}
 
 	ch := hc.GetLoadTabletsTrigger()

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -883,9 +883,9 @@ func TestStaleUpdateFromCanceledCheckConn(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx := t.Context()
 		ts := memorytopo.NewServer(ctx, "cell")
-		defer ts.Close()
+		t.Cleanup(func() { ts.Close() })
 		hc := createTestHc(ctx, ts)
-		defer hc.Close()
+		t.Cleanup(func() { hc.Close() })
 
 		target := &querypb.Target{Keyspace: "k", Shard: "s", TabletType: topodatapb.TabletType_REPLICA}
 
@@ -895,12 +895,12 @@ func TestStaleUpdateFromCanceledCheckConn(t *testing.T) {
 		oldInput := make(chan *querypb.StreamHealthResponse)
 		oldConn := createFakeConn(oldTablet, oldInput)
 		oldConn.releaseOnCancel = make(chan struct{})
-		// Always release the parked goroutine, even when an assertion fails
-		// before the inline release: the deferred hc.Close() waits for it, and
-		// a goroutine parked forever would turn the test failure into a
-		// synctest bubble-deadlock panic.
+		// Registered last so it runs before the hc.Close cleanup: hc.Close
+		// waits for this goroutine, and one parked forever would turn an early
+		// assertion failure into a synctest bubble-deadlock panic. OnceFunc
+		// guards against the double close from the deliberate inline release.
 		releaseOldConn := sync.OnceFunc(func() { close(oldConn.releaseOnCancel) })
-		defer releaseOldConn()
+		t.Cleanup(releaseOldConn)
 
 		// The same tablet after the restart: same alias, new ports.
 		newTablet := createTestTablet(0, "cell", "a")

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -910,6 +910,12 @@ func TestStaleUpdateFromCanceledCheckConn(t *testing.T) {
 		connMapMu.Lock()
 		connMap[TabletToMapKey(oldTablet)] = oldConn
 		connMapMu.Unlock()
+		// Always release the parked goroutine, even when an assertion fails
+		// before the inline release: the deferred hc.Close() waits for it, and
+		// a goroutine parked forever would turn the test failure into a
+		// synctest bubble-deadlock panic.
+		releaseOldConn := sync.OnceFunc(func() { close(oldConn.release) })
+		defer releaseOldConn()
 
 		// The same tablet after the restart: same alias, new ports.
 		newTablet := createTestTablet(0, "cell", "a")
@@ -945,7 +951,7 @@ func TestStaleUpdateFromCanceledCheckConn(t *testing.T) {
 		// the checkConn error path issues the final stale
 		// updateHealth(Serving: false) — after the replacement connection has
 		// already reported healthy.
-		close(oldConn.release)
+		releaseOldConn()
 		synctest.Wait()
 
 		// The tablet keeps reporting good health on the new connection: a

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -866,29 +866,19 @@ func TestRemoveTablet(t *testing.T) {
 // and issues one final updateHealth(Serving: false) from its error path
 // without re-checking its own context. Because updateHealth only verifies
 // that the alias still exists in healthByAlias — not that the update came
-// from the currently registered tabletHealthCheck — that stale update can be
-// applied after the replacement connection has already reported
-// Serving: true:
+// from the currently registered tabletHealthCheck — that stale update can
+// land after the replacement connection has already reported Serving: true,
+// removing the tablet from the healthy (routing) list and poisoning
+// healthData. Every subsequent response on the new connection is then a
+// trivialUpdate (the new tabletHealthCheck's own Serving field is still
+// true), so recomputeHealthy never runs again: the tablet receives zero
+// traffic until an unrelated non-trivial event in the same
+// keyspace/shard/type triggers a recompute.
 //
-//  1. ReplaceTablet cancels the old checkConn and registers a new
-//     tabletHealthCheck for the same alias.
-//  2. The new connection receives Serving: true; the tablet is added to the
-//     healthy list.
-//  3. The old goroutine's final updateHealth(Serving: false) lands, removing
-//     the tablet from the healthy list and poisoning healthData.
-//  4. Every subsequent response on the new connection is a trivialUpdate
-//     (the new tabletHealthCheck's own Serving field is still true), so
-//     recomputeHealthy never runs again: healthData shows a healthy, serving
-//     tablet with a live stream while the healthy (routing) list permanently
-//     omits it. The tablet receives zero traffic until an unrelated
-//     non-trivial event in the same keyspace/shard/type triggers a
-//     recompute.
-//
-// Step 3's timing is scheduler-dependent (the dying goroutine can be delayed
-// between its stream returning and acquiring hc.mu), so the old connection's
-// stream is gated: the canceled checkConn goroutine stays parked inside
-// stream() until the test releases it, and synctest.Wait() guarantees each
-// step is fully applied before the next.
+// The stale update's timing is scheduler-dependent (the dying goroutine can
+// be delayed between its stream returning and acquiring hc.mu), so the old
+// connection's stream is gated on cancellation, and synctest.Wait()
+// guarantees each step is fully applied before the next.
 func TestStaleUpdateFromCanceledCheckConn(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx := t.Context()

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -1368,9 +1368,7 @@ func TestLoadTabletsTrigger(t *testing.T) {
 	}
 	hc.AddTablet(tablet1)
 
-	hc.mu.Lock()
-	thc := hc.healthByAlias[tabletAliasString(topoproto.TabletAliasString(tablet1.Alias))]
-	hc.mu.Unlock()
+	thc := hc.registeredHealthCheck(tablet1.Alias)
 	require.NotNil(t, thc)
 
 	numTriggers := 10

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -939,11 +939,6 @@ func TestStaleUpdateFromCanceledCheckConn(t *testing.T) {
 		releaseOldConn()
 		synctest.Wait()
 
-		// The tablet keeps reporting good health on the new connection: a
-		// trivialUpdate, like the steady-state updates of a healthy replica.
-		newInput <- shr
-		synctest.Wait()
-
 		// The healthcheck cache (healthData) shows a serving tablet with a
 		// live stream, so the healthy (routing) list must include it as well.
 		healthy := hc.GetHealthyTabletStats(target)

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -856,29 +856,9 @@ func TestRemoveTablet(t *testing.T) {
 	assert.Empty(t, a, "wrong result, expected empty list")
 }
 
-// TestStaleUpdateFromCanceledCheckConn is a regression test for a race
-// between ReplaceTablet and the replaced tablet's checkConn goroutine.
-//
-// When the topology watcher observes that a tablet's address changed (same
-// alias, new host or port map), it calls ReplaceTablet, which cancels the
-// old tabletHealthCheck and registers a new one under the same alias. The
-// old checkConn goroutine reacts to the cancellation from inside stream()
-// and issues one final updateHealth(Serving: false) from its error path
-// without re-checking its own context. Because updateHealth only verifies
-// that the alias still exists in healthByAlias — not that the update came
-// from the currently registered tabletHealthCheck — that stale update can
-// land after the replacement connection has already reported Serving: true,
-// removing the tablet from the healthy (routing) list and poisoning
-// healthData. Every subsequent response on the new connection is then a
-// trivialUpdate (the new tabletHealthCheck's own Serving field is still
-// true), so recomputeHealthy never runs again: the tablet receives zero
-// traffic until an unrelated non-trivial event in the same
-// keyspace/shard/type triggers a recompute.
-//
-// The stale update's timing is scheduler-dependent (the dying goroutine can
-// be delayed between its stream returning and acquiring hc.mu), so the old
-// connection's stream is gated on cancellation, and synctest.Wait()
-// guarantees each step is fully applied before the next.
+// TestStaleUpdateFromCanceledCheckConn checks that a replaced tablet's
+// canceled checkConn cannot remove its healthy replacement from the routing
+// list with a final, stale updateHealth(Serving: false).
 func TestStaleUpdateFromCanceledCheckConn(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx := t.Context()
@@ -895,10 +875,6 @@ func TestStaleUpdateFromCanceledCheckConn(t *testing.T) {
 		oldInput := make(chan *querypb.StreamHealthResponse)
 		oldConn := createFakeConn(oldTablet, oldInput)
 		oldConn.releaseOnCancel = make(chan struct{})
-		// Registered last so it runs before the hc.Close cleanup: hc.Close
-		// waits for this goroutine, and one parked forever would turn an early
-		// assertion failure into a synctest bubble-deadlock panic. OnceFunc
-		// guards against the double close from the deliberate inline release.
 		releaseOldConn := sync.OnceFunc(func() { close(oldConn.releaseOnCancel) })
 		t.Cleanup(releaseOldConn)
 

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -1359,16 +1359,8 @@ func TestLoadTabletsTrigger(t *testing.T) {
 		Shard:    shard,
 	}
 
-	// We want to run updateHealth with arguments that always
-	// make it trigger load Tablets.
-	th := &TabletHealth{
-		Tablet: tablet1,
-		Target: &querypb.Target{
-			Keyspace:   ks,
-			Shard:      shard,
-			TabletType: topodatapb.TabletType_REPLICA,
-		},
-	}
+	// We want to run updateHealth with a previous target that always
+	// makes it trigger load Tablets.
 	prevTarget := &querypb.Target{
 		Keyspace:   ks,
 		Shard:      shard,
@@ -1387,7 +1379,7 @@ func TestLoadTabletsTrigger(t *testing.T) {
 		// primary tablets for the given keyspace shard, we will see the healtcheck
 		// send on the loadTablets trigger. We just want to verify the information
 		// there is correct.
-		hc.updateHealth(thc, th, prevTarget, false, false)
+		hc.updateHealth(thc, prevTarget, false, false)
 	}
 
 	ch := hc.GetLoadTabletsTrigger()

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -50,7 +50,7 @@ import (
 )
 
 var (
-	connMap   map[string]queryservice.QueryService
+	connMap   map[string]*fakeConn
 	connMapMu sync.Mutex
 )
 
@@ -62,7 +62,7 @@ func testChecksum(t *testing.T, want, got int64) {
 func init() {
 	tabletconn.RegisterDialer("fake_gateway", tabletDialer)
 	tabletconntest.SetProtocol("go.vt.discovery.healthcheck_test", "fake_gateway")
-	connMap = make(map[string]queryservice.QueryService)
+	connMap = make(map[string]*fakeConn)
 	refreshInterval = time.Minute
 }
 
@@ -903,18 +903,13 @@ func TestStaleUpdateFromCanceledCheckConn(t *testing.T) {
 		oldTablet := createTestTablet(0, "cell", "a")
 		oldTablet.Type = topodatapb.TabletType_REPLICA
 		oldInput := make(chan *querypb.StreamHealthResponse)
-		oldConn := &staleStreamConn{
-			fakeConn: createFakeConn(oldTablet, oldInput),
-			release:  make(chan struct{}),
-		}
-		connMapMu.Lock()
-		connMap[TabletToMapKey(oldTablet)] = oldConn
-		connMapMu.Unlock()
+		oldConn := createFakeConn(oldTablet, oldInput)
+		oldConn.releaseOnCancel = make(chan struct{})
 		// Always release the parked goroutine, even when an assertion fails
 		// before the inline release: the deferred hc.Close() waits for it, and
 		// a goroutine parked forever would turn the test failure into a
 		// synctest bubble-deadlock panic.
-		releaseOldConn := sync.OnceFunc(func() { close(oldConn.release) })
+		releaseOldConn := sync.OnceFunc(func() { close(oldConn.releaseOnCancel) })
 		defer releaseOldConn()
 
 		// The same tablet after the restart: same alias, new ports.
@@ -966,30 +961,6 @@ func TestStaleUpdateFromCanceledCheckConn(t *testing.T) {
 			"tablet is serving and streaming health but missing from the healthy list: stale update from the canceled checkConn poisoned the healthy list")
 		assert.True(t, healthy[0].Serving)
 	})
-}
-
-// staleStreamConn wraps fakeConn so that a canceled stream parks until
-// release is closed and then fails like a canceled gRPC stream, modeling the
-// window between a checkConn goroutine's cancellation and its final
-// updateHealth.
-type staleStreamConn struct {
-	*fakeConn
-	release chan struct{}
-}
-
-// StreamHealth implements queryservice.QueryService.
-func (c *staleStreamConn) StreamHealth(ctx context.Context, callback func(shr *querypb.StreamHealthResponse) error) error {
-	for {
-		select {
-		case shr := <-c.hcChan:
-			if err := callback(shr); err != nil {
-				return err
-			}
-		case <-ctx.Done():
-			<-c.release
-			return ctx.Err()
-		}
-	}
 }
 
 // When an external primary failover is performed,
@@ -1805,6 +1776,10 @@ type fakeConn struct {
 	errCh chan error
 	// cbErrCh is a channel which receives errors returned from the supplied callback.
 	cbErrCh chan error
+	// releaseOnCancel, if non-nil, parks a canceled stream until the channel
+	// is closed and then makes it return ctx.Err() like a real gRPC stream,
+	// instead of returning nil right away.
+	releaseOnCancel chan struct{}
 
 	mu       sync.Mutex
 	canceled bool
@@ -1848,6 +1823,10 @@ func (fc *fakeConn) StreamHealth(ctx context.Context, callback func(shr *querypb
 			fc.mu.Lock()
 			fc.canceled = true
 			fc.mu.Unlock()
+			if fc.releaseOnCancel != nil {
+				<-fc.releaseOnCancel
+				return ctx.Err()
+			}
 			return nil
 		}
 	}

--- a/go/vt/discovery/tablet_health_check.go
+++ b/go/vt/discovery/tablet_health_check.go
@@ -201,7 +201,7 @@ func (thc *tabletHealthCheck) processResponse(hc *HealthCheckImpl, shr *query.St
 	thc.setServingState(serving, reason)
 
 	// notify downstream for primary change
-	hc.updateHealth(thc, thc.SimpleCopy(), prevTarget, trivialUpdate, thc.Serving)
+	hc.updateHealth(thc, prevTarget, trivialUpdate, thc.Serving)
 	return nil
 }
 
@@ -302,7 +302,7 @@ func (thc *tabletHealthCheck) checkConn(hc *HealthCheckImpl) {
 			}
 			// trivialUpdate = false because this is an error
 			// up = false because we did not get a healthy response
-			hc.updateHealth(thc, thc.SimpleCopy(), thc.Target, false, false)
+			hc.updateHealth(thc, thc.Target, false, false)
 		}
 		// If there was a timeout send an error. We do this after stream has returned.
 		// This will ensure that this update prevails over any previous message that
@@ -313,7 +313,7 @@ func (thc *tabletHealthCheck) checkConn(hc *HealthCheckImpl) {
 			hcErrorCounters.Add([]string{thc.Target.Keyspace, thc.Target.Shard, topoproto.TabletTypeLString(thc.Target.TabletType)}, 1)
 			// trivialUpdate = false because this is an error
 			// up = false because we did not get a healthy response within the timeout
-			hc.updateHealth(thc, thc.SimpleCopy(), thc.Target, false, false)
+			hc.updateHealth(thc, thc.Target, false, false)
 		}
 
 		// Streaming RPC failed e.g. because vttablet was restarted or took too long.

--- a/go/vt/discovery/tablet_health_check.go
+++ b/go/vt/discovery/tablet_health_check.go
@@ -201,7 +201,7 @@ func (thc *tabletHealthCheck) processResponse(hc *HealthCheckImpl, shr *query.St
 	thc.setServingState(serving, reason)
 
 	// notify downstream for primary change
-	hc.updateHealth(thc.SimpleCopy(), prevTarget, trivialUpdate, thc.Serving)
+	hc.updateHealth(thc, thc.SimpleCopy(), prevTarget, trivialUpdate, thc.Serving)
 	return nil
 }
 
@@ -302,7 +302,7 @@ func (thc *tabletHealthCheck) checkConn(hc *HealthCheckImpl) {
 			}
 			// trivialUpdate = false because this is an error
 			// up = false because we did not get a healthy response
-			hc.updateHealth(thc.SimpleCopy(), thc.Target, false, false)
+			hc.updateHealth(thc, thc.SimpleCopy(), thc.Target, false, false)
 		}
 		// If there was a timeout send an error. We do this after stream has returned.
 		// This will ensure that this update prevails over any previous message that
@@ -313,7 +313,7 @@ func (thc *tabletHealthCheck) checkConn(hc *HealthCheckImpl) {
 			hcErrorCounters.Add([]string{thc.Target.Keyspace, thc.Target.Shard, topoproto.TabletTypeLString(thc.Target.TabletType)}, 1)
 			// trivialUpdate = false because this is an error
 			// up = false because we did not get a healthy response within the timeout
-			hc.updateHealth(thc.SimpleCopy(), thc.Target, false, false)
+			hc.updateHealth(thc, thc.SimpleCopy(), thc.Target, false, false)
 		}
 
 		// Streaming RPC failed e.g. because vttablet was restarted or took too long.

--- a/go/vt/discovery/topology_watcher_test.go
+++ b/go/vt/discovery/topology_watcher_test.go
@@ -33,6 +33,7 @@ import (
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
+	"vitess.io/vitess/go/vt/topo/topoproto"
 )
 
 func checkOpCounts(t *testing.T, prevCounts, deltas map[string]int64) map[string]int64 {
@@ -834,6 +835,15 @@ func TestDeadlockBetweenTopologyWatcherAndHealthCheck(t *testing.T) {
 			return nil
 		})
 		require.NoError(t, err)
-		hc.updateHealth(th, prevTarget, false, false)
+		// Refetch the registered tabletHealthCheck each iteration: the topology
+		// watcher concurrently replaces it, and during the remove-to-add gap of
+		// ReplaceTablet there is none registered at all.
+		hc.mu.Lock()
+		thc := hc.healthByAlias[tabletAliasString(topoproto.TabletAliasString(tablet1.Alias))]
+		hc.mu.Unlock()
+		if thc == nil {
+			continue
+		}
+		hc.updateHealth(thc, th, prevTarget, false, false)
 	}
 }

--- a/go/vt/discovery/topology_watcher_test.go
+++ b/go/vt/discovery/topology_watcher_test.go
@@ -806,16 +806,8 @@ func TestDeadlockBetweenTopologyWatcherAndHealthCheck(t *testing.T) {
 	hc.topoWatchers[0].loadTablets()
 	require.NoError(t, err)
 
-	// We want to run updateHealth with arguments that always
-	// make it trigger load Tablets.
-	th := &TabletHealth{
-		Tablet: tablet1,
-		Target: &querypb.Target{
-			Keyspace:   "keyspace",
-			Shard:      "shard",
-			TabletType: topodatapb.TabletType_REPLICA,
-		},
-	}
+	// We want to run updateHealth with a previous target that always
+	// makes it trigger load Tablets.
 	prevTarget := &querypb.Target{
 		Keyspace:   "keyspace",
 		Shard:      "shard",
@@ -844,6 +836,6 @@ func TestDeadlockBetweenTopologyWatcherAndHealthCheck(t *testing.T) {
 		if thc == nil {
 			continue
 		}
-		hc.updateHealth(thc, th, prevTarget, false, false)
+		hc.updateHealth(thc, prevTarget, false, false)
 	}
 }

--- a/go/vt/discovery/topology_watcher_test.go
+++ b/go/vt/discovery/topology_watcher_test.go
@@ -33,7 +33,6 @@ import (
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
-	"vitess.io/vitess/go/vt/topo/topoproto"
 )
 
 func checkOpCounts(t *testing.T, prevCounts, deltas map[string]int64) map[string]int64 {
@@ -830,9 +829,7 @@ func TestDeadlockBetweenTopologyWatcherAndHealthCheck(t *testing.T) {
 		// Refetch the registered tabletHealthCheck each iteration: the topology
 		// watcher concurrently replaces it, and during the remove-to-add gap of
 		// ReplaceTablet there is none registered at all.
-		hc.mu.Lock()
-		thc := hc.healthByAlias[tabletAliasString(topoproto.TabletAliasString(tablet1.Alias))]
-		hc.mu.Unlock()
+		thc := hc.registeredHealthCheck(tablet1.Alias)
 		if thc == nil {
 			continue
 		}

--- a/go/vt/discovery/topology_watcher_test.go
+++ b/go/vt/discovery/topology_watcher_test.go
@@ -818,6 +818,7 @@ func TestDeadlockBetweenTopologyWatcherAndHealthCheck(t *testing.T) {
 	// the tablet in the health check, but health check has the mutex acquired
 	// already because it is calling updateHealth.
 	// updateHealth itself will be stuck trying to send on the shared channel.
+	updates := 0
 	for i := range 10 {
 		// Update the port of the tablet so that when update Health asks topo watcher to
 		// refresh the tablets, it finds an update and tries to replace it.
@@ -834,5 +835,7 @@ func TestDeadlockBetweenTopologyWatcherAndHealthCheck(t *testing.T) {
 			continue
 		}
 		hc.updateHealth(thc, prevTarget, false, false)
+		updates++
 	}
+	require.NotZero(t, updates, "expected at least one updateHealth call")
 }

--- a/go/vt/discovery/topology_watcher_test.go
+++ b/go/vt/discovery/topology_watcher_test.go
@@ -818,7 +818,6 @@ func TestDeadlockBetweenTopologyWatcherAndHealthCheck(t *testing.T) {
 	// the tablet in the health check, but health check has the mutex acquired
 	// already because it is calling updateHealth.
 	// updateHealth itself will be stuck trying to send on the shared channel.
-	updates := 0
 	for i := range 10 {
 		// Update the port of the tablet so that when update Health asks topo watcher to
 		// refresh the tablets, it finds an update and tries to replace it.
@@ -835,7 +834,5 @@ func TestDeadlockBetweenTopologyWatcherAndHealthCheck(t *testing.T) {
 			continue
 		}
 		hc.updateHealth(thc, prevTarget, false, false)
-		updates++
 	}
-	require.NotZero(t, updates, "expected at least one updateHealth call")
 }


### PR DESCRIPTION
## Description

After `ReplaceTablet` cancels a tablet's `checkConn` goroutine, that goroutine's error path issues one final `updateHealth` with `Serving: false` without re-checking its own context, and that update can land after the replacement connection for the same alias has already reported `Serving: true`. The guard in `updateHealth` only checks that the alias still exists in `healthByAlias`, so the stale update is attributed to the new `tabletHealthCheck`. It overwrites `healthData` and `recomputeHealthy` drops the tablet from the healthy list. Every subsequent response on the new connection is a trivial update, because triviality is computed from the new `tabletHealthCheck`'s own fields, which still say `Serving: true`, and trivial updates never run `recomputeHealthy`. The tablet stays out of the healthy (routing) list indefinitely while `healthData` shows it serving over a live stream.

This passes the issuing `tabletHealthCheck` into `updateHealth`, which now skips the update unless it came from the one currently registered for the alias. `deleteTablet` cancels and deregisters under `hc.mu`, and `AddTablet` always registers a freshly constructed `tabletHealthCheck` under `hc.mu`, so the pointer comparison under the same mutex exactly identifies updates from replaced or removed tablets. The regression test pins the fatal interleaving with `testing/synctest`, gating the canceled goroutine inside its stream until after the replacement connection has reported healthy.

A couple of related issues surfaced while working on this and are deferred as follow-ups:

-   https://github.com/vitessio/vitess/issues/20325
-   https://github.com/vitessio/vitess/issues/20315

I've added the backport labels since this is a focused bug fix, and can have a significant impact if triggered. The conditions to trigger though are most likely quite rare.

## Related Issue(s)

Fixes #20286

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

This is a correctness fix for vtgate healthcheck: a healthy, streaming replica could previously be dropped from the routing list indefinitely after a tablet replacement. No configuration or migration changes are required.

### AI Disclosure

This PR was written primarily by Claude Code, with direction and review from me.
