### PR TITLE
Preserve query hints in field/impossible queries

### DIFF
--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -618,6 +618,24 @@ func TestJoinAggregation(t *testing.T) {
 	mcmp.Exec(`SELECT t1.name, CAST(SUM(b.bet_amount) AS DECIMAL(20,6)) AS bet_amount FROM bet_logs as b LEFT JOIN t1 ON b.merchant_game_id = t1.t1_id GROUP BY b.merchant_game_id`)
 }
 
+// TestJoinAggregationEmptyLeft is a regression test for https://github.com/vitessio/vitess/issues/20365.
+// When the left-hand side of an aggregation through a join returns no rows, vtgate fetches the
+// right-hand leg's column metadata using the field (impossible) query. That query must run under
+// the session's sql_mode, exactly like the main query. It previously dropped the
+// SET_VAR(sql_mode = ...) hint, so the field probe failed with errno 1055 under the tablet's
+// strict default sql_mode.
+func TestJoinAggregationEmptyLeft(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	// Only the right-hand table has rows; bet_logs (the left-hand side) stays empty, so the
+	// join falls back to the field probe to learn the t1 leg's columns.
+	mcmp.Exec("insert into t1(t1_id, `name`, `value`, shardkey) values(1,'a1','foo',100), (2,'b1','foo',200)")
+
+	mcmp.Exec("set @@sql_mode = ' '")
+	mcmp.Exec(`SELECT t1.name, SUM(b.bet_amount) AS bet_amount FROM bet_logs as b LEFT JOIN t1 ON b.merchant_game_id = t1.t1_id GROUP BY b.merchant_game_id`)
+}
+
 // TestGroupConcatAggregation tests the group_concat function with vitess doing the aggregation.
 func TestGroupConcatAggregation(t *testing.T) {
 	mcmp, closer := start(t)

--- a/go/vt/sqlparser/impossible_query.go
+++ b/go/vt/sqlparser/impossible_query.go
@@ -30,7 +30,9 @@ func FormatImpossibleQuery(buf *TrackedBuffer, node SQLNode) {
 		if node.With != nil {
 			node.With.Format(buf)
 		}
-		buf.Myprintf("select %v", node.SelectExprs)
+		// Preserve query hints (e.g. SET_VAR(sql_mode = ...)) so the field query is
+		// executed under the same session settings as the main query.
+		buf.Myprintf("select %v%v", node.Comments, node.SelectExprs)
 		if len(node.From) == 0 {
 			buf.Myprintf(" from dual")
 		} else {

--- a/go/vt/sqlparser/impossible_query_test.go
+++ b/go/vt/sqlparser/impossible_query_test.go
@@ -67,6 +67,11 @@ func TestFormatImpossibleQuery_Select(t *testing.T) {
 			expected: "select col from t where 1 != 1 group by col",
 		},
 		{
+			name:     "select with query hint comment is preserved",
+			input:    "select /*+ SET_VAR(sql_mode = ' ') */ col, count(*) from t group by .0",
+			expected: "select /*+ SET_VAR(sql_mode = ' ') */ col, count(*) from t where 1 != 1 group by .0",
+		},
+		{
 			name:     "select with with clause",
 			input:    "with cte as (select * from t) select * from cte",
 			expected: "with cte as (select * from t) select * from cte where 1 != 1",

--- a/go/vt/vtgate/planbuilder/testdata/foreignkey_checks_on_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/foreignkey_checks_on_cases.json
@@ -765,7 +765,7 @@
               "Name": "unsharded_fk_allow",
               "Sharded": false
             },
-            "FieldQuery": "select u_tbl2.id from u_tbl2 where 1 != 1",
+            "FieldQuery": "select /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2.id from u_tbl2 where 1 != 1",
             "Query": "select /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2.id from u_tbl2 limit 2 for update"
           },
           {
@@ -779,7 +779,7 @@
                   "Name": "unsharded_fk_allow",
                   "Sharded": false
                 },
-                "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
+                "FieldQuery": "select /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2.col2 from u_tbl2 where 1 != 1",
                 "Query": "select /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2.col2 from u_tbl2 where u_tbl2.id in ::dml_vals for update"
               },
               {
@@ -1250,7 +1250,7 @@
               "Name": "unsharded_fk_allow",
               "Sharded": false
             },
-            "FieldQuery": "select u_tbl2.id from u_tbl2 where 1 != 1",
+            "FieldQuery": "select /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2.id from u_tbl2 where 1 != 1",
             "Query": "select /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2.id from u_tbl2 limit 2 for update"
           },
           {
@@ -1264,7 +1264,7 @@
                   "Name": "unsharded_fk_allow",
                   "Sharded": false
                 },
