### PR TITLE
grpcvtgateconn: stop mutating shared dial options slice

### DIFF
--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -87,9 +87,14 @@ func Dial(opts ...grpc.DialOption) vtgateconn.DialerFunc {
 			return nil, err
 		}
 
-		opts = append(opts, opt)
+		// This dialer is shared and invoked concurrently for every new
+		// connection, so the captured opts must not be mutated: appending to
+		// it grows the slice on every dial and races between goroutines.
+		allOpts := make([]grpc.DialOption, 0, len(opts)+1)
+		allOpts = append(allOpts, opts...)
+		allOpts = append(allOpts, opt)
 
-		cc, err := grpcclient.DialContext(ctx, address, grpcclient.FailFast(failFast), opts...)
+		cc, err := grpcclient.DialContext(ctx, address, grpcclient.FailFast(failFast), allOpts...)
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/vtgate/grpcvtgateconn/conn_test.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpcvtgateconn
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// TestDialDoesNotAccumulateOpts ensures the dialer returned by Dial does not
+// append to the caller-provided options slice. The dialer is registered once
+// and invoked for every new connection, so appending to the captured slice
+// grows it by one option per dial and mutates the caller's backing array.
+// See https://github.com/vitessio/vitess/issues/12068.
+func TestDialDoesNotAccumulateOpts(t *testing.T) {
+	// Extra capacity so a buggy append to the captured slice writes into
+	// the caller's backing array instead of reallocating.
+	callerOpts := make([]grpc.DialOption, 1, 8)
+	callerOpts[0] = grpc.WithUserAgent("grpcvtgateconn-test")
+
+	dialer := Dial(callerOpts...)
+	for range 3 {
+		conn, err := dialer(t.Context(), "localhost:0")
+		require.NoError(t, err)
+		conn.Close()
+	}
+
+	for i, opt := range callerOpts[len(callerOpts):cap(callerOpts)] {
+		assert.Nil(t, opt, "dialer mutated the caller's options slice at index %d", len(callerOpts)+i)
+	}
+}
+
+// TestDialConcurrent ensures concurrent invocations of a shared dialer do not
+// race on the captured options slice. database/sql dials new pool connections
+// from multiple goroutines; a race here tears dial option interface values
+// and panics inside grpc when they are applied.
+// See https://github.com/vitessio/vitess/issues/12067.
+func TestDialConcurrent(t *testing.T) {
+	dialer := Dial(grpc.WithUserAgent("grpcvtgateconn-test"))
+
+	// Each goroutine writes its own index, so no synchronization is needed;
+	// require lives in the test goroutine after Wait, where FailNow is valid.
+	const n = 10
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Go(func() {
+			conn, err := dialer(t.Context(), "localhost:0")
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			conn.Close()
+		})
+	}
+	wg.Wait()
+
+	for _, err := range errs {
+		require.NoError(t, err)
+	}
+}


### PR DESCRIPTION
## Description

The dialer closure returned by `grpcvtgateconn.Dial()` captured the caller-provided `opts` slice and did `opts = append(opts, opt)` on **every** invocation. Since `vitessdriver.OpenWithConfiguration` registers this dialer once and `database/sql` invokes it for every new pool connection, the same slice ends up shared across all dials and all goroutines. That single line is the root cause of two long-standing issues:

- **Resource consumption (#12068):** each dial appends another `SecureDialOption` to the shared slice and never removes it, so dial N re-applies N accumulated options. This is why `grpc.(*funcDialOption).apply` dominated CPU profiles, `DialContext` allocated terabytes over time, and a process restart temporarily "fixed" it. It only bites users who pass `GRPCDialOptions`, which is why it wasn't universally noticed.
- **Panics (#12067):** concurrent pool dials race on the `append`, tearing an interface value so its type word says `*funcDialOption` while its data pointer is nil. gRPC then segfaults dereferencing it in `(*funcDialOption).apply` — exactly the panic frame we've been seeing hundreds of times per day for years.

The fix builds a fresh slice per invocation, leaving the captured `opts` read-only. Option ordering and precedence are unchanged, and `DialWithOpts` delegates to `Dial` so it's covered too.

I think this is a good backport candidate — it's a small, self-contained correctness fix for a bug that's been present for many major versions.

## Related Issue(s)

Fixes #12067
Fixes #12068

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

No config or behavioral changes for existing callers. Users passing custom `GRPCDialOptions` through the Go driver will see dial CPU/allocation drop back to baseline and the intermittent dial-option panic go away.

Two new tests, both verified to fail on the current code:
- `TestDialDoesNotAccumulateOpts` — asserts the caller's backing array is never written past its length (catches the accumulation).
- `TestDialConcurrent` — runs concurrent dials under `-race` (catches the data race).

### AI Disclosure

This PR was written primarily by Claude Code (Fable 5) — I provided direction, the root-cause context from our production profiles/Sentry, and review.
