### PR TITLE
VReplication: rename source tables by default on MoveTables complete

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -17,6 +17,7 @@
 - **[Minor Changes](#minor-changes)**
     - **[VReplication](#minor-changes-vreplication)**
         - [Default data protection for `_reverse` workflow cancel/complete](#vreplication-reverse-workflow-data-protection)
+        - [MoveTables complete renames source tables by default](#vreplication-movetables-complete-rename-default)
     - **[VTGate](#minor-changes-vtgate)**
         - [Ingress bytes in query LogStats](#vtgate-logstats-ingress-bytes)
         - [New controls for cross-keyspace reads](#vtgate-cross-keyspace-reads)
@@ -128,6 +129,19 @@ When calling `cancel` or `complete` on an auto-generated `_reverse` workflow wit
 The `--keep-data` flag help text has been updated to note this default explicitly. This change applies to MoveTables, Reshard, and other VReplication workflow types that use the shared cancel/complete paths.
 
 See [#19906](https://github.com/vitessio/vitess/pull/19906) for details.
+
+#### <a id="vreplication-movetables-complete-rename-default"/>MoveTables complete renames source tables by default</a>
+
+Completing a MoveTables workflow without `--rename-tables` or `--keep-data` now **renames** the source tables to `_<tablename>_old` instead of **dropping** them, so the data is taken out of service but remains recoverable if the removal was accidental. To restore the previous behavior and drop the source tables, pass `--rename-tables=false`. `--keep-data` continues to leave the source tables fully intact (neither dropped nor renamed).
+
+The new default lives in the `vtctldclient` CLI — the `--rename-tables` flag now defaults to `true` — and in the VTAdmin web UI. Direct gRPC callers of `MoveTablesComplete` and the legacy `vtctlclient`/`vtctl` path are unchanged and still drop the source tables unless `rename_tables` is set. Because the CLI now sends the flag value explicitly, the behavior is consistent across a mixed-version (rolling upgrade) cluster.
+
+**Caveats:**
+
+- A subsequent MoveTables of the same table can fail if a `_<tablename>_old` table already exists from a prior rename-complete, because the rename cannot overwrite it. Remove the leftover `_<tablename>_old` tables, or pass `--rename-tables=false`, in that case.
+- Renamed tables continue to consume disk on the source until they are removed manually; the previous drop behavior reclaimed that space immediately.
+
+See [#19930](https://github.com/vitessio/vitess/issues/19930) for details.
 
 ### <a id="minor-changes-vtgate"/>VTGate</a>
 

--- a/go/cmd/vtctldclient/command/vreplication/movetables/movetables.go
+++ b/go/cmd/vtctldclient/command/vreplication/movetables/movetables.go
@@ -104,7 +104,7 @@ func registerCommands(root *cobra.Command) {
 	complete := common.GetCompleteCommand(opts)
 	complete.Flags().BoolVar(&common.CompleteOptions.KeepData, "keep-data", false, common.ReverseWorkflowKeepDataHelpText("Keep the original source table data that was copied by the MoveTables workflow."))
 	complete.Flags().BoolVar(&common.CompleteOptions.KeepRoutingRules, "keep-routing-rules", false, "Keep the routing rules in place that direct table traffic from the source keyspace to the target keyspace of the MoveTables workflow.")
-	complete.Flags().BoolVar(&common.CompleteOptions.RenameTables, "rename-tables", false, "Keep the original source table data that was copied by the MoveTables workflow, but rename each table to '_<tablename>_old'.")
+	complete.Flags().BoolVar(&common.CompleteOptions.RenameTables, "rename-tables", true, "Instead of dropping the original source tables, rename each to '_<tablename>_old' so the data is out of service but recoverable. Enabled by default; pass --rename-tables=false to drop the source tables. Has no effect when --keep-data is set.")
 	complete.Flags().BoolVar(&common.CompleteOptions.DryRun, "dry-run", false, "Print the actions that would be taken and report any known errors that would have occurred.")
 	complete.Flags().BoolVar(&common.CompleteOptions.IgnoreSourceKeyspace, "ignore-source-keyspace", false, "WARNING: This option should only be used when absolutely necessary. Ignore the source keyspace as the workflow is completed and cleaned up. This allows the workflow to be completed if the source keyspace has been deleted or is not currently available.")
 	common.AddShardSubsetFlag(complete, &common.CompleteOptions.Shards)

--- a/go/cmd/vtctldclient/command/vreplication/movetables/movetables_test.go
+++ b/go/cmd/vtctldclient/command/vreplication/movetables/movetables_test.go
@@ -17,15 +17,31 @@ limitations under the License.
 package movetables
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	testRoot     *cobra.Command
+	testRootOnce sync.Once
+)
+
+// registeredTestRoot registers the MoveTables commands exactly once. registerCommands
+// adds flags to package-level command variables, so it panics if called more than once
+// per test binary.
+func registeredTestRoot() *cobra.Command {
+	testRootOnce.Do(func() {
+		testRoot = &cobra.Command{Use: "test"}
+		registerCommands(testRoot)
+	})
+	return testRoot
+}
+
 func TestKeepDataHelpMentionsReverseWorkflowDefault(t *testing.T) {
-	root := &cobra.Command{Use: "test"}
-	registerCommands(root)
+	root := registeredTestRoot()
 
 	completeCmd, _, err := root.Find([]string{"MoveTables", "complete"})
 	require.NoError(t, err)
@@ -34,4 +50,16 @@ func TestKeepDataHelpMentionsReverseWorkflowDefault(t *testing.T) {
 	cancelCmd, _, err := root.Find([]string{"MoveTables", "cancel"})
 	require.NoError(t, err)
 	require.Contains(t, cancelCmd.Flags().Lookup("keep-data").Usage, "Defaults to true for an explicitly specified _reverse workflow unless --keep-data=false is provided.")
+}
+
+func TestCompleteRenameTablesDefaultsToRename(t *testing.T) {
+	root := registeredTestRoot()
+
+	completeCmd, _, err := root.Find([]string{"MoveTables", "complete"})
+	require.NoError(t, err)
+
+	renameFlag := completeCmd.Flags().Lookup("rename-tables")
+	require.NotNil(t, renameFlag)
+	require.Equal(t, "true", renameFlag.DefValue)
+	require.Contains(t, renameFlag.Usage, "--rename-tables=false")
 }

--- a/web/vtadmin/src/components/routes/workflows/WorkflowActions.test.tsx
+++ b/web/vtadmin/src/components/routes/workflows/WorkflowActions.test.tsx
@@ -180,7 +180,7 @@ describe('WorkflowActions', () => {
                 workflow: 'test_workflow',
                 target_keyspace: 'test_keyspace',
                 keep_routing_rules: false,
-                rename_tables: false,
+                rename_tables: true,
             },
         });
     });
@@ -221,7 +221,7 @@ describe('WorkflowActions', () => {
                 // Toggled options.
                 keep_data: true,
                 keep_routing_rules: true,
-                rename_tables: true,
+                rename_tables: false,
             },
         });
     });

--- a/web/vtadmin/src/components/routes/workflows/WorkflowActions.tsx
+++ b/web/vtadmin/src/components/routes/workflows/WorkflowActions.tsx
@@ -39,7 +39,7 @@ interface CompleteMoveTablesOptions {
 
 const DefaultCompleteMoveTablesOptions: CompleteMoveTablesOptions = {
     keepRoutingRules: false,
-    renameTables: false,
+    renameTables: true,
 };
 
 interface CancelWorkflowOptions {


### PR DESCRIPTION
## Description

Completing a MoveTables workflow (`vtctldclient MoveTables ... complete`)
with no flags used to **drop** the source tables, which permanently
destroys data if you forget `--keep-data`. This is easy to do and
unrecoverable.

This PR makes **rename** the default instead: the source tables are renamed
to `_<tablename>_old`, so they're unambiguously out of service but still
recoverable. It follows the approach suggested in the issue, and continues
the "default data protection" direction started in #19906.

Behavior:

| Invocation | Result on source |
|---|---|
| `complete` (no flags) | tables renamed `_<t>_old` (**new default**) |
| `complete --rename-tables=false` | tables dropped (previous behavior) |
| `complete --keep-data` | tables left fully intact |
| `_reverse` workflow `complete` (no flags) | tables left intact (via #19906) |

The default is flipped in the clients, not on the server: the `vtctldclient`
`--rename-tables` flag now defaults to `true`, and the VTAdmin web UI
defaults to renaming. The `MoveTablesComplete` RPC and its `rename_tables`
field are left unchanged, so there is no version-skew hazard — because the
flag defaults to `true` the CLI always sends an explicit value, so old and
new binaries agree on it during a rolling upgrade. An explicit
`--rename-tables=false` still forces a drop. Direct gRPC callers and the
legacy `vtctlclient`/`vtctl` path are intentionally left unchanged (they
still drop unless `rename_tables` is set).

Caveats (documented in the release notes):
- A later MoveTables of the same table can fail if a `_<t>_old` table
  already exists from a prior rename-complete.
- Renamed tables keep consuming disk on the source until removed manually.

## Related Issue(s)

Fixes #19930

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

User-visible behavioral change: `MoveTables ... complete` now renames
source tables to `_<tablename>_old` by default instead of dropping them.
Automation that relied on the source tables being dropped should pass
`--rename-tables=false`. Documented in
`changelog/25.0/25.0.0/summary.md`.

### AI Disclosure

I used Claude code to understand the codebase, and implemented the fix myself.
Claude code was used for unit tests and documentation.