### PR TITLE
vtctldclient: fail fast on missing or malformed Reshard shard flags

### DIFF
--- a/go/cmd/vtctldclient/command/vreplication/reshard/create.go
+++ b/go/cmd/vtctldclient/command/vreplication/reshard/create.go
@@ -17,6 +17,9 @@ limitations under the License.
 package reshard
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"vitess.io/vitess/go/cmd/vtctldclient/cli"
@@ -42,6 +45,9 @@ var (
 		Aliases:               []string{"Create"},
 		Args:                  cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateShardFlags(); err != nil {
+				return err
+			}
 			if err := common.ParseAndValidateCreateOptions(cmd); err != nil {
 				return err
 			}
@@ -50,6 +56,28 @@ var (
 		RunE: commandReshardCreate,
 	}
 )
+
+// validateShardFlags fails fast on missing or malformed --source-shards /
+// --target-shards values instead of sending the request to vtctld, where an
+// omission only surfaces deep in resharder setup as errors like
+// "ValidateForReshard: there are no shards to combine".
+//
+// See https://github.com/vitessio/vitess/issues/20568.
+func validateShardFlags() error {
+	if len(reshardCreateOptions.sourceShards) == 0 {
+		return errors.New("--source-shards is required")
+	}
+	if len(reshardCreateOptions.targetShards) == 0 {
+		return errors.New("--target-shards is required")
+	}
+	if err := common.ValidateShards(reshardCreateOptions.sourceShards); err != nil {
+		return fmt.Errorf("invalid --source-shards value: %w", err)
+	}
+	if err := common.ValidateShards(reshardCreateOptions.targetShards); err != nil {
+		return fmt.Errorf("invalid --target-shards value: %w", err)
+	}
+	return nil
+}
 
 func commandReshardCreate(cmd *cobra.Command, args []string) error {
 	format, err := common.GetOutputFormat(cmd)

--- a/go/cmd/vtctldclient/command/vreplication/reshard/create_test.go
+++ b/go/cmd/vtctldclient/command/vreplication/reshard/create_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reshard
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateShardFlags(t *testing.T) {
+	tests := []struct {
+		name         string
+		sourceShards []string
+		targetShards []string
+		wantErr      string
+	}{
+		{name: "unsharded to sharded", sourceShards: []string{"0"}, targetShards: []string{"-80", "80-"}},
+		{name: "sharded to sharded", sourceShards: []string{"-80", "80-"}, targetShards: []string{"-40", "40-80", "80-"}},
+		{name: "missing source shards", targetShards: []string{"-80", "80-"}, wantErr: "--source-shards is required"},
+		{name: "missing target shards", sourceShards: []string{"0"}, wantErr: "--target-shards is required"},
+		{name: "malformed source shard", sourceShards: []string{"x80-"}, targetShards: []string{"-80", "80-"}, wantErr: "invalid --source-shards value"},
+		{name: "malformed target shard", sourceShards: []string{"0"}, targetShards: []string{"80"}, wantErr: "invalid --target-shards value"},
+		{name: "empty string shard", sourceShards: []string{""}, targetShards: []string{"-80", "80-"}, wantErr: "invalid --source-shards value"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				reshardCreateOptions.sourceShards = nil
+				reshardCreateOptions.targetShards = nil
+			}()
+			reshardCreateOptions.sourceShards = tt.sourceShards
+			reshardCreateOptions.targetShards = tt.targetShards
+
+			err := validateShardFlags()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

`Reshard create` sent requests to vtctld without checking `--source-shards`/`--target-shards` at all:

- Omitting either flag only surfaced deep in resharder setup as `buildResharder: ValidateForReshard: there are no shards to combine` — which says nothing about which flag is missing.
- Malformed shard names (e.g. `x80-`) failed server-side as wrapped topo errors like `GetShard(x80-) failed: node doesn't exist`.

This PR validates both flags in the create command's `PreRunE`: both are required, and their values are checked with the existing `common.ValidateShards` — mirroring what VDiff already does for its shard flags. `common.ValidateShards` uses `key.IsValidKeyRange`, whose pattern explicitly accepts the canonical unsharded shard name `"0"` (`^(0|([0-9a-fA-F]{2})*-([0-9a-fA-F]{2})*)$`), so the documented `create --source-shards="0" --target-shards="-80,80-"` flow is unaffected.

Includes a table-driven unit test covering the valid flows (unsharded→sharded, sharded→sharded) and the failure modes (missing flags, malformed names, empty-string shard).

## Related Issue(s)

Fixes #20568

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI? — I could not run the Go suite locally (no Go toolchain on my dev machine; Vitess targets Linux/macOS), so I'm relying on CI and will fix anything that comes back red promptly.
-   [x] Documentation was added or is not required

## Deployment Notes

Behavior change: `Reshard create` invocations that omit `--source-shards`/`--target-shards` or pass malformed shard names now fail fast client-side with a specific error, instead of a server round trip that failed anyway with a less actionable message. No previously-succeeding invocation changes behavior.

### AI Disclosure

This PR was authored with the assistance of Claude Code (Claude Opus 4.8): the source change and unit test were drafted with AI assistance from the linked issue's analysis and reviewed by me (the author).
