### PR TITLE
vtorc/reparentutil: harden read_only convergence and avoid former-primary ERS candidates

### DIFF
--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -288,6 +288,12 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 		}
 	}
 
+	// If we have any candidates that were discovered via PrimaryStatus (i.e. they
+	// previously reported "not a replica"), prefer true replicas from statusMap.
+	// This avoids promoting a recently demoted/stuck primary when replica candidates
+	// are available.
+	validCandidates = erp.preferReplicaStatusCandidates(validCandidates, stoppedReplicationSnapshot.statusMap, stoppedReplicationSnapshot.primaryStatusMap)
+
 	// Find the intermediate source for replication that we want other tablets to replicate from.
 	// This step chooses the most advanced tablet. Further ties are broken by using the promotion rule.
 	// In case the user has specified a tablet specifically, then it is selected, as long as it is the most advanced.
@@ -376,6 +382,42 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 	}
 	ev.NewPrimary = newPrimary.CloneVT()
 	return err
+}
+
+// preferReplicaStatusCandidates drops candidates that were only present in primaryStatusMap
+// when at least one true replica candidate (from statusMap) exists.
+func (erp *EmergencyReparenter) preferReplicaStatusCandidates(
+	validCandidates map[string]*RelayLogPositions,
+	statusMap map[string]*replicationdatapb.StopReplicationStatus,
+	primaryStatusMap map[string]*replicationdatapb.PrimaryStatus,
+) map[string]*RelayLogPositions {
+	if len(validCandidates) == 0 || len(primaryStatusMap) == 0 || len(statusMap) == 0 {
+		return validCandidates
+	}
+
+	filtered := make(map[string]*RelayLogPositions, len(validCandidates))
+	excluded := make([]string, 0, len(primaryStatusMap))
+	for alias, position := range validCandidates {
+		if _, ok := statusMap[alias]; ok {
+			filtered[alias] = position
+			continue
+		}
+		if _, ok := primaryStatusMap[alias]; ok {
+			excluded = append(excluded, alias)
+			continue
+		}
+		// Keep unexpected aliases to avoid over-filtering.
+		filtered[alias] = position
+	}
+
+	// If filtering would remove all candidates, keep the original set.
+	if len(filtered) == 0 {
+		return validCandidates
+	}
+	if len(excluded) > 0 {
+		erp.logger.Warningf("excluding %d former-primary candidate(s) from ERS candidate set because replica candidates are available: %v", len(excluded), excluded)
+	}
+	return filtered
 }
 
 // restartReplicationOnStoppedReplicas restarts replication on replicas whose IO threads were

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -2982,6 +2982,81 @@ func TestEmergencyReparenter_waitForAllRelayLogsToApply(t *testing.T) {
 	}
 }
 
