### PR TITLE
txthrottler: don't cancel the state context when restarting the healthcheck stream

### DIFF
--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
@@ -359,7 +359,10 @@ func (ts *txThrottlerStateImpl) healthChecksProcessor(topoServer *topo.Server, t
 			if err := ts.updateHealthCheckCells(topoServer, target); err != nil {
 				log.Error(fmt.Sprintf("txThrottler: failed to update cell list: %+v", err))
 			}
-		case th := <-ts.healthCheckChan:
+		case th, ok := <-ts.healthCheckChan:
+			if !ok {
+				return
+			}
 			ts.StatsUpdate(th)
 		}
 	}
@@ -403,12 +406,13 @@ outerloop:
 }
 
 func (ts *txThrottlerStateImpl) deallocateResources() {
+	// Stop healthChecksProcessor before closing the stream so it can't wake on the
+	// closed healthcheck channel. It runs for the lifetime of ts.ctx.
+	ts.cancel()
+
 	// Close healthcheck and topo watchers
 	ts.closeHealthCheckStream()
 	ts.healthCheck = nil
-
-	// Stop healthChecksProcessor, which runs for the lifetime of ts.ctx.
-	ts.cancel()
 
 	ts.done <- true
 	ts.waitForTermination.Wait()

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler.go
@@ -157,10 +157,11 @@ type txThrottlerStateImpl struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	healthCheck      discovery.HealthCheck
-	healthCheckChan  chan *discovery.TabletHealth
-	healthCheckCells []string
-	cellsFromTopo    bool
+	healthCheck       discovery.HealthCheck
+	healthCheckCancel context.CancelFunc
+	healthCheckChan   chan *discovery.TabletHealth
+	healthCheckCells  []string
+	cellsFromTopo     bool
 
 	// tabletTypes stores the tablet types for throttling
 	tabletTypes map[topodatapb.TabletType]bool
@@ -307,10 +308,16 @@ func newTxThrottlerState(txThrottler *txThrottler, config *tabletenv.TabletConfi
 }
 
 func (ts *txThrottlerStateImpl) initHealthCheckStream(topoServer *topo.Server, target *querypb.Target) (err error) {
-	ts.healthCheck, err = healthCheckFactory(ts.ctx, topoServer, target.Cell, target.Keyspace, target.Shard, ts.healthCheckCells)
+	// The healthcheck stream gets its own child context so that restarting it on a
+	// topology cell change (updateHealthCheckCells) does not cancel ts.ctx, which
+	// healthChecksProcessor and the rest of the state depend on for their lifetime.
+	hcCtx, hcCancel := context.WithCancel(ts.ctx)
+	ts.healthCheck, err = healthCheckFactory(hcCtx, topoServer, target.Cell, target.Keyspace, target.Shard, ts.healthCheckCells)
 	if err != nil {
+		hcCancel()
 		return err
 	}
+	ts.healthCheckCancel = hcCancel
 	ts.healthCheckChan = ts.healthCheck.Subscribe(txThrottlerHcName)
 	return nil
 }
@@ -319,7 +326,7 @@ func (ts *txThrottlerStateImpl) closeHealthCheckStream() {
 	if ts.healthCheck == nil {
 		return
 	}
-	ts.cancel()
+	ts.healthCheckCancel()
 	ts.healthCheck.Close()
 }
 
@@ -399,6 +406,9 @@ func (ts *txThrottlerStateImpl) deallocateResources() {
 	// Close healthcheck and topo watchers
 	ts.closeHealthCheckStream()
 	ts.healthCheck = nil
+
+	// Stop healthChecksProcessor, which runs for the lifetime of ts.ctx.
+	ts.cancel()
 
 	ts.done <- true
 	ts.waitForTermination.Wait()

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -240,6 +240,39 @@ func TestUpdateMaxLagTickerLowTargetLag(t *testing.T) {
 	assert.Zero(t, throttlerImpl.throttlerRunning.Get())
 }
 
+// TestRestartHealthCheckStreamKeepsStateContextAlive verifies that restarting the
+// healthcheck stream, which is what updateHealthCheckCells does when the topology
+// cell list changes, does not cancel the state context. If it does,
+// healthChecksProcessor returns on ts.ctx.Done() and the throttler stops seeing
+// replication lag for the rest of the tablet's life.
+func TestRestartHealthCheckStreamKeepsStateContextAlive(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	defer resetTxThrottlerFactories()
+	mockHealthCheck := NewMockHealthCheck(mockCtrl)
+	mockHealthCheck.EXPECT().Subscribe("TxThrottler").AnyTimes()
+	mockHealthCheck.EXPECT().Close().AnyTimes()
+	healthCheckFactory = func(ctx context.Context, topoServer *topo.Server, cell, keyspace, shard string, cellsToWatch []string) (discovery.HealthCheck, error) {
+		return mockHealthCheck, nil
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	ts := &txThrottlerStateImpl{
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	target := &querypb.Target{Cell: "cell1", Keyspace: "keyspace", Shard: "shard"}
+
+	require.NoError(t, ts.initHealthCheckStream(nil, target))
+	// updateHealthCheckCells restarts the stream by closing then re-initializing it.
+	ts.closeHealthCheckStream()
+	require.NoError(t, ts.initHealthCheckStream(nil, target))
+
+	assert.NoError(t, ts.ctx.Err())
+}
+
 func TestFetchKnownCells(t *testing.T) {
 	ctx := t.Context()
 	{

--- a/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/tx_throttler_test.go
@@ -273,6 +273,36 @@ func TestRestartHealthCheckStreamKeepsStateContextAlive(t *testing.T) {
 	assert.NoError(t, ts.ctx.Err())
 }
 
+// TestHealthChecksProcessorReturnsOnClosedChannel verifies that healthChecksProcessor
+// exits when its subscriber channel is closed (which is what HealthCheck.Close does
+// during teardown) instead of receiving the zero value and forwarding it to
+// StatsUpdate.
+func TestHealthChecksProcessorReturnsOnClosedChannel(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ch := make(chan *discovery.TabletHealth)
+	ts := &txThrottlerStateImpl{
+		ctx:             ctx,
+		cancel:          cancel,
+		healthCheckChan: ch,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		ts.healthChecksProcessor(nil, &querypb.Target{})
+		close(done)
+	}()
+
+	close(ch)
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		require.Fail(t, "healthChecksProcessor did not return after its channel was closed")
+	}
+}
+
 func TestFetchKnownCells(t *testing.T) {
 	ctx := t.Context()
 	{


### PR DESCRIPTION
## Description

When the transaction throttler discovers its cells from the topology (no `--tx-throttler-healthcheck-cells`), the first change to the topology cell list silently stops it from ever monitoring replication lag again.

`healthChecksProcessor` runs on the state context `ts.ctx` and periodically calls `updateHealthCheckCells`. When the cell list changes it restarts the healthcheck stream via `closeHealthCheckStream` + `initHealthCheckStream`. The trouble is `closeHealthCheckStream` called `ts.cancel()`, which cancels the state context, not a per-stream one. So after the first refresh:

- `initHealthCheckStream` re-created the healthcheck bound to the already-cancelled `ts.ctx`, and
- `healthChecksProcessor` returned on `case <-ts.ctx.Done()` and never ran again.

From then on `StatsUpdate` / `RecordReplicationLag` stop, the cached lag goes stale, and the throttler fails open. No panic, no error logged.

The fix gives the healthcheck stream its own child context derived from `ts.ctx`, so restarting it only tears down the stream and leaves the state context alive. `deallocateResources` now cancels the state context explicitly, which `closeHealthCheckStream` previously did as a side effect on the teardown path.

I think this is worth backporting: it's a silent reliability regression on the topology-cells path (introduced in #12477), the fix is small and self-contained, and there's no behavior change for anyone who is not on that path.

## Related Issue(s)

Fixes #20560

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None. Behavior only changes for tablets running `--enable-tx-throttler` without `--tx-throttler-healthcheck-cells`, which will now keep monitoring lag across topology cell changes instead of silently going quiet.

### AI Disclosure

This PR was written with Claude Code; I reviewed the change, the reasoning, and the test, and I can defend them.
