### PR TITLE
Upgrade github.com/hashicorp/consul/api to v2

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -28,7 +28,7 @@ BUILD_CONSUL=${BUILD_CONSUL:-1}
 BUILD_PROTOC=${BUILD_PROTOC:-1}
 
 VITESS_RESOURCES_DOWNLOAD_BASE_URL="https://github.com/vitessio/vitess-resources/releases/download"
-VITESS_RESOURCES_RELEASE="v4.0"
+VITESS_RESOURCES_RELEASE="v5.0"
 VITESS_RESOURCES_DOWNLOAD_URL="${VITESS_RESOURCES_DOWNLOAD_BASE_URL}/${VITESS_RESOURCES_RELEASE}"
 #
 # 0. Initialization and helper methods.
@@ -282,14 +282,14 @@ install_consul() {
 		;;
 	esac
 
-	# SHA256 checksums for consul 1.11.4 from Vitess resources mirror.
+	# SHA256 checksums for consul 2.0.1 from Vitess resources mirror.
 	# Note: darwin checksums differ from official HashiCorp releases.
 	local sha256
 	case "${platform}_${target}" in
-	linux_amd64) sha256="5155f6a3b7ff14d3671b0516f6b7310530b509a2b882b95b4fdf25f4219342c8" ;;
-	linux_arm64) sha256="97dbf36500dcefbe463f070471602992d148cb2fe91db7e37319e1b9c809f1f0" ;;
-	darwin_amd64) sha256="f00f81897ec0c608019a37dec243837ce0fd471b67401ea05be9a8b105d247ce" ;;
-	darwin_arm64) sha256="22a87e88c9fd36f773ebd62b18f41dad5512e753769f5a385a7842a0b9364e0a" ;;
+	linux_amd64) sha256="f8189736b05e3fe42d27dd83dfbd3a6d7e44b5669b2e51684362e9c1639babe0" ;;
+	linux_arm64) sha256="06a88f29c408f02a4c6388dccf30c059b8d8ce3778576701603fbb4dfc03b365" ;;
+	darwin_amd64) sha256="e5c1cf801dcd2f50cb0fec43feda03e74527fa4e28ee04890bfe3eb2ca0faaa1" ;;
+	darwin_arm64) sha256="ab6f2baa756b7ade58b335ec98312ff8235bc3d6d520de9c7ec95bd9c8a13485" ;;
 	*)
 		echo "ERROR: no checksum for consul ${platform}_${target}"
 		exit 1

--- a/build.env
+++ b/build.env
@@ -31,7 +31,7 @@ export PATH="$PWD/bin:$PATH"
 export PROTOC_VER=21.3
 export ZK_VER=${ZK_VERSION:-3.9.5}
 export ETCD_VER=v3.6.7
-export CONSUL_VER=1.11.4
+export CONSUL_VER=2.0.1
 
 mkdir -p "$VTDATAROOT"
 

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
-	github.com/hashicorp/consul/api v1.34.3
+	github.com/hashicorp/consul/api/v2 v2.0.0
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/serf v0.10.2 // indirect
 	github.com/klauspost/compress v1.18.6

--- a/go.sum
+++ b/go.sum
@@ -263,10 +263,10 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hanwen/go-fuse/v2 v2.10.1 h1:QAqZuc9+aBtTou+OPruU/hkYQYCkgPtQd2QaepHkTTs=
 github.com/hanwen/go-fuse/v2 v2.10.1/go.mod h1:aU7NkGYZUmuJrZapoI3mEcNve7PZTySUOLBuch/vR6U=
