### PR TITLE
vtgate: do not autocommit per-chunk in streaming insert-select

### DIFF
--- a/go/test/endtoend/vtgate/queries/misc/misc_test.go
+++ b/go/test/endtoend/vtgate/queries/misc/misc_test.go
@@ -981,3 +981,34 @@ func TestJoinMixedCaseExpr(t *testing.T) {
 	mcmp.Exec(`prepare prep_pk from 'SELECT t1.id from all_types t1 join all_types t2 on t1.int_unsigned = (case when t2.int_unsigned in (1, 2, 3) then 1 when t2.int_unsigned = 4 then 10 else 20 end)'`)
 	mcmp.AssertMatches(`execute prep_pk`, `[[INT64(1)] [INT64(1)] [INT64(1)]]`)
 }
+
+// TestOlapInsertSelectMultiChunk runs an insert-select over the streaming
+// (OLAP) path where the scatter select delivers one chunk of rows per shard
+// stream. No chunk's insert may claim the session's autocommit approval: the
+// approval can be claimed only once per statement, so the first chunk's
+// single-shard insert would run as an autocommit and mark the session
+// 'autocommitted', and the next chunk's insert would then fail with VT13001
+// ("unexpected 'autocommitted' state in transaction").
+//
+// The shape of the statement matters to keep the bug reachable: the target
+// table differs from the source (a self-referencing insert-select is forced
+// onto the buffered path) and has no sequence and no owned lookup vindex
+// (those execute their own statements in between, which takes the approval
+// away and hides the bug), and the seed rows are chosen so that each source
+// shard's rows map to a single target shard, which is what makes a chunk's
+// insert eligible for autocommit.
+func TestOlapInsertSelectMultiChunk(t *testing.T) {
+	mcmp, closer := start(t)
+	t.Cleanup(closer)
+
+	// id1 1 and 2 live on shard -80 and their id2 values map to 80-;
+	// id1 4 and 6 live on shard 80- and their id2 values map to -80.
+	mcmp.Exec("insert into t1(id1, id2) values (1,7), (2,8), (4,9), (6,10)")
+
+	utils.Exec(t, mcmp.VtConn, "set workload = olap")
+	mcmp.Exec("insert into all_types(id, int_unsigned) select id2, id1 from t1")
+
+	utils.Exec(t, mcmp.VtConn, "set workload = oltp")
+	mcmp.AssertMatches("select id, int_unsigned from all_types order by id",
+		`[[INT64(7) INT32(1)] [INT64(8) INT32(2)] [INT64(9) INT32(4)] [INT64(10) INT32(6)]]`)
+}

--- a/go/vt/vtgate/engine/insert.go
+++ b/go/vt/vtgate/engine/insert.go
@@ -131,7 +131,7 @@ func (ins *Insert) insertIntoUnshardedTable(ctx context.Context, vcursor VCursor
 		return nil, err
 	}
 
