### PR TITLE
Enforce recursion-depth limit on the streaming recursive CTE path

### DIFF
--- a/go/vt/vtgate/engine/recurse_cte.go
+++ b/go/vt/vtgate/engine/recurse_cte.go
@@ -18,6 +18,7 @@ package engine
 
 import (
 	"context"
+	"sync"
 
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -87,10 +88,17 @@ func (r *RecurseCTE) TryStreamExecute(ctx context.Context, vcursor VCursor, bind
 		return callback(res)
 	}
 
+	// A scatter source delivers its result chunks concurrently, one goroutine
+	// per shard, so both the shared frontier and the downstream callback must be
+	// serialized.
+	var mu sync.Mutex
+
 	// Stream the seed, emitting its rows and collecting them to drive the first
 	// recursion level.
 	var recurseRows []sqltypes.Row
 	err := vcursor.StreamExecutePrimitive(ctx, r.Seed, bindVars, wantfields, func(result *sqltypes.Result) error {
+		mu.Lock()
+		defer mu.Unlock()
 		recurseRows = append(recurseRows, result.Rows...)
 		return callback(result)
 	})
@@ -116,6 +124,8 @@ func (r *RecurseCTE) TryStreamExecute(ctx context.Context, vcursor VCursor, bind
 				return err
 			}
 			err := vcursor.StreamExecutePrimitive(ctx, r.Term, combineVars(bindVars, joinVars), false, func(result *sqltypes.Result) error {
+				mu.Lock()
+				defer mu.Unlock()
 				recurseRows = append(recurseRows, result.Rows...)
 				return callback(result)
 			})

--- a/go/vt/vtgate/engine/recurse_cte.go
+++ b/go/vt/vtgate/engine/recurse_cte.go
@@ -64,16 +64,16 @@ func (r *RecurseCTE) TryExecute(ctx context.Context, vcursor VCursor, bindVars m
 			if err := ctx.Err(); err != nil {
 				return nil, err
 			}
+			loops++
+			if loops > maxRecurseDepth {
+				return nil, vterrors.VT09030("")
+			}
 			rresult, err := vcursor.ExecutePrimitive(ctx, r.Term, combineVars(bindVars, joinVars), false)
 			if err != nil {
 				return nil, err
 			}
 			recurseRows = append(recurseRows, rresult.Rows...)
 			res.Rows = append(res.Rows, rresult.Rows...)
-			loops++
-			if loops > maxRecurseDepth {
-				return nil, vterrors.VT09030("")
-			}
 		}
 	}
 	return res, nil
@@ -123,6 +123,10 @@ func (r *RecurseCTE) TryStreamExecute(ctx context.Context, vcursor VCursor, bind
 			if err := ctx.Err(); err != nil {
 				return err
 			}
+			loops++
+			if loops > maxRecurseDepth {
+				return vterrors.VT09030("")
+			}
 			err := vcursor.StreamExecutePrimitive(ctx, r.Term, combineVars(bindVars, joinVars), false, func(result *sqltypes.Result) error {
 				mu.Lock()
 				defer mu.Unlock()
@@ -131,10 +135,6 @@ func (r *RecurseCTE) TryStreamExecute(ctx context.Context, vcursor VCursor, bind
 			})
 			if err != nil {
 				return err
-			}
-			loops++
-			if loops > maxRecurseDepth {
-				return vterrors.VT09030("")
 			}
 		}
 	}

