### PR TITLE
grpctmclient: evict a failed dedicated-pool dial so the next call redials

### DIFF
--- a/go/vt/vttablet/grpctmclient/client.go
+++ b/go/vt/vttablet/grpctmclient/client.go
@@ -294,6 +294,17 @@ func (client *grpcClient) dialDedicatedPool(ctx context.Context, dialPoolGroup D
 	})
 
 	if entry.err != nil {
+		// A failed dial must not be cached forever. The entry is guarded by a
+		// sync.Once, so without eviction every future call returns this same
+		// error even after the peer recovers — which would permanently mark a
+		// reachable tablet as down. Evict the entry so the next call redials.
+		// Only evict THIS entry: a concurrent caller may already have installed
+		// a fresh one for the same addr.
+		client.rpcDialPoolMapMu.Lock()
+		if poolEntries, ok := client.rpcDialPoolMap[dialPoolGroup]; ok && poolEntries[addr] == entry {
+			delete(poolEntries, addr)
+		}
+		client.rpcDialPoolMapMu.Unlock()
 		return nil, nil, entry.err
 	}
 

--- a/go/vt/vttablet/grpctmclient/client_test.go
+++ b/go/vt/vttablet/grpctmclient/client_test.go
@@ -18,6 +18,7 @@ package grpctmclient
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -251,4 +252,51 @@ func TestValidateTablet(t *testing.T) {
 		}
 		require.Error(t, validateTablet(tablet), "invalid tablet grpc port")
 	})
+}
+
+// TestDialDedicatedPoolEvictsFailedEntry verifies that a pooled dial that failed
+// to initialize is not cached forever. Each dedicated-pool entry is guarded by a
+// sync.Once, so a first createTmc failure would otherwise make every subsequent
+// dialDedicatedPool for that address return the same error without ever redialing,
+// permanently marking a reachable tablet as down until the client is recreated.
+// The failed entry must be evicted so the next dial reconnects.
+func TestDialDedicatedPoolEvictsFailedEntry(t *testing.T) {
+	ctx := t.Context()
+	client := NewClient()
+	tablet := &topodatapb.Tablet{
+		Hostname: "localhost",
+		PortMap:  map[string]int32{"grpc": 15992},
+	}
+	addr := netutil.JoinHostPort(tablet.Hostname, int32(tablet.PortMap["grpc"]))
+
+	rpcClient, ok := client.dialer.(*grpcClient)
+	require.True(t, ok)
+	poolDialer, ok := client.dialer.(poolDialer)
+	require.True(t, ok)
+
+	// Simulate a first dial that failed: install an entry whose once has already
+	// fired with an error, exactly as a createTmc failure would leave it.
+	failed := &tmcEntry{}
+	failed.once.Do(func() { failed.err = errors.New("simulated dial failure") })
+	rpcClient.rpcDialPoolMapMu.Lock()
+	rpcClient.rpcDialPoolMap = map[DialPoolGroup]addrTmcMap{
+		dialPoolGroupThrottler: {addr: failed},
+	}
+	rpcClient.rpcDialPoolMapMu.Unlock()
+
+	// A dial that finds the failed entry must surface the error AND evict it.
+	_, _, err := poolDialer.dialDedicatedPool(ctx, dialPoolGroupThrottler, tablet)
+	require.ErrorContains(t, err, "simulated dial failure")
+
+	rpcClient.rpcDialPoolMapMu.Lock()
+	_, stillCached := rpcClient.rpcDialPoolMap[dialPoolGroupThrottler][addr]
+	rpcClient.rpcDialPoolMapMu.Unlock()
+	assert.False(t, stillCached, "a failed pooled-dial entry must be evicted so the next dial redials")
+
+	// The next dial redials and succeeds (grpc dials lazily), proving the cached
+	// failure no longer permanently blocks recovery.
+	cli, invalidator, err := poolDialer.dialDedicatedPool(ctx, dialPoolGroupThrottler, tablet)
+	require.NoError(t, err)
+	assert.NotNil(t, cli)
+	assert.NotNil(t, invalidator)
 }


### PR DESCRIPTION
## Description

The `dialDedicatedPool` connection pool in `grpctmclient` caches one entry per `(DialPoolGroup, addr)` behind a `sync.Once`. If the one-time `createTmc` fails, that error is recorded permanently: every subsequent dial for the same address returns the same cached error and never redials, even after the peer recovers — so the pooled path to that tablet stays broken until the process holding the client restarts.

This is most visible for the throttler RPCs (`CheckThrottler` / `GetThrottlerStatus`, via `dialPoolGroupThrottler`): a single transient failure of the initial dial permanently degrades that path to a tablet.

The fix evicts the failed entry — identity-guarded, so a concurrently-installed fresh entry for the same address isn't dropped — so the next dial reconnects. It also adds `TestDialDedicatedPoolEvictsFailedEntry` as a regression test (it fails on the current code and passes with the fix).

This is a bug fix and should be backported. The `sync.Once`-based caching was introduced in 7bef87267b1, so any release branch carrying that commit is affected.

## Related Issue(s)

Fixes #20412

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — this is an internal connection-pool fix with no schema/migration, flag, or config changes.

### AI Disclosure

Claude Code helped write this fix and its regression test (originally part of #20253) and extract them into this stand-alone PR.
