### PR TITLE
Enforce stored-procedure safety checks on the streaming CALL path

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -87,15 +87,13 @@ type Conn struct {
 	// fields, this is set to an empty array (but not nil).
 	fields []*querypb.Field
 
-	// streamHadResultset records whether the most recent streaming query
-	// (ExecuteStreamFetch) returned a resultset rather than a bare OK packet.
-	streamHadResultset bool
-
-	// streamStatusFlags holds the status flags of the OK packet for a streaming
-	// query that returned no resultset. For such a query the OK packet is the
-	// only place its status flags appear, and ExecuteStreamFetch consumes it, so
-	// they are captured here for the caller to inspect once streaming completes.
-	streamStatusFlags uint16
+	// streamOK holds the OK packet of a streaming query (ExecuteStreamFetch) that
+	// returned no resultset — e.g. a CALL of a procedure that performs DML. For
+	// such a query the OK packet is the only place its RowsAffected, InsertID,
+	// Info and status flags appear, and ExecuteStreamFetch consumes it, so they
+	// are captured here for the caller to inspect once streaming completes. It is
+	// nil when the query returned a resultset, exposed via StreamOKResult.
+	streamOK *sqltypes.Result
 
 	// salt is sent by the server during initial handshake to be used for authentication
 	salt []byte

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -87,6 +87,16 @@ type Conn struct {
 	// fields, this is set to an empty array (but not nil).
 	fields []*querypb.Field
 
+	// streamHadResultset records whether the most recent streaming query
+	// (ExecuteStreamFetch) returned a resultset rather than a bare OK packet.
+	streamHadResultset bool
+
+	// streamStatusFlags holds the status flags of the OK packet for a streaming
+	// query that returned no resultset. For such a query the OK packet is the
+	// only place its status flags appear, and ExecuteStreamFetch consumes it, so
+	// they are captured here for the caller to inspect once streaming completes.
+	streamStatusFlags uint16
+
 	// salt is sent by the server during initial handshake to be used for authentication
 	salt []byte
 

--- a/go/mysql/streaming_query.go
+++ b/go/mysql/streaming_query.go
@@ -43,6 +43,10 @@ func (c *Conn) ExecuteStreamFetch(query string) (err error) {
 		return sqlerror.NewSQLError(sqlerror.CRCommandsOutOfSync, sqlerror.SSUnknownSQLState, "streaming query already in progress")
 	}
 
+	// Reset the status captured from the previous streaming query.
+	c.streamHadResultset = false
+	c.streamStatusFlags = 0
+
 	// Send the query as a COM_QUERY packet.
 	if err := c.WriteComQuery(query); err != nil {
 		return err
@@ -55,10 +59,13 @@ func (c *Conn) ExecuteStreamFetch(query string) (err error) {
 		return err
 	}
 	if colNumber == 0 {
-		// OK packet, means no results. Save an empty Fields array.
+		// OK packet, means no results. Save an empty Fields array. The status
+		// flags only appear on this OK packet, so capture them for the caller.
+		c.streamStatusFlags = packetOk.statusFlags
 		c.fields = make([]*querypb.Field, 0)
 		return nil
 	}
+	c.streamHadResultset = true
 
 	// Read the fields, save them.
 	fields := make([]querypb.Field, colNumber)
@@ -137,6 +144,14 @@ func (c *Conn) FetchNext(in []sqltypes.Value) ([]sqltypes.Value, error) {
 
 	// Regular row.
 	return c.parseRow(data, c.fields, readLenEncStringAsBytes, in)
+}
+
+// StreamResultStatus reports, for the streaming query started by the most
+// recent ExecuteStreamFetch, whether it returned a resultset and—when it did
+// not—the status flags from that query's OK packet. It is meant to be consulted
+// after the resultset (if any) has been fully fetched.
+func (c *Conn) StreamResultStatus() (hadResultset bool, statusFlags uint16) {
+	return c.streamHadResultset, c.streamStatusFlags
 }
 
 // CloseResult can be used to terminate a streaming query

--- a/go/mysql/streaming_query.go
+++ b/go/mysql/streaming_query.go
@@ -43,9 +43,8 @@ func (c *Conn) ExecuteStreamFetch(query string) (err error) {
 		return sqlerror.NewSQLError(sqlerror.CRCommandsOutOfSync, sqlerror.SSUnknownSQLState, "streaming query already in progress")
 	}
 
-	// Reset the status captured from the previous streaming query.
-	c.streamHadResultset = false
-	c.streamStatusFlags = 0
+	// Reset the OK packet captured from the previous streaming query.
+	c.streamOK = nil
 
 	// Send the query as a COM_QUERY packet.
 	if err := c.WriteComQuery(query); err != nil {
@@ -59,13 +58,21 @@ func (c *Conn) ExecuteStreamFetch(query string) (err error) {
 		return err
 	}
 	if colNumber == 0 {
-		// OK packet, means no results. Save an empty Fields array. The status
-		// flags only appear on this OK packet, so capture them for the caller.
-		c.streamStatusFlags = packetOk.statusFlags
+		// OK packet, means no results. Save an empty Fields array. The OK packet
+		// is the only place a no-resultset query's RowsAffected, InsertID, Info
+		// and status flags appear, so capture them for the caller, mirroring the
+		// Result the buffered ExecuteFetch path builds from the same packet.
+		c.streamOK = &sqltypes.Result{
+			RowsAffected:        packetOk.affectedRows,
+			InsertID:            packetOk.lastInsertID,
+			InsertIDChanged:     packetOk.lastInsertID > 0,
+			SessionStateChanges: packetOk.sessionStateData,
+			StatusFlags:         packetOk.statusFlags,
+			Info:                packetOk.info,
+		}
 		c.fields = make([]*querypb.Field, 0)
 		return nil
 	}
-	c.streamHadResultset = true
 
 	// Read the fields, save them.
 	fields := make([]querypb.Field, colNumber)
@@ -146,12 +153,12 @@ func (c *Conn) FetchNext(in []sqltypes.Value) ([]sqltypes.Value, error) {
 	return c.parseRow(data, c.fields, readLenEncStringAsBytes, in)
 }
 
-// StreamResultStatus reports, for the streaming query started by the most
-// recent ExecuteStreamFetch, whether it returned a resultset and—when it did
-// not—the status flags from that query's OK packet. It is meant to be consulted
-// after the resultset (if any) has been fully fetched.
-func (c *Conn) StreamResultStatus() (hadResultset bool, statusFlags uint16) {
-	return c.streamHadResultset, c.streamStatusFlags
+// StreamOKResult returns the OK-packet result of the streaming query started by
+// the most recent ExecuteStreamFetch when it returned no resultset (e.g. a CALL
+// of a procedure that performs DML), or nil when it returned a resultset. It is
+// meant to be consulted after the resultset (if any) has been fully fetched.
+func (c *Conn) StreamOKResult() *sqltypes.Result {
+	return c.streamOK
 }
 
 // CloseResult can be used to terminate a streaming query

--- a/go/mysql/streaming_query_test.go
+++ b/go/mysql/streaming_query_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mysql
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+// TestExecuteStreamFetchOKPacket verifies that a streaming query which returns an
+// OK packet instead of a result set (e.g. a CALL of a procedure that performs DML)
+// exposes the OK-packet RowsAffected and InsertID via StreamOKResult. This mirrors
+// the buffered ExecuteFetch path, which builds the same Result from the OK packet.
+func TestExecuteStreamFetchOKPacket(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	wg := sync.WaitGroup{}
+	var streamErr error
+	var okRes *sqltypes.Result
+	wg.Go(func() {
+		streamErr = cConn.ExecuteStreamFetch("CALL sp_insert()")
+		if streamErr != nil {
+			return
+		}
+		okRes = cConn.StreamOKResult()
+	})
+
+	// The server reads the COM_QUERY and responds with an OK packet carrying
+	// RowsAffected, InsertID and Info but no result set.
+	data, err := sConn.readEphemeralPacket()
+	require.NoError(t, err)
+	require.EqualValues(t, ComQuery, data[0])
+	sConn.recycleReadPacket()
+	require.NoError(t, sConn.writeOKPacket(&PacketOK{
+		affectedRows: 7,
+		lastInsertID: 99,
+	}))
+
+	wg.Wait()
+	require.NoError(t, streamErr)
+	require.NotNil(t, okRes, "streaming OK packet must be exposed via StreamOKResult")
+	assert.EqualValues(t, 7, okRes.RowsAffected)
+	assert.EqualValues(t, 99, okRes.InsertID)
+	assert.True(t, okRes.InsertIDChanged)
+}
+
+// TestExecuteStreamFetchNoOKResultForRows verifies that a streaming query which
+// returns a result set leaves StreamOKResult nil, so a later OK-packet query on a
+// recycled connection cannot observe a stale result.
+func TestExecuteStreamFetchNoOKResultForRows(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	result := &sqltypes.Result{
+		Fields: []*querypb.Field{{Type: querypb.Type_INT64, Name: "id"}},
+		Rows:   [][]sqltypes.Value{{sqltypes.MakeTrusted(querypb.Type_INT64, []byte("1"))}},
+	}
+
+	wg := sync.WaitGroup{}
+	var streamErr error
+	var okRes *sqltypes.Result
+	wg.Go(func() {
+		streamErr = cConn.ExecuteStreamFetch("select id from t")
+		if streamErr != nil {
+			return
+		}
+		okRes = cConn.StreamOKResult()
+		cConn.CloseResult()
+	})
+
+	handler := testHandler{result: result}
+	require.True(t, sConn.handleNextCommand(&handler))
+
+	wg.Wait()
+	require.NoError(t, streamErr)
+	assert.Nil(t, okRes, "a row-returning streaming query must not expose an OK result")
+}

--- a/go/vt/vttablet/endtoend/call_test.go
+++ b/go/vt/vttablet/endtoend/call_test.go
@@ -179,6 +179,25 @@ func TestCallProcedureStreamingMultiResultsetTxLeakClosesConnection(t *testing.T
 	assert.Empty(t, qr.Rows)
 }
 
+func TestCallProcedureStreamingMultiResultsetCleanConnectionReused(t *testing.T) {
+	setStreamPoolSize(t, 1)
+
+	client := framework.NewClient()
+
+	qr, err := client.StreamExecute("select connection_id()", nil)
+	require.NoError(t, err)
+	require.Len(t, qr.Rows, 1)
+	beforeConnID := qr.Rows[0][0].ToString()
+
+	_, err = client.StreamExecute("call proc_select4()", nil)
+	require.EqualError(t, err, "Multi-Resultset not supported in stored procedure (CallerID: dev)")
+
+	qr, err = client.StreamExecute("select connection_id()", nil)
+	require.NoError(t, err)
+	require.Len(t, qr.Rows, 1)
+	assert.Equal(t, beforeConnID, qr.Rows[0][0].ToString())
+}
+
 func TestCallProcedureStreamingCallbackErrorClosesConnection(t *testing.T) {
 	setStreamPoolSize(t, 1)
 

--- a/go/vt/vttablet/endtoend/call_test.go
+++ b/go/vt/vttablet/endtoend/call_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/vttablet/endtoend/framework"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
 var procSQL = []string{
@@ -95,6 +97,68 @@ func TestCallProcedure(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+		})
+	}
+}
+
+func TestCallProcedureStreaming(t *testing.T) {
+	client := framework.NewClient()
+	type testcases struct {
+		query   string
+		wantErr string
+	}
+	tcases := []testcases{{
+		// A single-resultset procedure legitimately benefits from streaming and
+		// is accepted, even though the buffered Execute path rejects it because
+		// of the trailing OK packet that follows the resultset.
+		query: "call proc_select1()",
+	}, {
+		// A multi-resultset procedure must be rejected, not silently truncated
+		// to its first resultset.
+		query:   "call proc_select4()",
+		wantErr: "Multi-Resultset not supported in stored procedure (CallerID: dev)",
+	}, {
+		// A procedure that returns no resultset and concludes its own transaction
+		// streams fine.
+		query: "call proc_dml()",
+	}, {
+		// Make sure the streaming connection isn't left dirty by the rejected
+		// multi-resultset procedure above.
+		query: "call proc_dml()",
+	}}
+
+	for _, tc := range tcases {
+		t.Run(tc.query, func(t *testing.T) {
+			_, err := client.StreamExecute(tc.query, nil)
+			if tc.wantErr != "" {
+				require.EqualError(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestCallProcedureLeakTxStreaming(t *testing.T) {
+	client := framework.NewClient()
+
+	_, err := client.StreamExecute(`call proc_tx_begin()`, nil)
+	require.EqualError(t, err, "Transaction not concluded inside the stored procedure, leaking transaction from stored procedure is not allowed (CallerID: dev)")
+}
+
+func TestCallProcedureChangedTxStreaming(t *testing.T) {
+	client := framework.NewClient()
+	defer client.Release()
+
+	queries := []string{
+		`call proc_tx_commit()`,
+		`call proc_tx_rollback()`,
+	}
+	for _, query := range queries {
+		t.Run(query, func(t *testing.T) {
+			_, err := client.StreamBeginExecuteWithOptions(query, nil, nil, &querypb.ExecuteOptions{IncludedFields: querypb.ExecuteOptions_ALL})
+			assert.EqualError(t, err, "Transaction state change inside the stored procedure is not allowed (CallerID: dev)")
+			client.Release()
 		})
 	}
 }

--- a/go/vt/vttablet/endtoend/call_test.go
+++ b/go/vt/vttablet/endtoend/call_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/vttablet/endtoend/framework"
 
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -38,6 +39,13 @@ var procSQL = []string{
 		select intval from vitess_test;
 		select intval from vitess_test;
 		select intval from vitess_test;
+	END;`,
+	`create procedure proc_select2_tx_insert()
+	BEGIN
+		select intval from vitess_test;
+		select intval from vitess_test;
+		start transaction;
+		insert into vitess_test(intval) values(8675309);
 	END;`,
 	`create procedure proc_dml()
 	BEGIN
@@ -137,6 +145,70 @@ func TestCallProcedureStreaming(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestCallProcedureStreamingMultiResultsetTxLeakClosesConnection(t *testing.T) {
+	setStreamPoolSize(t, 1)
+
+	client := framework.NewClient()
+	checkClient := framework.NewClient()
+	_, _ = checkClient.Execute("delete from vitess_test where intval = 8675309", nil)
+	t.Cleanup(func() {
+		_, _ = checkClient.Execute("delete from vitess_test where intval = 8675309", nil)
+	})
+
+	qr, err := client.StreamExecute("select connection_id()", nil)
+	require.NoError(t, err)
+	require.Len(t, qr.Rows, 1)
+	beforeConnID := qr.Rows[0][0].ToString()
+
+	_, err = client.StreamExecute("call proc_select2_tx_insert()", nil)
+	require.EqualError(t, err, "Multi-Resultset not supported in stored procedure (CallerID: dev)")
+
+	qr, err = client.StreamExecute("select connection_id()", nil)
+	require.NoError(t, err)
+	require.Len(t, qr.Rows, 1)
+	afterConnID := qr.Rows[0][0].ToString()
+
+	_, err = client.StreamExecute("call proc_tx_commit()", nil)
+	require.NoError(t, err)
+
+	qr, err = checkClient.Execute("select intval from vitess_test where intval = 8675309", nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, beforeConnID, afterConnID)
+	assert.Empty(t, qr.Rows)
+}
+
+func TestCallProcedureStreamingCallbackErrorClosesConnection(t *testing.T) {
+	setStreamPoolSize(t, 1)
+
+	client := framework.NewClient()
+
+	qr, err := client.StreamExecute("select connection_id()", nil)
+	require.NoError(t, err)
+	require.Len(t, qr.Rows, 1)
+	beforeConnID := qr.Rows[0][0].ToString()
+
+	err = client.Stream("call proc_select1()", nil, func(*sqltypes.Result) error {
+		return assert.AnError
+	})
+	require.ErrorContains(t, err, assert.AnError.Error())
+
+	qr, err = client.StreamExecute("select connection_id(), intval from vitess_test where intval = 1", nil)
+	require.NoError(t, err)
+	require.Len(t, qr.Rows, 1)
+	assert.NotEqual(t, beforeConnID, qr.Rows[0][0].ToString())
+	assert.Equal(t, "1", qr.Rows[0][1].ToString())
+}
+
+func setStreamPoolSize(t *testing.T, size int) {
+	t.Helper()
+
+	defaultPoolSize := framework.Server.StreamPoolSize()
+	require.NoError(t, framework.Server.SetStreamPoolSize(t.Context(), size))
+	t.Cleanup(func() {
+		require.NoError(t, framework.Server.SetStreamPoolSize(t.Context(), defaultPoolSize))
+	})
 }
 
 func TestCallProcedureLeakTxStreaming(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/connpool/dbconn.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn.go
@@ -242,6 +242,12 @@ func (dbc *Conn) FetchNext(ctx context.Context, maxrows int, wantfields bool) (*
 	return res, err
 }
 
+// StreamResultStatus reports, for the most recent streaming query, whether it
+// returned a resultset and—when it did not—the status flags from its OK packet.
+func (dbc *Conn) StreamResultStatus() (hadResultset bool, statusFlags uint16) {
+	return dbc.conn.StreamResultStatus()
+}
+
 // Stream executes the query and streams the results.
 func (dbc *Conn) Stream(ctx context.Context, query string, callback func(*sqltypes.Result) error, alloc func() *sqltypes.Result, streamBufferSize int, includedFields querypb.ExecuteOptions_IncludedFields) error {
 	span, ctx := trace.NewSpan(ctx, "DBConn.Stream")

--- a/go/vt/vttablet/tabletserver/connpool/dbconn.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn.go
@@ -242,10 +242,11 @@ func (dbc *Conn) FetchNext(ctx context.Context, maxrows int, wantfields bool) (*
 	return res, err
 }
 
-// StreamResultStatus reports, for the most recent streaming query, whether it
-// returned a resultset and—when it did not—the status flags from its OK packet.
-func (dbc *Conn) StreamResultStatus() (hadResultset bool, statusFlags uint16) {
-	return dbc.conn.StreamResultStatus()
+// StreamOKResult returns the OK-packet result of the most recent streaming query
+// when it returned no resultset (e.g. a CALL of a procedure that performs DML),
+// or nil when it returned a resultset.
+func (dbc *Conn) StreamOKResult() *sqltypes.Result {
+	return dbc.conn.StreamOKResult()
 }
 
 // Stream executes the query and streams the results.

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -278,9 +278,14 @@ func BuildStreaming(statement sqlparser.Statement, tables map[string]*schema.Tab
 			plan.NeedsReservedConn = true
 		}
 		plan.Table = lookupTables(stmt.From, tables)
-	case *sqlparser.Show, *sqlparser.Union, *sqlparser.CallProc, sqlparser.Explain:
+	case *sqlparser.Show, *sqlparser.Union, sqlparser.Explain:
 		plan = &Plan{
 			PlanID:    PlanSelectStream,
+			FullQuery: GenerateFullQuery(statement),
+		}
+	case *sqlparser.CallProc:
+		plan = &Plan{
+			PlanID:    PlanCallProc,
 			FullQuery: GenerateFullQuery(statement),
 		}
 	case *sqlparser.Analyze:

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -407,8 +407,9 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 
 	// if we have a transaction id, let's use the txPool for this query
 	var conn *connpool.PooledConn
+	var txConn *StatefulConnection
 	if qre.connID != 0 {
-		txConn, err := qre.tsv.te.txPool.GetAndLock(qre.connID, "for streaming query")
+		txConn, err = qre.tsv.te.txPool.GetAndLock(qre.connID, "for streaming query")
 		if err != nil {
 			return err
 		}
@@ -428,7 +429,7 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 		conn = dbConn
 	}
 
-	return qre.execStreamSQL(conn, qre.connID != 0, sql, func(result *sqltypes.Result) error {
+	err = qre.execStreamSQL(conn, qre.connID != 0, sql, func(result *sqltypes.Result) error {
 		// this stream result is only used by the calling client, so it can be
 		// returned to the pool once the callback has fully returned
 		defer returnStreamResult(result)
@@ -438,6 +439,14 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 		}
 		return callback(result)
 	})
+	if err != nil {
+		return err
+	}
+
+	if qre.plan.PlanID == p.PlanCallProc {
+		return qre.verifyStreamedCallProc(conn.Conn, txConn)
+	}
+	return nil
 }
 
 // streamDML executes a DML statement on the streaming path. A DML produces a
@@ -1117,6 +1126,71 @@ func (qre *QueryExecutor) execProc(conn *StatefulConnection) (*sqltypes.Result, 
 		return nil, err
 	}
 	return nil, vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "Multi-Resultset not supported in stored procedure")
+}
+
+// verifyStreamedCallProc enforces, after a stored procedure call has been
+// streamed, the same safety checks the buffered execCallProc/execProc apply: a
+// procedure must not return more than one resultset, nor leak or change the
+// transaction state. Unlike the buffered path, a single-resultset procedure is
+// allowed here, since streaming such a result is the whole point of the
+// streaming path. txConn is non-nil only when the call ran inside an existing
+// transaction or reserved connection.
+func (qre *QueryExecutor) verifyStreamedCallProc(conn *connpool.Conn, txConn *StatefulConnection) error {
+	hadResultset, statusFlags := conn.StreamResultStatus()
+	trailing := &sqltypes.Result{StatusFlags: statusFlags}
+
+	if hadResultset {
+		// A streamed resultset's terminating EOF always reports more results, as a
+		// stored procedure call is followed by a trailing status packet. Read one
+		// more result, discarding its rows, to tell a single-resultset call (only
+		// the trailing packet remains) from a multi-resultset one.
+		var err error
+		trailing, err = conn.FetchNext(qre.ctx, mysql.FETCH_NO_ROWS, false)
+		if err != nil {
+			return err
+		}
+		if trailing.IsMoreResultsExists() {
+			// More than one resultset: drain the rest so the connection stays clean
+			// for reuse, then reject like the buffered path does.
+			if err := qre.drainStreamedResultSets(conn); err != nil {
+				return err
+			}
+			return vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "Multi-Resultset not supported in stored procedure")
+		}
+	}
+
+	if txConn == nil {
+		// No transaction was active before the call (a stream pool connection); a
+		// procedure that leaves one open leaks it onto a pooled connection.
+		if trailing.IsInTransaction() {
+			conn.Close()
+			return vterrors.New(vtrpcpb.Code_CANCELED, "Transaction not concluded inside the stored procedure, leaking transaction from stored procedure is not allowed")
+		}
+		return nil
+	}
+
+	// A transaction or reserved connection was already active; the procedure must
+	// not change the transaction state.
+	if txConn.IsInTransaction() != trailing.IsInTransaction() {
+		txConn.Close()
+		return vterrors.New(vtrpcpb.Code_CANCELED, "Transaction state change inside the stored procedure is not allowed")
+	}
+	return nil
+}
+
+// drainStreamedResultSets discards any remaining resultsets on a streaming
+// connection without buffering their rows, leaving the connection clean for
+// reuse.
+func (qre *QueryExecutor) drainStreamedResultSets(conn *connpool.Conn) error {
+	for {
+		qr, err := conn.FetchNext(qre.ctx, mysql.FETCH_NO_ROWS, false)
+		if err != nil {
+			return err
+		}
+		if !qr.IsMoreResultsExists() {
+			return nil
+		}
+	}
 }
 
 func (qre *QueryExecutor) execAlterMigration() (*sqltypes.Result, error) {

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -440,6 +440,9 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 		return callback(result)
 	})
 	if err != nil {
+		if qre.plan.PlanID == p.PlanCallProc {
+			conn.Close()
+		}
 		return err
 	}
 
@@ -1150,11 +1153,13 @@ func (qre *QueryExecutor) verifyStreamedCallProc(conn *connpool.Conn, txConn *St
 			return err
 		}
 		if trailing.IsMoreResultsExists() {
-			// More than one resultset: drain the rest so the connection stays clean
-			// for reuse, then reject like the buffered path does.
+			// More than one resultset: drain the rest, close the connection, then
+			// reject like the buffered path does.
 			if err := qre.drainStreamedResultSets(conn); err != nil {
+				conn.Close()
 				return err
 			}
+			conn.Close()
 			return vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "Multi-Resultset not supported in stored procedure")
 		}
 	}

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -1153,17 +1153,24 @@ func (qre *QueryExecutor) verifyStreamedCallProc(conn *connpool.Conn, txConn *St
 			return err
 		}
 		if trailing.IsMoreResultsExists() {
-			// More than one resultset: drain the rest, close the connection, then
-			// reject like the buffered path does.
-			if err := qre.drainStreamedResultSets(conn); err != nil {
+			// More than one resultset: drain the rest, then reject like the
+			// buffered path does. Preserve the multi-resultset error for callers,
+			// but still close the connection if the final status shows that the
+			// procedure changed transaction state.
+			trailing, err = qre.drainStreamedResultSets(conn)
+			if err != nil {
 				conn.Close()
 				return err
 			}
-			conn.Close()
+			_ = qre.verifyStreamedCallProcTransactionState(conn, txConn, trailing)
 			return vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "Multi-Resultset not supported in stored procedure")
 		}
 	}
 
+	return qre.verifyStreamedCallProcTransactionState(conn, txConn, trailing)
+}
+
+func (qre *QueryExecutor) verifyStreamedCallProcTransactionState(conn *connpool.Conn, txConn *StatefulConnection, trailing *sqltypes.Result) error {
 	if txConn == nil {
 		// No transaction was active before the call (a stream pool connection); a
 		// procedure that leaves one open leaks it onto a pooled connection.
@@ -1184,16 +1191,16 @@ func (qre *QueryExecutor) verifyStreamedCallProc(conn *connpool.Conn, txConn *St
 }
 
 // drainStreamedResultSets discards any remaining resultsets on a streaming
-// connection without buffering their rows, leaving the connection clean for
-// reuse.
-func (qre *QueryExecutor) drainStreamedResultSets(conn *connpool.Conn) error {
+// connection without buffering their rows and returns the final result, whose
+// status flags describe the connection state after the stored procedure.
+func (qre *QueryExecutor) drainStreamedResultSets(conn *connpool.Conn) (*sqltypes.Result, error) {
 	for {
 		qr, err := conn.FetchNext(qre.ctx, mysql.FETCH_NO_ROWS, false)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if !qr.IsMoreResultsExists() {
-			return nil
+			return qr, nil
 		}
 	}
 }

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -405,31 +405,7 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 		}
 	}
 
-	// if we have a transaction id, let's use the txPool for this query
-	var conn *connpool.PooledConn
-	var txConn *StatefulConnection
-	if qre.connID != 0 {
-		txConn, err = qre.tsv.te.txPool.GetAndLock(qre.connID, "for streaming query")
-		if err != nil {
-			return err
-		}
-		defer txConn.Unlock()
-		if qre.setting != nil {
-			if _, err = txConn.ApplySetting(qre.ctx, qre.setting); err != nil {
-				return vterrors.Wrap(err, "failed to execute system setting on the connection")
-			}
-		}
-		conn = txConn.UnderlyingDBConn()
-	} else {
-		dbConn, err := qre.getStreamConn()
-		if err != nil {
-			return err
-		}
-		defer dbConn.Recycle()
-		conn = dbConn
-	}
-
-	err = qre.execStreamSQL(conn, qre.connID != 0, sql, func(result *sqltypes.Result) error {
+	streamCallback := func(result *sqltypes.Result) error {
 		// this stream result is only used by the calling client, so it can be
 		// returned to the pool once the callback has fully returned
 		defer returnStreamResult(result)
@@ -438,18 +414,86 @@ func (qre *QueryExecutor) Stream(callback StreamCallback) error {
 			result.ReplaceKeyspace(qre.tsv.config.DB.DBName, replaceKeyspace)
 		}
 		return callback(result)
-	})
-	if err != nil {
+	}
+
+	// If we have a transaction id, stream on the txPool connection; otherwise
+	// stream on a stream pool connection. Each branch holds the concrete
+	// connection it must clean up. For a stored procedure call, a mid-stream
+	// error closes that connection — it may have left trailing resultsets or the
+	// final OK packet unread, or already be killed, and the client is gone, so we
+	// close rather than attempt a drain-and-recover — while a clean stream runs
+	// the post-stream safety checks.
+	if qre.connID != 0 {
+		txConn, err := qre.tsv.te.txPool.GetAndLock(qre.connID, "for streaming query")
+		if err != nil {
+			return err
+		}
+		defer txConn.Unlock()
+		if qre.setting != nil {
+			if _, err := txConn.ApplySetting(qre.ctx, qre.setting); err != nil {
+				return vterrors.Wrap(err, "failed to execute system setting on the connection")
+			}
+		}
+
+		conn := txConn.UnderlyingDBConn()
+		err = qre.execStreamSQL(conn, true, sql, streamCallback)
 		if qre.plan.PlanID == p.PlanCallProc {
-			conn.Close()
+			if err != nil {
+				txConn.Close()
+				return err
+			}
+			trailing, multipleResultsets, err := qre.streamedCallProcTrailingStatus(conn.Conn)
+			if err != nil {
+				txConn.Close()
+				return err
+			}
+			// The procedure must not change the transaction state.
+			changedTx := txConn.IsInTransaction() != trailing.IsInTransaction()
+			if changedTx {
+				txConn.Close()
+			}
+			if multipleResultsets {
+				return vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "Multi-Resultset not supported in stored procedure")
+			}
+			if changedTx {
+				return vterrors.New(vtrpcpb.Code_CANCELED, "Transaction state change inside the stored procedure is not allowed")
+			}
+			return nil
 		}
 		return err
 	}
 
-	if qre.plan.PlanID == p.PlanCallProc {
-		return qre.verifyStreamedCallProc(conn.Conn, txConn)
+	dbConn, err := qre.getStreamConn()
+	if err != nil {
+		return err
 	}
-	return nil
+	defer dbConn.Recycle()
+
+	err = qre.execStreamSQL(dbConn, false, sql, streamCallback)
+	if qre.plan.PlanID == p.PlanCallProc {
+		if err != nil {
+			dbConn.Close()
+			return err
+		}
+		trailing, multipleResultsets, err := qre.streamedCallProcTrailingStatus(dbConn.Conn)
+		if err != nil {
+			dbConn.Close()
+			return err
+		}
+		// The procedure must not leak a transaction onto the pooled connection.
+		leakedTx := trailing.IsInTransaction()
+		if leakedTx {
+			dbConn.Close()
+		}
+		if multipleResultsets {
+			return vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "Multi-Resultset not supported in stored procedure")
+		}
+		if leakedTx {
+			return vterrors.New(vtrpcpb.Code_CANCELED, "Transaction not concluded inside the stored procedure, leaking transaction from stored procedure is not allowed")
+		}
+		return nil
+	}
+	return err
 }
 
 // streamDML executes a DML statement on the streaming path. A DML produces a
@@ -1131,63 +1175,38 @@ func (qre *QueryExecutor) execProc(conn *StatefulConnection) (*sqltypes.Result, 
 	return nil, vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "Multi-Resultset not supported in stored procedure")
 }
 
-// verifyStreamedCallProc enforces, after a stored procedure call has been
-// streamed, the same safety checks the buffered execCallProc/execProc apply: a
-// procedure must not return more than one resultset, nor leak or change the
-// transaction state. Unlike the buffered path, a single-resultset procedure is
-// allowed here, since streaming such a result is the whole point of the
-// streaming path. txConn is non-nil only when the call ran inside an existing
-// transaction or reserved connection.
-func (qre *QueryExecutor) verifyStreamedCallProc(conn *connpool.Conn, txConn *StatefulConnection) error {
+// streamedCallProcTrailingStatus reads what follows a streamed stored procedure
+// call's first resultset to determine the connection's final state. It returns
+// the trailing status — whose flags describe the post-call transaction state —
+// and whether the call produced more than one resultset (already drained). A
+// stored procedure call is always followed by a trailing status packet, so a
+// streamed resultset's EOF always reports more results; reading one more result
+// tells a single-resultset call (only the trailing packet remains) from a
+// multi-resultset one.
+func (qre *QueryExecutor) streamedCallProcTrailingStatus(conn *connpool.Conn) (trailing *sqltypes.Result, multipleResultsets bool, err error) {
 	hadResultset, statusFlags := conn.StreamResultStatus()
-	trailing := &sqltypes.Result{StatusFlags: statusFlags}
-
-	if hadResultset {
-		// A streamed resultset's terminating EOF always reports more results, as a
-		// stored procedure call is followed by a trailing status packet. Read one
-		// more result, discarding its rows, to tell a single-resultset call (only
-		// the trailing packet remains) from a multi-resultset one.
-		var err error
-		trailing, err = conn.FetchNext(qre.ctx, mysql.FETCH_NO_ROWS, false)
-		if err != nil {
-			return err
-		}
-		if trailing.IsMoreResultsExists() {
-			// More than one resultset: drain the rest, then reject like the
-			// buffered path does. Preserve the multi-resultset error for callers,
-			// but still close the connection if the final status shows that the
-			// procedure changed transaction state.
-			trailing, err = qre.drainStreamedResultSets(conn)
-			if err != nil {
-				conn.Close()
-				return err
-			}
-			_ = qre.verifyStreamedCallProcTransactionState(conn, txConn, trailing)
-			return vterrors.New(vtrpcpb.Code_UNIMPLEMENTED, "Multi-Resultset not supported in stored procedure")
-		}
+	if !hadResultset {
+		// No resultset was streamed, so the OK packet's status flags are all there
+		// is to inspect.
+		return &sqltypes.Result{StatusFlags: statusFlags}, false, nil
 	}
 
-	return qre.verifyStreamedCallProcTransactionState(conn, txConn, trailing)
-}
-
-func (qre *QueryExecutor) verifyStreamedCallProcTransactionState(conn *connpool.Conn, txConn *StatefulConnection, trailing *sqltypes.Result) error {
-	if txConn == nil {
-		// No transaction was active before the call (a stream pool connection); a
-		// procedure that leaves one open leaks it onto a pooled connection.
-		if trailing.IsInTransaction() {
-			conn.Close()
-			return vterrors.New(vtrpcpb.Code_CANCELED, "Transaction not concluded inside the stored procedure, leaking transaction from stored procedure is not allowed")
-		}
-		return nil
+	trailing, err = conn.FetchNext(qre.ctx, mysql.FETCH_NO_ROWS, false)
+	if err != nil {
+		return nil, false, err
+	}
+	if !trailing.IsMoreResultsExists() {
+		// Only the trailing status packet followed the single resultset.
+		return trailing, false, nil
 	}
 
-	// A transaction or reserved connection was already active; the procedure must
-	// not change the transaction state.
-	if txConn.IsInTransaction() != trailing.IsInTransaction() {
-		txConn.Close()
-		return vterrors.New(vtrpcpb.Code_CANCELED, "Transaction state change inside the stored procedure is not allowed")
+	// More than one resultset: drain the rest without buffering so the final
+	// status reflects the connection state and the connection stays clean.
+	trailing, err = qre.drainStreamedResultSets(conn)
+	if err != nil {
+		return nil, true, err
 	}
-	return nil
+	return trailing, true, nil
 }
 
 // drainStreamedResultSets discards any remaining resultsets on a streaming

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -1184,11 +1184,10 @@ func (qre *QueryExecutor) execProc(conn *StatefulConnection) (*sqltypes.Result, 
 // tells a single-resultset call (only the trailing packet remains) from a
 // multi-resultset one.
 func (qre *QueryExecutor) streamedCallProcTrailingStatus(conn *connpool.Conn) (trailing *sqltypes.Result, multipleResultsets bool, err error) {
-	hadResultset, statusFlags := conn.StreamResultStatus()
-	if !hadResultset {
+	if okResult := conn.StreamOKResult(); okResult != nil {
 		// No resultset was streamed, so the OK packet's status flags are all there
 		// is to inspect.
-		return &sqltypes.Result{StatusFlags: statusFlags}, false, nil
+		return &sqltypes.Result{StatusFlags: okResult.StatusFlags}, false, nil
 	}
 
 	trailing, err = conn.FetchNext(qre.ctx, mysql.FETCH_NO_ROWS, false)


### PR DESCRIPTION
## Description

`StreamExecute` (the OLAP / streaming path) was sending a `CALL` straight through `execStreamSQL`, which reads only the first resultset and throws away the terminating status flags. So the two safety checks the buffered `Execute` path enforces never ran on the streaming path:

- a **multi-resultset** procedure silently returned only its first resultset (truncated/wrong data, no error), and
- a procedure that **leaked or changed a transaction** was silently accepted, leaving the recycled streaming connection in an open transaction.

While digging in I also found that a perfectly fine *single-resultset* `CALL` left its trailing OK packet unread on the connection, so the next query that reused that pooled connection could blow up with an out-of-sequence error. The new test ordering (a single-resultset call followed by a multi-resultset one) reproduces that.

### How it works

The streaming protocol now records whether a query returned a resultset and, when it didn't, captures the status flags of the lone OK packet (the only place a no-resultset procedure's `IN_TRANS` flag is observable). A streamed `CALL` is then verified after streaming finishes: we read exactly one more result — with `FETCH_NO_ROWS`, so nothing is buffered — to tell a single-resultset call (only the trailing OK packet remains) from a multi-resultset one, drain any remainder so the connection stays clean for reuse, and reject a leaked/changed transaction (closing the connection in that case, like the buffered path does).

To get there, a streamed `CALL` is now planned as `PlanCallProc` instead of `PlanSelectStream`. That's what lets `Stream()` dispatch it to the new check, and it also takes it out of stream consolidation — which is the right thing regardless of this fix. Consolidation hands one execution's results to multiple concurrent callers of an identical query; that's safe for a plain `SELECT`, but a stored procedure can do DML, change transaction state, or otherwise have side effects, and every caller of a `CALL` expects their own invocation to actually run. Sharing a single procedure execution across callers was never correct, so classifying `CALL` as `PlanCallProc` (which the consolidator path is gated against) fixes that too.

### Deliberate deviation from `Execute`

This is **not** strict parity, on purpose. The buffered `Execute` path rejects *any* `CALL` that returns a resultset at all — even a single `SELECT` — because of the trailing OK packet that follows it (see `TestCallProcedure`, where `proc_select1` is a `wantErr` case). On the streaming path we deliberately **allow** a single-resultset `CALL` to stream, since streaming a large resultset is the whole reason to use this path; forcing every `CALL` through the buffered path would re-impose `maxResultSize` and defeat that. We still reject multi-resultset and transaction-leaking procedures, with the same error messages as `Execute`.

For what it's worth, the `Execute` behavior here looks wrong to me: rejecting a procedure that returns a single resultset with "Multi-Resultset not supported" is surprising, and a single-resultset `CALL` is a perfectly reasonable thing to want to run. But changing that is a user-visible behavior change on the buffered path with its own compatibility and test implications, so it should be done separately and deliberately rather than smuggled in here. This PR intentionally leaves `Execute` exactly as it is and only makes the streaming path safe; the streaming path just happens to be the more permissive (and, I'd argue, more correct) of the two for the single-resultset case.

One inherent consequence: for a multi-resultset `CALL` we've already streamed the first resultset's rows to the client by the time we can see the violation, so the client gets rows followed by an error (whereas `Execute` buffers and sends nothing). That's unavoidable without giving up streaming, and the blast radius is limited to the offending query.

## Related Issue(s)

Fixes #20371

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

### On backporting

This touches the MySQL protocol layer and changes how a streamed `CALL` is planned, so it's a bit more than a one-line bug fix and arguably more than you'd usually want in a backport. I think it's worth backporting anyway:

- It's a **silent correctness bug**: callers get truncated/wrong data from a multi-resultset `CALL` with `err == nil`, and a transaction leaked onto a pooled streaming connection can later surface out of band as an opaque `Code: CANCELED` on an *unrelated* query — very hard to diagnose in the field.
- It includes a real **connection-hygiene fix**: a successful single-resultset streamed `CALL` previously left its trailing OK packet on the connection, poisoning the next reuse. That's a latent source of flaky, hard-to-reproduce errors on the OLAP stream pool.
- The behavioral change is **narrowly scoped to the `CALL` path** and brings it in line with the long-standing buffered `Execute` behavior; it doesn't touch regular streaming SELECTs.

## Deployment Notes

Streamed `CALL`s are no longer eligible for stream consolidation (sharing one procedure execution across concurrent callers was never correct — see above), and their query-timing / log-stats now bucket under `CallProc` instead of `SelectStream` (matching the buffered `Execute` path). A multi-resultset or transaction-leaking `CALL` over `StreamExecute` now returns an error where it previously returned partial data or silently succeeded.

### AI Disclosure

This PR was written primarily by Claude Code — I provided the direction and review.