+func TestEmergencyReparenter_preferReplicaStatusCandidates(t *testing.T) {
+	t.Parallel()
+
+	replicaPos := &RelayLogPositions{}
+	formerPrimaryPos := &RelayLogPositions{}
+	otherPos := &RelayLogPositions{}
+
+	tests := []struct {
+		name             string
+		validCandidates  map[string]*RelayLogPositions
+		statusMap        map[string]*replicationdatapb.StopReplicationStatus
+		primaryStatusMap map[string]*replicationdatapb.PrimaryStatus
+		wantAliases      []string
+	}{
+		{
+			name: "exclude former primary when replica candidate exists",
+			validCandidates: map[string]*RelayLogPositions{
+				"zone1-0000000100": replicaPos,
+				"zone1-0000000101": formerPrimaryPos,
+			},
+			statusMap: map[string]*replicationdatapb.StopReplicationStatus{
+				"zone1-0000000100": {After: &replicationdatapb.Status{}},
+			},
+			primaryStatusMap: map[string]*replicationdatapb.PrimaryStatus{
+				"zone1-0000000101": {Position: "MySQL56/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:1-10"},
+			},
+			wantAliases: []string{"zone1-0000000100"},
+		},
+		{
+			name: "keep former primary when it is the only candidate",
+			validCandidates: map[string]*RelayLogPositions{
+				"zone1-0000000101": formerPrimaryPos,
+			},
+			statusMap: map[string]*replicationdatapb.StopReplicationStatus{
+				"zone1-0000000100": {After: &replicationdatapb.Status{}},
+			},
+			primaryStatusMap: map[string]*replicationdatapb.PrimaryStatus{
+				"zone1-0000000101": {Position: "MySQL56/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:1-10"},
+			},
+			wantAliases: []string{"zone1-0000000101"},
+		},
+		{
+			name: "keep unknown candidates to avoid over-filtering",
+			validCandidates: map[string]*RelayLogPositions{
+				"zone1-0000000100": replicaPos,
+				"zone1-0000000102": otherPos,
+			},
+			statusMap: map[string]*replicationdatapb.StopReplicationStatus{
+				"zone1-0000000100": {After: &replicationdatapb.Status{}},
+			},
+			primaryStatusMap: map[string]*replicationdatapb.PrimaryStatus{
+				"zone1-0000000101": {Position: "MySQL56/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:1-10"},
+			},
+			wantAliases: []string{"zone1-0000000100", "zone1-0000000102"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			erp := NewEmergencyReparenter(nil, nil, logutil.NewMemoryLogger())
+			got := erp.preferReplicaStatusCandidates(tt.validCandidates, tt.statusMap, tt.primaryStatusMap)
+
+			aliases := make([]string, 0, len(got))
+			for alias := range got {
+				aliases = append(aliases, alias)
+			}
+			slices.Sort(aliases)
+			slices.Sort(tt.wantAliases)
+			require.Equal(t, tt.wantAliases, aliases)
+		})
+	}
+}
+
 func TestEmergencyReparenterStats(t *testing.T) {
 	ersCounter.ResetAll()
 	reparentShardOpTimings.Reset()

--- a/go/vt/vtorc/logic/topology_recovery.go
+++ b/go/vt/vtorc/logic/topology_recovery.go
@@ -285,10 +285,11 @@ func lockShardWithRetry(ctx context.Context, keyspace, shard, lockAction string,
 		}
 
 		lockCtx, unlock, err := LockShard(attemptCtx, keyspace, shard, lockAction)
-		cancel()
 		if err == nil {
-			return lockCtx, unlock, nil
+			cancel()
+			return context.WithoutCancel(lockCtx), unlock, nil
 		}
+		cancel()
 
 		lastErr = err
 		if ctx.Err() != nil {

--- a/go/vt/vtorc/logic/topology_recovery.go
+++ b/go/vt/vtorc/logic/topology_recovery.go
@@ -307,10 +307,7 @@ func lockShardWithRetry(ctx context.Context, keyspace, shard, lockAction string,
 			return nil, nil, lastErr
 		}
 
-		backoffStep := attempt
-		if backoffStep > 5 {
-			backoffStep = 5
-		}
+		backoffStep := min(attempt, 5)
 		sleepFor := shardLockRetryBackoff * time.Duration(1<<backoffStep)
 		remaining := shardLockRetryTimeout - elapsed
 		if sleepFor > remaining {

--- a/go/vt/vtorc/logic/topology_recovery.go
+++ b/go/vt/vtorc/logic/topology_recovery.go
@@ -137,6 +137,15 @@ var (
 	// shardLockTimings measures the timing of LockShard operations.
 	shardLockTimingsActions = []string{"Lock", "Unlock"}
 	shardLockTimings        = stats.NewTimings("ShardLockTimings", "Timings of global shard locks", "Action", shardLockTimingsActions...)
+
+	// shardLockRetryTimeout controls how long recoveries keep retrying shard lock acquisition
+	// when they race another in-flight operation.
+	shardLockRetryTimeout = 15 * time.Second
+	// shardLockRetryBackoff controls the initial retry interval for lock contention retries.
+	shardLockRetryBackoff = 250 * time.Millisecond
+	// shardLockTryTimeout bounds each individual TryLockShard attempt. Some topo
+	// implementations can block before returning lock contention.
+	shardLockTryTimeout = 1 * time.Second
 )
 
 // recoveryFunction is the code of the recovery function to be used
@@ -258,6 +267,68 @@ func LockShard(ctx context.Context, keyspace, shard, lockAction string) (context
 		}()
 		unlock(e)
 	}, nil
+}
+
+// lockShardWithRetry retries shard lock acquisition for a bounded amount of time when
+// contention is detected. This allows actionable recoveries to proceed once an in-flight
+// operation releases the lock, instead of failing immediately on a transient collision.
+func lockShardWithRetry(ctx context.Context, keyspace, shard, lockAction string, logger *log.PrefixedLogger) (context.Context, func(*error), error) {
+	start := time.Now()
+	attempt := 0
+	var lastErr error
+
+	for {
+		attemptCtx := ctx
+		cancel := func() {}
+		if shardLockTryTimeout > 0 {
+			attemptCtx, cancel = context.WithTimeout(ctx, shardLockTryTimeout)
+		}
+
+		lockCtx, unlock, err := LockShard(attemptCtx, keyspace, shard, lockAction)
+		cancel()
+		if err == nil {
+			return lockCtx, unlock, nil
+		}
+
+		lastErr = err
+		if ctx.Err() != nil {
+			return nil, nil, ctx.Err()
+		}
+
+		// Retry when lock contention is explicit (NodeExists) and when lock attempts
+		// time out waiting for another holder.
+		if !topo.IsErrType(err, topo.NodeExists) && !topo.IsErrType(err, topo.Timeout) && !errors.Is(err, context.DeadlineExceeded) {
+			return nil, nil, err
+		}
+
+		elapsed := time.Since(start)
+		if elapsed >= shardLockRetryTimeout {
+			return nil, nil, lastErr
+		}
+
+		backoffStep := attempt
+		if backoffStep > 5 {
+			backoffStep = 5
+		}
+		sleepFor := shardLockRetryBackoff * time.Duration(1<<backoffStep)
+		remaining := shardLockRetryTimeout - elapsed
+		if sleepFor > remaining {
+			sleepFor = remaining
+		}
+
+		if logger != nil && (attempt == 0 || attempt%4 == 0) {
+			logger.Warn(fmt.Sprintf("Shard lock busy for %s/%s; retrying in %s (elapsed %s): %v", keyspace, shard, sleepFor, elapsed.Round(10*time.Millisecond), err))
+		}
+
+		timer := time.NewTimer(sleepFor)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, nil, ctx.Err()
+		case <-timer.C:
+		}
+		attempt++
+	}
 }
 
 // AuditTopologyRecovery audits a single step in a topology recovery process.
