### PR TITLE
tabletserver: pool the proto messages of streamed query results

### DIFF
--- a/go/sqltypes/proto3.go
+++ b/go/sqltypes/proto3.go
@@ -17,6 +17,8 @@ limitations under the License.
 package sqltypes
 
 import (
+	"sync"
+
 	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/vt/vterrors"
@@ -92,6 +94,58 @@ func proto3ToRows(fields []*querypb.Field, rows []*querypb.Row) [][]Value {
 		result[i] = MakeRowTrusted(fields, r)
 	}
 	return result
+}
+
+// queryResultPool holds QueryResult messages for ResultToProto3Pooled.
+var queryResultPool = sync.Pool{
+	New: func() any { return &querypb.QueryResult{} },
+}
+
+// ResultToProto3Pooled converts qr like ResultToProto3, drawing the
+// QueryResult and its Row messages from message pools. It is meant for
+// transient conversions such as marshaling a streamed result into a gRPC
+// response: once the message has been sent, the caller must release it with
+// ReleaseProto3Result and must not retain any reference to it or its rows.
+//
+// Unlike ResultToProto3 it never uses the cached proto3 rows, so the
+// returned message always owns its rows; the Fields remain shared with qr.
+func ResultToProto3Pooled(qr *Result) *querypb.QueryResult {
+	if qr == nil {
+		return nil
+	}
+	res := queryResultPool.Get().(*querypb.QueryResult)
+	res.Fields = qr.Fields
+	res.RowsAffected = qr.RowsAffected
+	res.InsertId = qr.InsertID
+	res.InsertIdChanged = qr.InsertIDChanged
+	res.Info = qr.Info
+	res.SessionStateChanges = qr.SessionStateChanges
+	if cap(res.Rows) < len(qr.Rows) {
+		res.Rows = make([]*querypb.Row, 0, len(qr.Rows))
+	}
+	for _, row := range qr.Rows {
+		r := querypb.RowFromVTPool()
+		RowToProto3Inplace(row, r)
+		res.Rows = append(res.Rows, r)
+	}
+	return res
+}
+
+// ReleaseProto3Result returns a QueryResult obtained from
+// ResultToProto3Pooled, along with its rows, to their pools. The Field
+// messages are shared with the Result the message was converted from, so
+// only the references are dropped; the fields themselves are not reset.
+func ReleaseProto3Result(res *querypb.QueryResult) {
+	if res == nil {
+		return
+	}
+	for _, r := range res.Rows {
+		r.ReturnToVTPool()
+	}
+	rows := res.Rows[:0]
+	res.Reset()
+	res.Rows = rows
+	queryResultPool.Put(res)
 }
 
 func ResultToProto3(qr *Result) *querypb.QueryResult {

--- a/go/sqltypes/proto3_test.go
+++ b/go/sqltypes/proto3_test.go
@@ -544,3 +544,52 @@ func BenchmarkConsolidationFanOut(b *testing.B) {
 		})
 	}
 }
+
+func TestResultToProto3Pooled(t *testing.T) {
+	fields := []*querypb.Field{{
+		Name: "col1",
+		Type: VarChar,
+	}, {
+		Name: "col2",
+		Type: Int64,
+	}}
+	result := &Result{
+		Fields:              fields,
+		InsertID:            11,
+		InsertIDChanged:     true,
+		RowsAffected:        3,
+		Info:                "info",
+		SessionStateChanges: "ssc",
+		Rows: [][]Value{{
+			TestValue(VarChar, "aa"),
+			TestValue(Int64, "1"),
+		}, {
+			NULL,
+			TestValue(Int64, "2"),
+		}},
+	}
+
+	// The pooled conversion must produce the same message as the regular one,
+	// including after the pooled objects have been released and reused.
+	for range 3 {
+		pooled := ResultToProto3Pooled(result)
+		require.True(t, proto.Equal(ResultToProto3(result), pooled))
+		ReleaseProto3Result(pooled)
+	}
+
+	// Reuse with a different shape must not leak previous contents.
+	shorter := &Result{
+		Fields: fields[:1],
+		Rows:   [][]Value{{TestValue(VarChar, "z")}},
+	}
+	pooled := ResultToProto3Pooled(shorter)
+	require.True(t, proto.Equal(ResultToProto3(shorter), pooled))
+	ReleaseProto3Result(pooled)
+
+	// The shared Field messages must survive the release untouched.
+	require.Equal(t, "col1", fields[0].Name)
+	require.Equal(t, VarChar, fields[0].Type)
+
+	// Releasing nil is a no-op.
+	ReleaseProto3Result(nil)
+}

