### PR TITLE
binlog: escape JSON diff paths when generating diff SQL

### DIFF
--- a/go/mysql/binlog/binlog_json.go
+++ b/go/mysql/binlog/binlog_json.go
@@ -205,9 +205,7 @@ func ParseBinaryJSONDiff(data []byte) (sqltypes.Value, error) {
 		// character set (e.g. vreplication always uses set names binary).
 		// The generated path will look like this: _utf8mb4'$.role'
 		diff.WriteString(sqlparser.Utf8mb4Str)
-		diff.WriteByte('\'')
-		diff.Write(path)
-		diff.WriteByte('\'')
+		diff.WriteString(sqltypes.EncodeStringSQL(string(path)))
 		if opType == jsonDiffOpRemove { // No value for remove
 			diff.WriteByte(')') // Close the JSON function
 			continue

--- a/go/mysql/binlog/binlog_json_test.go
+++ b/go/mysql/binlog/binlog_json_test.go
@@ -313,6 +313,39 @@ func TestBinaryJSONOpaqueErrors(t *testing.T) {
 	}
 }
 
+func TestParseBinaryJSONDiffPathEscaping(t *testing.T) {
+	testcases := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "plain path is unchanged",
+			path:     `$.role`,
+			expected: `JSON_REMOVE(%s, _utf8mb4'$.role')`,
+		},
+		{
+			name:     "single quote in key is escaped",
+			path:     `$."a'b"`,
+			expected: `JSON_REMOVE(%s, _utf8mb4'$."a\'b"')`,
+		},
+		{
+			name:     "backslash in key is escaped",
+			path:     `$."a\b"`,
+			expected: `JSON_REMOVE(%s, _utf8mb4'$."a\\b"')`,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := []byte{byte(jsonDiffOpRemove), byte(len(tc.path))}
+			data = append(data, tc.path...)
+			val, err := ParseBinaryJSONDiff(data)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, val.RawStr())
+		})
+	}
+}
+
 func TestMarshalJSONToSQL(t *testing.T) {
 	testcases := []struct {
 		name     string


### PR DESCRIPTION
## Description

Follow-up to @mattlord's review on #20448.

In `ParseBinaryJSONDiff` (`go/mysql/binlog/binlog_json.go`) the JSON value in a generated diff is already SQL-escaped through `EncodeStringSQL`, but the JSON path was written verbatim inside `_utf8mb4'...'`:

```go
diff.WriteString(sqlparser.Utf8mb4Str)
diff.WriteByte('\'')
diff.Write(path)
diff.WriteByte('\'')
```

A JSON path can contain a quoted key, and that key can legitimately contain a single quote or a backslash. For example `$."o'brien"` is a valid path. Written verbatim it becomes `_utf8mb4'$."o'brien"'`, where the embedded single quote closes the string literal early and the rest is parsed as SQL. On the vreplication target that produces a broken apply query.

The fix mirrors what the value side already does: build the quoted path with `sqltypes.EncodeStringSQL(string(path))`, which quotes and escapes both `'` and `\`. Escaping the path introduces no new format verbs, so this is safe for the printf-style substitution done on older targets as well.

`TestParseBinaryJSONDiffPathEscaping` covers a plain path (unchanged), a single quote in a key, and a backslash in a key.

This is reachable when the source uses `binlog-row-value-options=PARTIAL_JSON` and a JSON object key contains one of these characters, so I think it is a reasonable backport candidate alongside #20448.

## Related Issue(s)

Related to #20447 and the review on #20448 (same partial JSON diff code path).

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

The fix and test in this PR were developed with assistance from Claude Code. I reviewed the change and ran the go/mysql/binlog tests locally.
