### PR TITLE
vttablet: roll back canceled schema reload on a non-cancelable context

### DIFF
--- a/go/vt/vttablet/tabletserver/schema/db.go
+++ b/go/vt/vttablet/tabletserver/schema/db.go
@@ -133,11 +133,16 @@ const schemaReloadTxCleanupTimeout = 10 * time.Second
 // locks on _vt.tables and wedging every future reload. It is deferred before
 // `begin` is even checked because a canceled `begin` can open the transaction
 // on MySQL while still returning an error; with no transaction open the
-// rollback is a harmless no-op — including on the success path, where it
-// trails a commit. If the rollback itself fails the connection's transaction
-// state is unknown, so it is closed for the pool to discard.
+// rollback is a harmless no-op. A successful commit skips the rollback, so the
+// success path doesn't pay for a redundant round-trip. If the rollback itself
+// fails the connection's transaction state is unknown, so it is closed for the
+// pool to discard.
 func reloadInTransaction(ctx context.Context, conn *connpool.Conn, f func() error) error {
+	committed := false
 	defer func() {
+		if committed {
+			return
+		}
 		rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), schemaReloadTxCleanupTimeout)
 		defer cancel()
 		if _, err := conn.Exec(rollbackCtx, "rollback", 1, false); err != nil {
@@ -154,8 +159,11 @@ func reloadInTransaction(ctx context.Context, conn *connpool.Conn, f func() erro
 		return err
 	}
 
-	_, err := conn.Exec(ctx, "commit", 1, false)
-	return err
+	if _, err := conn.Exec(ctx, "commit", 1, false); err != nil {
+		return err
+	}
+	committed = true
+	return nil
 }
 
 // reloadTablesDataInDB reloads teh tables information we have stored in our database we use for schema-tracking.

--- a/go/vt/vttablet/tabletserver/schema/db.go
+++ b/go/vt/vttablet/tabletserver/schema/db.go
@@ -18,6 +18,8 @@ package schema
 
 import (
 	"context"
+	"log/slog"
+	"time"
 
 	"vitess.io/vitess/go/vt/log"
 
@@ -116,6 +118,41 @@ SELECT f.name, i.UDF_RETURN_TYPE, f.type FROM mysql.func f left join performance
 	fetchAggregateUdfs = `select function_name, function_return_type, function_type from %s.udfs`
 )
 
