### PR TITLE
CI: skip e2e workflows on unit-test-only changes, and unit tests on e2e-test-only changes

### DIFF
--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -113,6 +113,7 @@ jobs:
               - 'test/config.json'
               - 'test/config_partial_keyspace.json'
               - 'go/**/!(*_test).go'
+              - 'go/**/*.s'
               - 'go/test/endtoend/**'
               - 'go/vt/sidecardb/**/*.sql'
               - 'go/mysql/collations/colldata/**'

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -115,6 +115,8 @@ jobs:
               - 'go/**/!(*_test).go'
               - 'go/test/endtoend/**'
               - 'go/vt/sidecardb/**/*.sql'
+              - 'go/mysql/collations/colldata/**'
+              - 'go/mysql/icuregex/internal/icudata/**'
               - 'test.go'
               - 'Makefile'
               - 'build.env'

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -112,9 +112,9 @@ jobs:
             end_to_end:
               - 'test/config.json'
               - 'test/config_partial_keyspace.json'
-              - 'go/**/*.go'
+              - 'go/**/!(*_test).go'
+              - 'go/test/endtoend/**'
               - 'go/vt/sidecardb/**/*.sql'
-              - 'go/test/endtoend/onlineddl/vrepl_suite/**'
               - 'test.go'
               - 'Makefile'
               - 'build.env'

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -49,13 +49,16 @@ jobs:
       with:
         token: ''
         # With 'every', a file is relevant only if it matches all patterns: any
-        # path from the brace-list, and not an endtoend-only test file (those
-        # cannot be imported by unit tests).
+        # path from the brace-list, and not a test file in one of the endtoend
+        # test packages, which the coverage run never tests and which cannot
+        # be imported by unit tests. The endtoend trees are enumerated explicitly
+        # so that testdata fixtures whose paths merely contain an endtoend
+        # directory (e.g. under go/tools/ci-config) still count as relevant.
         predicate-quantifier: 'every'
         filters: |
           changed_files:
             - '{.github/workflows/codecov.yml,.github/actions/setup-mysql/action.yml,go/**,go.mod,go.sum,Makefile}'
-            - '!go/test/endtoend/**/*_test.go'
+            - '!{go/test/endtoend,go/flags/endtoend,go/mysql/endtoend,go/vt/vtctl/endtoend,go/vt/vtctl/grpcvtctldserver/endtoend,go/vt/vtgate/endtoend,go/vt/vttablet/endtoend}/**/*_test.go'
 
     - name: Set up Go
       if: steps.mode.outputs.is_full_run == 'true' || steps.changes.outputs.changed_files == 'true'

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -48,14 +48,14 @@ jobs:
       id: changes
       with:
         token: ''
+        # With 'every', a file is relevant only if it matches all patterns: any
+        # path from the brace-list, and not an endtoend-only test file (those
+        # cannot be imported by unit tests).
+        predicate-quantifier: 'every'
         filters: |
           changed_files:
-            - .github/workflows/codecov.yml
-            - .github/actions/setup-mysql/action.yml
-            - 'go/**'
-            - go.mod
-            - go.sum
-            - Makefile
+            - '{.github/workflows/codecov.yml,.github/actions/setup-mysql/action.yml,go/**,go.mod,go.sum,Makefile}'
+            - '!go/test/endtoend/**/*_test.go'
 
     - name: Set up Go
       if: steps.mode.outputs.is_full_run == 'true' || steps.changes.outputs.changed_files == 'true'

--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -54,7 +54,9 @@ jobs:
             end_to_end:
               - 'test/config.json'
               - 'go/**/!(*_test).go'
+              - 'go/**/*.s'
               - 'go/test/endtoend/**'
+              - 'go/vt/sidecardb/**/*.sql'
               - 'go/mysql/collations/colldata/**'
               - 'go/mysql/icuregex/internal/icudata/**'
               - 'test.go'

--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -53,7 +53,8 @@ jobs:
           filters: |
             end_to_end:
               - 'test/config.json'
-              - 'go/**/*.go'
+              - 'go/**/!(*_test).go'
+              - 'go/test/endtoend/**'
               - 'test.go'
               - 'Makefile'
               - 'build.env'

