### PR TITLE
evalengine: don't append a NUL byte to TO_BASE64 output at exact 57 byte multiples

### DIFF
--- a/go/vt/vtgate/evalengine/fn_base64.go
+++ b/go/vt/vtgate/evalengine/fn_base64.go
@@ -49,7 +49,13 @@ var (
 )
 
 func mysqlBase64Encode(in []byte) []byte {
-	newlines := len(in) / mysqlBase64InLineLength
+	// A newline is only written after a full 57 byte block that has more
+	// input following it, so an input that is an exact multiple of 57
+	// bytes gets one newline less than len(in)/57.
+	newlines := 0
+	if len(in) > 0 {
+		newlines = (len(in) - 1) / mysqlBase64InLineLength
+	}
 	encoded := make([]byte, base64.StdEncoding.EncodedLen(len(in))+newlines)
 	out := encoded
 	for len(in) > mysqlBase64InLineLength {

--- a/go/vt/vtgate/evalengine/fn_base64_test.go
+++ b/go/vt/vtgate/evalengine/fn_base64_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package evalengine
+
+import (
+	"bytes"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mysqlBase64Reference encodes the way MySQL does: standard base64 with a
+// newline after every 76 output characters, and no trailing newline.
+func mysqlBase64Reference(in []byte) []byte {
+	encoded := base64.StdEncoding.EncodeToString(in)
+	var out bytes.Buffer
+	for len(encoded) > mysqlBase64OutLineLength {
+		out.WriteString(encoded[:mysqlBase64OutLineLength])
+		out.WriteByte('\n')
+		encoded = encoded[mysqlBase64OutLineLength:]
+	}
+	out.WriteString(encoded)
+	return out.Bytes()
+}
+
+func TestMysqlBase64Encode(t *testing.T) {
+	// Inputs whose length is an exact non-zero multiple of 57 bytes used
+	// to get a spurious trailing NUL byte appended, because the newline
+	// count was over-estimated by one for the final full block.
+	lengths := []int{0, 1, 56, 57, 58, 113, 114, 115, 171}
+
+	for _, n := range lengths {
+		in := bytes.Repeat([]byte{'a'}, n)
+		encoded := mysqlBase64Encode(in)
+
+		assert.Equal(t, string(mysqlBase64Reference(in)), string(encoded), "input length %d", n)
+		assert.NotContains(t, string(encoded), "\x00", "input length %d: encoded output must not contain NUL", n)
+	}
+}
+
+func TestMysqlBase64EncodeDecodeRoundTrip(t *testing.T) {
+	for _, n := range []int{0, 1, 56, 57, 58, 113, 114, 115, 171, 500} {
+		in := bytes.Repeat([]byte{'x'}, n)
+
+		decoded, err := mysqlBase64Decode(mysqlBase64Encode(in))
+		require.NoError(t, err, "input length %d", n)
+		assert.Equal(t, in, decoded, "input length %d", n)
+	}
+}


### PR DESCRIPTION
## Description

`mysqlBase64Encode` (the `TO_BASE64` implementation) sizes its output buffer with `newlines := len(in) / 57`, but the write loop only inserts a newline after a full 57 byte block that has more input following it (`for len(in) > 57`, strict). So for an input that is an exact non-zero multiple of 57 bytes the loop writes one newline less than was allocated, and the unwritten `make`-zeroed slot ends up as a trailing `0x00` in the returned value.

The result for those lengths (57, 114, 171, ...):

* `TO_BASE64` output differs from MySQL (e.g. 77 bytes ending in `\x00` instead of 76 for a 57 byte input).
* `FROM_BASE64(TO_BASE64(x))` silently returns `NULL`, because `mysqlBase64Decode` only trims `" \t\r\n"` before decoding and the NUL makes `base64.StdEncoding.Decode` fail. Vitess's decoder rejects Vitess's own encoder output.

The fix counts newlines the same way the loop writes them: `(len(in) - 1) / 57` for non-empty input.

Tests: `TestMysqlBase64Encode` compares the output against MySQL's wrapping semantics (newline every 76 output chars, none trailing) for lengths around the 57/114 boundaries and asserts no NUL ever appears, and `TestMysqlBase64EncodeDecodeRoundTrip` pins the encode/decode round trip. Both fail on main without the fix (the round trip error is exactly the reported `illegal base64 data at input byte 76`) and pass with it. The existing evalengine integration cases exercise `TO_BASE64` but never with an input at an exact 57 byte multiple, which is how this survived.

I believe this should be backported: it is silent data corruption in a scalar function (wrong bytes returned to clients, and a NULL where MySQL returns the original value), the fix is a two line arithmetic change with no behavior change for any other input length, and the code is identical on the release branches.

## Related Issue(s)

Fixes #20473

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [ ] Documentation was added or is not required

## Deployment Notes

None: pure bug fix, output now matches MySQL for the affected input lengths.

### AI Disclosure

This was written with AI assistance (Claude Code) under my direction and review.
