### PR TITLE
Fix TestInitShardPrimary flakiness from racing startup replication queries

### DIFF
--- a/go/vt/vtctl/grpcvtctldserver/endtoend/init_shard_primary_test.go
+++ b/go/vt/vtctl/grpcvtctldserver/endtoend/init_shard_primary_test.go
@@ -19,9 +19,11 @@ package endtoend
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/mysqlctl"
+	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vtenv"
 
 	"github.com/stretchr/testify/assert"
@@ -88,7 +90,23 @@ func TestInitShardPrimary(t *testing.T) {
 	}
 	tablet3.FakeMysqlDaemon.SetReplicationSourceInputs = append(tablet3.FakeMysqlDaemon.SetReplicationSourceInputs, fmt.Sprintf("%v:%v", tablet1.Tablet.Hostname, tablet1.Tablet.MysqlPort))
 
-	for _, tablet := range []*testlib.FakeTablet{tablet1, tablet2, tablet3} {
+	// Start the primary-elect first and wait until it has recorded itself as the
+	// shard's primary in the topology. A replica only configures replication
+	// during its own startup if it observes a primary; making that observation
+	// deterministic keeps each replica's startup replication queries (STOP
+	// REPLICA, SET SOURCE, START REPLICA) ordered ahead of the ones
+	// InitShardPrimary issues. Otherwise the two sets race against each other on
+	// the fake mysql daemon's single ordered expected-query list, which flakes.
+	tablet1.StartActionLoop(t, wr)
+	defer tablet1.StopActionLoop(t)
+	tablet1.TM.QueryServiceControl.(*tabletservermock.Controller).SetQueryServiceEnabledForTests(true)
+
+	require.Eventually(t, func() bool {
+		si, err := ts.GetShard(ctx, tablet1.Tablet.Keyspace, tablet1.Tablet.Shard)
+		return err == nil && si.PrimaryAlias != nil && topoproto.TabletAliasEqual(si.PrimaryAlias, tablet1.Tablet.Alias)
+	}, 30*time.Second, 10*time.Millisecond, "primary-elect did not claim shard primaryship")
+
+	for _, tablet := range []*testlib.FakeTablet{tablet2, tablet3} {
 		tablet.StartActionLoop(t, wr)
 		defer tablet.StopActionLoop(t)
 


### PR DESCRIPTION
## Description

`TestInitShardPrimary` (in `go/vt/vtctl/grpcvtctldserver/endtoend`) is flaky. Each replica's fake mysql daemon is given a single, strictly-ordered `ExpectedExecuteSuperQueryList` that concatenates two independent query streams:

```go
// These come from tablet startup
"STOP REPLICA", "FAKE SET SOURCE", "START REPLICA",
// These come from InitShardPrimary
"FAKE RESET ALL REPLICATION", ...
```

Nothing orders those two streams. The primary-elect records itself as the shard primary asynchronously (via `startShardSync`), and a replica only runs its startup replication configuration (the first trio) if it observes a primary when it starts (`initializeReplication`, which is synchronous within `TM.Start`). When the replicas start before that async shard update is visible, they skip the startup trio, so `InitShardPrimary`'s queries land on the trio's slots and the fake daemon fails with:

```
wrong query for ExecuteSuperQueryList: expected STOP REPLICA got FAKE RESET ALL REPLICATION
```

The fix starts the primary-elect first and waits until it has claimed shard primaryship in the topology before starting the replicas. That makes each replica observe the primary at startup, so its synchronous startup replication configuration is ordered ahead of the queries `InitShardPrimary` issues, and the two streams can no longer interleave.

Verified with 100 iterations under `-race` (all green, no data race) and the full package.

Note: the fake daemon's `ExecuteSuperQueryList` reads/increments its cursor without taking `fmd.mu`, so concurrent callers are a latent data race. This fix sidesteps it by serializing the two streams in the test; hardening the fake daemon itself is a reasonable follow-up.

## Related Issue(s)

N/A — internal test-only fix.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — test-only change.

### AI Disclosure

This PR was written primarily by Claude Code, with direction and review from me.
