### PR TITLE
vtgate: fix data race on SafeSession.LastInsertId in wrapCallback

### DIFF
--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -798,7 +798,7 @@ func (vc *VCursorImpl) wrapCallback(callback func(*sqltypes.Result) error, primi
 	if vc.interOpStats == nil {
 		return func(r *sqltypes.Result) error {
 			if r.InsertIDUpdated() {
-				vc.SafeSession.LastInsertId = r.InsertID
+				vc.SetLastInsertID(r.InsertID)
 			}
 			return callback(r)
 		}
@@ -806,7 +806,7 @@ func (vc *VCursorImpl) wrapCallback(callback func(*sqltypes.Result) error, primi
 
 	return func(r *sqltypes.Result) error {
 		if r.InsertIDUpdated() {
-			vc.SafeSession.LastInsertId = r.InsertID
+			vc.SetLastInsertID(r.InsertID)
 		}
 		vc.logOpTraffic(primitive, r)
 		return callback(r)

--- a/go/vt/vtgate/executorcontext/vcursor_impl_test.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -623,4 +624,29 @@ func TestGetQueryPriority(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestWrapCallbackLastInsertIDRace verifies that concurrent callbacks through
+// wrapCallback do not race on SafeSession.LastInsertId (see GitHub #20487).
+// Run with -race to detect the race on unpatched code.
+func TestWrapCallbackLastInsertIDRace(t *testing.T) {
+	const goroutines = 32
+	vc := &VCursorImpl{
+		SafeSession: NewSafeSession(&vtgatepb.Session{}),
+	}
+	cb := vc.wrapCallback(func(r *sqltypes.Result) error { return nil }, nil)
+
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		wg.Add(1)
+		go func(id uint64) {
+			defer wg.Done()
+			result := &sqltypes.Result{InsertID: id, InsertIDChanged: true}
+			_ = cb(result)
+		}(uint64(i + 1))
+	}
+	wg.Wait()
+
+	// Last-writer wins; the important guarantee is no data race, not a specific value.
+	require.NotZero(t, vc.SafeSession.GetLastInsertId())
 }


### PR DESCRIPTION
## Summary

Fixes #20487.

`wrapCallback` is called in concurrent contexts — `StreamExecuteMulti` fans out one goroutine per shard, and `Concatenate.parallelStreamExec` runs multiple sources in parallel. Both closure paths wrote to `SafeSession.LastInsertId` directly, bypassing the `mu` mutex that `SetLastInsertID` already acquires.

**Root cause:** two sites in `wrapCallback` (`vcursor_impl.go`):
```go
// both paths had this unsynchronised write:
vc.SafeSession.LastInsertId = r.InsertID
```

**Fix:** route both writes through the existing locked setter:
```go
vc.SetLastInsertID(r.InsertID)
```

The other direct write sites (lines 750, 901, 943) are on sequential single-goroutine paths and are not racing.

## Test

Added `TestWrapCallbackLastInsertIDRace` which fires 32 concurrent callbacks with `InsertIDUpdated()` results against one `VCursorImpl`. Passes cleanly under `go test -race`. Without the fix, the race detector reports concurrent writes to `SafeSession.LastInsertId`.

Created with: Claude Code