### PR TITLE
vreplication: surface root-cause errors in `_vt.vreplication_log`

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -422,8 +422,8 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 	var pkfields []*querypb.Field
 
 	// Errors observed inside the VStreamRows callback. The callback returns
-	// io.EOF on the first Fail/Cancel; the post-VStreamRows drain reports
-	// them alongside any concurrent insert workers that race in afterwards.
+	// io.EOF on the first Fail; the post-VStreamRows drain reports them
+	// alongside any concurrent insert workers that race in afterwards.
 	var preTerrs []error
 
 	// Use this for task sequencing.
@@ -592,17 +592,16 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 				return io.EOF
 			}
 			switch result.state {
-			case vcopierCopyTaskCancel, vcopierCopyTaskFail:
+			case vcopierCopyTaskCancel:
+				log.Warn(fmt.Sprintf("task was canceled in workflow %s: %v", vc.vr.WorkflowName, result.err))
+				return io.EOF
+			case vcopierCopyTaskFail:
 				// Defer the report to the post-VStreamRows drain so
 				// concurrent insert workers that race in after this read
-				// are included. Log Cancel here as the forensic crumb that
-				// survives filterCtxCancelErrs dropping the err; the Fail
-				// aggregate is logged by the post-VStreamRows drain.
+				// are included. The Fail aggregate is logged by the
+				// post-VStreamRows drain.
 				if result.err != nil {
 					preTerrs = append(preTerrs, result.err)
-				}
-				if result.state == vcopierCopyTaskCancel {
-					log.Warn(fmt.Sprintf("task was canceled in workflow %s: %v", vc.vr.WorkflowName, result.err))
 				}
 				return io.EOF
 			case vcopierCopyTaskComplete:
@@ -621,32 +620,30 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 
 	// Drain late-arriving task results (async tasks that finished after
 	// VStreamRows exited). Seed with preTerrs from the VStreamRows
-	// callback. Cancel errors are included here (previously dropped);
-	// formatTaskError partitions sentinel dependent-batch failures out.
+	// callback. formatTaskError partitions sentinel dependent-batch
+	// failures out from real root-cause errors.
 	var empty bool
 	terrs := preTerrs
 	for !empty {
 		select {
 		case result := <-resultCh:
 			switch result.state {
-			case vcopierCopyTaskCancel, vcopierCopyTaskFail:
-				if result.err != nil {
-					terrs = append(terrs, result.err)
-				}
+			case vcopierCopyTaskCancel:
+				// A task cancellation probably indicates an expired
+				// context due to a PlannedReparentShard or elapsed copy
+				// phase duration, neither of which are error conditions.
 			case vcopierCopyTaskComplete:
 				// Get the latest lastpk, purely for logging purposes.
 				lastpk = result.args.lastpk
+			case vcopierCopyTaskFail:
+				// Aggregate non-nil errors.
+				if result.err != nil {
+					terrs = append(terrs, result.err)
+				}
 			}
 		default:
 			empty = true
 		}
-	}
-	// If the copy context was canceled (PRS / CopyPhaseDuration), strip
-	// cancellation-derived errors so the `<-ctx.Done()` clean-stop path
-	// below can fire. Real Fail-state errors that raced the cancellation
-	// (non-cancel codes) are preserved.
-	if ctx.Err() != nil {
-		terrs = filterCtxCancelErrs(terrs)
 	}
 	if terr := formatTaskError(terrs); terr != nil {
 		log.Warn(fmt.Sprintf("task error in workflow %s: %v", vc.vr.WorkflowName, terr))
@@ -913,39 +910,6 @@ func partitionTaskErrors(errs []error) (root, dependent []error) {
 		}
 	}
 	return root, dependent
-}
-
-// filterCtxCancelErrs drops cancellation-derived errors so a normal PRS or
-// CopyPhaseDuration interruption is not reported as a workflow error.
-// Callers invoke this when ctx.Err() != nil. Real Fail-state errors that
-// race the cancellation carry a non-cancel code and are preserved.
-//
-// Three dropped categories, each caught by a different check because vterrors
-// wrapping does not implement stdlib Unwrap and stdlib %w wrapping does not
-// implement Vitess Cause():
-//
-//   - *dependentBatchFailure (any code).
-//   - stdlib %w-wrapped context.Canceled / DeadlineExceeded (errors.Is).
-//   - vterrors-coded or Cause()-chained context errors (vterrors.Code).
-func filterCtxCancelErrs(errs []error) []error {
-	out := make([]error, 0, len(errs))
-	for _, e := range errs {
-		if e == nil {
-			continue
-		}
-		var dbf *dependentBatchFailure
-		if errors.As(e, &dbf) {
-			continue
-		}
-		if errors.Is(e, context.Canceled) || errors.Is(e, context.DeadlineExceeded) {
-			continue
-		}
-		if code := vterrors.Code(e); code == vtrpcpb.Code_CANCELED || code == vtrpcpb.Code_DEADLINE_EXCEEDED {
-			continue
-		}
-		out = append(out, e)
-	}
-	return out
 }
 
 // formatTaskError combines a batch of copy-task errors into the single error

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -422,8 +422,8 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 	var pkfields []*querypb.Field
 
 	// Errors observed inside the VStreamRows callback. The callback returns
-	// io.EOF on the first Fail/Cancel; the post-loop drain reports them
-	// alongside any concurrent insert workers that race in afterwards.
+	// io.EOF on the first Fail/Cancel; the post-VStreamRows drain reports
+	// them alongside any concurrent insert workers that race in afterwards.
 	var preTerrs []error
 
 	// Use this for task sequencing.