--- a/go/vt/vttablet/grpcqueryservice/server.go
+++ b/go/vt/vttablet/grpcqueryservice/server.go
@@ -65,8 +65,10 @@ func (q *query) StreamExecute(request *querypb.StreamExecuteRequest, stream quer
 		request.ImmediateCallerId,
 	)
 	err = q.server.StreamExecute(ctx, nil, request.Target, request.Query.Sql, request.Query.BindVariables, request.TransactionId, request.ReservedId, request.Options, func(reply *sqltypes.Result) error {
+		result := sqltypes.ResultToProto3Pooled(reply)
+		defer sqltypes.ReleaseProto3Result(result)
 		return stream.Send(&querypb.StreamExecuteResponse{
-			Result: sqltypes.ResultToProto3(reply),
+			Result: result,
 		})
 	})
 	return vterrors.ToGRPC(err)
@@ -280,8 +282,10 @@ func (q *query) BeginStreamExecute(request *querypb.BeginStreamExecuteRequest, s
 		request.ImmediateCallerId,
 	)
 	state, err := q.server.BeginStreamExecute(ctx, nil, request.Target, request.PreQueries, request.Query.Sql, request.Query.BindVariables, request.ReservedId, request.Options, func(reply *sqltypes.Result) error {
+		result := sqltypes.ResultToProto3Pooled(reply)
+		defer sqltypes.ReleaseProto3Result(result)
 		return stream.Send(&querypb.BeginStreamExecuteResponse{
-			Result: sqltypes.ResultToProto3(reply),
+			Result: result,
 		})
 	})
 
@@ -306,8 +310,10 @@ func (q *query) MessageStream(request *querypb.MessageStreamRequest, stream quer
 		request.ImmediateCallerId,
 	)
 	err = q.server.MessageStream(ctx, request.Target, request.Name, func(qr *sqltypes.Result) error {
+		result := sqltypes.ResultToProto3Pooled(qr)
+		defer sqltypes.ReleaseProto3Result(result)
 		return stream.Send(&querypb.MessageStreamResponse{
-			Result: sqltypes.ResultToProto3(qr),
+			Result: result,
 		})
 	})
 	return vterrors.ToGRPC(err)
@@ -431,8 +437,10 @@ func (q *query) ReserveStreamExecute(request *querypb.ReserveStreamExecuteReques
 	)
 
 	state, err := q.server.ReserveStreamExecute(ctx, nil, request.Target, request.PreQueries, request.Query.Sql, request.Query.BindVariables, request.TransactionId, request.Options, func(reply *sqltypes.Result) error {
+		result := sqltypes.ResultToProto3Pooled(reply)
+		defer sqltypes.ReleaseProto3Result(result)
 		return stream.Send(&querypb.ReserveStreamExecuteResponse{
-			Result: sqltypes.ResultToProto3(reply),
+			Result: result,
 		})
 	})
 	if err != nil && state.ReservedID == 0 {
@@ -487,8 +495,10 @@ func (q *query) ReserveBeginStreamExecute(request *querypb.ReserveBeginStreamExe
 	)
 
 	state, err := q.server.ReserveBeginStreamExecute(ctx, nil, request.Target, request.PreQueries, request.PostBeginQueries, request.Query.Sql, request.Query.BindVariables, request.Options, func(reply *sqltypes.Result) error {
+		result := sqltypes.ResultToProto3Pooled(reply)
+		defer sqltypes.ReleaseProto3Result(result)
 		return stream.Send(&querypb.ReserveBeginStreamExecuteResponse{
-			Result: sqltypes.ResultToProto3(reply),
+			Result: result,
 		})
 	})
 	if err != nil && state.ReservedID == 0 && state.TransactionID == 0 {


### PR DESCRIPTION
## Description

Every streamed result packet allocated a fresh `QueryResult` proto and one `Row` proto per row just to marshal it into the gRPC response — all garbage the moment `Send` returns. Since the gRPC server codec marshals synchronously inside `Send`, nothing retains these messages, so they can be pooled.

This adds `sqltypes.ResultToProto3Pooled`/`ReleaseProto3Result`, which draw the `QueryResult` from a pool and the rows from the existing vtprotobuf `Row` pool (reusing their `Lengths`/`Values` buffers), and uses the pair in all five streaming send sites in `grpcqueryservice`. The release only drops the `Field` references — the fields are shared with the `sqltypes.Result` and must not be reset — and the conversion deliberately bypasses the `proto3Rows` cache so the returned message always owns its rows.

On a two-shard sysbench read-only mix over streaming this cuts vttablet heap allocations by about 6%.

Extracted from #20378 so it can ship independently — it benefits all streaming consumers today.

## Related Issue(s)

- Part of the performance work split out of #20378

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

This PR was written primarily by Claude Code, with direction and review from me.
