### PR TITLE
VReplication: reconcile in-memory workflow state metric from the persisted row

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -496,14 +496,16 @@ func (vr *vreplicator) loadSettings(ctx context.Context, dbClient *vdbClient) (s
 		vr.WorkflowType = int32(settings.WorkflowType)
 		vr.WorkflowSubType = int32(settings.WorkflowSubType)
 		vr.WorkflowName = settings.WorkflowName
-		// Reconcile the in-memory state with the row we just read from
-		// _vt.vreplication, which is the source of truth. A previous
-		// setState() advances stats.State (and vr.state) before its DB
-		// UPDATE is sent; when that UPDATE fails (e.g. the target is
-		// read-only during a reparent) the in-memory state is left out of
-		// sync with the persisted row. Re-syncing here on every successful
-		// read recovers the metric once the stream resumes. See #20012.
-		vr.state = settings.State
+		// Reconcile the exported state metric with the row we just read
+		// from _vt.vreplication, which is the source of truth. setState()
+		// advances stats.State before its DB UPDATE is sent, while vr.state
+		// is only updated after a successful write; when that UPDATE fails
+		// (e.g. the target is read-only during a reparent) the metric is
+		// left out of sync with the persisted row. Re-syncing it here on
+		// every successful read recovers the metric once the stream
+		// resumes. vr.state is deliberately left alone: it already matches
+		// the persisted row, and overwriting it would break the state
+		// transitions Replicate() relies on. See #20012.
 		vr.stats.State.Store(settings.State.String())
 	}
 	return settings, numTablesToCopy, err

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -496,6 +496,15 @@ func (vr *vreplicator) loadSettings(ctx context.Context, dbClient *vdbClient) (s
 		vr.WorkflowType = int32(settings.WorkflowType)
 		vr.WorkflowSubType = int32(settings.WorkflowSubType)
 		vr.WorkflowName = settings.WorkflowName
+		// Reconcile the in-memory state with the row we just read from
+		// _vt.vreplication, which is the source of truth. A previous
+		// setState() advances stats.State (and vr.state) before its DB
+		// UPDATE is sent; when that UPDATE fails (e.g. the target is
+		// read-only during a reparent) the in-memory state is left out of
+		// sync with the persisted row. Re-syncing here on every successful
+		// read recovers the metric once the stream resumes. See #20012.
+		vr.state = settings.State
+		vr.stats.State.Store(settings.State.String())
 	}
 	return settings, numTablesToCopy, err
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/replication"
+	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/dbconfigs"
@@ -983,4 +984,73 @@ func TestThrottlerAppNames(t *testing.T) {
 	assert.Contains(t, vc.throttlerAppName, "vreplication")
 	assert.Contains(t, vc.throttlerAppName, "vcopier")
 	assert.NotContains(t, vc.throttlerAppName, "vplayer")
+}
+
+// TestStateMetricNotStuckAfterFailedErrorWrite reproduces issue #20012.
+//
+// setState() advances the in-memory state metric (stats.State) *before* it
+// writes state='Error' to _vt.vreplication. When that UPDATE fails — e.g. the
+// target MySQL is read-only during a reparent (errno 1290) — setState returns
+// an error, so vr.state and the persisted row stay at their prior value
+// (Copying) and no vreplication_log row is written, yet the metric has already
+// been left reporting "Error". The controller retry loop then resumes the
+// stream, but the metric stays stuck on "Error" until the next *successful*
+// state change (in production this was ~34h later, on copy completion).
+//
+// This drives that exact sequence — a failed Error write followed by the
+// settings re-read the retry loop performs — and asserts the observable
+// invariant: the exported state metric must reflect the persisted state
+// (Copying), never a transition the stream never actually committed. It fails
+// on main (metric stuck "Error") and passes once the in-memory state is kept
+// consistent with the persisted row.
+func TestStateMetricNotStuckAfterFailedErrorWrite(t *testing.T) {
+	stats := binlogplayer.NewStats()
+	defer stats.Stop()
+	stats.State.Store(binlogdatapb.VReplicationWorkflowState_Copying.String())
+
+	mockDBClient := binlogplayer.NewMockDBClient(t)
+	defer mockDBClient.Close()
+
+	// 1. The Copying stream hits a terminal apply error, so setState(Error)
+	//    tries to persist state='Error'. The target is read-only, so the
+	//    UPDATE fails exactly as it did in production (errno 1290).
+	readOnlyErr := sqlerror.NewSQLError(sqlerror.EROptionPreventsStatement, "HY000",
+		"The MySQL server is running with the --read-only option so it cannot execute this statement")
+	mockDBClient.ExpectRequestRE("update _vt.vreplication set state='Error'.*where id=1", nil, readOnlyErr)
+
+	// 2. The controller retry loop re-reads settings; the persisted row is
+	//    still Copying because the Error write never landed.
+	settingsResp := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"pos|stop_pos|max_tps|max_replication_lag|state|workflow_type|workflow|workflow_sub_type|defer_secondary_keys|options",
+			"varbinary|varbinary|int64|int64|varbinary|int64|varchar|int64|int64|varchar",
+		),
+		"MySQL56/1b03758e-0dd0-4d39-b0dc-bb7acede17c1:1-1083||9223372036854775807|9223372036854775807|Copying|1|wf|0|0|{}",
+	)
+	mockDBClient.ExpectRequest(binlogplayer.TestGetWorkflowQueryId1, settingsResp, nil)
+	mockDBClient.ExpectRequest("select count(distinct table_name) from _vt.copy_state where vrepl_id=1",
+		sqltypes.MakeTestResult(sqltypes.MakeTestFields("count", "int64"), "0"), nil)
+
+	vr := &vreplicator{
+		id:       1,
+		stats:    stats,
+		dbClient: newVDBClient(mockDBClient, stats, vttablet.DefaultVReplicationConfig.RelayLogMaxItems),
+		state:    binlogdatapb.VReplicationWorkflowState_Copying,
+	}
+
+	// The Error write fails; the stream never actually left Copying.
+	err := vr.setState(binlogdatapb.VReplicationWorkflowState_Error, "terminal error: read-only target")
+	require.Error(t, err)
+	require.Equal(t, binlogdatapb.VReplicationWorkflowState_Copying, vr.state,
+		"vr.state must not advance when the state write fails")
+
+	// The retry loop re-reads the (still Copying) settings.
+	settings, _, err := vr.loadSettings(context.Background(), vr.dbClient)
+	require.NoError(t, err)
+	require.Equal(t, binlogdatapb.VReplicationWorkflowState_Copying, settings.State)
+
+	// Invariant (#20012): the exported metric must reflect the persisted
+	// state, not the "Error" transition that was never committed.
+	assert.Equal(t, binlogdatapb.VReplicationWorkflowState_Copying.String(), stats.State.Load(),
+		"state metric must reflect the persisted state (Copying), not a stuck Error")
 }