-github.com/hashicorp/consul/api v1.34.3 h1:OiZaQnwkS6uvutie3CF6NFXj8uScNezDlsU9MEqKT0s=
-github.com/hashicorp/consul/api v1.34.3/go.mod h1:A4wKd7yw7Wz4zn07p74+o0bLBi5dXsSDMMcMCEinY40=
-github.com/hashicorp/consul/sdk v0.18.1 h1:RDTeBvAeOveI2xI86sV+8WkaN7OkP4zz+cG3fOobDCM=
-github.com/hashicorp/consul/sdk v0.18.1/go.mod h1:XdP2tEJmAvlK4jgoKTTtohGkRJlS4mU44mv9/sjU21s=
+github.com/hashicorp/consul/api/v2 v2.0.0 h1:FBzxiwnP8kJoHL2ByDUSvaItbc7jF7LxZLTnHtO75wA=
+github.com/hashicorp/consul/api/v2 v2.0.0/go.mod h1:1gEhzpcnl4X4ui7JFpFQvn7QRYQ60IFm6BxBXjrv0dg=
+github.com/hashicorp/consul/sdk/v2 v2.0.0 h1:3KJ7oqP5ZY0OGmUUMTTafPNM1CscXw9NMJ329UMMgcs=
+github.com/hashicorp/consul/sdk/v2 v2.0.0/go.mod h1:Si3zN9Zw40NHtow0yrGpgJ0wMsL9O2RWDevEzmKzbps=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/go/cmd/vttestserver/cli/main_test.go
+++ b/go/cmd/vttestserver/cli/main_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"

--- a/go/test/endtoend/vreplication/cluster_test.go
+++ b/go/test/endtoend/vreplication/cluster_test.go
@@ -254,7 +254,7 @@ func downloadDBTypeVersion(dbType string, majorVersion string, path string) erro
 		url = "https://dev.mysql.com/get/Downloads/MySQL-8.0/" + versionFile
 	} else if dbType == "mariadb" && majorVersion == "10.10" {
 		versionFile = "mariadb-10.10.3-linux-systemd-x86_64.tar.gz"
-		url = "https://github.com/vitessio/vitess-resources/releases/download/v4.0/" + versionFile
+		url = "https://github.com/vitessio/vitess-resources/releases/download/v5.0/" + versionFile
 	} else {
 		return fmt.Errorf("invalid/unsupported major version: %s for database: %s", majorVersion, dbType)
 	}

--- a/go/vt/topo/consultopo/election.go
+++ b/go/vt/topo/consultopo/election.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v2"
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/topo"

--- a/go/vt/topo/consultopo/file.go
+++ b/go/vt/topo/consultopo/file.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"path"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v2"
 
 	"vitess.io/vitess/go/vt/topo"
 )

--- a/go/vt/topo/consultopo/lock.go
+++ b/go/vt/topo/consultopo/lock.go
@@ -22,7 +22,7 @@ import (
 	"path"
 	"time"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v2"
 
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"

--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v2"
 	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/topo/consultopo/server_flaky_test.go
+++ b/go/vt/topo/consultopo/server_flaky_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/go/vt/topo/consultopo/watch.go
+++ b/go/vt/topo/consultopo/watch.go
@@ -21,7 +21,7 @@ import (
 	"path"
 	"time"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/v2"
 	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/vt/servenv"

--- a/go/vt/vtadmin/cluster/discovery/discovery_consul.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_consul.go
@@ -24,7 +24,7 @@ import (
 	"text/template"
 	"time"
 
-	consul "github.com/hashicorp/consul/api"
+	consul "github.com/hashicorp/consul/api/v2"
 	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/textutil"

--- a/go/vt/vtadmin/cluster/discovery/discovery_consul_test.go
+++ b/go/vt/vtadmin/cluster/discovery/discovery_consul_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"text/template"
 
-	consul "github.com/hashicorp/consul/api"
+	consul "github.com/hashicorp/consul/api/v2"
 	"github.com/stretchr/testify/assert"
 
 	vtadminpb "vitess.io/vitess/go/vt/proto/vtadmin"


### PR DESCRIPTION


## Description

* Upgrade `github.com/hashicorp/consul/api` to `v2`.
* Upgraded the Vitess resources mirror release (v4.0 → v5.0)
* Upgraded the Consul binary version


## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required