--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -55,6 +55,8 @@ jobs:
               - 'test/config.json'
               - 'go/**/!(*_test).go'
               - 'go/test/endtoend/**'
+              - 'go/mysql/collations/colldata/**'
+              - 'go/mysql/icuregex/internal/icudata/**'
               - 'test.go'
               - 'Makefile'
               - 'build.env'

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -39,7 +39,12 @@ jobs:
         filters: |
           end_to_end:
             - 'go/**/!(*_test).go'
-            - 'go/**/endtoend/**'
+            - 'go/**/*.s'
+            # Package-level endtoend suites (go/mysql/endtoend, go/vt/vtgate/endtoend, ...).
+            # The cluster test tree go/test/endtoend is excluded: its packages are not run
+            # here, and its non-test .go helpers already match the first pattern.
+            - 'go/!(test)/**/endtoend/**'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'
             - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -38,7 +38,8 @@ jobs:
         token: ''
         filters: |
           end_to_end:
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
+            - 'go/**/endtoend/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -40,6 +40,8 @@ jobs:
           end_to_end:
             - 'go/**/!(*_test).go'
             - 'go/**/endtoend/**'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -39,7 +39,12 @@ jobs:
         filters: |
           end_to_end:
             - 'go/**/!(*_test).go'
-            - 'go/**/endtoend/**'
+            - 'go/**/*.s'
+            # Package-level endtoend suites (go/mysql/endtoend, go/vt/vtgate/endtoend, ...).
+            # The cluster test tree go/test/endtoend is excluded: its packages are not run
+            # here, and its non-test .go helpers already match the first pattern.
+            - 'go/!(test)/**/endtoend/**'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'
             - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -38,7 +38,8 @@ jobs:
         token: ''
         filters: |
           end_to_end:
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
+            - 'go/**/endtoend/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -40,6 +40,8 @@ jobs:
           end_to_end:
             - 'go/**/!(*_test).go'
             - 'go/**/endtoend/**'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -49,6 +49,8 @@ jobs:
           examples:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/**/*.s'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'
             - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -48,7 +48,7 @@ jobs:
         filters: |
           examples:
             - 'test/config.json'
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -49,6 +49,8 @@ jobs:
           examples:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -49,6 +49,8 @@ jobs:
           examples:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/**/*.s'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'
             - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -48,7 +48,7 @@ jobs:
         filters: |
           examples:
             - 'test/config.json'
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -49,6 +49,8 @@ jobs:
           examples:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -108,13 +108,16 @@ jobs:
         with:
           token: ""
           # With 'every', a file is relevant only if it matches all patterns: any
-          # path from the brace-list, and not an endtoend-only test file (those
-          # cannot be imported by unit tests).
+          # path from the brace-list, and not a test file in one of the endtoend
+          # test packages, which the unit test runner never runs and which cannot
+          # be imported by unit tests. The endtoend trees are enumerated explicitly
+          # so that testdata fixtures whose paths merely contain an endtoend
+          # directory (e.g. under go/tools/ci-config) still count as relevant.
           predicate-quantifier: 'every'
           filters: |
             unit_tests:
               - '{test/config.json,go/**,test.go,Makefile,build.env,go.sum,go.mod,proto/*.proto,tools/**,config/**,bootstrap.sh,.github/workflows/unit_test.yml,.github/actions/setup-mysql/action.yml}'
-              - '!go/test/endtoend/**/*_test.go'
+              - '!{go/test/endtoend,go/flags/endtoend,go/mysql/endtoend,go/vt/vtctl/endtoend,go/vt/vtctl/grpcvtctldserver/endtoend,go/vt/vtgate/endtoend,go/vt/vttablet/endtoend}/**/*_test.go'
 
       - name: Set up Go
         if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -107,21 +107,14 @@ jobs:
         id: changes
         with:
           token: ""
+          # With 'every', a file is relevant only if it matches all patterns: any
+          # path from the brace-list, and not an endtoend-only test file (those
+          # cannot be imported by unit tests).
+          predicate-quantifier: 'every'
           filters: |
             unit_tests:
-              - 'test/config.json'
-              - 'go/**'
-              - 'test.go'
-              - 'Makefile'
-              - 'build.env'
-              - 'go.sum'
-              - 'go.mod'
-              - 'proto/*.proto'
-              - 'tools/**'
-              - 'config/**'
-              - 'bootstrap.sh'
-              - '.github/workflows/unit_test.yml'
-              - '.github/actions/setup-mysql/action.yml'
+              - '{test/config.json,go/**,test.go,Makefile,build.env,go.sum,go.mod,proto/*.proto,tools/**,config/**,bootstrap.sh,.github/workflows/unit_test.yml,.github/actions/setup-mysql/action.yml}'
+              - '!go/test/endtoend/**/*_test.go'
 
       - name: Set up Go
         if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -55,6 +55,7 @@ jobs:
           end_to_end:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/**/*.s'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -54,8 +54,9 @@ jobs:
         filters: |
           end_to_end:
             - 'test/config.json'
-            - 'go/**'
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
+            - 'go/test/endtoend/**'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -57,6 +57,8 @@ jobs:
             - 'go/**/!(*_test).go'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -57,6 +57,7 @@ jobs:
           end_to_end:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/**/*.s'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -59,6 +59,8 @@ jobs:
             - 'go/**/!(*_test).go'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -56,8 +56,9 @@ jobs:
         filters: |
           end_to_end:
             - 'test/config.json'
-            - 'go/**'
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
+            - 'go/test/endtoend/**'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -51,6 +51,7 @@ jobs:
           end_to_end:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/**/*.s'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -53,6 +53,8 @@ jobs:
             - 'go/**/!(*_test).go'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -50,8 +50,9 @@ jobs:
         filters: |
           end_to_end:
             - 'test/config.json'
-            - 'go/**'
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
+            - 'go/test/endtoend/**'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -52,6 +52,7 @@ jobs:
           end_to_end:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/**/*.s'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -54,6 +54,8 @@ jobs:
             - 'go/**/!(*_test).go'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -51,8 +51,9 @@ jobs:
         filters: |
           end_to_end:
             - 'test/config.json'
-            - 'go/**'
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
+            - 'go/test/endtoend/**'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
+++ b/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
@@ -52,6 +52,7 @@ jobs:
           end_to_end:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/**/*.s'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'

--- a/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
+++ b/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
@@ -54,6 +54,8 @@ jobs:
             - 'go/**/!(*_test).go'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
+++ b/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
@@ -51,8 +51,9 @@ jobs:
         filters: |
           end_to_end:
             - 'test/config.json'
-            - 'go/**'
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
+            - 'go/test/endtoend/**'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -59,6 +59,7 @@ jobs:
           end_to_end:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/**/*.s'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -61,6 +61,8 @@ jobs:
             - 'go/**/!(*_test).go'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -58,8 +58,9 @@ jobs:
         filters: |
           end_to_end:
             - 'test/config.json'
-            - 'go/**'
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
+            - 'go/test/endtoend/**'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
@@ -51,6 +51,7 @@ jobs:
           end_to_end:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/**/*.s'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
@@ -53,6 +53,8 @@ jobs:
             - 'go/**/!(*_test).go'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
@@ -50,8 +50,9 @@ jobs:
         filters: |
           end_to_end:
             - 'test/config.json'
-            - 'go/**'
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
+            - 'go/test/endtoend/**'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
@@ -60,6 +60,7 @@ jobs:
           end_to_end:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/**/*.s'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
@@ -62,6 +62,8 @@ jobs:
             - 'go/**/!(*_test).go'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
@@ -59,8 +59,9 @@ jobs:
         filters: |
           end_to_end:
             - 'test/config.json'
-            - 'go/**'
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
+            - 'go/test/endtoend/**'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -60,6 +60,7 @@ jobs:
           end_to_end:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/**/*.s'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -62,6 +62,8 @@ jobs:
             - 'go/**/!(*_test).go'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -59,8 +59,9 @@ jobs:
         filters: |
           end_to_end:
             - 'test/config.json'