+// schemaReloadTxCleanupTimeout bounds the rollback that runs after the
+// caller's context is canceled. It must stay bounded because schema reloads
+// hold the engine mutex while running; an unbounded rollback could re-wedge
+// reloads instead of fixing the wedge.
+const schemaReloadTxCleanupTimeout = 30 * time.Second
+
+// reloadInTransaction runs f inside a transaction on conn, then commits. A
+// rollback is always deferred (it is a no-op after a successful commit, which
+// matches the prior behavior of these reload functions). The rollback runs on
+// a fresh, non-cancelable context so it still reaches MySQL even when ctx is
+// already canceled — otherwise the connection is recycled with an open
+// transaction, holding locks on _vt.tables and wedging future reloads. If the
+// rollback itself fails, the connection is closed so the pool discards it
+// rather than reusing a session whose transaction state is unknown.
+func reloadInTransaction(ctx context.Context, conn *connpool.Conn, f func() error) error {
+	if _, err := conn.Exec(ctx, "begin", 1, false); err != nil {
+		return err
+	}
+	defer func() {
+		rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), schemaReloadTxCleanupTimeout)
+		defer cancel()
+		if _, err := conn.Exec(rollbackCtx, "rollback", 1, false); err != nil {
+			log.Warn("schema reload: rollback after canceled/failed reload failed; discarding connection", slog.Any("error", err))
+			conn.Close()
+		}
+	}()
+
+	if err := f(); err != nil {
+		return err
+	}
+
+	_, err := conn.Exec(ctx, "commit", 1, false)
+	return err
+}
+
 // reloadTablesDataInDB reloads teh tables information we have stored in our database we use for schema-tracking.
 func reloadTablesDataInDB(ctx context.Context, conn *connpool.Conn, tables []*Table, droppedTables []string, parser *sqlparser.Parser) error {
 	// No need to do anything if we have no tables to refresh or drop.
@@ -160,33 +197,25 @@ func reloadTablesDataInDB(ctx context.Context, conn *connpool.Conn, tables []*Ta
 	}
 
 	// Reload the tables in a transaction.
-	_, err = conn.Exec(ctx, "begin", 1, false)
-	if err != nil {
-		return err
-	}
-	defer conn.Exec(ctx, "rollback", 1, false)
-
-	_, err = conn.Exec(ctx, clearTableQuery, 1, false)
-	if err != nil {
-		return err
-	}
-
-	for idx, table := range tables {
-		bv["table_name"] = sqltypes.StringBindVariable(table.Name.String())
-		bv["create_statement"] = sqltypes.StringBindVariable(createStatements[idx])
-		bv["create_time"] = sqltypes.Int64BindVariable(table.CreateTime)
-		insertTableQuery, err := insertTablesParsedQuery.GenerateQuery(bv, nil)
-		if err != nil {
+	return reloadInTransaction(ctx, conn, func() error {
+		if _, err := conn.Exec(ctx, clearTableQuery, 1, false); err != nil {
 			return err
 		}
-		_, err = conn.Exec(ctx, insertTableQuery, 1, false)
-		if err != nil {
-			return err
-		}
-	}
 
-	_, err = conn.Exec(ctx, "commit", 1, false)
-	return err
+		for idx, table := range tables {
+			bv["table_name"] = sqltypes.StringBindVariable(table.Name.String())
+			bv["create_statement"] = sqltypes.StringBindVariable(createStatements[idx])
+			bv["create_time"] = sqltypes.Int64BindVariable(table.CreateTime)
+			insertTableQuery, err := insertTablesParsedQuery.GenerateQuery(bv, nil)
+			if err != nil {
+				return err
+			}
+			if _, err = conn.Exec(ctx, insertTableQuery, 1, false); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 // generateFullQuery generates the full query from the query as a string.
@@ -264,33 +293,25 @@ func reloadViewsDataInDB(ctx context.Context, conn *connpool.Conn, views []*Tabl
 	}
 
 	// Reload the views in a transaction.
-	_, err = conn.Exec(ctx, "begin", 1, false)
-	if err != nil {
-		return err
-	}
-	defer conn.Exec(ctx, "rollback", 1, false)
-
-	_, err = conn.Exec(ctx, clearViewQuery, 1, false)
-	if err != nil {
-		return err
-	}
-
-	for idx, view := range views {
-		bv["view_name"] = sqltypes.StringBindVariable(view.Name.String())
-		bv["create_statement"] = sqltypes.StringBindVariable(createStatements[idx])
-		bv["view_definition"] = sqltypes.StringBindVariable(viewDefinitions[view.Name.String()])
-		insertViewQuery, err := insertViewsParsedQuery.GenerateQuery(bv, nil)
-		if err != nil {
+	return reloadInTransaction(ctx, conn, func() error {
+		if _, err := conn.Exec(ctx, clearViewQuery, 1, false); err != nil {
 			return err
 		}
-		_, err = conn.Exec(ctx, insertViewQuery, 1, false)
-		if err != nil {
-			return err
-		}
-	}
 
-	_, err = conn.Exec(ctx, "commit", 1, false)
-	return err
+		for idx, view := range views {
+			bv["view_name"] = sqltypes.StringBindVariable(view.Name.String())
+			bv["create_statement"] = sqltypes.StringBindVariable(createStatements[idx])
+			bv["view_definition"] = sqltypes.StringBindVariable(viewDefinitions[view.Name.String()])
+			insertViewQuery, err := insertViewsParsedQuery.GenerateQuery(bv, nil)
+			if err != nil {
+				return err
+			}
+			if _, err = conn.Exec(ctx, insertViewQuery, 1, false); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 // getViewDefinition gets the viewDefinition for the given views.
@@ -455,28 +476,16 @@ func reloadUdfsInDB(ctx context.Context, conn *connpool.Conn, udfsChanged bool, 
 	copyUdfQuery := sqlparser.BuildParsedQuery(copyUdfs, sidecar.GetIdentifier()).Query
 
 	// Reload the udfs in a transaction.
-	_, err := conn.Exec(ctx, "begin", 1, false)
-	if err != nil {
-		return err
-	}
-	defer conn.Exec(ctx, "rollback", 1, false)
+	return reloadInTransaction(ctx, conn, func() error {
+		if _, err := conn.Exec(ctx, clearUdfQuery, 1, false); err != nil {
+			return err
+		}
 
-	_, err = conn.Exec(ctx, clearUdfQuery, 1, false)
-	if err != nil {
-		return err
-	}
-
-	_, err = conn.Exec(ctx, copyUdfQuery, 1, false)
-	if err != nil {
-		return err
-	}
-
-	_, err = conn.Exec(ctx, "commit", 1, false)
-	if err != nil {
-		return err
-	}
-
-	return nil
+		if _, err := conn.Exec(ctx, copyUdfQuery, 1, false); err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 // GetFetchViewQuery gets the fetch query to run for getting the listed views. If no views are provided, then all the views are fetched.

--- a/go/vt/vttablet/tabletserver/schema/db.go
+++ b/go/vt/vttablet/tabletserver/schema/db.go
@@ -118,25 +118,25 @@ SELECT f.name, i.UDF_RETURN_TYPE, f.type FROM mysql.func f left join performance
 	fetchAggregateUdfs = `select function_name, function_return_type, function_type from %s.udfs`
 )
 
-// schemaReloadTxCleanupTimeout bounds the rollback that runs after the
-// caller's context is canceled. A rollback after a killed query is normally
-// near-instant; this is only a safety net so a hung connection can't hold the
-// engine mutex (and re-wedge reloads) for long. Kept short for that reason —
-// well under the 30s schema-change-reload-timeout this cleanup runs within.
+// schemaReloadTxCleanupTimeout is a safety net so a hung connection can't hold
+// the engine mutex (and re-wedge reloads) indefinitely. The cleanup rollback
+// runs on a non-cancelable context, so it falls outside the
+// schema-change-reload-timeout and adds to the mutex hold on top of it — hence
+// kept short, as the rollback is otherwise near-instant.
 const schemaReloadTxCleanupTimeout = 10 * time.Second
 
-// reloadInTransaction runs f inside a transaction on conn, then commits. A
-// rollback is always deferred (it is a no-op after a successful commit, which
-// matches the prior behavior of these reload functions). The rollback runs on
-// a fresh, non-cancelable context so it still reaches MySQL even when ctx is
-// already canceled — otherwise the connection is recycled with an open
-// transaction, holding locks on _vt.tables and wedging future reloads. If the
-// rollback itself fails, the connection is closed so the pool discards it
-// rather than reusing a session whose transaction state is unknown.
+// reloadInTransaction runs f inside a transaction on conn, then commits.
+//
+// The deferred rollback is what keeps a canceled reload from poisoning the
+// pool: it runs on a non-cancelable context so it still reaches MySQL after
+// ctx is gone, otherwise the connection is recycled mid-transaction, holding
+// locks on _vt.tables and wedging every future reload. It is deferred before
+// `begin` is even checked because a canceled `begin` can open the transaction
+// on MySQL while still returning an error; with no transaction open the
+// rollback is a harmless no-op — including on the success path, where it
+// trails a commit. If the rollback itself fails the connection's transaction
+// state is unknown, so it is closed for the pool to discard.
 func reloadInTransaction(ctx context.Context, conn *connpool.Conn, f func() error) error {
-	if _, err := conn.Exec(ctx, "begin", 1, false); err != nil {
-		return err
-	}
 	defer func() {
 		rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), schemaReloadTxCleanupTimeout)
 		defer cancel()
@@ -145,6 +145,10 @@ func reloadInTransaction(ctx context.Context, conn *connpool.Conn, f func() erro
 			conn.Close()
 		}
 	}()
+
+	if _, err := conn.Exec(ctx, "begin", 1, false); err != nil {
+		return err
+	}
 
 	if err := f(); err != nil {
 		return err

--- a/go/vt/vttablet/tabletserver/schema/db.go
+++ b/go/vt/vttablet/tabletserver/schema/db.go
@@ -27,6 +27,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/connpool"
 )
 
@@ -152,7 +153,7 @@ func reloadInTransaction(ctx context.Context, conn *connpool.Conn, f func() erro
 	}()
 
 	if _, err := conn.Exec(ctx, "begin", 1, false); err != nil {
-		return err
+		return vterrors.Wrapf(err, "schema reload: begin transaction")
 	}
 
 	if err := f(); err != nil {
@@ -160,7 +161,7 @@ func reloadInTransaction(ctx context.Context, conn *connpool.Conn, f func() erro
 	}
 
 	if _, err := conn.Exec(ctx, "commit", 1, false); err != nil {
-		return err
+		return vterrors.Wrapf(err, "schema reload: commit transaction")
 	}
 	committed = true
 	return nil

--- a/go/vt/vttablet/tabletserver/schema/db.go
+++ b/go/vt/vttablet/tabletserver/schema/db.go
@@ -119,10 +119,11 @@ SELECT f.name, i.UDF_RETURN_TYPE, f.type FROM mysql.func f left join performance
 )
 
 // schemaReloadTxCleanupTimeout bounds the rollback that runs after the
-// caller's context is canceled. It must stay bounded because schema reloads
-// hold the engine mutex while running; an unbounded rollback could re-wedge
-// reloads instead of fixing the wedge.
-const schemaReloadTxCleanupTimeout = 30 * time.Second
+// caller's context is canceled. A rollback after a killed query is normally
+// near-instant; this is only a safety net so a hung connection can't hold the
+// engine mutex (and re-wedge reloads) for long. Kept short for that reason —
+// well under the 30s schema-change-reload-timeout this cleanup runs within.
+const schemaReloadTxCleanupTimeout = 10 * time.Second
 
 // reloadInTransaction runs f inside a transaction on conn, then commits. A
 // rollback is always deferred (it is a no-op after a successful commit, which

--- a/go/vt/vttablet/tabletserver/schema/db_test.go
+++ b/go/vt/vttablet/tabletserver/schema/db_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 
@@ -529,7 +530,7 @@ func TestReloadTablesInDBRollsBackOnCanceledContext(t *testing.T) {
 		select {
 		case <-killed:
 		case <-time.After(10 * time.Second):
-			require.FailNow(t, "cancellation handler never issued `kill query`")
+			assert.Fail(t, "cancellation handler never issued `kill query`")
 		}
 	})
 
@@ -602,7 +603,7 @@ func TestReloadTablesInDBRollsBackWhenBeginIsCanceled(t *testing.T) {
 		select {
 		case <-killed:
 		case <-time.After(10 * time.Second):
-			require.FailNow(t, "cancellation handler never issued `kill query`")
+			assert.Fail(t, "cancellation handler never issued `kill query`")
 		}
 	})
 

--- a/go/vt/vttablet/tabletserver/schema/db_test.go
+++ b/go/vt/vttablet/tabletserver/schema/db_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
@@ -466,6 +467,102 @@ func TestReloadTablesInDB(t *testing.T) {
 			require.NoError(t, db.LastError())
 		})
 	}
+}
+
+// reloadTestQueries are the exact queries a single-table (t1) reload issues.
+const (
+	reloadDeleteQuery = "delete from _vt.`tables` where table_schema = database() and `table_name` in ('t1')"
+	reloadInsertQuery = "insert into _vt.`tables`(table_schema, `table_name`, create_statement, create_time) values (database(), 't1', 'create_table_t1', 1234)"
+)
+
+// getReloadTestConn returns a pooled schema connection backed by db. It uses a
+// real connpool.Pool (not connpool.NewConn) so the connection is wired with a
+// dba pool, which the cancellation KillQuery path needs to issue `kill query`.
+func getReloadTestConn(t *testing.T, db *fakesqldb.DB, name string) *connpool.Conn {
+	t.Helper()
+	env := tabletenv.NewEnv(vtenv.NewTestEnv(), nil, name)
+	params := dbconfigs.New(db.ConnParams())
+	cp := connpool.NewPool(env, name, tabletenv.ConnPoolConfig{Size: 1, IdleTimeout: 10 * time.Second})
+	cp.Open(params, params, params)
+	t.Cleanup(cp.Close)
+
+	pooled, err := cp.Get(t.Context(), nil)
+	require.NoError(t, err)
+	t.Cleanup(pooled.Recycle)
+	return pooled.Conn
+}
+
+// TestReloadTablesInDBRollsBackOnCanceledContext guards the schema-reload wedge
+// (vitessio/vitess#20314): when the reload context is canceled mid-transaction,
+// the deferred rollback must still reach MySQL so the pooled connection is not
+// recycled with an open transaction holding locks on _vt.tables.
+func TestReloadTablesInDBRollsBackOnCanceledContext(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+
+	showCreateTableFields := sqltypes.MakeTestFields("Table | Create Table", "varchar|varchar")
+	conn := getReloadTestConn(t, db, "ReloadRollback")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	// killed is closed once the cancellation handler has issued `kill query`,
+	// proving the KillQuery path ran: the query is killed but the session and
+	// its open transaction survive (insideTxn=false).
+	killed := make(chan struct{})
+	db.AddQueryPatternWithCallback(`kill query \d+`, &sqltypes.Result{}, func(string) {
+		close(killed)
+	})
+
+	db.AddQuery("begin", &sqltypes.Result{})
+	db.AddQuery("commit", &sqltypes.Result{})
+	db.AddQuery("rollback", &sqltypes.Result{})
+	db.AddQuery("show create table t1", sqltypes.MakeTestResult(showCreateTableFields, "t1|create_table_t1"))
+	db.AddQuery(reloadInsertQuery, &sqltypes.Result{})
+
+	// Cancel while the DELETE is in flight, then block until the cancellation
+	// handler has actually killed the query. Holding the DELETE open until the
+	// kill is observed deterministically reproduces the poisoning sequence.
+	db.AddQuery(reloadDeleteQuery, &sqltypes.Result{})
+	db.SetBeforeFunc(reloadDeleteQuery, func() {
+		cancel()
+		<-killed
+	})
+
+	tables := []*Table{{Name: sqlparser.NewIdentifierCS("t1"), Type: NoType, CreateTime: 1234}}
+	err := reloadTablesDataInDB(ctx, conn, tables, nil, sqlparser.NewTestParser())
+	require.Error(t, err)
+
+	// The transaction must have been rolled back on MySQL despite the canceled
+	// context. Without the fix the deferred rollback short-circuits on the
+	// canceled context and never reaches MySQL.
+	require.Contains(t, db.QueryLog(), "rollback")
+}
+
+// TestReloadTablesInDBClosesConnectionOnRollbackFailure verifies that if the
+// cleanup rollback itself fails, the connection is closed so the pool discards
+// it rather than recycling a session whose transaction state is unknown.
+func TestReloadTablesInDBClosesConnectionOnRollbackFailure(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+
+	showCreateTableFields := sqltypes.MakeTestFields("Table | Create Table", "varchar|varchar")
+	conn := getReloadTestConn(t, db, "ReloadRollbackFail")
+
+	db.AddQuery("begin", &sqltypes.Result{})
+	db.AddQuery("commit", &sqltypes.Result{})
+	db.AddQuery("show create table t1", sqltypes.MakeTestResult(showCreateTableFields, "t1|create_table_t1"))
+	db.AddQuery(reloadInsertQuery, &sqltypes.Result{})
+	// The reload fails on the clear, then the rollback is refused too: the
+	// helper must discard the connection.
+	db.AddRejectedQuery(reloadDeleteQuery, errors.New("clear failed"))
+	db.AddRejectedQuery("rollback", errors.New("rollback failed"))
+
+	tables := []*Table{{Name: sqlparser.NewIdentifierCS("t1"), Type: NoType, CreateTime: 1234}}
+	err := reloadTablesDataInDB(t.Context(), conn, tables, nil, sqlparser.NewTestParser())
+	require.Error(t, err)
+
+	require.True(t, conn.IsClosed())
 }
 
 func TestReloadViewsInDB(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/schema/db_test.go
+++ b/go/vt/vttablet/tabletserver/schema/db_test.go
@@ -617,6 +617,28 @@ func TestReloadTablesInDBRollsBackWhenBeginIsCanceled(t *testing.T) {
 	require.Contains(t, db.QueryLog(), "rollback")
 }
 
+// TestReloadTablesInDBSkipsRollbackOnSuccess verifies that a reload that
+// commits successfully does not issue the cleanup rollback, so the success
+// path doesn't pay for a redundant round-trip while holding the engine mutex.
+func TestReloadTablesInDBSkipsRollbackOnSuccess(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+
+	showCreateTableFields := sqltypes.MakeTestFields("Table | Create Table", "varchar|varchar")
+	conn := getReloadTestConn(t, db, "ReloadNoRollback")
+
+	db.AddQuery("begin", &sqltypes.Result{})
+	db.AddQuery("commit", &sqltypes.Result{})
+	db.AddQuery("show create table t1", sqltypes.MakeTestResult(showCreateTableFields, "t1|create_table_t1"))
+	db.AddQuery(reloadDeleteQuery, &sqltypes.Result{})
+	db.AddQuery(reloadInsertQuery, &sqltypes.Result{})
+
+	tables := []*Table{{Name: sqlparser.NewIdentifierCS("t1"), Type: NoType, CreateTime: 1234}}
+	require.NoError(t, reloadTablesDataInDB(t.Context(), conn, tables, nil, sqlparser.NewTestParser()))
+
+	require.NotContains(t, db.QueryLog(), "rollback")
+}
+
 func TestReloadViewsInDB(t *testing.T) {
 	showCreateTableFields := sqltypes.MakeTestFields(" View | Create View | character_set_client | collation_connection", "varchar|varchar|varchar|varchar")
 	getViewDefinitionsFields := sqltypes.MakeTestFields("table_name|view_definition", "varchar|varchar")

--- a/go/vt/vttablet/tabletserver/schema/db_test.go
+++ b/go/vt/vttablet/tabletserver/schema/db_test.go
@@ -526,7 +526,11 @@ func TestReloadTablesInDBRollsBackOnCanceledContext(t *testing.T) {
 	db.AddQuery(reloadDeleteQuery, &sqltypes.Result{})
 	db.SetBeforeFunc(reloadDeleteQuery, func() {
 		cancel()
-		<-killed
+		select {
+		case <-killed:
+		case <-time.After(10 * time.Second):
+			require.FailNow(t, "cancellation handler never issued `kill query`")
+		}
 	})
 
 	tables := []*Table{{Name: sqlparser.NewIdentifierCS("t1"), Type: NoType, CreateTime: 1234}}
@@ -595,7 +599,11 @@ func TestReloadTablesInDBRollsBackWhenBeginIsCanceled(t *testing.T) {
 	db.AddQuery("begin", &sqltypes.Result{})
 	db.SetBeforeFunc("begin", func() {
 		cancel()
-		<-killed
+		select {
+		case <-killed:
+		case <-time.After(10 * time.Second):
+			require.FailNow(t, "cancellation handler never issued `kill query`")
+		}
 	})
 
 	tables := []*Table{{Name: sqlparser.NewIdentifierCS("t1"), Type: NoType, CreateTime: 1234}}

--- a/go/vt/vttablet/tabletserver/schema/db_test.go
+++ b/go/vt/vttablet/tabletserver/schema/db_test.go
@@ -565,6 +565,50 @@ func TestReloadTablesInDBClosesConnectionOnRollbackFailure(t *testing.T) {
 	require.True(t, conn.IsClosed())
 }
 
+// TestReloadTablesInDBRollsBackWhenBeginIsCanceled guards the same wedge as
+// TestReloadTablesInDBRollsBackOnCanceledContext, but for the narrow window
+// where the context is canceled while the `begin` itself is in flight. The
+// `begin` reaches MySQL and opens the transaction, but the killed query makes
+// Exec report an error — the cleanup rollback must still run so the connection
+// is not recycled holding an open transaction.
+func TestReloadTablesInDBRollsBackWhenBeginIsCanceled(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+
+	showCreateTableFields := sqltypes.MakeTestFields("Table | Create Table", "varchar|varchar")
+	conn := getReloadTestConn(t, db, "ReloadRollbackBegin")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	killed := make(chan struct{})
+	db.AddQueryPatternWithCallback(`kill query \d+`, &sqltypes.Result{}, func(string) {
+		close(killed)
+	})
+
+	db.AddQuery("rollback", &sqltypes.Result{})
+	db.AddQuery("show create table t1", sqltypes.MakeTestResult(showCreateTableFields, "t1|create_table_t1"))
+
+	// Cancel while `begin` is in flight, then block until the cancellation
+	// handler has killed the query. The transaction is opened on MySQL but
+	// Exec returns an error, so the reload never reaches the delete/insert.
+	db.AddQuery("begin", &sqltypes.Result{})
+	db.SetBeforeFunc("begin", func() {
+		cancel()
+		<-killed
+	})
+
+	tables := []*Table{{Name: sqlparser.NewIdentifierCS("t1"), Type: NoType, CreateTime: 1234}}
+	err := reloadTablesDataInDB(ctx, conn, tables, nil, sqlparser.NewTestParser())
+	require.Error(t, err)
+
+	// The transaction opened by `begin` must have been rolled back on MySQL.
+	// Without the fix the rollback is only deferred after `begin` succeeds, so
+	// a canceled `begin` leaves the transaction open and the connection is
+	// recycled poisoned.
+	require.Contains(t, db.QueryLog(), "rollback")
+}
+
 func TestReloadViewsInDB(t *testing.T) {
 	showCreateTableFields := sqltypes.MakeTestFields(" View | Create View | character_set_client | collation_connection", "varchar|varchar|varchar|varchar")
 	getViewDefinitionsFields := sqltypes.MakeTestFields("table_name|view_definition", "varchar|varchar")


### PR DESCRIPTION
## Description

A schema reload whose context is canceled mid-transaction could leave the schema-engine connection with an open transaction holding locks on `_vt.tables`. Two things combined to poison the connection:

- The reload runs its `begin`/`delete`/`insert`/`commit` through `conn.Exec`, which kills the in-flight query on cancellation (`insideTxn=false`) but leaves the MySQL session — and the open transaction — alive.
- The deferred `rollback` reused the already-canceled context, so it short-circuited before ever reaching MySQL.

The connection was then recycled into the pool still holding the transaction. Because schema reloads hold the engine mutex for their whole duration, every later reload blocked on those locks and timed out, wedging schema reloads on the primary until mysqld was restarted. (In the reported incident the primary stayed wedged for ~5 days while replicas reloaded normally.)

The fix routes the tables, views, and UDF reload paths through a small shared `reloadInTransaction` helper that runs the cleanup `rollback` on a fresh, time-bounded context (`context.WithoutCancel`) so it always reaches MySQL even when the caller's context is gone. If the rollback itself fails, the connection is closed so the pool discards it rather than reusing a session whose transaction state is unknown. The success-path query traffic (`begin … commit … rollback`) is unchanged.

This should be backported to all supported releases — the wedge affects the post-DDL reload path on v23, and the vstream-DDL-triggered reload path on v24/main widens the cancellation window. (v22 is EOL.)

## Related Issue(s)

Fixes #20314

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

This is a correctness fix on the primary schema-reload path; no migrations or config changes. Worth a callout in release notes since it changes recovery behavior after a canceled reload.

### AI Disclosure

This PR was written primarily by Claude Code — I provided the direction and review.