### PR TITLE
servenv/vtgate: fix cross-test data races in unit tests

### DIFF
--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -19,6 +19,7 @@ package servenv
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -348,9 +349,14 @@ func serveGRPC() {
 	//       runs all OnRun() hooks after createGRPCServer() and before
 	//       serveGRPC(). If this was not the case, the binary would crash with
 	//       the error "grpc: Server.RegisterService after Server.Serve".
+	// Capture the server so the goroutine below does not read the GRPCServer
+	// global, which tests swap out between runs.
+	server := GRPCServer
 	go func() {
-		err := GRPCServer.Serve(listener)
-		if err != nil {
+		err := server.Serve(listener)
+		// Serve returns ErrServerStopped when Stop or GracefulStop was called
+		// before it started; that is a clean shutdown, not a startup failure.
+		if err != nil && !errors.Is(err, grpc.ErrServerStopped) {
 			log.Error(fmt.Sprintf("Failed to start grpc server: %v", err))
 			os.Exit(1)
 		}

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -309,18 +309,21 @@ func interceptors() []grpc.ServerOption {
 	return interceptors.Build()
 }
 
-func serveGRPC() {
+// serveGRPC returns a stop function that terminates the ORCA metrics updater
+// goroutine, if one was started; it is a no-op otherwise.
+func serveGRPC() (stopOrcaUpdater func()) {
+	stopOrcaUpdater = func() {}
 	if grpccommon.EnableGRPCPrometheus() {
 		grpc_prometheus.Register(GRPCServer)
 		grpc_prometheus.EnableHandlingTimeHistogram()
 	}
 	// skip if not registered
 	if gRPCPort == 0 {
-		return
+		return stopOrcaUpdater
 	}
 
 	if gRPCEnableOrcaMetrics {
-		registerOrca()
+		stopOrcaUpdater = registerOrca()
 	}
 
 	// register reflection to support list calls :)
@@ -367,9 +370,14 @@ func serveGRPC() {
 		GRPCServer.GracefulStop()
 		log.Info("gRPC server stopped")
 	})
+
+	return stopOrcaUpdater
 }
 
-func registerOrca() {
+// registerOrca returns a stop function that terminates the metrics updater
+// goroutine and waits for it to exit, so that once it returns the goroutine
+// no longer touches any package state.
+func registerOrca() (stop func()) {
 	if err := orcaRegisterFunc(GRPCServer, orca.ServiceOptions{
 		// The minimum interval of orca is 30 seconds, unless we enable a testing flag.
 		MinReportingInterval:  30 * time.Second,
@@ -383,14 +391,30 @@ func registerOrca() {
 	GRPCServerMetricsRecorder.SetCPUUtilization(getCpuUsage())
 	GRPCServerMetricsRecorder.SetMemoryUtilization(getMemoryUsage())
 
+	// Capture the recorder so the goroutine below does not read the
+	// GRPCServerMetricsRecorder global, which tests swap out between runs.
+	recorder := GRPCServerMetricsRecorder
+	stopCh := make(chan struct{})
+	doneCh := make(chan struct{})
 	go func() {
+		defer close(doneCh)
 		ticker := time.NewTicker(30 * time.Second)
 		defer ticker.Stop()
-		for range ticker.C {
-			GRPCServerMetricsRecorder.SetCPUUtilization(getCpuUsage())
-			GRPCServerMetricsRecorder.SetMemoryUtilization(getMemoryUsage())
+		for {
+			select {
+			case <-ticker.C:
+				recorder.SetCPUUtilization(getCpuUsage())
+				recorder.SetMemoryUtilization(getMemoryUsage())
+			case <-stopCh:
+				return
+			}
 		}
 	}()
+
+	return func() {
+		close(stopCh)
+		<-doneCh
+	}
 }
 
 // GRPCCheckServiceMap returns if we should register a gRPC service

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -368,7 +368,7 @@ func serveGRPC() (stopOrcaUpdater func()) {
 
 	OnTermSync(func() {
 		log.Info("Initiated graceful stop of gRPC server")
-		GRPCServer.GracefulStop()
+		server.GracefulStop()
 		log.Info("gRPC server stopped")
 	})
 

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"sync"
 	"time"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
@@ -411,10 +412,10 @@ func registerOrca() (stop func()) {
 		}
 	}()
 
-	return func() {
+	return sync.OnceFunc(func() {
 		close(stopCh)
 		<-doneCh
-	}
+	})
 }
 
 // GRPCCheckServiceMap returns if we should register a gRPC service

--- a/go/vt/servenv/grpc_server_test.go
+++ b/go/vt/servenv/grpc_server_test.go
@@ -84,7 +84,9 @@ func TestReportedOrca(t *testing.T) {
 	// stopped before the withTempVar cleanups above restore the globals.
 	stopOrcaUpdater := serveGRPC()
 	t.Cleanup(stopOrcaUpdater)
-	defer GRPCServer.Stop()
+	// The method value binds the receiver now, so the cleanup stops this
+	// test's server no matter when the GRPCServer global gets restored.
+	t.Cleanup(GRPCServer.Stop)
 
 	serverMetrics := GRPCServerMetricsRecorder.ServerMetrics()
 	cpuUsage := serverMetrics.CPUUtilization
@@ -165,19 +167,19 @@ func runIngressStatsTestRPC(t *testing.T, ingressBytes *uint64) {
 	t.Helper()
 
 	port := getFreePort()
-	defer withTempVar(&gRPCPort, port)()
-	defer withTempVar(&gRPCBindAddress, "127.0.0.1")()
-	defer withTempVar(&GRPCServer, (*grpc.Server)(nil))()
+	t.Cleanup(withTempVar(&gRPCPort, port))
+	t.Cleanup(withTempVar(&gRPCBindAddress, "127.0.0.1"))
+	t.Cleanup(withTempVar(&GRPCServer, (*grpc.Server)(nil)))
 
 	createGRPCServer()
 	require.NotNil(t, GRPCServer)
 	GRPCServer.RegisterService(&ingressStatsTestServiceDesc, &ingressStatsTestServer{ingressBytes: ingressBytes})
 	serveGRPC()
-	defer GRPCServer.Stop()
+	t.Cleanup(GRPCServer.Stop)
 
 	conn, err := grpc.NewClient(fmt.Sprintf("127.0.0.1:%d", port), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
-	defer conn.Close()
+	t.Cleanup(func() { conn.Close() })
 
 	require.NoError(t, conn.Invoke(context.Background(), "/test.IngressStats/Check", &emptypb.Empty{}, &emptypb.Empty{}))
 }

--- a/go/vt/servenv/grpc_server_test.go
+++ b/go/vt/servenv/grpc_server_test.go
@@ -72,14 +72,17 @@ func TestOrcaRecorder(t *testing.T) {
 
 func TestReportedOrca(t *testing.T) {
 	// Set the port to enable gRPC server.
-	withTempVar(&gRPCPort, getFreePort())
-	withTempVar(&gRPCEnableOrcaMetrics, true)
-	withTempVar(&GRPCServerMetricsRecorder, nil)
+	t.Cleanup(withTempVar(&gRPCPort, getFreePort()))
+	t.Cleanup(withTempVar(&gRPCEnableOrcaMetrics, true))
+	t.Cleanup(withTempVar(&GRPCServerMetricsRecorder, nil))
 
 	createGRPCServer()
 	assert.NotNil(t, GRPCServerMetricsRecorder, "GRPCServerMetricsRecorder should be initialized when gRPCEnableOrcaMetrics is false")
 
-	serveGRPC()
+	// Cleanups run last-in-first-out, so the updater goroutine is fully
+	// stopped before the withTempVar cleanups above restore the globals.
+	stopOrcaUpdater := serveGRPC()
+	t.Cleanup(stopOrcaUpdater)
 	defer GRPCServer.Stop()
 
 	serverMetrics := GRPCServerMetricsRecorder.ServerMetrics()

--- a/go/vt/servenv/grpc_server_test.go
+++ b/go/vt/servenv/grpc_server_test.go
@@ -80,6 +80,8 @@ func TestReportedOrca(t *testing.T) {
 	assert.NotNil(t, GRPCServerMetricsRecorder, "GRPCServerMetricsRecorder should be initialized when gRPCEnableOrcaMetrics is false")
 
 	serveGRPC()
+	defer GRPCServer.Stop()
+
 	serverMetrics := GRPCServerMetricsRecorder.ServerMetrics()
 	cpuUsage := serverMetrics.CPUUtilization
 	assert.GreaterOrEqualf(t, cpuUsage, float64(0), "CPU Utilization is not set %.2f", cpuUsage)

--- a/go/vt/servenv/grpc_server_test.go
+++ b/go/vt/servenv/grpc_server_test.go
@@ -75,6 +75,7 @@ func TestReportedOrca(t *testing.T) {
 	t.Cleanup(withTempVar(&gRPCPort, getFreePort()))
 	t.Cleanup(withTempVar(&gRPCEnableOrcaMetrics, true))
 	t.Cleanup(withTempVar(&GRPCServerMetricsRecorder, nil))
+	t.Cleanup(withTempVar(&GRPCServer, (*grpc.Server)(nil)))
 
 	createGRPCServer()
 	assert.NotNil(t, GRPCServerMetricsRecorder, "GRPCServerMetricsRecorder should be initialized when gRPCEnableOrcaMetrics is false")

--- a/go/vt/servenv/run.go
+++ b/go/vt/servenv/run.go
@@ -42,6 +42,9 @@ func Run(bindAddress string, port int) {
 	populateListeningURL(int32(port))
 	createGRPCServer()
 	onRunHooks.Fire()
+	// The returned stop function is deliberately discarded: the ORCA metrics
+	// updater is meant to run for the lifetime of the process. It only needs
+	// stopping in tests, which would otherwise leak its goroutine across tests.
 	serveGRPC()
 	serveSocketFile()
 

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -987,6 +987,18 @@ func TestSlowQueryStatusFlagsComQuery(t *testing.T) {
 	assert.Zero(t, mysqlConn.StatusFlags&mysql.ServerQueryWasSlow)
 }
 
+// waitForConnectionsClosed waits until the handler has run ConnectionClosed
+// for every wire connection. Tests that accept real connections must drain
+// them before returning: the server-side connection goroutine reads package
+// globals (e.g. mysqlQueryTimeout) during teardown, which races with later
+// tests mutating them.
+func waitForConnectionsClosed(t *testing.T, vh *vtgateHandler) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return vh.numConnections() == 0
+	}, 30*time.Second, time.Millisecond)
+}
+
 func TestSlowQueryStatusFlagsComQueryOKOnlyOLAPWire(t *testing.T) {
 	executor, sbc1, _, _, _ := createExecutorEnv(t)
 
@@ -1007,6 +1019,7 @@ func TestSlowQueryStatusFlagsComQueryOKOnlyOLAPWire(t *testing.T) {
 	listener, err := mysql.NewListener("tcp", "127.0.0.1:", mysql.NewAuthServerNone(), vh, 0, 0, false, false, 0, 0, false)
 	require.NoError(t, err)
 	defer listener.Close()
+	defer waitForConnectionsClosed(t, vh)
 
 	go listener.Accept()
 
@@ -1048,6 +1061,7 @@ func TestSlowQueryStatusFlagsComQueryMultiOKOnlyOLAPFallbackWire(t *testing.T) {
 	listener, err := mysql.NewListener("tcp", "127.0.0.1:", mysql.NewAuthServerNone(), vh, 0, 0, false, false, 0, 0, true)
 	require.NoError(t, err)
 	defer listener.Close()
+	defer waitForConnectionsClosed(t, vh)
 
 	go listener.Accept()
 
@@ -1082,6 +1096,7 @@ func TestComQueryMultiOLAPDeferredOKRefreshesTransactionStatusWire(t *testing.T)
 	listener, err := mysql.NewListener("tcp", "127.0.0.1:", mysql.NewAuthServerNone(), vh, 0, 0, false, false, 0, 0, true)
 	require.NoError(t, err)
 	defer listener.Close()
+	defer waitForConnectionsClosed(t, vh)
 
 	go listener.Accept()
 
@@ -1222,6 +1237,7 @@ func TestSlowQueryStatusFlagsComQueryMulti(t *testing.T) {
 	listener, err := mysql.NewListener("tcp", "127.0.0.1:", mysql.NewAuthServerNone(), vh, 0, 0, false, false, 0, 0, false)
 	require.NoError(t, err)
 	defer listener.Close()
+	defer waitForConnectionsClosed(t, vh)
 
 	go listener.Accept()
 
@@ -1319,6 +1335,7 @@ func TestSlowQueryStatusFlagsComQueryMultiOLAPErrorAfterSlowRowsWire(t *testing.
 	listener, err := mysql.NewListener("tcp", "127.0.0.1:", mysql.NewAuthServerNone(), vh, 0, 0, false, false, 0, 0, true)
 	require.NoError(t, err)
 	defer listener.Close()
+	defer waitForConnectionsClosed(t, vh)
 
 	go listener.Accept()
 
@@ -1887,6 +1904,7 @@ func TestComQueryIngressBytes(t *testing.T) {
 	listener, err := mysql.NewListener("tcp", "127.0.0.1:", mysql.NewAuthServerNone(), vh, 0, 0, false, false, 0, 0, false)
 	require.NoError(t, err)
 	defer listener.Close()
+	defer waitForConnectionsClosed(t, vh)
 
 	go listener.Accept()
 
@@ -1947,6 +1965,7 @@ func TestComQueryMultiOLAPIngressBytes(t *testing.T) {
 	listener, err := mysql.NewListener("tcp", "127.0.0.1:", mysql.NewAuthServerNone(), vh, 0, 0, false, false, 0, 0, true)
 	require.NoError(t, err)
 	defer listener.Close()
+	defer waitForConnectionsClosed(t, vh)
 
 	go listener.Accept()
 
@@ -2001,6 +2020,7 @@ func TestComPrepareIngressBytes(t *testing.T) {
 	listener, err := mysql.NewListener("tcp", "127.0.0.1:", mysql.NewAuthServerNone(), vh, 0, 0, false, false, 0, 0, false)
 	require.NoError(t, err)
 	defer listener.Close()
+	defer waitForConnectionsClosed(t, vh)
 
 	go listener.Accept()
 


### PR DESCRIPTION
## Description

This [Unit Test (Race) run on main](https://github.com/vitessio/vitess/actions/runs/28605181759/job/84823427395) failed on two unrelated data races between tests, both of the same shape: a goroutine leaked by one test reads a package global that a later test writes.

**servenv**: `serveGRPC()` spawns a goroutine that read the `GRPCServer` global, and `TestReportedOrca` never stopped its server — so that goroutine raced with the ingress-stats tests (added in #20358) swapping the global out via `withTempVar`. The goroutine now captures the server in a local before starting, and `TestReportedOrca` stops its server when done. Stopping the server exposed a second small issue: if `Stop`/`GracefulStop` runs before the goroutine is scheduled, `Serve` returns `ErrServerStopped`, which hit the `os.Exit(1)` "failed to start" path. That's now treated as a clean shutdown — this also applies to production, where a termination signal landing in that window would previously have turned a graceful stop into `os.Exit(1)`.

Review follow-ups extended the servenv fix: `registerOrca()`'s metrics-updater goroutine had the same problem in miniature — a 30s ticker writing `GRPCServerMetricsRecorder` with no stop path. It now captures the recorder locally and returns an idempotent stop function that waits for the goroutine to exit; `TestReportedOrca` stops it via `t.Cleanup` before restoring the globals it previously left mutated. The `OnTermSync` hook in `serveGRPC` now also stops the captured server rather than reading the `GRPCServer` global, and the gRPC server tests use `t.Cleanup` consistently for teardown. Production behavior is unchanged — `Run` deliberately lets the updater live for the process lifetime.

**vtgate**: the wire tests in `plugin_mysql_server_test.go` (`go listener.Accept()` + a real client connection) leaked the server-side connection goroutine past the test boundary; its deferred `ConnectionClosed` reads `mysqlQueryTimeout`, racing with the next test writing it. The `EnsureNoLeaks` cleanup usually waits that goroutine out, but it only samples goroutine stacks and creates no happens-before edge, so on a slow runner the race detector still pairs the accesses. Wire tests now drain their connections before returning by waiting for `numConnections()` to hit zero — the connection goroutine deletes itself from that map under `vh.mu` *after* the racy read, so the wait gives a proper happens-before edge rather than just better timing.

The servenv race reproduced locally with `go test -race -count=5` before the fix; after it, 500+ stress iterations run clean. The vtgate race needs a starved runner to trigger, so that one rests on the CI trace plus the ordering argument above. Both packages pass `go test -race` in full.

## Related Issue(s)

Failing run: https://github.com/vitessio/vitess/actions/runs/28605181759

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

The `ErrServerStopped` handling in `serveGRPC` is a small production behavior change on the shutdown path only: a termination signal arriving before the gRPC serve goroutine starts now results in a clean shutdown instead of `os.Exit(1)`.

### AI Disclosure

This PR was written by Claude Code — I just provided direction.

