### PR TITLE
evalengine: round DOUBLE ties half to even in ROUND() like MySQL

### DIFF
--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -1796,7 +1796,7 @@ func (asm *assembler) Fn_SQRT() {
 func (asm *assembler) Fn_ROUND1_f() {
 	asm.emit(func(env *ExpressionEnv) int {
 		f := env.vm.stack[env.vm.sp-1].(*evalFloat)
-		f.f = math.Round(f.f)
+		f.f = math.RoundToEven(f.f)
 		return 1
 	}, "FN ROUND FLOAT64(SP-1)")
 }
@@ -1840,7 +1840,7 @@ func (asm *assembler) Fn_ROUND2_f() {
 		f := env.vm.stack[env.vm.sp-2].(*evalFloat)
 		r := env.vm.stack[env.vm.sp-1].(*evalInt64)
 		if r.i == 0 {
-			f.f = math.Round(f.f)
+			f.f = math.RoundToEven(f.f)
 			env.vm.sp--
 			return 1
 		}
@@ -1852,7 +1852,7 @@ func (asm *assembler) Fn_ROUND2_f() {
 			env.vm.sp--
 			return 1
 		}
-		f.f = math.Round(f.f*factor) / factor
+		f.f = math.RoundToEven(f.f*factor) / factor
 		env.vm.sp--
 		return 1
 	}, "FN ROUND FLOAT64(SP-2) INT64(SP-1)")

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -63,7 +63,8 @@ type Tracker struct {
 
 func NewTracker() *Tracker {
 	track := &Tracker{}
-	track.tbl = tablewriter.NewTable(&track.buf,
+	track.tbl = tablewriter.NewTable(
+		&track.buf,
 		tablewriter.WithAlignment(tw.Alignment{
 			tw.AlignLeft,
 			tw.AlignRight,
@@ -219,6 +220,39 @@ func TestCompilerSingle(t *testing.T) {
 			expression: "(128 - column0) * 3",
 			values:     []sqltypes.Value{sqltypes.NewFloat64(1)},
 			result:     "FLOAT64(381)",
+		},
+		{
+			expression: "ROUND(column0)",
+			values:     []sqltypes.Value{sqltypes.NewFloat64(2.5)},
+			result:     "FLOAT64(2)",
+		},
+		{
+			expression: "ROUND(column0)",
+			values:     []sqltypes.Value{sqltypes.NewFloat64(3.5)},
+			result:     "FLOAT64(4)",
+		},
+		{
+			expression: "ROUND(column0)",
+			values:     []sqltypes.Value{sqltypes.NewFloat64(-2.5)},
+			result:     "FLOAT64(-2)",
+		},
+		{
+			expression: "ROUND(column0, 2)",
+			values:     []sqltypes.Value{sqltypes.NewFloat64(0.125)},
+			result:     "FLOAT64(0.12)",
+		},
+		{
+			expression: "ROUND(column0, -1)",
+			values:     []sqltypes.Value{sqltypes.NewFloat64(25)},
+			result:     "FLOAT64(20)",
+		},
+		{
+			expression: "ROUND(2.5)",
+			result:     "DECIMAL(3)",
+		},
+		{
+			expression: "ROUND(-2.5)",
+			result:     "DECIMAL(-3)",
 		},
 		{
 			expression: "1.0e0 < column0",

--- a/go/vt/vtgate/evalengine/fn_numeric.go
+++ b/go/vt/vtgate/evalengine/fn_numeric.go
@@ -954,11 +954,14 @@ func (call *builtinRound) eval(env *ExpressionEnv) (eval, error) {
 		}
 		return newEvalDecimalWithPrec(rounded, digit), nil
 	case *evalFloat:
+		// MySQL rounds floating point values half to even (my_double_round
+		// uses rint), unlike the half away from zero rule it applies to
+		// exact-value numbers.
 		if arg.f == 0.0 {
 			return arg, nil
 		}
 		if round == 0 {
-			return newEvalFloat(math.Round(arg.f)), nil
+			return newEvalFloat(math.RoundToEven(arg.f)), nil
 		}
 
 		round = clampRounding(round)
@@ -966,7 +969,7 @@ func (call *builtinRound) eval(env *ExpressionEnv) (eval, error) {
 		if f == 0 {
 			return newEvalFloat(0), nil
 		}
-		return newEvalFloat(math.Round(arg.f*f) / f), nil
+		return newEvalFloat(math.RoundToEven(arg.f*f) / f), nil
 	default:
 		v, _ := evalToFloat(arg)
 		if v.f == 0.0 {
@@ -974,7 +977,7 @@ func (call *builtinRound) eval(env *ExpressionEnv) (eval, error) {
 		}
 
 		if round == 0 {
-			return newEvalFloat(math.Round(v.f)), nil
+			return newEvalFloat(math.RoundToEven(v.f)), nil
 		}
 
 		round = clampRounding(round)
@@ -982,7 +985,7 @@ func (call *builtinRound) eval(env *ExpressionEnv) (eval, error) {
 		if f == 0 {
 			return newEvalFloat(0), nil
 		}
-		return newEvalFloat(math.Round(v.f*f) / f), nil
+		return newEvalFloat(math.RoundToEven(v.f*f) / f), nil
 	}
 }
 


### PR DESCRIPTION
## Description

`ROUND()` on DOUBLE values used Go's `math.Round`, which rounds ties away from zero. MySQL rounds DOUBLE ties half to even: `my_double_round` computes the result with `std::rint`, which follows the default IEEE rounding mode. So the evalengine disagreed with MySQL on every tie that half-to-even resolves downward:

| expression | evalengine before | MySQL |
|---|---|---|
| `ROUND(2.5e0)` | 3 | 2 |
| `ROUND(-2.5e0)` | -3 | -2 |
| `ROUND(25e0, -1)` | 30 | 20 |
| `ROUND(0.125e0, 2)` | 0.13 | 0.12 |

That is a silent wrong-results divergence: the client gets a different answer depending on whether the expression was pushed down to MySQL or evaluated at the gate.

The change swaps `math.Round` for `math.RoundToEven` in the ROUND float paths only: the two float arms of `builtinRound.eval` in `fn_numeric.go` and the `Fn_ROUND1_f` / `Fn_ROUND2_f` instructions in `compiler_asm.go`. The integer and decimal paths are untouched, because for exact-value types MySQL genuinely rounds half away from zero (`ROUND(2.5)` is 3 for the DECIMAL literal) and the evalengine already matches that.

Tests: added cases to `TestCompilerSingle` (which runs every expression through both the interpreted and the compiled path) covering the four divergent shapes above plus `ROUND(3.5e0)`-style ties that both rules agree on, and pinning the DECIMAL literal behavior so this can't regress in the other direction. The four half-even-sensitive cases fail on main and pass with the fix. Also verified against a live MySQL through the `evalengine/integration` harness: `ROUND(2.5e0)` now matches, and the `TestMySQL` integration corpus shows no new failures with this change (the single mismatch it reports for me, `TIME(CAST(time '5 12:34:58' AS JSON))`, is unrelated to rounding and fails identically without this change; I'll look at that one separately).

The existing integration corpus exercises `ROUND` but never lands a DOUBLE tie exactly on a representable .5, which is why CI never caught this.

I believe this is backportable: wrong results returned to clients, two-line class of change confined to the ROUND float paths, and the code is identical on the release branches.

## Related Issue(s)

Fixes #20475

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [ ] Documentation was added or is not required

## Deployment Notes

`ROUND()` on DOUBLE values now returns the same result MySQL returns for ties (half to even). Anyone who depended on the previous away-from-zero behavior at the gate was already getting different results from MySQL for the same query.

### AI Disclosure

This was written with AI assistance (Claude Code) under my direction and review.
