### PR TITLE
go/mysql: streaming errors no longer surface as connection loss

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -17,6 +17,7 @@
         - [Default data protection for `_reverse` workflow cancel/complete](#vreplication-reverse-workflow-data-protection)
     - **[VTGate](#minor-changes-vtgate)**
         - [New controls for cross-keyspace reads](#vtgate-cross-keyspace-reads)
+        - [Streaming errors no longer surface as connection loss](#vtgate-streamexecute-real-errors)
     - **[VTTablet](#minor-changes-vttablet)**
         - [Consolidator Reject on Waiter Cap](#vttablet-consolidator-reject-on-cap)
     - **[VTTablet](#minor-changes-vttablet)**
@@ -113,6 +114,14 @@ When enabled, the planner will reject queries that require joining or combining 
 ```
 
 The VTGate flag prevents cross-keyspace reads globally, regardless of per-keyspace VSchema settings.
+
+#### <a id="vtgate-streamexecute-real-errors"/>Streaming errors no longer surface as connection loss</a>
+
+Streaming queries (under `SET workload = 'OLAP'`, multi-statement batches, and prepared-statement execution) previously returned `ERROR 2013 (HY000): Lost connection to MySQL server during query` and tore down the underlying TCP connection whenever the streaming handler returned an error *after* the first row or field packet had been emitted. VTGate now writes a proper ERR packet in place of the result-set terminator, so the real error code and message reach the client and the connection remains usable for subsequent queries.
+
+This affects all three streaming code paths in `go/mysql`: `COM_QUERY` (text protocol), multi-statement `COM_QUERY`, and `COM_STMT_EXECUTE` (binary protocol).
+
+**Impact**: Application error-handling and retry logic that branched on `2013 / Lost connection` will now see the real error code — for example, `errno 1317 / context canceled` after a `KILL QUERY` against a streaming session, or planner errors such as `specifying two different database in the query is not supported`.
 
 ### <a id="minor-changes-vttablet"/>VTTablet</a>
 

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1360,16 +1360,20 @@ func (c *Conn) handleComStmtExecute(handler Handler, data []byte) (kontinue bool
 		}
 	} else {
 		if err != nil {
-			// We can't send an error in the middle of a stream.
-			// All we can do is abort the send, which will cause a 2013.
-			log.Error(fmt.Sprintf("Error in the middle of a stream to %s: %v", c, err))
-			return false
-		}
-
-		// Send the end packet only sendFinished is false (results were streamed).
-		// In this case the affectedRows and lastInsertID are always 0 since it
-		// was a read operation.
-		if !sendFinished {
+			// An OK packet already terminated the result; we cannot safely
+			// append an ERR without desynchronizing the protocol for the
+			// next command. Tear down the connection instead.
+			if sendFinished {
+				log.Error("Error after OK-terminated result", slog.String("connection", c.String()), slog.Any("error", err))
+				return false
+			}
+			if !c.writeErrorPacketFromErrorAndLog(err) {
+				return false
+			}
+		} else if !sendFinished {
+			// Send the end packet only sendFinished is false (results were streamed).
+			// In this case the affectedRows and lastInsertID are always 0 since it
+			// was a read operation.
 			if err := c.writeEndResult(false, 0, 0, handler.WarningCount(c)); err != nil {
 				log.Error(fmt.Sprintf("Error writing result to %s: %v", c, err))
 				return false
@@ -1602,10 +1606,17 @@ func (c *Conn) execQueryMulti(query string, handler Handler) execResult {
 	}
 
 	if err != nil {
-		// We can't send an error in the middle of a stream.
-		// All we can do is abort the send, which will cause a 2013.
-		log.Error(fmt.Sprintf("Error in the middle of a stream to %s: %v", c, err))
-		return connErr
+		// An OK packet already terminated the last result; we cannot safely
+		// append an ERR without desynchronizing the protocol for the next
+		// command. Tear down the connection instead.
+		if !needsEndPacket {
+			log.Error("Error after OK-terminated result", slog.String("connection", c.String()), slog.Any("error", err))
+			return connErr
+		}
+		if !c.writeErrorPacketFromErrorAndLog(err) {
+			return connErr
+		}
+		return execErr
 	}
 
 	// If we haven't sent the final packet for the last query, we should send that too.
@@ -1725,10 +1736,17 @@ func (c *Conn) execQuery(query string, handler Handler, more bool) execResult {
 		return execErr
 	}
 	if err != nil {
-		// We can't send an error in the middle of a stream.
-		// All we can do is abort the send, which will cause a 2013.
-		log.Error(fmt.Sprintf("Error in the middle of a stream to %s: %v", c, err))
-		return connErr
+		// An OK packet already terminated the result; we cannot safely
+		// append an ERR without desynchronizing the protocol for the
+		// next command. Tear down the connection instead.
+		if sendFinished {
+			log.Error("Error after OK-terminated result", slog.String("connection", c.String()), slog.Any("error", err))
+			return connErr
+		}
+		if !c.writeErrorPacketFromErrorAndLog(err) {
+			return connErr
+		}
+		return execErr
 	}
 
 	// Send the end packet only sendFinished is false (results were streamed).

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -1080,6 +1080,47 @@ func TestExecQueryMultiStreamSurfacesMidStreamError(t *testing.T) {
 	require.True(t, result.Equal(selectRowsResult))
 }
 
+// TestExecQueryMultiStreamErrorAfterFirstResultSet exercises execQueryMulti with
+// multiple result sets: the first statement streams a full result set successfully
+// (with the more-results flag set), and the second statement streams rows and then
+// fails mid-stream. The client must read the first result set cleanly, then receive
+// the real SQL error for the second, and the connection must survive.
+func TestExecQueryMultiStreamErrorAfterFirstResultSet(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	sConn.multiQuery = true
+	sConn.Capabilities |= CapabilityClientMultiStatements
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	require.NoError(t, cConn.WriteComQuery("select rows; rows then error"))
+
+	handler := &testRun{err: sqlerror.NewSQLError(sqlerror.ERQueryInterrupted, sqlerror.SSQueryInterrupted, "context canceled")}
+	res := sConn.handleNextCommand(handler)
+	require.True(t, res, "mid-stream error must not tear down the connection")
+
+	// First result set arrives cleanly with the more-results flag set.
+	result, more, _, err := cConn.ReadQueryResult(100, true)
+	require.NoError(t, err)
+	require.True(t, result.Equal(selectRowsResult))
+	require.True(t, more, "more results must follow the first result set")
+
+	// Second result set streams rows and then fails: client sees the real error.
+	_, more, _, err = cConn.ReadQueryResult(100, true)
+	require.ErrorContains(t, err, "context canceled")
+	require.False(t, more, "no further results after an error packet")
+
+	// Connection must still be usable for the next query.
+	require.NoError(t, cConn.WriteComQuery("select rows"))
+	res = sConn.handleNextCommand(handler)
+	require.True(t, res, "subsequent query must be handled on a still-alive connection")
+	result, _, _, err = cConn.ReadQueryResult(100, true)
+	require.NoError(t, err)
+	require.True(t, result.Equal(selectRowsResult))
+}
+
 // TestExecQueryErrorAfterOKDoesNotDesyncProtocol guards against writing an ERR
 // packet after an OK packet has already terminated the result set. Appending a
 // second packet would leave a stale ERR queued for the next command. The
@@ -1222,6 +1263,28 @@ func TestHandleComStmtExecuteSurfacesMidStreamError(t *testing.T) {
 	sConn.PrepareData[stmtID].PrepareStmt = "select rows"
 	res = sConn.handleNextCommand(handler)
 	require.True(t, res, "subsequent COM_STMT_EXECUTE must be handled on a still-alive connection")
+
+	// Read the full binary result of the follow-up execution and assert it is a
+	// real (non-error) response: every packet up to the result terminator must
+	// arrive without an ERR packet. The result set ends after two EOF packets
+	// (columns then rows, since CapabilityClientDeprecateEOF is off here).
+	// Bounded by a read deadline and packet count so a regression fails fast
+	// instead of stalling CI.
+	require.NoError(t, cConn.conn.SetReadDeadline(time.Now().Add(30*time.Second)))
+	var eofCount int
+	for range 16 {
+		data, err := cConn.ReadPacket()
+		require.NoError(t, err)
+		require.NotEmpty(t, data)
+		require.NotEqualf(t, byte(ErrPacket), data[0], "follow-up execution must return a result, not an error packet")
+		if cConn.isEOFPacket(data) {
+			eofCount++
+			if eofCount == 2 {
+				break
+			}
+		}
+	}
+	require.EqualValues(t, 2, eofCount, "follow-up binary result must terminate cleanly")
 }
 
 func TestInitDbAgainstWrongDbDoesNotDropConnection(t *testing.T) {

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -1198,9 +1198,12 @@ func TestHandleComStmtExecuteSurfacesMidStreamError(t *testing.T) {
 	res := sConn.handleNextCommand(handler)
 	require.True(t, res, "mid-stream error must not tear down the connection")
 
-	// Drain packets until we see the ERR packet; assert it carries the real error.
+	// Drain packets until we see the ERR packet; assert it carries the real
+	// error. Bounded by a read deadline and packet count so a regression that
+	// fails to emit ERR fails the test fast instead of stalling CI.
+	require.NoError(t, cConn.conn.SetReadDeadline(time.Now().Add(30*time.Second)))
 	var sawErr bool
-	for {
+	for range 16 {
 		data, err := cConn.ReadPacket()
 		require.NoError(t, err)
 		require.NotEmpty(t, data)

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -1019,6 +1019,208 @@ func TestMultiStatementOnSplitError(t *testing.T) {
 	}
 }
 
+// TestExecQueryStreamSurfacesMidStreamError exercises go/mysql/conn.go execQuery (text
+// protocol, single statement): when the handler streams rows successfully and then
+// returns an error, the client must receive the real SQL error (not EOF/2013), and the
+// connection must remain usable for a subsequent query.
+func TestExecQueryStreamSurfacesMidStreamError(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	require.NoError(t, cConn.WriteComQuery("rows then error"))
+
+	handler := &testRun{err: sqlerror.NewSQLError(sqlerror.ERQueryInterrupted, sqlerror.SSQueryInterrupted, "context canceled")}
+	res := sConn.handleNextCommand(handler)
+	require.True(t, res, "mid-stream error must not tear down the connection")
+
+	_, _, _, err := cConn.ReadQueryResult(100, true)
+	require.ErrorContains(t, err, "context canceled")
+
+	// Connection must still be usable for the next query.
+	require.NoError(t, cConn.WriteComQuery("select rows"))
+	res = sConn.handleNextCommand(handler)
+	require.True(t, res, "subsequent query must be handled on a still-alive connection")
+	result, _, _, err := cConn.ReadQueryResult(100, true)
+	require.NoError(t, err)
+	require.True(t, result.Equal(selectRowsResult))
+}
+
+// TestExecQueryMultiStreamSurfacesMidStreamError exercises go/mysql/conn.go execQueryMulti
+// (text protocol, multi-statement). Same contract: mid-stream error reaches the client
+// as the real SQL error and the connection survives.
+func TestExecQueryMultiStreamSurfacesMidStreamError(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	sConn.multiQuery = true
+	sConn.Capabilities |= CapabilityClientMultiStatements
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	require.NoError(t, cConn.WriteComQuery("rows then error"))
+
+	handler := &testRun{err: sqlerror.NewSQLError(sqlerror.ERQueryInterrupted, sqlerror.SSQueryInterrupted, "context canceled")}
+	res := sConn.handleNextCommand(handler)
+	require.True(t, res, "mid-stream error must not tear down the connection")
+
+	_, more, _, err := cConn.ReadQueryResult(100, true)
+	require.ErrorContains(t, err, "context canceled")
+	require.False(t, more, "no further results after an error packet")
+
+	require.NoError(t, cConn.WriteComQuery("select rows"))
+	res = sConn.handleNextCommand(handler)
+	require.True(t, res, "subsequent query must be handled on a still-alive connection")
+	result, _, _, err := cConn.ReadQueryResult(100, true)
+	require.NoError(t, err)
+	require.True(t, result.Equal(selectRowsResult))
+}
+
+// TestExecQueryErrorAfterOKDoesNotDesyncProtocol guards against writing an ERR
+// packet after an OK packet has already terminated the result set. Appending a
+// second packet would leave a stale ERR queued for the next command. The
+// connection must be torn down instead.
+func TestExecQueryErrorAfterOKDoesNotDesyncProtocol(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	require.NoError(t, cConn.WriteComQuery("ok then error"))
+
+	handler := &testRun{err: sqlerror.NewSQLError(sqlerror.ERQueryInterrupted, sqlerror.SSQueryInterrupted, "context canceled")}
+	res := sConn.handleNextCommand(handler)
+	require.False(t, res, "connection must be torn down when an error follows an OK-terminated result")
+
+	// The client must have seen the successful OK packet, not a stale ERR.
+	result, _, _, err := cConn.ReadQueryResult(100, true)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, result.RowsAffected)
+}
+
+// TestExecQueryMultiErrorAfterOKDoesNotDesyncProtocol is the execQueryMulti variant
+// of the OK-then-error guard: when an OK packet has already terminated the last
+// result, do not append an ERR; tear the connection down instead.
+func TestExecQueryMultiErrorAfterOKDoesNotDesyncProtocol(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	sConn.multiQuery = true
+	sConn.Capabilities |= CapabilityClientMultiStatements
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	require.NoError(t, cConn.WriteComQuery("ok then error"))
+
+	handler := &testRun{err: sqlerror.NewSQLError(sqlerror.ERQueryInterrupted, sqlerror.SSQueryInterrupted, "context canceled")}
+	res := sConn.handleNextCommand(handler)
+	require.False(t, res, "connection must be torn down when an error follows an OK-terminated result")
+
+	result, _, _, err := cConn.ReadQueryResult(100, true)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, result.RowsAffected)
+}
+
+// TestHandleComStmtExecuteErrorAfterOKDoesNotDesyncProtocol is the binary-protocol
+// variant of the OK-then-error guard.
+func TestHandleComStmtExecuteErrorAfterOKDoesNotDesyncProtocol(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	const stmtID uint32 = 1
+	sConn.PrepareData[stmtID] = &PrepareData{
+		StatementID: stmtID,
+		PrepareStmt: "insert into t -- ok then error",
+		ParamsCount: 0,
+		BindVars:    map[string]*querypb.BindVariable{},
+	}
+
+	cConn.sequence = 0
+	buf, pos := cConn.startEphemeralPacketWithHeader(10)
+	pos = writeByte(buf, pos, ComStmtExecute)
+	pos = writeUint32(buf, pos, stmtID)
+	pos = writeByte(buf, pos, 0) // cursor type
+	_ = writeUint32(buf, pos, 1) // iteration count
+	require.NoError(t, cConn.writeEphemeralPacket())
+
+	handler := &testRun{err: sqlerror.NewSQLError(sqlerror.ERQueryInterrupted, sqlerror.SSQueryInterrupted, "context canceled")}
+	res := sConn.handleNextCommand(handler)
+	require.False(t, res, "connection must be torn down when an error follows an OK-terminated result")
+
+	data, err := cConn.ReadPacket()
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+	require.NotEqualf(t, byte(ErrPacket), data[0], "client must not receive a stale ERR packet after an OK terminator")
+}
+
+// TestHandleComStmtExecuteSurfacesMidStreamError exercises go/mysql/conn.go
+// handleComStmtExecute (binary protocol). Same contract.
+func TestHandleComStmtExecuteSurfacesMidStreamError(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	const stmtID uint32 = 1
+	sConn.PrepareData[stmtID] = &PrepareData{
+		StatementID: stmtID,
+		PrepareStmt: "select * from t where rows then error",
+		ParamsCount: 0,
+		BindVars:    map[string]*querypb.BindVariable{},
+	}
+
+	writeComStmtExecute := func() {
+		cConn.sequence = 0
+		buf, pos := cConn.startEphemeralPacketWithHeader(10)
+		pos = writeByte(buf, pos, ComStmtExecute)
+		pos = writeUint32(buf, pos, stmtID)
+		pos = writeByte(buf, pos, 0) // cursor type
+		_ = writeUint32(buf, pos, 1) // iteration count
+		require.NoError(t, cConn.writeEphemeralPacket())
+	}
+
+	writeComStmtExecute()
+
+	handler := &testRun{err: sqlerror.NewSQLError(sqlerror.ERQueryInterrupted, sqlerror.SSQueryInterrupted, "context canceled")}
+	res := sConn.handleNextCommand(handler)
+	require.True(t, res, "mid-stream error must not tear down the connection")
+
+	// Drain packets until we see the ERR packet; assert it carries the real error.
+	var sawErr bool
+	for {
+		data, err := cConn.ReadPacket()
+		require.NoError(t, err)
+		require.NotEmpty(t, data)
+		if data[0] == ErrPacket {
+			sqlErr := ParseErrorPacket(data)
+			require.ErrorContains(t, sqlErr, "context canceled")
+			sawErr = true
+			break
+		}
+	}
+	require.True(t, sawErr, "client must receive the real error packet, not connection loss")
+
+	// Connection must still be usable for the next binary-protocol execution.
+	writeComStmtExecute()
+	// Switch to a non-error prepared statement to verify the round-trip works.
+	sConn.PrepareData[stmtID].PrepareStmt = "select rows"
+	res = sConn.handleNextCommand(handler)
+	require.True(t, res, "subsequent COM_STMT_EXECUTE must be handled on a still-alive connection")
+}
+
 func TestInitDbAgainstWrongDbDoesNotDropConnection(t *testing.T) {
 	listener, sConn, cConn := createSocketPair(t)
 	sConn.Capabilities |= CapabilityClientMultiStatements
@@ -1391,7 +1593,19 @@ type testRun struct {
 }
 
 func (t testRun) ComStmtExecute(c *Conn, prepare *PrepareData, callback func(*sqltypes.Result) error) error {
-	panic("implement me")
+	if strings.Contains(prepare.PrepareStmt, "rows then error") {
+		if err := callback(selectRowsResult); err != nil {
+			return err
+		}
+		return t.err
+	}
+	if strings.Contains(prepare.PrepareStmt, "ok then error") {
+		if err := callback(&sqltypes.Result{RowsAffected: 1}); err != nil {
+			return err
+		}
+		return t.err
+	}
+	return callback(selectRowsResult)
 }
 
 func (t testRun) ComRegisterReplica(c *Conn, replicaHost string, replicaPort uint16, replicaUser string, replicaPassword string) error {
@@ -1407,6 +1621,18 @@ func (t testRun) ComBinlogDumpGTID(c *Conn, logFile string, logPos uint64, gtidS
 }
 
 func (t testRun) ComQuery(c *Conn, query string, callback func(*sqltypes.Result) error) error {
+	if strings.Contains(query, "rows then error") {
+		if err := callback(selectRowsResult); err != nil {
+			return err
+		}
+		return t.err
+	}
+	if strings.Contains(query, "ok then error") {
+		if err := callback(&sqltypes.Result{RowsAffected: 1}); err != nil {
+			return err
+		}
+		return t.err
+	}
 	if strings.Contains(query, "error") {
 		return t.err
 	}

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -676,14 +676,15 @@ func TestServer(t *testing.T) {
 	assert.Contains(t, output, "13 warnings", "Unexpected output for 'select rows'")
 	th.SetWarnings(0)
 
-	// If there's an error after streaming has started,
-	// we should get a 2013
+	// If there's an error after streaming has started, the server now
+	// sends an ERR packet in place of the result-set terminator instead
+	// of dropping the connection. The client should see the real error.
 	th.SetErr(sqlerror.NewSQLError(sqlerror.ERUnknownComError, sqlerror.SSNetError, "forced error after send"))
 	output, err = runMysqlWithErr(t, params, "error after send")
 	require.Error(t, err)
-	assert.Contains(t, output, "ERROR 2013 (HY000)", "Unexpected output for 'panic'")
-	// MariaDB might not print the MySQL bit here
-	assert.Regexp(t, `Lost connection to( MySQL)? server during query`, output, "Unexpected output for 'panic': %v", output)
+	assert.Contains(t, output, fmt.Sprintf("ERROR %d", sqlerror.ERUnknownComError), "Unexpected output for 'error after send': %v", output)
+	assert.Contains(t, output, "forced error after send", "Unexpected output for 'error after send': %v", output)
+	assert.NotContains(t, output, "ERROR 2013", "mid-stream error must not surface as connection loss: %v", output)
 
 	// Run an 'insert' command, no rows, but rows affected.
 	output, err = runMysqlWithErr(t, params, "insert")

--- a/go/test/endtoend/vtgate/queries/kill/kill_test.go
+++ b/go/test/endtoend/vtgate/queries/kill/kill_test.go
@@ -188,13 +188,13 @@ func TestKillStmtOnHugeData(t *testing.T) {
 	t.Run("olap - kill conn", func(t *testing.T) {
 		testHugeData(t, "olap", execFunc, func(conn *mysql.Conn, killConn *mysql.Conn) {
 			utils.ExecAllowError(t, killConn, fmt.Sprintf("kill query %d", conn.ConnectionID))
-		}, "context canceled (errno 1317) (sqlstate 70100)", "EOF (errno 2013) (sqlstate HY000)")
+		}, "context canceled (errno 1317) (sqlstate 70100)")
 	})
 
 	t.Run("olap - kill query", func(t *testing.T) {
 		testHugeData(t, "olap", execFunc, func(conn *mysql.Conn, killConn *mysql.Conn) {
 			utils.ExecAllowError(t, killConn, fmt.Sprintf("kill query %d", conn.ConnectionID))
-		}, "context canceled (errno 1317) (sqlstate 70100)", "EOF (errno 2013) (sqlstate HY000)")
+		}, "context canceled (errno 1317) (sqlstate 70100)")
 	})
 }
 

--- a/go/test/endtoend/vtgate/reservedconn/servingchange/main_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/servingchange/main_test.go
@@ -161,16 +161,13 @@ func TestServingChangeStreaming(t *testing.T) {
 	rdonlyTablet.Type = "replica"
 
 	// this should fail as there is no rdonly present
-	// This can also close the streaming connection if it goes to 80- shard first and sends the fields from that.
-	// Current, stream logic is to close the server connection if partial stream result is sent and an error is received later.
 	_, err = utils.ExecAllowError(t, conn, "select * from test")
 	require.Error(t, err)
 
-	// check if connection is still available
+	// The mid-stream error must surface to the client via an ERR packet without
+	// tearing down the connection — a subsequent query on the same conn must succeed.
 	_, err = utils.ExecAllowError(t, conn, "select 1")
-	if err != nil {
-		t.Skip("connection is closed, cannot continue with the test")
-	}
+	require.NoError(t, err, "streaming connection must survive a mid-stream error")
 
 	// changing replica tablet to rdonly to make rdonly available for serving.
 	replicaTablet := clusterInstance.Keyspaces[0].Shards[0].Replica()


### PR DESCRIPTION
## Description

When the streaming query handler returns an error after the first row or field packet has been emitted, vtgate today drops the underlying TCP connection and the client sees `ERROR 2013 (HY000): Lost connection to MySQL server during query`. Common triggers are `KILL QUERY` on an OLAP session, planner errors that surface late, and per-shard errors discovered after another shard has already returned rows

We're at a packet boundary when the streaming callback returns, and MySQL's wire protocol allows an ERR packet in place of the trailing OK/EOF. This PR writes the real ERR there instead of tearing down the connection, across all three streaming paths in `go/mysql`:

1. `COM_QUERY` _(`execQuery`)_
2. multi-statement `COM_QUERY` _(`execQueryMulti`)_
3. `COM_STMT_EXECUTE` _(`handleComStmtExecute`)_

When an OK packet has already terminated the result _(DML / write-only)_ the original tear-down is preserved, since appending an ERR there would leave it queued as a stale packet for the next command

The user-visible change is documented in the `25.0.0` changelog — clients that previously branched on `ERROR 2013` will now see the real error code _(e.g. `1317 / context canceled` after `KILL QUERY`, or planner errors such as `specifying two different database in the query is not supported`)_ and the connection remains usable for follow-up queries

cc @arthurschreiber / @maxenglander 

## Related Issue(s)

Resolves: https://github.com/vitessio/vitess/issues/20382

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes


### AI Disclosure

This PR was written primarily by Claude Code, including this summary