### PR TITLE
vtgate: copy bindVars per source in streaming Concatenate

### DIFF
--- a/go/test/endtoend/vtgate/misc_test.go
+++ b/go/test/endtoend/vtgate/misc_test.go
@@ -18,6 +18,7 @@ package vtgate
 
 import (
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -800,6 +801,28 @@ func TestUnionWithManyInfSchemaQueries(t *testing.T) {
                     TABLE_SCHEMA = 'ionescu'
                     AND
                     TABLE_NAME = 'user'`)
+}
+
+// TestUnionInfSchemaQueriesOLAP streams a UNION of many information_schema
+// queries (OLAP workload). Each branch routes through routeInfoSchemaQuery,
+// which mutates the bindVars map in place; the parallel streaming Concatenate
+// path must hand each source its own copy, otherwise the sources race on the
+// shared map and crash vtgate with a concurrent map write.
+func TestUnionInfSchemaQueriesOLAP(t *testing.T) {
+	conn, closer := start(t)
+	defer closer()
+
+	utils.Exec(t, conn, "set workload='olap'")
+
+	selects := make([]string, 0, 16)
+	for i := range 16 {
+		selects = append(selects, fmt.Sprintf("select TABLE_SCHEMA, TABLE_NAME from INFORMATION_SCHEMA.TABLES where TABLE_SCHEMA = 'ionescu' and TABLE_NAME = 'table_%d'", i))
+	}
+	query := strings.Join(selects, " UNION ")
+
+	for range 100 {
+		utils.Exec(t, conn, query)
+	}
 }
 
 func TestTransactionsInStreamingMode(t *testing.T) {

--- a/go/vt/vtgate/engine/concatenate.go
+++ b/go/vt/vtgate/engine/concatenate.go
@@ -244,8 +244,9 @@ func (c *Concatenate) parallelStreamExec(inCtx context.Context, vcursor VCursor,
 	// Start streaming query execution in parallel for all sources.
 	for i, source := range c.Sources {
 		currIndex, currSource := i, source
+		vars := copyBindVars(bindVars)
 		wg.Go(func() error {
-			err := vcursor.StreamExecutePrimitive(ctx, currSource, bindVars, true, func(resultChunk *sqltypes.Result) error {
+			err := vcursor.StreamExecutePrimitive(ctx, currSource, vars, true, func(resultChunk *sqltypes.Result) error {
 				muFields.Lock()
 
 				// Process fields when they arrive; coordinate field agreement across sources.
@@ -325,7 +326,8 @@ func (c *Concatenate) sequentialStreamExec(ctx context.Context, vcursor VCursor,
 
 	var mu sync.Mutex
 	for idx, source := range c.Sources {
-		err := vcursor.StreamExecutePrimitive(ctx, source, bindVars, true, func(resultChunk *sqltypes.Result) error {
+		vars := copyBindVars(bindVars)
+		err := vcursor.StreamExecutePrimitive(ctx, source, vars, true, func(resultChunk *sqltypes.Result) error {
 			// check if context has expired.
 			if ctx.Err() != nil {
 				return ctx.Err()

--- a/go/vt/vtgate/engine/concatenate_test.go
+++ b/go/vt/vtgate/engine/concatenate_test.go
@@ -175,6 +175,42 @@ func TestConcatenate_WithErrors(t *testing.T) {
 	require.EqualError(t, err, strFailed)
 }
 
+// TestConcatenateStreamBindVarIsolation ensures the streaming execution paths
+// hand each source its own copy of the bindVars map, matching the buffered
+// paths. Sources such as the information_schema route mutate bindVars in place
+// while routing; without an isolated copy, concurrent sources race on the
+// shared map (and can crash vtgate with a concurrent map write).
+func TestConcatenateStreamBindVarIsolation(t *testing.T) {
+	newSources := func() []Primitive {
+		fake := r("id|col1|col2", "int64|varbinary|varbinary", "1|a1|b1", "2|a2|b2")
+		var sources []Primitive
+		for i := range 8 {
+			sources = append(sources, &fakePrimitive{
+				results:      []*sqltypes.Result{fake},
+				noLog:        true,
+				writeBindVar: fmt.Sprintf("src%d", i),
+			})
+		}
+		return sources
+	}
+
+	t.Run("parallel", func(t *testing.T) {
+		concatenate := NewConcatenate(newSources(), nil)
+		bindVars := map[string]*querypb.BindVariable{"orig": sqltypes.Int64BindVariable(1)}
+		_, err := wrapStreamExecute(concatenate, &noopVCursor{}, bindVars, true)
+		require.NoError(t, err)
+		require.Equal(t, map[string]*querypb.BindVariable{"orig": sqltypes.Int64BindVariable(1)}, bindVars)
+	})
+
+	t.Run("sequential", func(t *testing.T) {
+		concatenate := NewConcatenate(newSources(), nil)
+		bindVars := map[string]*querypb.BindVariable{"orig": sqltypes.Int64BindVariable(1)}
+		_, err := wrapStreamExecute(concatenate, &noopVCursor{inTx: true}, bindVars, true)
+		require.NoError(t, err)
+		require.Equal(t, map[string]*querypb.BindVariable{"orig": sqltypes.Int64BindVariable(1)}, bindVars)
+	})
+}
+
 func TestConcatenateTypes(t *testing.T) {
 	tests := []struct {
 		t1, t2   string

--- a/go/vt/vtgate/engine/fake_primitive_test.go
+++ b/go/vt/vtgate/engine/fake_primitive_test.go
@@ -48,6 +48,12 @@ type fakePrimitive struct {
 	async bool
 
 	useNewPrintBindVars bool
+
+	// writeBindVar, when set, is written into the bindVars map on execution.
+	// It mirrors primitives such as the information_schema route that mutate
+	// the bindVars map in place, and lets tests assert each source is handed
+	// its own copy.
+	writeBindVar string
 }
 
 func (f *fakePrimitive) Inputs() ([]Primitive, []map[string]any) {
@@ -68,6 +74,10 @@ func (f *fakePrimitive) TryExecute(ctx context.Context, vcursor VCursor, bindVar
 		f.log = append(f.log, fmt.Sprintf("Execute %v %v", deprecatedPrintBindVars(bindVars), wantfields))
 	}
 
+	if f.writeBindVar != "" {
+		bindVars[f.writeBindVar] = sqltypes.Int64BindVariable(1)
+	}
+
 	if f.results == nil {
 		return nil, f.sendErr
 	}
@@ -84,6 +94,11 @@ func (f *fakePrimitive) TryStreamExecute(ctx context.Context, vcursor VCursor, b
 	if !f.noLog {
 		f.log = append(f.log, fmt.Sprintf("StreamExecute %v %v", deprecatedPrintBindVars(bindVars), wantfields))
 	}
+
+	if f.writeBindVar != "" {
+		bindVars[f.writeBindVar] = sqltypes.Int64BindVariable(1)
+	}
+
 	if f.results == nil {
 		return f.sendErr
 	}


### PR DESCRIPTION
## Description

The buffered `Concatenate` execution paths (`parallelExec`/`sequentialExec`) hand each source its own copy of the `bindVars` map, but the streaming paths (`parallelStreamExec`/`sequentialStreamExec`) passed the *shared* map to every source.

Routes over `information_schema` mutate the `bindVars` map in place while routing — `routeInfoSchemaQuery` writes the schema-name and table-name bind variables. When a `UNION` of such queries is streamed, the sources run concurrently in `parallelStreamExec` and race on the shared map, crashing vtgate with a `fatal error: concurrent map writes`.

This is reachable today, without any new flags, via the **OLAP workload**: `set workload='olap'` followed by a `UNION` of many `information_schema` queries streams through `Distinct → Concatenate.parallelStreamExec`, and the concurrent info_schema sources race on (and crash on) the shared `bindVars` map.

The fix copies `bindVars` per source in both streaming paths, matching the buffered paths, so each source only ever mutates its own map.

I think this is a good backport candidate — it's a pre-existing crash reachable on the OLAP path, present on `release-23.0` and `release-24.0` as well.

## How it works

- `parallelStreamExec` / `sequentialStreamExec` now do `vars := copyBindVars(bindVars)` per source, exactly like `parallelExec` / `sequentialExec`.
- Unit test `TestConcatenateStreamBindVarIsolation` (parallel + sequential) asserts the caller's `bindVars` map is left untouched — it fails deterministically without the fix.
- End-to-end test `TestUnionInfSchemaQueriesOLAP` streams a `UNION` of many `information_schema` queries under the OLAP workload; it crashes an unfixed vtgate (`concurrent map writes`) and passes with the fix.

## Related Issue(s)

Fixes #20437

Related to the historical `information_schema` UNION panic in #9139 (that was the buffered `CopyBindVariables` path; this is the streaming `Concatenate` variant).

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

This PR was written primarily by Claude Code — I provided direction and review.