@@ -593,11 +593,11 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 			}
 			switch result.state {
 			case vcopierCopyTaskCancel, vcopierCopyTaskFail:
-				// Defer the report to the post-loop drain so concurrent
-				// insert workers that race in after this read are included.
-				// Log Cancel here as the forensic crumb that survives
-				// filterCtxCancelErrs dropping the err; the Fail aggregate
-				// is logged by the post-loop drain.
+				// Defer the report to the post-VStreamRows drain so
+				// concurrent insert workers that race in after this read
+				// are included. Log Cancel here as the forensic crumb that
+				// survives filterCtxCancelErrs dropping the err; the Fail
+				// aggregate is logged by the post-VStreamRows drain.
 				if result.err != nil {
 					preTerrs = append(preTerrs, result.err)
 				}
@@ -620,9 +620,9 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 	copyWorkQueue.close()
 
 	// Drain late-arriving task results (async tasks that finished after
-	// VStreamRows exited). Seed with preTerrs from the inner-loop. Cancel
-	// errors are included here (previously dropped); formatTaskError
-	// partitions sentinel dependent-batch failures out.
+	// VStreamRows exited). Seed with preTerrs from the VStreamRows
+	// callback. Cancel errors are included here (previously dropped);
+	// formatTaskError partitions sentinel dependent-batch failures out.
 	var empty bool
 	terrs := preTerrs
 	for !empty {

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -423,7 +423,7 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 
 	// Errors observed inside the VStreamRows callback. The callback returns
 	// io.EOF on the first Fail/Cancel; the post-loop drain reports them
-	// alongside any siblings that race in afterwards.
+	// alongside any concurrent insert workers that race in afterwards.
 	var preTerrs []error
 
 	// Use this for task sequencing.
@@ -593,11 +593,11 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 			}
 			switch result.state {
 			case vcopierCopyTaskCancel, vcopierCopyTaskFail:
-				// Defer the report to the post-loop drain so siblings that
-				// race in after this read are included. Log Cancel here as
-				// the forensic crumb that survives filterCtxCancelErrs
-				// dropping the err; the Fail aggregate is logged by the
-				// post-loop drain.
+				// Defer the report to the post-loop drain so concurrent
+				// insert workers that race in after this read are included.
+				// Log Cancel here as the forensic crumb that survives
+				// filterCtxCancelErrs dropping the err; the Fail aggregate
+				// is logged by the post-loop drain.
 				if result.err != nil {
 					preTerrs = append(preTerrs, result.err)
 				}
@@ -877,9 +877,9 @@ func (vtl *vcopierCopyTaskLifecycle) onResult() *vcopierCopyTaskResultHooks {
 }
 
 // dependentBatchFailure tags errors produced by awaitCompletion. They convey
-// only that a sibling batch did not reach Complete — never the root cause.
-// formatTaskError partitions these out so the real error becomes the message
-// and dependent-batch failures become a count (issue #20316).
+// only that a concurrent insert worker's batch did not reach Complete — never
+// the root cause. formatTaskError partitions these out so the real error
+// becomes the message and dependent-batch failures become a count (#20316).
 type dependentBatchFailure struct {
 	msg  string
 	code vtrpcpb.Code
@@ -898,8 +898,8 @@ func (e *dependentBatchFailure) ErrorCode() vtrpcpb.Code {
 }
 
 // partitionTaskErrors splits errors collected from a batch of copy tasks into
-// real root-cause errors and dependent-batch failures (sibling tasks that
-// merely stalled waiting on a failed batch).
+// real root-cause errors and dependent-batch failures (concurrent insert
+// worker tasks that merely stalled waiting on a failed batch).
 func partitionTaskErrors(errs []error) (root, dependent []error) {
 	for _, e := range errs {
 		if e == nil {
@@ -962,7 +962,7 @@ func formatTaskError(errs []error) error {
 		return vterrors.Wrapf(vterrors.Aggregate(root), "task error")
 	case len(dependent) > 0:
 		return vterrors.Errorf(vterrors.Code(dependent[0]),
-			"task error: %d batches failed waiting on a sibling batch to complete; "+
+			"task error: %d batches failed waiting on a concurrent insert worker's batch to complete; "+
 				"original failure not captured this retry (see earlier rows for the root cause)",
 			len(dependent))
 	default:

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -421,6 +421,11 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 	var lastpk *querypb.Row
 	var pkfields []*querypb.Field
 
+	// Errors observed inside the VStreamRows callback. The callback returns
+	// io.EOF on the first Fail/Cancel; the post-loop drain reports them
+	// alongside any siblings that race in afterwards.
+	var preTerrs []error
+
 	// Use this for task sequencing.
 	var prevCh <-chan *vcopierCopyTaskResult
 
@@ -501,7 +506,8 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 			buf.Myprintf(
 				"insert into _vt.copy_state (lastpk, vrepl_id, table_name) values (%a, %s, %s)", ":lastpk",
 				strconv.Itoa(int(vc.vr.id)),
-				encodeString(tableName))
+				encodeString(tableName),
+			)
 			addLatestCopyState := buf.ParsedQuery()
 			copyWorkQueue.open(addLatestCopyState, pkfields, tablePlan)
 		}
@@ -582,19 +588,26 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 		// * We keep lastpk up-to-date.
 		select {
 		case result := <-resultCh:
-			if result != nil {
-				switch result.state {
-				case vcopierCopyTaskCancel:
-					log.Warn(fmt.Sprintf("task was canceled in workflow %s: %v", vc.vr.WorkflowName, result.err))
-					return io.EOF
-				case vcopierCopyTaskComplete:
-					// Collect lastpk. Needed for logging at the end.
-					lastpk = result.args.lastpk
-				case vcopierCopyTaskFail:
-					return vterrors.Wrapf(result.err, "task error")
-				}
-			} else {
+			if result == nil {
 				return io.EOF
+			}
+			switch result.state {
+			case vcopierCopyTaskCancel, vcopierCopyTaskFail:
+				// Defer the report to the post-loop drain so siblings that
+				// race in after this read are included. Log Cancel here as
+				// the forensic crumb that survives filterCtxCancelErrs
+				// dropping the err; the Fail aggregate is logged by the
+				// post-loop drain.
+				if result.err != nil {
+					preTerrs = append(preTerrs, result.err)
+				}
+				if result.state == vcopierCopyTaskCancel {
+					log.Warn(fmt.Sprintf("task was canceled in workflow %s: %v", vc.vr.WorkflowName, result.err))
+				}
+				return io.EOF
+			case vcopierCopyTaskComplete:
+				// Collect lastpk. Needed for logging at the end.
+				lastpk = result.args.lastpk
 			}
 		default:
 		}
@@ -606,34 +619,38 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 	// and will wait until all workers are returned to the worker pool.
 	copyWorkQueue.close()
 
-	// When tasks are executed async, there may be tasks that complete (or fail)
-	// after the last VStreamRows callback exits. Get the lastpk from completed
-	// tasks, or errors from failed ones.
+	// Drain late-arriving task results (async tasks that finished after
+	// VStreamRows exited). Seed with preTerrs from the inner-loop. Cancel
+	// errors are included here (previously dropped); formatTaskError
+	// partitions sentinel dependent-batch failures out.
 	var empty bool
-	var terrs []error
+	terrs := preTerrs
 	for !empty {
 		select {
 		case result := <-resultCh:
 			switch result.state {
-			case vcopierCopyTaskCancel:
-				// A task cancellation probably indicates an expired context due
-				// to a PlannedReparentShard or elapsed copy phase duration,
-				// neither of which are error conditions.
+			case vcopierCopyTaskCancel, vcopierCopyTaskFail:
+				if result.err != nil {
+					terrs = append(terrs, result.err)
+				}
 			case vcopierCopyTaskComplete:
 				// Get the latest lastpk, purely for logging purposes.
 				lastpk = result.args.lastpk
-			case vcopierCopyTaskFail:
-				// Aggregate non-nil errors.
-				terrs = append(terrs, result.err)
 			}
 		default:
 			empty = true
 		}
 	}
-	if len(terrs) > 0 {
-		terr := vterrors.Aggregate(terrs)
+	// If the copy context was canceled (PRS / CopyPhaseDuration), strip
+	// cancellation-derived errors so the `<-ctx.Done()` clean-stop path
+	// below can fire. Real Fail-state errors that raced the cancellation
+	// (non-cancel codes) are preserved.
+	if ctx.Err() != nil {
+		terrs = filterCtxCancelErrs(terrs)
+	}
+	if terr := formatTaskError(terrs); terr != nil {
 		log.Warn(fmt.Sprintf("task error in workflow %s: %v", vc.vr.WorkflowName, terr))
-		return vterrors.Wrapf(terr, "task error")
+		return terr
 	}
 
 	// Get the last committed pk into a loggable form.
@@ -859,6 +876,100 @@ func (vtl *vcopierCopyTaskLifecycle) onResult() *vcopierCopyTaskResultHooks {
 	return vtl.resultHooks
 }
 
+// dependentBatchFailure tags errors produced by awaitCompletion. They convey
+// only that a sibling batch did not reach Complete — never the root cause.
+// formatTaskError partitions these out so the real error becomes the message
+// and dependent-batch failures become a count (issue #20316).
+type dependentBatchFailure struct {
+	msg  string
+	code vtrpcpb.Code
+}
+
+func (e *dependentBatchFailure) Error() string { return e.msg }
+
+// ErrorCode satisfies vterrors.ErrorWithCode. The ctx.Done() awaitCompletion
+// site sets Code_CANCELED so tryAdvance maps it to vcopierCopyTaskCancel;
+// other sites leave code unset and report Code_UNKNOWN.
+func (e *dependentBatchFailure) ErrorCode() vtrpcpb.Code {
+	if e.code == vtrpcpb.Code_OK {
+		return vtrpcpb.Code_UNKNOWN
+	}
+	return e.code
+}
+
+// partitionTaskErrors splits errors collected from a batch of copy tasks into
+// real root-cause errors and dependent-batch failures (sibling tasks that
+// merely stalled waiting on a failed batch).
+func partitionTaskErrors(errs []error) (root, dependent []error) {
+	for _, e := range errs {
+		if e == nil {
+			continue
+		}
+		var dbf *dependentBatchFailure
+		if errors.As(e, &dbf) {
+			dependent = append(dependent, e)
+		} else {
+			root = append(root, e)
+		}
+	}
+	return root, dependent
+}
+
+// filterCtxCancelErrs drops cancellation-derived errors so a normal PRS or
+// CopyPhaseDuration interruption is not reported as a workflow error.
+// Callers invoke this when ctx.Err() != nil. Real Fail-state errors that
+// race the cancellation carry a non-cancel code and are preserved.
+//
+// Three dropped categories, each caught by a different check because vterrors
+// wrapping does not implement stdlib Unwrap and stdlib %w wrapping does not
+// implement Vitess Cause():
+//
+//   - *dependentBatchFailure (any code).
+//   - stdlib %w-wrapped context.Canceled / DeadlineExceeded (errors.Is).
+//   - vterrors-coded or Cause()-chained context errors (vterrors.Code).
+func filterCtxCancelErrs(errs []error) []error {
+	out := make([]error, 0, len(errs))
+	for _, e := range errs {
+		if e == nil {
+			continue
+		}
+		var dbf *dependentBatchFailure
+		if errors.As(e, &dbf) {
+			continue
+		}
+		if errors.Is(e, context.Canceled) || errors.Is(e, context.DeadlineExceeded) {
+			continue
+		}
+		if code := vterrors.Code(e); code == vtrpcpb.Code_CANCELED || code == vtrpcpb.Code_DEADLINE_EXCEEDED {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// formatTaskError combines a batch of copy-task errors into the single error
+// that gets surfaced to the operator (via vreplication_log). Real errors
+// dominate the message; dependent-batch failures collapse to a count.
+// Returns nil if there were no errors to report.
+func formatTaskError(errs []error) error {
+	root, dependent := partitionTaskErrors(errs)
+	switch {
+	case len(root) > 0 && len(dependent) > 0:
+		return vterrors.Wrapf(vterrors.Aggregate(root),
+			"task error (+%d batches failed waiting on this to complete)", len(dependent))
+	case len(root) > 0:
+		return vterrors.Wrapf(vterrors.Aggregate(root), "task error")
+	case len(dependent) > 0:
+		return vterrors.Errorf(vterrors.Code(dependent[0]),
+			"task error: %d batches failed waiting on a sibling batch to complete; "+
+				"original failure not captured this retry (see earlier rows for the root cause)",
+			len(dependent))
+	default:
+		return nil
+	}
+}
+
 // tryAdvance is a convenient way of wrapping up lifecycle hooks with task
 // execution steps. E.g.:
 //
@@ -973,13 +1084,13 @@ func (vth *vcopierCopyTaskHooks) awaitCompletion(resultCh <-chan *vcopierCopyTas
 		select {
 		case result := <-resultCh:
 			if result == nil {
-				return errors.New("channel was closed before a result received")
+				return &dependentBatchFailure{msg: "channel was closed before a result received"}
 			}
 			if !vcopierCopyTaskStateIsDone(result.state) {
-				return errors.New("received result is not done")
+				return &dependentBatchFailure{msg: "received result is not done"}
 			}
 			if result.state != vcopierCopyTaskComplete {
-				return errors.New("received result is not complete")
+				return &dependentBatchFailure{msg: "received result is not complete"}
 			}
 			return nil
 		case <-ctx.Done():
@@ -990,7 +1101,7 @@ func (vth *vcopierCopyTaskHooks) awaitCompletion(resultCh <-chan *vcopierCopyTas
 			// Task execution will detect the presence of the error, mark this
 			// task canceled, and abort. Subsequent tasks won't execute because
 			// this task didn't complete.
-			return vterrors.Errorf(vtrpcpb.Code_CANCELED, "context has expired")
+			return &dependentBatchFailure{msg: "context has expired", code: vtrpcpb.Code_CANCELED}
 		}
 	})
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
@@ -102,6 +102,11 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 	var prevCh <-chan *vcopierCopyTaskResult
 	var gtid string
 
+	// Errors observed inside the VStreamTables callback. The callback
+	// returns io.EOF on the first Fail/Cancel; drainAndAggregateErrors
+	// reports them alongside any siblings that race in afterwards.
+	var preTerrs []error
+
 	vstreamOptions := &binlogdatapb.VStreamOptions{
 		ConfigOverrides: vc.vr.workflowConfig.Overrides,
 	}
@@ -174,7 +179,8 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 			buf.Myprintf(
 				"insert into _vt.copy_state (lastpk, vrepl_id, table_name) values (%a, %s, %s)", ":lastpk",
 				strconv.Itoa(int(vc.vr.id)),
-				encodeString(tableName))
+				encodeString(tableName),
+			)
 			addLatestCopyState := buf.ParsedQuery()
 			copyWorkQueue.open(addLatestCopyState, pkfields, tablePlan)
 		}
@@ -262,19 +268,25 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 		// * We keep lastpk up-to-date.
 		select {
 		case result := <-resultCh:
-			if result != nil {
-				switch result.state {
-				case vcopierCopyTaskCancel:
-					log.Warn(fmt.Sprintf("task was canceled in workflow %s: %v", vc.vr.WorkflowName, result.err))
-					return io.EOF
-				case vcopierCopyTaskComplete:
-					// Collect lastpk. Needed for logging at the end.
-					lastpk = result.args.lastpk
-				case vcopierCopyTaskFail:
-					return result.err
-				}
-			} else {
+			if result == nil {
 				return io.EOF
+			}
+			switch result.state {
+			case vcopierCopyTaskCancel, vcopierCopyTaskFail:
+				// Defer the report to drainAndAggregateErrors so siblings
+				// that race in after this read are included. Log Cancel
+				// here as the forensic crumb that survives
+				// filterCtxCancelErrs dropping the err.
+				if result.err != nil {
+					preTerrs = append(preTerrs, result.err)
+				}
+				if result.state == vcopierCopyTaskCancel {
+					log.Warn(fmt.Sprintf("task was canceled in workflow %s: %v", vc.vr.WorkflowName, result.err))
+				}
+				return io.EOF
+			case vcopierCopyTaskComplete:
+				// Collect lastpk. Needed for logging at the end.
+				lastpk = result.args.lastpk
 			}
 		default:
 		}
@@ -285,10 +297,10 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 		copyWorkQueue.close()
 	}
 
-	// When tasks are executed async, there may be tasks that complete (or fail)
-	// after the last VStreamTables callback exits. Drain any remaining results
-	// and aggregate errors.
-	if terr := drainAndAggregateErrors(resultCh, serr); terr != nil {
+	// Drain late-arriving task results and aggregate. ctx is passed so a
+	// normal PRS / CopyPhaseDuration cancellation can be stripped, letting
+	// the descriptive ctx-expiration handler below fire.
+	if terr := drainAndAggregateErrors(ctx, resultCh, serr, preTerrs); terr != nil {
 		log.Warn(fmt.Sprintf("task errors in workflow %s: %v", vc.vr.WorkflowName, terr))
 		return terr
 	}
@@ -331,15 +343,22 @@ func (vc *vcopier) runPostCopyActionsAndDeleteCopyState(ctx context.Context, tab
 	return nil
 }
 
-// drainAndAggregateErrors drains any remaining results from the result channel,
-// collects errors from failed tasks, and combines them with an optional vstream
-// error into a single aggregated error.
-func drainAndAggregateErrors(resultCh <-chan *vcopierCopyTaskResult, vstreamErr error) error {
-	var terrs []error
+// drainAndAggregateErrors combines preTerrs (errors stashed by the caller's
+// inner-loop), any late-arriving Fail/Cancel results on resultCh, and an
+// optional vstream error into a single aggregated workflow error.
+// formatTaskError surfaces the root cause and collapses dependent-batch
+// failures to a count (issue #20316). When ctx is canceled (PRS /
+// CopyPhaseDuration), cancellation-derived errors are stripped so the
+// caller's existing ctx-expiration handling can fire.
+func drainAndAggregateErrors(ctx context.Context, resultCh <-chan *vcopierCopyTaskResult, vstreamErr error, preTerrs []error) error {
+	terrs := preTerrs
 	for {
 		select {
 		case result := <-resultCh:
-			if result != nil && result.state == vcopierCopyTaskFail {
+			if result == nil {
+				continue
+			}
+			if (result.state == vcopierCopyTaskFail || result.state == vcopierCopyTaskCancel) && result.err != nil {
 				terrs = append(terrs, result.err)
 			}
 		default:
@@ -347,11 +366,14 @@ func drainAndAggregateErrors(resultCh <-chan *vcopierCopyTaskResult, vstreamErr 
 		}
 	}
 done:
-	if vstreamErr != nil {
+	// Skip vstreamErr if it is the synthetic io.EOF the callback returned
+	// after observing a task Fail/Cancel — it would just noise the real
+	// root cause.
+	if vstreamErr != nil && !(errors.Is(vstreamErr, io.EOF) && len(terrs) > 0) {
 		terrs = append(terrs, vstreamErr)
 	}
-	if len(terrs) > 0 {
-		return vterrors.Wrapf(vterrors.Aggregate(terrs), "task error")
+	if ctx.Err() != nil {
+		terrs = filterCtxCancelErrs(terrs)
 	}
-	return nil
+	return formatTaskError(terrs)
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
@@ -103,7 +103,7 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 	var gtid string
 
 	// Errors observed inside the VStreamTables callback. The callback returns
-	// io.EOF on the first Fail/Cancel; drainAndAggregateErrors reports them
+	// io.EOF on the first Fail; drainAndAggregateErrors reports them
 	// alongside any concurrent insert workers that race in afterwards.
 	var preTerrs []error
 
@@ -272,16 +272,14 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 				return io.EOF
 			}
 			switch result.state {
-			case vcopierCopyTaskCancel, vcopierCopyTaskFail:
+			case vcopierCopyTaskCancel:
+				log.Warn(fmt.Sprintf("task was canceled in workflow %s: %v", vc.vr.WorkflowName, result.err))
+				return io.EOF
+			case vcopierCopyTaskFail:
 				// Defer the report to drainAndAggregateErrors so concurrent
 				// insert workers that race in after this read are included.
-				// Log Cancel here as the forensic crumb that survives
-				// filterCtxCancelErrs dropping the err.
 				if result.err != nil {
 					preTerrs = append(preTerrs, result.err)
-				}
-				if result.state == vcopierCopyTaskCancel {
-					log.Warn(fmt.Sprintf("task was canceled in workflow %s: %v", vc.vr.WorkflowName, result.err))
 				}
 				return io.EOF
 			case vcopierCopyTaskComplete:
@@ -297,10 +295,8 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 		copyWorkQueue.close()
 	}
 
-	// Drain late-arriving task results and aggregate. ctx is passed so a
-	// normal PRS / CopyPhaseDuration cancellation can be stripped, letting
-	// the descriptive ctx-expiration handler below fire.
-	if terr := drainAndAggregateErrors(ctx, resultCh, serr, preTerrs); terr != nil {
+	// Drain late-arriving task results and aggregate.
+	if terr := drainAndAggregateErrors(resultCh, serr, preTerrs); terr != nil {
 		log.Warn(fmt.Sprintf("task errors in workflow %s: %v", vc.vr.WorkflowName, terr))
 		return terr
 	}
@@ -344,13 +340,11 @@ func (vc *vcopier) runPostCopyActionsAndDeleteCopyState(ctx context.Context, tab
 }
 
 // drainAndAggregateErrors combines preTerrs (errors stashed by the caller's
-// VStreamTables callback), any late-arriving Fail/Cancel results on resultCh,
-// and an optional vstream error into a single aggregated workflow error.
+// VStreamTables callback), any late-arriving Fail results on resultCh, and
+// an optional vstream error into a single aggregated workflow error.
 // formatTaskError surfaces the root cause and collapses dependent-batch
-// failures to a count (issue #20316). When ctx is canceled (PRS /
-// CopyPhaseDuration), cancellation-derived errors are stripped so the
-// caller's existing ctx-expiration handling can fire.
-func drainAndAggregateErrors(ctx context.Context, resultCh <-chan *vcopierCopyTaskResult, vstreamErr error, preTerrs []error) error {
+// failures to a count (issue #20316).
+func drainAndAggregateErrors(resultCh <-chan *vcopierCopyTaskResult, vstreamErr error, preTerrs []error) error {
 	terrs := preTerrs
 	for {
 		select {
@@ -358,7 +352,7 @@ func drainAndAggregateErrors(ctx context.Context, resultCh <-chan *vcopierCopyTa
 			if result == nil {
 				continue
 			}
-			if (result.state == vcopierCopyTaskFail || result.state == vcopierCopyTaskCancel) && result.err != nil {
+			if result.state == vcopierCopyTaskFail && result.err != nil {
 				terrs = append(terrs, result.err)
 			}
 		default:
@@ -367,13 +361,10 @@ func drainAndAggregateErrors(ctx context.Context, resultCh <-chan *vcopierCopyTa
 	}
 done:
 	// Skip vstreamErr if it is the synthetic io.EOF the callback returned
-	// after observing a task Fail/Cancel — it would just noise the real
-	// root cause.
+	// after observing a task Fail — it would just noise the real root
+	// cause.
 	if vstreamErr != nil && !(errors.Is(vstreamErr, io.EOF) && len(terrs) > 0) {
 		terrs = append(terrs, vstreamErr)
-	}
-	if ctx.Err() != nil {
-		terrs = filterCtxCancelErrs(terrs)
 	}
 	return formatTaskError(terrs)
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
@@ -102,9 +102,9 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 	var prevCh <-chan *vcopierCopyTaskResult
 	var gtid string
 
-	// Errors observed inside the VStreamTables callback. The callback
-	// returns io.EOF on the first Fail/Cancel; drainAndAggregateErrors
-	// reports them alongside any siblings that race in afterwards.
+	// Errors observed inside the VStreamTables callback. The callback returns
+	// io.EOF on the first Fail/Cancel; drainAndAggregateErrors reports them
+	// alongside any concurrent insert workers that race in afterwards.
 	var preTerrs []error
 
 	vstreamOptions := &binlogdatapb.VStreamOptions{
@@ -273,9 +273,9 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 			}
 			switch result.state {
 			case vcopierCopyTaskCancel, vcopierCopyTaskFail:
-				// Defer the report to drainAndAggregateErrors so siblings
-				// that race in after this read are included. Log Cancel
-				// here as the forensic crumb that survives
+				// Defer the report to drainAndAggregateErrors so concurrent
+				// insert workers that race in after this read are included.
+				// Log Cancel here as the forensic crumb that survives
 				// filterCtxCancelErrs dropping the err.
 				if result.err != nil {
 					preTerrs = append(preTerrs, result.err)

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
@@ -344,8 +344,9 @@ func (vc *vcopier) runPostCopyActionsAndDeleteCopyState(ctx context.Context, tab
 }
 
 // drainAndAggregateErrors combines preTerrs (errors stashed by the caller's
-// inner-loop), any late-arriving Fail/Cancel results on resultCh, and an
-// optional vstream error into a single aggregated workflow error.
+// VStreamTables callback), any late-arriving Fail/Cancel results on
+// resultCh, and an optional vstream error into a single aggregated workflow
+// error.
 // formatTaskError surfaces the root cause and collapses dependent-batch
 // failures to a count (issue #20316). When ctx is canceled (PRS /
 // CopyPhaseDuration), cancellation-derived errors are stripped so the

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
@@ -344,9 +344,8 @@ func (vc *vcopier) runPostCopyActionsAndDeleteCopyState(ctx context.Context, tab
 }
 
 // drainAndAggregateErrors combines preTerrs (errors stashed by the caller's
-// VStreamTables callback), any late-arriving Fail/Cancel results on
-// resultCh, and an optional vstream error into a single aggregated workflow
-// error.
+// VStreamTables callback), any late-arriving Fail/Cancel results on resultCh,
+// and an optional vstream error into a single aggregated workflow error.
 // formatTaskError surfaces the root cause and collapses dependent-batch
 // failures to a count (issue #20316). When ctx is canceled (PRS /
 // CopyPhaseDuration), cancellation-derived errors are stripped so the

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic_test.go
@@ -17,20 +17,27 @@ limitations under the License.
 package vreplication
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/vterrors"
+
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
 func TestDrainAndAggregateErrors(t *testing.T) {
 	tests := []struct {
-		name       string
-		results    []*vcopierCopyTaskResult
-		vstreamErr error
-		wantNil    bool
-		wantSubstr []string
+		name          string
+		results       []*vcopierCopyTaskResult
+		vstreamErr    error
+		wantNil       bool
+		wantSubstr    []string
+		wantNotSubstr []string
 	}{
 		{
 			name:    "no results and no vstream error",
@@ -106,7 +113,128 @@ func TestDrainAndAggregateErrors(t *testing.T) {
 			},
 			wantSubstr: []string{"task error", "the only error"},
 		},
+		{
+			// Cancel-state results were silently dropped in main; their
+			// result.err must now appear in the aggregated message.
+			name: "cancel state with real root cause is surfaced",
+			results: []*vcopierCopyTaskResult{
+				{state: vcopierCopyTaskCancel, err: errors.New("upstream rpc canceled: connection reset")},
+			},
+			wantSubstr: []string{"task error", "upstream rpc canceled", "connection reset"},
+		},
+		{
+			// The dependentBatchFailure sentinel must be partitioned out as
+			// a count, not surfaced as a real error.
+			name: "context-expired cancels collapse to a count",
+			results: []*vcopierCopyTaskResult{
+				{state: vcopierCopyTaskCancel, err: &dependentBatchFailure{msg: "context has expired"}},
+				{state: vcopierCopyTaskCancel, err: &dependentBatchFailure{msg: "context has expired"}},
+			},
+			wantSubstr: []string{"task error", "2 batches failed waiting on a sibling batch"},
+		},
+		{
+			// A real Fail mixed with dependent-batch echoes: the real error
+			// must dominate the message, echoes collapse to the count.
+			name: "fail with dependent-batch echoes surfaces the root cause",
+			results: []*vcopierCopyTaskResult{
+				{state: vcopierCopyTaskFail, err: errors.New("failed inserting rows: EOF")},
+				{state: vcopierCopyTaskFail, err: &dependentBatchFailure{msg: "received result is not complete"}},
+				{state: vcopierCopyTaskFail, err: &dependentBatchFailure{msg: "received result is not complete"}},
+				{state: vcopierCopyTaskFail, err: &dependentBatchFailure{msg: "received result is not complete"}},
+			},
+			wantSubstr: []string{
+				"task error",
+				"failed inserting rows: EOF",
+				"+3 batches failed waiting on this to complete",
+			},
+			wantNotSubstr: []string{"received result is not complete"},
+		},
 	}
+
+	// Under a canceled ctx, dependent-batch and ctx-derived errors must be
+	// stripped so copyAll's "interrupted due to context expiration" path
+	// fires instead of a generic workflow error. Real Fail-state errors
+	// that raced the cancellation still surface.
+	cancelTests := []struct {
+		name    string
+		results []*vcopierCopyTaskResult
+		wantNil bool
+		wantErr string
+	}{
+		{
+			name: "pure dependent cancels returns nil",
+			results: []*vcopierCopyTaskResult{
+				{state: vcopierCopyTaskCancel, err: &dependentBatchFailure{msg: "context has expired", code: vtrpcpb.Code_CANCELED}},
+				{state: vcopierCopyTaskCancel, err: &dependentBatchFailure{msg: "context has expired", code: vtrpcpb.Code_CANCELED}},
+			},
+			wantNil: true,
+		},
+		{
+			name: "real Fail mixed with dep cancels still surfaces real error",
+			results: []*vcopierCopyTaskResult{
+				{state: vcopierCopyTaskCancel, err: &dependentBatchFailure{msg: "context has expired", code: vtrpcpb.Code_CANCELED}},
+				{state: vcopierCopyTaskFail, err: errors.New("failed inserting rows: EOF")},
+			},
+			wantErr: "failed inserting rows: EOF",
+		},
+		{
+			name: "raw context.Canceled and vterrors-wrapped variants return nil",
+			results: []*vcopierCopyTaskResult{
+				{state: vcopierCopyTaskCancel, err: context.Canceled},
+				{state: vcopierCopyTaskCancel, err: vterrors.Wrap(context.Canceled, "ExecuteWithRetry")},
+			},
+			wantNil: true,
+		},
+		{
+			name: "stdlib fmt.Errorf %w-wrapped context errors return nil",
+			results: []*vcopierCopyTaskResult{
+				{state: vcopierCopyTaskCancel, err: fmt.Errorf("row stream ended: %w", context.Canceled)},
+				{state: vcopierCopyTaskCancel, err: fmt.Errorf("vstream deadline: %w", context.DeadlineExceeded)},
+			},
+			wantNil: true,
+		},
+	}
+	for _, tt := range cancelTests {
+		t.Run("ctx canceled / "+tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+			ch := make(chan *vcopierCopyTaskResult, len(tt.results))
+			for _, r := range tt.results {
+				ch <- r
+			}
+			err := drainAndAggregateErrors(ctx, ch, nil, nil)
+			if tt.wantNil {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+
+	t.Run("preTerrs is included in aggregation", func(t *testing.T) {
+		// VStreamTables callback stashes result.err in preTerrs before
+		// returning io.EOF. The drain must surface those stashed errors
+		// even when the channel has no further Fail/Cancel results.
+		ch := make(chan *vcopierCopyTaskResult, 1)
+		preTerrs := []error{errors.New("failed inserting rows: EOF")}
+
+		err := drainAndAggregateErrors(t.Context(), ch, nil, preTerrs)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed inserting rows: EOF")
+	})
+
+	t.Run("preTerrs combined with channel results and a vstream error", func(t *testing.T) {
+		ch := make(chan *vcopierCopyTaskResult, 2)
+		ch <- &vcopierCopyTaskResult{state: vcopierCopyTaskFail, err: &dependentBatchFailure{msg: "received result is not complete"}}
+		preTerrs := []error{errors.New("failed inserting rows: EOF")}
+
+		err := drainAndAggregateErrors(t.Context(), ch, errors.New("vstream connection lost"), preTerrs)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed inserting rows: EOF")
+		assert.ErrorContains(t, err, "vstream connection lost")
+		assert.ErrorContains(t, err, "+1 batches failed waiting on this to complete")
+	})
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -115,7 +243,7 @@ func TestDrainAndAggregateErrors(t *testing.T) {
 				ch <- r
 			}
 
-			err := drainAndAggregateErrors(ch, tt.vstreamErr)
+			err := drainAndAggregateErrors(t.Context(), ch, tt.vstreamErr, nil)
 
 			// Verify the channel was fully drained.
 			assert.Equal(t, 0, len(ch), "channel should be empty after draining")
@@ -127,6 +255,9 @@ func TestDrainAndAggregateErrors(t *testing.T) {
 			require.Error(t, err)
 			for _, substr := range tt.wantSubstr {
 				assert.Contains(t, err.Error(), substr)
+			}
+			for _, substr := range tt.wantNotSubstr {
+				assert.NotContains(t, err.Error(), substr)
 			}
 		})
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic_test.go
@@ -130,7 +130,7 @@ func TestDrainAndAggregateErrors(t *testing.T) {
 				{state: vcopierCopyTaskCancel, err: &dependentBatchFailure{msg: "context has expired"}},
 				{state: vcopierCopyTaskCancel, err: &dependentBatchFailure{msg: "context has expired"}},
 			},
-			wantSubstr: []string{"task error", "2 batches failed waiting on a sibling batch"},
+			wantSubstr: []string{"task error", "2 batches failed waiting on a concurrent insert worker's batch"},
 		},
 		{
 			// A real Fail mixed with dependent-batch echoes: the real error

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic_test.go
@@ -17,17 +17,11 @@ limitations under the License.
 package vreplication
 
 import (
-	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"vitess.io/vitess/go/vt/vterrors"
-
-	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
 func TestDrainAndAggregateErrors(t *testing.T) {
@@ -114,25 +108,6 @@ func TestDrainAndAggregateErrors(t *testing.T) {
 			wantSubstr: []string{"task error", "the only error"},
 		},
 		{
-			// Cancel-state results were silently dropped in main; their
-			// result.err must now appear in the aggregated message.
-			name: "cancel state with real root cause is surfaced",
-			results: []*vcopierCopyTaskResult{
-				{state: vcopierCopyTaskCancel, err: errors.New("upstream rpc canceled: connection reset")},
-			},
-			wantSubstr: []string{"task error", "upstream rpc canceled", "connection reset"},
-		},
-		{
-			// The dependentBatchFailure sentinel must be partitioned out as
-			// a count, not surfaced as a real error.
-			name: "context-expired cancels collapse to a count",
-			results: []*vcopierCopyTaskResult{
-				{state: vcopierCopyTaskCancel, err: &dependentBatchFailure{msg: "context has expired"}},
-				{state: vcopierCopyTaskCancel, err: &dependentBatchFailure{msg: "context has expired"}},
-			},
-			wantSubstr: []string{"task error", "2 batches failed waiting on a concurrent insert worker's batch"},
-		},
-		{
 			// A real Fail mixed with dependent-batch echoes: the real error
 			// must dominate the message, echoes collapse to the count.
 			name: "fail with dependent-batch echoes surfaces the root cause",
@@ -151,75 +126,14 @@ func TestDrainAndAggregateErrors(t *testing.T) {
 		},
 	}
 
-	// Under a canceled ctx, dependent-batch and ctx-derived errors must be
-	// stripped so copyAll's "interrupted due to context expiration" path
-	// fires instead of a generic workflow error. Real Fail-state errors
-	// that raced the cancellation still surface.
-	cancelTests := []struct {
-		name    string
-		results []*vcopierCopyTaskResult
-		wantNil bool
-		wantErr string
-	}{
-		{
-			name: "pure dependent cancels returns nil",
-			results: []*vcopierCopyTaskResult{
-				{state: vcopierCopyTaskCancel, err: &dependentBatchFailure{msg: "context has expired", code: vtrpcpb.Code_CANCELED}},
-				{state: vcopierCopyTaskCancel, err: &dependentBatchFailure{msg: "context has expired", code: vtrpcpb.Code_CANCELED}},
-			},
-			wantNil: true,
-		},
-		{
-			name: "real Fail mixed with dep cancels still surfaces real error",
-			results: []*vcopierCopyTaskResult{
-				{state: vcopierCopyTaskCancel, err: &dependentBatchFailure{msg: "context has expired", code: vtrpcpb.Code_CANCELED}},
-				{state: vcopierCopyTaskFail, err: errors.New("failed inserting rows: EOF")},
-			},
-			wantErr: "failed inserting rows: EOF",
-		},
-		{
-			name: "raw context.Canceled and vterrors-wrapped variants return nil",
-			results: []*vcopierCopyTaskResult{
-				{state: vcopierCopyTaskCancel, err: context.Canceled},
-				{state: vcopierCopyTaskCancel, err: vterrors.Wrap(context.Canceled, "ExecuteWithRetry")},
-			},
-			wantNil: true,
-		},
-		{
-			name: "stdlib fmt.Errorf %w-wrapped context errors return nil",
-			results: []*vcopierCopyTaskResult{
-				{state: vcopierCopyTaskCancel, err: fmt.Errorf("row stream ended: %w", context.Canceled)},
-				{state: vcopierCopyTaskCancel, err: fmt.Errorf("vstream deadline: %w", context.DeadlineExceeded)},
-			},
-			wantNil: true,
-		},
-	}
-	for _, tt := range cancelTests {
-		t.Run("ctx canceled / "+tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(t.Context())
-			cancel()
-			ch := make(chan *vcopierCopyTaskResult, len(tt.results))
-			for _, r := range tt.results {
-				ch <- r
-			}
-			err := drainAndAggregateErrors(ctx, ch, nil, nil)
-			if tt.wantNil {
-				assert.NoError(t, err)
-				return
-			}
-			require.Error(t, err)
-			assert.ErrorContains(t, err, tt.wantErr)
-		})
-	}
-
 	t.Run("preTerrs is included in aggregation", func(t *testing.T) {
 		// VStreamTables callback stashes result.err in preTerrs before
 		// returning io.EOF. The drain must surface those stashed errors
-		// even when the channel has no further Fail/Cancel results.
+		// even when the channel has no further Fail results.
 		ch := make(chan *vcopierCopyTaskResult, 1)
 		preTerrs := []error{errors.New("failed inserting rows: EOF")}
 
-		err := drainAndAggregateErrors(t.Context(), ch, nil, preTerrs)
+		err := drainAndAggregateErrors(ch, nil, preTerrs)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "failed inserting rows: EOF")
 	})
@@ -229,7 +143,7 @@ func TestDrainAndAggregateErrors(t *testing.T) {
 		ch <- &vcopierCopyTaskResult{state: vcopierCopyTaskFail, err: &dependentBatchFailure{msg: "received result is not complete"}}
 		preTerrs := []error{errors.New("failed inserting rows: EOF")}
 
-		err := drainAndAggregateErrors(t.Context(), ch, errors.New("vstream connection lost"), preTerrs)
+		err := drainAndAggregateErrors(ch, errors.New("vstream connection lost"), preTerrs)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "failed inserting rows: EOF")
 		assert.ErrorContains(t, err, "vstream connection lost")
@@ -243,7 +157,7 @@ func TestDrainAndAggregateErrors(t *testing.T) {
 				ch <- r
 			}
 
-			err := drainAndAggregateErrors(t.Context(), ch, tt.vstreamErr, nil)
+			err := drainAndAggregateErrors(ch, tt.vstreamErr, nil)
 
 			// Verify the channel was fully drained.
 			assert.Equal(t, 0, len(ch), "channel should be empty after draining")

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_errors_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_errors_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vreplication
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/vterrors"
+
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+)
+
+func TestFormatTaskError(t *testing.T) {
+	root := errors.New("failed inserting rows: EOF")
+	dep := &dependentBatchFailure{msg: "received result is not complete"}
+	cancelDep := &dependentBatchFailure{msg: "context has expired", code: vtrpcpb.Code_CANCELED}
+
+	t.Run("nil for empty input", func(t *testing.T) {
+		assert.NoError(t, formatTaskError(nil))
+		assert.NoError(t, formatTaskError([]error{}))
+		assert.NoError(t, formatTaskError([]error{nil, nil}))
+	})
+
+	t.Run("root only surfaces the root cause", func(t *testing.T) {
+		err := formatTaskError([]error{root})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "task error")
+		assert.ErrorContains(t, err, "failed inserting rows: EOF")
+		assert.NotContains(t, err.Error(), "batches failed waiting on")
+	})
+
+	t.Run("mixed root + dependent prefers the root and counts the dependents", func(t *testing.T) {
+		err := formatTaskError([]error{root, dep, dep, dep})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed inserting rows: EOF")
+		assert.ErrorContains(t, err, "+3 batches failed waiting on this to complete")
+		assert.NotContains(t, err.Error(), "received result is not complete",
+			"dependent-batch echo strings must not appear in the message")
+	})
+
+	t.Run("dependent only directs operators to earlier rows", func(t *testing.T) {
+		err := formatTaskError([]error{dep, dep, dep, dep})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "4 batches failed waiting on a sibling batch")
+		assert.ErrorContains(t, err, "original failure not captured this retry")
+		assert.ErrorContains(t, err, "see earlier rows for the root cause")
+	})
+
+	t.Run("dependent only preserves Code_CANCELED for ctx.Done() case", func(t *testing.T) {
+		// tryAdvance maps Code_CANCELED to vcopierCopyTaskCancel; the
+		// ctx.Done() dependentBatchFailure must keep that code so existing
+		// cancel detection downstream still works.
+		err := formatTaskError([]error{cancelDep, cancelDep})
+		require.Error(t, err)
+		assert.Equal(t, vtrpcpb.Code_CANCELED, vterrors.Code(err))
+	})
+
+	t.Run("multiple distinct root causes are all surfaced", func(t *testing.T) {
+		err := formatTaskError([]error{
+			errors.New("failed inserting rows: EOF"),
+			errors.New("error committing transaction: write conflict"),
+			dep,
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed inserting rows: EOF")
+		assert.ErrorContains(t, err, "error committing transaction: write conflict")
+		assert.ErrorContains(t, err, "+1 batches failed waiting on this to complete")
+	})
+}
+
+func TestFilterCtxCancelErrs(t *testing.T) {
+	// Callers invoke filterCtxCancelErrs when ctx.Err() != nil. Errors
+	// arising from that cancellation must be dropped so the clean-stop path
+	// can fire; non-cancel codes (real Fail-state errors that raced the
+	// cancellation) are preserved.
+	depPlain := &dependentBatchFailure{msg: "received result is not complete"}
+	depCanceled := &dependentBatchFailure{msg: "context has expired", code: vtrpcpb.Code_CANCELED}
+	rawCanceled := context.Canceled
+	rawDeadline := context.DeadlineExceeded
+	wrappedCanceled := vterrors.Wrap(context.Canceled, "ExecuteWithRetry failed")
+	stdWrappedCanceled := fmt.Errorf("row stream ended: %w", context.Canceled)
+	stdWrappedDeadline := fmt.Errorf("vstream deadline: %w", context.DeadlineExceeded)
+	codeCanceled := vterrors.New(vtrpcpb.Code_CANCELED, "tryAdvance canceled while running InsertRows")
+	codeDeadline := vterrors.New(vtrpcpb.Code_DEADLINE_EXCEEDED, "tryAdvance deadline exceeded")
+	realFail := errors.New("failed inserting rows: duplicate key on customer.email")
+	realFailFP := vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "row JSON payload exceeds cap")
+
+	tests := []struct {
+		name string
+		in   []error
+		want []error
+	}{
+		{name: "nil entries are skipped", in: []error{nil, nil}, want: nil},
+		{name: "drops dependent-batch sentinels regardless of code", in: []error{depPlain, depCanceled}, want: nil},
+		{name: "drops raw context.Canceled and context.DeadlineExceeded", in: []error{rawCanceled, rawDeadline}, want: nil},
+		{name: "drops vterrors-wrapped context.Canceled", in: []error{wrappedCanceled}, want: nil},
+		{name: "drops stdlib fmt.Errorf %w-wrapped context errors", in: []error{stdWrappedCanceled, stdWrappedDeadline}, want: nil},
+		{name: "drops errors with Code_CANCELED or Code_DEADLINE_EXCEEDED", in: []error{codeCanceled, codeDeadline}, want: nil},
+		{
+			name: "preserves real Fail-state errors that race the cancellation",
+			in:   []error{realFail, depCanceled, realFailFP, rawCanceled},
+			want: []error{realFail, realFailFP},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterCtxCancelErrs(tt.in)
+			if len(tt.want) == 0 {
+				assert.Empty(t, got)
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_errors_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_errors_test.go
@@ -17,9 +17,7 @@ limitations under the License.
 package vreplication
 
 import (
-	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -86,51 +84,4 @@ func TestFormatTaskError(t *testing.T) {
 		assert.ErrorContains(t, err, "error committing transaction: write conflict")
 		assert.ErrorContains(t, err, "+1 batches failed waiting on this to complete")
 	})
-}
-
-func TestFilterCtxCancelErrs(t *testing.T) {
-	// Callers invoke filterCtxCancelErrs when ctx.Err() != nil. Errors
-	// arising from that cancellation must be dropped so the clean-stop path
-	// can fire; non-cancel codes (real Fail-state errors that raced the
-	// cancellation) are preserved.
-	depPlain := &dependentBatchFailure{msg: "received result is not complete"}
-	depCanceled := &dependentBatchFailure{msg: "context has expired", code: vtrpcpb.Code_CANCELED}
-	rawCanceled := context.Canceled
-	rawDeadline := context.DeadlineExceeded
-	wrappedCanceled := vterrors.Wrap(context.Canceled, "ExecuteWithRetry failed")
-	stdWrappedCanceled := fmt.Errorf("row stream ended: %w", context.Canceled)
-	stdWrappedDeadline := fmt.Errorf("vstream deadline: %w", context.DeadlineExceeded)
-	codeCanceled := vterrors.New(vtrpcpb.Code_CANCELED, "tryAdvance canceled while running InsertRows")
-	codeDeadline := vterrors.New(vtrpcpb.Code_DEADLINE_EXCEEDED, "tryAdvance deadline exceeded")
-	realFail := errors.New("failed inserting rows: duplicate key on customer.email")
-	realFailFP := vterrors.New(vtrpcpb.Code_FAILED_PRECONDITION, "row JSON payload exceeds cap")
-
-	tests := []struct {
-		name string
-		in   []error
-		want []error
-	}{
-		{name: "nil entries are skipped", in: []error{nil, nil}, want: nil},
-		{name: "drops dependent-batch sentinels regardless of code", in: []error{depPlain, depCanceled}, want: nil},
-		{name: "drops raw context.Canceled and context.DeadlineExceeded", in: []error{rawCanceled, rawDeadline}, want: nil},
-		{name: "drops vterrors-wrapped context.Canceled", in: []error{wrappedCanceled}, want: nil},
-		{name: "drops stdlib fmt.Errorf %w-wrapped context errors", in: []error{stdWrappedCanceled, stdWrappedDeadline}, want: nil},
-		{name: "drops errors with Code_CANCELED or Code_DEADLINE_EXCEEDED", in: []error{codeCanceled, codeDeadline}, want: nil},
-		{
-			name: "preserves real Fail-state errors that race the cancellation",
-			in:   []error{realFail, depCanceled, realFailFP, rawCanceled},
-			want: []error{realFail, realFailFP},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := filterCtxCancelErrs(tt.in)
-			if len(tt.want) == 0 {
-				assert.Empty(t, got)
-				return
-			}
-			assert.Equal(t, tt.want, got)
-		})
-	}
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_errors_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_errors_test.go
@@ -61,7 +61,7 @@ func TestFormatTaskError(t *testing.T) {
 	t.Run("dependent only directs operators to earlier rows", func(t *testing.T) {
 		err := formatTaskError([]error{dep, dep, dep, dep})
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "4 batches failed waiting on a sibling batch")
+		assert.ErrorContains(t, err, "4 batches failed waiting on a concurrent insert worker's batch")
 		assert.ErrorContains(t, err, "original failure not captured this retry")
 		assert.ErrorContains(t, err, "see earlier rows for the root cause")
 	})


### PR DESCRIPTION
## Description

`_vt.vreplication_log` should record the root-cause error when a COPY-phase task fails, but two places in `vcopier` lose the real error and surface only repeated `received result is not complete` messages. The real `failed inserting rows: EOF` / `FAILED_PRECONDITION: row JSON payload exceeds ...` / `error committing transaction: ...` errors get silently dropped or buried, leaving operators to dig through raw `vttablet` stdout. This has complicated production incident investigations.

Each copy task publishes its result (Fail / Complete / Cancel) to a shared `resultCh`. The `VStreamRows` callback polls `resultCh` between row-batches and returns `io.EOF` on the first Fail it sees, then the post-`VStreamRows` drain collects any late-arriving results from the same channel.

The bug surfaces with concurrent insert workers (i.e. `--vreplication-parallel-insert-workers > 1`). With the default 1 worker, tasks run serially and the originating `Fail` result lands in `resultCh` deterministically before any waiting worker can emit a dependent-batch failure, so the callback catches the real error. With >1 workers, multiple tasks publish to `resultCh` concurrently, and the early-return can grab a dependent-batch failure (a worker that merely stalled waiting on another worker's batch) before the originating real error lands.

This PR tags `awaitCompletion`'s placeholder errors with a sentinel type so the post-`VStreamRows` drain can partition real Fail-state errors from dependent-batch failures (collapsed to a count). The callback's early-return is also deferred to the drain so it can wait for every worker, closing the race where a dependent-batch failure could be returned before the originating real error landed.

### Reproduction

Local `examples/local` cluster, one JSON "poison" row + ~500 normal rows on `commerce.customer`, then `MoveTables` with `--config-overrides "max-row-json-bytes=100,vreplication-parallel-insert-workers=4,vstream-packet-size=200,vstream-dynamic-packet-size=false"`. Query the target primary:

```sql
SELECT id, type, state, LEFT(message, 4000) AS message, count, created_at
FROM _vt.vreplication_log WHERE vrepl_id = 1 ORDER BY id DESC LIMIT 15\G
```

**Before (`main` @ HEAD)** — workflow retries every ~6s indefinitely, every cycle inserts a fresh `Message` row with the same useless string; the `FAILED_PRECONDITION` is nowhere:

```
*** 1. row ***
         id: 22
       type: Message
      state: Copying
    message: task error: received result is not complete
      count: 1
 created_at: 2026-06-18 17:36:34
*** 2. row ***
         id: 21
       type: Restarted Copy Phase
      state: Copying
    message: Copy phase restarted for 1 table(s)
      count: 1
 created_at: 2026-06-18 17:36:33
*** 3. row ***
         id: 20
       type: Message
      state: Copying
    message: task error: received result is not complete
      count: 1
 created_at: 2026-06-18 17:36:28
(retry pattern continues for ids 19 → 14, every ~6s, every Message row identical)
```

**After (this PR)** — one `Message` row with the root cause, then a clean `State Changed → Error`; `FAILED_PRECONDITION` is unrecoverable so the workflow stops instead of retrying forever:

```
*** 1. row ***
         id: 7
       type: State Changed
      state: Error
    message: terminal error: task error (+1 batches failed waiting on this to complete): failed inserting rows: vreplication: row JSON payload 519 bytes exceeds vreplication-max-row-json-bytes=100 (table=customer, largest_json_column=info @ 519 bytes)
      count: 1
 created_at: 2026-06-18 17:51:12
*** 2. row ***
         id: 6
       type: Message
      state: Copying
    message: task error (+1 batches failed waiting on this to complete): failed inserting rows: vreplication: row JSON payload 519 bytes exceeds vreplication-max-row-json-bytes=100 (table=customer, largest_json_column=info @ 519 bytes)
      count: 1
 created_at: 2026-06-18 17:51:12
```

Operator gets the root cause directly: a 519-byte row exceeded `vreplication-max-row-json-bytes=100` on `customer.info`. Same shape applies to other swallowed roots seen in production (`failed inserting rows: EOF` from mysqld OOM, `error committing transaction: …`, etc.).

## Related Issue(s)

Fixes #20316

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

**Backport justification:** the bug is structural to `vcopier` and present on every supported release; suggesting backports to `release-22.0`, `release-23.0`, and `release-24.0` so operators get the diagnostic improvement without waiting for the next major.

## Deployment Notes

**Behaviour change:** Unrecoverable upstream errors that were previously hidden behind repeated `received result is not complete` messages will now correctly transition the workflow to `Error` state (instead of silently retrying every ~6s). This is strictly a correctness improvement (these workflows were already wedged in production).

No schema changes to `_vt.vreplication_log`. The `message` column content changes; the row volume *decreases* for unrecoverable errors (one row instead of N retries).

### AI Disclosure

Claude Code (Opus 4.7) assisted with the code and testing. I provided direction, production proof/data, criteria, etc.