-                "FieldQuery": "select u_tbl2.col2 from u_tbl2 where 1 != 1",
+                "FieldQuery": "select /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2.col2 from u_tbl2 where 1 != 1",
                 "Query": "select /*+ SET_VAR(foreign_key_checks=On) */ u_tbl2.col2 from u_tbl2 where u_tbl2.id in ::dml_vals for update"
               },
               {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -109,7 +109,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select * from `user` where 1 != 1",
+        "FieldQuery": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from `user` where 1 != 1",
         "Query": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from `user`",
         "QueryTimeout": 1000
       },
@@ -137,7 +137,7 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select count(*) from `user` where 1 != 1",
+            "FieldQuery": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ count(*) from `user` where 1 != 1",
             "Query": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ count(*) from `user`",
             "QueryTimeout": 1000
           }
@@ -166,7 +166,7 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select * from `user` where 1 != 1",
+            "FieldQuery": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from `user` where 1 != 1",
             "Query": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from `user` limit 10",
             "QueryTimeout": 1000
           }
@@ -191,7 +191,7 @@
           "Name": "main",
           "Sharded": false
         },
-        "FieldQuery": "select * from unsharded where 1 != 1",
+        "FieldQuery": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from unsharded where 1 != 1",
         "Query": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from unsharded limit 10",
         "QueryTimeout": 1000
       },
@@ -215,7 +215,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select * from `user` where 1 != 1",
+        "FieldQuery": "select /*vt+ SCATTER_ERRORS_AS_WARNINGS */ * from `user` where 1 != 1",
         "Query": "select /*vt+ SCATTER_ERRORS_AS_WARNINGS */ * from `user`",
         "ScatterErrorsAsWarnings": true
       },
@@ -243,7 +243,7 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select count(*) from `user` where 1 != 1",
+            "FieldQuery": "select /*vt+ SCATTER_ERRORS_AS_WARNINGS=1 */ count(*) from `user` where 1 != 1",
             "Query": "select /*vt+ SCATTER_ERRORS_AS_WARNINGS=1 */ count(*) from `user`",
             "ScatterErrorsAsWarnings": true
           }
@@ -273,7 +273,7 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select count(*) from `user` where 1 != 1",
+            "FieldQuery": "select /*vt+ SCATTER_ERRORS_AS_WARNINGS=1 */ count(*) from `user` where 1 != 1",
             "Query": "select /*vt+ SCATTER_ERRORS_AS_WARNINGS=1 */ count(*) from `user`",
             "ScatterErrorsAsWarnings": true
           }
@@ -302,7 +302,7 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select * from `user` where 1 != 1",
+            "FieldQuery": "select /*vt+ SCATTER_ERRORS_AS_WARNINGS=1 */ * from `user` where 1 != 1",
             "Query": "select /*vt+ SCATTER_ERRORS_AS_WARNINGS=1 */ * from `user` limit 10",
             "ScatterErrorsAsWarnings": true
           }
@@ -913,7 +913,7 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select `user`.col from `user` where 1 != 1",
+            "FieldQuery": "select /* comment */ `user`.col from `user` where 1 != 1",
             "Query": "select /* comment */ `user`.col from `user`"
           },
           {
@@ -923,7 +923,7 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select 1 from user_extra where 1 != 1",
+            "FieldQuery": "select /* comment */ 1 from user_extra where 1 != 1",
             "Query": "select /* comment */ 1 from user_extra"
           }
         ]
@@ -949,7 +949,7 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "select `user`.col from `user` where 1 != 1",
+        "FieldQuery": "select /* comment */ `user`.col from `user` where 1 != 1",
         "Query": "select /* comment */ `user`.col from `user` where id in (select id from `user` where id > 1 and id < 10)"
       },
       "TablesUsed": [
@@ -981,7 +981,7 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select id from `user` where 1 != 1",
+            "FieldQuery": "select /* comment */ id from `user` where 1 != 1",
             "Query": "select /* comment */ id from `user` where id > 1 and id < 10"
           },
           {
@@ -992,7 +992,7 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select `user`.col from `user` where 1 != 1",
+            "FieldQuery": "select /* comment */ `user`.col from `user` where 1 != 1",
             "Query": "select /* comment */ `user`.col from `user` where :__sq_has_values and foo in ::__sq1"
           }
         ]
