### PR TITLE
test: rename reservedconn reconnect packages to descriptive names

### DIFF
--- a/go/test/endtoend/vtgate/reservedconn/mysqldown/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/mysqldown/main_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package reservedconn
+package mysqldown
 
 import (
 	"flag"
@@ -73,7 +73,7 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
-func TestVttabletDownServingChange(t *testing.T) {
+func TestMysqlDownServingChange(t *testing.T) {
 	conn, err := mysql.Connect(t.Context(), &vtParams)
 	require.NoError(t, err)
 	defer conn.Close()
@@ -91,8 +91,6 @@ func TestVttabletDownServingChange(t *testing.T) {
 	primaryTablet := clusterInstance.Keyspaces[0].Shards[0].PrimaryTablet()
 	require.NoError(t,
 		primaryTablet.MysqlctlProcess.Stop())
-	// kill vttablet process
-	_ = primaryTablet.VttabletProcess.TearDown()
 	require.NoError(t,
 		clusterInstance.VtctldClientProcess.ExecuteCommand("EmergencyReparentShard", "ks/0"))
 

--- a/go/test/endtoend/vtgate/reservedconn/servingchange/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/servingchange/main_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package reservedconn
+package servingchange
 
 import (
 	"flag"

--- a/go/test/endtoend/vtgate/reservedconn/tabletchange/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/tabletchange/main_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package reservedconn
+package tabletchange
 
 import (
 	"flag"

--- a/go/test/endtoend/vtgate/reservedconn/vttabletdown/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/vttabletdown/main_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package reservedconn
+package vttabletdown
 
 import (
 	"flag"
@@ -73,7 +73,7 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
-func TestMysqlDownServingChange(t *testing.T) {
+func TestVttabletDownServingChange(t *testing.T) {
 	conn, err := mysql.Connect(t.Context(), &vtParams)
 	require.NoError(t, err)
 	defer conn.Close()
@@ -91,6 +91,8 @@ func TestMysqlDownServingChange(t *testing.T) {
 	primaryTablet := clusterInstance.Keyspaces[0].Shards[0].PrimaryTablet()
 	require.NoError(t,
 		primaryTablet.MysqlctlProcess.Stop())
+	// kill vttablet process
+	_ = primaryTablet.VttabletProcess.TearDown()
 	require.NoError(t,
 		clusterInstance.VtctldClientProcess.ExecuteCommand("EmergencyReparentShard", "ks/0"))
 

--- a/test/config.json
+++ b/test/config.json
@@ -1380,7 +1380,7 @@
     "vtgate_reserved_conn1": {
       "File": "unused.go",
       "Packages": [
-        "vitess.io/vitess/go/test/endtoend/vtgate/reservedconn/reconnect1"
+        "vitess.io/vitess/go/test/endtoend/vtgate/reservedconn/servingchange"
       ],
       "Args": [],
       "Command": [],
@@ -1392,7 +1392,7 @@
     "vtgate_reserved_conn2": {
       "File": "unused.go",
       "Packages": [
-        "vitess.io/vitess/go/test/endtoend/vtgate/reservedconn/reconnect2"
+        "vitess.io/vitess/go/test/endtoend/vtgate/reservedconn/tabletchange"
       ],
       "Args": [],
       "Command": [],
@@ -1404,7 +1404,7 @@
     "vtgate_reserved_conn3": {
       "File": "unused.go",
       "Packages": [
-        "vitess.io/vitess/go/test/endtoend/vtgate/reservedconn/reconnect3"
+        "vitess.io/vitess/go/test/endtoend/vtgate/reservedconn/mysqldown"
       ],
       "Args": [],
       "Command": [],
@@ -1416,7 +1416,7 @@
     "vtgate_reserved_conn4": {
       "File": "unused.go",
       "Packages": [
-        "vitess.io/vitess/go/test/endtoend/vtgate/reservedconn/reconnect4"
+        "vitess.io/vitess/go/test/endtoend/vtgate/reservedconn/vttabletdown"
       ],
       "Args": [],
       "Command": [],


### PR DESCRIPTION
Closes #15320

Renamed the numeric `reconnect1-4` sub-packages to names that reflect what each scenario tests:

| Old | New | Tests |
|-----|-----|-------|
| `reconnect1` | `servingchange` | rdonly tablet serving type changes |
| `reconnect2` | `tabletchange` | primary tablet change via PlannedReparentShard |
| `reconnect3` | `mysqldown` | MySQL process killed, EmergencyReparentShard |
| `reconnect4` | `vttabletdown` | vttablet process killed, EmergencyReparentShard |

No logic changes, only directory renames and matching package declarations.