### PR TITLE
VReplication: Avoid sending mixed batch of row changes to bulk insert or bulk delete in vplayer batch mode

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -893,11 +893,12 @@ func (tp *TablePlan) applyBulkDeleteChanges(rowDeletes []*binlogdatapb.RowChange
 	pkVals := make([]sqltypes.Value, 0, len(rowDeletes))
 	for _, rowDelete := range rowDeletes {
 		// The caller must only route homogeneous delete-shaped events here: a
-		// nil Before image would panic in MakeRowTrusted, and a change with an
-		// After image (an insert or update) would be silently applied as a
+		// nil Before image would panic in MakeRowTrusted, an empty one (the
+		// #20360 shape) would panic indexing vals[pkIndex], and a change with
+		// an After image (an insert or update) would be silently applied as a
 		// DELETE, discarding that image. The Get accessors also make a nil
 		// change in the slice error instead of panicking.
-		if rowDelete.GetBefore() == nil || rowDelete.GetAfter() != nil {
+		if len(rowDelete.GetBefore().GetLengths()) == 0 || rowDelete.GetAfter() != nil {
 			return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
 				"vreplication: bulk-delete change for table %s is not delete-shaped (Before image only); a mixed row event must be applied per-change",
 				tp.TargetName)
@@ -950,11 +951,12 @@ func (tp *TablePlan) applyBulkInsertChanges(rowInserts []*binlogdatapb.RowChange
 	newStmt := true
 	for _, rowInsert := range rowInserts {
 		// The caller must only route homogeneous insert-shaped events here: a
-		// nil After image would panic in MakeRowTrusted, and a change with a
+		// nil After image would panic in MakeRowTrusted, an empty one would
+		// panic indexing the row in the field loop, and a change with a
 		// Before image (a delete or update) would be silently applied as an
 		// INSERT, discarding that image. The Get accessors also make a nil
 		// change in the slice error instead of panicking.
-		if rowInsert.GetAfter() == nil || rowInsert.GetBefore() != nil {
+		if len(rowInsert.GetAfter().GetLengths()) == 0 || rowInsert.GetBefore() != nil {
 			return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
 				"vreplication: bulk-insert change for table %s is not insert-shaped (After image only); a mixed row event must be applied per-change",
 				tp.TargetName)

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -898,7 +898,7 @@ func (tp *TablePlan) applyBulkDeleteChanges(rowDeletes []*binlogdatapb.RowChange
 		// DELETE, discarding that image. The Get accessors also make a nil
 		// change in the slice error instead of panicking.
 		if rowDelete.GetBefore() == nil || rowDelete.GetAfter() != nil {
-			return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL,
+			return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
 				"vreplication: bulk-delete change for table %s is not delete-shaped (Before image only); a mixed row event must be applied per-change",
 				tp.TargetName)
 		}
@@ -955,7 +955,7 @@ func (tp *TablePlan) applyBulkInsertChanges(rowInserts []*binlogdatapb.RowChange
 		// INSERT, discarding that image. The Get accessors also make a nil
 		// change in the slice error instead of panicking.
 		if rowInsert.GetAfter() == nil || rowInsert.GetBefore() != nil {
-			return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL,
+			return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
 				"vreplication: bulk-insert change for table %s is not insert-shaped (After image only); a mixed row event must be applied per-change",
 				tp.TargetName)
 		}

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -893,11 +893,13 @@ func (tp *TablePlan) applyBulkDeleteChanges(rowDeletes []*binlogdatapb.RowChange
 	pkVals := make([]sqltypes.Value, 0, len(rowDeletes))
 	for _, rowDelete := range rowDeletes {
 		// The caller must only route homogeneous delete-shaped events here: a
-		// nil Before image would panic in MakeRowTrusted, and any other shape
-		// would be silently applied as a DELETE.
-		if rowDelete.Before == nil {
+		// nil Before image would panic in MakeRowTrusted, and a change with an
+		// After image (an insert or update) would be silently applied as a
+		// DELETE, discarding that image. The Get accessors also make a nil
+		// change in the slice error instead of panicking.
+		if rowDelete.GetBefore() == nil || rowDelete.GetAfter() != nil {
 			return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL,
-				"vreplication: bulk-delete change for table %s has no Before image; a mixed row event must be applied per-change",
+				"vreplication: bulk-delete change for table %s is not delete-shaped (Before image only); a mixed row event must be applied per-change",
 				tp.TargetName)
 		}
 		vals := sqltypes.MakeRowTrusted(tp.Fields, rowDelete.Before)
@@ -948,11 +950,13 @@ func (tp *TablePlan) applyBulkInsertChanges(rowInserts []*binlogdatapb.RowChange
 	newStmt := true
 	for _, rowInsert := range rowInserts {
 		// The caller must only route homogeneous insert-shaped events here: a
-		// nil After image would panic in MakeRowTrusted, and any other shape
-		// would be silently applied as an INSERT.
-		if rowInsert.After == nil {
+		// nil After image would panic in MakeRowTrusted, and a change with a
+		// Before image (a delete or update) would be silently applied as an
+		// INSERT, discarding that image. The Get accessors also make a nil
+		// change in the slice error instead of panicking.
+		if rowInsert.GetAfter() == nil || rowInsert.GetBefore() != nil {
 			return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL,
-				"vreplication: bulk-insert change for table %s has no After image; a mixed row event must be applied per-change",
+				"vreplication: bulk-insert change for table %s is not insert-shaped (After image only); a mixed row event must be applied per-change",
 				tp.TargetName)
 		}
 		if limit > 0 {

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -892,6 +892,14 @@ func (tp *TablePlan) applyBulkDeleteChanges(rowDeletes []*binlogdatapb.RowChange
 
 	pkVals := make([]sqltypes.Value, 0, len(rowDeletes))
 	for _, rowDelete := range rowDeletes {
+		// The caller must only route homogeneous delete-shaped events here: a
+		// nil Before image would panic in MakeRowTrusted, and any other shape
+		// would be silently applied as a DELETE.
+		if rowDelete.Before == nil {
+			return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL,
+				"vreplication: bulk-delete change for table %s has no Before image; a mixed row event must be applied per-change",
+				tp.TargetName)
+		}
 		vals := sqltypes.MakeRowTrusted(tp.Fields, rowDelete.Before)
 		addedSize := int64(len(vals[pkIndex].Raw()) + 2) // Plus 2 for the comma and space
 		if querySize+addedSize > maxQuerySize {
@@ -939,6 +947,14 @@ func (tp *TablePlan) applyBulkInsertChanges(rowInserts []*binlogdatapb.RowChange
 	limit := tp.maxRowJSONBytes()
 	newStmt := true
 	for _, rowInsert := range rowInserts {
+		// The caller must only route homogeneous insert-shaped events here: a
+		// nil After image would panic in MakeRowTrusted, and any other shape
+		// would be silently applied as an INSERT.
+		if rowInsert.After == nil {
+			return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL,
+				"vreplication: bulk-insert change for table %s has no After image; a mixed row event must be applied per-change",
+				tp.TargetName)
+		}
 		if limit > 0 {
 			if err := tp.checkInsertJSONRowSize(rowInsert.After, nil, nil, limit); err != nil {
 				return nil, err

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -1280,7 +1280,7 @@ func TestApplyBulkDeleteChanges(t *testing.T) {
 			executed = append(executed, sql)
 			return &sqltypes.Result{RowsAffected: 1}, nil
 		}, 1024)
-		require.ErrorContains(t, err, "no Before image")
+		require.ErrorContains(t, err, "not delete-shaped")
 		assert.Empty(t, executed)
 	})
 
@@ -1364,7 +1364,7 @@ func TestApplyBulkInsertChangesMixedShapes(t *testing.T) {
 			executed = append(executed, sql)
 			return &sqltypes.Result{RowsAffected: 1}, nil
 		}, 1024)
-		require.ErrorContains(t, err, "no After image")
+		require.ErrorContains(t, err, "not insert-shaped")
 		assert.Empty(t, executed)
 	})
 

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -1283,6 +1283,49 @@ func TestApplyBulkDeleteChanges(t *testing.T) {
 		require.ErrorContains(t, err, "no Before image")
 		assert.Empty(t, executed)
 	})
+
+	t.Run("update-shaped change returns an error instead of being applied as a delete", func(t *testing.T) {
+		// A change with both images (an update) riding in a bulk-delete event
+		// passes a nil-Before check and is silently applied as a DELETE,
+		// discarding its After image. The guard must require the exact
+		// delete shape: Before image only.
+		tp := newTablePlan()
+		rowChanges := []*binlogdatapb.RowChange{
+			makeRowDelete(1, "a"),
+			{
+				Before: sqltypes.RowToProto3([]sqltypes.Value{
+					sqltypes.NewInt64(2),
+					sqltypes.NewVarChar("b"),
+				}),
+				After: sqltypes.RowToProto3([]sqltypes.Value{
+					sqltypes.NewInt64(2),
+					sqltypes.NewVarChar("c"),
+				}),
+			},
+		}
+		var executed []string
+		_, err := tp.applyBulkDeleteChanges(rowChanges, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 1024)
+		require.ErrorContains(t, err, "not delete-shaped")
+		assert.Empty(t, executed)
+	})
+
+	t.Run("nil change returns an error instead of panicking", func(t *testing.T) {
+		tp := newTablePlan()
+		rowChanges := []*binlogdatapb.RowChange{
+			makeRowDelete(1, "a"),
+			nil,
+		}
+		var executed []string
+		_, err := tp.applyBulkDeleteChanges(rowChanges, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 1024)
+		require.ErrorContains(t, err, "not delete-shaped")
+		assert.Empty(t, executed)
+	})
 }
 
 func TestApplyBulkInsertChangesMixedShapes(t *testing.T) {
@@ -1322,6 +1365,38 @@ func TestApplyBulkInsertChangesMixedShapes(t *testing.T) {
 			return &sqltypes.Result{RowsAffected: 1}, nil
 		}, 1024)
 		require.ErrorContains(t, err, "no After image")
+		assert.Empty(t, executed)
+	})
+
+	t.Run("update-shaped change returns an error instead of being applied as an insert", func(t *testing.T) {
+		// A change with both images (an update) riding in a bulk-insert event
+		// passes a nil-After check and is silently applied as an INSERT,
+		// discarding its Before image. The guard must require the exact
+		// insert shape: After image only.
+		rowChanges := []*binlogdatapb.RowChange{
+			{After: makeRow(1, "a")},
+			{Before: makeRow(2, "b"), After: makeRow(2, "c")},
+		}
+		var executed []string
+		_, err := tp.applyBulkInsertChanges(rowChanges, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 1024)
+		require.ErrorContains(t, err, "not insert-shaped")
+		assert.Empty(t, executed)
+	})
+
+	t.Run("nil change returns an error instead of panicking", func(t *testing.T) {
+		rowChanges := []*binlogdatapb.RowChange{
+			{After: makeRow(1, "a")},
+			nil,
+		}
+		var executed []string
+		_, err := tp.applyBulkInsertChanges(rowChanges, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 1024)
+		require.ErrorContains(t, err, "not insert-shaped")
 		assert.Empty(t, executed)
 	})
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -1314,6 +1314,25 @@ func TestApplyBulkDeleteChanges(t *testing.T) {
 		assert.Empty(t, executed)
 	})
 
+	t.Run("empty Before image returns an error instead of panicking", func(t *testing.T) {
+		// The malformed shape from issue #20360: a Before image that is
+		// present but has no column values. MakeRowTrusted returns an empty
+		// row and vals[pkIndex] used to panic with index out of range.
+		tp := newTablePlan()
+		rowChanges := []*binlogdatapb.RowChange{
+			makeRowDelete(1, "a"),
+			{Before: &querypb.Row{}},
+		}
+		var executed []string
+		_, err := tp.applyBulkDeleteChanges(rowChanges, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 1024)
+		require.ErrorContains(t, err, "not delete-shaped")
+		assert.True(t, isUnrecoverableError(err), "error must be terminal")
+		assert.Empty(t, executed)
+	})
+
 	t.Run("nil change returns an error instead of panicking", func(t *testing.T) {
 		tp := newTablePlan()
 		rowChanges := []*binlogdatapb.RowChange{
@@ -1380,6 +1399,24 @@ func TestApplyBulkInsertChangesMixedShapes(t *testing.T) {
 		rowChanges := []*binlogdatapb.RowChange{
 			{After: makeRow(1, "a")},
 			{Before: makeRow(2, "b"), After: makeRow(2, "c")},
+		}
+		var executed []string
+		_, err := tp.applyBulkInsertChanges(rowChanges, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 1024)
+		require.ErrorContains(t, err, "not insert-shaped")
+		assert.True(t, isUnrecoverableError(err), "error must be terminal")
+		assert.Empty(t, executed)
+	})
+
+	t.Run("empty After image returns an error instead of panicking", func(t *testing.T) {
+		// Mirror of the #20360 shape on the insert side: an After image that
+		// is present but has no column values used to panic with index out of
+		// range when the field loop indexed the empty row.
+		rowChanges := []*binlogdatapb.RowChange{
+			{After: makeRow(1, "a")},
+			{After: &querypb.Row{}},
 		}
 		var executed []string
 		_, err := tp.applyBulkInsertChanges(rowChanges, func(sql string) (*sqltypes.Result, error) {

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -1262,6 +1262,68 @@ func TestApplyBulkDeleteChanges(t *testing.T) {
 		require.Len(t, executed, 1)
 		assert.Equal(t, "delete from t where id in (1, 2)", executed[0])
 	})
+
+	t.Run("insert-shaped change returns an error instead of panicking", func(t *testing.T) {
+		// A change with no Before image (an insert) riding in a bulk-delete
+		// event used to panic with a nil pointer dereference in MakeRowTrusted,
+		// killing the entire vttablet process.
+		tp := newTablePlan()
+		rowChanges := []*binlogdatapb.RowChange{
+			makeRowDelete(1, "a"),
+			{After: sqltypes.RowToProto3([]sqltypes.Value{
+				sqltypes.NewInt64(2),
+				sqltypes.NewVarChar("b"),
+			})},
+		}
+		var executed []string
+		_, err := tp.applyBulkDeleteChanges(rowChanges, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 1024)
+		require.ErrorContains(t, err, "no Before image")
+		assert.Empty(t, executed)
+	})
+}
+
+func TestApplyBulkInsertChangesMixedShapes(t *testing.T) {
+	tp := &TablePlan{
+		TargetName:      "t",
+		BulkInsertFront: sqlparser.BuildParsedQuery("insert into t(c1, c2)"),
+		BulkInsertValues: sqlparser.BuildParsedQuery("(%a, %a)",
+			":a_c1", ":a_c2",
+		),
+		Fields: []*querypb.Field{
+			{Name: "c1", Type: querypb.Type_INT32},
+			{Name: "c2", Type: querypb.Type_VARCHAR},
+		},
+		FieldsToSkip:     map[string]bool{},
+		TablePlanBuilder: &tablePlanBuilder{stats: binlogplayer.NewStats()},
+	}
+	makeRow := func(id int, val string) *querypb.Row {
+		return sqltypes.RowToProto3([]sqltypes.Value{
+			sqltypes.NewInt64(int64(id)),
+			sqltypes.NewVarChar(val),
+		})
+	}
+
+	t.Run("delete-shaped change returns an error instead of panicking", func(t *testing.T) {
+		// A change with no After image (a delete) riding in a bulk-insert
+		// event used to panic with a nil pointer dereference in MakeRowTrusted,
+		// killing the entire vttablet process. This is what a mixed row event
+		// produced by a sharding-key update crossing an in_keyrange filter
+		// boundary looks like by the time it reaches the bulk-insert path.
+		rowChanges := []*binlogdatapb.RowChange{
+			{After: makeRow(1, "a")},
+			{Before: makeRow(2, "b")},
+		}
+		var executed []string
+		_, err := tp.applyBulkInsertChanges(rowChanges, func(sql string) (*sqltypes.Result, error) {
+			executed = append(executed, sql)
+			return &sqltypes.Result{RowsAffected: 1}, nil
+		}, 1024)
+		require.ErrorContains(t, err, "no After image")
+		assert.Empty(t, executed)
+	})
 }
 
 func TestMarshalJSONForSQL(t *testing.T) {

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -1281,6 +1281,7 @@ func TestApplyBulkDeleteChanges(t *testing.T) {
 			return &sqltypes.Result{RowsAffected: 1}, nil
 		}, 1024)
 		require.ErrorContains(t, err, "not delete-shaped")
+		assert.True(t, isUnrecoverableError(err), "error must be terminal")
 		assert.Empty(t, executed)
 	})
 
@@ -1309,6 +1310,7 @@ func TestApplyBulkDeleteChanges(t *testing.T) {
 			return &sqltypes.Result{RowsAffected: 1}, nil
 		}, 1024)
 		require.ErrorContains(t, err, "not delete-shaped")
+		assert.True(t, isUnrecoverableError(err), "error must be terminal")
 		assert.Empty(t, executed)
 	})
 
@@ -1324,6 +1326,7 @@ func TestApplyBulkDeleteChanges(t *testing.T) {
 			return &sqltypes.Result{RowsAffected: 1}, nil
 		}, 1024)
 		require.ErrorContains(t, err, "not delete-shaped")
+		assert.True(t, isUnrecoverableError(err), "error must be terminal")
 		assert.Empty(t, executed)
 	})
 }