-            - 'go/**'
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
+            - 'go/test/endtoend/**'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -59,6 +59,7 @@ jobs:
           end_to_end:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/**/*.s'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -61,6 +61,8 @@ jobs:
             - 'go/**/!(*_test).go'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -58,8 +58,9 @@ jobs:
         filters: |
           end_to_end:
             - 'test/config.json'
-            - 'go/**'
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
+            - 'go/test/endtoend/**'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -60,6 +60,7 @@ jobs:
           end_to_end:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/**/*.s'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -62,6 +62,8 @@ jobs:
             - 'go/**/!(*_test).go'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -59,8 +59,9 @@ jobs:
         filters: |
           end_to_end:
             - 'test/config.json'
-            - 'go/**'
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
+            - 'go/test/endtoend/**'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -60,6 +60,7 @@ jobs:
           end_to_end:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/**/*.s'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -62,6 +62,8 @@ jobs:
             - 'go/**/!(*_test).go'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -59,8 +59,9 @@ jobs:
         filters: |
           end_to_end:
             - 'test/config.json'
-            - 'go/**'
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
+            - 'go/test/endtoend/**'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -60,6 +60,7 @@ jobs:
           end_to_end:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/**/*.s'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -62,6 +62,8 @@ jobs:
             - 'go/**/!(*_test).go'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -59,8 +59,9 @@ jobs:
         filters: |
           end_to_end:
             - 'test/config.json'
-            - 'go/**'
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
+            - 'go/test/endtoend/**'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -59,6 +59,7 @@ jobs:
           end_to_end:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/**/*.s'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -61,6 +61,8 @@ jobs:
             - 'go/**/!(*_test).go'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -58,8 +58,9 @@ jobs:
         filters: |
           end_to_end:
             - 'test/config.json'
-            - 'go/**'
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
+            - 'go/test/endtoend/**'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -59,6 +59,7 @@ jobs:
           end_to_end:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/**/*.s'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -61,6 +61,8 @@ jobs:
             - 'go/**/!(*_test).go'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -58,8 +58,9 @@ jobs:
         filters: |
           end_to_end:
             - 'test/config.json'
-            - 'go/**'
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
+            - 'go/test/endtoend/**'
+            - 'go/vt/sidecardb/**/*.sql'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/vitess_tester_vtgate.yml
+++ b/.github/workflows/vitess_tester_vtgate.yml
@@ -50,6 +50,7 @@ jobs:
           end_to_end:
             - 'test/config.json'
             - 'go/**/!(*_test).go'
+            - 'go/**/*.s'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
             - 'go/mysql/collations/colldata/**'

--- a/.github/workflows/vitess_tester_vtgate.yml
+++ b/.github/workflows/vitess_tester_vtgate.yml
@@ -52,6 +52,8 @@ jobs:
             - 'go/**/!(*_test).go'
             - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
+            - 'go/mysql/collations/colldata/**'
+            - 'go/mysql/icuregex/internal/icudata/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/vitess_tester_vtgate.yml
+++ b/.github/workflows/vitess_tester_vtgate.yml
@@ -49,9 +49,9 @@ jobs:
         filters: |
           end_to_end:
             - 'test/config.json'
-            - 'go/**/*.go'
+            - 'go/**/!(*_test).go'
+            - 'go/test/endtoend/**'
             - 'go/vt/sidecardb/**/*.sql'
-            - 'go/test/endtoend/vtgate/vitess_tester/**'
             - 'test.go'
             - 'Makefile'
             - 'build.env'

--- a/.github/workflows/vtop_example.yml
+++ b/.github/workflows/vtop_example.yml
@@ -45,6 +45,7 @@ jobs:
           filters: |
             end_to_end:
               - 'go/**/!(*_test).go'
+              - 'go/**/*.s'
               - 'go/vt/sidecardb/**/*.sql'
               - 'go/mysql/collations/colldata/**'
               - 'go/mysql/icuregex/internal/icudata/**'

--- a/.github/workflows/vtop_example.yml
+++ b/.github/workflows/vtop_example.yml
@@ -46,6 +46,8 @@ jobs:
             end_to_end:
               - 'go/**/!(*_test).go'
               - 'go/vt/sidecardb/**/*.sql'
