### PR TITLE
ci: fix mysql57 setup by bumping removed libtinfo5 pin, fail fast on download errors

### DIFF
--- a/.github/actions/setup-mysql/action.yml
+++ b/.github/actions/setup-mysql/action.yml
@@ -34,13 +34,19 @@ runs:
         else
           # We have to install this old version of libaio1. See also:
           # https://bugs.launchpad.net/ubuntu/+source/libaio/+bug/2067501
+          # Note: these commands must stay separate statements: `set -e` does
+          # not fire for failures inside a `&&` chain, and the install must
+          # fail right here rather than in a later, unrelated apt-get run.
           wget \
             --tries=3 \
             --waitretry=2 \
             --timeout=30 \
-            https://archive.ubuntu.com/ubuntu/pool/main/liba/libaio/libaio1_0.3.112-13build1_amd64.deb && \
-          echo "2dcfe0b49d7cccfbf1bd6a3f627cf44bea9f51fb32f7e0e552a0df75698e0d27  libaio1_0.3.112-13build1_amd64.deb" | sha256sum --check && \
-          sudo dpkg -i libaio1_0.3.112-13build1_amd64.deb && \
+            https://archive.ubuntu.com/ubuntu/pool/main/liba/libaio/libaio1_0.3.112-13build1_amd64.deb || {
+            echo "Failed to download libaio1. The pinned version may have been superseded and removed from archive.ubuntu.com; check https://archive.ubuntu.com/ubuntu/pool/main/liba/libaio/ for the current version."
+            exit 1
+          }
+          echo "2dcfe0b49d7cccfbf1bd6a3f627cf44bea9f51fb32f7e0e552a0df75698e0d27  libaio1_0.3.112-13build1_amd64.deb" | sha256sum --check
+          sudo dpkg -i libaio1_0.3.112-13build1_amd64.deb
           rm libaio1_0.3.112-13build1_amd64.deb
 
           # Get key to latest MySQL repo
@@ -54,13 +60,17 @@ runs:
             echo mysql-apt-config mysql-apt-config/select-server select mysql-5.7 | sudo debconf-set-selections
             sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
             sudo apt-get update
-            # libtinfo5 is also needed for older MySQL 5.7 builds.
-            curl -fsSL -O https://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb \
+            # libtinfo5 is also needed for older MySQL 5.7 builds. Separate
+            # statements for the same fail-fast reason as libaio1 above.
+            curl -fsSL -O https://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.2_amd64.deb \
               --retry 3 \
-              --retry-delay 2 && \
-              echo "ab89265d8dd18bda6a29d7c796367d6d9f22a39a8fa83589577321e7caf3857b  libtinfo5_6.3-2ubuntu0.1_amd64.deb" | sha256sum --check && \
-              sudo dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb && \
-              rm libtinfo5_6.3-2ubuntu0.1_amd64.deb
+              --retry-delay 2 || {
+              echo "Failed to download libtinfo5. The pinned version may have been superseded and removed from archive.ubuntu.com; check https://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/ for the current version."
+              exit 1
+            }
+            echo "b9bb64e716a7d9de05b1b33992763142ca81bcae3a7f8ce7e29fa3c6fd32f1e8  libtinfo5_6.3-2ubuntu0.2_amd64.deb" | sha256sum --check
+            sudo dpkg -i libtinfo5_6.3-2ubuntu0.2_amd64.deb
+            rm libtinfo5_6.3-2ubuntu0.2_amd64.deb
             sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-client=5.7* mysql-community-server=5.7* mysql-server=5.7* libncurses6
           elif [[ "${{ inputs.flavor }}" == "mysql-8.0" ]]; then
             echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -125,6 +125,7 @@ jobs:
               - 'config/**'
               - 'bootstrap.sh'
               - '.github/workflows/cluster_endtoend.yml'
+              - '.github/actions/setup-mysql/action.yml'
 
       - name: Set up Go
         if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_disk_health_monitor.yml
+++ b/.github/workflows/cluster_endtoend_disk_health_monitor.yml
@@ -64,6 +64,7 @@ jobs:
               - 'config/**'
               - 'bootstrap.sh'
               - '.github/workflows/cluster_endtoend_disk_health_monitor.yml'
+              - '.github/actions/setup-mysql/action.yml'
 
       - name: Set up Go
         if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -51,6 +51,7 @@ jobs:
         filters: |
           changed_files:
             - .github/workflows/codecov.yml
+            - .github/actions/setup-mysql/action.yml
             - 'go/**'
             - go.mod
             - go.sum

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -49,6 +49,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/e2e_race.yml'
+            - '.github/actions/setup-mysql/action.yml'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -49,6 +49,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/endtoend.yml'
+            - '.github/actions/setup-mysql/action.yml'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -121,6 +121,7 @@ jobs:
               - 'config/**'
               - 'bootstrap.sh'
               - '.github/workflows/unit_test.yml'
+              - '.github/actions/setup-mysql/action.yml'
 
       - name: Set up Go
         if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -66,6 +66,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/upgrade_downgrade_test_backups_e2e.yml'
