### PR TITLE
schemadiff, tablegc: reject foreign-key shadow-table conflicts and reclaim FK-linked GC tables safely

### DIFF
--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -391,7 +391,7 @@ type ForeignKeyShadowConflictError struct {
 
 func (e *ForeignKeyShadowConflictError) Error() string {
 	return fmt.Sprintf(
-		"foreign key constraint %s in table %s references %s.%s, which is altered incompatibly in the same batch; the original table would survive with this foreign key while %s is altered, corrupting it. Split into separate migrations",
+		"foreign key constraint %s in table %s references %s.%s, which is altered incompatibly in the same batch; the original table would survive with this foreign key while %s is altered, corrupting it. These changes must be split into separate migrations",
 		sqlescape.EscapeID(e.Constraint),
 		sqlescape.EscapeID(e.Table),
 		sqlescape.EscapeID(e.ReferencedTable),

--- a/go/vt/schemadiff/errors.go
+++ b/go/vt/schemadiff/errors.go
@@ -352,7 +352,8 @@ type ForeignKeyColumnTypeMismatchError struct {
 }
 
 func (e *ForeignKeyColumnTypeMismatchError) Error() string {
-	return fmt.Sprintf("mismatching column type %s.%s and %s.%s referenced by foreign key constraint %s in table %s",
+	return fmt.Sprintf(
+		"mismatching column type %s.%s and %s.%s referenced by foreign key constraint %s in table %s",
 		sqlescape.EscapeID(e.ReferencedTable),
 		sqlescape.EscapeID(e.ReferencedColumn),
 		sqlescape.EscapeID(e.Table),
@@ -369,10 +370,33 @@ type MissingForeignKeyReferencedIndexError struct {
 }
 
 func (e *MissingForeignKeyReferencedIndexError) Error() string {
-	return fmt.Sprintf("missing index in referenced table %s for foreign key constraint %s in table %s",
+	return fmt.Sprintf(
+		"missing index in referenced table %s for foreign key constraint %s in table %s",
 		sqlescape.EscapeID(e.ReferencedTable),
 		sqlescape.EscapeID(e.Constraint),
 		sqlescape.EscapeID(e.Table),
+	)
+}
+
+// ForeignKeyShadowConflictError indicates that a foreign key constraint present in the source schema
+// would survive on an OnlineDDL held table (`_vt_hld_…`) while the referenced parent table is
+// concurrently altered into a signature incompatible with that foreign key. Such a batch cannot be
+// safely executed under any ordering, and must be split into separate, time-spaced migrations.
+type ForeignKeyShadowConflictError struct {
+	Table            string
+	Constraint       string
+	ReferencedTable  string
+	ReferencedColumn string
+}
+
+func (e *ForeignKeyShadowConflictError) Error() string {
+	return fmt.Sprintf(
+		"foreign key constraint %s in table %s references %s.%s, which is altered incompatibly in the same batch; the original table would survive with this foreign key while %s is altered, corrupting it. Split into separate migrations",
+		sqlescape.EscapeID(e.Constraint),
+		sqlescape.EscapeID(e.Table),
+		sqlescape.EscapeID(e.ReferencedTable),
+		sqlescape.EscapeID(e.ReferencedColumn),
+		sqlescape.EscapeID(e.ReferencedTable),
 	)
 }
 
@@ -382,7 +406,8 @@ type IndexNeededByForeignKeyError struct {
 }
 
 func (e *IndexNeededByForeignKeyError) Error() string {
-	return fmt.Sprintf("key %s needed by a foreign key constraint in table %s",
+	return fmt.Sprintf(
+		"key %s needed by a foreign key constraint in table %s",
 		sqlescape.EscapeID(e.Key),
 		sqlescape.EscapeID(e.Table),
 	)

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -995,6 +995,88 @@ func (s *Schema) SchemaDiff(other *Schema, hints *DiffHints) (*SchemaDiff, error
 		return true, nil
 	}
 
+	// checkForeignKeyShadowConflict detects "shadow table" foreign key corruption. A foreign key
+	// present in the source schema survives on the OnlineDDL held table (`_vt_hld_…`) for the duration
+	// of the child's migration (and until table GC). If the referenced parent table is concurrently
+	// altered in this same batch such that the surviving foreign key becomes invalid — an incompatible
+	// referenced column signature, a dropped or renamed referenced column, a dropped covering index, or
+	// a dropped parent table — the held table is corrupted. No ordering can resolve this, so we record
+	// an impossible-execution dependency. This is gated behind ForeignKeyShadowConflictStrategyReject,
+	// since it is specific to OnlineDDL's held-table mechanism and is safe under direct strategy.
+	checkForeignKeyShadowConflict := func(childDiff EntityDiff, cFrom *CreateTableEntity, constraintName string, fk *sqlparser.ForeignKeyDefinition) {
+		referencedTableName := fk.ReferenceDefinition.ReferencedTable.Name.String()
+		parentDiffs := schemaDiff.diffsByEntityName(referencedTableName)
+		if len(parentDiffs) == 0 {
+			// Parent table is not migrated in this batch: there is no held parent table, and the
+			// final-schema foreign key validation already governs any incompatibility.
+			return
+		}
+		childColumns := cFrom.ColumnDefinitionEntitiesMap()
+		for _, parentDiff := range parentDiffs {
+			breaking := false
+			referencedColumn := ""
+			switch parentDiff := parentDiff.(type) {
+			case *DropTableEntityDiff:
+				// The parent table is dropped while the foreign key survives on the held child table.
+				breaking = true
+			case *AlterTableEntityDiff:
+				_, parentTo := parentDiff.Entities()
+				parentTable, ok := parentTo.(*CreateTableEntity)
+				if !ok {
+					continue
+				}
+				parentColumns := parentTable.ColumnDefinitionEntitiesMap()
+				for i, referencedCol := range fk.ReferenceDefinition.ReferencedColumns {
+					if i >= len(fk.Source) {
+						break
+					}
+					parentCol, ok := parentColumns[referencedCol.Lowered()]
+					if !ok {
+						// Referenced column was dropped or renamed by the parent's ALTER.
+						breaking, referencedColumn = true, referencedCol.String()
+						break
+					}
+					childCol, ok := childColumns[fk.Source[i].Lowered()]
+					if !ok {
+						continue
+					}
+					if !colTypeEqualForForeignKey(s.env, cFrom.TableSpec, parentTable.TableSpec, childCol.ColumnDefinition.Type, parentCol.ColumnDefinition.Type) {
+						// The surviving foreign key's referenced column changed to an incompatible signature.
+						breaking, referencedColumn = true, referencedCol.String()
+						break
+					}
+				}
+				if !breaking && !parentTable.columnsCoveredByInOrderIndex(fk.ReferenceDefinition.ReferencedColumns) {
+					// The parent no longer has an index covering the referenced columns, which the
+					// surviving foreign key requires.
+					breaking = true
+				}
+			default:
+				continue
+			}
+			if breaking {
+				schemaDiff.addDep(childDiff, parentDiff, DiffDependencyImpossibleExecution)
+				schemaDiff.foreignKeyShadowConflicts = append(schemaDiff.foreignKeyShadowConflicts, &ForeignKeyShadowConflictError{
+					Table:            cFrom.Name(),
+					Constraint:       constraintName,
+					ReferencedTable:  referencedTableName,
+					ReferencedColumn: referencedColumn,
+				})
+			}
+		}
+	}
+
+	checkSourceForeignKeyShadowConflicts := func(childDiff EntityDiff, cFrom *CreateTableEntity) {
+		if hints == nil || hints.ForeignKeyShadowConflictStrategy != ForeignKeyShadowConflictStrategyReject {
+			return
+		}
+		for _, constraint := range cFrom.TableSpec.Constraints {
+			if fk, ok := constraint.Details.(*sqlparser.ForeignKeyDefinition); ok {
+				checkForeignKeyShadowConflict(childDiff, cFrom, constraint.Name.String(), fk)
+			}
+		}
+	}
+
 	for _, diff := range schemaDiff.UnorderedDiffs() {
 		switch diff := diff.(type) {
 		case *CreateViewEntityDiff:
@@ -1024,6 +1106,7 @@ func (s *Schema) SchemaDiff(other *Schema, hints *DiffHints) (*SchemaDiff, error
 			}, diff.Statement())
 
 		case *AlterTableEntityDiff:
+			checkSourceForeignKeyShadowConflicts(diff, diff.from)
 			_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
 				switch node := node.(type) {
 				case *sqlparser.AddConstraintDefinition:
@@ -1054,7 +1137,9 @@ func (s *Schema) SchemaDiff(other *Schema, hints *DiffHints) (*SchemaDiff, error
 				return true, nil
 			}, diff.Statement())
 		case *DropTableEntityDiff:
-			// No need to handle. Any dependencies will be resolved by any of the other cases
+			// Dropping a child table also leaves a held original (`_vt_hld_…`) that retains its
+			// foreign keys, so it is subject to the same shadow-table conflict as an ALTER.
+			checkSourceForeignKeyShadowConflicts(diff, diff.from)
 		}
 	}
 

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -1146,8 +1146,10 @@ func (s *Schema) SchemaDiff(other *Schema, hints *DiffHints) (*SchemaDiff, error
 				return true, nil
 			}, diff.Statement())
 		case *DropTableEntityDiff:
-			// Dropping a child table also leaves a held original (`_vt_hld_…`) that retains its
-			// foreign keys, so it is subject to the same shadow-table conflict as an ALTER.
+			// Dropping a child table leaves a held original (`_vt_hld_…`) that retains its foreign
+			// keys, so it conflicts when a referenced parent *survives* this batch but is altered
+			// incompatibly. A dropped parent is not a conflict (it falls through below): the table GC
+			// reclaims the held pair with foreign key checks disabled, regardless of order.
 			checkSourceForeignKeyShadowConflicts(diff, diff.from)
 		}
 	}

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -1005,6 +1005,12 @@ func (s *Schema) SchemaDiff(other *Schema, hints *DiffHints) (*SchemaDiff, error
 	// since it is specific to OnlineDDL's held-table mechanism and is safe under direct strategy.
 	checkForeignKeyShadowConflict := func(childDiff EntityDiff, cFrom *CreateTableEntity, constraintName string, fk *sqlparser.ForeignKeyDefinition) {
 		referencedTableName := fk.ReferenceDefinition.ReferencedTable.Name.String()
+		if referencedTableName == cFrom.Name() {
+			// Self-referencing foreign key: the held original table is internally consistent (its
+			// foreign key references its own columns, all at the same version), so it cannot conflict
+			// with a separately-migrated parent. There is no shadow conflict.
+			return
+		}
 		parentDiffs := schemaDiff.diffsByEntityName(referencedTableName)
 		if len(parentDiffs) == 0 {
 			// Parent table is not migrated in this batch: there is no held parent table, and the
@@ -1014,7 +1020,13 @@ func (s *Schema) SchemaDiff(other *Schema, hints *DiffHints) (*SchemaDiff, error
 		childColumns := cFrom.ColumnDefinitionEntitiesMap()
 		for _, parentDiff := range parentDiffs {
 			breaking := false
+			// Default to the first referenced column so that table-level conflicts (a dropped parent
+			// table or a dropped covering index) still name a column in the error. Column-specific
+			// branches below override this with the exact offending column.
 			referencedColumn := ""
+			if len(fk.ReferenceDefinition.ReferencedColumns) > 0 {
+				referencedColumn = fk.ReferenceDefinition.ReferencedColumns[0].String()
+			}
 			switch parentDiff := parentDiff.(type) {
 			case *DropTableEntityDiff:
 				// The parent table is dropped while the foreign key survives on the held child table.

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -1028,9 +1028,6 @@ func (s *Schema) SchemaDiff(other *Schema, hints *DiffHints) (*SchemaDiff, error
 				referencedColumn = fk.ReferenceDefinition.ReferencedColumns[0].String()
 			}
 			switch parentDiff := parentDiff.(type) {
-			case *DropTableEntityDiff:
-				// The parent table is dropped while the foreign key survives on the held child table.
-				breaking = true
 			case *AlterTableEntityDiff:
 				_, parentTo := parentDiff.Entities()
 				parentTable, ok := parentTo.(*CreateTableEntity)

--- a/go/vt/schemadiff/schema.go
+++ b/go/vt/schemadiff/schema.go
@@ -997,12 +997,14 @@ func (s *Schema) SchemaDiff(other *Schema, hints *DiffHints) (*SchemaDiff, error
 
 	// checkForeignKeyShadowConflict detects "shadow table" foreign key corruption. A foreign key
 	// present in the source schema survives on the OnlineDDL held table (`_vt_hld_…`) for the duration
-	// of the child's migration (and until table GC). If the referenced parent table is concurrently
-	// altered in this same batch such that the surviving foreign key becomes invalid — an incompatible
-	// referenced column signature, a dropped or renamed referenced column, a dropped covering index, or
-	// a dropped parent table — the held table is corrupted. No ordering can resolve this, so we record
-	// an impossible-execution dependency. This is gated behind ForeignKeyShadowConflictStrategyReject,
-	// since it is specific to OnlineDDL's held-table mechanism and is safe under direct strategy.
+	// of the child's migration (and until table GC). If a parent table that *survives* this batch is
+	// concurrently altered such that the surviving foreign key becomes invalid — an incompatible
+	// referenced column signature, a dropped or renamed referenced column, or a dropped covering
+	// index — the held table is corrupted. No ordering can resolve this, so we record an
+	// impossible-execution dependency. A *dropped* parent is not a conflict: the table GC reclaims the
+	// held pair with foreign key checks disabled. This is gated behind
+	// ForeignKeyShadowConflictStrategyReject, since it is specific to OnlineDDL's held-table mechanism
+	// and is safe under direct strategy.
 	checkForeignKeyShadowConflict := func(childDiff EntityDiff, cFrom *CreateTableEntity, constraintName string, fk *sqlparser.ForeignKeyDefinition) {
 		referencedTableName := fk.ReferenceDefinition.ReferencedTable.Name.String()
 		if referencedTableName == cFrom.Name() {

--- a/go/vt/schemadiff/schema_diff.go
+++ b/go/vt/schemadiff/schema_diff.go
@@ -32,6 +32,7 @@ const (
 	DiffDependencyOrderUnknown
 	DiffDependencyInOrderCompletion
 	DiffDependencySequentialExecution
+	DiffDependencyImpossibleExecution
 )
 
 // DiffDependency indicates a dependency between two diffs, and the type of that dependency
@@ -78,6 +79,12 @@ func (d *DiffDependency) IsInOrder() bool {
 // IsSequential returns true if this is a sequential dependency
 func (d *DiffDependency) IsSequential() bool {
 	return d.typ >= DiffDependencySequentialExecution
+}
+
+// IsImpossible returns true if this is an impossible-execution dependency, ie the two diffs
+// cannot be safely applied together in the same batch under any ordering.
+func (d *DiffDependency) IsImpossible() bool {
+	return d.typ >= DiffDependencyImpossibleExecution
 }
 
 /*
@@ -200,6 +207,8 @@ type SchemaDiff struct {
 	diffMap      map[string]EntityDiff // key is diff's CanonicalStatementString()
 	dependencies map[string]*DiffDependency
 
+	foreignKeyShadowConflicts []*ForeignKeyShadowConflictError
+
 	r *mathutil.EquivalenceRelation // internal structure to help determine diffs
 }
 
@@ -317,9 +326,41 @@ func (d *SchemaDiff) HasSequentialExecutionDependencies() bool {
 	return false
 }
 
+// AllImpossibleExecutionDependencies returns all diffs that are of "impossible execution" type.
+func (d *SchemaDiff) AllImpossibleExecutionDependencies() (deps []*DiffDependency) {
+	for _, dep := range d.dependencies {
+		if dep.typ >= DiffDependencyImpossibleExecution {
+			deps = append(deps, dep)
+		}
+	}
+	return deps
+}
+
+// HasImpossibleExecutionDependencies returns `true` if there is at least one "impossible execution" type diff.
+// If so, the diffs cannot be linearized into a safe order and the batch must be rejected.
+func (d *SchemaDiff) HasImpossibleExecutionDependencies() bool {
+	for _, dep := range d.dependencies {
+		if dep.typ >= DiffDependencyImpossibleExecution {
+			return true
+		}
+	}
+	return false
+}
+
 // OrderedDiffs returns the list of diff in applicable order, if possible. This is a linearized representation
 // where diffs may be applied in-order one after another, keeping the schema in valid state at all times.
 func (d *SchemaDiff) OrderedDiffs(ctx context.Context) ([]EntityDiff, error) {
+	// An impossible-execution dependency cannot be resolved by any ordering of the diffs, so we
+	// reject the batch up front with a precise error rather than failing the permutation search.
+	if d.HasImpossibleExecutionDependencies() {
+		if len(d.foreignKeyShadowConflicts) > 0 {
+			return nil, d.foreignKeyShadowConflicts[0]
+		}
+		return nil, &ImpossibleApplyDiffOrderError{
+			UnorderedDiffs:   d.UnorderedDiffs(),
+			ConflictingDiffs: d.UnorderedDiffs(),
+		}
+	}
 	lastGoodSchema := d.schema.copy()
 	var orderedDiffs []EntityDiff
 	m := d.r.Map()

--- a/go/vt/schemadiff/schema_diff_test.go
+++ b/go/vt/schemadiff/schema_diff_test.go
@@ -686,7 +686,8 @@ func TestSchemaDiff(t *testing.T) {
 		},
 		{
 			name: "two table cycle with create, strict",
-			fromQueries: append(createQueries,
+			fromQueries: append(
+				createQueries,
 				"create table t11 (id int primary key, i0 int);",
 			),
 			toQueries: append(
@@ -704,7 +705,8 @@ func TestSchemaDiff(t *testing.T) {
 		},
 		{
 			name: "two table cycle with create, strict, changed lexicographic order",
-			fromQueries: append(createQueries,
+			fromQueries: append(
+				createQueries,
 				"create table t12 (id int primary key, i0 int);",
 			),
 			toQueries: append(
@@ -722,7 +724,8 @@ func TestSchemaDiff(t *testing.T) {
 		},
 		{
 			name: "two table cycle with create, ignore",
-			fromQueries: append(createQueries,
+			fromQueries: append(
+				createQueries,
 				"create table t11 (id int primary key, i0 int);",
 			),
 			toQueries: append(
@@ -740,7 +743,8 @@ func TestSchemaDiff(t *testing.T) {
 		},
 		{
 			name: "two table cycle with create, ignore, changed lexicographic order",
-			fromQueries: append(createQueries,
+			fromQueries: append(
+				createQueries,
 				"create table t12 (id int primary key, i0 int);",
 			),
 			toQueries: append(
@@ -758,7 +762,8 @@ func TestSchemaDiff(t *testing.T) {
 		},
 		{
 			name: "two table cycle with create, existing column, ignore",
-			fromQueries: append(createQueries,
+			fromQueries: append(
+				createQueries,
 				"create table t12 (id int primary key, i int, key (i));",
 			),
 			toQueries: append(
@@ -776,7 +781,8 @@ func TestSchemaDiff(t *testing.T) {
 		},
 		{
 			name: "two table cycle with create, existing column, changed lexicographic order, ignore",
-			fromQueries: append(createQueries,
+			fromQueries: append(
+				createQueries,
 				"create table t11 (id int primary key, i int, key (i));",
 			),
 			toQueries: append(
@@ -794,7 +800,8 @@ func TestSchemaDiff(t *testing.T) {
 		},
 		{
 			name: "two table cycle with create, create table first",
-			fromQueries: append(createQueries,
+			fromQueries: append(
+				createQueries,
 				"create table t12 (id int primary key, i int, key (i));",
 			),
 			toQueries: append(
@@ -812,7 +819,8 @@ func TestSchemaDiff(t *testing.T) {
 		},
 		{
 			name: "two table cycle with create, changed lexicographic order, create table first",
-			fromQueries: append(createQueries,
+			fromQueries: append(
+				createQueries,
 				"create table t11 (id int primary key, i int, key (i));",
 			),
 			toQueries: append(
@@ -1383,6 +1391,166 @@ func TestSchemaDiff(t *testing.T) {
 			}
 			instantCapability := schemaDiff.InstantDDLCapability()
 			assert.Equal(t, tc.instantCapability, instantCapability, "for instant capability")
+		})
+	}
+}
+
+// TestSchemaDiffForeignKeyShadowConflict validates detection of "shadow table" foreign key conflicts:
+// a foreign key present in the source schema survives on the OnlineDDL held table while the referenced
+// parent is concurrently altered into an incompatible signature in the same batch. Such a batch must be
+// rejected when ForeignKeyShadowConflictStrategyReject is set, and left untouched otherwise.
+func TestSchemaDiffForeignKeyShadowConflict(t *testing.T) {
+	ctx := t.Context()
+	tt := []struct {
+		name           string
+		fromQueries    []string
+		toQueries      []string
+		reject         bool // set ForeignKeyShadowConflictStrategyReject
+		expectConflict bool // expect an impossible-execution dependency and a rejected OrderedDiffs
+	}{
+		{
+			name: "drop fk on child, change referenced column type on parent",
+			fromQueries: []string{
+				"create table parent (id int primary key)",
+				"create table child (id int primary key, parent_id int, key parent_id_idx (parent_id), constraint f foreign key (parent_id) references parent (id))",
+			},
+			toQueries: []string{
+				"create table parent (id varchar(32) primary key)",
+				"create table child (id int primary key, parent_id int, key parent_id_idx (parent_id))",
+			},
+			reject:         true,
+			expectConflict: true,
+		},
+		{
+			name: "drop fk on child, drop referenced column on parent",
+			fromQueries: []string{
+				"create table parent (id int primary key, ref int, key ref_idx (ref))",
+				"create table child (id int primary key, parent_id int, key parent_id_idx (parent_id), constraint f foreign key (parent_id) references parent (ref))",
+			},
+			toQueries: []string{
+				"create table parent (id int primary key)",
+				"create table child (id int primary key, parent_id int, key parent_id_idx (parent_id))",
+			},
+			reject:         true,
+			expectConflict: true,
+		},
+		{
+			name: "drop fk on child, drop referenced index on parent",
+			fromQueries: []string{
+				"create table parent (id int primary key, ref int, key ref_idx (ref))",
+				"create table child (id int primary key, parent_id int, key parent_id_idx (parent_id), constraint f foreign key (parent_id) references parent (ref))",
+			},
+			toQueries: []string{
+				"create table parent (id int primary key, ref int)",
+				"create table child (id int primary key, parent_id int, key parent_id_idx (parent_id))",
+			},
+			reject:         true,
+			expectConflict: true,
+		},
+		{
+			name: "drop child table, drop parent table",
+			fromQueries: []string{
+				"create table parent (id int primary key)",
+				"create table child (id int primary key, parent_id int, key parent_id_idx (parent_id), constraint f foreign key (parent_id) references parent (id))",
+			},
+			toQueries:      []string{},
+			reject:         true,
+			expectConflict: true,
+		},
+		{
+			name: "drop fk on child, change referenced column collation on parent",
+			fromQueries: []string{
+				"create table parent (id varchar(32) charset utf8mb4 collate utf8mb4_bin primary key)",
+				"create table child (id int primary key, parent_id varchar(32) charset utf8mb4 collate utf8mb4_bin, key parent_id_idx (parent_id), constraint f foreign key (parent_id) references parent (id))",
+			},
+			toQueries: []string{
+				"create table parent (id varchar(32) charset utf8mb4 collate utf8mb4_general_ci primary key)",
+				"create table child (id int primary key, parent_id varchar(32) charset utf8mb4 collate utf8mb4_bin, key parent_id_idx (parent_id))",
+			},
+			reject:         true,
+			expectConflict: true,
+		},
+		{
+			name: "lockstep type change on both parent and child, fk preserved",
+			fromQueries: []string{
+				"create table parent (id int primary key)",
+				"create table child (id int primary key, parent_id int, key parent_id_idx (parent_id), constraint f foreign key (parent_id) references parent (id))",
+			},
+			toQueries: []string{
+				"create table parent (id varchar(32) primary key)",
+				"create table child (id int primary key, parent_id varchar(32), key parent_id_idx (parent_id), constraint f foreign key (parent_id) references parent (id))",
+			},
+			reject:         true,
+			expectConflict: true,
+		},
+		{
+			name: "same conflict but strategy not set: not rejected",
+			fromQueries: []string{
+				"create table parent (id int primary key)",
+				"create table child (id int primary key, parent_id int, key parent_id_idx (parent_id), constraint f foreign key (parent_id) references parent (id))",
+			},
+			toQueries: []string{
+				"create table parent (id varchar(32) primary key)",
+				"create table child (id int primary key, parent_id int, key parent_id_idx (parent_id))",
+			},
+			reject:         false,
+			expectConflict: false,
+		},
+		{
+			name: "parent altered compatibly, child untouched: not rejected",
+			fromQueries: []string{
+				"create table parent (id int primary key)",
+				"create table child (id int primary key, parent_id int, key parent_id_idx (parent_id), constraint f foreign key (parent_id) references parent (id))",
+			},
+			toQueries: []string{
+				"create table parent (id int primary key, extra int)",
+				"create table child (id int primary key, parent_id int, key parent_id_idx (parent_id), constraint f foreign key (parent_id) references parent (id))",
+			},
+			reject:         true,
+			expectConflict: false,
+		},
+		{
+			name: "char to varchar lockstep stays fk-compatible: not rejected",
+			fromQueries: []string{
+				"create table parent (id char(32) primary key)",
+				"create table child (id int primary key, parent_id char(32), key parent_id_idx (parent_id), constraint f foreign key (parent_id) references parent (id))",
+			},
+			toQueries: []string{
+				"create table parent (id varchar(32) primary key)",
+				"create table child (id int primary key, parent_id varchar(32), key parent_id_idx (parent_id), constraint f foreign key (parent_id) references parent (id))",
+			},
+			reject:         true,
+			expectConflict: false,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			venv, err := vtenv.New(vtenv.Options{})
+			require.NoError(t, err)
+			env := NewEnv(venv, collations.CollationUtf8mb4ID)
+
+			fromSchema, err := NewSchemaFromQueries(env, tc.fromQueries)
+			require.NoError(t, err)
+			toSchema, err := NewSchemaFromQueries(env, tc.toQueries)
+			require.NoError(t, err)
+
+			hints := &DiffHints{RangeRotationStrategy: RangeRotationDistinctStatements}
+			if tc.reject {
+				hints.ForeignKeyShadowConflictStrategy = ForeignKeyShadowConflictStrategyReject
+			}
+			schemaDiff, err := fromSchema.SchemaDiff(toSchema, hints)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectConflict, schemaDiff.HasImpossibleExecutionDependencies())
+
+			_, err = schemaDiff.OrderedDiffs(ctx)
+			if tc.expectConflict {
+				require.Error(t, err)
+				var conflictErr *ForeignKeyShadowConflictError
+				assert.ErrorAs(t, err, &conflictErr)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/go/vt/schemadiff/schema_diff_test.go
+++ b/go/vt/schemadiff/schema_diff_test.go
@@ -1448,14 +1448,26 @@ func TestSchemaDiffForeignKeyShadowConflict(t *testing.T) {
 			expectConflict: true,
 		},
 		{
-			name: "drop child table, drop parent table",
+			name: "drop child table, change referenced column type on parent",
+			fromQueries: []string{
+				"create table parent (id int primary key)",
+				"create table child (id int primary key, parent_id int, key parent_id_idx (parent_id), constraint f foreign key (parent_id) references parent (id))",
+			},
+			toQueries: []string{
+				"create table parent (id varchar(32) primary key)",
+			},
+			reject:         true,
+			expectConflict: true,
+		},
+		{
+			name: "drop child table, drop parent table: reclaimable by GC, not rejected",
 			fromQueries: []string{
 				"create table parent (id int primary key)",
 				"create table child (id int primary key, parent_id int, key parent_id_idx (parent_id), constraint f foreign key (parent_id) references parent (id))",
 			},
 			toQueries:      []string{},
 			reject:         true,
-			expectConflict: true,
+			expectConflict: false,
 		},
 		{
 			name: "drop fk on child, change referenced column collation on parent",

--- a/go/vt/schemadiff/schema_diff_test.go
+++ b/go/vt/schemadiff/schema_diff_test.go
@@ -1510,6 +1510,17 @@ func TestSchemaDiffForeignKeyShadowConflict(t *testing.T) {
 			expectConflict: false,
 		},
 		{
+			name: "self-referencing fk, referenced column type change: not rejected",
+			fromQueries: []string{
+				"create table t (id int primary key, parent_id int, key parent_id_idx (parent_id), constraint f foreign key (parent_id) references t (id))",
+			},
+			toQueries: []string{
+				"create table t (id bigint primary key, parent_id bigint, key parent_id_idx (parent_id), constraint f foreign key (parent_id) references t (id))",
+			},
+			reject:         true,
+			expectConflict: false,
+		},
+		{
 			name: "char to varchar lockstep stays fk-compatible: not rejected",
 			fromQueries: []string{
 				"create table parent (id char(32) primary key)",
@@ -1548,6 +1559,8 @@ func TestSchemaDiffForeignKeyShadowConflict(t *testing.T) {
 				require.Error(t, err)
 				var conflictErr *ForeignKeyShadowConflictError
 				assert.ErrorAs(t, err, &conflictErr)
+				// The error must name the referenced column; it must never render an empty identifier.
+				assert.NotContains(t, err.Error(), "``")
 			} else {
 				require.NoError(t, err)
 			}

--- a/go/vt/schemadiff/types.go
+++ b/go/vt/schemadiff/types.go
@@ -141,6 +141,11 @@ const (
 	SubsequentDiffStrategyReject
 )
 
+const (
+	ForeignKeyShadowConflictStrategyAllow int = iota
+	ForeignKeyShadowConflictStrategyReject
+)
+
 // DiffHints is an assortment of rules for diffing entities
 type DiffHints struct {
 	StrictIndexOrdering         bool
@@ -156,6 +161,8 @@ type DiffHints struct {
 	EnumReorderStrategy         int
 	ForeignKeyCheckStrategy     int
 	SubsequentDiffStrategy      int
+
+	ForeignKeyShadowConflictStrategy int
 }
 
 func EmptyDiffHints() *DiffHints {

--- a/go/vt/vttablet/tabletserver/gc/tablegc.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"maps"
 	"sort"
 	"strings"
@@ -594,7 +595,7 @@ func (collector *TableGC) purge(ctx context.Context) (tableName string, err erro
 	defer func() {
 		if !conn.IsClosed() {
 			if _, err := conn.ExecuteFetch("SET SESSION foreign_key_checks = 1", 0, false); err != nil {
-				log.Error(fmt.Sprintf("TableGC: error setting foreign_key_checks = 1: %+v", err))
+				log.Error("TableGC: error setting foreign_key_checks = 1", slog.Any("error", err))
 			}
 		}
 	}()
@@ -648,7 +649,7 @@ func (collector *TableGC) dropTable(ctx context.Context, tableName string, isBas
 	defer func() {
 		if !conn.IsClosed() {
 			if _, err := conn.Conn.ExecuteFetch("SET SESSION foreign_key_checks = 1", 0, false); err != nil {
-				log.Error(fmt.Sprintf("TableGC: error setting foreign_key_checks = 1: %+v", err))
+				log.Error("TableGC: error setting foreign_key_checks = 1", slog.Any("error", err))
 			}
 		}
 	}()

--- a/go/vt/vttablet/tabletserver/gc/tablegc.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc.go
@@ -584,6 +584,21 @@ func (collector *TableGC) purge(ctx context.Context) (tableName string, err erro
 		}
 	}()
 
+	// Disable foreign key checks: the rows we purge belong to a doomed table, and another doomed
+	// table (e.g. a child table also being garbage collected) may still reference them. We must not
+	// let an ON DELETE RESTRICT constraint block reclamation. The connection is dedicated and closed
+	// when we're done, but we restore the value defensively, in case this ever becomes pooled.
+	if _, err := conn.ExecuteFetch("SET SESSION foreign_key_checks = 0", 0, false); err != nil {
+		return tableName, err
+	}
+	defer func() {
+		if !conn.IsClosed() {
+			if _, err := conn.ExecuteFetch("SET SESSION foreign_key_checks = 1", 0, false); err != nil {
+				log.Error(fmt.Sprintf("TableGC: error setting foreign_key_checks = 1: %+v", err))
+			}
+		}
+	}()
+
 	log.Info("TableGC: purge begin for " + tableName)
 	for {
 		if ctx.Err() != nil {
@@ -622,6 +637,21 @@ func (collector *TableGC) dropTable(ctx context.Context, tableName string, isBas
 		sqlDrop = sqlDropView
 	}
 	parsed := sqlparser.BuildParsedQuery(sqlDrop, tableName)
+
+	// Disable foreign key checks so we can drop a table that is still referenced by another
+	// (also-doomed) table's foreign key, regardless of the order in which the GC drops them. The
+	// connection is dedicated and closed when we're done, but we restore the value defensively, in
+	// case this ever becomes pooled.
+	if _, err := conn.Conn.ExecuteFetch("SET SESSION foreign_key_checks = 0", 0, false); err != nil {
+		return err
+	}
+	defer func() {
+		if !conn.IsClosed() {
+			if _, err := conn.Conn.ExecuteFetch("SET SESSION foreign_key_checks = 1", 0, false); err != nil {
+				log.Error(fmt.Sprintf("TableGC: error setting foreign_key_checks = 1: %+v", err))
+			}
+		}
+	}()
 
 	log.Info("TableGC: dropping table: " + tableName)
 	_, err = conn.Conn.ExecuteFetch(parsed.Query, 1, false)

--- a/go/vt/vttablet/tabletserver/gc/tablegc_test.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc_test.go
@@ -18,16 +18,52 @@ package gc
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
-	"vitess.io/vitess/go/mysql/capabilities"
-	"vitess.io/vitess/go/sqltypes"
-	"vitess.io/vitess/go/vt/schema"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/capabilities"
+	"vitess.io/vitess/go/mysql/fakesqldb"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/schema"
+	"vitess.io/vitess/go/vt/vtenv"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
+
+// TestDropTableDisablesForeignKeyChecks verifies that dropTable disables foreign key checks before
+// issuing the DROP (and restores them afterwards). This lets the GC drop a table that is still
+// referenced by another (also-doomed) table's foreign key, regardless of the order in which held
+// tables are reclaimed.
+func TestDropTableDisablesForeignKeyChecks(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+	db.SetNeverFail(true)
+
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.DB = dbconfigs.NewTestDBConfigs(*db.ConnParams(), *db.ConnParams(), "fakesqldb")
+	env := tabletenv.NewEnv(vtenv.NewTestEnv(), cfg, "TableGCTest")
+
+	collector := &TableGC{env: env}
+
+	err := collector.dropTable(t.Context(), "_vt_DROP_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_", true)
+	require.NoError(t, err)
+
+	queryLog := strings.ToLower(db.QueryLog())
+	disableIdx := strings.Index(queryLog, "set session foreign_key_checks = 0")
+	dropIdx := strings.Index(queryLog, "drop table if exists")
+	restoreIdx := strings.Index(queryLog, "set session foreign_key_checks = 1")
+
+	require.GreaterOrEqual(t, disableIdx, 0, "foreign_key_checks must be disabled; query log: %s", queryLog)
+	require.GreaterOrEqual(t, dropIdx, 0, "table must be dropped; query log: %s", queryLog)
+	require.GreaterOrEqual(t, restoreIdx, 0, "foreign_key_checks must be restored; query log: %s", queryLog)
+	// foreign_key_checks must be disabled before the drop, and restored after it.
+	assert.Less(t, disableIdx, dropIdx, "foreign_key_checks must be disabled before the drop")
+	assert.Less(t, dropIdx, restoreIdx, "foreign_key_checks must be restored after the drop")
+}
 
 func TestNextTableToPurge(t *testing.T) {
 	tt := []struct {

--- a/go/vt/vttablet/tabletserver/gc/tablegc_test.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc_test.go
@@ -32,7 +32,27 @@ import (
 	"vitess.io/vitess/go/vt/schema"
 	"vitess.io/vitess/go/vt/vtenv"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/throttle"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/throttle/base"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/throttle/throttlerapp"
 )
+
+// newFakeDBTableGC builds a TableGC wired to a fake MySQL, sufficient for exercising purge/dropTable.
+func newFakeDBTableGC(t *testing.T, db *fakesqldb.DB) *TableGC {
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.DB = dbconfigs.NewTestDBConfigs(*db.ConnParams(), *db.ConnParams(), "fakesqldb")
+	env := tabletenv.NewEnv(vtenv.NewTestEnv(), cfg, "TableGCTest")
+
+	collector := &TableGC{
+		env:             env,
+		throttlerClient: throttle.NewBackgroundClient(nil, throttlerapp.TableGCName, base.UndefinedScope),
+		purgingTables:   map[string]bool{},
+	}
+	var err error
+	collector.lifecycleStates, err = schema.ParseGCLifecycle("hold,purge,evac,drop")
+	require.NoError(t, err)
+	return collector
+}
 
 // TestDropTableDisablesForeignKeyChecks verifies that dropTable disables foreign key checks before
 // issuing the DROP (and restores them afterwards). This lets the GC drop a table that is still
@@ -43,11 +63,7 @@ func TestDropTableDisablesForeignKeyChecks(t *testing.T) {
 	defer db.Close()
 	db.SetNeverFail(true)
 
-	cfg := tabletenv.NewDefaultConfig()
-	cfg.DB = dbconfigs.NewTestDBConfigs(*db.ConnParams(), *db.ConnParams(), "fakesqldb")
-	env := tabletenv.NewEnv(vtenv.NewTestEnv(), cfg, "TableGCTest")
-
-	collector := &TableGC{env: env}
+	collector := newFakeDBTableGC(t, db)
 
 	err := collector.dropTable(t.Context(), "_vt_DROP_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_", true)
 	require.NoError(t, err)
@@ -63,6 +79,33 @@ func TestDropTableDisablesForeignKeyChecks(t *testing.T) {
 	// foreign_key_checks must be disabled before the drop, and restored after it.
 	assert.Less(t, disableIdx, dropIdx, "foreign_key_checks must be disabled before the drop")
 	assert.Less(t, dropIdx, restoreIdx, "foreign_key_checks must be restored after the drop")
+}
+
+// TestPurgeDisablesForeignKeyChecks verifies that purge disables foreign key checks before deleting
+// rows. This lets the GC purge a doomed parent table's rows even while a doomed child still
+// references them under ON DELETE RESTRICT, without wedging.
+func TestPurgeDisablesForeignKeyChecks(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+	db.SetNeverFail(true)
+
+	collector := newFakeDBTableGC(t, db)
+	require.True(t, collector.addPurgingTable("_vt_prg_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_"))
+
+	_, err := collector.purge(t.Context())
+	require.NoError(t, err)
+
+	queryLog := strings.ToLower(db.QueryLog())
+	disableIdx := strings.Index(queryLog, "set session foreign_key_checks = 0")
+	deleteIdx := strings.Index(queryLog, "delete from")
+	restoreIdx := strings.Index(queryLog, "set session foreign_key_checks = 1")
+
+	require.GreaterOrEqual(t, disableIdx, 0, "foreign_key_checks must be disabled; query log: %s", queryLog)
+	require.GreaterOrEqual(t, deleteIdx, 0, "rows must be purged; query log: %s", queryLog)
+	require.GreaterOrEqual(t, restoreIdx, 0, "foreign_key_checks must be restored; query log: %s", queryLog)
+	// foreign_key_checks must be disabled before purging rows, and restored afterwards.
+	assert.Less(t, disableIdx, deleteIdx, "foreign_key_checks must be disabled before purging rows")
+	assert.Less(t, deleteIdx, restoreIdx, "foreign_key_checks must be restored after purging")
 }
 
 func TestNextTableToPurge(t *testing.T) {


### PR DESCRIPTION
## What's this?

Two related foreign-key safety fixes for OnlineDDL with `--unsafe-allow-foreign-keys`.

OnlineDDL doesn't alter/drop a table in place — it builds a shadow table (or renames the original to a `_vt_HOLD_…` table for the GC), and the original sticks around as a held table until table GC reclaims it. With the fork's `rename_table_preserve_foreign_key`, that held table **keeps its original foreign key**. That opens two distinct hazards.

### 1. schemadiff: reject shadow-table FK conflicts (data-dictionary corruption)

Consider, in a single `ApplySchema`:

- `child` drops its FK to `parent`, and
- `parent.id` (the referenced column) changes `int` → `varchar(32)`.

The *final* schema is valid (no FK), so schemadiff allows both changes today. But while `child` is migrating, its held original still carries the old FK referencing `parent.id`, and on the fork the `parent.id` type change is allowed to proceed. The held table's FK is now type-incompatible, the data dictionary breaks, and the instance has to be decommissioned. Reordering within the batch doesn't help — the held table lingers — so this is genuinely impossible to do safely in one batch.

schemadiff now detects this family and rejects it with a clear, actionable `ForeignKeyShadowConflictError`. The conflict is any source-schema FK that would survive on a held table while the **surviving parent** is altered into an incompatible state: referenced column type/charset/collation/unsigned/zerofill change, a dropped/renamed referenced column, or a dropped covering index. This fires whether the child is being `ALTER`ed or `DROP`ped, as long as the parent is altered (and survives) incompatibly.

Self-referencing FKs are excluded (the held copy references its own columns at the same version — internally consistent).

### 2. tablegc: disable `foreign_key_checks` when reclaiming GC tables (reclamation hazard)

A separate, weaker hazard: when two FK-related tables are garbage collected together (e.g. a child **and** its parent both dropped in one batch), the GC could wedge. It reclaims held tables one at a time, oldest-first, FK-unaware, with `foreign_key_checks` left ON — so purging the parent fails under `ON DELETE RESTRICT` while the child still has referencing rows, and dropping the still-referenced parent fails outright. Circular FKs could never be reclaimed.

The fix disables `foreign_key_checks` on the GC's dedicated purge and drop connections — the data in these doomed tables no longer matters, so reclamation should succeed regardless of order or FK relationship. (Connections are closed after use; the value is restored defensively in case they ever become pooled.)

Because the GC can now reclaim an FK-linked held pair cleanly, **dropping a child and its parent in a single batch is safe**, so schemadiff no longer rejects that case — only the genuinely-unsafe ALTER cases above remain rejected.

## How it works

- New strictest dependency type `DiffDependencyImpossibleExecution`, with `Has/AllImpossibleExecutionDependencies()` mirroring the existing sequential-dependency API.
- Detection in `SchemaDiff()` records the conflict; `OrderedDiffs()` rejects with `ForeignKeyShadowConflictError`.
- Gated behind a new `DiffHints.ForeignKeyShadowConflictStrategy` (default = today's behavior). The corruption is specific to OnlineDDL's held-table mechanism and is safe under `direct` strategy, so only that consumer opts in. Zero-value preserves existing behavior.
- `tablegc`: `SET SESSION foreign_key_checks = 0` in `purge` and `dropTable`, restored defensively via `defer`.

## Scope / notes

- This spans two subsystems (`go/vt/schemadiff` and `go/vt/vttablet/tabletserver/gc`) because the GC fix is what makes the drop+drop case safe and therefore lets schemadiff stop rejecting it.
- Wiring `ForeignKeyShadowConflictStrategyReject` into the actual ApplySchema / OnlineDDL path (when strategy is online + `--unsafe-allow-foreign-keys`) is a separate consumer change — this PR delivers the detection + rejection capability and surfaces it via the hint and the new dependency type.
- User-visible: a new rejection under the opt-in hint, plus the GC now reclaims FK-linked tables. Worth a release-note callout when the consumer wiring lands.
- Testing: schemadiff changes are covered by `TestSchemaDiffForeignKeyShadowConflict` (positive cases for each conflict shape; negatives for the gating hint, self-reference, char↔varchar lockstep, and drop+drop now being allowed). The `tablegc` `foreign_key_checks` behavior is best validated end-to-end against a real server; the existing GC unit tests pass, but an e2e test exercising FK-linked GC reclamation would be the ideal follow-up.

Related to vitessio/vitess#20353

---

_Most of this was written by Claude Code — I just provided direction and review._
