### PR TITLE
fix: remove unused vtorc waitgroup

### DIFF
--- a/go/vt/vtorc/inst/instance_dao.go
+++ b/go/vt/vtorc/inst/instance_dao.go
@@ -168,7 +168,6 @@ func ReadTopologyInstanceBufferable(tabletAlias *topodatapb.TabletAlias, latency
 		}
 	}()
 
-	var waitGroup sync.WaitGroup
 	var tablet *topodatapb.Tablet
 	var fs *replicationdatapb.FullStatus
 	readingStartTime := time.Now()
@@ -367,7 +366,6 @@ func ReadTopologyInstanceBufferable(tabletAlias *topodatapb.TabletAlias, latency
 	}
 
 Cleanup:
-	waitGroup.Wait()
 	close(errorChan)
 	err = func() error {
 		if err != nil {


### PR DESCRIPTION
## Description

Removes an unused `sync.WaitGroup` in vtorc's `ReadTopologyInstanceBufferable` (`go/vt/vtorc/inst/instance_dao.go`). The `WaitGroup` was declared and `Wait()` was called in the `Cleanup` block, but nothing ever calls `Add()`/`Done()` on it, so `Wait()` is a no-op. Removing the dead declaration and call.

Found by [goconcurrencylint](https://github.com/sanbricio/goconcurrencylint) rule GCL2010.

## Related Issue(s)

N/A — trivial dead-code cleanup surfaced by static analysis.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None. Pure dead-code removal, no behavioral change.

### AI Disclosure

No AI was used to author the code. The issue was surfaced by [goconcurrencylint](https://github.com/sanbricio/goconcurrencylint) (static analysis).
