### PR TITLE
repltracker: surface fatal replication IO errors

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -22,8 +22,6 @@
         - [Consolidator Reject on Waiter Cap](#vttablet-consolidator-reject-on-cap)
     - **[VTTablet](#minor-changes-vttablet)**
         - [Schema engine table-count limit is now configurable](#vttablet-schema-max-table-count)
-    - **[VTTablet](#minor-changes-vttablet)**
-        - [Polling replication reporter surfaces fatal IO errors](#vttablet-fatal-replication-io-error)
     - **[General](#minor-changes-general)**
         - [Build version metadata now sourced from VCS stamping](#build-info-from-vcs)
 
@@ -149,14 +147,6 @@ Two changes:
 Tablets that already have more tracked schema objects than the configured limit will reload fine — only new creations are gated. Operators who need to support more tables and views should increase the flag and ensure both vttablet and mysqld have enough memory to comfortably hold the larger schema.
 
 See [#19978](https://github.com/vitessio/vitess/issues/19978) for details.
-
-### <a id="minor-changes-vttablet"/>VTTablet</a>
-
-#### <a id="vttablet-fatal-replication-io-error"/>Polling replication reporter surfaces fatal IO errors</a>
-
-The polling replication reporter (used when the heartbeat reporter is disabled) previously kept reporting a replica as healthy — serving its last estimated lag — until it crossed `--unhealthy_threshold`, even when replication had hit an unrecoverable IO error. It now reports the replica `UNAVAILABLE` immediately when `Last_IO_Errno` is MySQL error `1236` (`ER_MASTER/SOURCE_FATAL_ERROR_READING_BINLOG`), which the source raises when the replica requests binlog events the source no longer has. The original `Last_IO_Error` message is returned to the caller, and the estimated lag is still included alongside it when a cached sample exists. Other, non-fatal replication states keep the existing cached-lag behavior.
-
-See [#20446](https://github.com/vitessio/vitess/pull/20446) for details.
 
 ### <a id="minor-changes-general"/>General</a>
 

--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -22,6 +22,8 @@
         - [Consolidator Reject on Waiter Cap](#vttablet-consolidator-reject-on-cap)
     - **[VTTablet](#minor-changes-vttablet)**
         - [Schema engine table-count limit is now configurable](#vttablet-schema-max-table-count)
+    - **[VTTablet](#minor-changes-vttablet)**
+        - [Polling replication reporter surfaces fatal IO errors](#vttablet-fatal-replication-io-error)
     - **[General](#minor-changes-general)**
         - [Build version metadata now sourced from VCS stamping](#build-info-from-vcs)
 
@@ -147,6 +149,14 @@ Two changes:
 Tablets that already have more tracked schema objects than the configured limit will reload fine — only new creations are gated. Operators who need to support more tables and views should increase the flag and ensure both vttablet and mysqld have enough memory to comfortably hold the larger schema.
 
 See [#19978](https://github.com/vitessio/vitess/issues/19978) for details.
+
+### <a id="minor-changes-vttablet"/>VTTablet</a>
+
+#### <a id="vttablet-fatal-replication-io-error"/>Polling replication reporter surfaces fatal IO errors</a>
+
+The polling replication reporter (used when the heartbeat reporter is disabled) previously kept reporting a replica as healthy — serving its last estimated lag — until it crossed `--unhealthy_threshold`, even when replication had hit an unrecoverable IO error. It now reports the replica `UNAVAILABLE` immediately when `Last_IO_Errno` is MySQL error `1236` (`ER_MASTER/SOURCE_FATAL_ERROR_READING_BINLOG`), which the source raises when the replica requests binlog events the source no longer has. The original `Last_IO_Error` message is returned to the caller, and the estimated lag is still included alongside it when a cached sample exists. Other, non-fatal replication states keep the existing cached-lag behavior.
+
+See [#20446](https://github.com/vitessio/vitess/pull/20446) for details.
 
 ### <a id="minor-changes-general"/>General</a>
 

--- a/go/mysql/replication/replication_status.go
+++ b/go/mysql/replication/replication_status.go
@@ -78,14 +78,18 @@ type ReplicationStatus struct {
 // fatalReplicationIOErrnos are the IO thread error codes (Last_IO_Errno) that
 // we treat as fatal: the replica has stopped replicating and cannot recover on
 // its own, so it needs operator intervention (e.g. a PRS/ERS) rather than time
-// to catch up. Currently the only such error is 1236,
-// ER_MASTER/SOURCE_FATAL_ERROR_READING_BINLOG, which the source raises when the
-// replica asks for binlog events the source no longer has. Comparing the
-// numeric errno (rather than matching Last_IO_Error text) is cheap and robust
-// across MySQL versions and the "master"/"source" message wording, which share
-// the same code. Additional fatal codes can be added here as they're identified.
+// to catch up. Currently the only such condition is the source raising fatal
+// error 1236 because the replica asks for binlog events the source no longer
+// has. Which code the replica records for it depends on the MySQL version:
+// since 8.0.26 Last_IO_Errno holds the server-side code 13114
+// (ER_SERVER_SOURCE_FATAL_ERROR_READING_BINLOG); older versions record 1236
+// (ER_MASTER_FATAL_ERROR_READING_BINLOG) directly. Comparing numeric errnos
+// (rather than matching Last_IO_Error text) is cheap and robust across the
+// "master"/"source" message wording changes. Additional fatal codes can be
+// added here as they're identified.
 var fatalReplicationIOErrnos = map[sqlerror.ErrorCode]bool{
-	sqlerror.ERMasterFatalReadingBinlog: true,
+	sqlerror.ERMasterFatalReadingBinlog:            true,
+	sqlerror.ERServerSourceFatalErrorReadingBinlog: true,
 }
 
 // Running returns true if both the IO and SQL threads are running.

--- a/go/mysql/replication/replication_status.go
+++ b/go/mysql/replication/replication_status.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/vt/log"
@@ -55,6 +54,7 @@ type ReplicationStatus struct {
 	SourceServerID         uint32
 	IOState                ReplicationState
 	LastIOError            string
+	LastIOErrno            uint32
 	SQLState               ReplicationState
 	LastSQLError           string
 	ReplicationLagSeconds  uint32
@@ -75,7 +75,18 @@ type ReplicationStatus struct {
 	SemiSyncReplicaStatus  bool
 }
 
-var fatalReplicationIOError = "Got fatal error " + sqlerror.ERMasterFatalReadingBinlog.ToString() + " from "
+// fatalReplicationIOErrnos are the IO thread error codes (Last_IO_Errno) that
+// we treat as fatal: the replica has stopped replicating and cannot recover on
+// its own, so it needs operator intervention (e.g. a PRS/ERS) rather than time
+// to catch up. Currently the only such error is 1236,
+// ER_MASTER/SOURCE_FATAL_ERROR_READING_BINLOG, which the source raises when the
+// replica asks for binlog events the source no longer has. Comparing the
+// numeric errno (rather than matching Last_IO_Error text) is cheap and robust
+// across MySQL versions and the "master"/"source" message wording, which share
+// the same code. Additional fatal codes can be added here as they're identified.
+var fatalReplicationIOErrnos = map[sqlerror.ErrorCode]bool{
+	sqlerror.ERMasterFatalReadingBinlog: true,
+}
 
 // Running returns true if both the IO and SQL threads are running.
 func (s *ReplicationStatus) Running() bool {
@@ -101,8 +112,12 @@ func (s *ReplicationStatus) SQLHealthy() bool {
 	return s.SQLState == ReplicationStateRunning
 }
 
-func (s *ReplicationStatus) HasFatalError() bool {
-	return strings.Contains(s.LastIOError, fatalReplicationIOError)
+// HasFatalReplicationError returns true when the replica has stopped due to a
+// fatal IO error (see fatalReplicationIOErrnos). Such a replica should be
+// reported unhealthy immediately, regardless of the reported/estimated lag,
+// because it will not recover without operator intervention.
+func (s *ReplicationStatus) HasFatalReplicationError() bool {
+	return fatalReplicationIOErrnos[sqlerror.ErrorCode(s.LastIOErrno)]
 }
 
 // ReplicationStatusToProto translates a Status to proto3.
@@ -365,6 +380,8 @@ func ParseReplicationStatus(fields map[string]string, replica bool) ReplicationS
 	status.SourceServerID = uint32(parseUint)
 	parseUint, _ = strconv.ParseUint(fields["SQL_Delay"], 10, 32)
 	status.SQLDelay = uint32(parseUint)
+	parseUint, _ = strconv.ParseUint(fields["Last_IO_Errno"], 10, 32)
+	status.LastIOErrno = uint32(parseUint)
 
 	executedPosStr := fields[execSourceLogPosField]
 	file := fields[relaySourceLogFileField]

--- a/go/mysql/replication/replication_status.go
+++ b/go/mysql/replication/replication_status.go
@@ -20,7 +20,9 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
+	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/vt/log"
 	replicationdatapb "vitess.io/vitess/go/vt/proto/replicationdata"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -73,6 +75,8 @@ type ReplicationStatus struct {
 	SemiSyncReplicaStatus  bool
 }
 
+var fatalReplicationIOError = "Got fatal error " + sqlerror.ERMasterFatalReadingBinlog.ToString() + " from "
+
 // Running returns true if both the IO and SQL threads are running.
 func (s *ReplicationStatus) Running() bool {
 	return s.IOState == ReplicationStateRunning && s.SQLState == ReplicationStateRunning
@@ -95,6 +99,10 @@ func (s *ReplicationStatus) IOHealthy() bool {
 // For consistency and to support altering this calculation in the future.
 func (s *ReplicationStatus) SQLHealthy() bool {
 	return s.SQLState == ReplicationStateRunning
+}
+
+func (s *ReplicationStatus) HasFatalError() bool {
+	return strings.Contains(s.LastIOError, fatalReplicationIOError)
 }
 
 // ReplicationStatusToProto translates a Status to proto3.

--- a/go/mysql/replication/replication_status_test.go
+++ b/go/mysql/replication/replication_status_test.go
@@ -72,8 +72,13 @@ func TestStatusHasFatalReplicationError(t *testing.T) {
 			want:        false,
 		},
 		{
-			name:        "fatal binlog read error",
+			name:        "fatal binlog read error pre 8.0.26",
 			lastIOErrno: uint32(sqlerror.ERMasterFatalReadingBinlog),
+			want:        true,
+		},
+		{
+			name:        "fatal binlog read error 8.0.26 and later",
+			lastIOErrno: uint32(sqlerror.ERServerSourceFatalErrorReadingBinlog),
 			want:        true,
 		},
 		{

--- a/go/mysql/replication/replication_status_test.go
+++ b/go/mysql/replication/replication_status_test.go
@@ -54,6 +54,47 @@ func TestStatusSQLThreadNotRunning(t *testing.T) {
 	assert.Equalf(t, want, got, "%#v.Running() = %v, want %v", input, got, want)
 }
 
+func TestStatusHasFatalError(t *testing.T) {
+	tests := []struct {
+		name        string
+		lastIOError string
+		want        bool
+	}{
+		{
+			name:        "no io error",
+			lastIOError: "",
+			want:        false,
+		},
+		{
+			name:        "fatal binlog read error",
+			lastIOError: "Got fatal error 1236 from source when reading data from binary log: 'Could not find first log file name in binary log index file'",
+			want:        true,
+		},
+		{
+			name:        "non fatal io error",
+			lastIOError: "error connecting to source",
+			want:        false,
+		},
+		{
+			name:        "different fatal error",
+			lastIOError: "Got fatal error 1235 from source when reading data from binary log",
+			want:        false,
+		},
+		{
+			name:        "longer error number",
+			lastIOError: "Got fatal error 12367 from source when reading data from binary log",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status := &ReplicationStatus{LastIOError: tt.lastIOError}
+			assert.Equal(t, tt.want, status.HasFatalError())
+		})
+	}
+}
+
 func TestFindErrantGTIDs(t *testing.T) {
 	sid1 := SID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	sid2 := SID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16}

--- a/go/mysql/replication/replication_status_test.go
+++ b/go/mysql/replication/replication_status_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/sqlerror"
 )
 
 func TestStatusReplicationRunning(t *testing.T) {
@@ -54,43 +56,37 @@ func TestStatusSQLThreadNotRunning(t *testing.T) {
 	assert.Equalf(t, want, got, "%#v.Running() = %v, want %v", input, got, want)
 }
 
-func TestStatusHasFatalError(t *testing.T) {
+// TestStatusHasFatalReplicationError verifies that a replica is flagged as
+// having a fatal replication error based on the numeric Last_IO_Errno, so the
+// check is independent of the Last_IO_Error message wording (which differs
+// between the "master" and "source" variants and across MySQL versions).
+func TestStatusHasFatalReplicationError(t *testing.T) {
 	tests := []struct {
 		name        string
-		lastIOError string
+		lastIOErrno uint32
 		want        bool
 	}{
 		{
 			name:        "no io error",
-			lastIOError: "",
+			lastIOErrno: 0,
 			want:        false,
 		},
 		{
 			name:        "fatal binlog read error",
-			lastIOError: "Got fatal error 1236 from source when reading data from binary log: 'Could not find first log file name in binary log index file'",
+			lastIOErrno: uint32(sqlerror.ERMasterFatalReadingBinlog),
 			want:        true,
 		},
 		{
 			name:        "non fatal io error",
-			lastIOError: "error connecting to source",
-			want:        false,
-		},
-		{
-			name:        "different fatal error",
-			lastIOError: "Got fatal error 1235 from source when reading data from binary log",
-			want:        false,
-		},
-		{
-			name:        "longer error number",
-			lastIOError: "Got fatal error 12367 from source when reading data from binary log",
+			lastIOErrno: uint32(sqlerror.ERAccessDeniedError),
 			want:        false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			status := &ReplicationStatus{LastIOError: tt.lastIOError}
-			assert.Equal(t, tt.want, status.HasFatalError())
+			status := &ReplicationStatus{LastIOErrno: tt.lastIOErrno}
+			assert.Equal(t, tt.want, status.HasFatalReplicationError())
 		})
 	}
 }

--- a/go/mysql/sqlerror/constants.go
+++ b/go/mysql/sqlerror/constants.go
@@ -320,6 +320,12 @@ const (
 
 	// server not available
 	ERServerIsntAvailable = ErrorCode(3168)
+
+	// ERServerSourceFatalErrorReadingBinlog is
+	// ER_SERVER_SOURCE_FATAL_ERROR_READING_BINLOG (MY-013114). Since MySQL
+	// 8.0.26 the replica records this server-side code in Last_IO_Errno when
+	// the source raises fatal error 1236; older versions record 1236 itself.
+	ERServerSourceFatalErrorReadingBinlog = ErrorCode(13114)
 )
 
 // HandlerErrorCode is for errors thrown by the handler, and which are then embedded in other errors.

--- a/go/test/endtoend/tabletmanager/replication_manager/tablet_test.go
+++ b/go/test/endtoend/tabletmanager/replication_manager/tablet_test.go
@@ -21,14 +21,18 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path"
 	"strconv"
 	"testing"
 	"time"
 
 	"vitess.io/vitess/go/vt/sidecardb"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	replicationdatapb "vitess.io/vitess/go/vt/proto/replicationdata"
 	tabletpb "vitess.io/vitess/go/vt/proto/topodata"
@@ -132,7 +136,8 @@ func resurrectTablet(t *testing.T, tab cluster.Vttablet) {
 	_, err := tab.MysqlctlProcess.ExecuteCommandWithOutput(
 		"--tablet-uid", strconv.Itoa(tab.MysqlctlProcess.TabletUID),
 		"--mysql-port", strconv.Itoa(tab.MysqlctlProcess.MySQLPort),
-		"init_config")
+		"init_config",
+	)
 	require.NoError(t, err)
 
 	tab.MysqlctlProcess.InitMysql = false
@@ -215,4 +220,63 @@ func TestReparentJournalInfo(t *testing.T) {
 		require.NoError(t, err)
 		require.EqualValues(t, 1, length)
 	}
+}
+
+// runSQL runs a query directly against the MySQL instance of the given
+// tablet, as the dba user.
+func runSQL(ctx context.Context, t *testing.T, tablet cluster.Vttablet, query string) *sqltypes.Result {
+	t.Helper()
+	connParams := mysql.ConnParams{
+		Uname:      "vt_dba",
+		UnixSocket: path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/mysql.sock", tablet.TabletUID)),
+	}
+	conn, err := mysql.Connect(ctx, &connParams)
+	require.NoError(t, err)
+	defer conn.Close()
+	qr, err := conn.ExecuteFetch(query, 1000, true)
+	require.NoError(t, err)
+	return qr
+}
+
+// TestFatalReplicationErrorMakesTabletUnhealthy breaks replication
+// unrecoverably: the primary purges binlogs the replica still needs, so the
+// replica's IO thread stops with the fatal binlog read error (1236, recorded
+// as errno 13114 by MySQL 8.0.26+). The replica must be reported unhealthy
+// right away, instead of quietly serving an estimated replication lag until
+// the unhealthy threshold is crossed.
+//
+// This test intentionally leaves the replica unable to replicate (the purged
+// transactions cannot be recovered), so it must remain the last test in this
+// package.
+func TestFatalReplicationErrorMakesTabletUnhealthy(t *testing.T) {
+	ctx := t.Context()
+
+	err := waitForSourcePort(ctx, t, replicaTablet, int32(primaryTablet.MySQLPort))
+	require.NoError(t, err)
+	require.NoError(t, replicaTablet.VttabletProcess.WaitForTabletStatus("SERVING"))
+
+	// Stop replication, move the primary ahead, and purge its binlogs so the
+	// replica can never catch up.
+	err = tmClient.StopReplication(ctx, getTablet(replicaTablet.GrpcPort))
+	require.NoError(t, err)
+
+	runSQL(ctx, t, primaryTablet, "insert into vt_ks.t1(id, value) values (100, 'unreachable')")
+	runSQL(ctx, t, primaryTablet, "flush binary logs")
+	binlogs := runSQL(ctx, t, primaryTablet, "show binary logs")
+	require.NotEmpty(t, binlogs.Rows)
+	lastFile := binlogs.Rows[len(binlogs.Rows)-1][0].ToString()
+	runSQL(ctx, t, primaryTablet, fmt.Sprintf("purge binary logs to '%s'", lastFile))
+
+	err = tmClient.StartReplication(ctx, getTablet(replicaTablet.GrpcPort), false)
+	require.NoError(t, err)
+
+	// The IO thread now stops with the fatal purged-binlogs error. The tablet
+	// must go unhealthy well before the replication lag unhealthy threshold
+	// would catch it.
+	err = replicaTablet.VttabletProcess.WaitForTabletStatusesForTimeout([]string{"NOT_SERVING"}, 2*time.Minute)
+	require.NoError(t, err)
+
+	status, err := tmcGetReplicationStatus(ctx, replicaTablet.GrpcPort)
+	require.NoError(t, err)
+	assert.Contains(t, status.LastIoError, "Got fatal error 1236")
 }

--- a/go/vt/mysqlctl/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon.go
@@ -107,6 +107,8 @@ type FakeMysqlDaemon struct {
 
 	// ReplicationStatusError is used by ReplicationStatus.
 	ReplicationStatusError error
+	LastIOError            string
+	LastSQLError           string
 
 	// StartReplicationError is used by StartReplication.
 	StartReplicationError error
@@ -382,10 +384,12 @@ func (fmd *FakeMysqlDaemon) ReplicationStatus(ctx context.Context) (replication.
 		ReplicationLagSeconds:                  fmd.ReplicationLagSeconds,
 		// Implemented as AND to avoid changing all tests that were
 		// previously using Replicating = false.
-		IOState:    replication.ReplicationStatusToState(strconv.FormatBool(fmd.Replicating && fmd.IOThreadRunning)),
-		SQLState:   replication.ReplicationStatusToState(strconv.FormatBool(fmd.Replicating)),
-		SourceHost: fmd.CurrentSourceHost,
-		SourcePort: fmd.CurrentSourcePort,
+		IOState:      replication.ReplicationStatusToState(strconv.FormatBool(fmd.Replicating && fmd.IOThreadRunning)),
+		SQLState:     replication.ReplicationStatusToState(strconv.FormatBool(fmd.Replicating)),
+		LastIOError:  fmd.LastIOError,
+		LastSQLError: fmd.LastSQLError,
+		SourceHost:   fmd.CurrentSourceHost,
+		SourcePort:   fmd.CurrentSourcePort,
 	}, nil
 }
 

--- a/go/vt/mysqlctl/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon.go
@@ -108,6 +108,7 @@ type FakeMysqlDaemon struct {
 	// ReplicationStatusError is used by ReplicationStatus.
 	ReplicationStatusError error
 	LastIOError            string
+	LastIOErrno            uint32
 	LastSQLError           string
 
 	// StartReplicationError is used by StartReplication.
@@ -387,6 +388,7 @@ func (fmd *FakeMysqlDaemon) ReplicationStatus(ctx context.Context) (replication.
 		IOState:      replication.ReplicationStatusToState(strconv.FormatBool(fmd.Replicating && fmd.IOThreadRunning)),
 		SQLState:     replication.ReplicationStatusToState(strconv.FormatBool(fmd.Replicating)),
 		LastIOError:  fmd.LastIOError,
+		LastIOErrno:  fmd.LastIOErrno,
 		LastSQLError: fmd.LastSQLError,
 		SourceHost:   fmd.CurrentSourceHost,
 		SourcePort:   fmd.CurrentSourcePort,

--- a/go/vt/vttablet/tabletserver/repltracker/poller.go
+++ b/go/vt/vttablet/tabletserver/repltracker/poller.go
@@ -59,6 +59,12 @@ func (p *poller) Status() (time.Duration, error) {
 	// value and it's thus NULL -- then we will estimate the lag ourselves using the last seen
 	// value + the time elapsed since.
 	if !status.Healthy() || status.ReplicationLagUnknown {
+		if status.HasFatalError() {
+			if p.timeRecorded.IsZero() {
+				return 0, vterrors.Errorf(vtrpcpb.Code_UNAVAILABLE, "%s", status.LastIOError)
+			}
+			return time.Since(p.timeRecorded) + p.lag, vterrors.Errorf(vtrpcpb.Code_UNAVAILABLE, "%s", status.LastIOError)
+		}
 		if p.timeRecorded.IsZero() {
 			return 0, vterrors.Errorf(vtrpcpb.Code_UNAVAILABLE, "replication is not running")
 		}

--- a/go/vt/vttablet/tabletserver/repltracker/poller.go
+++ b/go/vt/vttablet/tabletserver/repltracker/poller.go
@@ -59,7 +59,7 @@ func (p *poller) Status() (time.Duration, error) {
 	// value and it's thus NULL -- then we will estimate the lag ourselves using the last seen
 	// value + the time elapsed since.
 	if !status.Healthy() || status.ReplicationLagUnknown {
-		if status.HasFatalError() {
+		if status.HasFatalReplicationError() {
 			if p.timeRecorded.IsZero() {
 				return 0, vterrors.Errorf(vtrpcpb.Code_UNAVAILABLE, "%s", status.LastIOError)
 			}

--- a/go/vt/vttablet/tabletserver/repltracker/poller_test.go
+++ b/go/vt/vttablet/tabletserver/repltracker/poller_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/vt/mysqlctl"
 )
@@ -51,4 +52,46 @@ func TestPoller(t *testing.T) {
 	lag, err = poller.Status()
 	assert.NoError(t, err)
 	assert.Less(t, int64(1*time.Second), int64(lag))
+}
+
+func TestPollerReturnsFatalReplicationError(t *testing.T) {
+	poller := &poller{
+		lag:          time.Second,
+		timeRecorded: time.Now().Add(-10 * time.Millisecond),
+	}
+	mysqld := mysqlctl.NewFakeMysqlDaemon(nil)
+	poller.InitDBConfig(mysqld)
+
+	mysqld.LastIOError = "Got fatal error 1236 from source when reading data from binary log"
+
+	lag, err := poller.Status()
+	require.ErrorContains(t, err, mysqld.LastIOError)
+	assert.GreaterOrEqual(t, lag, time.Second)
+}
+
+func TestPollerReturnsFatalReplicationErrorWithoutCachedLag(t *testing.T) {
+	poller := &poller{}
+	mysqld := mysqlctl.NewFakeMysqlDaemon(nil)
+	poller.InitDBConfig(mysqld)
+
+	mysqld.LastIOError = "Got fatal error 1236 from source when reading data from binary log"
+
+	lag, err := poller.Status()
+	require.ErrorContains(t, err, mysqld.LastIOError)
+	assert.Zero(t, lag)
+}
+
+func TestPollerKeepsEstimatedLagForNonFatalReplicationError(t *testing.T) {
+	poller := &poller{
+		lag:          time.Second,
+		timeRecorded: time.Now().Add(-10 * time.Millisecond),
+	}
+	mysqld := mysqlctl.NewFakeMysqlDaemon(nil)
+	poller.InitDBConfig(mysqld)
+
+	mysqld.LastIOError = "error connecting to source"
+
+	lag, err := poller.Status()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, lag, time.Second)
 }

--- a/go/vt/vttablet/tabletserver/repltracker/poller_test.go
+++ b/go/vt/vttablet/tabletserver/repltracker/poller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/vt/mysqlctl"
 )
 
@@ -63,6 +64,7 @@ func TestPollerReturnsFatalReplicationError(t *testing.T) {
 	poller.InitDBConfig(mysqld)
 
 	mysqld.LastIOError = "Got fatal error 1236 from source when reading data from binary log"
+	mysqld.LastIOErrno = uint32(sqlerror.ERMasterFatalReadingBinlog)
 
 	lag, err := poller.Status()
 	require.ErrorContains(t, err, mysqld.LastIOError)
@@ -75,6 +77,7 @@ func TestPollerReturnsFatalReplicationErrorWithoutCachedLag(t *testing.T) {
 	poller.InitDBConfig(mysqld)
 
 	mysqld.LastIOError = "Got fatal error 1236 from source when reading data from binary log"
+	mysqld.LastIOErrno = uint32(sqlerror.ERMasterFatalReadingBinlog)
 
 	lag, err := poller.Status()
 	require.ErrorContains(t, err, mysqld.LastIOError)
@@ -90,6 +93,7 @@ func TestPollerKeepsEstimatedLagForNonFatalReplicationError(t *testing.T) {
 	poller.InitDBConfig(mysqld)
 
 	mysqld.LastIOError = "error connecting to source"
+	mysqld.LastIOErrno = uint32(sqlerror.ERAccessDeniedError)
 
 	lag, err := poller.Status()
 	require.NoError(t, err)

--- a/go/vt/vttablet/tabletserver/repltracker/poller_test.go
+++ b/go/vt/vttablet/tabletserver/repltracker/poller_test.go
@@ -63,8 +63,10 @@ func TestPollerReturnsFatalReplicationError(t *testing.T) {
 	mysqld := mysqlctl.NewFakeMysqlDaemon(nil)
 	poller.InitDBConfig(mysqld)
 
+	// MySQL 8.0.26+ records the server-side code 13114 in Last_IO_Errno
+	// while the message text still references the source's error 1236.
 	mysqld.LastIOError = "Got fatal error 1236 from source when reading data from binary log"
-	mysqld.LastIOErrno = uint32(sqlerror.ERMasterFatalReadingBinlog)
+	mysqld.LastIOErrno = uint32(sqlerror.ERServerSourceFatalErrorReadingBinlog)
 
 	lag, err := poller.Status()
 	require.ErrorContains(t, err, mysqld.LastIOError)

--- a/go/vt/vttablet/tabletserver/repltracker/poller_test.go
+++ b/go/vt/vttablet/tabletserver/repltracker/poller_test.go
@@ -26,6 +26,9 @@ import (
 
 	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/vt/mysqlctl"
+	"vitess.io/vitess/go/vt/vterrors"
+
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
 func TestPoller(t *testing.T) {
@@ -70,6 +73,9 @@ func TestPollerReturnsFatalReplicationError(t *testing.T) {
 
 	lag, err := poller.Status()
 	require.ErrorContains(t, err, mysqld.LastIOError)
+	// The point of this path is the CODE, not just the text: healthcheck keys
+	// off UNAVAILABLE to take the tablet out of rotation.
+	assert.Equal(t, vtrpcpb.Code_UNAVAILABLE, vterrors.Code(err))
 	assert.GreaterOrEqual(t, lag, time.Second)
 }
 
@@ -83,6 +89,7 @@ func TestPollerReturnsFatalReplicationErrorWithoutCachedLag(t *testing.T) {
 
 	lag, err := poller.Status()
 	require.ErrorContains(t, err, mysqld.LastIOError)
+	assert.Equal(t, vtrpcpb.Code_UNAVAILABLE, vterrors.Code(err))
 	assert.Zero(t, lag)
 }
 


### PR DESCRIPTION
## Description

The polling replication reporter keeps serving estimated lag when replication is unhealthy but it has a cached lag sample. That is useful for transient replication problems, but it hides the fatal binlog-read error reported in `Last_IO_Error`.

This adds a narrow check for MySQL fatal binlog read error 1236 in `Last_IO_Error`. When that specific error is present, the poller returns `UNAVAILABLE` with the original replication error. If a cached lag sample exists, it still returns the estimated lag alongside the error.

Non-fatal replication errors keep the existing estimated-lag behavior.

Tests run:

- `go test ./go/mysql/replication`
- `go test ./go/vt/vttablet/tabletserver/repltracker`
- `go test ./go/vt/mysqlctl -run '^TestReplicationStatus$'`

## Related Issue(s)

Fixes #13722

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Replicas using the polling replication reporter will now be reported unavailable immediately when `Last_IO_Error` contains MySQL fatal binlog read error 1236. Other unhealthy or transient replication states keep using the existing cached-lag behavior.

### AI Disclosure

This PR was written with Codex. I reviewed the issue context, kept the scope narrow, and ran the tests listed above.