@@ -1365,6 +1368,7 @@ func TestApplyBulkInsertChangesMixedShapes(t *testing.T) {
 			return &sqltypes.Result{RowsAffected: 1}, nil
 		}, 1024)
 		require.ErrorContains(t, err, "not insert-shaped")
+		assert.True(t, isUnrecoverableError(err), "error must be terminal")
 		assert.Empty(t, executed)
 	})
 
@@ -1383,6 +1387,7 @@ func TestApplyBulkInsertChangesMixedShapes(t *testing.T) {
 			return &sqltypes.Result{RowsAffected: 1}, nil
 		}, 1024)
 		require.ErrorContains(t, err, "not insert-shaped")
+		assert.True(t, isUnrecoverableError(err), "error must be terminal")
 		assert.Empty(t, executed)
 	})
 
@@ -1397,6 +1402,7 @@ func TestApplyBulkInsertChangesMixedShapes(t *testing.T) {
 			return &sqltypes.Result{RowsAffected: 1}, nil
 		}, 1024)
 		require.ErrorContains(t, err, "not insert-shaped")
+		assert.True(t, isUnrecoverableError(err), "error must be terminal")
 		assert.Empty(t, executed)
 	})
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -370,8 +370,8 @@ func bulkApplicableShapes(tableName string, rowChanges []*binlogdatapb.RowChange
 		// shape from issue #20360: MakeRowTrusted returns an empty row that
 		// later indexing panics on, so it cannot be treated as either a
 		// usable or a missing image.
-		if (change.GetBefore() != nil && len(change.Before.Lengths) == 0) ||
-			(change.GetAfter() != nil && len(change.After.Lengths) == 0) {
+		if (change.GetBefore() != nil && len(change.GetBefore().GetLengths()) == 0) ||
+			(change.GetAfter() != nil && len(change.GetAfter().GetLengths()) == 0) {
 			return false, false, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
 				"vreplication: malformed row change with an empty row image in event for table %s", tableName)
 		}

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -366,6 +366,15 @@ func (vp *vplayer) applyStmtEvent(ctx context.Context, event *binlogdatapb.VEven
 func bulkApplicableShapes(tableName string, rowChanges []*binlogdatapb.RowChange) (deletesOnly, insertsOnly bool, err error) {
 	deletesOnly, insertsOnly = true, true
 	for _, change := range rowChanges {
+		// An image that is present but has no column values is the malformed
+		// shape from issue #20360: MakeRowTrusted returns an empty row that
+		// later indexing panics on, so it cannot be treated as either a
+		// usable or a missing image.
+		if (change.GetBefore() != nil && len(change.Before.Lengths) == 0) ||
+			(change.GetAfter() != nil && len(change.After.Lengths) == 0) {
+			return false, false, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
+				"vreplication: malformed row change with an empty row image in event for table %s", tableName)
+		}
 		switch {
 		case change.GetBefore() == nil && change.GetAfter() == nil:
 			return false, false, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -360,22 +360,22 @@ func (vp *vplayer) applyStmtEvent(ctx context.Context, event *binlogdatapb.VEven
 // the vstreamer never produces one -- and is rejected with an error rather
 // than being routed to either apply path: the per-change path would
 // dereference a nil change and silently treat an empty one as a no-op.
+// The scan visits every change, even once the event is already known not to
+// be bulk-applicable, so a malformed entry is detected regardless of its
+// position.
 func bulkApplicableShapes(tableName string, rowChanges []*binlogdatapb.RowChange) (deletesOnly, insertsOnly bool, err error) {
 	deletesOnly, insertsOnly = true, true
 	for _, change := range rowChanges {
 		switch {
+		case change.GetBefore() == nil && change.GetAfter() == nil:
+			return false, false, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
+				"vreplication: malformed row change with no row images in event for table %s", tableName)
 		case change.GetBefore() != nil && change.GetAfter() == nil:
 			insertsOnly = false
 		case change.GetBefore() == nil && change.GetAfter() != nil:
 			deletesOnly = false
-		case change.GetBefore() == nil && change.GetAfter() == nil:
-			return false, false, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
-				"vreplication: malformed row change with no row images in event for table %s", tableName)
 		default: // Update-shaped (both images).
-			return false, false, nil
-		}
-		if !deletesOnly && !insertsOnly {
-			return false, false, nil
+			deletesOnly, insertsOnly = false, false
 		}
 	}
 	return deletesOnly, insertsOnly, nil

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -358,12 +358,14 @@ func (vp *vplayer) applyStmtEvent(ctx context.Context, event *binlogdatapb.VEven
 func bulkApplicableShapes(rowChanges []*binlogdatapb.RowChange) (deletesOnly, insertsOnly bool) {
 	deletesOnly, insertsOnly = true, true
 	for _, change := range rowChanges {
+		// The Get accessors make a nil change classify as not bulk-applicable
+		// instead of panicking here, before the bulk helpers' guards run.
 		switch {
-		case change.Before != nil && change.After == nil:
+		case change.GetBefore() != nil && change.GetAfter() == nil:
 			insertsOnly = false
-		case change.Before == nil && change.After != nil:
+		case change.GetBefore() == nil && change.GetAfter() != nil:
 			deletesOnly = false
-		default: // Update-shaped (both images) or empty.
+		default: // Update-shaped (both images), empty, or nil.
 			return false, false
 		}
 		if !deletesOnly && !insertsOnly {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -37,6 +37,7 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/throttle/throttlerapp"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
 const failedToRecordHeartbeatMsg = "failed to record heartbeat"
@@ -355,24 +356,29 @@ func (vp *vplayer) applyStmtEvent(ctx context.Context, event *binlogdatapb.VEven
 // emitted, so one multi-row UPDATE can yield insert-shaped, delete-shaped and
 // update-shaped changes in the same event. The bulk DELETE/INSERT statements
 // assume a homogeneous event, so a mixed event must be applied per-change.
-func bulkApplicableShapes(rowChanges []*binlogdatapb.RowChange) (deletesOnly, insertsOnly bool) {
+// A change with no images at all (nil, or present but empty) is malformed --
+// the vstreamer never produces one -- and is rejected with an error rather
+// than being routed to either apply path: the per-change path would
+// dereference a nil change and silently treat an empty one as a no-op.
+func bulkApplicableShapes(tableName string, rowChanges []*binlogdatapb.RowChange) (deletesOnly, insertsOnly bool, err error) {
 	deletesOnly, insertsOnly = true, true
 	for _, change := range rowChanges {
-		// The Get accessors make a nil change classify as not bulk-applicable
-		// instead of panicking here, before the bulk helpers' guards run.
 		switch {
 		case change.GetBefore() != nil && change.GetAfter() == nil:
 			insertsOnly = false
 		case change.GetBefore() == nil && change.GetAfter() != nil:
 			deletesOnly = false
-		default: // Update-shaped (both images), empty, or nil.
-			return false, false
+		case change.GetBefore() == nil && change.GetAfter() == nil:
+			return false, false, vterrors.Errorf(vtrpcpb.Code_INTERNAL,
+				"vreplication: malformed row change with no row images in event for table %s", tableName)
+		default: // Update-shaped (both images).
+			return false, false, nil
 		}
 		if !deletesOnly && !insertsOnly {
-			return false, false
+			return false, false, nil
 		}
 	}
-	return deletesOnly, insertsOnly
+	return deletesOnly, insertsOnly, nil
 }
 
 func (vp *vplayer) applyRowEvent(ctx context.Context, rowEvent *binlogdatapb.RowEvent) error {
@@ -396,7 +402,10 @@ func (vp *vplayer) applyRowEvent(ctx context.Context, rowEvent *binlogdatapb.Row
 	}
 
 	if vp.batchMode && len(rowEvent.RowChanges) > 1 {
-		deletesOnly, insertsOnly := bulkApplicableShapes(rowEvent.RowChanges)
+		deletesOnly, insertsOnly, err := bulkApplicableShapes(rowEvent.TableName, rowEvent.RowChanges)
+		if err != nil {
+			return err
+		}
 		// If we have multiple delete row events for a table with a single PK column
 		// then we can perform a simple bulk DELETE using an IN clause.
 		if deletesOnly && tplan.MultiDelete != nil {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -369,7 +369,7 @@ func bulkApplicableShapes(tableName string, rowChanges []*binlogdatapb.RowChange
 		case change.GetBefore() == nil && change.GetAfter() != nil:
 			deletesOnly = false
 		case change.GetBefore() == nil && change.GetAfter() == nil:
-			return false, false, vterrors.Errorf(vtrpcpb.Code_INTERNAL,
+			return false, false, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION,
 				"vreplication: malformed row change with no row images in event for table %s", tableName)
 		default: // Update-shaped (both images).
 			return false, false, nil

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -347,6 +347,32 @@ func (vp *vplayer) applyStmtEvent(ctx context.Context, event *binlogdatapb.VEven
 	return fmt.Errorf("filter rules are not supported for SBR replication: %v", vp.vr.source.Filter.GetRules())
 }
 
+// bulkApplicableShapes scans a row event's changes and reports whether they
+// are all delete-shaped (Before image only) or all insert-shaped (After image
+// only). A single event can mix shapes: when only one side of an update passes
+// the source vstreamer's workflow filter (e.g. a sharding-key update that
+// moves rows across an in_keyrange boundary), only that side's image is
+// emitted, so one multi-row UPDATE can yield insert-shaped, delete-shaped and
+// update-shaped changes in the same event. The bulk DELETE/INSERT statements
+// assume a homogeneous event, so a mixed event must be applied per-change.
+func bulkApplicableShapes(rowChanges []*binlogdatapb.RowChange) (deletesOnly, insertsOnly bool) {
+	deletesOnly, insertsOnly = true, true
+	for _, change := range rowChanges {
+		switch {
+		case change.Before != nil && change.After == nil:
+			insertsOnly = false
+		case change.Before == nil && change.After != nil:
+			deletesOnly = false
+		default: // Update-shaped (both images) or empty.
+			return false, false
+		}
+		if !deletesOnly && !insertsOnly {
+			return false, false
+		}
+	}
+	return deletesOnly, insertsOnly
+}
+
 func (vp *vplayer) applyRowEvent(ctx context.Context, rowEvent *binlogdatapb.RowEvent) error {
 	if err := vp.updateFKCheck(ctx, rowEvent.Flags); err != nil {
 		return err
@@ -368,17 +394,17 @@ func (vp *vplayer) applyRowEvent(ctx context.Context, rowEvent *binlogdatapb.Row
 	}
 
 	if vp.batchMode && len(rowEvent.RowChanges) > 1 {
+		deletesOnly, insertsOnly := bulkApplicableShapes(rowEvent.RowChanges)
 		// If we have multiple delete row events for a table with a single PK column
 		// then we can perform a simple bulk DELETE using an IN clause.
-		if (rowEvent.RowChanges[0].Before != nil && rowEvent.RowChanges[0].After == nil) &&
-			tplan.MultiDelete != nil {
+		if deletesOnly && tplan.MultiDelete != nil {
 			_, err := tplan.applyBulkDeleteChanges(rowEvent.RowChanges, applyFunc, vp.vr.dbClient.maxBatchSize)
 			return err
 		}
 		// If we're done with the copy phase then we will be replicating all INSERTS
 		// regardless of the PK value and can use a single INSERT statment with
 		// multiple VALUES clauses.
-		if len(vp.copyState) == 0 && (rowEvent.RowChanges[0].Before == nil && rowEvent.RowChanges[0].After != nil) {
+		if len(vp.copyState) == 0 && insertsOnly {
 			_, err := tplan.applyBulkInsertChanges(rowEvent.RowChanges, applyFunc, vp.vr.dbClient.maxBatchSize)
 			return err
 		}

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -3891,6 +3891,83 @@ func TestPlayerBatchMode(t *testing.T) {
 	}
 }
 
+// TestPlayerBatchModeMixedRowEvent confirms that a row event whose changes do
+// not all have the same shape is applied per-change in batch mode. The source
+// vstreamer emits only the Before or After image of an update when just one
+// side passes the workflow filter, so a single multi-row UPDATE that moves
+// rows across an in_keyrange boundary (e.g. a sharding-key update replicated
+// by a MoveTables or Reshard workflow) produces one row event mixing
+// insert-shaped and delete-shaped changes. Batch mode used to pick the
+// bulk-insert or bulk-delete statement by looking only at the first change
+// and then apply every change in the event with that shape, panicking on the
+// first change of the opposite shape (nil row image in MakeRowTrusted).
+func TestPlayerBatchModeMixedRowEvent(t *testing.T) {
+	oldVreplicationExperimentalFlags := vttablet.DefaultVReplicationConfig.ExperimentalFlags
+	vttablet.DefaultVReplicationConfig.ExperimentalFlags = vttablet.VReplicationExperimentalFlagVPlayerBatching
+	defer func() {
+		vttablet.DefaultVReplicationConfig.ExperimentalFlags = oldVreplicationExperimentalFlags
+	}()
+
+	defer deleteTablet(addTablet(100))
+	execStatements(t, []string{
+		"create table t1(id bigint, val varbinary(128), primary key(id))",
+		fmt.Sprintf("create table %s.t1(id bigint, val varbinary(128), primary key(id))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table t1",
+		fmt.Sprintf("drop table %s.t1", vrepldb),
+	})
+
+	// Replicate only the rows whose id hashes into -80, like one target shard
+	// of a MoveTables or Reshard workflow. With the hash vindex, ids 2, 3 and
+	// 5 map into -80 while ids 4 and 6 map into 80-.
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match:  "t1",
+			Filter: "select * from t1 where in_keyrange(id, 'hash', '-80')",
+		}},
+	}
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
+	}
+	cancel, _ := startVReplication(t, bls, "")
+	defer cancel()
+
+	execStatements(t, []string{"insert into t1 values (4, 'a'), (5, 'b')"})
+	expectNontxQueries(t, qh.Expect("insert into t1(id,val) values (5,_binary'b')"), recvTimeout)
+	expectData(t, "t1", [][]string{{"5", "b"}})
+
+	// One UPDATE whose first row moves into the keyrange (an insert-shaped
+	// change with only an After image) and whose second row moves out of it
+	// (a delete-shaped change with only a Before image). Batch mode used to
+	// route the whole event to the bulk-insert path based on the first change
+	// and panic on the delete-shaped change's nil After image.
+	execStatements(t, []string{
+		"update t1 set id = case id when 4 then 2 when 5 then 6 end where id in (4, 5)",
+	})
+	expectNontxQueries(t, qh.Expect(
+		"insert into t1(id,val) values (2,_binary'a')",
+		"delete from t1 where id=5",
+	), recvTimeout)
+	expectData(t, "t1", [][]string{{"2", "a"}})
+
+	// The mirror image: the first row moves out of the keyrange (a
+	// delete-shaped change) and the second moves in (an insert-shaped
+	// change). Batch mode used to route the whole event to the bulk-delete
+	// path and panic on the insert-shaped change's nil Before image.
+	execStatements(t, []string{
+		"update t1 set id = case id when 2 then 4 when 6 then 3 end where id in (2, 6)",
+	})
+	expectNontxQueries(t, qh.Expect(
+		"delete from t1 where id=2",
+		"insert into t1(id,val) values (3,_binary'b')",
+	), recvTimeout)
+	expectData(t, "t1", [][]string{{"3", "b"}})
+}
+
 // TestPlayerStalls confirms that the vplayer will detect a stall and generate
 // a meaningful error -- which is stored in the vreplication record and the
 // vreplication_log table as well as being logged -- when it does.

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
@@ -111,6 +111,9 @@ func TestBulkApplicableShapes(t *testing.T) {
 	}, {
 		name:       "empty change",
 		rowChanges: []*binlogdatapb.RowChange{{}, insert(1)},
+	}, {
+		name:       "nil change",
+		rowChanges: []*binlogdatapb.RowChange{insert(1), nil},
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
@@ -119,6 +119,17 @@ func TestBulkApplicableShapes(t *testing.T) {
 		name:       "nil change",
 		rowChanges: []*binlogdatapb.RowChange{insert(1), nil},
 		wantErr:    "malformed row change",
+	}, {
+		// Malformed changes must be detected even after the scan has already
+		// concluded the event is not bulk-applicable: an early exit would
+		// pass the unvalidated entry to the per-change path.
+		name:       "nil change after update",
+		rowChanges: []*binlogdatapb.RowChange{update(1), nil},
+		wantErr:    "malformed row change",
+	}, {
+		name:       "nil change after mixed shapes",
+		rowChanges: []*binlogdatapb.RowChange{insert(1), del(2), nil},
+		wantErr:    "malformed row change",
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
@@ -125,6 +125,10 @@ func TestBulkApplicableShapes(t *testing.T) {
 			deletesOnly, insertsOnly, err := bulkApplicableShapes("t1", tc.rowChanges)
 			if tc.wantErr != "" {
 				require.ErrorContains(t, err, tc.wantErr)
+				// A malformed event replays identically on every retry, so
+				// the workflow must transition to the Error state instead of
+				// retrying forever.
+				assert.True(t, isUnrecoverableError(err), "error must be terminal")
 				return
 			}
 			require.NoError(t, err)

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
@@ -88,6 +88,7 @@ func TestBulkApplicableShapes(t *testing.T) {
 		rowChanges      []*binlogdatapb.RowChange
 		wantDeletesOnly bool
 		wantInsertsOnly bool
+		wantErr         string
 	}{{
 		name:            "all inserts",
 		rowChanges:      []*binlogdatapb.RowChange{insert(1), insert(2)},
@@ -109,15 +110,24 @@ func TestBulkApplicableShapes(t *testing.T) {
 		name:       "update then delete",
 		rowChanges: []*binlogdatapb.RowChange{update(1), del(2)},
 	}, {
+		// A change with no images (nil or empty) is malformed: neither apply
+		// path can handle it, so it must be rejected before routing.
 		name:       "empty change",
 		rowChanges: []*binlogdatapb.RowChange{{}, insert(1)},
+		wantErr:    "malformed row change",
 	}, {
 		name:       "nil change",
 		rowChanges: []*binlogdatapb.RowChange{insert(1), nil},
+		wantErr:    "malformed row change",
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			deletesOnly, insertsOnly := bulkApplicableShapes(tc.rowChanges)
+			deletesOnly, insertsOnly, err := bulkApplicableShapes("t1", tc.rowChanges)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
 			assert.Equal(t, tc.wantDeletesOnly, deletesOnly, "deletesOnly")
 			assert.Equal(t, tc.wantInsertsOnly, insertsOnly, "insertsOnly")
 		})

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
@@ -22,6 +22,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
 func TestRunWithRecover(t *testing.T) {
@@ -62,4 +67,56 @@ func TestRunWithRecover(t *testing.T) {
 		})
 		assert.NoError(t, err)
 	})
+}
+
+func TestBulkApplicableShapes(t *testing.T) {
+	row := func(id int64) *querypb.Row {
+		return sqltypes.RowToProto3([]sqltypes.Value{sqltypes.NewInt64(id)})
+	}
+	insert := func(id int64) *binlogdatapb.RowChange {
+		return &binlogdatapb.RowChange{After: row(id)}
+	}
+	del := func(id int64) *binlogdatapb.RowChange {
+		return &binlogdatapb.RowChange{Before: row(id)}
+	}
+	update := func(id int64) *binlogdatapb.RowChange {
+		return &binlogdatapb.RowChange{Before: row(id), After: row(id)}
+	}
+
+	testcases := []struct {
+		name            string
+		rowChanges      []*binlogdatapb.RowChange
+		wantDeletesOnly bool
+		wantInsertsOnly bool
+	}{{
+		name:            "all inserts",
+		rowChanges:      []*binlogdatapb.RowChange{insert(1), insert(2)},
+		wantInsertsOnly: true,
+	}, {
+		name:            "all deletes",
+		rowChanges:      []*binlogdatapb.RowChange{del(1), del(2)},
+		wantDeletesOnly: true,
+	}, {
+		name:       "insert then delete",
+		rowChanges: []*binlogdatapb.RowChange{insert(1), del(2)},
+	}, {
+		name:       "delete then insert",
+		rowChanges: []*binlogdatapb.RowChange{del(1), insert(2)},
+	}, {
+		name:       "insert then update",
+		rowChanges: []*binlogdatapb.RowChange{insert(1), update(2)},
+	}, {
+		name:       "update then delete",
+		rowChanges: []*binlogdatapb.RowChange{update(1), del(2)},
+	}, {
+		name:       "empty change",
+		rowChanges: []*binlogdatapb.RowChange{{}, insert(1)},
+	}}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			deletesOnly, insertsOnly := bulkApplicableShapes(tc.rowChanges)
+			assert.Equal(t, tc.wantDeletesOnly, deletesOnly, "deletesOnly")
+			assert.Equal(t, tc.wantInsertsOnly, insertsOnly, "insertsOnly")
+		})
+	}
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_test.go
@@ -130,6 +130,22 @@ func TestBulkApplicableShapes(t *testing.T) {
 		name:       "nil change after mixed shapes",
 		rowChanges: []*binlogdatapb.RowChange{insert(1), del(2), nil},
 		wantErr:    "malformed row change",
+	}, {
+		// An image that is present but has no column values is the malformed
+		// shape from https://github.com/vitessio/vitess/issues/20360 and must
+		// be rejected rather than classified by the nil checks: MakeRowTrusted
+		// returns an empty row that later indexing panics on.
+		name:       "empty Before image",
+		rowChanges: []*binlogdatapb.RowChange{del(1), {Before: &querypb.Row{}}},
+		wantErr:    "malformed row change",
+	}, {
+		name:       "empty After image",
+		rowChanges: []*binlogdatapb.RowChange{insert(1), {After: &querypb.Row{}}},
+		wantErr:    "malformed row change",
+	}, {
+		name:       "update with empty After image",
+		rowChanges: []*binlogdatapb.RowChange{{Before: row(1), After: &querypb.Row{}}},
+		wantErr:    "malformed row change",
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

With vplayer batching enabled (default since v22.0.0), `applyRowEvent` picked the bulk DELETE/INSERT statement by inspecting only `RowChanges[0]` and then applied every change in the batch with that one shape. A single RowEvent.RowChanges can contain mix of RowChange shapes: the vstreamer emits only the Before or After image of an update when just one side passes the workflow filter, so one multi-row UPDATE that moves rows across an `in_keyrange` boundary (a sharding-key update replicated by a Materialize workflow) yields insert-shaped, delete-shaped and update-shaped row changes in the same RowEvent.

A change of the opposite shape then dereferences a nil row image in `MakeRowTrusted`. On release-22.0 (no #20377) the panic kills the whole vttablet process and the tablet crash-loops on the same GTID; on main the recover from #20377 turns it into a workflow error, but the workflow retries the same event forever and never progresses. Mixes that don't panic are worse: an update-shaped RowChange riding inside RowChanges is silently applied as a plain INSERT or DELETE.

The fix routes RowChanges to the bulk paths only when every change in it has the same shape (`bulkApplicableShapes`), falling back to the existing per-change apply — which handles events correctly — otherwise. `applyBulkInsertChanges` and `applyBulkDeleteChanges` additionally return a clean INTERNAL error instead of panicking if a wrong-shaped change ever reaches them, since silently applying it would corrupt data.

The first commit adds the tests and fails on main: `TestPlayerBatchModeMixedRowEvent` reproduces the scenario end to end (in_keyrange 'hash' filter, one two-row UPDATE crossing the boundary in each direction), and mixed-shape unit tests pin both crash sites (SIGSEGV in `MakeRowTrusted`). The second commit makes them pass.

Batching is default-on from v22.0.0, so this should be backported to release-22.0, release-23.0 and release-24.0. Justification: reachable by any Materialize workflow whose source updates sharding-key columns in multi-row statements; the failure mode is a wedged workflow (or, on 22.0, a crash-looping vttablet) plus potential silent data corruption.

## Related Issue(s)

Fixes: #20564
Related: #20360, #20377, #20418

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

Behavior change is confined to vreplication batch mode: shape-homogeneous events batch exactly as before; mixed events (which previously panicked or were mis-applied) are applied per-change. Operators who worked around the crash by removing `VPlayerBatching` from `--vreplication-experimental-flags` can re-enable it after upgrading.

### AI Disclosure

This PR (diagnosis, fix, tests, and description) was written primarily by Claude Code (Claude Fable 5); jjpersch provided direction and ran the red/green verification against a local MySQL 8.0 test environment.