--- a/go/vt/vtgate/engine/recurse_cte.go
+++ b/go/vt/vtgate/engine/recurse_cte.go
@@ -37,6 +37,10 @@ type RecurseCTE struct {
 
 var _ Primitive = (*RecurseCTE)(nil)
 
+// maxRecurseDepth caps the number of recursion iterations before we abort.
+// TODO: This should be controlled with the cte_max_recursion_depth system variable.
+const maxRecurseDepth = 1000
+
 func (r *RecurseCTE) TryExecute(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
 	res, err := vcursor.ExecutePrimitive(ctx, r.Seed, bindVars, wantfields)
 	if err != nil {
@@ -66,7 +70,7 @@ func (r *RecurseCTE) TryExecute(ctx context.Context, vcursor VCursor, bindVars m
 			recurseRows = append(recurseRows, rresult.Rows...)
 			res.Rows = append(res.Rows, rresult.Rows...)
 			loops++
-			if loops > 1000 { // TODO: This should be controlled with a system variable setting
+			if loops > maxRecurseDepth {
 				return nil, vterrors.VT09030("")
 			}
 		}
@@ -82,34 +86,46 @@ func (r *RecurseCTE) TryStreamExecute(ctx context.Context, vcursor VCursor, bind
 		}
 		return callback(res)
 	}
-	return vcursor.StreamExecutePrimitive(ctx, r.Seed, bindVars, wantfields, func(result *sqltypes.Result) error {
-		err := callback(result)
-		if err != nil {
-			return err
-		}
-		return r.recurse(ctx, vcursor, bindVars, result, callback)
+
+	// Stream the seed, emitting its rows and collecting them to drive the first
+	// recursion level.
+	var recurseRows []sqltypes.Row
+	err := vcursor.StreamExecutePrimitive(ctx, r.Seed, bindVars, wantfields, func(result *sqltypes.Result) error {
+		recurseRows = append(recurseRows, result.Rows...)
+		return callback(result)
 	})
-}
-
-func (r *RecurseCTE) recurse(ctx context.Context, vcursor VCursor, bindvars map[string]*querypb.BindVariable, result *sqltypes.Result, callback func(*sqltypes.Result) error) error {
-	if len(result.Rows) == 0 {
-		return nil
+	if err != nil {
+		return err
 	}
-	joinVars := make(map[string]*querypb.BindVariable)
-	for _, row := range result.Rows {
-		for k, col := range r.Vars {
-			joinVars[k] = sqltypes.ValueBindVariable(row[col])
-		}
 
-		err := vcursor.StreamExecutePrimitive(ctx, r.Term, combineVars(bindvars, joinVars), false, func(result *sqltypes.Result) error {
-			err := callback(result)
+	// Expand each recursion level iteratively, mirroring the buffered path. Only
+	// one Term stream is active at a time: recursing inside the Term callback
+	// would nest a live stream per level and exhaust the connection pool.
+	joinVars := make(map[string]*querypb.BindVariable)
+	loops := 0
+	for len(recurseRows) > 0 {
+		// copy over the results from the previous recursion
+		theseRows := recurseRows
+		recurseRows = nil
+		for _, row := range theseRows {
+			for k, col := range r.Vars {
+				joinVars[k] = sqltypes.ValueBindVariable(row[col])
+			}
+			// check if the context is done - we might be in a long running recursion
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			err := vcursor.StreamExecutePrimitive(ctx, r.Term, combineVars(bindVars, joinVars), false, func(result *sqltypes.Result) error {
+				recurseRows = append(recurseRows, result.Rows...)
+				return callback(result)
+			})
 			if err != nil {
 				return err
 			}
-			return r.recurse(ctx, vcursor, bindvars, result, callback)
-		})
-		if err != nil {
-			return err
+			loops++
+			if loops > maxRecurseDepth {
+				return vterrors.VT09030("")
+			}
 		}
 	}
 	return nil

--- a/go/vt/vtgate/engine/recurse_cte_test.go
+++ b/go/vt/vtgate/engine/recurse_cte_test.go
@@ -166,3 +166,33 @@ func TestRecurseCTERecursionLimit(t *testing.T) {
 	_, err = wrapStreamExecute(cte, &noopVCursor{}, bv, true)
 	require.ErrorContains(t, err, "Recursive query aborted")
 }
+
+// TestRecurseCTEStreamConcurrentDelivery verifies that the streaming path is
+// safe when a source delivers its result chunks concurrently, as a multi-shard
+// scatter does (StreamExecuteMulti fans out one goroutine per shard, each
+// invoking the callback without serialization). Run with -race to catch
+// unsynchronized access to the shared recursion frontier.
+func TestRecurseCTEStreamConcurrentDelivery(t *testing.T) {
+	fields := sqltypes.MakeTestFields("col1", "int64")
+
+	// The seed delivers many chunks concurrently, mimicking a scatter.
+	const seedChunks = 64
+	seedResults := make([]*sqltypes.Result, 0, seedChunks)
+	for i := range seedChunks {
+		seedResults = append(seedResults, sqltypes.MakeTestResult(fields, strconv.Itoa(i)))
+	}
+	seed := &fakePrimitive{results: seedResults, async: true, noLog: true}
+	// The Term returns no rows, so recursion stops after the seed level.
+	term := &fakePrimitive{results: []*sqltypes.Result{sqltypes.MakeTestResult(fields)}, noLog: true}
+
+	cte := &RecurseCTE{
+		Seed: seed,
+		Term: term,
+		Vars: map[string]int{"col1": 0},
+	}
+	bv := map[string]*querypb.BindVariable{}
+
+	res, err := wrapStreamExecute(cte, &noopVCursor{}, bv, true)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, seedChunks)
+}

--- a/go/vt/vtgate/engine/recurse_cte_test.go
+++ b/go/vt/vtgate/engine/recurse_cte_test.go
@@ -160,11 +160,19 @@ func TestRecurseCTERecursionLimit(t *testing.T) {
 	_, err := cte.TryExecute(t.Context(), &noopVCursor{}, bv, true)
 	require.ErrorContains(t, err, "Recursive query aborted")
 
-	// Streaming path must enforce the same guard.
+	// Streaming path must enforce the same guard. Streamed rows cannot be
+	// unsent, so the guard must fire before the over-limit Term stream starts:
+	// the client receives the seed row plus one row per allowed iteration, and
+	// nothing from iteration 1001.
 	seed.rewind()
 	term.rewind()
-	_, err = wrapStreamExecute(cte, &noopVCursor{}, bv, true)
+	var streamed []sqltypes.Row
+	err = cte.TryStreamExecute(t.Context(), &noopVCursor{}, bv, true, func(r *sqltypes.Result) error {
+		streamed = append(streamed, r.Rows...)
+		return nil
+	})
 	require.ErrorContains(t, err, "Recursive query aborted")
+	require.Len(t, streamed, 1001)
 }
 
 // TestRecurseCTEStreamConcurrentDelivery verifies that the streaming path is

--- a/go/vt/vtgate/engine/recurse_cte_test.go
+++ b/go/vt/vtgate/engine/recurse_cte_test.go
@@ -18,6 +18,7 @@ package engine
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -125,4 +126,43 @@ func TestRecurseDualQuery(t *testing.T) {
 		fmt.Sprintf(`Execute col1: %v false`, sqltypes.Int64BindVariable(4)),
 	})
 	expectResult(t, r, wantRes)
+}
+
+// TestRecurseCTERecursionLimit verifies that the recursion-depth guard is
+// enforced on both the buffered and streaming execution paths. The buffered
+// path aborts after 1000 iterations with VT09030 ("Recursive query aborted
+// after 1000 iterations."); the streaming path must enforce the same guard
+// rather than recursing unbounded.
+func TestRecurseCTERecursionLimit(t *testing.T) {
+	fields := sqltypes.MakeTestFields("col1", "int64")
+
+	// The Term keeps returning a single row well past the 1000-iteration guard,
+	// so an unguarded recursion would run all the way to the end of the results.
+	const iterations = 1100
+	results := make([]*sqltypes.Result, 0, iterations)
+	for i := range iterations {
+		results = append(results, sqltypes.MakeTestResult(fields, strconv.Itoa(i+2)))
+	}
+
+	seed := &fakePrimitive{
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(fields, "1")},
+	}
+	term := &fakePrimitive{results: results, noLog: true}
+
+	cte := &RecurseCTE{
+		Seed: seed,
+		Term: term,
+		Vars: map[string]int{"col1": 0},
+	}
+	bv := map[string]*querypb.BindVariable{}
+
+	// Buffered path aborts at the guard.
+	_, err := cte.TryExecute(t.Context(), &noopVCursor{}, bv, true)
+	require.ErrorContains(t, err, "Recursive query aborted")
+
+	// Streaming path must enforce the same guard.
+	seed.rewind()
+	term.rewind()
+	_, err = wrapStreamExecute(cte, &noopVCursor{}, bv, true)
+	require.ErrorContains(t, err, "Recursive query aborted")
 }


### PR DESCRIPTION
## Description

Recursive CTEs handled at vtgate by the `RecurseCTE` primitive enforce a 1000-iteration guard on the buffered (`TryExecute`) path — aborting with `VT09030` — but the streaming (`TryStreamExecute`) path had no such guard. Worse than just running longer, the streaming path could **hang vtgate**: `recurse()` called `StreamExecutePrimitive` on the `Term` and then recursed *inside that stream's own callback*, nesting a live stream per recursion level and exhausting the connection pool. A recursive CTE run under `workload=olap` (or via the gRPC `StreamExecute` API) could therefore never return — neither a result nor the `VT09030` error.

This rewrites the streaming path to expand each recursion level **iteratively**, mirroring the buffered path, so only one `Term` stream is active at a time. It adds the same iteration guard and per-iteration `ctx.Err()` check, and extracts the shared limit into a `maxRecurseDepth` constant.

One behavioral note: the streaming path previously expanded depth-first; it now expands breadth-first, **matching the buffered path**. Recursive-CTE row order without `ORDER BY` is unspecified, so this is a streaming/buffered consistency improvement rather than a correctness change — the result set is identical either way.

This should be backported to `release-23.0` and `release-24.0`: the affected code is byte-identical there and the streaming path is reachable via `SET workload = olap` today, so those releases can hang on a recursive CTE.

Note: honoring MySQL's `cte_max_recursion_depth` system variable (so the hardcoded 1000 becomes configurable) is tracked separately in #20433 and will be a main-only follow-up, since it's a new feature rather than a bug fix.

## Related Issue(s)

Fixes #18049

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Recursive CTEs executed on the streaming path (OLAP workload, or the gRPC `StreamExecute` API) now abort with `VT09030` ("Recursive query aborted after 1000 iterations.") once they exceed 1000 iterations, matching the buffered path, instead of hanging. Recursive CTEs that previously hung under the OLAP workload will now return this error.

### AI Disclosure

This PR was written primarily by Claude Code, with direction and review from me.
