### PR TITLE
rulesctl: add validate command for offline query-rules file checks

### DIFF
--- a/go/cmd/rulesctl/cmd/main.go
+++ b/go/cmd/rulesctl/cmd/main.go
@@ -55,6 +55,7 @@ func Main() *cobra.Command {
 	rootCmd.AddCommand(Remove())
 	rootCmd.AddCommand(Add())
 	rootCmd.AddCommand(Explain())
+	rootCmd.AddCommand(Validate())
 
 	return rootCmd
 }

--- a/go/cmd/rulesctl/cmd/testdata/invalid-rules.json
+++ b/go/cmd/rulesctl/cmd/testdata/invalid-rules.json
@@ -1,0 +1,18 @@
+[
+  {
+    "Name": "good_rule",
+    "Description": "A valid rule",
+    "Action": "FAIL"
+  },
+  {
+    "Name": "bad_plan",
+    "Description": "References a plan type that does not exist",
+    "Plans": ["NotARealPlanType"],
+    "Action": "FAIL"
+  },
+  {
+    "Name": "bad_attribute",
+    "Description": "Contains an unknown attribute",
+    "Frobnicate": true
+  }
+]

--- a/go/cmd/rulesctl/cmd/testdata/not-a-list.json
+++ b/go/cmd/rulesctl/cmd/testdata/not-a-list.json
@@ -1,0 +1,4 @@
+{
+  "Name": "single_rule_object_not_a_list",
+  "Action": "FAIL"
+}

--- a/go/cmd/rulesctl/cmd/validate.go
+++ b/go/cmd/rulesctl/cmd/validate.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/rules"
+)
+
+func Validate() *cobra.Command {
+	validateCmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate the rules in the config file without applying them",
+		Long: "Validate parses every rule in the config file using the same logic vttablet " +
+			"uses when loading it and reports all invalid rules, so it can gate CI or a " +
+			"config rollout. It exits non-zero if any rule is invalid.",
+		Args: cobra.NoArgs,
+	}
+
+	validateCmd.Run = func(cmd *cobra.Command, args []string) {
+		numRules, errs := validateRulesFile(configFile)
+		if len(errs) == 0 {
+			fmt.Printf("%d rule(s) in %q are valid\n", numRules, configFile)
+			return
+		}
+		for _, err := range errs {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+		}
+		log.Fatalf("%d of %d rule(s) in %q are invalid", len(errs), numRules, configFile)
+	}
+
+	return validateCmd
+}
+
+// validateRulesFile parses every rule in the file individually — with the
+// same BuildQueryRule logic vttablet uses when loading it — and returns all
+// per-rule errors, rather than stopping at the first one the way
+// rules.UnmarshalJSON does.
+func validateRulesFile(path string) (numRules int, errs []error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, []error{err}
+	}
+
+	var rulesInfo []map[string]any
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&rulesInfo); err != nil {
+		return 0, []error{fmt.Errorf("not a valid JSON list of rules: %v", err)}
+	}
+
+	for i, ruleInfo := range rulesInfo {
+		if _, err := rules.BuildQueryRule(ruleInfo); err != nil {
+			name := "?"
+			if n, ok := ruleInfo["Name"].(string); ok {
+				name = n
+			}
+			errs = append(errs, fmt.Errorf("rule %d (Name: %s): %v", i, name, err))
+		}
+	}
+	return len(rulesInfo), errs
+}

--- a/go/cmd/rulesctl/cmd/validate_test.go
+++ b/go/cmd/rulesctl/cmd/validate_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateCommand(t *testing.T) {
+	cmd := Validate()
+	require.NotNil(t, cmd)
+	require.Equal(t, "validate", cmd.Name())
+}
+
+func TestValidateRulesFile(t *testing.T) {
+	t.Run("valid file", func(t *testing.T) {
+		numRules, errs := validateRulesFile("./testdata/rules.json")
+		require.Empty(t, errs)
+		require.Equal(t, 1, numRules)
+	})
+
+	t.Run("invalid rules are all reported", func(t *testing.T) {
+		numRules, errs := validateRulesFile("./testdata/invalid-rules.json")
+		require.Equal(t, 3, numRules)
+		require.Len(t, errs, 2)
+		require.ErrorContains(t, errs[0], "bad_plan")
+		require.ErrorContains(t, errs[1], "bad_attribute")
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		_, errs := validateRulesFile("./testdata/does-not-exist.json")
+		require.Len(t, errs, 1)
+	})
+
+	t.Run("not a JSON list", func(t *testing.T) {
+		_, errs := validateRulesFile("./testdata/not-a-list.json")
+		require.Len(t, errs, 1)
+		require.ErrorContains(t, errs[0], "not a valid JSON list of rules")
+	})
+}


### PR DESCRIPTION
## Description

There was no way to check a vttablet custom query-rules file (`--filecustomrules` / topo custom rules) without deploying it to a live vttablet — where a single invalid rule discards the entire file (`rules.UnmarshalJSON` stops at the first `BuildQueryRule` error) and the tablet keeps serving with no file rules applied (#20522).

This PR adds a `validate` subcommand to `rulesctl`:

```
$ rulesctl -f rules.json validate
3 rule(s) in "rules.json" are valid

$ rulesctl -f broken.json validate
rule 1 (Name: bad_plan): invalid plan name: NotARealPlanType
rule 2 (Name: bad_attribute): unrecognized tag Frobnicate
2 of 3 rule(s) in "broken.json" are invalid   # exits non-zero
```

Design points:

- Parses every rule with the **same `rules.BuildQueryRule` logic vttablet uses at load time**, so validation can't drift from runtime behavior.
- Reports **all** invalid rules (index + Name + reason) rather than stopping at the first, unlike `rules.UnmarshalJSON` — so one pass surfaces every problem in the file.
- Exits non-zero on any invalid rule (via `log.Fatalf`, consistent with the other `rulesctl` commands), so it can gate CI or a config rollout.

Includes unit tests (valid file, multiple invalid rules all reported, missing file, non-list JSON) plus new `testdata` fixtures, following the existing per-command test layout in `go/cmd/rulesctl/cmd`.

## Related Issue(s)

Fixes #20570
Related: #20522 (fail-open startup semantics — this command gives operators a preflight check regardless of which startup semantics are chosen there)

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI? — I could not run the Go suite locally (no Go toolchain on my dev machine; Vitess targets Linux/macOS), so I'm relying on CI and will fix anything that comes back red promptly.
-   [x] Documentation was added or is not required

## Deployment Notes

Purely additive: a new `rulesctl` subcommand. No existing behavior changes.

### AI Disclosure

This PR was authored with the assistance of Claude Code (Claude Opus 4.8): the source change and unit tests were drafted with AI assistance from the linked issue's analysis and reviewed by me (the author).