### PR DESCRIPTION
## Description

`(*vreplicator).setState()` stores the in-memory state metric (`stats.State`) *before* it writes the row to `_vt.vreplication`. When the controller hits a terminal error and calls `setState(Error, …)` but that `UPDATE` fails because the target MySQL is read-only (errno 1290, e.g. during a reparent), the metric is left reporting `Error` while the persisted row — the real source of truth — is unchanged (`Copying`) and no `_vt.vreplication_log` row is written. The stream then resumes copying, but the exported metric (`VReplicationStreamState` / `vttablet_v_replication_stream_state`) stays `Error` until the next *successful* `setState()`, giving operators a false, sticky `Error` alert on a perfectly healthy stream.

This reconciles `stats.State` from the freshly-read settings row on every successful `loadSettings()` call — the persisted workflow record is the source of truth — so the exported metric tracks reality and recovers as soon as the stream resumes. It's cheap and, as discussed in the issue, correct to always do.

Discussed with @mattlord in #20012.

Impact / backport note: on `main`, `release-23.0` and `release-24.0` the copy loop already re-emits `Copying` on retry as a side effect of #17804, so those branches self-heal within a retry — this change makes that reconcile intentional and robust rather than incidental (and also covers the batched-commit path). The long-lived stuck `Error` (a production incident kept a healthy stream reporting `Error` for ~34h) was on `release-22.0`, which is EOL upstream and is handled separately downstream.

## Related Issue(s)

Fixes #20012

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches — _I don't have triage access; requesting **Backport to: release-23.0** and **Backport to: release-24.0** (justification below). Could a maintainer apply these?_
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

Backport justification: this is a low-risk, cheap correctness fix for a metric that can otherwise falsely and stickily report `Error` on a healthy stream; backporting keeps the reconcile behavior consistent across supported releases.

## Deployment Notes

None.

### AI Disclosure

The fix and its regression test (`TestStateMetricNotStuckAfterFailedErrorWrite`) were written with Claude Code (Opus 4.8), under my direction and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