@@ -2015,7 +2015,7 @@
           "Name": "main",
           "Sharded": false
         },
-        "FieldQuery": "select * from unsharded as route2 where 1 != 1",
+        "FieldQuery": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from unsharded as route2 where 1 != 1",
         "Query": "select /*vt+ QUERY_TIMEOUT_MS=1000 */ * from unsharded as route2",
         "QueryTimeout": 1000
       },

--- a/go/vt/vtgate/planbuilder/testdata/wireup_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/wireup_cases.json
@@ -912,7 +912,7 @@
                   "Name": "user",
                   "Sharded": true
                 },
-                "FieldQuery": "select `user`.col from `user` where 1 != 1",
+                "FieldQuery": "select /*vt+ PLANNER=left2right */ `user`.col from `user` where 1 != 1",
                 "Query": "select /*vt+ PLANNER=left2right */ `user`.col from `user`"
               },
               {
@@ -922,7 +922,7 @@
                   "Name": "main",
                   "Sharded": false
                 },
-                "FieldQuery": "select 1 from unsharded as m1 where 1 != 1",
+                "FieldQuery": "select /*vt+ PLANNER=left2right */ 1 from unsharded as m1 where 1 != 1",
                 "Query": "select /*vt+ PLANNER=left2right */ 1 from unsharded as m1"
               }
             ]
@@ -934,7 +934,7 @@
               "Name": "main",
               "Sharded": false
             },
-            "FieldQuery": "select 1 from unsharded as m2 where 1 != 1",
+            "FieldQuery": "select /*vt+ PLANNER=left2right */ 1 from unsharded as m2 where 1 != 1",
             "Query": "select /*vt+ PLANNER=left2right */ 1 from unsharded as m2"
           }
         ]


### PR DESCRIPTION
## Description

vtgate builds two SQL strings per `Route`: the main `Query`, rendered with the statement's comments — including the `SET_VAR(...)` hints used to propagate session system variables such as `sql_mode` — and a *field query* (an "impossible query" of the form `select ... where 1 != 1`) used to fetch column metadata. `FormatImpossibleQuery` dropped those comments, so the field query ran under the tablet's **default** session settings instead of the caller's.

The most visible symptom is `sql_mode`. An aggregation pushed through a join generates a leg like `select count(*), col from t ... group by .0`, whose validity under `only_full_group_by` depends on a relaxed `sql_mode`. When the session relaxes `sql_mode`, the main query carries `SET_VAR(sql_mode = ...)` and succeeds, but the field query lost the hint and failed with **errno 1055** under the tablet's strict default. This is reachable in plain buffered execution whenever a join's left-hand side returns no rows — `Join.TryExecute` fetches the right leg's fields via the field query.

The fix renders the statement's comments in the impossible query, so the field query carries the same hints as the main query. This isn't specific to `sql_mode`: any `SET_VAR` hint attached to the main query was previously lost on the field query.

> [!NOTE]
> **Backport reason (release-23.0, release-24.0):** This is a long-standing correctness bug, not a recent regression. A valid query can fail with `only_full_group_by` (errno 1055) whenever vtgate fetches column metadata via the field/impossible query — for example an aggregation through a join whose left-hand side returns no rows, or a prepared-statement field fetch — because that query is sent without the `SET_VAR(sql_mode = ...)` hint the main query carries. The fix is minimal and low-risk: it only makes the field query use the same session settings as the main query, so it is safe to backport to the supported releases.

## Related Issue(s)

Fixes #20365

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

Tests added:
- `TestFormatImpossibleQuery_Select` gains a case asserting query-hint comments are preserved (`go/vt/sqlparser/impossible_query_test.go`).
- `TestJoinAggregationEmptyLeft` — an e2e regression test that exercises an aggregation through a join with an empty left-hand side, so the field probe is hit in plain buffered execution. It fails on `main` with errno 1055 and passes with this change.

## Deployment Notes

Field queries now include the leading comments / query hints that the corresponding main query already carries (e.g. `SET_VAR`). There is no behavioral change beyond making field-metadata fetches use the same session settings as the main query.

### AI Disclosure

This PR was written primarily by Claude Code; I provided direction and review.

