### PR TITLE
vtgate: classify prepare statements from the plan, reject statements MySQL disallows in the prepared statement protocol

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1307,18 +1307,18 @@ func (e *Executor) getCachedOrBuildPlan(
 
 	preparedPlan := planKey.Query != ""
 	if preparedPlan {
-		// MySQL rejects statement text that itself manages prepared
-		// statements with ER_UNSUPPORTED_PS. The check must run before the
-		// statement is planned: planning an EXECUTE plans its stored
-		// statement text, and the gRPC API lets clients store arbitrary
-		// text in the session's prepared-statement map, so nested EXECUTE
-		// text would otherwise recurse through the planner without bound.
-		// No statement is returned with the error so that a failed
-		// binary-protocol prepare does not fall back to accepting the
-		// statement with NULL field types.
-		switch stmt.(type) {
-		case *sqlparser.PrepareStmt, *sqlparser.ExecuteStmt, *sqlparser.DeallocateStmt:
-			return nil, false, nil, vterrors.NewErrorf(vtrpcpb.Code_UNIMPLEMENTED, vterrors.UnsupportedPS, "This command is not supported in the prepared statement protocol yet")
+		// MySQL only permits a subset of statement types in the prepared
+		// statement protocol and rejects everything else with
+		// ER_UNSUPPORTED_PS; vitess must not be more permissive. The check
+		// must run before the statement is planned: planning an EXECUTE
+		// plans its stored statement text, and the gRPC API lets clients
+		// store arbitrary text in the session's prepared-statement map, so
+		// nested EXECUTE text would otherwise recurse through the planner
+		// without bound. No statement is returned with the error so that a
+		// failed binary-protocol prepare does not fall back to accepting
+		// the statement with NULL field types.
+		if !preparableStatement(sqlparser.ASTToStatementType(stmt)) {
+			return nil, false, nil, errUnsupportedPS()
 		}
 	}
 
@@ -1924,6 +1924,13 @@ func (e *Executor) PlanPrepareStmt(ctx context.Context, safeSession *econtext.Sa
 	plan, _, _, err := e.fetchOrCreatePlan(ctx, safeSession, query, nil, false, true, lStats, false)
 	if err != nil {
 		return nil, err
+	}
+	// Non-preparable statement text is rejected before planning in
+	// getCachedOrBuildPlan. Checking the plan's query type here also
+	// covers plans fetched from the plan cache, which bypass that check:
+	// STREAM and VSTREAM statements are cachable but not preparable.
+	if !preparableStatement(plan.QueryType) {
+		return nil, errUnsupportedPS()
 	}
 	return plan, nil
 }

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1579,6 +1579,15 @@ func (e *Executor) Prepare(ctx context.Context, method string, safeSession *econ
 
 func (e *Executor) prepare(ctx context.Context, safeSession *econtext.SafeSession, sql string, logStats *logstats.LogStats) ([]*querypb.Field, uint16, error) {
 	stmtType := sqlparser.Preview(sql)
+	if stmtType == sqlparser.StmtUnknown {
+		// Preview only looks at the first keyword, so statements starting with
+		// a WITH clause come back as unknown. Classify those from the AST.
+		stmt, err := e.env.Parser().Parse(sql)
+		if err != nil {
+			return nil, 0, err
+		}
+		stmtType = sqlparser.ASTToStatementType(stmt)
+	}
 	logStats.StmtType = stmtType.String()
 
 	// Mysql warnings are scoped to the current session, but are

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1578,17 +1578,29 @@ func (e *Executor) Prepare(ctx context.Context, method string, safeSession *econ
 }
 
 func (e *Executor) prepare(ctx context.Context, safeSession *econtext.SafeSession, sql string, logStats *logstats.LogStats) ([]*querypb.Field, uint16, error) {
-	stmtType := sqlparser.Preview(sql)
-	if stmtType == sqlparser.StmtUnknown {
-		// Preview only looks at the first keyword, so statements starting with
-		// a WITH clause come back as unknown. Classify those from the AST.
-		stmt, err := e.env.Parser().Parse(sql)
-		if err != nil {
-			return nil, 0, err
+	plan, vcursor, stmt, err := e.fetchOrCreatePlan(ctx, safeSession, sql, nil, false, true, logStats, false)
+	execStart := time.Now()
+	logStats.PlanTime = execStart.Sub(logStats.StartTime)
+
+	if err != nil {
+		if stmt == nil || sqlparser.ASTToStatementType(stmt) != sqlparser.StmtShow {
+			safeSession.ClearWarnings()
 		}
-		stmtType = sqlparser.ASTToStatementType(stmt)
+		if stmt != nil {
+			// Attempt to build NULL field types for the statement in case planning fails,
+			// allowing the client to proceed with preparing the statement even without a valid execution plan.
+			// Hoping that an optimized plan can be built later when parameter values are available.
+			flds, paramCount, success := buildNullFieldTypes(stmt)
+			if success {
+				logStats.StmtType = sqlparser.ASTToStatementType(stmt).String()
+				return flds, paramCount, nil
+			}
+		}
+		logStats.Error = err
+		return nil, 0, err
 	}
-	logStats.StmtType = stmtType.String()
+
+	logStats.StmtType = plan.QueryType.String()
 
 	// Mysql warnings are scoped to the current session, but are
 	// cleared when a "non-diagnostic statement" is executed:
@@ -1597,19 +1609,40 @@ func (e *Executor) prepare(ctx context.Context, safeSession *econtext.SafeSessio
 	// To emulate this behavior, clear warnings from the session
 	// for all statements _except_ SHOW, so that SHOW WARNINGS
 	// can actually return them.
-	if stmtType != sqlparser.StmtShow {
+	if plan.QueryType != sqlparser.StmtShow {
 		safeSession.ClearWarnings()
 	}
 
-	switch stmtType {
+	switch plan.QueryType {
 	case sqlparser.StmtSelect, sqlparser.StmtShow,
 		sqlparser.StmtInsert, sqlparser.StmtReplace, sqlparser.StmtUpdate, sqlparser.StmtDelete:
-		return e.handlePrepare(ctx, safeSession, sql, logStats)
+		// These return field information, fetched from the tablets below.
 	case sqlparser.StmtDDL, sqlparser.StmtBegin, sqlparser.StmtCommit, sqlparser.StmtRollback, sqlparser.StmtSet,
-		sqlparser.StmtUse, sqlparser.StmtOther, sqlparser.StmtAnalyze, sqlparser.StmtComment, sqlparser.StmtExplain, sqlparser.StmtFlush, sqlparser.StmtKill:
+		sqlparser.StmtUse, sqlparser.StmtOther, sqlparser.StmtAnalyze, sqlparser.StmtComment, sqlparser.StmtCommentOnly,
+		sqlparser.StmtExplain, sqlparser.StmtFlush, sqlparser.StmtKill:
 		return nil, 0, nil
+	default:
+		return nil, 0, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] unrecognized prepare statement: %s", sql)
 	}
-	return nil, 0, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] unrecognized prepare statement: %s", sql)
+
+	bindVars := prepareBindVars(plan.ParamsCount)
+	if err := e.addNeededBindVars(vcursor, plan.BindVarNeeds, bindVars, safeSession); err != nil {
+		logStats.Error = err
+		return nil, 0, err
+	}
+
+	qr, err := plan.Instructions.GetFields(ctx, vcursor, bindVars)
+	logStats.ExecuteTime = time.Since(execStart)
+	if err != nil {
+		logStats.Error = err
+		plan.AddStats(1, time.Since(logStats.StartTime), logStats.ShardQueries, 0, 0, 1)
+		return nil, 0, err
+	}
+	logStats.RowsAffected = qr.RowsAffected
+
+	plan.AddStats(1, time.Since(logStats.StartTime), logStats.ShardQueries, qr.RowsAffected, uint64(len(qr.Rows)), 0)
+
+	return qr.Fields, plan.ParamsCount, nil
 }
 
 func (e *Executor) initVConfig(warnOnShardedOnly bool, pv plancontext.PlannerVersion) {
@@ -1697,46 +1730,6 @@ func prepareBindVars(paramsCount uint16) map[string]*querypb.BindVariable {
 		bindVars[parameterID] = &querypb.BindVariable{}
 	}
 	return bindVars
-}
-
-func (e *Executor) handlePrepare(ctx context.Context, safeSession *econtext.SafeSession, sql string, logStats *logstats.LogStats) ([]*querypb.Field, uint16, error) {
-	plan, vcursor, stmt, err := e.fetchOrCreatePlan(ctx, safeSession, sql, nil, false, true, logStats, false)
-	execStart := time.Now()
-	logStats.PlanTime = execStart.Sub(logStats.StartTime)
-
-	if err != nil {
-		if stmt != nil {
-			// Attempt to build NULL field types for the statement in case planning fails,
-			// allowing the client to proceed with preparing the statement even without a valid execution plan.
-			// Hoping that an optimized plan can be built later when parameter values are available.
-			flds, paramCount, success := buildNullFieldTypes(stmt)
-			if success {
-				return flds, paramCount, nil
-			}
-		}
-		logStats.Error = err
-		return nil, 0, err
-	}
-
-	bindVars := prepareBindVars(plan.ParamsCount)
-	err = e.addNeededBindVars(vcursor, plan.BindVarNeeds, bindVars, safeSession)
-	if err != nil {
-		logStats.Error = err
-		return nil, 0, err
-	}
-
-	qr, err := plan.Instructions.GetFields(ctx, vcursor, bindVars)
-	logStats.ExecuteTime = time.Since(execStart)
-	if err != nil {
-		logStats.Error = err
-		plan.AddStats(1, time.Since(logStats.StartTime), logStats.ShardQueries, 0, 0, 1)
-		return nil, 0, err
-	}
-	logStats.RowsAffected = qr.RowsAffected
-
-	plan.AddStats(1, time.Since(logStats.StartTime), logStats.ShardQueries, qr.RowsAffected, uint64(len(qr.Rows)), 0)
-
-	return qr.Fields, plan.ParamsCount, err
 }
 
 // buildNullFieldTypes builds a list of NULL field types for the given statement.

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1583,18 +1583,25 @@ func (e *Executor) prepare(ctx context.Context, safeSession *econtext.SafeSessio
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
 
 	if err != nil {
-		if stmt == nil || sqlparser.ASTToStatementType(stmt) != sqlparser.StmtShow {
+		if stmt == nil {
+			safeSession.ClearWarnings()
+			logStats.Error = err
+			return nil, 0, err
+		}
+		stmtType := sqlparser.ASTToStatementType(stmt)
+		if stmtType != sqlparser.StmtShow {
 			safeSession.ClearWarnings()
 		}
-		if stmt != nil {
-			// Attempt to build NULL field types for the statement in case planning fails,
-			// allowing the client to proceed with preparing the statement even without a valid execution plan.
-			// Hoping that an optimized plan can be built later when parameter values are available.
-			flds, paramCount, success := buildNullFieldTypes(stmt)
-			if success {
-				logStats.StmtType = sqlparser.ASTToStatementType(stmt).String()
-				return flds, paramCount, nil
-			}
+		if !preparableStatement(stmtType) {
+			return nil, 0, errUnsupportedPS()
+		}
+		// Attempt to build NULL field types for the statement in case planning fails,
+		// allowing the client to proceed with preparing the statement even without a valid execution plan.
+		// Hoping that an optimized plan can be built later when parameter values are available.
+		flds, paramCount, success := buildNullFieldTypes(stmt)
+		if success {
+			logStats.StmtType = stmtType.String()
+			return flds, paramCount, nil
 		}
 		logStats.Error = err
 		return nil, 0, err
@@ -1613,16 +1620,16 @@ func (e *Executor) prepare(ctx context.Context, safeSession *econtext.SafeSessio
 		safeSession.ClearWarnings()
 	}
 
+	if !preparableStatement(plan.QueryType) {
+		return nil, 0, errUnsupportedPS()
+	}
+
 	switch plan.QueryType {
 	case sqlparser.StmtSelect, sqlparser.StmtShow,
 		sqlparser.StmtInsert, sqlparser.StmtReplace, sqlparser.StmtUpdate, sqlparser.StmtDelete:
 		// These return field information, fetched from the tablets below.
-	case sqlparser.StmtDDL, sqlparser.StmtBegin, sqlparser.StmtCommit, sqlparser.StmtRollback, sqlparser.StmtSet,
-		sqlparser.StmtUse, sqlparser.StmtOther, sqlparser.StmtAnalyze, sqlparser.StmtComment, sqlparser.StmtCommentOnly,
-		sqlparser.StmtExplain, sqlparser.StmtFlush, sqlparser.StmtKill:
-		return nil, 0, nil
 	default:
-		return nil, 0, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] unrecognized prepare statement: %s", sql)
+		return nil, 0, nil
 	}
 
 	bindVars := prepareBindVars(plan.ParamsCount)
@@ -1730,6 +1737,26 @@ func prepareBindVars(paramsCount uint16) map[string]*querypb.BindVariable {
 		bindVars[parameterID] = &querypb.BindVariable{}
 	}
 	return bindVars
+}
+
+// preparableStatement reports whether MySQL permits the statement type in the
+// prepared statement protocol. MySQL rejects everything else with
+// ER_UNSUPPORTED_PS, and vitess must not be more permissive.
+func preparableStatement(stmtType sqlparser.StatementType) bool {
+	switch stmtType {
+	case sqlparser.StmtSelect, sqlparser.StmtShow,
+		sqlparser.StmtInsert, sqlparser.StmtReplace, sqlparser.StmtUpdate, sqlparser.StmtDelete,
+		sqlparser.StmtDDL, sqlparser.StmtSet, sqlparser.StmtCommit, sqlparser.StmtRollback,
+		sqlparser.StmtOther, sqlparser.StmtAnalyze, sqlparser.StmtComment, sqlparser.StmtCommentOnly,
+		sqlparser.StmtExplain, sqlparser.StmtFlush, sqlparser.StmtKill:
+		return true
+	}
+	return false
+}
+
+func errUnsupportedPS() error {
+	return vterrors.NewErrorf(vtrpcpb.Code_UNIMPLEMENTED, vterrors.UnsupportedPS,
+		"This command is not supported in the prepared statement protocol yet")
 }
 
 // buildNullFieldTypes builds a list of NULL field types for the given statement.

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -3111,6 +3111,37 @@ func TestSelectBindvarswithPrepare(t *testing.T) {
 	assert.Empty(t, sbc2.Queries)
 }
 
+func TestPrepareWithCTE(t *testing.T) {
+	testcases := []struct {
+		name        string
+		sql         string
+		paramsCount uint16
+	}{{
+		name:        "recursive cte select",
+		sql:         "with recursive rec as (select id from main1 where id = ? union all select id + 1 from rec where id < ?) select id from rec",
+		paramsCount: 2,
+	}, {
+		name:        "cte update",
+		sql:         "with cte as (select id from main1 where id = ?) update simple set name = ? where id in (select id from cte)",
+		paramsCount: 2,
+	}, {
+		name:        "cte delete",
+		sql:         "with cte as (select id from main1 where id = ?) delete from simple where id in (select id from cte)",
+		paramsCount: 1,
+	}}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			executor, _, _, _, ctx := createExecutorEnv(t)
+			session := &vtgatepb.Session{TargetString: KsTestUnsharded}
+
+			_, paramsCount, err := executorPrepare(ctx, executor, session, tc.sql)
+			require.NoError(t, err)
+			require.Equal(t, tc.paramsCount, paramsCount)
+		})
+	}
+}
+
 func assertOptimizedPlanCondition(t *testing.T, executor *Executor, sql string, condition ...engine.Condition) *engine.PlanSwitcher {
 	var plan *engine.Plan
 	executor.ForEachPlan(func(p *engine.Plan) bool {

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -2960,7 +2960,7 @@ func TestExecutorTruncateErrors(t *testing.T) {
 	require.EqualError(t, err, "syntax error at posi [TRUNCATED]")
 
 	_, _, err = executor.Prepare(t.Context(), "TestExecute", session, "invalid statement")
-	assert.EqualError(t, err, "[BUG] unrecognized p [TRUNCATED]")
+	assert.EqualError(t, err, "syntax error at posi [TRUNCATED]")
 }
 
 func TestPrepareDoesNotStartTransaction(t *testing.T) {

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -3132,6 +3132,9 @@ func TestPrepareUnsupportedStatements(t *testing.T) {
 		"prepare p1 from 'select 1'",
 		"execute p1",
 		"deallocate prepare p1",
+		// The alternate DEALLOCATE syntax previously slipped past the
+		// keyword-based Preview gate as DDL and returned an empty success.
+		"drop prepare p1",
 	}
 	for _, sql := range queries {
 		t.Run(sql, func(t *testing.T) {

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -41,6 +41,7 @@ import (
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/srvtopo/fakesrvtopo"
+	"vitess.io/vitess/go/vt/vterrors"
 
 	econtext "vitess.io/vitess/go/vt/vtgate/executorcontext"
 
@@ -3109,6 +3110,35 @@ func TestExecuteRejectsStoredNonPreparableStatements(t *testing.T) {
 
 			_, err := executorExecSession(ctx, executor, session, "execute prep", nil)
 			require.ErrorContains(t, err, "This command is not supported in the prepared statement protocol yet")
+		})
+	}
+}
+
+func TestPrepareUnsupportedStatements(t *testing.T) {
+	// MySQL rejects these in the prepared statement protocol with
+	// ER_UNSUPPORTED_PS (1295); vitess must not be more permissive.
+	executor, _, _, _, ctx := createExecutorEnv(t)
+
+	queries := []string{
+		"begin",
+		"start transaction",
+		"use " + KsTestUnsharded,
+		"savepoint sp1",
+		"rollback to sp1",
+		"release savepoint sp1",
+		"lock tables main1 read",
+		"unlock tables",
+		"prepare p1 from 'select 1'",
+		"execute p1",
+		"deallocate prepare p1",
+	}
+	for _, sql := range queries {
+		t.Run(sql, func(t *testing.T) {
+			session := &vtgatepb.Session{TargetString: KsTestUnsharded}
+
+			_, _, err := executorPrepare(ctx, executor, session, sql)
+			require.ErrorContains(t, err, "not supported in the prepared statement protocol")
+			require.Equal(t, vterrors.UnsupportedPS, vterrors.ErrState(err))
 		})
 	}
 }

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -3061,8 +3061,9 @@ func TestPrepareRejectsNonPreparableStatements(t *testing.T) {
 			_, err = executorExecSession(ctx, executor, session, tcase.sql, nil)
 			require.ErrorContains(t, err, "This command is not supported in the prepared statement protocol yet")
 			// A failed PREPARE deallocates the statement previously
-			// registered under the same name.
-			require.Nil(t, session.PrepareStatement["prep"])
+			// registered under the same name, and the rejected inner
+			// statement must not have been registered either.
+			require.Empty(t, session.PrepareStatement)
 		})
 	}
 }
@@ -3141,6 +3142,33 @@ func TestPrepareUnsupportedStatements(t *testing.T) {
 			require.Equal(t, vterrors.UnsupportedPS, vterrors.ErrState(err))
 		})
 	}
+}
+
+func TestPrepareUnsupportedStatementsLeaveSessionStateUntouched(t *testing.T) {
+	// A COM_STMT_PREPARE of a SQL-level PREPARE or DEALLOCATE statement is
+	// rejected before anything executes; the session's prepared-statement
+	// state must remain unchanged.
+	executor, _, _, _, ctx := createExecutorEnv(t)
+
+	t.Run("prepare", func(t *testing.T) {
+		session := &vtgatepb.Session{TargetString: KsTestUnsharded}
+
+		_, _, err := executorPrepare(ctx, executor, session, "prepare p1 from 'select 1'")
+		require.ErrorContains(t, err, "not supported in the prepared statement protocol")
+		require.Empty(t, session.PrepareStatement)
+	})
+
+	t.Run("deallocate", func(t *testing.T) {
+		session := &vtgatepb.Session{TargetString: KsTestUnsharded}
+
+		_, err := executorExec(ctx, executor, session, "prepare p1 from 'select 1'", nil)
+		require.NoError(t, err)
+		require.Contains(t, session.PrepareStatement, "p1")
+
+		_, _, err = executorPrepare(ctx, executor, session, "deallocate prepare p1")
+		require.ErrorContains(t, err, "not supported in the prepared statement protocol")
+		require.Contains(t, session.PrepareStatement, "p1")
+	})
 }
 
 func TestExecutorFlushStmt(t *testing.T) {

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -169,8 +169,8 @@ func TestVTGatePrepareError(t *testing.T) {
 	require.Nil(t, qr)
 
 	newCounts := errorCounts.Counts()
-	require.Contains(t, newCounts, "Prepare.TestUnsharded.primary.INTERNAL")
-	require.Equal(t, counts["Prepare.TestUnsharded.primary.INTERNAL"]+1, newCounts["Prepare.TestUnsharded.primary.INTERNAL"])
+	require.Contains(t, newCounts, "Prepare.TestUnsharded.primary.INVALID_ARGUMENT")
+	require.Equal(t, counts["Prepare.TestUnsharded.primary.INVALID_ARGUMENT"]+1, newCounts["Prepare.TestUnsharded.primary.INVALID_ARGUMENT"])
 
 	for k, v := range newCounts {
 		if strings.HasPrefix(k, "Execute") {


### PR DESCRIPTION
## Description

Preparing any statement that starts with a `WITH` clause failed with `[BUG] unrecognized prepare statement`, as reported in https://github.com/vitessio/vitess/issues/16415#issuecomment-3260955729 (Grafana prepares all its queries, including recursive CTEs). The prepare path classified statements with the textual `sqlparser.Preview` heuristic, which only looks at the first keyword and has no case for `with` — the regular execute path classifies from the AST, which is why the same queries work fine outside of PREPARE.

This PR fixes that and then aligns the prepare path with both the execute path and MySQL semantics, in four steps:

1. **Targeted fix** (backport-friendly): when `Preview` returns `StmtUnknown`, parse the statement and classify it with `ASTToStatementType`. Handles `WITH ... SELECT/UPDATE/DELETE`.
2. **Refactor**: restructure `prepare` to work the way the execute path does — fetch or create the plan first, then dispatch on `plan.QueryType`. This removes `Preview` from the prepare path entirely (it was the only place where the textual heuristic gated behavior), folds `handlePrepare` into `prepare`, and makes the parse-fallback from step 1 unnecessary since the plan lookup does the classification.
3. **MySQL parity for unsupported statements**: MySQL only permits a specific set of statements in the prepared statement protocol and rejects everything else with `ER_UNSUPPORTED_PS` (1295) — verified against MySQL 8.0.46. vtgate diverged in both directions: it accepted preparing `USE` and `BEGIN` (empty success) and returned an internal `[BUG]` error for things like `SAVEPOINT` and `LOCK TABLES`. All of those now return MySQL's 1295 error.
4. **The same restriction inside SQL-level PREPARE**: `PREPARE p1 FROM 'PREPARE p2 FROM ...'` (and any other non-preparable statement text) now fails with 1295 like MySQL, instead of silently registering the inner statement in the session.

Step 4 builds on #20562 (merged): plan building for SQL-level `PREPARE`/`DEALLOCATE` used to mutate the session's prepared-statement state as a side effect (flagged by Codex review here — a rejected `COM_STMT_PREPARE` of `PREPARE p1 FROM ...` returned 1295 but still created/deleted `p1`). With #20562 moving those side effects to execution time, rejecting a statement at any point before execution is guaranteed to leave the session untouched, and tests here pin that down.

Behavior changes to be aware of:

- Preparing an unparseable statement now returns a proper syntax error (`INVALID_ARGUMENT`) instead of the internal `[BUG]` error, matching Execute and StreamExecute.
- Preparing `USE`, `BEGIN`/`START TRANSACTION`, `SAVEPOINT`/`ROLLBACK TO`/`RELEASE`, `LOCK`/`UNLOCK TABLES`, and SQL-level `PREPARE`/`EXECUTE`/`DEALLOCATE` now returns `ER_UNSUPPORTED_PS` (1295) like MySQL, instead of empty success (`USE`, `BEGIN`) or the `[BUG]` error (the rest). The same applies to those statements appearing as the text of a SQL-level `PREPARE`.
- Statements like DDL and SET are now planned at prepare time (previously skipped); if planning fails, the existing NULL-field fallback preserves the empty-success behavior for non-SELECT statements. MySQL also defers DDL name resolution to execute (`ALTER TABLE nonexistent_table` prepares fine there), so this stays compatible.
- `logStats` records `PlanTime` for every prepare and derives `StmtType` from the plan, so a `WITH ... UPDATE` is logged as UPDATE.

Remaining gaps versus MySQL (preparing `CALL`, parameter count for `SET @@x = ?`, and `LOAD DATA` slipping through the allowlist) are tracked in #20542.

Now that #20562 and #20538 have merged, this PR is based on `main` and contains only its own commits: the WITH fix, the classify-from-plan refactor, the two `ER_UNSUPPORTED_PS` commits, and a test pinning the `drop prepare` rejection over the binary protocol. The non-preparable rejection extends the check #20562 put on the shared prepared-statement planning path, with a plan-cache backstop: cached plans skip that check, and STREAM/VSTREAM statements are cachable but not preparable.

The `WITH` fix is split out into #20665 for backporting — it is identical to this PR's first commit, which will drop out of this PR on rebase once #20665 merges. The refactor and parity changes here are intended for main only.

## Related Issue(s)

Part of #16415

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

- Preparing an invalid (unparseable) statement returns a syntax error instead of an internal `[BUG] unrecognized prepare statement` error; the `Prepare` error metric for such statements moves from `INTERNAL` to `INVALID_ARGUMENT`.
- Preparing statements MySQL disallows in the prepared statement protocol (`USE`, `BEGIN`, `SAVEPOINT`, `LOCK TABLES`, ...) now fails with `ER_UNSUPPORTED_PS` (1295) like MySQL. Clients that prepared `USE` or `BEGIN` against vtgate relied on behavior MySQL never allowed.
- SQL-level `PREPARE` with non-preparable statement text (e.g. a nested `PREPARE`) now fails with 1295 instead of silently registering the inner statement.

### AI Disclosure

This PR was written by Claude Code — I provided direction and reviewed.


