### PR TITLE
ci: avoid the slow Oracle Cloud apt mirror on arm64 runners

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -137,6 +137,14 @@ jobs:
         if: steps.changes.outputs.unit_tests == 'true'
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
 
+      - name: Avoid the Oracle Cloud apt mirror
+        if: steps.changes.outputs.unit_tests == 'true' && matrix.arch == 'arm64'
+        run: |
+          # The Oracle Cloud regional apt mirror (e.g. us-sanjose-1-ad-1.clouds.ports.ubuntu.com)
+          # is extremely slow; point apt at the default Ubuntu ports archive instead.
+          sudo grep -rl '\.clouds\.ports\.ubuntu\.com' /etc/apt --include='*.list' --include='*.sources' \
+            | xargs -r sudo sed -i 's|https\?://[^/ ]*\.clouds\.ports\.ubuntu\.com|http://ports.ubuntu.com|g'
+
       - name: Tune the OS
         if: steps.changes.outputs.unit_tests == 'true'
         timeout-minutes: 5


### PR DESCRIPTION
## Description

The self-hosted arm64 runners come up with apt pointed at the Oracle Cloud regional mirror (e.g. `us-sanjose-1-ad-1.clouds.ports.ubuntu.com`), which is extremely slow — apt-heavy steps like "Tune the OS" and "Get dependencies" each take ~4 minutes on arm64 unit test jobs (see [this job](https://github.com/vitessio/vitess/actions/runs/29085498488/job/86338120085) for an example).

This adds a small step to the unit test workflow (the only one using arm64 runners) that rewrites any `*.clouds.ports.ubuntu.com` mirror URI in `/etc/apt` to the default `ports.ubuntu.com` archive before the first apt usage. It's a no-op on runners that don't use the Oracle mirror (e.g. GitHub-hosted `ubuntu-24.04-arm` runners on forks). The amd64 runners already use the default `archive.ubuntu.com` mirror, so nothing to do there.

## Related Issue(s)

N/A

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

N/A

### AI Disclosure

This PR was written by Claude Code, with direction from me.