+            - '.github/actions/setup-mysql/action.yml'
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -68,6 +68,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml'
+            - '.github/actions/setup-mysql/action.yml'
 
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -62,6 +62,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/upgrade_downgrade_test_backups_manual.yml'
+            - '.github/actions/setup-mysql/action.yml'
             - 'examples/**'
 
 

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -63,6 +63,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml'
+            - '.github/actions/setup-mysql/action.yml'
             - 'examples/**'
 
     - name: Set output with latest release branch

--- a/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
+++ b/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
@@ -63,6 +63,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml'
+            - '.github/actions/setup-mysql/action.yml'
 
     - name: Set output with latest release branch
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -70,6 +70,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/upgrade_downgrade_test_query_serving_queries.yml'
+            - '.github/actions/setup-mysql/action.yml'
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
@@ -62,6 +62,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/upgrade_downgrade_test_query_serving_queries.yml'
+            - '.github/actions/setup-mysql/action.yml'
 
     - name: Set output with latest release branch
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
@@ -71,6 +71,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml'
+            - '.github/actions/setup-mysql/action.yml'
 
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -71,6 +71,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml'
+            - '.github/actions/setup-mysql/action.yml'
 
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -70,6 +70,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/upgrade_downgrade_test_query_serving_schema.yml'
+            - '.github/actions/setup-mysql/action.yml'
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -71,6 +71,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml'
+            - '.github/actions/setup-mysql/action.yml'
 
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -71,6 +71,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml'
+            - '.github/actions/setup-mysql/action.yml'
 
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -71,6 +71,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml'
+            - '.github/actions/setup-mysql/action.yml'
 
     - name: Tune the OS
       if: steps.output-next-release-ref.outputs.next_release_ref != '' && steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -70,6 +70,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml'
+            - '.github/actions/setup-mysql/action.yml'
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -70,6 +70,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml'
+            - '.github/actions/setup-mysql/action.yml'
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/vitess_tester_vtgate.yml
+++ b/.github/workflows/vitess_tester_vtgate.yml
@@ -62,6 +62,7 @@ jobs:
             - 'config/**'
             - 'bootstrap.sh'
             - '.github/workflows/vitess_tester_vtgate.yml'
+            - '.github/actions/setup-mysql/action.yml'
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/vtop_example.yml
+++ b/.github/workflows/vtop_example.yml
@@ -57,6 +57,7 @@ jobs:
               - 'examples/**'
               - 'test/**'
               - '.github/workflows/vtop_example.yml'
+              - '.github/actions/setup-mysql/action.yml'
 
       - name: Set up Go
         if: steps.changes.outputs.end_to_end == 'true'


### PR DESCRIPTION
## Description

All `mysql57` CI jobs (`Unit Test (mysql57)`, `Unit Test (evalengine_mysql57)`) started failing on July 5th on every PR, before running a single test. Three things fixed here:

1. **The pinned libtinfo5 download 404s.** The `setup-mysql` action downloads `libtinfo5_6.3-2ubuntu0.1_amd64.deb` from archive.ubuntu.com (MySQL 5.7's bionic builds need ncurses5, which modern runners don't ship). Ubuntu published `6.3-2ubuntu0.2` and, as the archive does, removed the superseded version from the pool — so the pinned URL is gone. This PR bumps the pin and its sha256 to the current version.

2. **The failure was silently swallowed**, so the job died much later in `apt-get install mysql-...=5.7*` with a misleading `libtinfo5 (>= 6) but it is not installable` unmet-dependency error. The download/verify/install commands were chained with `&&`, and `set -e` doesn't fire for non-final commands in an AND list — the chain short-circuited and the script kept going. The chains (both libtinfo5 and the identically structured libaio1 block above it) are now separate statements, with an explicit error message when a pinned download fails, so the next pin rot points straight at the culprit.

3. **Changes to the setup-mysql action didn't trigger the jobs that use it.** None of the workflows' `paths-filter` change-detection lists included `.github/actions/setup-mysql/action.yml`, so this PR initially skipped the very mysql57 jobs it fixes. Added the action to the filter list of all 23 workflows that use it and have a changes check.

Notes:
- The same pin-rot will recur whenever Ubuntu ships another ncurses/libaio SRU; with the fail-fast in place it'll at least be a one-look diagnosis.
- Spotted in passing, not touched here: `upgrade_downgrade_test_query_serving_queries_2.yml` and its `_next_release` sibling reference `upgrade_downgrade_test_query_serving_queries.yml` (without `_2`) in their own change filters, so edits to those two workflow files don't trigger their own runs. Same blind-spot class; fixed separately in #20482.
- The mysql57 jobs run on release branches too, so this likely wants backporting.

## Related Issue(s)

None filed; CI-only breakage. First seen failing on July 5th, last green run on main was July 3rd.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required (CI-only change; verified the new deb URL + sha256 and the fail-fast shell behavior locally)
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — CI infrastructure only.

### AI Disclosure

This PR was diagnosed and written by Claude Code, with direction and review from me.

