### PR TITLE
tabletserver: surface stream consolidations on /debug/consolidations

### DIFF
--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -246,8 +246,14 @@ func (vttablet *VttabletProcess) GetConsolidations() (map[string]int, error) {
 		if splits[0] == "Length" {
 			continue
 		}
-		countS := splits[0]
-		countI, err := strconv.Atoi(countS)
+		// Lines are either "<count>: <query>" or "<label> <count>: <query>"
+		// (the label tags streaming vs non-streaming), so the count is the last
+		// whitespace-separated token before the colon.
+		fields := strings.Fields(splits[0])
+		if len(fields) == 0 {
+			return nil, fmt.Errorf("failed to parse consolidations line: %q", line)
+		}
+		countI, err := strconv.Atoi(fields[len(fields)-1])
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse consolidations count: %v", err)
 		}

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -716,21 +716,33 @@ func (qe *QueryEngine) handleHTTPConsolidations(response http.ResponseWriter, re
 		acl.SendError(response, err)
 		return
 	}
-	items := qe.consolidator.Items()
 	response.Header().Set("Content-Type", "text/plain")
-	if items == nil {
+
+	nonStreaming := qe.consolidator.Items()
+	var streaming []sync2.ConsolidatorCacheItem
+	if qe.streamConsolidator != nil {
+		streaming = qe.streamConsolidator.Items()
+	}
+	if nonStreaming == nil && streaming == nil {
 		response.Write([]byte("empty\n"))
 		return
 	}
-	fmt.Fprintf(response, "Length: %d\n", len(items))
+	fmt.Fprintf(response, "Length: %d\n", len(nonStreaming)+len(streaming))
+	qe.writeConsolidations(response, "non-streaming", nonStreaming)
+	qe.writeConsolidations(response, "streaming", streaming)
+}
+
+// writeConsolidations renders one consolidator's items, tagging each line with the
+// execution path (streaming or non-streaming) so identical queries from different
+// paths are distinguishable. The count stays the first colon-delimited token's
+// trailing number so the line remains machine-parseable.
+func (qe *QueryEngine) writeConsolidations(response http.ResponseWriter, label string, items []sync2.ConsolidatorCacheItem) {
 	for _, v := range items {
-		var query string
+		query := v.Query
 		if qe.redactUIQuery {
 			query, _ = qe.env.Environment().Parser().RedactSQLQuery(v.Query)
-		} else {
-			query = v.Query
 		}
-		fmt.Fprintf(response, "%v: %s\n", v.Count, query)
+		fmt.Fprintf(response, "%s %v: %s\n", label, v.Count, query)
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -413,6 +413,33 @@ func TestConsolidationsUIRedaction(t *testing.T) {
 	require.Containsf(t, redactedResponse.Body.String(), redactedSQL, "Response missing redacted consolidated query: %v %v", redactedSQL, redactedResponse.Body.String())
 }
 
+func TestConsolidationsUITagsStreamingAndNonStreaming(t *testing.T) {
+	request, _ := http.NewRequest("GET", "/debug/consolidations", nil)
+
+	const sql = "select * from test_db_01 where id = 1"
+
+	db := fakesqldb.New(t)
+	defer db.Close()
+	qe := newTestQueryEngine(1*time.Second, true, newDBConfigs(db))
+	qe.se.Open()
+	qe.Open()
+	defer qe.Close()
+
+	require.NotNil(t, qe.streamConsolidator, "stream consolidator should be enabled by the default config")
+
+	// Record the same query on both paths so we can confirm they're labelled
+	// separately rather than collapsed onto one ambiguous line.
+	qe.consolidator.Record(sql)
+	qe.streamConsolidator.consolidations.Record(sql)
+
+	response := httptest.NewRecorder()
+	qe.handleHTTPConsolidations(response, request)
+	body := response.Body.String()
+
+	require.Containsf(t, body, "non-streaming 1: "+sql, "missing non-streaming entry: %v", body)
+	require.Containsf(t, body, "streaming 1: "+sql, "missing streaming entry: %v", body)
+}
+
 func BenchmarkPlanCacheThroughput(b *testing.B) {
 	db := fakesqldb.New(b)
 	defer db.Close()

--- a/go/vt/vttablet/tabletserver/stream_consolidator.go
+++ b/go/vt/vttablet/tabletserver/stream_consolidator.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/sync2"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -33,6 +34,8 @@ const streamBufferSize = 8
 // StreamConsolidator is a data structure capable of merging several identical streaming queries so only
 // one query is executed in MySQL and its response is fanned out to all the clients simultaneously.
 type StreamConsolidator struct {
+	consolidations *sync2.ConsolidatorCache
+
 	mu                             sync.Mutex
 	inflight                       map[string]*streamInFlight
 	memory                         int64
@@ -46,12 +49,19 @@ type StreamConsolidator struct {
 // only use up to maxMemoryQuery bytes of memory as a history buffer to catch up.
 func NewStreamConsolidator(maxMemoryTotal, maxMemoryQuery int64, cleanup StreamCallback) *StreamConsolidator {
 	return &StreamConsolidator{
+		consolidations: sync2.NewConsolidatorCache(1000),
 		inflight:       make(map[string]*streamInFlight),
 		maxMemoryTotal: maxMemoryTotal,
 		maxMemoryQuery: maxMemoryQuery,
 		blocking:       false,
 		cleanup:        cleanup,
 	}
+}
+
+// Items returns the per-query consolidation counts recorded by this consolidator,
+// for display on the /debug/consolidations page.
+func (sc *StreamConsolidator) Items() []sync2.ConsolidatorCacheItem {
+	return sc.consolidations.Items()
 }
 
 // StreamCallback is a function that is called with every Result object from a streaming query
@@ -102,6 +112,10 @@ func (sc *StreamConsolidator) Consolidate(waitTimings *servenv.TimingsWrapper, l
 
 	// if we have a followChan, we're following up on a query that is already being served
 	if followChan != nil {
+		// We consolidated onto an in-flight leader; record it for /debug/consolidations.
+		// This mirrors the buffered consolidator, which records each follower (not the
+		// leader) in Wait(). Runs after sc.mu is released; the cache has its own lock.
+		sc.consolidations.Record(sql)
 		startTime := time.Now()
 		defer func() {
 			memchange := inflight.unfollow(followChan, sc.cleanup)

--- a/go/vt/vttablet/tabletserver/stream_consolidator_test.go
+++ b/go/vt/vttablet/tabletserver/stream_consolidator_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletserver
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/streamlog"
+	"vitess.io/vitess/go/sync2"
+	"vitess.io/vitess/go/vt/servenv"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/tabletenv"
+)
+
+func consolidationCount(items []sync2.ConsolidatorCacheItem, query string) int64 {
+	for _, item := range items {
+		if item.Query == query {
+			return item.Count
+		}
+	}
+	return 0
+}
+
+// TestStreamConsolidatorRecordsFollowers verifies that a streaming query which
+// consolidates onto an in-flight leader is recorded for /debug/consolidations,
+// while the leader itself is not. The test is deterministic: the leader registers
+// itself in the inflight map before its leaderCallback runs, so gating the leader
+// open until the follower has recorded guarantees the follower attaches rather
+// than becoming a new leader.
+func TestStreamConsolidatorRecordsFollowers(t *testing.T) {
+	sc := NewStreamConsolidator(128*1024, 2*1024, nocleanup)
+
+	const sql = "select 1"
+
+	newTimings := func() *servenv.TimingsWrapper {
+		return servenv.NewExporter("ConsolidatorTest", "").NewTimings("ConsolidatorWaits", "", "StreamConsolidations")
+	}
+	newLogStats := func() *tabletenv.LogStats {
+		return tabletenv.NewLogStats(context.Background(), "StreamConsolidation", streamlog.NewQueryLogConfigForTest())
+	}
+
+	leaderInflight := make(chan struct{}) // closed once the leader is registered + streaming
+	releaseLeader := make(chan struct{})  // unblocks the leader so it can finish
+
+	var (
+		leaderErr, followerErr error
+		followerRanLeader      atomic.Bool
+		wg                     sync.WaitGroup
+	)
+	wg.Go(func() {
+		leaderErr = sc.Consolidate(newTimings(), newLogStats(), sql,
+			func(*sqltypes.Result) error { return nil },
+			func(stream StreamCallback) error {
+				close(leaderInflight)
+				<-releaseLeader
+				return stream(&sqltypes.Result{})
+			})
+	})
+
+	<-leaderInflight
+
+	wg.Go(func() {
+		followerErr = sc.Consolidate(newTimings(), newLogStats(), sql,
+			func(*sqltypes.Result) error { return nil },
+			func(StreamCallback) error {
+				// A follower must never run the leader callback.
+				followerRanLeader.Store(true)
+				return nil
+			})
+	})
+
+	// The follower records as soon as it attaches to the leader; once that's
+	// visible, it's safe to let the leader finish.
+	require.Eventually(t, func() bool {
+		return consolidationCount(sc.Items(), sql) == 1
+	}, 5*time.Second, time.Millisecond, "follower consolidation was not recorded")
+
+	close(releaseLeader)
+	wg.Wait()
+
+	require.NoError(t, leaderErr)
+	require.NoError(t, followerErr)
+	require.False(t, followerRanLeader.Load(), "follower wrongly executed the leader callback")
+	// Exactly one follower consolidated; the leader is not counted.
+	require.Equal(t, int64(1), consolidationCount(sc.Items(), sql))
+}


### PR DESCRIPTION
## Description

The `StreamConsolidator` (used for streaming/OLAP query consolidation) never recorded any stats, so streaming consolidations were invisible on `/debug/consolidations` — only the buffered `Consolidator` showed up there.

This records each consolidated follower in the `StreamConsolidator` and renders both consolidators on the page, tagging every line `streaming` or `non-streaming` so a query consolidated on both paths is distinguishable instead of appearing as two indistinguishable lines:

```
Length: 2
non-streaming 12: select ... where id = 5
streaming 4: select ... where id = 5
```

A few notes:

- The label is the execution path (which consolidator recorded it), **not** the session workload — OLAP/OLTP doesn't come into it (with streaming-mode work, OLTP traffic can also go through the stream consolidator).
- Counts are per-tablet and best-effort, exactly like the existing buffered consolidator: bounded LRU (so "since last eviction", not lifetime), atomic once cached, counting followers (not the leader), and never aggregated across tablets.
- The count stays the first colon-delimited token's trailing number, so the line is still machine-parseable; the e2e `GetConsolidations()` helper is updated to tolerate the optional label prefix.

## Related Issue(s)

No tracking issue — small, self-contained observability improvement. Adapted from the larger streaming work in #20213.

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [ ] Documentation was added or is not required

## Deployment Notes

The `/debug/consolidations` page now also lists streaming consolidations and prepends a `streaming`/`non-streaming` tag to each line. The count remains the first numeric token on the line, so consumers that read `<count>: <query>` keep working as long as they take the count as the trailing number before the colon (the in-repo e2e helper is updated for this).

### AI Disclosure

This PR was written primarily by Claude Code; I provided direction and review.
