### PR TITLE
vtgate: do not start an implicit transaction on prepare

### DIFF
--- a/go/test/endtoend/preparestmt/stmt_methods_test.go
+++ b/go/test/endtoend/preparestmt/stmt_methods_test.go
@@ -28,7 +28,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
 	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vtgate/vtgateconn"
 )
 
 // TestDMLNone tests that impossible query run without an error.
@@ -696,4 +698,24 @@ func getVarValue[T any](t *testing.T, key string, varFunc func() map[string]any)
 	castValue, ok := value.(T)
 	assert.True(t, ok, "unexpected type, want: %T, got %T", new(T), value)
 	return castValue
+}
+
+// TestPrepareDoesNotStartTransaction verifies that preparing a statement does
+// not start an implicit transaction when autocommit is disabled. MySQL starts
+// the transaction at the first execution, not at prepare. The gRPC API is
+// used because it returns the session state, which the MySQL protocol does
+// not expose to clients.
+func TestPrepareDoesNotStartTransaction(t *testing.T) {
+	ctx := t.Context()
+	vtgateAddr := fmt.Sprintf("%s:%d", clusterInstance.Hostname, clusterInstance.VtgateProcess.GrpcPort)
+	vtConn, err := vtgateconn.Dial(ctx, vtgateAddr)
+	require.NoError(t, err)
+	t.Cleanup(vtConn.Close)
+
+	session := vtConn.SessionFromPb(&vtgatepb.Session{TargetString: uks, Autocommit: false})
+
+	_, paramsCount, err := session.Prepare(ctx, "select msg from vt_prepare_stmt_test where id = ?")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, paramsCount)
+	require.False(t, session.SessionPb().InTransaction, "prepare must not start an implicit transaction")
 }

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1562,12 +1562,6 @@ func (e *Executor) Prepare(ctx context.Context, method string, safeSession *econ
 }
 
 func (e *Executor) prepare(ctx context.Context, safeSession *econtext.SafeSession, sql string, logStats *logstats.LogStats) ([]*querypb.Field, uint16, error) {
-	// Start an implicit transaction if necessary.
-	if !safeSession.Autocommit && !safeSession.InTransaction() {
-		if err := e.txConn.Begin(ctx, safeSession, nil); err != nil {
-			return nil, 0, err
-		}
-	}
 	stmtType := sqlparser.Preview(sql)
 	logStats.StmtType = stmtType.String()
 

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -2874,6 +2874,18 @@ func TestExecutorTruncateErrors(t *testing.T) {
 	assert.EqualError(t, err, "[BUG] unrecognized p [TRUNCATED]")
 }
 
+func TestPrepareDoesNotStartTransaction(t *testing.T) {
+	// MySQL does not start an implicit transaction for COM_STMT_PREPARE, even
+	// with autocommit disabled; the transaction starts at first execution.
+	executor, _, _, _, ctx := createExecutorEnv(t)
+
+	session := &vtgatepb.Session{TargetString: KsTestUnsharded, Autocommit: false}
+
+	_, _, err := executorPrepare(ctx, executor, session, "select id from main1 where id = ?")
+	require.NoError(t, err)
+	require.False(t, session.InTransaction)
+}
+
 func TestExecutorFlushStmt(t *testing.T) {
 	executor, _, _, _, _ := createExecutorEnv(t)
 


### PR DESCRIPTION
## Description

vtgate starts an implicit transaction at the top of the prepare path whenever the session has `autocommit=0` and no open transaction. MySQL doesn't do this: `COM_STMT_PREPARE` never starts a transaction (verified against MySQL 8.0.46 by watching `information_schema.innodb_trx` — nothing after preparing a SELECT or an UPDATE, a `RUNNING` transaction only after `COM_STMT_EXECUTE`).

The practical impact is that an `autocommit=0` client pins a transaction on the shard primary from the moment it prepares its first statement — the prepare's field-metadata query starts a real shard transaction that's held until the client eventually commits or rolls back, for what should be a pure metadata operation.

The transaction-start block dates back to the original `COM_STMT_PREPARE` support (#5018) and looks like a copy of the execute path's then-unconditional transaction start. The execute path has since become plan-aware (only data-accessing statements start implicit transactions); prepare was never revisited.

This PR removes the transaction start from the prepare path entirely. The transaction now starts at `COM_STMT_EXECUTE` through the normal execute path, exactly like MySQL. Preparing inside an explicitly opened transaction is unaffected — an open transaction stays open and the metadata query runs inside it as before.

Backport justification: this affects every `autocommit=0` client on all supported releases, holds primary connections hostage to idle clients, and the fix is a small, self-contained deletion.

## Related Issue(s)

Fixes #20537

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

With `autocommit=0`, `COM_STMT_PREPARE` no longer starts an implicit transaction; the transaction starts at first execution, matching MySQL. Clients that (incorrectly) relied on prepare opening the transaction will see the transaction begin at `COM_STMT_EXECUTE` instead.

### AI Disclosure

This PR was written by Claude Code — I provided direction and reviewed.
