### PR TITLE
evalengine: use MySQL 1-based ordinal for ENUM in numeric context

### DIFF
--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -853,6 +853,17 @@ func TestEnumSetVals(t *testing.T) {
 
 	mcmp.AssertMatches("select id, enum_col, cast(enum_col as signed) from tbl_enum_set order by enum_col, id", `[[INT64(4) ENUM("xsmall") INT64(1)] [INT64(2) ENUM("small") INT64(2)] [INT64(1) ENUM("medium") INT64(3)] [INT64(5) ENUM("medium") INT64(3)] [INT64(3) ENUM("large") INT64(4)]]`)
 	mcmp.AssertMatches("select id, set_col, cast(set_col as unsigned) from tbl_enum_set order by set_col, id", `[[INT64(4) SET("a,b") UINT64(3)] [INT64(3) SET("c") UINT64(4)] [INT64(5) SET("a,d") UINT64(9)] [INT64(1) SET("a,b,e") UINT64(19)] [INT64(2) SET("e,f,g") UINT64(112)]]`)
+
+	// An ENUM used in a numeric context must use MySQL's 1-based ordinal
+	// (xsmall=1 ... xlarge=5), and a SET its bitmap value. These compare Vitess
+	// against MySQL directly so any divergence in the numeric conversion fails.
+	mcmp.Exec("select id, enum_col + 0 from tbl_enum_set order by id")
+	mcmp.Exec("select id, enum_col + 1 from tbl_enum_set order by id")
+	mcmp.Exec("select id, cast(enum_col as unsigned) from tbl_enum_set order by id")
+	mcmp.Exec("select id from tbl_enum_set where enum_col = 3 order by id")
+	mcmp.Exec("select id, enum_col from tbl_enum_set where enum_col > 2 order by enum_col, id")
+	mcmp.Exec("select id, set_col + 0 from tbl_enum_set order by id")
+	mcmp.Exec("select max(cast(enum_col as signed)) from tbl_enum_set")
 }
 
 func TestTimeZones(t *testing.T) {

--- a/go/vt/vtgate/evalengine/api_compare_test.go
+++ b/go/vt/vtgate/evalengine/api_compare_test.go
@@ -1198,6 +1198,35 @@ func TestNullsafeCompare(t *testing.T) {
 	}
 }
 
