### PR TITLE
discovery: hoist replication-lag flag getters out of the filter loop

### DIFF
--- a/go/vt/discovery/replicationlag.go
+++ b/go/vt/discovery/replicationlag.go
@@ -156,11 +156,25 @@ func filterStatsByLag(tabletHealthList []*TabletHealth) []*TabletHealth {
 	// Sort by replication lag.
 	sort.Sort(tabletLagSnapshotList(list))
 
-	// Pick tablets with low replication lag, but at least minNumTablets tablets regardless.
-	minTablets := minNumTablets.Get()
+	// Pick tablets with low replication lag, but at least minNumTablets tablets
+	// regardless. minNumTablets.Get() is a viper read that allocates, so defer it:
+	// the list is sorted by ascending lag, so once we reach a high-lag tablet every
+	// later one is also high-lag. Read minNumTablets at most once, and only when a
+	// high-lag tablet actually forces the question — zero times when all tablets
+	// are healthy, which is the common case on the healthcheck hot path.
 	res := make([]*TabletHealth, 0, len(list))
+	var minTablets int
+	minTabletsRead := false
 	for i := 0; i < len(list); i++ {
-		if float64(list[i].ts.Stats.ReplicationLagSeconds) <= lowLag || i < minTablets {
+		if float64(list[i].ts.Stats.ReplicationLagSeconds) <= lowLag {
+			res = append(res, list[i].ts)
+			continue
+		}
+		if !minTabletsRead {
+			minTablets = minNumTablets.Get()
+			minTabletsRead = true
+		}
+		if i < minTablets {
 			res = append(res, list[i].ts)
 		}
 	}

--- a/go/vt/discovery/replicationlag.go
+++ b/go/vt/discovery/replicationlag.go
@@ -111,18 +111,6 @@ func SetMinNumTablets(numTablets int) {
 	minNumTablets.Set(numTablets)
 }
 
-// IsReplicationLagHigh verifies that the given TabletHealth refers to a tablet with high
-// replication lag, i.e. higher than the configured discovery_low_replication_lag flag.
-func IsReplicationLagHigh(tabletHealth *TabletHealth) bool {
-	return float64(tabletHealth.Stats.ReplicationLagSeconds) > lowReplicationLag.Get().Seconds()
-}
-
-// IsReplicationLagVeryHigh verifies that the given TabletHealth refers to a tablet with very high
-// replication lag, i.e. higher than the configured discovery_high_replication_lag_minimum_serving flag.
-func IsReplicationLagVeryHigh(tabletHealth *TabletHealth) bool {
-	return float64(tabletHealth.Stats.ReplicationLagSeconds) > highReplicationLagMinServing.Get().Seconds()
-}
-
 // FilterStatsByReplicationLag filters the list of TabletHealth by TabletHealth.Stats.ReplicationLagSeconds.
 // Note that TabletHealth that is non-serving or has error is ignored.
 //
@@ -168,23 +156,11 @@ func filterStatsByLag(tabletHealthList []*TabletHealth) []*TabletHealth {
 	// Sort by replication lag.
 	sort.Sort(tabletLagSnapshotList(list))
 
-	// Pick tablets with low replication lag, but at least minNumTablets tablets
-	// regardless. The list is sorted by ascending lag, so once we reach a
-	// high-lag tablet every later one is also high-lag; read minNumTablets at
-	// most once, and only when a high-lag tablet actually forces the question.
+	// Pick tablets with low replication lag, but at least minNumTablets tablets regardless.
+	minTablets := minNumTablets.Get()
 	res := make([]*TabletHealth, 0, len(list))
-	var minTablets int
-	minTabletsRead := false
 	for i := 0; i < len(list); i++ {
-		if float64(list[i].ts.Stats.ReplicationLagSeconds) <= lowLag {
-			res = append(res, list[i].ts)
-			continue
-		}
-		if !minTabletsRead {
-			minTablets = minNumTablets.Get()
-			minTabletsRead = true
-		}
-		if i < minTablets {
+		if float64(list[i].ts.Stats.ReplicationLagSeconds) <= lowLag || i < minTablets {
 			res = append(res, list[i].ts)
 		}
 	}

--- a/go/vt/discovery/replicationlag.go
+++ b/go/vt/discovery/replicationlag.go
@@ -148,10 +148,11 @@ func FilterStatsByReplicationLag(tabletHealthList []*TabletHealth) []*TabletHeal
 func filterStatsByLag(tabletHealthList []*TabletHealth) []*TabletHealth {
 	// These thresholds are viper-backed flags whose Get() is comparatively
 	// expensive, so read them once instead of per tablet: filtering runs over
-	// every tablet in a shard while holding the healthcheck lock.
+	// every tablet in a shard while holding the healthcheck lock. minNumTablets
+	// is left in the condition below so it keeps short-circuiting: it is only
+	// read when a tablet's lag is actually high.
 	lowLag := lowReplicationLag.Get().Seconds()
 	highLag := highReplicationLagMinServing.Get().Seconds()
-	minTablets := minNumTablets.Get()
 
 	list := make([]tabletLagSnapshot, 0, len(tabletHealthList))
 	// Filter out non-serving tablets and those with very high replication lag.
@@ -172,7 +173,7 @@ func filterStatsByLag(tabletHealthList []*TabletHealth) []*TabletHealth {
 	// Pick tablets with low replication lag, but at least minNumTablets tablets regardless.
 	res := make([]*TabletHealth, 0, len(list))
 	for i := 0; i < len(list); i++ {
-		if float64(list[i].ts.Stats.ReplicationLagSeconds) <= lowLag || i < minTablets {
+		if float64(list[i].ts.Stats.ReplicationLagSeconds) <= lowLag || i < minNumTablets.Get() {
 			res = append(res, list[i].ts)
 		}
 	}

--- a/go/vt/discovery/replicationlag.go
+++ b/go/vt/discovery/replicationlag.go
@@ -148,9 +148,7 @@ func FilterStatsByReplicationLag(tabletHealthList []*TabletHealth) []*TabletHeal
 func filterStatsByLag(tabletHealthList []*TabletHealth) []*TabletHealth {
 	// These thresholds are viper-backed flags whose Get() is comparatively
 	// expensive, so read them once instead of per tablet: filtering runs over
-	// every tablet in a shard while holding the healthcheck lock. minNumTablets
-	// is left in the condition below so it keeps short-circuiting: it is only
-	// read when a tablet's lag is actually high.
+	// every tablet in a shard while holding the healthcheck lock.
 	lowLag := lowReplicationLag.Get().Seconds()
 	highLag := highReplicationLagMinServing.Get().Seconds()
 
@@ -170,10 +168,23 @@ func filterStatsByLag(tabletHealthList []*TabletHealth) []*TabletHealth {
 	// Sort by replication lag.
 	sort.Sort(tabletLagSnapshotList(list))
 
-	// Pick tablets with low replication lag, but at least minNumTablets tablets regardless.
+	// Pick tablets with low replication lag, but at least minNumTablets tablets
+	// regardless. The list is sorted by ascending lag, so once we reach a
+	// high-lag tablet every later one is also high-lag; read minNumTablets at
+	// most once, and only when a high-lag tablet actually forces the question.
 	res := make([]*TabletHealth, 0, len(list))
+	var minTablets int
+	minTabletsRead := false
 	for i := 0; i < len(list); i++ {
-		if float64(list[i].ts.Stats.ReplicationLagSeconds) <= lowLag || i < minNumTablets.Get() {
+		if float64(list[i].ts.Stats.ReplicationLagSeconds) <= lowLag {
+			res = append(res, list[i].ts)
+			continue
+		}
+		if !minTabletsRead {
+			minTablets = minNumTablets.Get()
+			minTabletsRead = true
+		}
+		if i < minTablets {
 			res = append(res, list[i].ts)
 		}
 	}

--- a/go/vt/discovery/replicationlag.go
+++ b/go/vt/discovery/replicationlag.go
@@ -146,10 +146,17 @@ func FilterStatsByReplicationLag(tabletHealthList []*TabletHealth) []*TabletHeal
 }
 
 func filterStatsByLag(tabletHealthList []*TabletHealth) []*TabletHealth {
+	// These thresholds are viper-backed flags whose Get() is comparatively
+	// expensive, so read them once instead of per tablet: filtering runs over
+	// every tablet in a shard while holding the healthcheck lock.
+	lowLag := lowReplicationLag.Get().Seconds()
+	highLag := highReplicationLagMinServing.Get().Seconds()
+	minTablets := minNumTablets.Get()
+
 	list := make([]tabletLagSnapshot, 0, len(tabletHealthList))
 	// Filter out non-serving tablets and those with very high replication lag.
 	for _, ts := range tabletHealthList {
-		if !ts.Serving || ts.LastError != nil || ts.Stats == nil || IsReplicationLagVeryHigh(ts) {
+		if !ts.Serving || ts.LastError != nil || ts.Stats == nil || float64(ts.Stats.ReplicationLagSeconds) > highLag {
 			continue
 		}
 		// Save the current replication lag for a stable sort later.
@@ -165,7 +172,7 @@ func filterStatsByLag(tabletHealthList []*TabletHealth) []*TabletHealth {
 	// Pick tablets with low replication lag, but at least minNumTablets tablets regardless.
 	res := make([]*TabletHealth, 0, len(list))
 	for i := 0; i < len(list); i++ {
-		if !IsReplicationLagHigh(list[i].ts) || i < minNumTablets.Get() {
+		if float64(list[i].ts.Stats.ReplicationLagSeconds) <= lowLag || i < minTablets {
 			res = append(res, list[i].ts)
 		}
 	}

--- a/go/vt/discovery/replicationlag_test.go
+++ b/go/vt/discovery/replicationlag_test.go
@@ -222,6 +222,32 @@ func TestFilterStatsByReplicationLagOneTabletMin(t *testing.T) {
 	testSetMinNumTablets(2)
 }
 
+// TestFilterStatsByReplicationLagNegativeMin verifies that a negative
+// min-number-serving-vttablets behaves like zero: the "keep at least N"
+// fallback never fires (i < negative is always false), so only low-lag tablets
+// are returned. This pins the behavior of the lazy minNumTablets read, which
+// reaches the negative value through a high-lag tablet.
+func TestFilterStatsByReplicationLagNegativeMin(t *testing.T) {
+	defer utils.EnsureNoLeaks(t)
+	testSetMinNumTablets(-1)
+	defer testSetMinNumTablets(2)
+
+	// One low-lag tablet and one with high (but not very high) lag.
+	ts1 := &TabletHealth{
+		Tablet:  topo.NewTablet(1, "cell", "host1"),
+		Serving: true,
+		Stats:   &querypb.RealtimeStats{ReplicationLagSeconds: 1},
+	}
+	ts2 := &TabletHealth{
+		Tablet:  topo.NewTablet(2, "cell", "host2"),
+		Serving: true,
+		Stats:   &querypb.RealtimeStats{ReplicationLagSeconds: 40 * 60},
+	}
+	got := FilterStatsByReplicationLag([]*TabletHealth{ts1, ts2})
+	want := []*TabletHealth{ts1}
+	mustMatch(t, want, got, "FilterStatsByReplicationLag")
+}
+
 // BenchmarkFilterStatsByReplicationLag measures the cost of filtering a shard's
 // worth of tablet health by replication lag, across a range of replica counts.
 // recomputeHealthy calls this on every non-trivial health update while holding

--- a/go/vt/discovery/replicationlag_test.go
+++ b/go/vt/discovery/replicationlag_test.go
@@ -223,11 +223,11 @@ func TestFilterStatsByReplicationLagOneTabletMin(t *testing.T) {
 }
 
 // BenchmarkFilterStatsByReplicationLag measures the cost of filtering a shard's
-// worth of tablet health by replication lag, across a range of shard sizes.
-// recomputeHealthy calls this while holding the healthcheck lock, so its cost
-// bounds how long that lock is held per health update.
+// worth of tablet health by replication lag, across a range of replica counts.
+// recomputeHealthy calls this on every non-trivial health update while holding
+// the healthcheck lock, so its cost bounds how long that lock is held.
 func BenchmarkFilterStatsByReplicationLag(b *testing.B) {
-	for _, n := range []int{5, 50, 500} {
+	for _, n := range []int{1, 5, 20} {
 		b.Run(fmt.Sprintf("%d_tablets", n), func(b *testing.B) {
 			tablets := make([]*TabletHealth, n)
 			for i := range tablets {

--- a/go/vt/discovery/replicationlag_test.go
+++ b/go/vt/discovery/replicationlag_test.go
@@ -221,3 +221,25 @@ func TestFilterStatsByReplicationLagOneTabletMin(t *testing.T) {
 	// Reset to the default
 	testSetMinNumTablets(2)
 }
+
+// BenchmarkFilterStatsByReplicationLag measures the cost of filtering a shard's
+// worth of tablet health by replication lag, across a range of shard sizes.
+// recomputeHealthy calls this while holding the healthcheck lock, so its cost
+// bounds how long that lock is held per health update.
+func BenchmarkFilterStatsByReplicationLag(b *testing.B) {
+	for _, n := range []int{5, 50, 500} {
+		b.Run(fmt.Sprintf("%d_tablets", n), func(b *testing.B) {
+			tablets := make([]*TabletHealth, n)
+			for i := range tablets {
+				tablets[i] = &TabletHealth{
+					Tablet:  topo.NewTablet(uint32(i+1), "cell", fmt.Sprintf("host-%d", i)),
+					Serving: true,
+					Stats:   &querypb.RealtimeStats{ReplicationLagSeconds: uint32(i % 60)},
+				}
+			}
+			for b.Loop() {
+				_ = FilterStatsByReplicationLag(tablets)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

`filterStatsByLag` (the body of `FilterStatsByReplicationLag`) read viper-backed flags **once per tablet**:

- `discovery-low-replication-lag` and `discovery-high-replication-lag-minimum-serving`, via the `IsReplicationLagHigh` / `IsReplicationLagVeryHigh` helpers, and
- `min-number-serving-vttablets`, via `minNumTablets.Get()`.

viper's `Get()` is comparatively expensive (~90 ns each here: key normalization + map lookups), and this filter runs on **every non-trivial health update** inside `recomputeHealthy`, which holds the healthcheck lock (`hc.mu`) — the same lock every routing read (`GetHealthyTabletStats`) takes. So the per-tablet getter cost was paid on the healthcheck hot path, under the global lock, for every shard.

This:
- hoists `lowReplicationLag` / `highReplicationLagMinServing` into locals once per call (they're used unconditionally per tablet), and
- reads `minNumTablets` **lazily, at most once**. The list is sorted by ascending lag, so the first high-lag tablet is the only place the value is needed; a bool guard reads it zero times when all tablets are healthy (the common case) and once otherwise.

`IsReplicationLagHigh` / `IsReplicationLagVeryHigh` had their logic inlined here and have no other callers, so they're removed.

It's behavior-preserving: these are dynamic flags, but they only change via `debugenv`, and reading them once per call is if anything more consistent than re-reading per tablet.

Note on the lazy read: `min-number-serving-vttablets` is an unvalidated, dynamically-settable `int` flag, so a negative value is reachable. Today `i < minNumTablets.Get()` (with `i >= 0`) makes a negative value behave like `0`; the bool guard preserves that exactly and avoids the collision a `-1` sentinel would introduce. A test pins this.

Why lazy rather than reading `minNumTablets` once up front (see [discussion](https://github.com/vitessio/vitess/pull/20330#discussion_r3421548319)): a viper `Get()` here is ~103 ns and **3 allocs**, and decomposing the function shows the getters are the dominant per-call cost — 9 of the 12 allocs/op, and at a single tablet the three getters (~286 ns) are ~8× the entire `make`+`sort.Sort` work (~34 ns), with sort+make only catching up around 20 tablets. So an eager read isn't free: it adds ~100 ns + 3 allocs to every call, including the all-healthy common path — allocation on the lock-held hot path. The lazy read skips it whenever no high-lag tablet forces the question.

### Benchmark

`BenchmarkFilterStatsByReplicationLag` (added here), `-cpu=1`, `-count=6`, arm64, via `benchstat`. Sizes reflect realistic per-(keyspace, shard, tablet-type) replica counts:

| replicas | before | after | change | abs. saving |
|---|---|---|---|---|
| 1 | 346 ns/op | 315 ns/op | ~ (neutral) | ~31 ns |
| 5 | 1554 ns/op | 364 ns/op | −77% | ~1.2 µs |
| 20 | 5345 ns/op | 534 ns/op | −90% | ~4.8 µs |

What this means in practice: `main` scales ~linearly with replica count (≈2 viper getters per tablet) while this branch is roughly flat (a couple of getters per call plus the sort), so the win grows with shard size. The percentages are large, but the **absolute** saving is low-single-digit microseconds of `hc.mu` hold time per health update at realistic shard sizes — neutral at a single replica. It's a hot-path micro-optimization that shortens lock-hold time on each health update; it does not change the lock model.

These are single-machine `-cpu=1` microbenchmarks with ~5–10% run-to-run variance.

## Related Issue(s)

None — standalone performance fix.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

No user-visible behavior change and no configuration/migration changes. Purely an internal hot-path optimization in vtgate's healthcheck.

### AI Disclosure

This PR was written primarily by Claude Code, with direction and review from me. The investigation that found the hot spot (healthcheck lock-contention profiling and benchmark decomposition) was also done with Claude Code.

