### PR TITLE
ci: fix self-references in query_serving_queries_2 change-detection filters

### DIFF
--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
@@ -61,7 +61,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
-            - '.github/workflows/upgrade_downgrade_test_query_serving_queries.yml'
+            - '.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml'
             - '.github/actions/setup-mysql/action.yml'
 
     - name: Set output with latest release branch

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
@@ -70,7 +70,7 @@ jobs:
             - 'tools/**'
             - 'config/**'
             - 'bootstrap.sh'
-            - '.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml'
+            - '.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml'
             - '.github/actions/setup-mysql/action.yml'
 
     - name: Tune the OS


### PR DESCRIPTION
## Description

Follow-up to #20481, split out since it's unrelated to the mysql57 breakage (spotted while auditing the change-detection filters there, and flagged by Copilot's review as well).

The `_2` variants of the query-serving-queries upgrade-downgrade workflows watch the non-`_2` workflow file in their `paths-filter` change detection — a copy-paste slip from when they were split out. As a result, editing `upgrade_downgrade_test_query_serving_queries_2.yml` (or its `_next_release` sibling) doesn't trigger the workflow's own run, so a broken edit to those files sails through CI unnoticed. This points each filter at its own workflow file.

Heads-up: this touches lines adjacent to #20481's changes, so whichever merges second will need a trivial rebase/conflict resolution — happy to handle that.

## Related Issue(s)

Sibling of #20481.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required (CI-only change)
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — CI infrastructure only.

### AI Disclosure

Written by Claude Code, with direction and review from me.