+// TestNullsafeCompareEnumNumeric ensures an ENUM compared against an integer
+// uses MySQL's 1-based ordinal (a=1, b=2, c=3), not a 0-based index. Comparing
+// enum('a','b','c') to the integer 2 must equal 'b'.
+func TestNullsafeCompareEnumNumeric(t *testing.T) {
+	values := &EnumSetValues{"'a'", "'b'", "'c'"}
+	collation := collations.ID(collations.CollationUtf8mb4ID)
+	tcases := []struct {
+		enum string
+		num  int64
+		out  int
+	}{
+		{"a", 2, -1},
+		{"b", 2, 0}, // 'b' is the 2nd member => ordinal 2
+		{"c", 2, 1},
+		{"a", 1, 0}, // 'a' is the 1st member => ordinal 1
+		{"c", 3, 0}, // 'c' is the 3rd member => ordinal 3
+	}
+	for _, tc := range tcases {
+		t.Run(fmt.Sprintf("%s?%d", tc.enum, tc.num), func(t *testing.T) {
+			got, err := NullsafeCompare(
+				sqltypes.TestValue(sqltypes.Enum, tc.enum),
+				sqltypes.NewInt64(tc.num),
+				collations.MySQL8(), collation, values)
+			require.NoError(t, err)
+			assert.Equal(t, tc.out, got)
+		})
+	}
+}
+
 func getCollationID(collation string) collations.ID {
 	id, _ := collationEnv.LookupID(collation)
 	return id

--- a/go/vt/vtgate/evalengine/eval_enum.go
+++ b/go/vt/vtgate/evalengine/eval_enum.go
@@ -69,6 +69,18 @@ func (e *evalEnum) Hash(h *vthash.Hasher) {
 	h.Write64(uint64(e.value))
 }
 
+// enumNumeric returns the value of an enum in a numeric context. MySQL uses the
+// 1-based ordinal of the value within the enum definition. A negative value is
+// the sentinel for a value that could not be resolved against the enum
+// definition (e.g. the definition was not available); it is passed through
+// unchanged to preserve the existing best-effort behavior for that case.
+func enumNumeric(value int) int64 {
+	if value < 0 {
+		return int64(value)
+	}
+	return int64(value) + 1
+}
+
 func valueIdx(values *EnumSetValues, value string) int {
 	if values == nil {
 		return -1

--- a/go/vt/vtgate/evalengine/eval_numeric.go
+++ b/go/vt/vtgate/evalengine/eval_numeric.go
@@ -162,7 +162,7 @@ func evalToNumeric(e eval, preciseDatetime bool) evalNumeric {
 		}
 		return &evalFloat{f: e.toFloat()}
 	case *evalEnum:
-		return &evalFloat{f: float64(e.value)}
+		return &evalFloat{f: float64(enumNumeric(e.value))}
 	case *evalSet:
 		return &evalFloat{f: float64(e.set)}
 	default:
@@ -222,7 +222,7 @@ func evalToFloat(e eval) (*evalFloat, bool) {
 	case *evalTemporal:
 		return &evalFloat{f: e.toFloat()}, true
 	case *evalEnum:
-		return &evalFloat{f: float64(e.value)}, e.value != -1
+		return &evalFloat{f: float64(enumNumeric(e.value))}, e.value != -1
 	case *evalSet:
 		return &evalFloat{f: float64(e.set)}, true
 	default:
@@ -290,7 +290,7 @@ func evalToDecimal(e eval, m, d int32) *evalDecimal {
 	case *evalTemporal:
 		return newEvalDecimal(e.toDecimal(), m, d)
 	case *evalEnum:
-		return newEvalDecimal(decimal.NewFromInt(int64(e.value)), m, d)
+		return newEvalDecimal(decimal.NewFromInt(enumNumeric(e.value)), m, d)
 	case *evalSet:
 		return newEvalDecimal(decimal.NewFromUint(e.set), m, d)
 	default:
@@ -357,7 +357,7 @@ func evalToInt64(e eval) *evalInt64 {
 	case *evalTemporal:
 		return newEvalInt64(e.toInt64())
 	case *evalEnum:
-		return newEvalInt64(int64(e.value))
+		return newEvalInt64(enumNumeric(e.value))
 	case *evalSet:
 		return newEvalInt64(int64(e.set))
 	default:


### PR DESCRIPTION
## Description

An `ENUM` evaluated in a numeric context was using its 0-based position within the enum definition instead of MySQL's 1-based ordinal. For `enum('a','b','c')`, `'a'` came out as `0` instead of `1`, `'b'` as `1` instead of `2`, and so on, and the empty/error value came out as `-1` instead of `0`.

This makes any numeric use of an enum off by one, including comparisons against integers. For example `WHERE enum_col = 2` matched `'c'` (the 3rd member) instead of `'b'` (the 2nd), so the query silently returned the wrong rows. It also affects `enum_col + 0`, `CAST(enum_col AS SIGNED/UNSIGNED)`, `SUM(enum_col)`, etc.

The four numeric conversions for `*evalEnum` in `eval_numeric.go` now go through a small `enumNumeric` helper that returns the 1-based ordinal for resolved values and passes the negative "unresolved" sentinel (used when the enum definition isn't available) through unchanged, so that path keeps its existing behavior. `SET` is unaffected (its numeric value is the bitmap), and enum ordering, weight strings and hashing are also unchanged since those only rely on the index for relative order, which stays consistent.

This is a correctness fix for silently-wrong query results, so it seems like a good candidate to backport to the supported release branches.

## Related Issue(s)

Fixes #20453

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

This PR was written primarily by Claude Code. I reviewed and verified the change, confirmed the behavior against MySQL, and directed the work.
