### PR TITLE
Source build version metadata from VCS stamping to fix build-cache thrashing

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -21,6 +21,8 @@
         - [Consolidator Reject on Waiter Cap](#vttablet-consolidator-reject-on-cap)
     - **[VTTablet](#minor-changes-vttablet)**
         - [Schema engine table-count limit is now configurable](#vttablet-schema-max-table-count)
+    - **[General](#minor-changes-general)**
+        - [Build version metadata now sourced from VCS stamping](#build-info-from-vcs)
 
 ## <a id="major-changes"/>Major Changes</a>
 
@@ -136,3 +138,16 @@ Two changes:
 Tablets that already have more tracked schema objects than the configured limit will reload fine — only new creations are gated. Operators who need to support more tables and views should increase the flag and ensure both vttablet and mysqld have enough memory to comfortably hold the larger schema.
 
 See [#19978](https://github.com/vitessio/vitess/issues/19978) for details.
+
+### <a id="minor-changes-general"/>General</a>
+
+#### <a id="build-info-from-vcs"/>Build version metadata now sourced from VCS stamping</a>
+
+The build timestamp is no longer injected via linker flags. Because it changed on every `make build`, it forced every binary to be re-linked even when nothing else changed. Build metadata is now read from the VCS information the Go toolchain stamps into the binary (`runtime/debug.ReadBuildInfo`), which makes the linker flags stable across rebuilds and lets the build cache hit.
+
+User-visible consequences:
+
+- The `build_time` reported by `--version`, exposed via `/debug/vars` (`BuildTimestamp`), and set as a tablet tag (`build_time`) is now the **commit time** of the built revision rather than the wall-clock time of the build.
+- Binaries built from a dirty working tree report their Git revision with a `-dirty` suffix.
+
+The `BUILD_GIT_REV` and `BUILD_GIT_BRANCH` environment-variable overrides still work for builds without VCS metadata (e.g. from a release tarball).

--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -147,7 +147,7 @@ The build timestamp is no longer injected via linker flags. Because it changed o
 
 User-visible consequences:
 
-- The `build_time` reported by `--version`, exposed via `/debug/vars` (`BuildTimestamp`), and set as a tablet tag (`build_time`) is now the **commit time** of the built revision rather than the wall-clock time of the build.
+- The `build_time` reported by `--version`, exposed via `/debug/vars` (`BuildTimestamp`), and set as a tablet tag (`build_time`) now defaults to the **commit time** of the built revision rather than the wall-clock time of the build.
 - Binaries built from a dirty working tree report their Git revision with a `-dirty` suffix.
 
-The `BUILD_GIT_REV` and `BUILD_GIT_BRANCH` environment-variable overrides still work for builds without VCS metadata (e.g. from a release tarball).
+The `BUILD_GIT_REV`, `BUILD_GIT_BRANCH`, and `BUILD_TIME` environment-variable overrides still work for builds without VCS metadata (e.g. from a release tarball). When `BUILD_TIME` is set, it takes precedence over the commit time.

--- a/go/vt/servenv/buildinfo.go
+++ b/go/vt/servenv/buildinfo.go
@@ -19,6 +19,7 @@ package servenv
 import (
 	"fmt"
 	"runtime"
+	"runtime/debug"
 	"strconv"
 	"time"
 
@@ -30,7 +31,6 @@ import (
 var (
 	buildHost         = ""
 	buildUser         = ""
-	buildTime         = ""
 	buildGitRev       = ""
 	buildGitBranch    = ""
 	statsBuildVersion *stats.String
@@ -101,11 +101,58 @@ func (v *versionInfo) MySQLVersion() string {
 	return mySQLServerVersion
 }
 
-func init() {
-	t, err := time.Parse(time.UnixDate, buildTime)
-	if buildTime != "" && err != nil {
-		panic(fmt.Sprintf("Couldn't parse build timestamp %q: %v", buildTime, err))
+// readVCSInfo returns the VCS revision, commit time, and dirty state that the Go
+// toolchain stamps into the binary. The values are empty/false when the binary
+// was built without VCS metadata (for example from a release tarball).
+func readVCSInfo() (revision, revisionTime string, modified bool) {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "", "", false
 	}
+	for _, setting := range bi.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			revision = setting.Value
+		case "vcs.time":
+			revisionTime = setting.Value
+		case "vcs.modified":
+			modified = setting.Value == "true"
+		}
+	}
+	return revision, revisionTime, modified
+}
+
+// resolveGitRev prefers the VCS-stamped revision, falling back to the value
+// injected via ldflags when no VCS metadata is available. A dirty working tree
+// is reflected with a "-dirty" suffix.
+func resolveGitRev(vcsRevision string, modified bool, fallback string) string {
+	if vcsRevision == "" {
+		return fallback
+	}
+	if modified {
+		return vcsRevision + "-dirty"
+	}
+	return vcsRevision
+}
+
+// parseBuildTime converts the VCS-stamped commit time (RFC3339) into the pretty
+// string and Unix timestamp used by AppVersion. It returns zero values when no
+// commit time is available.
+func parseBuildTime(vcsTime string) (pretty string, unix int64) {
+	if vcsTime == "" {
+		return "", 0
+	}
+	t, err := time.Parse(time.RFC3339, vcsTime)
+	if err != nil {
+		panic(fmt.Sprintf("Couldn't parse build timestamp %q: %v", vcsTime, err))
+	}
+	return vcsTime, t.Unix()
+}
+
+func init() {
+	revision, revisionTime, modified := readVCSInfo()
+	gitRev := resolveGitRev(revision, modified, buildGitRev)
+	buildTimePretty, buildTime := parseBuildTime(revisionTime)
 
 	buildNumber, err := strconv.ParseInt(buildNumberStr, 10, 64)
 	if err != nil {
@@ -115,9 +162,9 @@ func init() {
 	AppVersion = versionInfo{
 		buildHost:       buildHost,
 		buildUser:       buildUser,
-		buildTime:       t.Unix(),
-		buildTimePretty: buildTime,
-		buildGitRev:     buildGitRev,
+		buildTime:       buildTime,
+		buildTimePretty: buildTimePretty,
+		buildGitRev:     gitRev,
 		buildGitBranch:  buildGitBranch,
 		buildNumber:     buildNumber,
 		buildSystem:     buildSystem,

--- a/go/vt/servenv/buildinfo.go
+++ b/go/vt/servenv/buildinfo.go
@@ -18,6 +18,7 @@ package servenv
 
 import (
 	"fmt"
+	"log/slog"
 	"runtime"
 	"runtime/debug"
 	"strconv"
@@ -26,11 +27,13 @@ import (
 	"github.com/spf13/pflag"
 
 	"vitess.io/vitess/go/stats"
+	"vitess.io/vitess/go/vt/log"
 )
 
 var (
 	buildHost         = ""
 	buildUser         = ""
+	buildTimeOverride = ""
 	buildGitRev       = ""
 	buildGitBranch    = ""
 	statsBuildVersion *stats.String
@@ -135,24 +138,35 @@ func resolveGitRev(vcsRevision string, modified bool, fallback string) string {
 	return vcsRevision
 }
 
-// parseBuildTime converts the VCS-stamped commit time (RFC3339) into the pretty
-// string and Unix timestamp used by AppVersion. It returns zero values when no
-// commit time is available.
-func parseBuildTime(vcsTime string) (pretty string, unix int64) {
-	if vcsTime == "" {
-		return "", 0
+// parseBuildTime resolves the build timestamp into the pretty string and Unix
+// timestamp used by AppVersion. An explicitly injected BUILD_TIME (via ldflags,
+// in time.UnixDate format) takes precedence so that package/tarball builds can set
+// it deliberately; otherwise it uses the VCS-stamped commit time (RFC3339), which
+// the Go toolchain records for normal git builds. An unparseable override is logged
+// and ignored so it falls through to the VCS time. It returns zero values when no
+// usable timestamp is available.
+func parseBuildTime(override, vcsTime string) (pretty string, unix int64) {
+	if override != "" {
+		t, err := time.Parse(time.UnixDate, override)
+		if err == nil {
+			return override, t.Unix()
+		}
+		log.Warn("Ignoring unparseable BUILD_TIME override", slog.String("build_time", override), slog.Any("error", err))
 	}
-	t, err := time.Parse(time.RFC3339, vcsTime)
-	if err != nil {
-		panic(fmt.Sprintf("Couldn't parse build timestamp %q: %v", vcsTime, err))
+	if vcsTime != "" {
+		t, err := time.Parse(time.RFC3339, vcsTime)
+		if err != nil {
+			panic(fmt.Sprintf("Couldn't parse build timestamp %q: %v", vcsTime, err))
+		}
+		return vcsTime, t.Unix()
 	}
-	return vcsTime, t.Unix()
+	return "", 0
 }
 
 func init() {
 	revision, revisionTime, modified := readVCSInfo()
 	gitRev := resolveGitRev(revision, modified, buildGitRev)
-	buildTimePretty, buildTime := parseBuildTime(revisionTime)
+	buildTimePretty, buildTime := parseBuildTime(buildTimeOverride, revisionTime)
 
 	buildNumber, err := strconv.ParseInt(buildNumberStr, 10, 64)
 	if err != nil {

--- a/go/vt/servenv/buildinfo_test.go
+++ b/go/vt/servenv/buildinfo_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVersionString(t *testing.T) {
@@ -51,6 +52,40 @@ func TestVersionString(t *testing.T) {
 	assert.Equal(t, "Version: v1.2.3-SNAPSHOT (GHA build 422) (Git revision d54b87ca0be09b678bb4490060e8f23f890ddb92 branch 'gitBranch') built on time is now by user@host using 1.20.2 amiga/amd64", v.String())
 
 	assert.Equal(t, "8.4.6-Vitess", v.MySQLVersion())
+}
+
+func TestResolveGitRev(t *testing.T) {
+	// VCS revision present and clean: used verbatim, ldflag fallback ignored.
+	assert.Equal(t, "abc123", resolveGitRev("abc123", false, "fallback"))
+
+	// VCS revision present and dirty: "-dirty" suffix appended.
+	assert.Equal(t, "abc123-dirty", resolveGitRev("abc123", true, "fallback"))
+
+	// No VCS revision (e.g. tarball build): the ldflag fallback is used as-is,
+	// regardless of the modified flag.
+	assert.Equal(t, "fallback", resolveGitRev("", false, "fallback"))
+	assert.Equal(t, "fallback", resolveGitRev("", true, "fallback"))
+
+	// No VCS revision and no fallback: empty.
+	assert.Empty(t, resolveGitRev("", false, ""))
+}
+
+func TestParseBuildTime(t *testing.T) {
+	// No commit time available yields zero values.
+	pretty, unix := parseBuildTime("")
+	assert.Empty(t, pretty)
+	assert.Equal(t, int64(0), unix)
+
+	// RFC3339 commit time (as stamped by the Go toolchain) is parsed.
+	const commitTime = "2020-09-15T12:04:10Z"
+	expected, err := time.Parse(time.RFC3339, commitTime)
+	require.NoError(t, err)
+	pretty, unix = parseBuildTime(commitTime)
+	assert.Equal(t, commitTime, pretty)
+	assert.Equal(t, expected.Unix(), unix)
+
+	// A non-RFC3339 value is unexpected from the toolchain and panics.
+	assert.Panics(t, func() { parseBuildTime("Tue Sep 15 12:04:10 UTC 2020") })
 }
 
 func TestBuildVersionStats(t *testing.T) {

--- a/go/vt/servenv/buildinfo_test.go
+++ b/go/vt/servenv/buildinfo_test.go
@@ -71,21 +71,46 @@ func TestResolveGitRev(t *testing.T) {
 }
 
 func TestParseBuildTime(t *testing.T) {
-	// No commit time available yields zero values.
-	pretty, unix := parseBuildTime("")
+	// No override and no commit time yields zero values.
+	pretty, unix := parseBuildTime("", "")
 	assert.Empty(t, pretty)
 	assert.Equal(t, int64(0), unix)
 
-	// RFC3339 commit time (as stamped by the Go toolchain) is parsed.
+	// RFC3339 commit time (as stamped by the Go toolchain) is parsed when no
+	// override is set.
 	const commitTime = "2020-09-15T12:04:10Z"
-	expected, err := time.Parse(time.RFC3339, commitTime)
+	expectedVCS, err := time.Parse(time.RFC3339, commitTime)
 	require.NoError(t, err)
-	pretty, unix = parseBuildTime(commitTime)
+	pretty, unix = parseBuildTime("", commitTime)
 	assert.Equal(t, commitTime, pretty)
-	assert.Equal(t, expected.Unix(), unix)
+	assert.Equal(t, expectedVCS.Unix(), unix)
 
-	// A non-RFC3339 value is unexpected from the toolchain and panics.
-	assert.Panics(t, func() { parseBuildTime("Tue Sep 15 12:04:10 UTC 2020") })
+	// An explicit BUILD_TIME override (UnixDate format, as emitted by `date`) is
+	// used as-is. This covers package/tarball builds.
+	const override = "Tue Sep 15 12:04:10 UTC 2020"
+	expectedOverride, err := time.Parse(time.UnixDate, override)
+	require.NoError(t, err)
+	pretty, unix = parseBuildTime(override, "")
+	assert.Equal(t, override, pretty)
+	assert.Equal(t, expectedOverride.Unix(), unix)
+
+	// The override takes precedence over the VCS commit time.
+	pretty, unix = parseBuildTime(override, commitTime)
+	assert.Equal(t, override, pretty)
+	assert.Equal(t, expectedOverride.Unix(), unix)
+
+	// An unparseable override is ignored and falls through to the VCS time.
+	pretty, unix = parseBuildTime("not a date", commitTime)
+	assert.Equal(t, commitTime, pretty)
+	assert.Equal(t, expectedVCS.Unix(), unix)
+
+	// An unparseable override with no VCS time yields zero values.
+	pretty, unix = parseBuildTime("not a date", "")
+	assert.Empty(t, pretty)
+	assert.Equal(t, int64(0), unix)
+
+	// A non-RFC3339 VCS time is unexpected from the toolchain and panics.
+	assert.Panics(t, func() { parseBuildTime("", "Tue Sep 15 12:04:10 UTC 2020") })
 }
 
 func TestBuildVersionStats(t *testing.T) {

--- a/tools/build_version_flags.sh
+++ b/tools/build_version_flags.sh
@@ -26,11 +26,21 @@ source $DIR/shell_functions.inc
 DEFAULT_BUILD_GIT_REV=$(git rev-parse HEAD)
 DEFAULT_BUILD_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
+# Only inject a build time when BUILD_TIME is explicitly set. Normal builds leave
+# it unset and source the commit time from VCS metadata instead; injecting a value
+# that changes on every build would thrash the linker's build cache. Package/tarball
+# builds that lack VCS metadata can set BUILD_TIME to retain build-time metadata.
+BUILD_TIME_FLAG=""
+if [ -n "${BUILD_TIME}" ]; then
+  BUILD_TIME_FLAG="-X 'vitess.io/vitess/go/vt/servenv.buildTimeOverride=${BUILD_TIME}'"
+fi
+
 echo "\
   -X 'vitess.io/vitess/go/vt/servenv.buildHost=$(hostname)' \
   -X 'vitess.io/vitess/go/vt/servenv.buildUser=$(whoami)' \
   -X 'vitess.io/vitess/go/vt/servenv.buildGitRev=${BUILD_GIT_REV:-$DEFAULT_BUILD_GIT_REV}' \
   -X 'vitess.io/vitess/go/vt/servenv.buildGitBranch=${BUILD_GIT_BRANCH:-$DEFAULT_BUILD_GIT_BRANCH}' \
+  ${BUILD_TIME_FLAG} \
   -X 'vitess.io/vitess/go/vt/servenv.buildNumberStr=${BUILD_NUMBER}' \
   -X 'vitess.io/vitess/go/vt/servenv.buildSystem=${BUILD_SYSTEM}' \
 "

--- a/tools/build_version_flags.sh
+++ b/tools/build_version_flags.sh
@@ -17,20 +17,20 @@
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]:-$0}" )" && pwd )
 source $DIR/shell_functions.inc
 
-# Normal builds run directly against the git repo, but when packaging (for example with rpms)
-# a tar ball might be used, which will prevent the git metadata from being available.
+# Normal builds run directly against the git repo, where the Go toolchain stamps
+# the revision, commit time, and dirty state into the binary automatically (read
+# back via runtime/debug.ReadBuildInfo). When packaging (for example with rpms) a
+# tar ball might be used, which prevents the git metadata from being available.
 # Should this be the case then allow environment variables to be used to source
-# this information instead.
+# the revision and branch instead.
 DEFAULT_BUILD_GIT_REV=$(git rev-parse HEAD)
 DEFAULT_BUILD_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-DEFAULT_BUILD_TIME=$(LC_ALL=C date)
 
 echo "\
   -X 'vitess.io/vitess/go/vt/servenv.buildHost=$(hostname)' \
   -X 'vitess.io/vitess/go/vt/servenv.buildUser=$(whoami)' \
   -X 'vitess.io/vitess/go/vt/servenv.buildGitRev=${BUILD_GIT_REV:-$DEFAULT_BUILD_GIT_REV}' \
   -X 'vitess.io/vitess/go/vt/servenv.buildGitBranch=${BUILD_GIT_BRANCH:-$DEFAULT_BUILD_GIT_BRANCH}' \
-  -X 'vitess.io/vitess/go/vt/servenv.buildTime=${BUILD_TIME:-$DEFAULT_BUILD_TIME}' \
   -X 'vitess.io/vitess/go/vt/servenv.buildNumberStr=${BUILD_NUMBER}' \
   -X 'vitess.io/vitess/go/vt/servenv.buildSystem=${BUILD_SYSTEM}' \
 "


### PR DESCRIPTION
## Description

The build timestamp was injected into every binary via `-ldflags -X` (`tools/build_version_flags.sh` used `$(date)`). Because that value changed on every invocation, it keyed the linker action's build cache and forced **every** Vitess binary to be re-linked on every `make build`, even when nothing else changed.

This stops injecting the timestamp via ldflags by default. Instead, the Git revision, commit time, and dirty state are read from the VCS information the Go toolchain already stamps into binaries (`runtime/debug.ReadBuildInfo`). The remaining ldflags are stable across rebuilds on the same commit, so the link cache hits.

What changed:

- `tools/build_version_flags.sh` no longer injects `buildTime` by default. It injects a `buildTimeOverride` ldflag **only when `BUILD_TIME` is explicitly set** (e.g. package/tarball/Docker builds), so normal builds keep stable link inputs. Everything else it set before (`buildHost`, `buildUser`, `buildGitRev`/`buildGitBranch` with their `BUILD_GIT_REV`/`BUILD_GIT_BRANCH` env fallbacks for tarball/rpm builds, `buildNumberStr`/`buildSystem`) is unchanged.
- `servenv` sources rev/commit-time/dirty from `debug.ReadBuildInfo()`. An explicitly-set `BUILD_TIME` takes precedence over the VCS commit time; the Git revision falls back to the `buildGitRev` ldflag when VCS metadata is absent. An unparseable `BUILD_TIME` is logged and ignored, falling through to the VCS time rather than panicking at startup.

Verified empirically: rebuilding with the new stable ldflags is a link cache hit (0 linker invocations); with a changing timestamp the linker re-runs every build (1 invocation).

This is a main-only change; I don't think it warrants a backport.

## Related Issue(s)

None — small build-system improvement. Happy to open a tracking issue if maintainers prefer one.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

This changes some user-visible build metadata (also captured in the v25.0.0 changelog):

- `build_time` (in `--version`, the `/debug/vars` `BuildTimestamp`, and the `build_time` tablet tag) now defaults to the **commit time** of the built revision rather than the wall-clock time of the build. Builds that explicitly set `BUILD_TIME` still get that value.
- Binaries built from a dirty working tree report their Git revision with a `-dirty` suffix.

## AI Disclosure

This PR was written primarily by Claude Code, with direction and review from me.
