### PR TITLE
mysql: end the streaming result set when an error packet arrives

### DIFF
--- a/go/mysql/streaming_query.go
+++ b/go/mysql/streaming_query.go
@@ -145,7 +145,10 @@ func (c *Conn) FetchNext(in []sqltypes.Value) ([]sqltypes.Value, error) {
 		c.fields = nil
 		return nil, nil
 	} else if isErrorPacket(data) {
-		// Error packet.
+		// An error packet terminates the result set: the server sends nothing
+		// further for this query. Mark the result done so a later CloseResult
+		// does not block reading packets that will never arrive.
+		c.fields = nil
 		return nil, ParseErrorPacket(data)
 	}
 

--- a/go/mysql/streaming_query_test.go
+++ b/go/mysql/streaming_query_test.go
@@ -114,11 +114,11 @@ func TestExecuteStreamFetchNoOKResultForRows(t *testing.T) {
 // aborting with ER_CTE_MAX_RECURSION_DEPTH after the fields were sent).
 func TestStreamFetchErrorMidResultSet(t *testing.T) {
 	listener, sConn, cConn := createSocketPair(t)
-	defer func() {
+	t.Cleanup(func() {
 		listener.Close()
 		sConn.Close()
 		cConn.Close()
-	}()
+	})
 
 	result := &sqltypes.Result{
 		Fields: []*querypb.Field{{Type: querypb.Type_INT64, Name: "n"}},

--- a/go/mysql/streaming_query_test.go
+++ b/go/mysql/streaming_query_test.go
@@ -19,10 +19,12 @@ package mysql
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
@@ -103,4 +105,61 @@ func TestExecuteStreamFetchNoOKResultForRows(t *testing.T) {
 	wg.Wait()
 	require.NoError(t, streamErr)
 	assert.Nil(t, okRes, "a row-returning streaming query must not expose an OK result")
+}
+
+// TestStreamFetchErrorMidResultSet verifies that an error packet received while
+// fetching rows ends the result set: an ERR packet terminates the resultset on
+// the wire, so a subsequent CloseResult must not try to read further packets.
+// It would block forever on the idle connection otherwise (e.g. a recursive CTE
+// aborting with ER_CTE_MAX_RECURSION_DEPTH after the fields were sent).
+func TestStreamFetchErrorMidResultSet(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	result := &sqltypes.Result{
+		Fields: []*querypb.Field{{Type: querypb.Type_INT64, Name: "n"}},
+	}
+
+	wg := sync.WaitGroup{}
+	var fetchErr error
+	wg.Go(func() {
+		if err := cConn.ExecuteStreamFetch("select n from cte"); err != nil {
+			fetchErr = err
+			return
+		}
+		var row []sqltypes.Value
+		row, fetchErr = cConn.FetchNext(nil)
+		for fetchErr == nil && row != nil {
+			row, fetchErr = cConn.FetchNext(nil)
+		}
+		// This must not block: the error packet already ended the result set.
+		cConn.CloseResult()
+	})
+
+	// The server sends the fields, one row, and then aborts the result set
+	// with an error packet.
+	data, err := sConn.readEphemeralPacket()
+	require.NoError(t, err)
+	require.EqualValues(t, ComQuery, data[0])
+	sConn.recycleReadPacket()
+	require.NoError(t, sConn.writeFields(result))
+	require.NoError(t, sConn.writeRow([]sqltypes.Value{sqltypes.MakeTrusted(querypb.Type_INT64, []byte("1"))}))
+	require.NoError(t, sConn.writeErrorPacket(sqlerror.ERCTEMaxRecursionDepth, sqlerror.SSUnknownSQLState, "Recursive query aborted after 1001 iterations."))
+	require.NoError(t, sConn.FlushWriteBuffer())
+
+	doneCh := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+	case <-time.After(30 * time.Second):
+		require.FailNow(t, "CloseResult blocked reading a result set that already ended with an error packet")
+	}
+	require.ErrorContains(t, fetchErr, "Recursive query aborted")
 }

--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -981,3 +981,34 @@ func TestJoinMixedCaseExpr(t *testing.T) {
 	mcmp.Exec(`prepare prep_pk from 'SELECT t1.id from all_types t1 join all_types t2 on t1.int_unsigned = (case when t2.int_unsigned in (1, 2, 3) then 1 when t2.int_unsigned = 4 then 10 else 20 end)'`)
 	mcmp.AssertMatches(`execute prep_pk`, `[[INT64(1)] [INT64(1)] [INT64(1)]]`)
 }
+
+// TestOlapErrorAfterFields verifies that a streamed (OLAP) query whose error
+// arrives mid result set - after the field packets were already sent, like a
+// recursive CTE aborting with ER_CTE_MAX_RECURSION_DEPTH while producing rows -
+// returns the error promptly. The tablet's streaming path used to try to drain
+// the already-terminated result set, blocking forever on the MySQL connection
+// and leaving the client waiting indefinitely.
+func TestOlapErrorAfterFields(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	utils.Exec(t, mcmp.VtConn, "set workload = olap")
+
+	query := "with recursive cte as (select 1 as n union all select n + 1 from cte) select * from cte"
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := mcmp.VtConn.ExecuteFetch(query, 1000, false)
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		require.ErrorContains(t, err, "Recursive query aborted")
+	case <-time.After(60 * time.Second):
+		require.FailNow(t, "the streamed query did not return",
+			"the tablet is stuck draining a result set that already ended with an error packet")
+	}
+
+	// The error ended the result set cleanly, so the connection stays usable.
+	utils.AssertMatches(t, mcmp.VtConn, "select 1", "[[INT64(1)]]")
+}

--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -990,7 +990,7 @@ func TestJoinMixedCaseExpr(t *testing.T) {
 // and leaving the client waiting indefinitely.
 func TestOlapErrorAfterFields(t *testing.T) {
 	mcmp, closer := start(t)
-	defer closer()
+	t.Cleanup(closer)
 
 	utils.Exec(t, mcmp.VtConn, "set workload = olap")
 


### PR DESCRIPTION
## Description

A streamed query whose error arrives mid result set — after MySQL already sent the field packets — hangs the tablet's streaming path forever instead of returning the error.

An ERR packet terminates a result set on the wire; the server sends nothing further for that query. But `mysql.Conn.FetchNext` only cleared `c.fields` on the EOF path, not on the error path. The deferred `CloseResult()` in `dbconnpool.ExecuteStreamFetch` then tried to drain the "remaining" rows and blocked forever reading from a connection that has nothing more to send. From there it cascades: vttablet's query timeout fires `kill query`, which is a no-op because the query finished on MySQL long ago, so the goroutine and the stream connection leak permanently and the client hangs until it gives up.

Any `workload=olap` query that errors after fields hits this — a recursive CTE aborting with `ER_CTE_MAX_RECURSION_DEPTH`, or a streamed query killed mid-stream. The flaw dates back to the introduction of `go/mysql` in 2017 (5057fb0658): the EOF and error paths have been asymmetric from day one.

The fix is one line plus a comment: clear `c.fields` when `FetchNext` sees an error packet, so `CloseResult` knows the result set is already done.

Tests:
- A unit test in `go/mysql` that replays the exact packet sequence (fields, row, ERR) and fails on the drain hang without the fix.
- An end-to-end test in `vtgate/queries/misc` that runs the recursive CTE over `workload=olap`. On an unpatched build it hangs and fails after a 60s guard; with the fix it returns the MySQL error promptly and the connection stays usable.

**Backport justification:** this is a hang-forever bug reachable on all supported releases by any OLAP query that errors mid stream, and each occurrence permanently leaks a tablet goroutine and a stream pool connection. The fix is a one-line protocol-layer change with no behavioral impact on healthy streams.

## Related Issue(s)

Fixes #20496

Found while investigating a 45-minute CI timeout of the Vitess Tester CTE suite on #20378, which makes streaming the default delivery path and therefore hits this on every mid-stream error.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — the change only affects the error path of streamed queries, which previously hung.

### AI Disclosure

This PR was written by Claude Code — I provided direction and reviewed the result.
