### PR TITLE
`go/mysql`: send ERR instead of teardown after an OK carrying `SERVER_MORE_RESULTS_EXISTS`

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -1367,6 +1367,9 @@ func (c *Conn) handleComStmtExecute(handler Handler, data []byte) (kontinue bool
 	receivedResult := false
 	// sendFinished is set if the response should just be an OK packet.
 	sendFinished := false
+	// okSentWithMoreResults is set if that OK carried SERVER_MORE_RESULTS_EXISTS,
+	// meaning an ERR is still a protocol-legal next result after it.
+	okSentWithMoreResults := false
 	prepare := c.PrepareData[stmtID]
 	err = handler.ComStmtExecute(c, prepare, func(qr *sqltypes.Result) error {
 		if sendFinished {
@@ -1379,6 +1382,7 @@ func (c *Conn) handleComStmtExecute(handler Handler, data []byte) (kontinue bool
 
 			if len(qr.Fields) == 0 {
 				sendFinished = true
+				okSentWithMoreResults = c.StatusFlags&ServerMoreResultsExists != 0
 				// We should not send any more packets after this.
 				ok := PacketOK{
 					affectedRows:     qr.RowsAffected,
@@ -1409,10 +1413,10 @@ func (c *Conn) handleComStmtExecute(handler Handler, data []byte) (kontinue bool
 		}
 	} else {
 		if err != nil {
-			// An OK packet already terminated the result; we cannot safely
-			// append an ERR without desynchronizing the protocol for the
-			// next command. Tear down the connection instead.
-			if sendFinished {
+			// A final OK (no SERVER_MORE_RESULTS_EXISTS) already terminated
+			// the result. Appending an ERR would desynchronize the protocol,
+			// so tear down the connection instead.
+			if sendFinished && !okSentWithMoreResults {
 				log.Error("Error after OK-terminated result", slog.String("connection", c.String()), slog.Any("error", err))
 				return false
 			}
@@ -1560,6 +1564,9 @@ func (c *Conn) execQueryMulti(query string, handler Handler) execResult {
 	// end packet after the query is done or not. Initially we don't need to send an end packet
 	// so we initialize this value to false.
 	needsEndPacket := false
+	// lastOKHadMoreResults is set if the last OK carried SERVER_MORE_RESULTS_EXISTS,
+	// meaning an ERR is still a protocol-legal next result after it.
+	lastOKHadMoreResults := false
 	callbackCalled := false
 	res := execSuccess
 	previousStatusFlags := c.StatusFlags
@@ -1623,6 +1630,7 @@ func (c *Conn) execQueryMulti(query string, handler Handler) execResult {
 					sessionStateData: qr.QueryResult.SessionStateChanges,
 				}
 				needsEndPacket = false
+				lastOKHadMoreResults = flags&ServerMoreResultsExists != 0
 				return c.writeOKPacket(&ok)
 			}
 
@@ -1655,10 +1663,10 @@ func (c *Conn) execQueryMulti(query string, handler Handler) execResult {
 	}
 
 	if err != nil {
-		// An OK packet already terminated the last result; we cannot safely
-		// append an ERR without desynchronizing the protocol for the next
-		// command. Tear down the connection instead.
-		if !needsEndPacket {
+		// A final OK (no SERVER_MORE_RESULTS_EXISTS) already terminated the
+		// last result. Appending an ERR would desynchronize the protocol,
+		// so tear down the connection instead.
+		if !needsEndPacket && !lastOKHadMoreResults {
 			log.Error("Error after OK-terminated result", slog.String("connection", c.String()), slog.Any("error", err))
 			return connErr
 		}
@@ -1757,6 +1765,9 @@ func (c *Conn) execQuery(query string, handler Handler, more bool) execResult {
 	callbackCalled := false
 	// sendFinished is set if the response should just be an OK packet.
 	sendFinished := false
+	// okSentWithMoreResults is set if that OK carried SERVER_MORE_RESULTS_EXISTS,
+	// meaning an ERR is still a protocol-legal next result after it.
+	okSentWithMoreResults := false
 	defer func() {
 		c.StatusFlags &^= ServerQueryWasSlow
 	}()
@@ -1776,6 +1787,7 @@ func (c *Conn) execQuery(query string, handler Handler, more bool) execResult {
 
 			if len(qr.Fields) == 0 {
 				sendFinished = true
+				okSentWithMoreResults = flag&ServerMoreResultsExists != 0
 
 				// A successful callback with no fields means that this was a
 				// DML or other write-only operation.
@@ -1813,10 +1825,10 @@ func (c *Conn) execQuery(query string, handler Handler, more bool) execResult {
 		return execErr
 	}
 	if err != nil {
-		// An OK packet already terminated the result; we cannot safely
-		// append an ERR without desynchronizing the protocol for the
-		// next command. Tear down the connection instead.
-		if sendFinished {
+		// A final OK (no SERVER_MORE_RESULTS_EXISTS) already terminated the
+		// result. Appending an ERR would desynchronize the protocol, so
+		// tear down the connection instead.
+		if sendFinished && !okSentWithMoreResults {
 			log.Error("Error after OK-terminated result", slog.String("connection", c.String()), slog.Any("error", err))
 			return connErr
 		}

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -1701,13 +1701,17 @@ func TestHandleComStmtExecuteErrorAfterMoreResultsOKSurfacesError(t *testing.T) 
 		BindVars:    map[string]*querypb.BindVariable{},
 	}
 
-	cConn.sequence = 0
-	buf, pos := cConn.startEphemeralPacketWithHeader(10)
-	pos = writeByte(buf, pos, ComStmtExecute)
-	pos = writeUint32(buf, pos, stmtID)
-	pos = writeByte(buf, pos, 0) // cursor type
-	_ = writeUint32(buf, pos, 1) // iteration count
-	require.NoError(t, cConn.writeEphemeralPacket())
+	writeComStmtExecute := func() {
+		cConn.sequence = 0
+		buf, pos := cConn.startEphemeralPacketWithHeader(10)
+		pos = writeByte(buf, pos, ComStmtExecute)
+		pos = writeUint32(buf, pos, stmtID)
+		pos = writeByte(buf, pos, 0) // cursor type
+		_ = writeUint32(buf, pos, 1) // iteration count
+		require.NoError(t, cConn.writeEphemeralPacket())
+	}
+
+	writeComStmtExecute()
 
 	handler := &testRun{err: sqlerror.NewSQLError(sqlerror.ERQueryInterrupted, sqlerror.SSQueryInterrupted, "context canceled")}
 	res := sConn.handleNextCommand(handler)
@@ -1727,6 +1731,35 @@ func TestHandleComStmtExecuteErrorAfterMoreResultsOKSurfacesError(t *testing.T) 
 	require.NotEmpty(t, data)
 	require.EqualValues(t, ErrPacket, data[0], "the next result must be the real error packet")
 	require.ErrorContains(t, ParseErrorPacket(data), "context canceled")
+
+	// Connection must still be usable for the next binary-protocol execution.
+	writeComStmtExecute()
+	// Switch to a non-error prepared statement to verify the round-trip works.
+	sConn.PrepareData[stmtID].PrepareStmt = "select rows"
+	res = sConn.handleNextCommand(handler)
+	require.True(t, res, "subsequent COM_STMT_EXECUTE must be handled on a still-alive connection")
+
+	// Read the full binary result of the follow-up execution and assert it is a
+	// real (non-error) response: every packet up to the result terminator must
+	// arrive without an ERR packet. The result set ends after two EOF packets
+	// (columns then rows, since CapabilityClientDeprecateEOF is off here).
+	// Bounded by a read deadline and packet count so a regression fails fast
+	// instead of stalling CI.
+	require.NoError(t, cConn.conn.SetReadDeadline(time.Now().Add(30*time.Second)))
+	var eofCount int
+	for range 16 {
+		data, err := cConn.ReadPacket()
+		require.NoError(t, err)
+		require.NotEmpty(t, data)
+		require.NotEqualf(t, byte(ErrPacket), data[0], "follow-up execution must return a result, not an error packet")
+		if cConn.isEOFPacket(data) {
+			eofCount++
+			if eofCount == 2 {
+				break
+			}
+		}
+	}
+	require.Equal(t, 2, eofCount, "follow-up binary result must terminate cleanly")
 }
 
 func TestInitDbAgainstWrongDbDoesNotDropConnection(t *testing.T) {

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -1602,6 +1602,133 @@ func TestHandleComStmtExecuteSurfacesMidStreamError(t *testing.T) {
 	require.Equal(t, 2, eofCount, "follow-up binary result must terminate cleanly")
 }
 
+// TestExecQueryMultiErrorAfterMoreResultsOKSurfacesError exercises execQueryMulti
+// erroring right after an OK that carried SERVER_MORE_RESULTS_EXISTS. The client is
+// expecting another result, so an ERR is protocol-legal there: the real SQL error
+// must reach the client and the connection must survive.
+func TestExecQueryMultiErrorAfterMoreResultsOKSurfacesError(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	sConn.multiQuery = true
+	sConn.Capabilities |= CapabilityClientMultiStatements
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	// Statement 1 OKs with the more-results flag, then the handler errors
+	// before statement 2 emits anything.
+	require.NoError(t, cConn.WriteComQuery("ok then error; select rows"))
+
+	handler := &testRun{err: sqlerror.NewSQLError(sqlerror.ERQueryInterrupted, sqlerror.SSQueryInterrupted, "context canceled")}
+	res := sConn.handleNextCommand(handler)
+	require.True(t, res, "error after a more-results OK must not tear down the connection")
+
+	// First result arrives cleanly with the more-results flag set.
+	result, more, _, err := cConn.ReadQueryResult(100, true)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, result.RowsAffected)
+	require.True(t, more, "more results must follow the first OK")
+
+	// The next result is the real error, not connection loss.
+	_, more, _, err = cConn.ReadQueryResult(100, true)
+	require.ErrorContains(t, err, "context canceled")
+	require.False(t, more, "no further results after an error packet")
+
+	// Connection must still be usable for the next query.
+	require.NoError(t, cConn.WriteComQuery("select rows"))
+	res = sConn.handleNextCommand(handler)
+	require.True(t, res, "subsequent query must be handled on a still-alive connection")
+	result, _, _, err = cConn.ReadQueryResult(100, true)
+	require.NoError(t, err)
+	require.True(t, result.Equal(selectRowsResult))
+}
+
+// TestExecQueryErrorAfterMoreResultsOKSurfacesError is the execQuery variant:
+// handleComQuery splits the batch itself and calls execQuery with more=true for the
+// non-final statement. Same contract.
+func TestExecQueryErrorAfterMoreResultsOKSurfacesError(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	sConn.Capabilities |= CapabilityClientMultiStatements
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	require.NoError(t, cConn.WriteComQuery("ok then error; select rows"))
+
+	handler := &testRun{err: sqlerror.NewSQLError(sqlerror.ERQueryInterrupted, sqlerror.SSQueryInterrupted, "context canceled")}
+	res := sConn.handleNextCommand(handler)
+	require.True(t, res, "error after a more-results OK must not tear down the connection")
+
+	result, more, _, err := cConn.ReadQueryResult(100, true)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, result.RowsAffected)
+	require.True(t, more, "more results must follow the first OK")
+
+	_, more, _, err = cConn.ReadQueryResult(100, true)
+	require.ErrorContains(t, err, "context canceled")
+	require.False(t, more, "no further results after an error packet")
+
+	// Connection must still be usable for the next query.
+	require.NoError(t, cConn.WriteComQuery("select rows"))
+	res = sConn.handleNextCommand(handler)
+	require.True(t, res, "subsequent query must be handled on a still-alive connection")
+	result, _, _, err = cConn.ReadQueryResult(100, true)
+	require.NoError(t, err)
+	require.True(t, result.Equal(selectRowsResult))
+}
+
+// TestHandleComStmtExecuteErrorAfterMoreResultsOKSurfacesError is the
+// binary-protocol variant. The OK takes its status flags from c.StatusFlags, so the
+// test pre-sets SERVER_MORE_RESULTS_EXISTS there. With that flag on the wire an ERR
+// is a protocol-legal next result and the connection must survive.
+func TestHandleComStmtExecuteErrorAfterMoreResultsOKSurfacesError(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	sConn.StatusFlags |= ServerMoreResultsExists
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	const stmtID uint32 = 1
+	sConn.PrepareData[stmtID] = &PrepareData{
+		StatementID: stmtID,
+		PrepareStmt: "insert into t -- ok then error",
+		ParamsCount: 0,
+		BindVars:    map[string]*querypb.BindVariable{},
+	}
+
+	cConn.sequence = 0
+	buf, pos := cConn.startEphemeralPacketWithHeader(10)
+	pos = writeByte(buf, pos, ComStmtExecute)
+	pos = writeUint32(buf, pos, stmtID)
+	pos = writeByte(buf, pos, 0) // cursor type
+	_ = writeUint32(buf, pos, 1) // iteration count
+	require.NoError(t, cConn.writeEphemeralPacket())
+
+	handler := &testRun{err: sqlerror.NewSQLError(sqlerror.ERQueryInterrupted, sqlerror.SSQueryInterrupted, "context canceled")}
+	res := sConn.handleNextCommand(handler)
+	require.True(t, res, "error after a more-results OK must not tear down the connection")
+
+	// Bounded by a read deadline so a regression fails fast instead of stalling CI.
+	require.NoError(t, cConn.conn.SetReadDeadline(time.Now().Add(30*time.Second)))
+
+	// Client sees the successful OK first, then the real error as the next result.
+	data, err := cConn.ReadPacket()
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+	require.EqualValues(t, OKPacket, data[0], "first packet must be the successful OK")
+
+	data, err = cConn.ReadPacket()
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+	require.EqualValues(t, ErrPacket, data[0], "the next result must be the real error packet")
+	require.ErrorContains(t, ParseErrorPacket(data), "context canceled")
+}
+
 func TestInitDbAgainstWrongDbDoesNotDropConnection(t *testing.T) {
 	listener, sConn, cConn := createSocketPair(t)
 	sConn.Capabilities |= CapabilityClientMultiStatements


### PR DESCRIPTION
## Description

This PR narrows the teardown guard added in https://github.com/vitessio/vitess/pull/20383: an error after an OK packet that carried `SERVER_MORE_RESULTS_EXISTS` tore down the connection, so the client saw `ERROR 2013 (HY000): Lost connection to MySQL server during query` instead of the real error — the same failure mode #20383 fixed for the mid-result-set case

When the OK carried `SERVER_MORE_RESULTS_EXISTS` the client is expecting another result, and the protocol allows that next result to be an ERR packet; only a final OK _(no more-results flag)_ makes appending an ERR unsafe. All 3 x streaming paths _(`execQuery`, `execQueryMulti` and `handleComStmtExecute`)_ now capture whether the last-written OK carried the flag at the time it's written, and only tear down when it didn't

Hitting this requires an OLAP multi-statement batch where a fieldless result _(e.g. a DML)_ was terminated by an OK with more-results set, and the stream fails before the next statement's first packet, e.g. a `KILL QUERY` or tablet failover. See the issue for a full breakdown

cc @arthurschreiber

### Backport Reason

Backporting to be consistent with https://github.com/vitessio/vitess/pull/20383

## Related Issue(s)

Resolves: https://github.com/vitessio/vitess/issues/20547

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

### AI Disclosure

This PR was assisted by Claude Code
