### PR TITLE
mysqlctl: force TZ=UTC for mysqlbinlog during point-in-time restore

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -1483,13 +1483,15 @@ func (mysqld *Mysqld) ApplyBinlogFile(ctx context.Context, req *mysqlctlpb.Apply
 
 		args := []string{}
 		if gtids := req.BinlogRestorePosition; gtids != "" {
-			args = append(args,
+			args = append(
+				args,
 				"--include-gtids",
 				gtids,
 			)
 		}
 		if restoreToTimestamp := protoutil.TimeFromProto(req.BinlogRestoreDatetime).UTC(); !restoreToTimestamp.IsZero() {
-			args = append(args,
+			args = append(
+				args,
 				"--stop-datetime",
 				restoreToTimestamp.Format(sqltypes.TimestampFormat),
 			)
@@ -1700,6 +1702,12 @@ func (mysqld *Mysqld) ReadBinlogFilesTimestamps(ctx context.Context, req *mysqlc
 	if err != nil {
 		return nil, err
 	}
+	// mysqlbinlog prints event timestamps in its own process time zone, and the
+	// MySQL 5.7 fallback in parseBinlogEntryTimestamp parses the zone-less value
+	// as UTC. Force TZ=UTC so the recorded First/LastTimestamp match that
+	// assumption on non-UTC hosts, the same way ApplyBinlogFile does for
+	// --stop-datetime. See https://github.com/vitessio/vitess/issues/20373.
+	mysqlbinlogEnv := mysqlbinlogEnviron(env)
 
 	lastMatchedTimeMap := map[string]time.Time{} // a simple cache to avoid rescanning same files. Key=binlog file name
 
@@ -1707,7 +1715,7 @@ func (mysqld *Mysqld) ReadBinlogFilesTimestamps(ctx context.Context, req *mysqlc
 	// Find first timestamp
 	err = func() error {
 		for _, binlogFile := range req.BinlogFileNames {
-			firstMatchedTime, lastMatchedTime, err := mysqld.scanBinlogTimestamp(dir, env, mysqlbinlogName, binlogFile, true)
+			firstMatchedTime, lastMatchedTime, err := mysqld.scanBinlogTimestamp(dir, mysqlbinlogEnv, mysqlbinlogName, binlogFile, true)
 			if err != nil {
 				return vterrors.Wrapf(err, "while scanning for first binlog timestamp in %v", binlogFile)
 			}
@@ -1736,7 +1744,7 @@ func (mysqld *Mysqld) ReadBinlogFilesTimestamps(ctx context.Context, req *mysqlc
 			lastMatchedTime, ok := lastMatchedTimeMap[binlogFile]
 			if !ok {
 				var err error
-				_, lastMatchedTime, err = mysqld.scanBinlogTimestamp(dir, env, mysqlbinlogName, binlogFile, false)
+				_, lastMatchedTime, err = mysqld.scanBinlogTimestamp(dir, mysqlbinlogEnv, mysqlbinlogName, binlogFile, false)
 				if err != nil {
 					return vterrors.Wrapf(err, "while scanning for last binlog timestamp in %v", binlogFile)
 				}

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -1431,6 +1431,20 @@ func (mysqld *Mysqld) HostMetrics(ctx context.Context, cnf *Mycnf) (*mysqlctlpb.
 	return hostMetrics(ctx, cnf)
 }
 
+// mysqlbinlogEnviron returns the environment to use when running mysqlbinlog.
+// mysqlbinlog interprets --stop-datetime (and --start-datetime) in its own
+// process time zone. ApplyBinlogFile formats the restore timestamp in UTC, and
+// Vitess clears the host environment before invoking mysqlbinlog, so we force
+// TZ=UTC here to make mysqlbinlog read that timestamp as UTC too. Without this,
+// on a host whose time zone is not UTC, mysqlbinlog stops at the wrong point and
+// the wrong point in time is restored.
+// See https://github.com/vitessio/vitess/issues/20373.
+func mysqlbinlogEnviron(baseEnv []string) []string {
+	// Use a full three-index slice so the append never mutates baseEnv, which is
+	// shared with the mysql command that applies the output.
+	return append(baseEnv[:len(baseEnv):len(baseEnv)], "TZ=UTC")
+}
+
 // ApplyBinlogFile extracts a binary log file and applies it to MySQL. It is the equivalent of:
 // $ mysqlbinlog --include-gtids binlog.file | mysql
 func (mysqld *Mysqld) ApplyBinlogFile(ctx context.Context, req *mysqlctlpb.ApplyBinlogFileRequest) error {
@@ -1485,7 +1499,7 @@ func (mysqld *Mysqld) ApplyBinlogFile(ctx context.Context, req *mysqlctlpb.Apply
 
 		mysqlbinlogCmd = exec.Command(name, args...)
 		mysqlbinlogCmd.Dir = dir
-		mysqlbinlogCmd.Env = env
+		mysqlbinlogCmd.Env = mysqlbinlogEnviron(env)
 		mysqlbinlogCmd.Stderr = mysqlbinlogErrFile
 		log.Info(fmt.Sprintf("ApplyBinlogFile: running mysqlbinlog command: %#v with errfile=%v", mysqlbinlogCmd, mysqlbinlogErrFile.Name()))
 		pipe, err = mysqlbinlogCmd.StdoutPipe() // to be piped into mysql

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -1440,9 +1440,18 @@ func (mysqld *Mysqld) HostMetrics(ctx context.Context, cnf *Mycnf) (*mysqlctlpb.
 // the wrong point in time is restored.
 // See https://github.com/vitessio/vitess/issues/20373.
 func mysqlbinlogEnviron(baseEnv []string) []string {
-	// Use a full three-index slice so the append never mutates baseEnv, which is
-	// shared with the mysql command that applies the output.
-	return append(baseEnv[:len(baseEnv):len(baseEnv)], "TZ=UTC")
+	// baseEnv can already carry a TZ entry (e.g. from os.Environ() via
+	// buildLdPaths()). Drop it so mysqlbinlog only ever sees one TZ entry;
+	// otherwise the effective time zone would depend on how the child
+	// process resolves duplicate environment variables.
+	env := make([]string, 0, len(baseEnv)+1)
+	for _, e := range baseEnv {
+		if strings.HasPrefix(e, "TZ=") {
+			continue
+		}
+		env = append(env, e)
+	}
+	return append(env, "TZ=UTC")
 }
 
 // ApplyBinlogFile extracts a binary log file and applies it to MySQL. It is the equivalent of:

--- a/go/vt/mysqlctl/mysqld_test.go
+++ b/go/vt/mysqlctl/mysqld_test.go
@@ -449,3 +449,25 @@ func TestMysqlbinlogEnvironForcesUTC(t *testing.T) {
 	// command that applies the mysqlbinlog output)
 	require.Equal(t, baseCopy, base)
 }
+
+// TestMysqlbinlogEnvironOverridesExistingTZ verifies that a pre-existing TZ
+// entry in the base environment (e.g. from os.Environ() via buildLdPaths())
+// is replaced, not duplicated, so mysqlbinlog can't end up seeing two TZ
+// values.
+func TestMysqlbinlogEnvironOverridesExistingTZ(t *testing.T) {
+	base := []string{"LD_LIBRARY_PATH=/opt/mysql/lib", "TZ=Europe/Berlin"}
+	baseCopy := append([]string(nil), base...)
+
+	got := mysqlbinlogEnviron(base)
+
+	count := 0
+	for _, e := range got {
+		if strings.HasPrefix(e, "TZ=") {
+			count++
+		}
+	}
+	require.Equal(t, 1, count, "expected exactly one TZ entry, got %v", got)
+	require.Contains(t, got, "TZ=UTC")
+	require.NotContains(t, got, "TZ=Europe/Berlin")
+	require.Equal(t, baseCopy, base)
+}

--- a/go/vt/mysqlctl/mysqld_test.go
+++ b/go/vt/mysqlctl/mysqld_test.go
@@ -429,3 +429,23 @@ func TestBuildLdPathsTZ(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, env, "TZ=Europe/Berlin")
 }
+
+// TestMysqlbinlogEnvironForcesUTC verifies that the environment used for
+// mysqlbinlog forces TZ=UTC so that the UTC-formatted --stop-datetime is
+// interpreted as UTC regardless of the host time zone. It also verifies that
+// the shared base environment is not mutated. Regression test for #20373.
+func TestMysqlbinlogEnvironForcesUTC(t *testing.T) {
+	base := []string{"LD_LIBRARY_PATH=/opt/mysql/lib", "LD_PRELOAD="}
+	baseCopy := append([]string(nil), base...)
+
+	got := mysqlbinlogEnviron(base)
+
+	require.Contains(t, got, "TZ=UTC")
+	// every entry from the base environment is preserved
+	for _, e := range baseCopy {
+		require.Contains(t, got, e)
+	}
+	// the shared base environment is left untouched (it is reused by the mysql
+	// command that applies the mysqlbinlog output)
+	require.Equal(t, baseCopy, base)
+}


### PR DESCRIPTION
## Description

On a host whose time zone is not UTC, a point-in-time restore stops at the wrong point and restores the wrong data.

`Mysqld.ApplyBinlogFile` formats the restore timestamp in UTC and passes it to `mysqlbinlog` as `--stop-datetime`:

```go
restoreToTimestamp := protoutil.TimeFromProto(req.BinlogRestoreDatetime).UTC()
args = append(args, "--stop-datetime", restoreToTimestamp.Format(sqltypes.TimestampFormat))
```

But `mysqlbinlog` interprets `--stop-datetime` in its own process time zone, and Vitess clears the host environment before invoking it (only `LD_*` paths are set). So on a host in, say, `America/New_York`, mysqlbinlog reads the UTC-formatted timestamp as local time and stops several hours off, restoring the wrong point in time. `mysqlbinlog` has no option or `my.cnf` setting to specify a time zone, so the environment is the only lever.

This forces `TZ=UTC` in the mysqlbinlog environment, so the UTC-formatted timestamp is read as UTC. This matches the approach suggested in the issue and keeps Vitess consistent with its UTC handling elsewhere. The base environment is shared with the `mysql` command that applies the mysqlbinlog output, so the helper builds a fresh slice rather than mutating it.

`TestMysqlbinlogEnvironForcesUTC` verifies `TZ=UTC` is present, the base entries are preserved, and the shared base environment is not mutated.

This is silent data corruption (wrong data restored, no error), so I think it is a good backport candidate.

## Related Issue(s)

Fixes #20373

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

The fix and test were developed with assistance from Claude Code. I reviewed the change and ran the go/vt/mysqlctl unit tests locally.