@@ -925,8 +996,9 @@ func executeCheckAndRecoverFunction(analysisEntry *inst.DetectionAnalysis) (err 
 	}
 
 	// We lock the shard here and then refresh the tablets information
-	ctx, unlock, err := LockShard(context.Background(), analysisEntry.AnalyzedKeyspace, analysisEntry.AnalyzedShard,
+	ctx, unlock, err := lockShardWithRetry(context.Background(), analysisEntry.AnalyzedKeyspace, analysisEntry.AnalyzedShard,
 		getLockAction(analysisEntry.AnalyzedInstanceAlias, analysisEntry.Analysis),
+		logger,
 	)
 	if err != nil {
 		logger.Error(fmt.Sprintf("Failed to lock shard, aborting recovery: %v", err))

--- a/go/vt/vtorc/logic/topology_recovery_test.go
+++ b/go/vt/vtorc/logic/topology_recovery_test.go
@@ -803,6 +803,7 @@ func TestLockShardWithRetryEventuallySucceeds(t *testing.T) {
 	lockCtx, unlock, err := lockShardWithRetry(context.Background(), "ks", "0", "retry-lock", log.NewPrefixedLogger("test"))
 	require.NoError(t, err)
 	require.NotNil(t, lockCtx)
+	require.NoError(t, lockCtx.Err())
 	require.NotNil(t, unlock)
 
 	var unlockErr error

--- a/go/vt/vtorc/logic/topology_recovery_test.go
+++ b/go/vt/vtorc/logic/topology_recovery_test.go
@@ -767,6 +767,86 @@ func TestRecoverShardAnalyses(t *testing.T) {
 	require.Equal(t, inst.ReplicaIsWritable, order[3])
 }
 
+func TestLockShardWithRetryEventuallySucceeds(t *testing.T) {
+	ctx := t.Context()
+
+	oldTS := ts
+	ts = memorytopo.NewServer(ctx, "zone1")
+	defer func() {
+		ts = oldTS
+	}()
+
+	require.NoError(t, ts.CreateKeyspace(ctx, "ks", &topodatapb.Keyspace{}))
+	require.NoError(t, ts.CreateShard(ctx, "ks", "0"))
+
+	_, heldUnlock, err := ts.LockShard(ctx, "ks", "0", "held-by-test")
+	require.NoError(t, err)
+
+	oldTimeout := shardLockRetryTimeout
+	oldBackoff := shardLockRetryBackoff
+	oldTryTimeout := shardLockTryTimeout
+	shardLockRetryTimeout = 500 * time.Millisecond
+	shardLockRetryBackoff = 20 * time.Millisecond
+	shardLockTryTimeout = 30 * time.Millisecond
+	defer func() {
+		shardLockRetryTimeout = oldTimeout
+		shardLockRetryBackoff = oldBackoff
+		shardLockTryTimeout = oldTryTimeout
+	}()
+
+	go func() {
+		time.Sleep(60 * time.Millisecond)
+		var unlockErr error
+		heldUnlock(&unlockErr)
+	}()
+
+	lockCtx, unlock, err := lockShardWithRetry(context.Background(), "ks", "0", "retry-lock", log.NewPrefixedLogger("test"))
+	require.NoError(t, err)
+	require.NotNil(t, lockCtx)
+	require.NotNil(t, unlock)
+
+	var unlockErr error
+	unlock(&unlockErr)
+	require.NoError(t, unlockErr)
+}
+
+func TestLockShardWithRetryTimesOutOnContention(t *testing.T) {
+	ctx := t.Context()
+
+	oldTS := ts
+	ts = memorytopo.NewServer(ctx, "zone1")
+	defer func() {
+		ts = oldTS
+	}()
+
+	require.NoError(t, ts.CreateKeyspace(ctx, "ks", &topodatapb.Keyspace{}))
+	require.NoError(t, ts.CreateShard(ctx, "ks", "0"))
+
+	_, heldUnlock, err := ts.LockShard(ctx, "ks", "0", "held-by-test")
+	require.NoError(t, err)
+	defer func() {
+		var unlockErr error
+		heldUnlock(&unlockErr)
+		require.NoError(t, unlockErr)
+	}()
+
+	oldTimeout := shardLockRetryTimeout
+	oldBackoff := shardLockRetryBackoff
+	oldTryTimeout := shardLockTryTimeout
+	shardLockRetryTimeout = 90 * time.Millisecond
+	shardLockRetryBackoff = 20 * time.Millisecond
+	shardLockTryTimeout = 30 * time.Millisecond
+	defer func() {
+		shardLockRetryTimeout = oldTimeout
+		shardLockRetryBackoff = oldBackoff
+		shardLockTryTimeout = oldTryTimeout
+	}()
+
+	_, _, err = lockShardWithRetry(context.Background(), "ks", "0", "retry-lock", log.NewPrefixedLogger("test"))
+	require.Error(t, err)
+	require.True(t, topo.IsErrType(err, topo.NodeExists) || topo.IsErrType(err, topo.Timeout) || errors.Is(err, context.DeadlineExceeded), "expected lock-contention style error, got: %v", err)
+}
+
 func TestRecoverIncapacitatedPrimary(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION


<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
This PR fixes a VTOrc recovery deadlock pattern where ERS repeatedly fails with split-brain after earlier `PrimaryIsReadOnly `/ `ReplicaIsWritable` recoveries fail to converge MySQL `read_only` with topology state under lock contention.

Changes in this PR:

- Added bounded shard-lock retry for VTOrc recoveries so actionable recoveries don’t abort on transient lock collisions.

- In ERS, will prefer candidates from replica status over candidates only discovered as former primaries (primaryStatusMap) when replica candidates are available.
  
- keep split-brain checks intact (no safety relaxation), but avoid entering the dead-end candidate path in recoverable cases.
  
- Add focused tests for both behaviors

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

Fixes - #20078 

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