-	return ins.executeUnshardedTableQuery(ctx, vcursor, ins, bindVars, ins.Query, uint64(insertID))
+	return ins.executeUnshardedTableQuery(ctx, vcursor, ins, bindVars, ins.Query, uint64(insertID), true /* canAutocommit */)
 }
 
 func (ins *Insert) insertIntoShardedTable(

--- a/go/vt/vtgate/engine/insert_common.go
+++ b/go/vt/vtgate/engine/insert_common.go
@@ -134,7 +134,7 @@ func (code InsertOpcode) MarshalJSON() ([]byte, error) {
 	return json.Marshal(insName[code])
 }
 
-func (ins *InsertCommon) executeUnshardedTableQuery(ctx context.Context, vcursor VCursor, loggingPrimitive Primitive, bindVars map[string]*querypb.BindVariable, query string, insertID uint64) (*sqltypes.Result, error) {
+func (ins *InsertCommon) executeUnshardedTableQuery(ctx context.Context, vcursor VCursor, loggingPrimitive Primitive, bindVars map[string]*querypb.BindVariable, query string, insertID uint64, canAutocommit bool) (*sqltypes.Result, error) {
 	rss, _, err := vcursor.ResolveDestinations(ctx, ins.Keyspace.Name, nil, []key.ShardDestination{key.DestinationAllShards{}})
 	if err != nil {
 		return nil, err
@@ -146,7 +146,7 @@ func (ins *InsertCommon) executeUnshardedTableQuery(ctx context.Context, vcursor
 	if err != nil {
 		return nil, err
 	}
-	qr, err := execShard(ctx, loggingPrimitive, vcursor, query, bindVars, rss[0], true, !ins.PreventAutoCommit /* canAutocommit */, ins.FetchLastInsertID)
+	qr, err := execShard(ctx, loggingPrimitive, vcursor, query, bindVars, rss[0], true, canAutocommit && !ins.PreventAutoCommit /* canAutocommit */, ins.FetchLastInsertID)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/engine/insert_select.go
+++ b/go/vt/vtgate/engine/insert_select.go
@@ -118,10 +118,15 @@ func (ins *InsertSelect) TryStreamExecute(ctx context.Context, vcursor VCursor, 
 
 		var qr *sqltypes.Result
 		var err error
+		// The select streams rows in multiple chunks, so each chunk is inserted
+		// separately. Autocommit must be prevented: it is a one-shot approval, so
+		// the first chunk would consume it and later chunks would then run in a
+		// transaction that conflicts with the already-autocommitted state. Instead
+		// every chunk runs in the surrounding transaction and commits together.
 		if sharded {
-			qr, err = ins.insertIntoShardedTable(ctx, vcursor, bindVars, irr)
+			qr, err = ins.insertIntoShardedTable(ctx, vcursor, bindVars, irr, false /* canAutocommit */)
 		} else {
-			qr, err = ins.insertIntoUnshardedTable(ctx, vcursor, bindVars, irr)
+			qr, err = ins.insertIntoUnshardedTable(ctx, vcursor, bindVars, irr, false /* canAutocommit */)
 		}
 		if err != nil {
 			return err
@@ -148,12 +153,14 @@ func (ins *InsertSelect) execInsertUnsharded(ctx context.Context, vcursor VCurso
 	if len(irr.rows) == 0 {
 		return &sqltypes.Result{}, nil
 	}
-	return ins.insertIntoUnshardedTable(ctx, vcursor, bindVars, irr)
+	// The buffered path inserts every selected row in a single statement, so it
+	// may autocommit.
+	return ins.insertIntoUnshardedTable(ctx, vcursor, bindVars, irr, true /* canAutocommit */)
 }
 
-func (ins *InsertSelect) insertIntoUnshardedTable(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, irr insertRowsResult) (*sqltypes.Result, error) {
+func (ins *InsertSelect) insertIntoUnshardedTable(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable, irr insertRowsResult, canAutocommit bool) (*sqltypes.Result, error) {
 	query := ins.getInsertUnshardedQuery(irr.rows, bindVars)
-	return ins.executeUnshardedTableQuery(ctx, vcursor, ins, bindVars, query, irr.insertID)
+	return ins.executeUnshardedTableQuery(ctx, vcursor, ins, bindVars, query, irr.insertID, canAutocommit)
 }
 
 func (ins *InsertSelect) getInsertUnshardedQuery(rows []sqltypes.Row, bindVars map[string]*querypb.BindVariable) string {
@@ -175,13 +182,14 @@ func (ins *InsertSelect) insertIntoShardedTable(
 	vcursor VCursor,
 	bindVars map[string]*querypb.BindVariable,
 	irr insertRowsResult,
+	canAutocommit bool,
 ) (*sqltypes.Result, error) {
 	rss, queries, err := ins.getInsertShardedQueries(ctx, vcursor, bindVars, irr.rows)
 	if err != nil {
 		return nil, err
 	}
 
-	qr, err := ins.executeInsertQueries(ctx, vcursor, rss, queries, irr.insertID)
+	qr, err := ins.executeInsertQueries(ctx, vcursor, rss, queries, irr.insertID, canAutocommit)
 	if err != nil {
 		return nil, err
 	}
@@ -195,8 +203,9 @@ func (ins *InsertSelect) executeInsertQueries(
 	rss []*srvtopo.ResolvedShard,
 	queries []*querypb.BoundQuery,
 	insertID uint64,
+	canAutocommit bool,
 ) (*sqltypes.Result, error) {
-	autocommit := (len(rss) == 1 || ins.MultiShardAutocommit) && vcursor.AutocommitApproval()
+	autocommit := canAutocommit && (len(rss) == 1 || ins.MultiShardAutocommit) && vcursor.AutocommitApproval()
 	err := allowOnlyPrimary(rss...)
 	if err != nil {
 		return nil, err
@@ -309,7 +318,9 @@ func (ins *InsertSelect) execInsertSharded(ctx context.Context, vcursor VCursor,
 		return &sqltypes.Result{}, nil
 	}
 
-	return ins.insertIntoShardedTable(ctx, vcursor, bindVars, result)
+	// The buffered path inserts every selected row in one set of shard queries,
+	// so it may autocommit.
+	return ins.insertIntoShardedTable(ctx, vcursor, bindVars, result, true /* canAutocommit */)
 }
 
 func (ins *InsertSelect) description() PrimitiveDescription {

--- a/go/vt/vtgate/engine/insert_test.go
+++ b/go/vt/vtgate/engine/insert_test.go
@@ -2473,7 +2473,7 @@ func TestInsertSelectShardingCases(t *testing.T) {
 
 		// the query exec
 		`ResolveDestinations sks1 [value:"0"] Destinations:DestinationKeyspaceID(166b40b44aba4bd6)`,
-		fmt.Sprintf(`ExecuteMultiShard sks1.-20: prefix values (:_c0_0) {_c0_0: %v} true true`, sqltypes.Int64BindVariable(1)),
+		fmt.Sprintf(`ExecuteMultiShard sks1.-20: prefix values (:_c0_0) {_c0_0: %v} true false`, sqltypes.Int64BindVariable(1)),
 	})
 
 	// sks1 and uks2
@@ -2504,7 +2504,7 @@ func TestInsertSelectShardingCases(t *testing.T) {
 
 		// the query exec
 		`ResolveDestinations sks1 [value:"0"] Destinations:DestinationKeyspaceID(166b40b44aba4bd6)`,
-		fmt.Sprintf(`ExecuteMultiShard sks1.-20: prefix values (:_c0_0) {_c0_0: %v} true true`, sqltypes.Int64BindVariable(1)),
+		fmt.Sprintf(`ExecuteMultiShard sks1.-20: prefix values (:_c0_0) {_c0_0: %v} true false`, sqltypes.Int64BindVariable(1)),
 	})
 
 	// uks1 and sks2
@@ -2543,7 +2543,7 @@ func TestInsertSelectShardingCases(t *testing.T) {
 
 		// the query exec
 		`ResolveDestinations uks1 [] Destinations:DestinationAllShards()`,
-		fmt.Sprintf(`ExecuteMultiShard uks1.0: prefix values (:_c0_0) {_c0_0: %v} true true`, sqltypes.Int64BindVariable(1)),
+		fmt.Sprintf(`ExecuteMultiShard uks1.0: prefix values (:_c0_0) {_c0_0: %v} true false`, sqltypes.Int64BindVariable(1)),
 	})
 
 	// uks1 and uks2
@@ -2574,6 +2574,6 @@ func TestInsertSelectShardingCases(t *testing.T) {
 
 		// the query exec
 		`ResolveDestinations uks1 [] Destinations:DestinationAllShards()`,
-		fmt.Sprintf(`ExecuteMultiShard uks1.0: prefix values (:_c0_0) {_c0_0: %v} true true`, sqltypes.Int64BindVariable(1)),
+		fmt.Sprintf(`ExecuteMultiShard uks1.0: prefix values (:_c0_0) {_c0_0: %v} true false`, sqltypes.Int64BindVariable(1)),
 	})
 }

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -3072,7 +3072,16 @@ func TestInsertSelectFromTable(t *testing.T) {
 // those execute their own statements in between, which takes the approval
 // away before any chunk can claim it and hides the bug.
 func TestStreamingInsertSelectFromTable(t *testing.T) {
-	executor, sbc1, _, _, ctx := createExecutorEnv(t)
+	// The scatter select keeps streaming from the other shards while each
+	// chunk's insert executes, so the sandbox conns record queries from
+	// concurrent goroutines and need locking around their Queries field.
+	var sbc1 *sandboxconn.SandboxConn
+	executor, ctx := createExecutorEnvCallback(t, createExecutorConfig(), func(shard, ks string, tabletType topodatapb.TabletType, conn *sandboxconn.SandboxConn) {
+		conn.RequireQueriesLocking()
+		if ks == KsTestSharded && shard == "-20" {
+			sbc1 = conn
+		}
+	})
 
 	session := econtext.NewAutocommitSession(&vtgatepb.Session{})
 

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -3060,6 +3060,33 @@ func TestInsertSelectFromTable(t *testing.T) {
 	}
 }
 
+// TestStreamingInsertSelectFromTable runs an insert-select whose select
+// scatters over the streaming path. The select delivers its rows in multiple
+// chunks, and no chunk's insert may claim the session's autocommit approval:
+// the approval can be claimed only once per statement, so the first chunk
+// would run as an autocommit and mark the session 'autocommitted', and the
+// next chunk's insert would then open a shard transaction and fail with
+// VT13001 ("unexpected 'autocommitted' state in transaction"). All chunks
+// must run in the transaction the executor opened for the autocommit session.
+// The target table deliberately has no sequence and no owned lookup vindex:
+// those execute their own statements in between, which takes the approval
+// away before any chunk can claim it and hides the bug.
+func TestStreamingInsertSelectFromTable(t *testing.T) {
+	executor, sbc1, _, _, ctx := createExecutorEnv(t)
+
+	session := econtext.NewAutocommitSession(&vtgatepb.Session{})
+
+	err := executor.StreamExecute(ctx, nil, "TestStreamingInsertSelect", session, "insert into user_extra(user_id, extra_id) select c1, c2 from music", nil, false, func(result *sqltypes.Result) error {
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Every chunk's insert ran inside the transaction opened for the
+	// autocommit session, committed once at the end.
+	assert.EqualValues(t, 1, sbc1.CommitCount.Load(), "sbc1 commits")
+	assert.False(t, session.GetInTransaction())
+}
+
 func TestInsertReference(t *testing.T) {
 	executor, sbc1, sbc2, sbclookup, ctx := createExecutorEnv(t)
 

--- a/go/vt/vtgate/planbuilder/operators/insert.go
+++ b/go/vt/vtgate/planbuilder/operators/insert.go
@@ -425,9 +425,11 @@ func insertSelectPlan(
 		binaryOperator: newBinaryOp(newLockAndComment(selOp, nil, sqlparser.ShareModeLock), routeOp),
 	}
 
-	// When the table you are streaming data from and table you are inserting from are same.
-	// Then due to locking of the index range on the table we might not be able to insert into the table.
-	// Therefore, instead of streaming, this flag will ensure the records are first read and then inserted.
+	// When the table we are inserting into also appears in the select, the
+	// streamed select holds shared locks (it runs with "lock in share mode")
+	// on ranges the insert writes to, which can block or deadlock the insert.
+	// This flag makes us read the full select result first, so the locks are
+	// released before the rows are inserted.
 	insertTbl := insOp.tableTarget()
 	selTables := TablesUsed(selOp)
 	if slices.Contains(selTables, insertTbl) {


### PR DESCRIPTION
## Description

A multi-chunk `INSERT INTO ... SELECT` over the streaming execution path (`workload=olap` or the StreamExecute API) fails with `VT13001: unexpected 'autocommitted' state in transaction` — and worse, leaves the first chunk's rows permanently committed even though the statement failed.

`InsertSelect.TryStreamExecute` streams the select and runs one INSERT per streamed chunk. Each chunk's insert asked the session for autocommit approval, but that approval can be claimed only once per statement: the first chunk claimed it, ran as a standalone autocommit outside the transaction the executor had opened for the session, and the session was marked `'autocommitted'` from then on. The next chunk got no approval, opened a real shard transaction, and registering it on a session already marked `'autocommitted'` trips VT13001. The automatic rollback then only undoes the in-transaction chunks — the first chunk's autocommitted rows survive, so a failed insert-select leaves a partial write behind.

The fix threads a `canAutocommit` flag through the insert primitives: the streaming path forces it off, so every chunk's insert joins the surrounding transaction and the statement commits or rolls back as a whole. The buffered path — which inserts all selected rows in a single statement — keeps autocommitting as before. The sharded insert path also honors the flag now; it previously ignored it.

The bug is shape-sensitive, which the two new regression tests pin down (both verified red before the fix, green after):

- a chunk only claims the approval when its rows land on a single target shard,
- the target table must differ from the select source (self-referencing insert-selects are planned `ForceNonStreaming` and buffer),
- and the target must have no sequence and no owned lookup vindex — those execute their own statements in between, which takes the approval away and hides the bug.

There's a unit-level regression test in the executor package and an end-to-end test (`TestOlapInsertSelectMultiChunk` in `vtgate/queries/misc`) that reproduces the failure on a real cluster. Also fixes the source-vs-target mixup in the planner comment explaining why self-referencing insert-selects buffer.

**Backport justification:** reachable on all supported releases — `workload=olap` routes every statement through StreamExecute, so an OLAP insert-select hits this today on release-23.0 and release-24.0. It's a correctness bug (partially committed data on failure) with a small, self-contained fix.

## Related Issue(s)

Fixes #20498

Found while working on #20378, which makes streaming the default delivery path and therefore hits this for regular workloads too.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — streaming insert-selects that used to fail (or partially commit) now execute transactionally; the buffered path is unchanged.

### AI Disclosure

This PR was written by Claude Code — I provided direction and reviewed the result.
