### PR TITLE
ci: use GitHub App token for Go upgrade workflows

### DIFF
--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -21,6 +21,13 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -48,7 +55,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.CREATE_PR_VITESS_BOT }}
+          token: ${{ steps.app-token.outputs.token }}
           branch: "upgrade-go-deps-on-main"
           commit-message: "upgrade go deps"
           signoff: true

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -23,6 +23,13 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -72,7 +79,7 @@ jobs:
         if: steps.detect-and-update.outputs.create-pr == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.CREATE_PR_VITESS_BOT }}
+          token: ${{ steps.app-token.outputs.token }}
           branch: "upgrade-go-to-${{steps.detect-and-update.outputs.go-version}}-on-${{ matrix.branch }}"
           commit-message: "bump go version to go${{steps.detect-and-update.outputs.go-version}}"
           signoff: true


### PR DESCRIPTION
## Description

The **Update Golang Version** and **Update Golang Dependencies** workflows have been silently failing to open their PRs. The detection/update steps run fine, but the `Create Pull Request` step dies when it tries to push:

```
fatal: could not read Username for 'https://github.com': No such device or address
##[error]The process '/usr/bin/git' failed with exit code 128
```

These two are the **only** workflows still pushing with the legacy `CREATE_PR_VITESS_BOT` personal access token. This switches them to mint a short-lived GitHub App installation token via `actions/create-github-app-token` (using `vars.APP_ID` + `secrets.APP_PRIVATE_KEY`) and pass it to `peter-evans/create-pull-request` — exactly the pattern `backport.yml` and `error_code_docs_update.yml` already use successfully.

### What I *think* happened (a guess, not confirmed)

I can't see the secret's contents, so this is my best reconstruction from the run history rather than something I've verified:

- The `CREATE_PR_VITESS_BOT` secret was last modified on **April 14**.
- The `Update Golang Dependencies` workflow last succeeded on its **5/1** run and has failed with the git-auth error above ever since, starting **5/15**.
- The `Update Golang Version` workflow kept going green through **6/2**, but those runs **skipped** the `Create Pull Request` step (it's conditional, and there was no new Go release to push), so they never exercised the token. It only started failing on **6/3**, the first run with an actual upgrade to push.

That pattern — a stored credential that works on 5/1, fails by 5/15, with nobody editing it in between — looks a lot like an **expired personal access token**. April 14 plus a standard 30-day PAT lifetime lands around May 14, which fits the deps failure on 5/15. I'm not certain that's the cause, but if it is, it would recur roughly every time the PAT lapses.

Either way, moving to a GitHub App token removes the long-lived stored credential entirely: the installation token is minted fresh (1-hour TTL) on every run, so this class of outage shouldn't recur regardless of the exact root cause.

## Related Issue(s)

<!-- none -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

This relies on the same GitHub App (`APP_ID` / `APP_PRIVATE_KEY`) already used by the backport and error-code-docs workflows; no new secrets are required. The `CREATE_PR_VITESS_BOT` secret can be retired once nothing else references it.

These are `schedule`-triggered workflows, which only ever run from the default branch (`main`), so no backport to release branches is needed — `main`'s copy drives the upgrade for all branches via the job matrix.

### AI Disclosure

This PR was written by Claude Code — I just provided direction.