### PR TITLE
txthrottler: don't panic on target_replication_lag_sec of 1

### DIFF
--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
@@ -374,7 +374,7 @@ func (ts *txThrottlerStateImpl) throttle() bool {
 func (ts *txThrottlerStateImpl) updateMaxLag() {
 	defer ts.waitForTermination.Done()
 	// We use half of the target lag to ensure we have enough resolution to see changes in lag below that value
-	ticker := time.NewTicker(time.Duration(ts.config.TxThrottlerConfig.TargetReplicationLagSec/2) * time.Second)
+	ticker := time.NewTicker(time.Duration(ts.config.TxThrottlerConfig.TargetReplicationLagSec) * time.Second / 2)
 	defer ticker.Stop()
 outerloop:
 	for {

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -187,6 +187,59 @@ func TestEnabledThrottler(t *testing.T) {
 	assert.Zero(t, throttlerImpl.throttlerRunning.Get())
 }
 
+// TestUpdateMaxLagTickerLowTargetLag verifies that a target replication lag of 1
+// second, which passes config verification, does not make the updateMaxLag
+// goroutine build a time.NewTicker with a non-positive interval and panic the
+// tablet. The old code computed TargetReplicationLagSec/2, which rounds down to 0
+// for a target of 1.
+func TestUpdateMaxLagTickerLowTargetLag(t *testing.T) {
+	ctx := t.Context()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	defer resetTxThrottlerFactories()
+	ts := memorytopo.NewServer(ctx, "cell1")
+
+	mockHealthCheck := NewMockHealthCheck(mockCtrl)
+	mockHealthCheck.EXPECT().Subscribe("TxThrottler").AnyTimes()
+	mockHealthCheck.EXPECT().RegisterStats().AnyTimes()
+	mockHealthCheck.EXPECT().Close().AnyTimes()
+	healthCheckFactory = func(ctx context.Context, topoServer *topo.Server, cell, keyspace, shard string, cellsToWatch []string) (discovery.HealthCheck, error) {
+		return mockHealthCheck, nil
+	}
+
+	mockThrottler := NewMockThrottler(mockCtrl)
+	mockThrottler.EXPECT().UpdateConfiguration(gomock.Any(), true /* copyZeroValues */).AnyTimes()
+	mockThrottler.EXPECT().MaxLag(gomock.Any()).Return(uint32(0)).AnyTimes()
+	mockThrottler.EXPECT().Close().AnyTimes()
+	throttlerFactory = func(name, unit string, threadCount int, maxRate int64, maxReplicationLagConfig throttler.MaxReplicationLagModuleConfig) (throttler.Throttler, error) {
+		return mockThrottler, nil
+	}
+
+	cfg := tabletenv.NewDefaultConfig()
+	cfg.EnableTxThrottler = true
+	cfg.TxThrottlerTabletTypes = &topoproto.TabletTypeListFlag{topodatapb.TabletType_REPLICA}
+	// A target replication lag of 1s is accepted by Verify (it only rejects < 1).
+	cfg.TxThrottlerConfig.Get().TargetReplicationLagSec = 1
+
+	env := tabletenv.NewEnv(vtenv.NewTestEnv(), cfg, t.Name())
+	throttler := NewTxThrottler(env, ts)
+	throttlerImpl, ok := throttler.(*txThrottler)
+	require.True(t, ok)
+	throttler.InitDBConfig(&querypb.Target{
+		Cell:     "cell1",
+		Keyspace: "keyspace",
+		Shard:    "shard",
+	})
+
+	// Open starts the updateMaxLag goroutine, which builds the ticker immediately.
+	// Close blocks until that goroutine has terminated, so a non-positive ticker
+	// interval panics within this test rather than being lost in a background crash.
+	require.NoError(t, throttlerImpl.Open())
+	throttler.Close()
+	assert.Zero(t, throttlerImpl.throttlerRunning.Get())
+}
+
 func TestFetchKnownCells(t *testing.T) {
 	ctx := t.Context()
 	{


### PR DESCRIPTION
## Description

When the transaction throttler is enabled with `target_replication_lag_sec: 1`, `vttablet` panics shortly after startup with `panic: non-positive interval for NewTicker`.

`updateMaxLag` builds its ticker from `TargetReplicationLagSec / 2`. Since `TargetReplicationLagSec` is an integer, a target of `1` rounds down to `0` and `time.NewTicker(0)` panics. A target of `1` is a valid config — `verifyTxThrottlerConfig` (via `MaxReplicationLagModuleConfig.Verify()`) only rejects values `< 1` — so a config that passes validation still crashes the tablet.

The fix computes the interval in `time.Duration` space (`target * time.Second / 2`) instead of doing the integer division first. A target of `1` now yields a 500ms ticker, and no valid config (`target >= 1`) can produce a non-positive interval. This also makes the interval slightly more precise for odd targets (e.g. a target of `5` becomes `2.5s` instead of `2s`), matching the "half of the target lag" comment.

Added a regression test that opens the throttler with `target_replication_lag_sec: 1` and confirms the `updateMaxLag` goroutine no longer panics. The test fails on `main` (panics) and passes with this change.

## Related Issue(s)

Fixes #20553

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

This change was written with the help of Claude Code, reviewed and directed by me.
