### PR TITLE
test: fix topo-flavor e2e shards silently running zero tests

### DIFF
--- a/tools/assert_tests_ran.sh
+++ b/tools/assert_tests_ran.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2026 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# gotestsum --post-run-command hook: a test run that executed zero tests is
+# never a pass. go test exits 0 when flag ordering or a -run regex leaves it
+# with nothing to run, so without this guard such a shard stays silently green.
+# TESTS_TOTAL is set by gotestsum and counts skipped tests too, so a shard
+# whose tests all t.Skip does not trip this.
+if [[ "${TESTS_TOTAL:-0}" -eq 0 ]]; then
+	echo "ERROR: gotestsum ran 0 tests for $PACKAGES: flag ordering or -run filtering may have broken package selection"
+	exit 1
+fi

--- a/tools/e2e_go_test.sh
+++ b/tools/e2e_go_test.sh
@@ -16,6 +16,7 @@ GOTESTSUM_ARGS=(
 	--rerun-fails-run-root-test
 	--format-hide-empty-pkg
 	--hide-summary=skipped
+	--post-run-command "bash tools/assert_tests_ran.sh"
 )
 
 if [[ -n "$JUNIT_OUTPUT" ]]; then

--- a/tools/e2e_go_test.sh
+++ b/tools/e2e_go_test.sh
@@ -22,4 +22,14 @@ if [[ -n "$JUNIT_OUTPUT" ]]; then
 	GOTESTSUM_ARGS+=("--junitfile" "$JUNIT_OUTPUT")
 fi
 
-go tool -modfile=tools/gotestsum/go.mod gotestsum "${GOTESTSUM_ARGS[@]}" --packages "$PACKAGES" -- -v -count=1 "$@"
+# The test packages must come before "$@" on the go test command line: "$@"
+# can contain test-binary flags such as --topo-flavor or -keep-data, which
+# go test only forwards to the test binary when they appear after the package
+# list. In --packages mode gotestsum appends the packages last, so any
+# test-binary flag made go test silently test the empty current directory
+# instead ("EMPTY Package ., DONE 0 tests") while still exiting 0.
+# On a rerun of a failed test, gotestsum appends "-run=^TestFoo$ <package>" to
+# this command; go test applies the -run flag (the last occurrence wins) and
+# hands the trailing package string to the test binary, which ignores it.
+# shellcheck disable=SC2086
+go tool -modfile=tools/gotestsum/go.mod gotestsum "${GOTESTSUM_ARGS[@]}" --raw-command -- go test -json -v -count=1 $PACKAGES "$@"


### PR DESCRIPTION
## Description

While profiling the Docker Test Cluster CI job I noticed its two zk2 shards finish in seconds and print `EMPTY Package ., DONE 0 tests in 0.000s` — while reporting success. It turns out **every e2e shard that passes a test-binary flag (like `--topo-flavor`) has been running zero tests since the switch to gotestsum in #19182** (2026-01-29).

The mechanism: in `--packages` mode gotestsum appends the package list *after* the caller's arguments, producing `go test -json -v -count=1 --topo-flavor=zk2 <package>`. `go test` stops flag parsing at the first flag it doesn't recognize and treats everything from there on — including the package path — as arguments for a test binary in the *current directory*, which has no test files, so it exits 0 having tested nothing.

Affected shards, all green-but-empty for ~5.5 months:
- `topo_zk2` and `tabletmanager_zk2` (Docker Test Cluster)
- `topo_consul` (shard `vtgate_topo_consul`) and `tabletmanager_consul` (cluster matrix)

The `-keep-data` and `--partial-keyspace` pass-throughs in `test.go` hit the same problem when used.

## The fix

Switch to gotestsum's `--raw-command` mode so the packages come *before* the caller's arguments; `go test` forwards post-package flags to the test binary, which was the behavior before #19182. Reruns of failed tests still work: gotestsum appends `-run=^TestFoo$ <package>` to the raw command, `go test` applies the `-run` (last occurrence wins) and passes the trailing package string to the test binary, which ignores it.

Verified locally:
- old script: zk2 shard → `DONE 0 tests`, exit 0 (reproduced byte-for-byte)
- fixed script: `topotest/zk2` runs its 4 tests against a real zookeeper and passes; `topotest/consul` runs its 4 tests against a real consul and passes
- the exact rerun command shape gotestsum produces was simulated and runs precisely the selected test

## Heads-up for reviewers

- This PR *restores* the dead coverage, so the affected jobs will get slower again — in particular `tabletmanager_zk2` re-runs the whole tabletmanager suite under zookeeper inside Docker Test Cluster. If those suites have rotted in the meantime, this PR's CI will show it; that's the point.
- Both release-23.0 and release-24.0 carry the same buggy invocation (release-23.0 with an extra `-args -alsologtostderr` variation), hence the backport labels. The release-23.0 backport needs its own verification because of the `-args` difference.

## Related Issue(s)

- Regression introduced by #19182
- Related to the silently-skipped e2e tests theme in #20261

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — CI tooling only.

### AI Disclosure

This bug was found and this PR was written by Claude Code — I provided direction and reviewed the changes.
