### PR TITLE
test/endtoend/robustness: add linearizability model foundation (part of #20470)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.9.0
+	github.com/anishathalye/porcupine v1.3.0
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.26
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.2.12

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/anishathalye/porcupine v1.3.0 h1:yo51Niv8Tg0tAAn5XOG2UVvJXUregK4WFuLrBRoowP8=
+github.com/anishathalye/porcupine v1.3.0/go.mod h1:WM0SsFjWNl2Y4BqHr/E/ll2yY1GY1jqn+W7Z/84Zoog=
 github.com/aquarapid/vaultlib v0.5.1 h1:vuLWR6bZzLHybjJBSUYPgZlIp6KZ+SXeHLRRYTuk6d4=
 github.com/aquarapid/vaultlib v0.5.1/go.mod h1:yT7AlEXtuabkxylOc/+Ulyp18tff1+QjgNLTnFWTlOs=
 github.com/armon/go-metrics v0.4.1 h1:hR91U9KYmb6bLBYLQjyM+3j+rcd/UhE+G78SFnF8gJA=

--- a/go/test/endtoend/robustness/linearizability.go
+++ b/go/test/endtoend/robustness/linearizability.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package robustness holds the foundation for Vitess robustness testing:
+// deterministic fault injection paired with linearizability checking of the
+// distributed layer, as proposed in
+// https://github.com/vitessio/vitess/issues/20470.
+//
+// This first commit lands only the reusable pieces that need no live cluster:
+// a linearizability model of a single versioned register plus history helpers,
+// checked with anishathalye/porcupine (the same checker etcd uses in
+// tests/robustness), and self-tests that prove the checker distinguishes a
+// linearizable history from a stale-read one. The healthy-cluster baseline and
+// the fault drivers (tablet kill, PlannedReparentShard/EmergencyReparentShard,
+// network partition) are follow-ups tracked in #20470.
+package robustness
+
+import "github.com/anishathalye/porcupine"
+
+type opKind int
+
+const (
+	opPut opKind = iota
+	opGet
+)
+
+type registerInput struct {
+	kind  opKind
+	value int
+}
+
+// RegisterModel is a linearizability model of a single versioned register that
+// supports Put(value) and Get(). It is intentionally minimal: it captures the
+// externally observable consistency a client expects from a single row/key, so
+// a history recorded from a real cluster (a workload over VTGate) can be
+// checked for stale or torn reads after failovers.
+var RegisterModel = porcupine.Model{
+	Init: func() any { return 0 },
+	Step: func(state, input, output any) (bool, any) {
+		in := input.(registerInput)
+		st := state.(int)
+		if in.kind == opPut {
+			// A write always succeeds and advances the register to its value.
+			return true, in.value
+		}
+		// A read is valid only if it observed the current register value.
+		return output.(int) == st, st
+	},
+	Equal: func(a, b any) bool { return a.(int) == b.(int) },
+}
+
+// Put returns a porcupine operation for a write of value by client, with the
+// given logical call and return timestamps.
+func Put(client, value int, call, ret int64) porcupine.Operation {
+	return porcupine.Operation{
+		ClientId: client,
+		Input:    registerInput{kind: opPut, value: value},
+		Call:     call,
+		Output:   value,
+		Return:   ret,
+	}
+}
+
+// Get returns a porcupine operation for a read that observed value by client,
+// with the given logical call and return timestamps.
+func Get(client, observed int, call, ret int64) porcupine.Operation {
+	return porcupine.Operation{
+		ClientId: client,
+		Input:    registerInput{kind: opGet},
+		Call:     call,
+		Output:   observed,
+		Return:   ret,
+	}
+}

--- a/go/test/endtoend/robustness/linearizability_test.go
+++ b/go/test/endtoend/robustness/linearizability_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"testing"
+
+	"github.com/anishathalye/porcupine"
+)
+
+// TestRegisterModelLinearizable checks that a history where a read observes the
+// value of a write that fully precedes it is accepted as linearizable.
+func TestRegisterModelLinearizable(t *testing.T) {
+	ops := []porcupine.Operation{
+		Put(0, 1, 0, 10),  // client 0: Put(1) during [0,10]
+		Get(1, 1, 20, 30), // client 1: Get()->1 during [20,30], after the write returned
+	}
+	if !porcupine.CheckOperations(RegisterModel, ops) {
+		t.Fatal("expected the history to be linearizable")
+	}
+}
+
+// TestRegisterModelStaleReadNonLinearizable checks that a read of the old value
+// after a committed write that fully precedes it (the class of bug a failover
+// can introduce) is correctly rejected as non-linearizable.
+func TestRegisterModelStaleReadNonLinearizable(t *testing.T) {
+	ops := []porcupine.Operation{
+		Put(0, 1, 0, 10),  // client 0: Put(1) during [0,10]
+		Get(1, 0, 20, 30), // client 1: Get()->0 during [20,30]: stale read of a lost write
+	}
+	if porcupine.CheckOperations(RegisterModel, ops) {
+		t.Fatal("expected the stale-read history to be non-linearizable")
+	}
+}
+
+// TestRegisterModelConcurrentReadEitherValue checks that when a read overlaps a
+// write, observing either the old or the new value is linearizable.
+func TestRegisterModelConcurrentReadEitherValue(t *testing.T) {
+	oldValue := []porcupine.Operation{
+		Put(0, 1, 0, 30),  // Put(1) during [0,30]
+		Get(1, 0, 10, 20), // Get()->0 overlaps the write: valid (ordered before it)
+	}
+	newValue := []porcupine.Operation{
+		Put(0, 1, 0, 30),  // Put(1) during [0,30]
+		Get(1, 1, 10, 20), // Get()->1 overlaps the write: valid (ordered after it)
+	}
+	if !porcupine.CheckOperations(RegisterModel, oldValue) {
+		t.Fatal("expected observing the old value during a concurrent write to be linearizable")
+	}
+	if !porcupine.CheckOperations(RegisterModel, newValue) {
+		t.Fatal("expected observing the new value during a concurrent write to be linearizable")
+	}
+}


### PR DESCRIPTION
## Description

First, cluster-free piece of the linearizability-checking proposal in #20470.

Context: Vitess already runs robustness tests under Antithesis (`test/antithesis/`) with bank-balance and CRUD validators. Those check **aggregate invariants**. This adds the building block for a **per-operation linearizability** check — verifying that the individual reads/writes a client observed match some valid sequential history (which an aggregate balance invariant can miss). See #20470 for the corrected scope.

It adds `go/test/endtoend/robustness/`:

- `linearizability.go` — a minimal linearizability model of a single versioned register (`Put`/`Get`) plus history helpers.
- `linearizability_test.go` — self-tests proving the checker accepts a linearizable history, rejects a stale read of a committed write, and accepts either value observed by a read overlapping a write.

The checker is [anishathalye/porcupine](https://github.com/anishathalye/porcupine) — the same one etcd uses in `tests/robustness`. Test-only; no production dependency.

Deliberately tiny so the direction can be judged before wiring it into normal e2e CI or the existing `test/antithesis` harness (see #20470 for that discussion).

## Related Issue(s)

- Part of #20470

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

Test-only; no production or deployment impact.

### AI Disclosure

This was written with AI assistance (Claude Code) under my direction and review.
