### PR TITLE
vtctldclient: send MoveTables global-keyspace warning to stderr

### DIFF
--- a/go/cmd/vtctldclient/command/vreplication/movetables/create.go
+++ b/go/cmd/vtctldclient/command/vreplication/movetables/create.go
@@ -101,7 +101,9 @@ var (
 			}
 			createOptions.WorkflowOptions.ShardedAutoIncrementHandling = vtctldatapb.ShardedAutoIncrementHandling(val)
 			if val == int32(vtctldatapb.ShardedAutoIncrementHandling_REPLACE) && createOptions.WorkflowOptions.GlobalKeyspace == "" {
-				fmt.Println("WARNING: no global-keyspace value provided so all sequence table references not fully qualified must be created manually before switching traffic")
+				// This is a diagnostic, not command output: it must go to stderr so
+				// that stdout stays parseable (e.g. for --format=json consumers).
+				fmt.Fprintln(cmd.ErrOrStderr(), "WARNING: no global-keyspace value provided so all sequence table references not fully qualified must be created manually before switching traffic")
 			}
 
 			return nil


### PR DESCRIPTION
## Description

`MoveTables create` printed its global-keyspace WARNING to stdout from `PreRunE`. Since stdout is where vtctldclient writes parseable command output (including `--format=json`), any invocation using `--sharded-auto-increment-handling=REPLACE` without `--global-keyspace` prepended a plain-text line to the JSON document and broke consumers like `jq`.

One-line fix: send the diagnostic to stderr via `fmt.Fprintln(cmd.ErrOrStderr(), ...)`, keeping stdout clean for output. I checked the other `WARNING` occurrences under `go/cmd/vtctldclient/` — the rest are flag help text, so this was the only runtime print to the wrong stream.

Note: this is independent of #20567, which touches different hunks of the same file; whichever lands second rebases trivially.

## Related Issue(s)

Fixes #20574

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required — one-line output-stream redirection; no behavior logic changed
-   [x] Did the new or modified tests pass consistently locally and on CI? — no Go toolchain on my dev machine (Vitess targets Linux/macOS); relying on CI
-   [x] Documentation was added or is not required

## Deployment Notes

The WARNING moves from stdout to stderr. Anything that (incorrectly) scraped the warning from stdout would need to read stderr instead; JSON consumers of stdout stop breaking.

### AI Disclosure

This PR was authored with the assistance of Claude Code (Claude Opus 4.8) and reviewed by me (the author).
