### PR TITLE
mysql: encode zero DATE/DATETIME/TIMESTAMP values as zero-length in the binary protocol

### DIFF
--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -1233,6 +1233,23 @@ func (c *Conn) writeBinaryRows(result *sqltypes.Result) error {
 	return nil
 }
 
+// isZeroDateTime reports whether the raw DATE, DATETIME or TIMESTAMP value is
+// the MySQL zero value (every date and time component is zero, e.g.
+// "0000-00-00 00:00:00"). MySQL encodes this as a zero-length value in the
+// binary protocol, so we must do the same to avoid clients decoding a length-4
+// or length-7 packet with all-zero components into a garbage date.
+func isZeroDateTime(raw []byte) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	for _, b := range raw {
+		if b >= '1' && b <= '9' {
+			return false
+		}
+	}
+	return true
+}
+
 func val2MySQL(v sqltypes.Value) ([]byte, error) {
 	var out []byte
 	pos := 0
@@ -1312,7 +1329,10 @@ func val2MySQL(v sqltypes.Value) ([]byte, error) {
 		out = make([]byte, 8)
 		writeUint64(out, pos, bits)
 	case sqltypes.Timestamp, sqltypes.Date, sqltypes.Datetime:
-		if len(v.Raw()) > 19 {
+		if isZeroDateTime(v.Raw()) {
+			out = make([]byte, 1)
+			out[pos] = 0x00
+		} else if len(v.Raw()) > 19 {
 			out = make([]byte, 1+11)
 			out[pos] = 0x0b
 			pos++
@@ -1559,7 +1579,9 @@ func val2MySQLLen(v sqltypes.Value) (int, error) {
 	case sqltypes.Uint64, sqltypes.Int64, sqltypes.Float64:
 		length = 8
 	case sqltypes.Timestamp, sqltypes.Date, sqltypes.Datetime:
-		if len(v.Raw()) > 19 {
+		if isZeroDateTime(v.Raw()) {
+			length = 1
+		} else if len(v.Raw()) > 19 {
 			length = 12
 		} else if len(v.Raw()) > 10 {
 			length = 8

--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -1123,7 +1123,7 @@ func (c *Conn) writePrepare(fld []*querypb.Field, prepare *PrepareData) error {
 	ok := PacketComStmtPrepareOK{
 		status:       OKPacket,
 		stmtID:       prepare.StatementID,
-		numCols:      (uint16)(columnCount),
+		numCols:      uint16(columnCount),
 		numParams:    paramsCount,
 		warningCount: 0,
 	}
@@ -1233,21 +1233,40 @@ func (c *Conn) writeBinaryRows(result *sqltypes.Result) error {
 	return nil
 }
 
-// isZeroDateTime reports whether the raw DATE, DATETIME or TIMESTAMP value is
-// the MySQL zero value (every date and time component is zero, e.g.
-// "0000-00-00 00:00:00"). MySQL encodes this as a zero-length value in the
-// binary protocol, so we must do the same to avoid clients decoding a length-4
-// or length-7 packet with all-zero components into a garbage date.
+// isZeroDateTime reports whether raw is a MySQL zero temporal value in one of
+// the canonical textual forms Vitess receives from MySQL:
+//
+//	"0000-00-00"                        (DATE)
+//	"0000-00-00 00:00:00"               (DATETIME / TIMESTAMP)
+//	"0000-00-00 00:00:00.0" … ".000000" (with 1-6 all-zero fractional digits)
+//
+// MySQL encodes these as a zero-length value in the binary protocol, so we must
+// do the same to avoid clients decoding a length-4/7/11 packet with all-zero
+// components into a garbage date. Only these exact forms are treated as zero;
+// anything malformed (e.g. "----", "0000/00/00", or a trailing "." with no
+// fractional digits) falls through to the normal length-based path rather than
+// being silently accepted as a valid zero date.
 func isZeroDateTime(raw []byte) bool {
-	if len(raw) == 0 {
-		return false
-	}
-	for _, b := range raw {
-		if b >= '1' && b <= '9' {
+	const zeroDateTime = "0000-00-00 00:00:00" // its 10-char prefix is the zero DATE
+	switch {
+	case string(raw) == zeroDateTime[:10], string(raw) == zeroDateTime:
+		return true
+	case len(raw) > len(zeroDateTime) && raw[len(zeroDateTime)] == '.' &&
+		string(raw[:len(zeroDateTime)]) == zeroDateTime:
+		// Fractional seconds must be 1-6 digits, all zero.
+		frac := raw[len(zeroDateTime)+1:]
+		if len(frac) == 0 || len(frac) > 6 {
 			return false
 		}
+		for _, b := range frac {
+			if b != '0' {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
 	}
-	return true
 }
 
 func val2MySQL(v sqltypes.Value) ([]byte, error) {

--- a/go/mysql/query_test.go
+++ b/go/mysql/query_test.go
@@ -769,3 +769,48 @@ func RowString(row []sqltypes.Value) string {
 	result += resultSb767.String()
 	return result
 }
+
+// TestVal2MySQLZeroDateTime verifies that the MySQL zero DATE/DATETIME/TIMESTAMP
+// value is serialized in the binary protocol as a zero-length value, matching
+// what MySQL itself emits, so clients decode it identically over the text and
+// binary protocols.
+func TestVal2MySQLZeroDateTime(t *testing.T) {
+	testcases := []struct {
+		name string
+		val  sqltypes.Value
+	}{
+		{"datetime", sqltypes.MakeTrusted(sqltypes.Datetime, []byte("0000-00-00 00:00:00"))},
+		{"datetime with microseconds", sqltypes.MakeTrusted(sqltypes.Datetime, []byte("0000-00-00 00:00:00.000000"))},
+		{"date", sqltypes.MakeTrusted(sqltypes.Date, []byte("0000-00-00"))},
+		{"timestamp", sqltypes.MakeTrusted(sqltypes.Timestamp, []byte("0000-00-00 00:00:00"))},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := val2MySQL(tc.val)
+			require.NoError(t, err)
+			require.Equal(t, []byte{0x00}, out)
+
+			l, err := val2MySQLLen(tc.val)
+			require.NoError(t, err)
+			require.Equal(t, len(out), l)
+		})
+	}
+}
+
+// TestVal2MySQLNonZeroDateTime guards that a non-zero DATE/DATETIME value keeps
+// its full binary encoding and is not mistaken for the zero value.
+func TestVal2MySQLNonZeroDateTime(t *testing.T) {
+	dt := sqltypes.MakeTrusted(sqltypes.Datetime, []byte("2020-01-02 03:04:05"))
+	out, err := val2MySQL(dt)
+	require.NoError(t, err)
+	require.Equal(t, byte(0x07), out[0])
+	l, err := val2MySQLLen(dt)
+	require.NoError(t, err)
+	require.Equal(t, len(out), l)
+
+	// A year of "0001" contains a non-zero digit and must not be treated as zero.
+	d := sqltypes.MakeTrusted(sqltypes.Date, []byte("0001-00-00"))
+	out, err = val2MySQL(d)
+	require.NoError(t, err)
+	require.Equal(t, byte(0x04), out[0])
+}

--- a/go/mysql/query_test.go
+++ b/go/mysql/query_test.go
@@ -814,3 +814,34 @@ func TestVal2MySQLNonZeroDateTime(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, byte(0x04), out[0])
 }
+
+// TestIsZeroDateTime pins the exact set of textual forms treated as the MySQL
+// zero temporal value. Only the canonical zero DATE/DATETIME/TIMESTAMP forms
+// (including all-zero fractional seconds) are zero; malformed values fall
+// through to the normal length-based path instead of being silently accepted
+// as a zero-length date.
+func TestIsZeroDateTime(t *testing.T) {
+	testcases := []struct {
+		raw  string
+		want bool
+	}{
+		{"0000-00-00", true},
+		{"0000-00-00 00:00:00", true},
+		{"0000-00-00 00:00:00.0", true},
+		{"0000-00-00 00:00:00.000000", true},
+		{"", false},
+		{"2020-01-02 03:04:05", false},
+		{"0001-00-00", false},
+		{"0000-00-00 00:00:01", false},
+		{"----", false},
+		{"0000/00/00", false},
+		{"0000-00-00 00:00:00.", false},
+		{"0000-00-00 00:00:00.0000000", false}, // 7 fractional digits
+		{"0000-00-00 00:00:00.00000a", false},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.raw, func(t *testing.T) {
+			assert.Equal(t, tc.want, isZeroDateTime([]byte(tc.raw)))
+		})
+	}
+}


### PR DESCRIPTION
## Description

The binary protocol encoder in `go/mysql/query.go` picks the packet layout for `DATE`/`DATETIME`/`TIMESTAMP` values purely from the string length. The MySQL zero value `0000-00-00 00:00:00` is 19 characters, so it gets encoded as a length-7 packet with all-zero year/month/day components (and `0000-00-00` as a length-4 packet). MySQL itself sends a zero-length value (a single `0x00` length byte) for the zero date, and clients rely on that.

The result is that clients decoding the components get a garbage date. For example go-sql-driver/mysql with `parseTime=true` decodes the all-zero component packet into `-0001-11-30 00:00:00`, so `time.Time.IsZero()` returns `false` and "not set" sentinel checks silently break. The text protocol path is fine, which also means prepared statements return a different value than plain queries for the same row.

The fix mirrors the existing `Time` special case (`00:00:00` is already emitted as zero-length): a small `isZeroDateTime` helper checks that the raw value contains no digit 1-9, and both `val2MySQL` and `val2MySQLLen` handle that case first so the emitted packet and the reported length stay consistent. Partially zero values like `2020-00-00` are unaffected and still encode their components, which matches what MySQL sends byte for byte.

Tests: `TestVal2MySQLZeroDateTime` covers the zero value for all three types plus the microseconds form, and `TestVal2MySQLNonZeroDateTime` guards that normal values and near-zero values like `0001-00-00` keep their full encoding. Both tests fail on main and pass with the fix, no live MySQL needed.

I think this should be backported: it is silent wrong data for any binary protocol client (every driver using prepared statements), there is no client-side workaround, and the fix is small and self-contained.

## Related Issue(s)

Fixes #20348

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

The fix and tests in this PR were developed with assistance from Claude Code. I reviewed the change, and ran the new tests plus the go/mysql binary/query/prepare test suites locally.
