### PR TITLE
rulesctl: exit non-zero when a command fails

### DIFF
--- a/go/cmd/rulesctl/main.go
+++ b/go/cmd/rulesctl/main.go
@@ -35,6 +35,6 @@ func main() {
 	acl.RegisterFlags(rootCmd.PersistentFlags())
 	servenv.RegisterMySQLServerFlags(rootCmd.PersistentFlags())
 	if err := rootCmd.Execute(); err != nil {
-		log.Printf("%v", err)
+		log.Fatalf("%v", err)
 	}
 }


### PR DESCRIPTION
## Description

`rulesctl` exited with status 0 when `rootCmd.Execute()` returned an error — an unknown subcommand or a bad flag was logged and then `main` returned normally. Scripts and CI consuming the exit code saw success on failure.

One-line fix: `log.Printf` → `log.Fatalf` in `main()`, so cobra-level errors exit 1 like every other failure path in the tool (subcommand `Run` functions already use `log.Fatalf`).

## Related Issue(s)

Fixes #20575

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required — one-line exit-status change in main(); not practically unit-testable
-   [x] Did the new or modified tests pass consistently locally and on CI? — no Go toolchain on my dev machine (Vitess targets Linux/macOS); relying on CI
-   [x] Documentation was added or is not required

## Deployment Notes

Behavior change: `rulesctl` invocations that fail at the command-parsing level now exit 1 instead of 0. Anything relying on the erroneous 0 exit would need updating — which is precisely the point of the fix.

### AI Disclosure

This PR was authored with the assistance of Claude Code (Claude Opus 4.8) and reviewed by me (the author).
