### PR TITLE
vtctldclient: validate MoveTables table-selection flag combinations

### DIFF
--- a/go/cmd/vtctldclient/command/vreplication/common/utils.go
+++ b/go/cmd/vtctldclient/command/vreplication/common/utils.go
@@ -258,6 +258,30 @@ func ValidateShards(shards []string) error {
 	return nil
 }
 
+// ValidateTableSelection checks the table-selection options by their
+// effective values, mirroring the server-side validation in
+// workflow.Server.moveTablesCreate: a selection is required, a non-empty
+// include list cannot be combined with all-tables, and an exclude list needs
+// a selection to apply to. Checking effective values keeps
+// --tables=t1 --all-tables=false and --tables= --all-tables=true valid, so
+// automation can always emit flags explicitly, while rejecting the
+// selection-less forms (--tables= --exclude-tables=t1) that a flag presence
+// check accepts because pflag marks an empty value as changed.
+//
+// See https://github.com/vitessio/vitess/issues/20566.
+func ValidateTableSelection(includeTables, excludeTables []string, allTables bool) error {
+	if len(includeTables) > 0 && allTables {
+		return errors.New("--tables and --all-tables are mutually exclusive")
+	}
+	if len(includeTables) == 0 && !allTables {
+		if len(excludeTables) > 0 {
+			return errors.New("--exclude-tables requires --all-tables or a non-empty --tables list")
+		}
+		return errors.New("tables or all-tables are required to specify which tables to move")
+	}
+	return nil
+}
+
 func ParseAndValidateCreateOptions(cmd *cobra.Command) error {
 	if err := validateOnDDL(cmd); err != nil {
 		return err

--- a/go/cmd/vtctldclient/command/vreplication/migrate/migrate.go
+++ b/go/cmd/vtctldclient/command/vreplication/migrate/migrate.go
@@ -59,12 +59,33 @@ var createCommand = &cobra.Command{
 		if !cmd.Flags().Lookup("tables").Changed && !cmd.Flags().Lookup("all-tables").Changed {
 			return errors.New("tables or all-tables are required to specify which tables to move")
 		}
+		if err := validateTableSelectionFlags(cmd); err != nil {
+			return err
+		}
 		if err := common.ParseAndValidateCreateOptions(cmd); err != nil {
 			return err
 		}
 		return nil
 	},
 	RunE: commandCreate,
+}
+
+// validateTableSelectionFlags ensures the table-selection flags are not
+// combined in contradictory ways that would otherwise be silently resolved:
+//   - --tables and --all-tables are mutually exclusive; specifying both would
+//     otherwise silently ignore --all-tables.
+//   - --exclude-tables only makes sense together with --all-tables; excluding
+//     tables from an explicitly provided --tables list is contradictory.
+//
+// See https://github.com/vitessio/vitess/issues/20566.
+func validateTableSelectionFlags(cmd *cobra.Command) error {
+	if cmd.Flags().Lookup("tables").Changed && cmd.Flags().Lookup("all-tables").Changed {
+		return errors.New("--tables and --all-tables are mutually exclusive")
+	}
+	if len(createOptions.ExcludeTables) > 0 && !createOptions.AllTables {
+		return errors.New("--exclude-tables can only be used together with --all-tables")
+	}
+	return nil
 }
 
 func commandCreate(cmd *cobra.Command, args []string) error {

--- a/go/cmd/vtctldclient/command/vreplication/migrate/migrate.go
+++ b/go/cmd/vtctldclient/command/vreplication/migrate/migrate.go
@@ -70,20 +70,15 @@ var createCommand = &cobra.Command{
 	RunE: commandCreate,
 }
 
-// validateTableSelectionFlags ensures the table-selection flags are not
-// combined in contradictory ways that would otherwise be silently resolved:
-//   - --tables and --all-tables are mutually exclusive; specifying both would
-//     otherwise silently ignore --all-tables.
-//   - --exclude-tables only makes sense together with --all-tables; excluding
-//     tables from an explicitly provided --tables list is contradictory.
+// validateTableSelectionFlags rejects combining an explicit --tables list
+// with an effective --all-tables=true, which would otherwise silently ignore
+// --all-tables. An explicit --all-tables=false alongside --tables stays
+// valid so that automation can always emit boolean flags explicitly.
 //
 // See https://github.com/vitessio/vitess/issues/20566.
 func validateTableSelectionFlags(cmd *cobra.Command) error {
-	if cmd.Flags().Lookup("tables").Changed && cmd.Flags().Lookup("all-tables").Changed {
+	if cmd.Flags().Lookup("tables").Changed && createOptions.AllTables {
 		return errors.New("--tables and --all-tables are mutually exclusive")
-	}
-	if len(createOptions.ExcludeTables) > 0 && !createOptions.AllTables {
-		return errors.New("--exclude-tables can only be used together with --all-tables")
 	}
 	return nil
 }

--- a/go/cmd/vtctldclient/command/vreplication/migrate/migrate.go
+++ b/go/cmd/vtctldclient/command/vreplication/migrate/migrate.go
@@ -59,7 +59,7 @@ var createCommand = &cobra.Command{
 		if !cmd.Flags().Lookup("tables").Changed && !cmd.Flags().Lookup("all-tables").Changed {
 			return errors.New("tables or all-tables are required to specify which tables to move")
 		}
-		if err := validateTableSelectionFlags(cmd); err != nil {
+		if err := validateTableSelectionFlags(); err != nil {
 			return err
 		}
 		if err := common.ParseAndValidateCreateOptions(cmd); err != nil {
@@ -70,14 +70,16 @@ var createCommand = &cobra.Command{
 	RunE: commandCreate,
 }
 
-// validateTableSelectionFlags rejects combining an explicit --tables list
+// validateTableSelectionFlags rejects combining a non-empty --tables list
 // with an effective --all-tables=true, which would otherwise silently ignore
-// --all-tables. An explicit --all-tables=false alongside --tables stays
-// valid so that automation can always emit boolean flags explicitly.
+// --all-tables. Checking the effective values rather than flag presence keeps
+// --tables=t1 --all-tables=false and --tables= --all-tables=true valid, so
+// automation can always emit flags explicitly. This matches the server-side
+// validation in workflow.Server.moveTablesCreate.
 //
 // See https://github.com/vitessio/vitess/issues/20566.
-func validateTableSelectionFlags(cmd *cobra.Command) error {
-	if cmd.Flags().Lookup("tables").Changed && createOptions.AllTables {
+func validateTableSelectionFlags() error {
+	if len(createOptions.IncludeTables) > 0 && createOptions.AllTables {
 		return errors.New("--tables and --all-tables are mutually exclusive")
 	}
 	return nil

--- a/go/cmd/vtctldclient/command/vreplication/migrate/migrate.go
+++ b/go/cmd/vtctldclient/command/vreplication/migrate/migrate.go
@@ -17,8 +17,6 @@ limitations under the License.
 package migrate
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
 
 	"vitess.io/vitess/go/cmd/vtctldclient/cli"
@@ -55,7 +53,7 @@ var createCommand = &cobra.Command{
 	Aliases:               []string{"Create"},
 	Args:                  cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if err := validateTableSelectionFlags(); err != nil {
+		if err := common.ValidateTableSelection(createOptions.IncludeTables, createOptions.ExcludeTables, createOptions.AllTables); err != nil {
 			return err
 		}
 		if err := common.ParseAndValidateCreateOptions(cmd); err != nil {
@@ -64,30 +62,6 @@ var createCommand = &cobra.Command{
 		return nil
 	},
 	RunE: commandCreate,
-}
-
-// validateTableSelectionFlags checks the table-selection options by their
-// effective values rather than by flag presence, mirroring the server-side
-// validation in workflow.Server.moveTablesCreate: a selection is required, a
-// non-empty include list cannot be combined with all-tables, and an exclude
-// list needs a selection to apply to. Using the effective values keeps
-// --tables=t1 --all-tables=false and --tables= --all-tables=true valid, so
-// automation can always emit flags explicitly, and it rejects the
-// selection-less forms (--tables= --exclude-tables=t1) that a flag presence
-// check accepts because pflag marks an empty value as changed.
-//
-// See https://github.com/vitessio/vitess/issues/20566.
-func validateTableSelectionFlags() error {
-	if len(createOptions.IncludeTables) > 0 && createOptions.AllTables {
-		return errors.New("--tables and --all-tables are mutually exclusive")
-	}
-	if len(createOptions.IncludeTables) == 0 && !createOptions.AllTables {
-		if len(createOptions.ExcludeTables) > 0 {
-			return errors.New("--exclude-tables requires --all-tables or a non-empty --tables list")
-		}
-		return errors.New("tables or all-tables are required to specify which tables to move")
-	}
-	return nil
 }
 
 func commandCreate(cmd *cobra.Command, args []string) error {

--- a/go/cmd/vtctldclient/command/vreplication/migrate/migrate.go
+++ b/go/cmd/vtctldclient/command/vreplication/migrate/migrate.go
@@ -55,10 +55,6 @@ var createCommand = &cobra.Command{
 	Aliases:               []string{"Create"},
 	Args:                  cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// Either specific tables or the all tables flags are required.
-		if !cmd.Flags().Lookup("tables").Changed && !cmd.Flags().Lookup("all-tables").Changed {
-			return errors.New("tables or all-tables are required to specify which tables to move")
-		}
 		if err := validateTableSelectionFlags(); err != nil {
 			return err
 		}
@@ -70,17 +66,26 @@ var createCommand = &cobra.Command{
 	RunE: commandCreate,
 }
 
-// validateTableSelectionFlags rejects combining a non-empty --tables list
-// with an effective --all-tables=true, which would otherwise silently ignore
-// --all-tables. Checking the effective values rather than flag presence keeps
+// validateTableSelectionFlags checks the table-selection options by their
+// effective values rather than by flag presence, mirroring the server-side
+// validation in workflow.Server.moveTablesCreate: a selection is required, a
+// non-empty include list cannot be combined with all-tables, and an exclude
+// list needs a selection to apply to. Using the effective values keeps
 // --tables=t1 --all-tables=false and --tables= --all-tables=true valid, so
-// automation can always emit flags explicitly. This matches the server-side
-// validation in workflow.Server.moveTablesCreate.
+// automation can always emit flags explicitly, and it rejects the
+// selection-less forms (--tables= --exclude-tables=t1) that a flag presence
+// check accepts because pflag marks an empty value as changed.
 //
 // See https://github.com/vitessio/vitess/issues/20566.
 func validateTableSelectionFlags() error {
 	if len(createOptions.IncludeTables) > 0 && createOptions.AllTables {
 		return errors.New("--tables and --all-tables are mutually exclusive")
+	}
+	if len(createOptions.IncludeTables) == 0 && !createOptions.AllTables {
+		if len(createOptions.ExcludeTables) > 0 {
+			return errors.New("--exclude-tables requires --all-tables or a non-empty --tables list")
+		}
+		return errors.New("tables or all-tables are required to specify which tables to move")
 	}
 	return nil
 }

--- a/go/cmd/vtctldclient/command/vreplication/migrate/migrate_test.go
+++ b/go/cmd/vtctldclient/command/vreplication/migrate/migrate_test.go
@@ -17,53 +17,30 @@ limitations under the License.
 package migrate
 
 import (
-	"strings"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
 func TestValidateTableSelectionFlags(t *testing.T) {
-	// newCmd builds a command exposing only the table-selection flags and binds
-	// the package-level createOptions the same way the real create command does.
-	// allTablesFlag is "" (not passed), "true", or "false" so that explicitly
-	// passing --all-tables=false is covered.
-	newCmd := func(tables []string, allTablesFlag string, excludeTables []string) *cobra.Command {
-		cmd := &cobra.Command{Use: "create"}
-		cmd.Flags().StringSlice("tables", nil, "")
-		cmd.Flags().Bool("all-tables", false, "")
-		cmd.Flags().StringSlice("exclude-tables", nil, "")
-
-		createOptions.IncludeTables = tables
-		createOptions.AllTables = allTablesFlag == "true"
-		createOptions.ExcludeTables = excludeTables
-
-		if tables != nil {
-			require.NoError(t, cmd.Flags().Set("tables", strings.Join(tables, ",")))
-		}
-		if allTablesFlag != "" {
-			require.NoError(t, cmd.Flags().Set("all-tables", allTablesFlag))
-		}
-		if excludeTables != nil {
-			require.NoError(t, cmd.Flags().Set("exclude-tables", strings.Join(excludeTables, ",")))
-		}
-		return cmd
-	}
-
+	// The helper checks the effective option values, mirroring the server-side
+	// validation in workflow.Server.moveTablesCreate: only a non-empty include
+	// list combined with all-tables is contradictory. An empty --tables= list
+	// (pflag marks the flag as changed but produces an empty slice) must stay
+	// valid with --all-tables.
 	tests := []struct {
 		name          string
 		tables        []string
-		allTablesFlag string
+		allTables     bool
 		excludeTables []string
 		wantErr       string
 	}{
 		{name: "only --tables", tables: []string{"t1", "t2"}},
-		{name: "only --all-tables", allTablesFlag: "true"},
-		{name: "--all-tables with --exclude-tables", allTablesFlag: "true", excludeTables: []string{"t2"}},
+		{name: "only --all-tables", allTables: true},
+		{name: "--all-tables with --exclude-tables", allTables: true, excludeTables: []string{"t2"}},
 		{name: "--tables with --exclude-tables", tables: []string{"t1", "t2"}, excludeTables: []string{"t2"}},
-		{name: "--tables with explicit --all-tables=false", tables: []string{"t1"}, allTablesFlag: "false"},
-		{name: "--tables and --all-tables together", tables: []string{"t1"}, allTablesFlag: "true", wantErr: "mutually exclusive"},
+		{name: "empty --tables= list with --all-tables", tables: []string{}, allTables: true},
+		{name: "--tables and --all-tables together", tables: []string{"t1"}, allTables: true, wantErr: "mutually exclusive"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -72,7 +49,11 @@ func TestValidateTableSelectionFlags(t *testing.T) {
 				createOptions.AllTables = false
 				createOptions.ExcludeTables = nil
 			}()
-			err := validateTableSelectionFlags(newCmd(tt.tables, tt.allTablesFlag, tt.excludeTables))
+			createOptions.IncludeTables = tt.tables
+			createOptions.AllTables = tt.allTables
+			createOptions.ExcludeTables = tt.excludeTables
+
+			err := validateTableSelectionFlags()
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 			} else {

--- a/go/cmd/vtctldclient/command/vreplication/migrate/migrate_test.go
+++ b/go/cmd/vtctldclient/command/vreplication/migrate/migrate_test.go
@@ -27,21 +27,23 @@ import (
 func TestValidateTableSelectionFlags(t *testing.T) {
 	// newCmd builds a command exposing only the table-selection flags and binds
 	// the package-level createOptions the same way the real create command does.
-	newCmd := func(tables []string, allTables bool, excludeTables []string) *cobra.Command {
+	// allTablesFlag is "" (not passed), "true", or "false" so that explicitly
+	// passing --all-tables=false is covered.
+	newCmd := func(tables []string, allTablesFlag string, excludeTables []string) *cobra.Command {
 		cmd := &cobra.Command{Use: "create"}
 		cmd.Flags().StringSlice("tables", nil, "")
 		cmd.Flags().Bool("all-tables", false, "")
 		cmd.Flags().StringSlice("exclude-tables", nil, "")
 
 		createOptions.IncludeTables = tables
-		createOptions.AllTables = allTables
+		createOptions.AllTables = allTablesFlag == "true"
 		createOptions.ExcludeTables = excludeTables
 
 		if tables != nil {
 			require.NoError(t, cmd.Flags().Set("tables", strings.Join(tables, ",")))
 		}
-		if allTables {
-			require.NoError(t, cmd.Flags().Set("all-tables", "true"))
+		if allTablesFlag != "" {
+			require.NoError(t, cmd.Flags().Set("all-tables", allTablesFlag))
 		}
 		if excludeTables != nil {
 			require.NoError(t, cmd.Flags().Set("exclude-tables", strings.Join(excludeTables, ",")))
@@ -52,15 +54,16 @@ func TestValidateTableSelectionFlags(t *testing.T) {
 	tests := []struct {
 		name          string
 		tables        []string
-		allTables     bool
+		allTablesFlag string
 		excludeTables []string
 		wantErr       string
 	}{
 		{name: "only --tables", tables: []string{"t1", "t2"}},
-		{name: "only --all-tables", allTables: true},
-		{name: "--all-tables with --exclude-tables", allTables: true, excludeTables: []string{"t2"}},
-		{name: "--tables and --all-tables together", tables: []string{"t1"}, allTables: true, wantErr: "mutually exclusive"},
-		{name: "--exclude-tables without --all-tables", tables: []string{"t1"}, excludeTables: []string{"t2"}, wantErr: "can only be used together with --all-tables"},
+		{name: "only --all-tables", allTablesFlag: "true"},
+		{name: "--all-tables with --exclude-tables", allTablesFlag: "true", excludeTables: []string{"t2"}},
+		{name: "--tables with --exclude-tables", tables: []string{"t1", "t2"}, excludeTables: []string{"t2"}},
+		{name: "--tables with explicit --all-tables=false", tables: []string{"t1"}, allTablesFlag: "false"},
+		{name: "--tables and --all-tables together", tables: []string{"t1"}, allTablesFlag: "true", wantErr: "mutually exclusive"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -69,7 +72,7 @@ func TestValidateTableSelectionFlags(t *testing.T) {
 				createOptions.AllTables = false
 				createOptions.ExcludeTables = nil
 			}()
-			err := validateTableSelectionFlags(newCmd(tt.tables, tt.allTables, tt.excludeTables))
+			err := validateTableSelectionFlags(newCmd(tt.tables, tt.allTablesFlag, tt.excludeTables))
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 			} else {

--- a/go/cmd/vtctldclient/command/vreplication/migrate/migrate_test.go
+++ b/go/cmd/vtctldclient/command/vreplication/migrate/migrate_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateTableSelectionFlags(t *testing.T) {
+	// newCmd builds a command exposing only the table-selection flags and binds
+	// the package-level createOptions the same way the real create command does.
+	newCmd := func(tables []string, allTables bool, excludeTables []string) *cobra.Command {
+		cmd := &cobra.Command{Use: "create"}
+		cmd.Flags().StringSlice("tables", nil, "")
+		cmd.Flags().Bool("all-tables", false, "")
+		cmd.Flags().StringSlice("exclude-tables", nil, "")
+
+		createOptions.IncludeTables = tables
+		createOptions.AllTables = allTables
+		createOptions.ExcludeTables = excludeTables
+
+		if tables != nil {
+			require.NoError(t, cmd.Flags().Set("tables", strings.Join(tables, ",")))
+		}
+		if allTables {
+			require.NoError(t, cmd.Flags().Set("all-tables", "true"))
+		}
+		if excludeTables != nil {
+			require.NoError(t, cmd.Flags().Set("exclude-tables", strings.Join(excludeTables, ",")))
+		}
+		return cmd
+	}
+
+	tests := []struct {
+		name          string
+		tables        []string
+		allTables     bool
+		excludeTables []string
+		wantErr       string
+	}{
+		{name: "only --tables", tables: []string{"t1", "t2"}},
+		{name: "only --all-tables", allTables: true},
+		{name: "--all-tables with --exclude-tables", allTables: true, excludeTables: []string{"t2"}},
+		{name: "--tables and --all-tables together", tables: []string{"t1"}, allTables: true, wantErr: "mutually exclusive"},
+		{name: "--exclude-tables without --all-tables", tables: []string{"t1"}, excludeTables: []string{"t2"}, wantErr: "can only be used together with --all-tables"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				createOptions.IncludeTables = nil
+				createOptions.AllTables = false
+				createOptions.ExcludeTables = nil
+			}()
+			err := validateTableSelectionFlags(newCmd(tt.tables, tt.allTables, tt.excludeTables))
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/go/cmd/vtctldclient/command/vreplication/migrate/migrate_test.go
+++ b/go/cmd/vtctldclient/command/vreplication/migrate/migrate_test.go
@@ -19,41 +19,50 @@ package migrate
 import (
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidateTableSelectionFlags(t *testing.T) {
-	// The helper checks the effective option values, mirroring the server-side
-	// validation in workflow.Server.moveTablesCreate: only a non-empty include
-	// list combined with all-tables is contradictory. An empty --tables= list
-	// (pflag marks the flag as changed but produces an empty slice) must stay
-	// valid with --all-tables.
+// TestCreatePreRunETableSelection runs the create command's PreRunE with the
+// flag forms an operator or automation actually passes. pflag marks --tables=
+// and --all-tables=false as changed while producing an empty list and false,
+// so a flag presence check accepts them; the selection-less forms must be
+// rejected here rather than reaching the server-side guard (or, against an
+// older vtctld, the late "no tables to move" failure).
+func TestCreatePreRunETableSelection(t *testing.T) {
+	// registerCommands binds flags to the package-level command vars, so it
+	// can only run once per test binary.
+	root := &cobra.Command{Use: "test"}
+	registerCommands(root)
+	cmd, _, err := root.Find([]string{"Migrate", "create"})
+	require.NoError(t, err)
+
 	tests := []struct {
-		name          string
-		tables        []string
-		allTables     bool
-		excludeTables []string
-		wantErr       string
+		name    string
+		args    []string
+		wantErr string
 	}{
-		{name: "only --tables", tables: []string{"t1", "t2"}},
-		{name: "only --all-tables", allTables: true},
-		{name: "--all-tables with --exclude-tables", allTables: true, excludeTables: []string{"t2"}},
-		{name: "--tables with --exclude-tables", tables: []string{"t1", "t2"}, excludeTables: []string{"t2"}},
-		{name: "empty --tables= list with --all-tables", tables: []string{}, allTables: true},
-		{name: "--tables and --all-tables together", tables: []string{"t1"}, allTables: true, wantErr: "mutually exclusive"},
+		{name: "--tables", args: []string{"--tables=t1,t2"}},
+		{name: "--all-tables", args: []string{"--all-tables"}},
+		{name: "--all-tables with --exclude-tables", args: []string{"--all-tables", "--exclude-tables=t2"}},
+		{name: "--tables with --exclude-tables", args: []string{"--tables=t1,t2", "--exclude-tables=t2"}},
+		{name: "--tables with --all-tables=false", args: []string{"--tables=t1", "--all-tables=false"}},
+		{name: "empty --tables= with --all-tables=true", args: []string{"--tables=", "--all-tables=true"}},
+		{name: "--tables with --all-tables", args: []string{"--tables=t1", "--all-tables"}, wantErr: "mutually exclusive"},
+		{name: "empty --tables= with --exclude-tables", args: []string{"--tables=", "--exclude-tables=t1"}, wantErr: "--exclude-tables requires"},
+		{name: "--all-tables=false with --exclude-tables", args: []string{"--all-tables=false", "--exclude-tables=t1"}, wantErr: "--exclude-tables requires"},
+		{name: "no table selection", args: nil, wantErr: "tables or all-tables are required"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer func() {
-				createOptions.IncludeTables = nil
-				createOptions.AllTables = false
-				createOptions.ExcludeTables = nil
-			}()
-			createOptions.IncludeTables = tt.tables
-			createOptions.AllTables = tt.allTables
-			createOptions.ExcludeTables = tt.excludeTables
+			// The flags bind to package-level options that persist across
+			// parses, so reset the ones under test for each case.
+			createOptions.IncludeTables = nil
+			createOptions.AllTables = false
+			createOptions.ExcludeTables = nil
+			require.NoError(t, cmd.ParseFlags(tt.args))
 
-			err := validateTableSelectionFlags()
+			err := cmd.PreRunE(cmd, nil)
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 			} else {

--- a/go/cmd/vtctldclient/command/vreplication/migrate/migrate_test.go
+++ b/go/cmd/vtctldclient/command/vreplication/migrate/migrate_test.go
@@ -17,11 +17,27 @@ limitations under the License.
 package migrate
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
+
+// registerCommands binds flags to the package-level command vars, so it can
+// only run once per test binary; the resulting tree is shared by the tests.
+var (
+	testRoot         = &cobra.Command{Use: "test"}
+	registerTestOnce sync.Once
+)
+
+func testCommand(t *testing.T, path ...string) *cobra.Command {
+	t.Helper()
+	registerTestOnce.Do(func() { registerCommands(testRoot) })
+	cmd, _, err := testRoot.Find(path)
+	require.NoError(t, err)
+	return cmd
+}
 
 // TestCreatePreRunETableSelection runs the create command's PreRunE with the
 // flag forms an operator or automation actually passes. pflag marks --tables=
@@ -30,12 +46,7 @@ import (
 // rejected here rather than reaching the server-side guard (or, against an
 // older vtctld, the late "no tables to move" failure).
 func TestCreatePreRunETableSelection(t *testing.T) {
-	// registerCommands binds flags to the package-level command vars, so it
-	// can only run once per test binary.
-	root := &cobra.Command{Use: "test"}
-	registerCommands(root)
-	cmd, _, err := root.Find([]string{"Migrate", "create"})
-	require.NoError(t, err)
+	cmd := testCommand(t, "Migrate", "create")
 
 	tests := []struct {
 		name    string

--- a/go/cmd/vtctldclient/command/vreplication/movetables/create.go
+++ b/go/cmd/vtctldclient/command/vreplication/movetables/create.go
@@ -59,6 +59,9 @@ var (
 			if !cmd.Flags().Lookup("tables").Changed && !cmd.Flags().Lookup("all-tables").Changed {
 				return errors.New("tables or all-tables are required to specify which tables to move")
 			}
+			if err := validateTableSelectionFlags(cmd); err != nil {
+				return err
+			}
 			if err := common.ParseAndValidateCreateOptions(cmd); err != nil {
 				return err
 			}
@@ -109,6 +112,24 @@ var (
 		RunE: commandCreate,
 	}
 )
+
+// validateTableSelectionFlags ensures the table-selection flags are not
+// combined in contradictory ways that would otherwise be silently resolved:
+//   - --tables and --all-tables are mutually exclusive; specifying both would
+//     otherwise silently ignore --all-tables.
+//   - --exclude-tables only makes sense together with --all-tables; excluding
+//     tables from an explicitly provided --tables list is contradictory.
+//
+// See https://github.com/vitessio/vitess/issues/20566.
+func validateTableSelectionFlags(cmd *cobra.Command) error {
+	if cmd.Flags().Lookup("tables").Changed && cmd.Flags().Lookup("all-tables").Changed {
+		return errors.New("--tables and --all-tables are mutually exclusive")
+	}
+	if len(createOptions.ExcludeTables) > 0 && !createOptions.AllTables {
+		return errors.New("--exclude-tables can only be used together with --all-tables")
+	}
+	return nil
+}
 
 func commandCreate(cmd *cobra.Command, args []string) error {
 	format, err := common.GetOutputFormat(cmd)

--- a/go/cmd/vtctldclient/command/vreplication/movetables/create.go
+++ b/go/cmd/vtctldclient/command/vreplication/movetables/create.go
@@ -113,20 +113,15 @@ var (
 	}
 )
 
-// validateTableSelectionFlags ensures the table-selection flags are not
-// combined in contradictory ways that would otherwise be silently resolved:
-//   - --tables and --all-tables are mutually exclusive; specifying both would
-//     otherwise silently ignore --all-tables.
-//   - --exclude-tables only makes sense together with --all-tables; excluding
-//     tables from an explicitly provided --tables list is contradictory.
+// validateTableSelectionFlags rejects combining an explicit --tables list
+// with an effective --all-tables=true, which would otherwise silently ignore
+// --all-tables. An explicit --all-tables=false alongside --tables stays
+// valid so that automation can always emit boolean flags explicitly.
 //
 // See https://github.com/vitessio/vitess/issues/20566.
 func validateTableSelectionFlags(cmd *cobra.Command) error {
-	if cmd.Flags().Lookup("tables").Changed && cmd.Flags().Lookup("all-tables").Changed {
+	if cmd.Flags().Lookup("tables").Changed && createOptions.AllTables {
 		return errors.New("--tables and --all-tables are mutually exclusive")
-	}
-	if len(createOptions.ExcludeTables) > 0 && !createOptions.AllTables {
-		return errors.New("--exclude-tables can only be used together with --all-tables")
 	}
 	return nil
 }

--- a/go/cmd/vtctldclient/command/vreplication/movetables/create.go
+++ b/go/cmd/vtctldclient/command/vreplication/movetables/create.go
@@ -59,7 +59,7 @@ var (
 			if !cmd.Flags().Lookup("tables").Changed && !cmd.Flags().Lookup("all-tables").Changed {
 				return errors.New("tables or all-tables are required to specify which tables to move")
 			}
-			if err := validateTableSelectionFlags(cmd); err != nil {
+			if err := validateTableSelectionFlags(); err != nil {
 				return err
 			}
 			if err := common.ParseAndValidateCreateOptions(cmd); err != nil {
@@ -113,14 +113,16 @@ var (
 	}
 )
 
-// validateTableSelectionFlags rejects combining an explicit --tables list
+// validateTableSelectionFlags rejects combining a non-empty --tables list
 // with an effective --all-tables=true, which would otherwise silently ignore
-// --all-tables. An explicit --all-tables=false alongside --tables stays
-// valid so that automation can always emit boolean flags explicitly.
+// --all-tables. Checking the effective values rather than flag presence keeps
+// --tables=t1 --all-tables=false and --tables= --all-tables=true valid, so
+// automation can always emit flags explicitly. This matches the server-side
+// validation in workflow.Server.moveTablesCreate.
 //
 // See https://github.com/vitessio/vitess/issues/20566.
-func validateTableSelectionFlags(cmd *cobra.Command) error {
-	if cmd.Flags().Lookup("tables").Changed && createOptions.AllTables {
+func validateTableSelectionFlags() error {
+	if len(createOptions.IncludeTables) > 0 && createOptions.AllTables {
 		return errors.New("--tables and --all-tables are mutually exclusive")
 	}
 	return nil

--- a/go/cmd/vtctldclient/command/vreplication/movetables/create.go
+++ b/go/cmd/vtctldclient/command/vreplication/movetables/create.go
@@ -55,10 +55,6 @@ var (
 		Aliases:               []string{"Create"},
 		Args:                  cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			// Either specific tables or the all tables flags are required.
-			if !cmd.Flags().Lookup("tables").Changed && !cmd.Flags().Lookup("all-tables").Changed {
-				return errors.New("tables or all-tables are required to specify which tables to move")
-			}
 			if err := validateTableSelectionFlags(); err != nil {
 				return err
 			}
@@ -113,17 +109,26 @@ var (
 	}
 )
 
-// validateTableSelectionFlags rejects combining a non-empty --tables list
-// with an effective --all-tables=true, which would otherwise silently ignore
-// --all-tables. Checking the effective values rather than flag presence keeps
+// validateTableSelectionFlags checks the table-selection options by their
+// effective values rather than by flag presence, mirroring the server-side
+// validation in workflow.Server.moveTablesCreate: a selection is required, a
+// non-empty include list cannot be combined with all-tables, and an exclude
+// list needs a selection to apply to. Using the effective values keeps
 // --tables=t1 --all-tables=false and --tables= --all-tables=true valid, so
-// automation can always emit flags explicitly. This matches the server-side
-// validation in workflow.Server.moveTablesCreate.
+// automation can always emit flags explicitly, and it rejects the
+// selection-less forms (--tables= --exclude-tables=t1) that a flag presence
+// check accepts because pflag marks an empty value as changed.
 //
 // See https://github.com/vitessio/vitess/issues/20566.
 func validateTableSelectionFlags() error {
 	if len(createOptions.IncludeTables) > 0 && createOptions.AllTables {
 		return errors.New("--tables and --all-tables are mutually exclusive")
+	}
+	if len(createOptions.IncludeTables) == 0 && !createOptions.AllTables {
+		if len(createOptions.ExcludeTables) > 0 {
+			return errors.New("--exclude-tables requires --all-tables or a non-empty --tables list")
+		}
+		return errors.New("tables or all-tables are required to specify which tables to move")
 	}
 	return nil
 }

--- a/go/cmd/vtctldclient/command/vreplication/movetables/create.go
+++ b/go/cmd/vtctldclient/command/vreplication/movetables/create.go
@@ -55,7 +55,7 @@ var (
 		Aliases:               []string{"Create"},
 		Args:                  cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateTableSelectionFlags(); err != nil {
+			if err := common.ValidateTableSelection(createOptions.IncludeTables, createOptions.ExcludeTables, createOptions.AllTables); err != nil {
 				return err
 			}
 			if err := common.ParseAndValidateCreateOptions(cmd); err != nil {
@@ -108,30 +108,6 @@ var (
 		RunE: commandCreate,
 	}
 )
-
-// validateTableSelectionFlags checks the table-selection options by their
-// effective values rather than by flag presence, mirroring the server-side
-// validation in workflow.Server.moveTablesCreate: a selection is required, a
-// non-empty include list cannot be combined with all-tables, and an exclude
-// list needs a selection to apply to. Using the effective values keeps
-// --tables=t1 --all-tables=false and --tables= --all-tables=true valid, so
-// automation can always emit flags explicitly, and it rejects the
-// selection-less forms (--tables= --exclude-tables=t1) that a flag presence
-// check accepts because pflag marks an empty value as changed.
-//
-// See https://github.com/vitessio/vitess/issues/20566.
-func validateTableSelectionFlags() error {
-	if len(createOptions.IncludeTables) > 0 && createOptions.AllTables {
-		return errors.New("--tables and --all-tables are mutually exclusive")
-	}
-	if len(createOptions.IncludeTables) == 0 && !createOptions.AllTables {
-		if len(createOptions.ExcludeTables) > 0 {
-			return errors.New("--exclude-tables requires --all-tables or a non-empty --tables list")
-		}
-		return errors.New("tables or all-tables are required to specify which tables to move")
-	}
-	return nil
-}
 
 func commandCreate(cmd *cobra.Command, args []string) error {
 	format, err := common.GetOutputFormat(cmd)

--- a/go/cmd/vtctldclient/command/vreplication/movetables/movetables_test.go
+++ b/go/cmd/vtctldclient/command/vreplication/movetables/movetables_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package movetables
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -34,4 +35,59 @@ func TestKeepDataHelpMentionsReverseWorkflowDefault(t *testing.T) {
 	cancelCmd, _, err := root.Find([]string{"MoveTables", "cancel"})
 	require.NoError(t, err)
 	require.Contains(t, cancelCmd.Flags().Lookup("keep-data").Usage, "Defaults to true for an explicitly specified _reverse workflow unless --keep-data=false is provided.")
+}
+
+func TestValidateTableSelectionFlags(t *testing.T) {
+	// newCmd builds a command exposing only the table-selection flags and binds
+	// the package-level createOptions the same way the real create command does.
+	newCmd := func(tables []string, allTables bool, excludeTables []string) *cobra.Command {
+		cmd := &cobra.Command{Use: "create"}
+		cmd.Flags().StringSlice("tables", nil, "")
+		cmd.Flags().Bool("all-tables", false, "")
+		cmd.Flags().StringSlice("exclude-tables", nil, "")
+
+		createOptions.IncludeTables = tables
+		createOptions.AllTables = allTables
+		createOptions.ExcludeTables = excludeTables
+
+		if tables != nil {
+			require.NoError(t, cmd.Flags().Set("tables", strings.Join(tables, ",")))
+		}
+		if allTables {
+			require.NoError(t, cmd.Flags().Set("all-tables", "true"))
+		}
+		if excludeTables != nil {
+			require.NoError(t, cmd.Flags().Set("exclude-tables", strings.Join(excludeTables, ",")))
+		}
+		return cmd
+	}
+
+	tests := []struct {
+		name          string
+		tables        []string
+		allTables     bool
+		excludeTables []string
+		wantErr       string
+	}{
+		{name: "only --tables", tables: []string{"t1", "t2"}},
+		{name: "only --all-tables", allTables: true},
+		{name: "--all-tables with --exclude-tables", allTables: true, excludeTables: []string{"t2"}},
+		{name: "--tables and --all-tables together", tables: []string{"t1"}, allTables: true, wantErr: "mutually exclusive"},
+		{name: "--exclude-tables without --all-tables", tables: []string{"t1"}, excludeTables: []string{"t2"}, wantErr: "can only be used together with --all-tables"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				createOptions.IncludeTables = nil
+				createOptions.AllTables = false
+				createOptions.ExcludeTables = nil
+			}()
+			err := validateTableSelectionFlags(newCmd(tt.tables, tt.allTables, tt.excludeTables))
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/go/cmd/vtctldclient/command/vreplication/movetables/movetables_test.go
+++ b/go/cmd/vtctldclient/command/vreplication/movetables/movetables_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package movetables
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -38,45 +37,24 @@ func TestKeepDataHelpMentionsReverseWorkflowDefault(t *testing.T) {
 }
 
 func TestValidateTableSelectionFlags(t *testing.T) {
-	// newCmd builds a command exposing only the table-selection flags and binds
-	// the package-level createOptions the same way the real create command does.
-	// allTablesFlag is "" (not passed), "true", or "false" so that explicitly
-	// passing --all-tables=false is covered.
-	newCmd := func(tables []string, allTablesFlag string, excludeTables []string) *cobra.Command {
-		cmd := &cobra.Command{Use: "create"}
-		cmd.Flags().StringSlice("tables", nil, "")
-		cmd.Flags().Bool("all-tables", false, "")
-		cmd.Flags().StringSlice("exclude-tables", nil, "")
-
-		createOptions.IncludeTables = tables
-		createOptions.AllTables = allTablesFlag == "true"
-		createOptions.ExcludeTables = excludeTables
-
-		if tables != nil {
-			require.NoError(t, cmd.Flags().Set("tables", strings.Join(tables, ",")))
-		}
-		if allTablesFlag != "" {
-			require.NoError(t, cmd.Flags().Set("all-tables", allTablesFlag))
-		}
-		if excludeTables != nil {
-			require.NoError(t, cmd.Flags().Set("exclude-tables", strings.Join(excludeTables, ",")))
-		}
-		return cmd
-	}
-
+	// The helper checks the effective option values, mirroring the server-side
+	// validation in workflow.Server.moveTablesCreate: only a non-empty include
+	// list combined with all-tables is contradictory. An empty --tables= list
+	// (pflag marks the flag as changed but produces an empty slice) must stay
+	// valid with --all-tables.
 	tests := []struct {
 		name          string
 		tables        []string
-		allTablesFlag string
+		allTables     bool
 		excludeTables []string
 		wantErr       string
 	}{
 		{name: "only --tables", tables: []string{"t1", "t2"}},
-		{name: "only --all-tables", allTablesFlag: "true"},
-		{name: "--all-tables with --exclude-tables", allTablesFlag: "true", excludeTables: []string{"t2"}},
+		{name: "only --all-tables", allTables: true},
+		{name: "--all-tables with --exclude-tables", allTables: true, excludeTables: []string{"t2"}},
 		{name: "--tables with --exclude-tables", tables: []string{"t1", "t2"}, excludeTables: []string{"t2"}},
-		{name: "--tables with explicit --all-tables=false", tables: []string{"t1"}, allTablesFlag: "false"},
-		{name: "--tables and --all-tables together", tables: []string{"t1"}, allTablesFlag: "true", wantErr: "mutually exclusive"},
+		{name: "empty --tables= list with --all-tables", tables: []string{}, allTables: true},
+		{name: "--tables and --all-tables together", tables: []string{"t1"}, allTables: true, wantErr: "mutually exclusive"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -85,7 +63,11 @@ func TestValidateTableSelectionFlags(t *testing.T) {
 				createOptions.AllTables = false
 				createOptions.ExcludeTables = nil
 			}()
-			err := validateTableSelectionFlags(newCmd(tt.tables, tt.allTablesFlag, tt.excludeTables))
+			createOptions.IncludeTables = tt.tables
+			createOptions.AllTables = tt.allTables
+			createOptions.ExcludeTables = tt.excludeTables
+
+			err := validateTableSelectionFlags()
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 			} else {

--- a/go/cmd/vtctldclient/command/vreplication/movetables/movetables_test.go
+++ b/go/cmd/vtctldclient/command/vreplication/movetables/movetables_test.go
@@ -40,21 +40,23 @@ func TestKeepDataHelpMentionsReverseWorkflowDefault(t *testing.T) {
 func TestValidateTableSelectionFlags(t *testing.T) {
 	// newCmd builds a command exposing only the table-selection flags and binds
 	// the package-level createOptions the same way the real create command does.
-	newCmd := func(tables []string, allTables bool, excludeTables []string) *cobra.Command {
+	// allTablesFlag is "" (not passed), "true", or "false" so that explicitly
+	// passing --all-tables=false is covered.
+	newCmd := func(tables []string, allTablesFlag string, excludeTables []string) *cobra.Command {
 		cmd := &cobra.Command{Use: "create"}
 		cmd.Flags().StringSlice("tables", nil, "")
 		cmd.Flags().Bool("all-tables", false, "")
 		cmd.Flags().StringSlice("exclude-tables", nil, "")
 
 		createOptions.IncludeTables = tables
-		createOptions.AllTables = allTables
+		createOptions.AllTables = allTablesFlag == "true"
 		createOptions.ExcludeTables = excludeTables
 
 		if tables != nil {
 			require.NoError(t, cmd.Flags().Set("tables", strings.Join(tables, ",")))
 		}
-		if allTables {
-			require.NoError(t, cmd.Flags().Set("all-tables", "true"))
+		if allTablesFlag != "" {
+			require.NoError(t, cmd.Flags().Set("all-tables", allTablesFlag))
 		}
 		if excludeTables != nil {
 			require.NoError(t, cmd.Flags().Set("exclude-tables", strings.Join(excludeTables, ",")))
@@ -65,15 +67,16 @@ func TestValidateTableSelectionFlags(t *testing.T) {
 	tests := []struct {
 		name          string
 		tables        []string
-		allTables     bool
+		allTablesFlag string
 		excludeTables []string
 		wantErr       string
 	}{
 		{name: "only --tables", tables: []string{"t1", "t2"}},
-		{name: "only --all-tables", allTables: true},
-		{name: "--all-tables with --exclude-tables", allTables: true, excludeTables: []string{"t2"}},
-		{name: "--tables and --all-tables together", tables: []string{"t1"}, allTables: true, wantErr: "mutually exclusive"},
-		{name: "--exclude-tables without --all-tables", tables: []string{"t1"}, excludeTables: []string{"t2"}, wantErr: "can only be used together with --all-tables"},
+		{name: "only --all-tables", allTablesFlag: "true"},
+		{name: "--all-tables with --exclude-tables", allTablesFlag: "true", excludeTables: []string{"t2"}},
+		{name: "--tables with --exclude-tables", tables: []string{"t1", "t2"}, excludeTables: []string{"t2"}},
+		{name: "--tables with explicit --all-tables=false", tables: []string{"t1"}, allTablesFlag: "false"},
+		{name: "--tables and --all-tables together", tables: []string{"t1"}, allTablesFlag: "true", wantErr: "mutually exclusive"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -82,7 +85,7 @@ func TestValidateTableSelectionFlags(t *testing.T) {
 				createOptions.AllTables = false
 				createOptions.ExcludeTables = nil
 			}()
-			err := validateTableSelectionFlags(newCmd(tt.tables, tt.allTables, tt.excludeTables))
+			err := validateTableSelectionFlags(newCmd(tt.tables, tt.allTablesFlag, tt.excludeTables))
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 			} else {

--- a/go/cmd/vtctldclient/command/vreplication/movetables/movetables_test.go
+++ b/go/cmd/vtctldclient/command/vreplication/movetables/movetables_test.go
@@ -17,57 +17,71 @@ limitations under the License.
 package movetables
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
-func TestKeepDataHelpMentionsReverseWorkflowDefault(t *testing.T) {
-	root := &cobra.Command{Use: "test"}
-	registerCommands(root)
+// registerCommands binds flags to the package-level command vars, so it can
+// only run once per test binary; the resulting tree is shared by the tests.
+var (
+	testRoot         = &cobra.Command{Use: "test"}
+	registerTestOnce sync.Once
+)
 
-	completeCmd, _, err := root.Find([]string{"MoveTables", "complete"})
+func testCommand(t *testing.T, path ...string) *cobra.Command {
+	t.Helper()
+	registerTestOnce.Do(func() { registerCommands(testRoot) })
+	cmd, _, err := testRoot.Find(path)
 	require.NoError(t, err)
+	return cmd
+}
+
+func TestKeepDataHelpMentionsReverseWorkflowDefault(t *testing.T) {
+	completeCmd := testCommand(t, "MoveTables", "complete")
 	require.Contains(t, completeCmd.Flags().Lookup("keep-data").Usage, "Defaults to true for an explicitly specified _reverse workflow unless --keep-data=false is provided.")
 
-	cancelCmd, _, err := root.Find([]string{"MoveTables", "cancel"})
-	require.NoError(t, err)
+	cancelCmd := testCommand(t, "MoveTables", "cancel")
 	require.Contains(t, cancelCmd.Flags().Lookup("keep-data").Usage, "Defaults to true for an explicitly specified _reverse workflow unless --keep-data=false is provided.")
 }
 
-func TestValidateTableSelectionFlags(t *testing.T) {
-	// The helper checks the effective option values, mirroring the server-side
-	// validation in workflow.Server.moveTablesCreate: only a non-empty include
-	// list combined with all-tables is contradictory. An empty --tables= list
-	// (pflag marks the flag as changed but produces an empty slice) must stay
-	// valid with --all-tables.
+// TestCreatePreRunETableSelection runs the create command's PreRunE with the
+// flag forms an operator or automation actually passes. pflag marks --tables=
+// and --all-tables=false as changed while producing an empty list and false,
+// so a flag presence check accepts them; the selection-less forms must be
+// rejected here rather than reaching the server-side guard (or, against an
+// older vtctld, the late "no tables to move" failure).
+func TestCreatePreRunETableSelection(t *testing.T) {
+	cmd := testCommand(t, "MoveTables", "create")
+
 	tests := []struct {
-		name          string
-		tables        []string
-		allTables     bool
-		excludeTables []string
-		wantErr       string
+		name    string
+		args    []string
+		wantErr string
 	}{
-		{name: "only --tables", tables: []string{"t1", "t2"}},
-		{name: "only --all-tables", allTables: true},
-		{name: "--all-tables with --exclude-tables", allTables: true, excludeTables: []string{"t2"}},
-		{name: "--tables with --exclude-tables", tables: []string{"t1", "t2"}, excludeTables: []string{"t2"}},
-		{name: "empty --tables= list with --all-tables", tables: []string{}, allTables: true},
-		{name: "--tables and --all-tables together", tables: []string{"t1"}, allTables: true, wantErr: "mutually exclusive"},
+		{name: "--tables", args: []string{"--tables=t1,t2"}},
+		{name: "--all-tables", args: []string{"--all-tables"}},
+		{name: "--all-tables with --exclude-tables", args: []string{"--all-tables", "--exclude-tables=t2"}},
+		{name: "--tables with --exclude-tables", args: []string{"--tables=t1,t2", "--exclude-tables=t2"}},
+		{name: "--tables with --all-tables=false", args: []string{"--tables=t1", "--all-tables=false"}},
+		{name: "empty --tables= with --all-tables=true", args: []string{"--tables=", "--all-tables=true"}},
+		{name: "--tables with --all-tables", args: []string{"--tables=t1", "--all-tables"}, wantErr: "mutually exclusive"},
+		{name: "empty --tables= with --exclude-tables", args: []string{"--tables=", "--exclude-tables=t1"}, wantErr: "--exclude-tables requires"},
+		{name: "--all-tables=false with --exclude-tables", args: []string{"--all-tables=false", "--exclude-tables=t1"}, wantErr: "--exclude-tables requires"},
+		{name: "no table selection", args: nil, wantErr: "tables or all-tables are required"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer func() {
-				createOptions.IncludeTables = nil
-				createOptions.AllTables = false
-				createOptions.ExcludeTables = nil
-			}()
-			createOptions.IncludeTables = tt.tables
-			createOptions.AllTables = tt.allTables
-			createOptions.ExcludeTables = tt.excludeTables
+			// The flags bind to package-level options that persist across
+			// parses, so reset the ones under test for each case.
+			createOptions.IncludeTables = nil
+			createOptions.AllTables = false
+			createOptions.ExcludeTables = nil
+			require.NoError(t, cmd.ParseFlags(tt.args))
 
-			err := validateTableSelectionFlags()
+			err := cmd.PreRunE(cmd, nil)
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 			} else {

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1085,7 +1085,14 @@ func (s *Server) moveTablesCreate(ctx context.Context, req *vtctldatapb.MoveTabl
 
 	sourceKeyspace := req.SourceKeyspace
 	targetKeyspace := req.TargetKeyspace
-	// FIXME validate tableSpecs, allTables, excludeTables
+	// Enforce the table-selection invariant at the RPC boundary, not only in
+	// vtctldclient: VTAdmin forwards a raw request and direct gRPC callers
+	// bypass the CLI checks. An explicit include list combined with
+	// all_tables=true would otherwise silently move only the explicit subset.
+	// Combining an include list with exclude_tables is supported behavior.
+	if req.AllTables && len(req.IncludeTables) > 0 {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "cannot specify both all_tables and an explicit list of tables to include")
+	}
 
 	if workflowType == binlogdatapb.VReplicationWorkflowType_MoveTables && sourceKeyspace == targetKeyspace {
 		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "source and target keyspace must be different for MoveTables workflows")

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1085,6 +1085,10 @@ func (s *Server) moveTablesCreate(ctx context.Context, req *vtctldatapb.MoveTabl
 
 	sourceKeyspace := req.SourceKeyspace
 	targetKeyspace := req.TargetKeyspace
+	if workflowType == binlogdatapb.VReplicationWorkflowType_MoveTables && sourceKeyspace == targetKeyspace {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "source and target keyspace must be different for MoveTables workflows")
+	}
+
 	// Enforce the table-selection invariants at the RPC boundary, mirroring
 	// the vtctldclient validation in common.ValidateTableSelection: VTAdmin
 	// forwards a raw request and direct gRPC callers bypass the CLI checks.
@@ -1092,7 +1096,8 @@ func (s *Server) moveTablesCreate(ctx context.Context, req *vtctldatapb.MoveTabl
 	// silently move only the explicit subset, and a request with no selection
 	// at all would only fail later, after topo access, with a less clear
 	// error. Combining an include list with exclude_tables is supported
-	// behavior.
+	// behavior. This runs after the keyspace check so that the more
+	// fundamental source/target error still takes precedence.
 	if req.AllTables && len(req.IncludeTables) > 0 {
 		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "cannot specify both all_tables and an explicit list of tables to include")
 	}
@@ -1101,10 +1106,6 @@ func (s *Server) moveTablesCreate(ctx context.Context, req *vtctldatapb.MoveTabl
 			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "exclude_tables requires all_tables or an explicit list of tables to include")
 		}
 		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "either all_tables or an explicit list of tables to include must be specified")
-	}
-
-	if workflowType == binlogdatapb.VReplicationWorkflowType_MoveTables && sourceKeyspace == targetKeyspace {
-		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "source and target keyspace must be different for MoveTables workflows")
 	}
 
 	var (

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1085,13 +1085,18 @@ func (s *Server) moveTablesCreate(ctx context.Context, req *vtctldatapb.MoveTabl
 
 	sourceKeyspace := req.SourceKeyspace
 	targetKeyspace := req.TargetKeyspace
-	// Enforce the table-selection invariant at the RPC boundary, not only in
+	// Enforce the table-selection invariants at the RPC boundary, not only in
 	// vtctldclient: VTAdmin forwards a raw request and direct gRPC callers
 	// bypass the CLI checks. An explicit include list combined with
-	// all_tables=true would otherwise silently move only the explicit subset.
-	// Combining an include list with exclude_tables is supported behavior.
+	// all_tables=true would otherwise silently move only the explicit subset,
+	// and an exclude list with no table selection to apply it to would only
+	// fail later, after topo access, with a less clear error. Combining an
+	// include list with exclude_tables is supported behavior.
 	if req.AllTables && len(req.IncludeTables) > 0 {
 		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "cannot specify both all_tables and an explicit list of tables to include")
+	}
+	if len(req.ExcludeTables) > 0 && !req.AllTables && len(req.IncludeTables) == 0 {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "exclude_tables requires all_tables or an explicit list of tables to include")
 	}
 
 	if workflowType == binlogdatapb.VReplicationWorkflowType_MoveTables && sourceKeyspace == targetKeyspace {

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -1085,18 +1085,22 @@ func (s *Server) moveTablesCreate(ctx context.Context, req *vtctldatapb.MoveTabl
 
 	sourceKeyspace := req.SourceKeyspace
 	targetKeyspace := req.TargetKeyspace
-	// Enforce the table-selection invariants at the RPC boundary, not only in
-	// vtctldclient: VTAdmin forwards a raw request and direct gRPC callers
-	// bypass the CLI checks. An explicit include list combined with
-	// all_tables=true would otherwise silently move only the explicit subset,
-	// and an exclude list with no table selection to apply it to would only
-	// fail later, after topo access, with a less clear error. Combining an
-	// include list with exclude_tables is supported behavior.
+	// Enforce the table-selection invariants at the RPC boundary, mirroring
+	// the vtctldclient validation in common.ValidateTableSelection: VTAdmin
+	// forwards a raw request and direct gRPC callers bypass the CLI checks.
+	// An explicit include list combined with all_tables=true would otherwise
+	// silently move only the explicit subset, and a request with no selection
+	// at all would only fail later, after topo access, with a less clear
+	// error. Combining an include list with exclude_tables is supported
+	// behavior.
 	if req.AllTables && len(req.IncludeTables) > 0 {
 		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "cannot specify both all_tables and an explicit list of tables to include")
 	}
-	if len(req.ExcludeTables) > 0 && !req.AllTables && len(req.IncludeTables) == 0 {
-		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "exclude_tables requires all_tables or an explicit list of tables to include")
+	if !req.AllTables && len(req.IncludeTables) == 0 {
+		if len(req.ExcludeTables) > 0 {
+			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "exclude_tables requires all_tables or an explicit list of tables to include")
+		}
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "either all_tables or an explicit list of tables to include must be specified")
 	}
 
 	if workflowType == binlogdatapb.VReplicationWorkflowType_MoveTables && sourceKeyspace == targetKeyspace {

--- a/go/vt/vtctl/workflow/server_create_validation_test.go
+++ b/go/vt/vtctl/workflow/server_create_validation_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
+)
+
+// TestCreateRejectsAllTablesWithIncludeList ensures the table-selection
+// invariant is enforced at the RPC boundary, not only in vtctldclient:
+// VTAdmin forwards a raw request and direct gRPC callers bypass the CLI
+// checks, so all_tables=true combined with an explicit include list would
+// otherwise silently move only the explicit subset.
+func TestCreateRejectsAllTablesWithIncludeList(t *testing.T) {
+	ctx := context.Background()
+	s := &Server{}
+
+	t.Run("MoveTablesCreate", func(t *testing.T) {
+		_, err := s.MoveTablesCreate(ctx, &vtctldatapb.MoveTablesCreateRequest{
+			Workflow:       "wf1",
+			SourceKeyspace: "sourceks",
+			TargetKeyspace: "targetks",
+			AllTables:      true,
+			IncludeTables:  []string{"t1"},
+		})
+		require.ErrorContains(t, err, "cannot specify both all_tables")
+	})
+
+	t.Run("MigrateCreate", func(t *testing.T) {
+		_, err := s.MigrateCreate(ctx, &vtctldatapb.MigrateCreateRequest{
+			Workflow:       "wf1",
+			MountName:      "ext1",
+			SourceKeyspace: "sourceks",
+			TargetKeyspace: "targetks",
+			AllTables:      true,
+			IncludeTables:  []string{"t1"},
+		})
+		require.ErrorContains(t, err, "cannot specify both all_tables")
+	})
+}

--- a/go/vt/vtctl/workflow/server_create_validation_test.go
+++ b/go/vt/vtctl/workflow/server_create_validation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package workflow
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,11 +30,10 @@ import (
 // checks, so all_tables=true combined with an explicit include list would
 // otherwise silently move only the explicit subset.
 func TestCreateRejectsAllTablesWithIncludeList(t *testing.T) {
-	ctx := context.Background()
 	s := &Server{}
 
 	t.Run("MoveTablesCreate", func(t *testing.T) {
-		_, err := s.MoveTablesCreate(ctx, &vtctldatapb.MoveTablesCreateRequest{
+		_, err := s.MoveTablesCreate(t.Context(), &vtctldatapb.MoveTablesCreateRequest{
 			Workflow:       "wf1",
 			SourceKeyspace: "sourceks",
 			TargetKeyspace: "targetks",
@@ -46,7 +44,7 @@ func TestCreateRejectsAllTablesWithIncludeList(t *testing.T) {
 	})
 
 	t.Run("MigrateCreate", func(t *testing.T) {
-		_, err := s.MigrateCreate(ctx, &vtctldatapb.MigrateCreateRequest{
+		_, err := s.MigrateCreate(t.Context(), &vtctldatapb.MigrateCreateRequest{
 			Workflow:       "wf1",
 			MountName:      "ext1",
 			SourceKeyspace: "sourceks",
@@ -65,11 +63,10 @@ func TestCreateRejectsAllTablesWithIncludeList(t *testing.T) {
 // The vtctldclient cannot produce this request (it requires --tables or
 // --all-tables), so only raw gRPC callers and VTAdmin can hit it.
 func TestCreateRejectsExcludeTablesWithoutSelection(t *testing.T) {
-	ctx := context.Background()
 	s := &Server{}
 
 	t.Run("MoveTablesCreate", func(t *testing.T) {
-		_, err := s.MoveTablesCreate(ctx, &vtctldatapb.MoveTablesCreateRequest{
+		_, err := s.MoveTablesCreate(t.Context(), &vtctldatapb.MoveTablesCreateRequest{
 			Workflow:       "wf1",
 			SourceKeyspace: "sourceks",
 			TargetKeyspace: "targetks",
@@ -79,7 +76,7 @@ func TestCreateRejectsExcludeTablesWithoutSelection(t *testing.T) {
 	})
 
 	t.Run("MigrateCreate", func(t *testing.T) {
-		_, err := s.MigrateCreate(ctx, &vtctldatapb.MigrateCreateRequest{
+		_, err := s.MigrateCreate(t.Context(), &vtctldatapb.MigrateCreateRequest{
 			Workflow:       "wf1",
 			MountName:      "ext1",
 			SourceKeyspace: "sourceks",

--- a/go/vt/vtctl/workflow/server_create_validation_test.go
+++ b/go/vt/vtctl/workflow/server_create_validation_test.go
@@ -57,3 +57,35 @@ func TestCreateRejectsAllTablesWithIncludeList(t *testing.T) {
 		require.ErrorContains(t, err, "cannot specify both all_tables")
 	})
 }
+
+// TestCreateRejectsExcludeTablesWithoutSelection ensures the RPC boundary
+// also considers exclude_tables: an exclude list with neither all_tables nor
+// an explicit include list has no table selection to apply to, and would
+// otherwise only fail later, after topo access, with a less clear error.
+// The vtctldclient cannot produce this request (it requires --tables or
+// --all-tables), so only raw gRPC callers and VTAdmin can hit it.
+func TestCreateRejectsExcludeTablesWithoutSelection(t *testing.T) {
+	ctx := context.Background()
+	s := &Server{}
+
+	t.Run("MoveTablesCreate", func(t *testing.T) {
+		_, err := s.MoveTablesCreate(ctx, &vtctldatapb.MoveTablesCreateRequest{
+			Workflow:       "wf1",
+			SourceKeyspace: "sourceks",
+			TargetKeyspace: "targetks",
+			ExcludeTables:  []string{"t1"},
+		})
+		require.ErrorContains(t, err, "exclude_tables requires all_tables")
+	})
+
+	t.Run("MigrateCreate", func(t *testing.T) {
+		_, err := s.MigrateCreate(ctx, &vtctldatapb.MigrateCreateRequest{
+			Workflow:       "wf1",
+			MountName:      "ext1",
+			SourceKeyspace: "sourceks",
+			TargetKeyspace: "targetks",
+			ExcludeTables:  []string{"t1"},
+		})
+		require.ErrorContains(t, err, "exclude_tables requires all_tables")
+	})
+}

--- a/go/vt/vtctl/workflow/server_create_validation_test.go
+++ b/go/vt/vtctl/workflow/server_create_validation_test.go
@@ -56,16 +56,17 @@ func TestCreateRejectsAllTablesWithIncludeList(t *testing.T) {
 	})
 }
 
-// TestCreateRejectsExcludeTablesWithoutSelection ensures the RPC boundary
-// also considers exclude_tables: an exclude list with neither all_tables nor
-// an explicit include list has no table selection to apply to, and would
-// otherwise only fail later, after topo access, with a less clear error.
-// The vtctldclient cannot produce this request (it requires --tables or
-// --all-tables), so only raw gRPC callers and VTAdmin can hit it.
-func TestCreateRejectsExcludeTablesWithoutSelection(t *testing.T) {
+// TestCreateRejectsSelectionlessRequests ensures the RPC boundary rejects
+// requests with neither all_tables nor an explicit include list, mirroring
+// the vtctldclient validation: with an exclude list there is no selection to
+// apply it to, and with no selection at all the request would otherwise only
+// fail later, after topo access, with a less clear error. The vtctldclient
+// cannot produce these requests, so only raw gRPC callers and VTAdmin can
+// hit this.
+func TestCreateRejectsSelectionlessRequests(t *testing.T) {
 	s := &Server{}
 
-	t.Run("MoveTablesCreate", func(t *testing.T) {
+	t.Run("exclude_tables only", func(t *testing.T) {
 		_, err := s.MoveTablesCreate(t.Context(), &vtctldatapb.MoveTablesCreateRequest{
 			Workflow:       "wf1",
 			SourceKeyspace: "sourceks",
@@ -73,10 +74,8 @@ func TestCreateRejectsExcludeTablesWithoutSelection(t *testing.T) {
 			ExcludeTables:  []string{"t1"},
 		})
 		require.ErrorContains(t, err, "exclude_tables requires all_tables")
-	})
 
-	t.Run("MigrateCreate", func(t *testing.T) {
-		_, err := s.MigrateCreate(t.Context(), &vtctldatapb.MigrateCreateRequest{
+		_, err = s.MigrateCreate(t.Context(), &vtctldatapb.MigrateCreateRequest{
 			Workflow:       "wf1",
 			MountName:      "ext1",
 			SourceKeyspace: "sourceks",
@@ -84,5 +83,22 @@ func TestCreateRejectsExcludeTablesWithoutSelection(t *testing.T) {
 			ExcludeTables:  []string{"t1"},
 		})
 		require.ErrorContains(t, err, "exclude_tables requires all_tables")
+	})
+
+	t.Run("no selection at all", func(t *testing.T) {
+		_, err := s.MoveTablesCreate(t.Context(), &vtctldatapb.MoveTablesCreateRequest{
+			Workflow:       "wf1",
+			SourceKeyspace: "sourceks",
+			TargetKeyspace: "targetks",
+		})
+		require.ErrorContains(t, err, "either all_tables or an explicit list")
+
+		_, err = s.MigrateCreate(t.Context(), &vtctldatapb.MigrateCreateRequest{
+			Workflow:       "wf1",
+			MountName:      "ext1",
+			SourceKeyspace: "sourceks",
+			TargetKeyspace: "targetks",
+		})
+		require.ErrorContains(t, err, "either all_tables or an explicit list")
 	})
 }


### PR DESCRIPTION
## Description

`MoveTables`/`Migrate` `create` silently accepted `--tables` together with an effective `--all-tables=true` and resolved it without any error: the server takes the `len(tables) > 0` branch and never looks at `req.AllTables`, so `--all-tables` is silently ignored.

Because MoveTables copies/moves production data, silently picking a winner here can move an **unintended set of tables**. This PR rejects that combination in the `create` command's `PreRunE`, extracted into a small, unit-tested helper (`validateTableSelectionFlags`).

**Scope note (narrowed after review):** the issue originally also flagged `--exclude-tables` combined with an explicit `--tables` list, and an earlier revision of this PR rejected it. Review feedback pointed out the existing vreplication e2e (`testMoveTablesFlags1`) deliberately combines `--tables customer,customer2` with `--exclude-tables customer2`, so that combination is supported behavior and is intentionally **not** rejected here (see the correction comment on #20566). An explicit `--all-tables=false` alongside `--tables` is also accepted, since the check now looks at the effective value rather than whether the flag was passed.

**Update:** `Migrate create` registers its own `PreRunE` and flags (it does not share MoveTables' CLI wiring), so a second commit mirrors the same validation + unit test there. The duplication follows the existing pattern — the tables-or-all-tables check is already duplicated verbatim across both commands — but I'm happy to consolidate the helper into the `common` package if that's preferred.

**Server-side enforcement (added per review):** the invariant is now also enforced in `moveTablesCreate` at the site of the old `// FIXME validate tableSpecs, allTables, excludeTables` — `all_tables=true` with a non-empty `include_tables` returns `INVALID_ARGUMENT` using the effective request values, covering VTAdmin (which forwards a raw `MoveTablesCreateRequest`) and direct gRPC callers that bypass the CLI. Server tests cover both public RPCs (`MoveTablesCreate` and `MigrateCreate`, which share the `moveTablesCreate` path). The CLI checks remain for faster feedback.

> Note: the existing `--atomic-copy` path already rejects mixing table flags via `checkAtomicCopyOptions`; this PR covers the normal (non-atomic) path.

## Related Issue(s)

Fixes #20566

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI? — **Transparency: I was unable to build/run the Go suite locally (no Go toolchain on my dev machine; Vitess targets Linux/macOS), so I'm relying on CI. The build/test workflows are currently gated on first-time-contributor approval; happy to push fixes promptly if anything comes back red once they run.**
-   [x] Documentation was added or is not required

## Deployment Notes

Behavior change: combining an explicit table list with an effective `all_tables=true` now fails fast — in `vtctldclient MoveTables/Migrate create` with a CLI error, and at the vtctld RPC boundary (`MoveTablesCreate`/`MigrateCreate`) with `INVALID_ARGUMENT` for non-CLI callers such as VTAdmin. Tooling relying on the old lenient behavior (where `all_tables` was silently ignored) would need to drop the contradictory field. Combining `--tables` with `--exclude-tables` is unchanged and remains supported.

Separate RPC behavior change for non-CLI callers: a `MoveTablesCreate`/`MigrateCreate` request with neither `all_tables` nor a non-empty `include_tables` — with or without `exclude_tables` — now fails immediately with `INVALID_ARGUMENT`, matching the CLI validation. Previously such requests proceeded through the topology lookups and ended in `FAILED_PRECONDITION` ("no tables to move"), or surfaced an earlier topology error, so both the gRPC status code and the point of failure change for those shapes. `vtctldclient` cannot produce them — it rejects the equivalent invocations up front. The late `FAILED_PRECONDITION` remains for state-dependent cases (`all_tables` on a keyspace with no tables, or an exclusion that filters out every selected table).

### AI Disclosure

This PR was authored with the assistance of Claude Code (Claude Opus 4.8): the source changes and unit tests were drafted with AI assistance from the referenced issue analysis and reviewed by me (the author).




