### PR TITLE
test: remove dead waits from the e2e cluster harness

### DIFF
--- a/go/test/endtoend/backup/vtbackup/backup_only_test.go
+++ b/go/test/endtoend/backup/vtbackup/backup_only_test.go
@@ -120,8 +120,6 @@ func TestTabletInitialBackup(t *testing.T) {
 }
 
 func prepareCluster(t *testing.T) {
-	waitForReplicationToCatchup([]cluster.Vttablet{*replica1, *replica2})
-
 	dataPointReader := vtBackup(t, true, false, false)
 	verifyBackupCount(t, shardKsName, 1)
 	verifyBackupStats(t, dataPointReader, true /* initialBackup */)
@@ -129,10 +127,8 @@ func prepareCluster(t *testing.T) {
 	// Initialize the tablets
 	initTablets(t, false, false)
 
-	err := primary.VttabletProcess.CreateDB("testDB")
-	require.ErrorContains(t, err, "The MySQL server is running with the --super-read-only option so it cannot execute this statement")
-	err = replica1.VttabletProcess.CreateDB("testDB")
-	require.ErrorContains(t, err, "The MySQL server is running with the --super-read-only option so it cannot execute this statement")
+	assertMysqldIsSuperReadOnly(t, primary)
+	assertMysqldIsSuperReadOnly(t, replica1)
 
 	// Restore the Tablet
 	restore(t, primary, "replica", "NOT_SERVING")
@@ -143,7 +139,7 @@ func prepareCluster(t *testing.T) {
 	waitForRestoreComplete(t, primary.VttabletProcess, 180*time.Second)
 	// Vitess expects that the user has set the database into ReadWrite mode before calling
 	// TabletExternallyReparented
-	err = localCluster.VtctldClientProcess.ExecuteCommand(
+	err := localCluster.VtctldClientProcess.ExecuteCommand(
 		"SetWritable", primary.Alias, "true",
 	)
 	require.NoError(t, err)
@@ -226,9 +222,8 @@ func firstBackupTest(t *testing.T, removeBackup bool) {
 	err = localCluster.InitTablet(replica2, keyspaceName, shardName)
 	require.NoError(t, err)
 	restore(t, replica2, "replica", "SERVING")
-	// Replica2 takes time to serve. Sleeping for 5 sec.
-	time.Sleep(5 * time.Second)
-	// check the new replica has the data
+	// check the new replica has the data; VerifyRowsInTablet polls for up to
+	// 60s, which covers replica2's remaining catch-up time after the restore.
 	cluster.VerifyRowsInTablet(t, replica2, keyspaceName, 2)
 
 	if removeBackup {
@@ -562,6 +557,18 @@ func TestVtBackupWithChunking(t *testing.T) {
 
 	removeBackups(t)
 	tearDown(t, true)
+}
+
+// assertMysqldIsSuperReadOnly verifies that writes against the tablet's
+// mysqld fail because vtbackup left it in super-read-only mode. It uses a
+// direct connection with a single attempt: the QueryTablet helper retries
+// failing statements for ~10s each, but here the failure is the assertion.
+func assertMysqldIsSuperReadOnly(t *testing.T, tablet *cluster.Vttablet) {
+	conn, err := tablet.VttabletProcess.TabletConn(keyspaceName, false)
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = conn.ExecuteFetch("create database testdb_fail", 1000, true)
+	require.ErrorContains(t, err, "The MySQL server is running with the --super-read-only option so it cannot execute this statement")
 }
 
 // This helper function wait for all replicas to catch-up the replication.

--- a/go/test/endtoend/backup/vtctlbackup/backup_test.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_test.go
@@ -40,7 +40,13 @@ func TestBuiltinBackupWithZstdCompression(t *testing.T) {
 		ExternalDecompressorCmd: "zstd -d",
 	}
 
-	TestBackup(t, BuiltinBackup, "xbstream", 0, cDetails, []string{"TestReplicaBackup", "TestPrimaryBackup"})
+	// TestReplicaBackup covers the full compression surface of this variant:
+	// backup through the configured compressor and a complete replica2
+	// restore through the configured decompressor (asserted via restore
+	// stats in vtctlBackup). Everything TestPrimaryBackup adds on top
+	// (allow-primary gating, PRS, tablet deletion) is compression-agnostic
+	// and remains covered by TestBuiltinBackup under the default engine.
+	TestBackup(t, BuiltinBackup, "xbstream", 0, cDetails, []string{"TestReplicaBackup"})
 }
 
 func TestBuiltinBackupWithExternalZstdCompression(t *testing.T) {
@@ -53,7 +59,13 @@ func TestBuiltinBackupWithExternalZstdCompression(t *testing.T) {
 		ExternalDecompressorCmd: "zstd -d",
 	}
 
-	TestBackup(t, BuiltinBackup, "xbstream", 0, cDetails, []string{"TestReplicaBackup", "TestPrimaryBackup"})
+	// TestReplicaBackup covers the full compression surface of this variant:
+	// backup through the configured compressor and a complete replica2
+	// restore through the configured decompressor (asserted via restore
+	// stats in vtctlBackup). Everything TestPrimaryBackup adds on top
+	// (allow-primary gating, PRS, tablet deletion) is compression-agnostic
+	// and remains covered by TestBuiltinBackup under the default engine.
+	TestBackup(t, BuiltinBackup, "xbstream", 0, cDetails, []string{"TestReplicaBackup"})
 }
 
 func TestBuiltinBackupWithExternalZstdCompressionAndManifestedDecompressor(t *testing.T) {
@@ -67,7 +79,13 @@ func TestBuiltinBackupWithExternalZstdCompressionAndManifestedDecompressor(t *te
 		ManifestExternalDecompressorCmd: "zstd -d",
 	}
 
-	TestBackup(t, BuiltinBackup, "xbstream", 0, cDetails, []string{"TestReplicaBackup", "TestPrimaryBackup"})
+	// TestReplicaBackup covers the full compression surface of this variant:
+	// backup through the configured compressor and a complete replica2
+	// restore through the configured decompressor (asserted via restore
+	// stats in vtctlBackup). Everything TestPrimaryBackup adds on top
+	// (allow-primary gating, PRS, tablet deletion) is compression-agnostic
+	// and remains covered by TestBuiltinBackup under the default engine.
+	TestBackup(t, BuiltinBackup, "xbstream", 0, cDetails, []string{"TestReplicaBackup"})
 }
 
 // TestBuiltinBackupChunked uses a low chunk threshold and chunk size (4MiB each) to force

--- a/go/test/endtoend/backup/vtctlbackup/backup_utils.go
+++ b/go/test/endtoend/backup/vtctlbackup/backup_utils.go
@@ -1006,6 +1006,9 @@ func vtctlBackup(t *testing.T, tabletType string) {
 	err = replica2.VttabletProcess.WaitForTabletStatusesForTimeout([]string{"SERVING"}, 25*time.Second)
 	require.NoError(t, err)
 	cluster.VerifyRowsInTablet(t, replica2, keyspaceName, 2)
+	// replica2 was restored from the backup, so this pins that a decompressor
+	// actually processed the backup data during the restore.
+	verifyRestoreRanThroughDecompressor(t, replica2.VttabletProcess.GetVars())
 
 	verifyAfterRemovingBackupNoBackupShouldBePresent(t, backups)
 	err = replica2.VttabletProcess.TearDown()
@@ -1645,6 +1648,27 @@ func verifyRestorePositionAndTimeStats(t *testing.T, vars map[string]any) {
 	rp, err := replication.DecodePosition(backupPosition)
 	require.NoError(t, err)
 	require.False(t, rp.IsZero())
+}
+
+// verifyRestoreRanThroughDecompressor asserts that the restore read bytes
+// through a decompressor. Unlike verifyTabletRestoreStats it does not assert
+// on the stats' implementation label: the label reflects the tablet's
+// configured engine, and vtctlBackup deliberately configures a fake one
+// (restoreWaitForBackup) to prove the restore follows the engine recorded in
+// the backup manifest.
+func verifyRestoreRanThroughDecompressor(t *testing.T, vars map[string]any) {
+	require.Contains(t, vars, "RestoreBytes")
+	restoreBytes, ok := vars["RestoreBytes"].(map[string]any)
+	require.True(t, ok, "unexpected type %T for RestoreBytes", vars["RestoreBytes"])
+	for key, val := range restoreBytes {
+		if strings.HasSuffix(key, "Decompressor:Read") {
+			read, ok := val.(float64)
+			require.True(t, ok, "unexpected type %T for %s", val, key)
+			require.Positive(t, read, "the decompressor read no bytes during the restore")
+			return
+		}
+	}
+	require.Failf(t, "no decompressor restore stats found", "RestoreBytes: %v", restoreBytes)
 }
 
 func verifyTabletRestoreStats(t *testing.T, vars map[string]any) {

--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -1059,13 +1059,24 @@ func (cluster *LocalProcessCluster) Teardown() {
 		log.Error(fmt.Sprintf("Error in vtadmin teardown: %v", err))
 	}
 
+	// On CI the data directory is discarded after the test run, so nothing
+	// needs to be flushed to disk and a graceful mysqld shutdown buys us
+	// nothing. Killing mysqld skips the shutdown ack wait that can stall a
+	// semi-sync primary for many seconds per cluster. Coverage runs still
+	// shut down gracefully so that the mysqlctl shutdown path stays exercised.
+	killMySQL := os.Getenv("CI") == "true" && !*isCoverage
+
 	var mysqlctlProcessList []*exec.Cmd
 	var mysqlctlTabletUIDs []int
 	for _, keyspace := range cluster.Keyspaces {
 		for _, shard := range keyspace.Shards {
 			for _, tablet := range shard.Vttablets {
 				if tablet.MysqlctlProcess.TabletUID > 0 {
-					if proc, err := tablet.MysqlctlProcess.StopProcess(); err != nil {
+					if killMySQL {
+						if err := tablet.MysqlctlProcess.Kill(); err != nil {
+							log.Error(fmt.Sprintf("Error in mysqlctl teardown: %v", err))
+						}
+					} else if proc, err := tablet.MysqlctlProcess.StopProcess(); err != nil {
 						log.Error(fmt.Sprintf("Error in mysqlctl teardown: %v", err))
 					} else {
 						mysqlctlProcessList = append(mysqlctlProcessList, proc)

--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -190,6 +190,14 @@ func (mysqlctl *MysqlctlProcess) Stop() (err error) {
 		}
 		break
 	}
+	return mysqlctl.Kill()
+}
+
+// Kill kills the mysqld and any associated mysqld_safe processes without a
+// graceful shutdown. This is safe when the data directory is discarded right
+// after: nothing needs to be flushed, and it skips the semi-sync ack wait
+// that can stall a graceful shutdown of a primary for many seconds.
+func (mysqlctl *MysqlctlProcess) Kill() error {
 	pidFile := path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/mysql.pid", mysqlctl.TabletUID))
 	pidBytes, err := os.ReadFile(pidFile)
 	if err != nil {
@@ -203,8 +211,11 @@ func (mysqlctl *MysqlctlProcess) Stop() (err error) {
 	}
 	// We first need to try and kill any associated mysqld_safe process or
 	// else it will immediately restart the mysqld process when we kill it.
+	// The bracketed first characters keep the patterns from matching the
+	// command line of this pipeline's own sh process, which contains both
+	// the pattern and the tablet directory name.
 	mspidb, err := exec.Command("sh", "-c",
-		fmt.Sprintf("ps auxww | grep -E 'mysqld_safe|mariadbd-safe' | grep vt_%010d | awk '{print $2}'", mysqlctl.TabletUID)).Output()
+		fmt.Sprintf("ps auxww | grep -E '[m]ysqld_safe|[m]ariadbd-safe' | grep vt_%010d | awk '{print $2}'", mysqlctl.TabletUID)).Output()
 	if err != nil {
 		return err
 	}

--- a/go/test/endtoend/cluster/vtgate_process.go
+++ b/go/test/endtoend/cluster/vtgate_process.go
@@ -352,12 +352,14 @@ func (vtgate *VtgateProcess) TearDown() error {
 
 	// We are not checking vtgate's exit code because it sometimes
 	// returns exit code 2, even though vtgate terminates cleanly.
+	// Since the exit result is ignored either way, a long wait for a
+	// graceful exit buys nothing: force-kill after a short grace period.
 	select {
 	case <-vtgate.exit:
 		vtgate.proc = nil
 		return nil
 
-	case <-time.After(30 * time.Second):
+	case <-time.After(5 * time.Second):
 		vtgate.proc.Process.Kill()
 		err := <-vtgate.exit
 		vtgate.proc = nil

--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -2365,7 +2365,10 @@ DROP TABLE IF EXISTS stress_test
 
 	var openEndedUUID string
 	t.Run("open ended migration", func(t *testing.T) {
-		openEndedUUID = testOnlineDDLStatement(t, createParams(alterTableThrottlingStatement, "vitess --singleton --postpone-completion", "vtgate", "", "hint_col", "", false))
+		// A --postpone-completion migration never reaches a terminal state on its
+		// own, so skip the terminal-state wait and wait for Running instead.
+		openEndedUUID = testOnlineDDLStatement(t, createParams(alterTableThrottlingStatement, "vitess --singleton --postpone-completion", "vtgate", "", "hint_col", "", true))
+		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, openEndedUUID, normalWaitTime, schema.OnlineDDLStatusRunning)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, openEndedUUID, schema.OnlineDDLStatusRunning)
 	})
 	t.Run("failed singleton migration, vtgate", func(t *testing.T) {
@@ -2423,7 +2426,9 @@ DROP TABLE IF EXISTS stress_test
 		onlineddl.CheckCancelAllMigrations(t, &vtParams, 1)
 	})
 	t.Run("fail singleton-table same table multi submission", func(t *testing.T) {
-		uuid := testOnlineDDLStatement(t, createParams(alterTableThrottlingStatement, "vitess --singleton-table --postpone-completion", "vtctl", "", "hint_col", "", false))
+		// skipWait: a --postpone-completion migration never reaches a terminal
+		// state on its own; the wait for Running below is the one that matters.
+		uuid := testOnlineDDLStatement(t, createParams(alterTableThrottlingStatement, "vitess --singleton-table --postpone-completion", "vtctl", "", "hint_col", "", true))
 		uuids = append(uuids, uuid)
 		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalWaitTime, schema.OnlineDDLStatusRunning)
 
@@ -2434,7 +2439,9 @@ DROP TABLE IF EXISTS stress_test
 	var throttledUUIDs []string
 	// singleton-context
 	t.Run("postponed migrations, singleton-context", func(t *testing.T) {
-		uuidList := testOnlineDDLStatement(t, createParams(multiAlterTableThrottlingStatement, "vitess --singleton-context --postpone-completion", "vtctl", "", "hint_col", "", false))
+		// skipWait: --postpone-completion migrations never reach a terminal state
+		// on their own; the status checks below accept Queued/Ready/Running.
+		uuidList := testOnlineDDLStatement(t, createParams(multiAlterTableThrottlingStatement, "vitess --singleton-context --postpone-completion", "vtctl", "", "hint_col", "", true))
 		throttledUUIDs = strings.Split(uuidList, "\n")
 		assert.Len(t, throttledUUIDs, 3)
 		for _, uuid := range throttledUUIDs {
@@ -2492,7 +2499,9 @@ DROP TABLE IF EXISTS stress_test
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
 	})
 	t.Run("fail concurrent singleton-context with revert", func(t *testing.T) {
-		revertUUID := testRevertMigration(t, createRevertParams(uuids[len(uuids)-1], "vitess --allow-concurrent --postpone-completion --singleton-context", "vtctl", "rev:ctx", "", false))
+		// skipWait: a --postpone-completion revert never reaches a terminal state
+		// on its own; the wait for Running below is the one that matters.
+		revertUUID := testRevertMigration(t, createRevertParams(uuids[len(uuids)-1], "vitess --allow-concurrent --postpone-completion --singleton-context", "vtctl", "rev:ctx", "", true))
 		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, revertUUID, normalWaitTime, schema.OnlineDDLStatusRunning)
 		// revert is running
 		_ = testOnlineDDLStatement(t, createParams(dropNonexistentTableStatement, "vitess --allow-concurrent --singleton-context", "vtctl", "migrate:ctx", "", "rejected", true))
@@ -2502,7 +2511,9 @@ DROP TABLE IF EXISTS stress_test
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, revertUUID, schema.OnlineDDLStatusCancelled)
 	})
 	t.Run("success concurrent singleton-context with no-context revert", func(t *testing.T) {
-		revertUUID := testRevertMigration(t, createRevertParams(uuids[len(uuids)-1], "vitess --allow-concurrent --postpone-completion", "vtctl", "rev:ctx", "", false))
+		// skipWait: a --postpone-completion revert never reaches a terminal state
+		// on its own; the wait for Running below is the one that matters.
+		revertUUID := testRevertMigration(t, createRevertParams(uuids[len(uuids)-1], "vitess --allow-concurrent --postpone-completion", "vtctl", "rev:ctx", "", true))
 		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, revertUUID, normalWaitTime, schema.OnlineDDLStatusRunning)
 		// revert is running but has no --singleton-context. Our next migration should be able to run.
 		uuid := testOnlineDDLStatement(t, createParams(dropNonexistentTableStatement, "vitess --allow-concurrent --singleton-context", "vtctl", "migrate:ctx", "", "", false))
@@ -3648,8 +3659,16 @@ func testOnlineDDLStatement(t *testing.T, params *testOnlineDDLStatementParams) 
 	fmt.Printf("<%s>\n", uuid)
 
 	if !strategySetting.Strategy.IsDirect() && !params.skipWait && uuid != "" {
-		status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalWaitTime, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
-		fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
+		// A multi-statement migration returns one UUID per statement, newline
+		// separated; wait for each of them to reach a terminal state.
+		for migrationUUID := range strings.SplitSeq(uuid, "\n") {
+			migrationUUID = strings.TrimSpace(migrationUUID)
+			if migrationUUID == "" {
+				continue
+			}
+			status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, migrationUUID, normalWaitTime, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
+			fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
+		}
 	}
 
 	if params.expectError == "" && params.expectHint != "" {
@@ -3686,8 +3705,9 @@ func testRevertMigration(t *testing.T, params *testRevertMigrationParams) (uuid 
 		fmt.Println("# Generated UUID (for debug purposes):")
 		fmt.Printf("<%s>\n", uuid)
 	}
-	if !params.skipWait {
-		time.Sleep(time.Second * 20)
+	if !params.skipWait && uuid != "" {
+		status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalWaitTime, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
+		fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
 	}
 	return uuid
 }

--- a/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
@@ -89,7 +89,10 @@ func TestMain(m *testing.M) {
 		clusterInstance.VtTabletExtraArgs = []string{
 			"--heartbeat-interval", "250ms",
 			"--heartbeat-on-demand-duration", "5s",
-			"--migration-check-interval", "5s",
+			// With a 5s interval, every migration paid up to a full extra tick
+			// waiting for cut-over after the mandatory 5s test-suite DML window
+			// (vreplicationTestSuiteWaitSeconds) had already elapsed.
+			"--migration-check-interval", "1s",
 		}
 
 		if err := clusterInstance.StartTopo(); err != nil {

--- a/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
+++ b/go/test/endtoend/onlineddl/vrepl_suite/onlineddl_vrepl_suite_test.go
@@ -89,10 +89,7 @@ func TestMain(m *testing.M) {
 		clusterInstance.VtTabletExtraArgs = []string{
 			"--heartbeat-interval", "250ms",
 			"--heartbeat-on-demand-duration", "5s",
-			// With a 5s interval, every migration paid up to a full extra tick
-			// waiting for cut-over after the mandatory 5s test-suite DML window
-			// (vreplicationTestSuiteWaitSeconds) had already elapsed.
-			"--migration-check-interval", "1s",
+			"--migration-check-interval", "5s",
 		}
 
 		if err := clusterInstance.StartTopo(); err != nil {

--- a/go/test/endtoend/vreplication/cluster_test.go
+++ b/go/test/endtoend/vreplication/cluster_test.go
@@ -790,7 +790,7 @@ func (vc *VitessCluster) teardown() {
 	}
 
 	for _, keyspace := range keyspaces {
-		_ = vc.TearDownKeyspace(keyspace)
+		_ = vc.killKeyspaceProcesses(keyspace)
 	}
 	if err := vc.Vtctld.TearDown(); err != nil {
 		log.Info("Error stopping Vtctld:  " + err.Error())
@@ -811,6 +811,34 @@ func (vc *VitessCluster) teardown() {
 			log.Info("Error stopping VTOrc: " + err.Error())
 		}
 	}
+}
+
+// killKeyspaceProcesses kills the keyspace's vttablet and mysqld processes
+// without a graceful shutdown. This is only safe during the final cluster
+// teardown, where the data directory is deleted right afterwards: nothing
+// needs to be flushed, and killing skips both the semi-sync ack wait that
+// stalls a graceful primary mysqld shutdown and the vttablet termination
+// timeout once its mysqld is gone. Mid-test decommissioning of a keyspace
+// must keep using TearDownKeyspace.
+func (vc *VitessCluster) killKeyspaceProcesses(ks *Keyspace) error {
+	eg := errgroup.Group{}
+	for _, shard := range ks.Shards {
+		for _, tablet := range shard.Tablets {
+			eg.Go(func() error {
+				// The returned error is the process exit status: after a kill
+				// that is always non-nil ("signal: killed"), so it is not
+				// logged here.
+				_ = tablet.Vttablet.Kill()
+				if tablet.DbServer != nil && tablet.DbServer.TabletUID > 0 {
+					if err := tablet.DbServer.Kill(); err != nil {
+						log.Info(fmt.Sprintf("Error killing mysql process associated with vttablet %s: %v", tablet.Name, err))
+					}
+				}
+				return nil
+			})
+		}
+	}
+	return eg.Wait()
 }
 
 func (vc *VitessCluster) TearDownKeyspace(ks *Keyspace) error {
@@ -861,8 +889,7 @@ func (vc *VitessCluster) TearDown() {
 	case <-time.After(1 * time.Minute):
 		log.Info("TearDown() timed out")
 	}
-	// some processes seem to hang around for a bit
-	time.Sleep(5 * time.Second)
+	// Straggling processes are covered by CleanupDataroot's retry loop.
 	vc.CleanupDataroot(vc.t, false)
 }
 

--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -824,15 +824,24 @@ const (
 	loadTestBufferingWindowDuration = 10 * time.Second
 	loadTestAvgWaitBetweenQueries   = 500 * time.Microsecond
 	loadTestDefaultConnections      = 100
+	// After a traffic switch, this many new successful queries prove that any
+	// buffering has drained and traffic is flowing again.
+	loadTestPostSwitchQueryCount = 100
+	// A failover starting within vtgate's --buffer-min-time-between-failovers
+	// (1s in this cluster's config, see extraVTGateArgs) of the previous drain
+	// is not buffered at all and would fail queries, so consecutive traffic
+	// switches must be spaced further apart than that.
+	loadTestMinTimeBetweenSwitches = 2 * time.Second
 )
 
 type loadGenerator struct {
-	t           *testing.T
-	vc          *VitessCluster
-	ctx         context.Context
-	cancel      context.CancelFunc
-	connections int
-	wg          sync.WaitGroup
+	t                 *testing.T
+	vc                *VitessCluster
+	ctx               context.Context
+	cancel            context.CancelFunc
+	connections       int
+	wg                sync.WaitGroup
+	successfulQueries atomic.Int64
 }
 
 func newLoadGenerator(t *testing.T, vc *VitessCluster) *loadGenerator {
@@ -844,12 +853,33 @@ func newLoadGenerator(t *testing.T, vc *VitessCluster) *loadGenerator {
 }
 
 func (lg *loadGenerator) stop() {
-	// Wait for buffering to stop and additional records to be inserted by start
-	// after traffic is switched.
-	time.Sleep(loadTestBufferingWindowDuration * 2)
+	// Make sure fresh queries succeeded after the last traffic switch before
+	// canceling, so the final assertions cover the post-switch period.
+	lg.waitForTrafficToResume()
 	log.Info("Canceling load")
 	lg.cancel()
 	lg.wg.Wait()
+}
+
+// waitForTrafficToResume waits until the load generator executes new
+// successful queries, proving that any buffering triggered by a preceding
+// traffic switch has drained and traffic is flowing again, and then holds a
+// short gap so that a subsequent switch stays out of vtgate's
+// --buffer-min-time-between-failovers cooldown.
+func (lg *loadGenerator) waitForTrafficToResume() {
+	t := lg.t
+	start := lg.successfulQueries.Load()
+	timer := time.NewTimer(defaultTimeout)
+	defer timer.Stop()
+	for lg.successfulQueries.Load()-start < loadTestPostSwitchQueryCount {
+		select {
+		case <-timer.C:
+			require.FailNowf(t, "load generator did not resume", "no %d successful queries within %s after a traffic switch", loadTestPostSwitchQueryCount, defaultTimeout)
+		default:
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	time.Sleep(loadTestMinTimeBetweenSwitches)
 }
 
 func (lg *loadGenerator) start() {
@@ -860,12 +890,13 @@ func (lg *loadGenerator) start() {
 	var id atomic.Int64
 	log.Info("loadGenerator: starting")
 	queryTemplate := "insert into loadtest(id, name) values (%d, 'name-%d')"
-	var totalQueries, successfulQueries int64
+	lg.successfulQueries.Store(0)
+	var totalQueries int64
 	var deniedErrors, ambiguousErrors, reshardedErrors, tableNotFoundErrors, otherErrors int64
 	lg.wg.Add(1)
 	defer func() {
 		defer lg.wg.Done()
-		log.Info(fmt.Sprintf("loadGenerator: totalQueries: %d, successfulQueries: %d, deniedErrors: %d, ambiguousErrors: %d, reshardedErrors: %d, tableNotFoundErrors: %d, otherErrors: %d", totalQueries, successfulQueries, deniedErrors, ambiguousErrors, reshardedErrors, tableNotFoundErrors, otherErrors))
+		log.Info(fmt.Sprintf("loadGenerator: totalQueries: %d, successfulQueries: %d, deniedErrors: %d, ambiguousErrors: %d, reshardedErrors: %d, tableNotFoundErrors: %d, otherErrors: %d", totalQueries, lg.successfulQueries.Load(), deniedErrors, ambiguousErrors, reshardedErrors, tableNotFoundErrors, otherErrors))
 	}()
 	for {
 		select {
@@ -875,7 +906,7 @@ func (lg *loadGenerator) start() {
 			require.Equal(t, int64(0), deniedErrors)
 			require.Equal(t, int64(0), otherErrors)
 			require.Equal(t, int64(0), reshardedErrors)
-			require.Equal(t, totalQueries, successfulQueries)
+			require.Equal(t, totalQueries, lg.successfulQueries.Load())
 			return
 		default:
 			if int(connectionCount.Load()) < lg.connections {
@@ -916,7 +947,7 @@ func (lg *loadGenerator) start() {
 								atomic.AddInt64(&otherErrors, 1)
 							}
 						} else {
-							atomic.AddInt64(&successfulQueries, 1)
+							lg.successfulQueries.Add(1)
 						}
 						time.Sleep(time.Duration(int64(float64(loadTestAvgWaitBetweenQueries.Microseconds()) * rand.Float64())))
 					}

--- a/go/test/endtoend/vreplication/movetables_buffering_test.go
+++ b/go/test/endtoend/vreplication/movetables_buffering_test.go
@@ -18,7 +18,6 @@ package vreplication
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -59,9 +58,9 @@ func TestMoveTablesBuffering(t *testing.T) {
 	waitForLowLag(t, defaultTargetKs, defaultWorkflowName)
 	for range 10 {
 		tstWorkflowSwitchReadsAndWrites(t)
-		time.Sleep(loadTestBufferingWindowDuration + 1*time.Second)
+		lg.waitForTrafficToResume()
 		tstWorkflowReverseReadsAndWrites(t)
-		time.Sleep(loadTestBufferingWindowDuration + 1*time.Second)
+		lg.waitForTrafficToResume()
 	}
 	log.Info("SwitchWrites done")
 	lg.stop()

--- a/go/test/endtoend/vreplication/movetables_mirrortraffic_test.go
+++ b/go/test/endtoend/vreplication/movetables_mirrortraffic_test.go
@@ -17,13 +17,20 @@ limitations under the License.
 package vreplication
 
 import (
-	"fmt"
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/grpcclient"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+	"vitess.io/vitess/go/vt/vtgate/executorcontext"
+	"vitess.io/vitess/go/vt/vttablet/tabletconn"
 )
 
 func testMoveTablesMirrorTraffic(t *testing.T, flavor workflowFlavor) {
@@ -165,29 +172,43 @@ func TestMoveTablesMirrorTraffic_AllowReads(t *testing.T) {
 	mt.MirrorTraffic()
 	confirmMirrorRulesExist(t)
 
-	// Use shard-targeted queries to bypass vtgate routing rules and test
-	// vttablet-level denied tables behavior directly.
-	vtgateConn := getConnection(t, vc.ClusterConfig.hostname, vc.ClusterConfig.vtgateMySQLPort)
-	defer vtgateConn.Close()
-	_, err := vtgateConn.ExecuteFetch(fmt.Sprintf("use `%s:-80`", defaultTargetKs), 0, false)
-	require.NoError(t, err)
+	// Probe the target shard primary's queryservice directly to test
+	// vttablet-level denied tables behavior. Going through vtgate (even
+	// shard-targeted) would entangle the probes with its failover resilience:
+	// the expect-error DMLs get buffered or retried for the full buffer
+	// window / retry deadline before the denied-tables error surfaces.
+	execOnTargetShardPrimary := func(query string) (*sqltypes.Result, error) {
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+		tablet, err := vc.VtctldClient.GetTablet(targetTab1.Name)
+		require.NoError(t, err)
+		conn, err := tabletconn.GetDialer()(ctx, tablet, grpcclient.FailFast(false))
+		require.NoError(t, err)
+		defer conn.Close(ctx)
+		session := executorcontext.NewSafeSession(&vtgatepb.Session{})
+		return conn.Execute(ctx, session, &querypb.Target{
+			Keyspace:   tablet.Keyspace,
+			Shard:      tablet.Shard,
+			TabletType: tablet.Type,
+		}, query, nil, 0, 0, nil)
+	}
 
 	// Test 1: SELECT queries should succeed on denied tables when allow_reads=true
-	qr, err := vtgateConn.ExecuteFetch("SELECT count(*) FROM customer", 1, false)
+	qr, err := execOnTargetShardPrimary("SELECT count(*) FROM customer")
 	require.NoError(t, err, "SELECT should succeed on denied table when allow_reads=true")
 	require.NotEmpty(t, qr.Rows)
 
 	// Test 2: INSERT should be blocked on denied tables
-	_, err = vtgateConn.ExecuteFetch("INSERT INTO customer(cid, name) VALUES (999, 'test')", 1, false)
-	require.Error(t, err, "INSERT should fail on denied table even with allow_reads=true")
+	_, err = execOnTargetShardPrimary("INSERT INTO customer(cid, name) VALUES (999, 'test')")
+	require.ErrorContains(t, err, "disallowed due to rule", "INSERT should fail on denied table even with allow_reads=true")
 
 	// Test 3: UPDATE should be blocked on denied tables
-	_, err = vtgateConn.ExecuteFetch("UPDATE customer SET name = 'test' WHERE cid = 1", 1, false)
-	require.Error(t, err, "UPDATE should fail on denied table even with allow_reads=true")
+	_, err = execOnTargetShardPrimary("UPDATE customer SET name = 'test' WHERE cid = 1")
+	require.ErrorContains(t, err, "disallowed due to rule", "UPDATE should fail on denied table even with allow_reads=true")
 
 	// Test 4: DELETE should be blocked on denied tables
-	_, err = vtgateConn.ExecuteFetch("DELETE FROM customer WHERE cid = 999", 1, false)
-	require.Error(t, err, "DELETE should fail on denied table even with allow_reads=true")
+	_, err = execOnTargetShardPrimary("DELETE FROM customer WHERE cid = 999")
+	require.ErrorContains(t, err, "disallowed due to rule", "DELETE should fail on denied table even with allow_reads=true")
 
 	// Clean up: switch traffic and verify mirror rules are removed
 	mt.SwitchReadsAndWrites()

--- a/go/test/endtoend/vreplication/vdiff_helper_test.go
+++ b/go/test/endtoend/vreplication/vdiff_helper_test.go
@@ -39,7 +39,7 @@ const (
 	vdiffTimeout             = 180 * time.Second // We can leverage auto retry on error with this longer-than-usual timeout
 	maxDiffDurationTimeout   = 5 * time.Minute
 	vdiffRetryTimeout        = 30 * time.Second
-	vdiffStatusCheckInterval = 5 * time.Second
+	vdiffStatusCheckInterval = 1 * time.Second
 	vdiffRetryInterval       = 5 * time.Second
 )
 
@@ -71,8 +71,10 @@ func waitForVDiff2ToCompleteWithTimeout(t *testing.T, ksWorkflow, cells, uuid st
 	// goroutine (go-require).
 	go func() {
 		defer func() { ch <- true }()
-		for {
-			time.Sleep(vdiffStatusCheckInterval)
+		for i := 0; ; i++ {
+			if i > 0 {
+				time.Sleep(vdiffStatusCheckInterval)
+			}
 			var err error
 			_, jsonStr, err = performVDiff2Action(t, ksWorkflow, cells, "show", uuid, false)
 			if !assert.NoError(t, err) {

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -1193,10 +1193,12 @@ func reshard(t *testing.T, ksName string, tableName string, workflow string, sou
 		var sourceTablets, targetTablets []*cluster.VttabletProcess
 
 		// Test multi-primary setups, like a Galera cluster, which have auto increment steps > 1.
-		for _, tablet := range tablets {
-			autoIncrementSetQuery := fmt.Sprintf("set @@session.auto_increment_increment = %d; set @@global.auto_increment_increment = %d",
-				autoIncrementStep, autoIncrementStep)
-			tablet.QueryTablet(autoIncrementSetQuery, "", false)
+		if autoIncrementStep > 1 {
+			for _, tablet := range tablets {
+				autoIncrementSetQuery := fmt.Sprintf("set @@session.auto_increment_increment = %d; set @@global.auto_increment_increment = %d",
+					autoIncrementStep, autoIncrementStep)
+				require.NoError(t, tablet.MultiQueryTabletWithDB(autoIncrementSetQuery, ""))
+			}
 		}
 		reshardAction(t, "Create", workflow, ksName, sourceShards, targetShards, sourceCellOrAlias, "replica,primary")
 

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -1186,10 +1186,24 @@ func reshardCustomer3to1Merge(t *testing.T) { // to unsharded
 	})
 }
 
+// reshardOptions holds optional behavior changes for reshard.
+type reshardOptions struct {
+	// skipSwitchWritesErrorHandling skips the switch-writes error-handling
+	// subtest that reshard normally piggybacks onto workflows over the
+	// customer table. The vstream tests use it: the subtest asserts nothing
+	// about vstream, costs ~20s plus a known flake surface, and runs
+	// unchanged via the vreplication_basic and vreplication_cellalias shards.
+	skipSwitchWritesErrorHandling bool
+}
+
 func reshard(t *testing.T, ksName string, tableName string, workflow string, sourceShards string, targetShards string,
 	tabletIDBase int, counts map[string]int, dryRunResultSwitchReads, dryRunResultSwitchWrites []string, cells []*Cell, sourceCellOrAlias string,
-	autoIncrementStep int,
+	autoIncrementStep int, opts ...reshardOptions,
 ) {
+	var opt reshardOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
 	t.Run("reshard", func(t *testing.T) {
 		defaultCell := vc.Cells[vc.CellNames[0]]
 		if cells == nil {
@@ -1237,7 +1251,7 @@ func reshard(t *testing.T, ksName string, tableName string, workflow string, sou
 		if dryRunResultSwitchWrites != nil {
 			reshardAction(t, "SwitchTraffic", workflow, ksName, "", "", callNames, "primary", "--dry-run")
 		}
-		if tableName == "customer" {
+		if tableName == "customer" && !opt.skipSwitchWritesErrorHandling {
 			testSwitchWritesErrorHandling(t, sourceTablets, targetTablets, workflow, "reshard")
 		}
 		// Now let's confirm that it works as expected with an error.

--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -681,6 +681,20 @@ func testVStreamCellFlag(t *testing.T) {
 					log.Info(fmt.Sprintf("%s:: remote error: %v", time.Now(), err))
 				}
 			})
+			if tc.expectError {
+				// The stream can never start since the cell has no tablets, so
+				// Recv would block until the full context timeout. The failed
+				// tablet pick is registered in vtgate's stats and is what we
+				// assert on anyway, so wait for it and end the stream early.
+				// getDebugVar is not usable here: it requires the var to exist,
+				// which it doesn't until the first failed pick is registered.
+				require.Eventually(t, func() bool {
+					body := getHTTPBody(t, fmt.Sprintf("http://localhost:%d/debug/vars", vc.ClusterConfig.vtgatePort))
+					val, _, _, err := jsonparser.Get(body, "TabletPickerNoTabletFoundErrorCount")
+					return err == nil && strings.Contains(string(val), nonExistingCell)
+				}, 10*time.Second, 100*time.Millisecond)
+				cancel()
+			}
 			wg.Wait()
 
 			if tc.expectError {

--- a/go/test/endtoend/vreplication/vstream_test.go
+++ b/go/test/endtoend/vreplication/vstream_test.go
@@ -1341,6 +1341,12 @@ func TestVStreamStopOnReshardFalse(t *testing.T) {
 func TestVStreamWithKeyspacesToWatch(t *testing.T) {
 	extraVTGateArgs = append(extraVTGateArgs, []string{
 		"--keyspaces-to-watch", defaultSourceKs,
+		// The harness starts vtgate before the keyspace has any tablets, and
+		// with --keyspaces-to-watch set, vtgate only becomes ready once the
+		// gateway's initial-tablet wait on the watched-but-empty keyspace
+		// gives up: the default 30s is a guaranteed dead wait here. The
+		// gateway keeps discovering tablets after this timeout either way.
+		"--gateway-initial-tablet-timeout", "2s",
 	}...)
 
 	testVStreamWithFailover(t, false)

--- a/go/test/endtoend/vreplication/vstream_test.go
+++ b/go/test/endtoend/vreplication/vstream_test.go
@@ -754,7 +754,8 @@ func testVStreamStopOnReshardFlag(t *testing.T, stopOnReshard bool, baseTabletID
 		switch tickCount {
 		case 1:
 			reshard(t, "sharded", "customer", "vstreamStopOnReshard", "-80,80-",
-				"-40,40-", baseTabletID+400, nil, nil, nil, nil, defaultCellName, 1)
+				"-40,40-", baseTabletID+400, nil, nil, nil, nil, defaultCellName, 1,
+				reshardOptions{skipSwitchWritesErrorHandling: true})
 		case 60:
 			done = true
 		}

--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -34,6 +34,14 @@ func start(t *testing.T) (utils.MySQLCompare, func()) {
 	// ensure that the vschema and the tables have been created before running any tests
 	_ = utils.WaitForAuthoritative(t, keyspaceName, "t1", clusterInstance.VtgateProcess.ReadVSchema)
 
+	return startWithoutSchemaTracking(t)
+}
+
+// startWithoutSchemaTracking must be used by tests that run vtgate with
+// --schema-change-signal=false: with schema tracking disabled the tables
+// never become authoritative in the vschema, so waiting for that would
+// always burn the full WaitForAuthoritative timeout.
+func startWithoutSchemaTracking(t *testing.T) (utils.MySQLCompare, func()) {
 	mcmp, err := utils.NewMySQLCompare(t, vtParams, mysqlParams)
 	require.NoError(t, err)
 
@@ -531,7 +539,7 @@ func TestScalarAggregate(t *testing.T) {
 		vtParams = clusterInstance.GetVTParams(keyspaceName)
 	}()
 
-	mcmp, closer := start(t)
+	mcmp, closer := startWithoutSchemaTracking(t)
 	defer closer()
 
 	mcmp.Exec("insert into aggr_test(id, val1, val2) values(1,'a',1), (2,'A',1), (3,'b',1), (4,'c',3), (5,'c',4)")


### PR DESCRIPTION
## Description

While digging into why our slowest PR CI jobs take 20+ minutes, I found that a big chunk of e2e time is spent waiting on things that can't succeed or don't matter. This PR fixes five of them in the shared harness and test helpers:

- **`reshard()` burned ~40s per call on an auto_increment statement that has never executed.** The multi-statement `set @@session...; set @@global...` was sent through the single-statement `QueryTablet` helper, so it failed all 10 retries (1s sleep each) on every tablet and the error was discarded. Now we skip it for the default step of 1, and for larger steps send it through the multi-query helper and require success — so the multi-primary case is actually exercised for the first time. This alone recovers ~2 minutes in the `vstream` shard and speeds up every shard that calls `reshard()`.
- **vtgate teardown waited 30s for a graceful exit whose result is ignored.** The exit error is discarded either way, so force-kill after 5s instead. (In practice vtgate exits ~50ms after SIGTERM, so this is mostly a safety cap.)
- **CI cluster teardown now kills mysqld instead of gracefully shutting it down.** The data directory is discarded after the run, so there's nothing to flush, and a graceful shutdown of a semi-sync primary reliably stalls ~12s waiting on acks. In shards that build a cluster per test (e.g. `ers_prs_newfeatures_heavy` with 35 clusters) that's minutes of nothing. Gated on `CI=true` (same signal the reparent utils already use) and off for coverage runs.
- **`TestScalarAggregate` burned a full 60s in a wait that can never succeed.** The test restarts vtgate with `--schema-change-signal=false`, then `start()` called `utils.WaitForAuthoritative` (error discarded) — with schema tracking disabled the table never becomes authoritative, so the call always hit its 60s timeout. Confirmed with a goroutine dump taken mid-wait. The test now skips that wait and drops from 61.4s to 1.4s.

- **41% of `TestSchedulerSchemaChanges` (441s of 1083s) was waits that provably cannot succeed.** `testRevertMigration` slept an unconditional 20s after every revert (17 executions = 340s) even though every caller immediately checks for a terminal status; multi-statement migrations return newline-separated UUIDs so the terminal-status wait matched nothing and burned its full 20s timeout; and `--postpone-completion` migrations can never reach a terminal state, making their waits guaranteed timeouts. All replaced with status waits on the right condition (per-UUID where needed), which also makes the checks stronger. `TestSchedulerSchemaChanges` drops from ~18 to ~11 minutes with all subtests passing.

Along the way this fixes a latent bug in the existing `Stop()` kill fallback: the `ps | grep` pipeline used to find the `mysqld_safe` pid matched its own `sh` process, so the pid parse always failed, `mysqld_safe` was never killed, and it immediately respawned the mysqld we had just killed. Verified by running `clustertest` with `CI=true`: before the fix, 5 `mysqld_safe` + 5 respawned `mysqld` processes survived teardown; after it, none do.

First CI run of this branch (first three fixes only): `ers_prs_newfeatures_heavy` 23.2m → 15.5m, `vreplication_basic` 14.8m → 9.9m, Upgrade-Downgrade Reparent jobs −4 to −5m, `vreplication_across_db_versions` −3.5m, `vtctlbackup_sharded_clustertest_heavy` −1.9m, `vstream` −1.6m, with all checks green.

## Round 2 (vreplication + onlineddl_vrepl_suite jobs)

- **onlineddl vrepl_suite**: `--migration-check-interval` 5s → 1s. Every migration is held for a mandatory 5s DML window before cut-over, and then paid up to a full extra 5s tick on top. Measured ~1.5s saved per successful case × 97 cases ≈ 2.5 min per run.
- **vreplication harness**: final cluster teardown now kills vttablet/mysqld instead of gracefully shutting down state that is `rm -rf`'d immediately after (~12s semi-sync mysqld stall + ~10s vttablet term timeout + a fixed 5s sleep, ×~12 teardowns per job). Mid-test keyspace decommissioning stays graceful.
- **TestMoveTablesBuffering**: replaced ~240s of fixed 11s post-switch sleeps with condition waits on the load generator's success counter (buffer drained + traffic flowing), plus a 2s spacing to stay out of the `--buffer-min-time-between-failovers` cooldown. Progress is now verified after every switch instead of only via the final counters.
- **vdiff helper**: status polling checked first only after a 5s sleep and then at 5s; now checks immediately and polls at 1s. **VStreamCellsFlag zone7**: the no-tablets case burned its full 10s context timeout; it now ends as soon as the failed tablet pick shows up in vtgate's stats (10s → 0.1s).
- **TestMoveTablesMirrorTraffic_AllowReads**: the denied-table DML probes went through vtgate, whose failover machinery held each one for the buffer window (~14s each, 43s total). They now probe the tablet's queryservice directly and pin the actual "disallowed due to rule" error (68s → 27s).

First CI run with the round-2 teardown+buffering fixes: `vreplication_cellalias` 19–20m → **13m**, `vreplication_basic` → **9m**.

## Round 3

- **Reverted the vrepl_suite 1s check interval** from round 2: it helped locally but measurably hurt CI (+64s). Root cause: the executor's migration-check tick keeps its reentrance flag set until 1s *after* tick end and silently drops triggers in that window, so a 1s ticker sits exactly on a scheduling race that idle machines win and starved CI runners lose.
- **vtbackup dead waits (~75s per prepareCluster caller)**: a replication-catchup wait that ran before any vttablet existed (always its full 30s, result discarded), a super-read-only assertion whose intentionally-failing statements were retried 10×1s each by the harness (~40s), and a fixed 5s sleep already covered by a polling check. `TestTabletInitialBackup`: 192.5s (CI) → 112s locally.
- **zstd compression variants now run only `TestReplicaBackup`** (backup through the configured compressor + full replica2 restore through the configured decompressor, now pinned by a restore-stats assertion). The `TestPrimaryBackup` they each re-ran is compression-agnostic and stays covered under the default engine. ~311s → ~88s for the three variants. Interesting wrinkle: replica2 is deliberately configured with a fake backup engine (proving restores follow the manifest), and the restore stats' implementation label follows the configured value — so the assertion checks the decompressor bytes without pinning the label.
- **vstream reshards skip the switch-writes error-handling subtest** (~20s of fixed sleeps, no vstream relevance, runs unchanged in vreplication_basic/cellalias — and it flaked in the vstream shard on a recent run, costing a 117s re-run).
- **TestVStreamWithKeyspacesToWatch: bounded a guaranteed 30s vtgate startup stall** — the harness starts vtgate before any tablet exists, and with `--keyspaces-to-watch` the gateway's initial-tablet wait can only expire. `--gateway-initial-tablet-timeout=2s` for this test; 66s → 35.8s locally, on par with the filter-less TestVStreamFailover.

## Related Issue(s)

-

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — test-infrastructure only, no production code changes.

### AI Disclosure

This PR was written by Claude Code — I provided direction and reviewed the changes.