+              - 'go/mysql/collations/colldata/**'
+              - 'go/mysql/icuregex/internal/icudata/**'
               - 'test.go'
               - 'Makefile'
               - 'build.env'

--- a/.github/workflows/vtop_example.yml
+++ b/.github/workflows/vtop_example.yml
@@ -44,7 +44,7 @@ jobs:
           token: ""
           filters: |
             end_to_end:
-              - 'go/**/*.go'
+              - 'go/**/!(*_test).go'
               - 'go/vt/sidecardb/**/*.sql'
               - 'test.go'
               - 'Makefile'


### PR DESCRIPTION
## Description

The paths filters gating our e2e workflows use `go/**/*.go`, which matches every Go file — including unit tests. So a PR that only touches unit test files still runs the full cluster matrix, all upgrade-downgrade workflows, docker tests, and the examples. Over the last 600 commits on main, ~4% of go-touching PRs were unit-test-only, and they're disproportionately flaky-test fixes — exactly the PRs where fast CI iteration matters most.

Since Go cannot import `_test.go` files across packages, a `_test.go` file outside an endtoend directory cannot affect any e2e run. This PR makes the filters reflect that, in both directions:

**E2e workflows skip unit-test-only changes.** `go/**/*.go` becomes `go/**/!(*_test).go` (extglob, supported by picomatch which dorny/paths-filter uses) plus the endtoend tree each workflow actually exercises:
- Cluster shard workflows (`cluster_endtoend`, `vitess_tester_vtgate`, `docker_ci`, all `upgrade_downgrade_test_*`) add `go/test/endtoend/**` — as a side effect, non-Go testdata under `go/test/endtoend/**` now correctly triggers them too (previously only `.go` files there did). The upgrade-downgrade workflows also drop their redundant `go/**` entry and gain an explicit `go/vt/sidecardb/**/*.sql` to preserve sidecar schema coverage.
- `endtoend` and `e2e_race` add `go/**/endtoend/**` instead, since they run the package-level endtoend tests (`go/mysql/endtoend`, `go/vt/vttablet/endtoend`, ...).
- The example workflows (`local_example`, `region_example`, `vtop_example`) only build binaries and run shell scripts, so they get just `go/**/!(*_test).go` — this also stops rerunning them on every e2e test edit.

**Unit tests skip e2e-test-only changes.** `unit_test.yml` and `codecov.yml` use paths-filter's `predicate-quantifier: every` with a negation pattern to exclude `_test.go` files under `go/test/endtoend/**`, which the unit test runner never compiles (`tools/unit_test_runner.sh` filters out endtoend packages). Non-test files there still trigger unit tests, because some unit tests import endtoend helper packages (e.g. `go/cmd/vttestserver/cli/main_test.go`).

### Verification

All patterns were verified against picomatch 2.3.1 — the exact dependency of the pinned dorny/paths-filter version, with its `{dot: true}` options — including an exhaustive check of `go/**/!(*_test).go` against all 3174 Go files in the repo (0 misclassifications) and scenario simulations of every edited filter block (unit-test-only, e2e-test-only, source, testdata, sidecar schema, and docs-only change sets). One notable finding baked into the patterns: picomatch 2.x segment negation like `go/!(test)/**` incorrectly rejects sibling names sharing the prefix (e.g. `go/testfiles/`), so the unit test filters use the documented `every`-quantifier + `!pattern` approach instead.

One behavior note: the upgrade-downgrade workflows previously triggered on any file under `go/**`. They now use the same explicit list as the cluster workflows: non-test Go, the endtoend tree, sidecar SQL, and the two directories whose data is embedded into the binaries via `go:embed` (`go/mysql/collations/colldata`, `go/mysql/icuregex/internal/icudata`). The embed directories were also added to the other binary-building workflows (cluster, docker, vitess-tester, examples), which closes a pre-existing gap there — `go/**/*.go` never matched those files. Thanks to the Codex review comment for catching the upgrade-downgrade regression.

## Related Issue(s)

n/a

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — CI-only change.

### AI Disclosure

This PR was written by Claude Code, with direction and review from me.
