### PR TITLE
vtgate healthcheck: log tablet alias instead of full Tablet struct on stale-update skip

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -531,7 +531,7 @@ func (hc *HealthCheckImpl) updateHealth(thc *tabletHealthCheck, prevTarget *quer
 	defer hc.mu.Unlock()
 	// Verify that this update came from the tabletHealthCheck currently registered for this alias.
 	if !hc.isRegisteredHealthCheckLocked(tabletAlias, thc) {
-		hc.logger().Infof("Tablet %v has been deleted or replaced, skipping health update", thc.Tablet)
+		hc.logger().Infof("Tablet %v has been deleted or replaced, skipping health update", tabletAlias)
 		return
 	}
 


### PR DESCRIPTION
## Description

Follow-up to #20328. While reviewing that PR, @mattlord pointed out in https://github.com/vitessio/vitess/pull/20328#discussion_r3421964409 that the stale-update skip log in `updateHealth` printed the full `Tablet` struct via `%v`, which is noisy and hard to read.

This swaps it for the already-computed `tabletAlias` (a readable `zone-uid` string), which is more meaningful to a human reading the logs. No behavioral change.

This doesn't need a backport: the same change has already been applied directly to the #20328 backport branches in #20374 (release-23.0) and #20375 (release-24.0).

## Related Issue(s)

Follow-up to #20328.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Log message change only; no configuration or migration changes required.

### AI Disclosure

This PR was written by Claude Code, with direction and review from me.
