### PR TITLE
Backport #20410: vtadmin: fix tab navigation URL corruption in splat routes

### DIFF
--- a/web/vtadmin/src/components/routes/keyspace/Keyspace.test.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/Keyspace.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2026 The Vitess Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, it, expect } from 'vitest';
+
+import { Keyspace } from './Keyspace';
+
+const renderHelper = (entries: string[]) => {
+    const queryClient = new QueryClient();
+
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter initialEntries={entries}>
+                <Routes>
+                    <Route path="/keyspace/:clusterID/:name/*" element={<Keyspace />} />
+                    <Route path="*" element={<div>no match</div>} />
+                </Routes>
+            </MemoryRouter>
+        </QueryClientProvider>
+    );
+};
+
+describe('Keyspace tab navigation', () => {
+    it('tab links use absolute paths and do not append to the current splat URL', () => {
+        renderHelper(['/keyspace/iad/aux1/shards']);
+
+        const tabs = screen.getAllByRole('tab');
+        const hrefs = tabs.map((tab) => tab.getAttribute('href'));
+
+        expect(hrefs).toContain('/keyspace/iad/aux1/shards');
+        expect(hrefs).toContain('/keyspace/iad/aux1/vschema');
+        expect(hrefs).toContain('/keyspace/iad/aux1/json');
+        expect(hrefs).toContain('/keyspace/iad/aux1/json_tree');
+
+        // Ensure no tab link contains a doubled path segment (the regression pattern)
+        hrefs.forEach((href) => {
+            expect(href).not.toMatch(/\/shards\/vschema/);
+            expect(href).not.toMatch(/\/shards\/json/);
+            expect(href).not.toMatch(/\/shards\/shards/);
+        });
+    });
+});

--- a/web/vtadmin/src/components/routes/keyspace/Keyspace.tsx
+++ b/web/vtadmin/src/components/routes/keyspace/Keyspace.tsx
@@ -90,13 +90,13 @@ export const Keyspace = () => {
 
             <ContentContainer>
                 <TabContainer>
-                    <Tab text="Shards" to="shards" />
-                    <Tab text="VSchema" to="vschema" />
-                    <Tab text="JSON" to="json" />
-                    <Tab text="JSON Tree" to="json_tree" />
+                    <Tab text="Shards" to={`/keyspace/${clusterID}/${name}/shards`} />
+                    <Tab text="VSchema" to={`/keyspace/${clusterID}/${name}/vschema`} />
+                    <Tab text="JSON" to={`/keyspace/${clusterID}/${name}/json`} />
+                    <Tab text="JSON Tree" to={`/keyspace/${clusterID}/${name}/json_tree`} />
 
                     <ReadOnlyGate>
-                        <Tab text="Advanced" to="advanced" />
+                        <Tab text="Advanced" to={`/keyspace/${clusterID}/${name}/advanced`} />
                     </ReadOnlyGate>
                 </TabContainer>
 

--- a/web/vtadmin/src/components/routes/shard/Shard.tsx
+++ b/web/vtadmin/src/components/routes/shard/Shard.tsx
@@ -111,10 +111,22 @@ export const Shard = () => {
 
             <ContentContainer>
                 <TabContainer>
-                    <Tab text="Tablets" to="tablets" />
-                    <Tab text="JSON" to="json" />
-                    <Tab text="JSON Tree" to="json_tree" />
-                    <Tab text="Advanced" to="advanced" />
+                    <Tab
+                        text="Tablets"
+                        to={`/keyspace/${params.clusterID}/${params.keyspace}/shard/${params.shard}/tablets`}
+                    />
+                    <Tab
+                        text="JSON"
+                        to={`/keyspace/${params.clusterID}/${params.keyspace}/shard/${params.shard}/json`}
+                    />
+                    <Tab
+                        text="JSON Tree"
+                        to={`/keyspace/${params.clusterID}/${params.keyspace}/shard/${params.shard}/json_tree`}
+                    />
+                    <Tab
+                        text="Advanced"
+                        to={`/keyspace/${params.clusterID}/${params.keyspace}/shard/${params.shard}/advanced`}
+                    />
                 </TabContainer>
 
                 <Routes>

--- a/web/vtadmin/src/components/routes/stream/Stream.tsx
+++ b/web/vtadmin/src/components/routes/stream/Stream.tsx
@@ -76,8 +76,14 @@ export const Stream = () => {
             </WorkspaceHeader>
             <ContentContainer>
                 <TabContainer>
-                    <Tab text="JSON" to="json" />
-                    <Tab text="JSON Tree" to="json_tree" />
+                    <Tab
+                        text="JSON"
+                        to={`/workflow/${params.clusterID}/${params.keyspace}/${params.workflowName}/stream/${params.tabletCell}/${params.tabletUID}/${params.streamID}/json`}
+                    />
+                    <Tab
+                        text="JSON Tree"
+                        to={`/workflow/${params.clusterID}/${params.keyspace}/${params.workflowName}/stream/${params.tabletCell}/${params.tabletUID}/${params.streamID}/json_tree`}
+                    />
                 </TabContainer>
 
                 <Routes>

--- a/web/vtadmin/src/components/routes/tablet/Tablet.tsx
+++ b/web/vtadmin/src/components/routes/tablet/Tablet.tsx
@@ -104,12 +104,12 @@ export const Tablet = () => {
 
             <ContentContainer>
                 <TabContainer>
-                    <Tab text="QPS" to="qps" />
-                    <Tab text="Full Status" to="full-status" />
-                    <Tab text="JSON" to="json" />
-                    <Tab text="JSON Tree" to="json_tree" />
+                    <Tab text="QPS" to={`/tablet/${clusterID}/${alias}/qps`} />
+                    <Tab text="Full Status" to={`/tablet/${clusterID}/${alias}/full-status`} />
+                    <Tab text="JSON" to={`/tablet/${clusterID}/${alias}/json`} />
+                    <Tab text="JSON Tree" to={`/tablet/${clusterID}/${alias}/json_tree`} />
                     <ReadOnlyGate>
-                        <Tab text="Advanced" to="advanced" />
+                        <Tab text="Advanced" to={`/tablet/${clusterID}/${alias}/advanced`} />
                     </ReadOnlyGate>
                 </TabContainer>
 

--- a/web/vtadmin/src/components/routes/workflow/Workflow.tsx
+++ b/web/vtadmin/src/components/routes/workflow/Workflow.tsx
@@ -164,11 +164,15 @@ export const Workflow = () => {
 
             <ContentContainer>
                 <TabContainer>
-                    <Tab text="Streams" to="streams" count={streams.length} />
-                    <Tab text="Details" to="details" />
-                    <Tab text="VDiff" to="vdiff" />
-                    <Tab text="JSON" to="json" />
-                    <Tab text="JSON Tree" to="json_tree" />
+                    <Tab
+                        text="Streams"
+                        to={`/workflow/${clusterID}/${keyspace}/${name}/streams`}
+                        count={streams.length}
+                    />
+                    <Tab text="Details" to={`/workflow/${clusterID}/${keyspace}/${name}/details`} />
+                    <Tab text="VDiff" to={`/workflow/${clusterID}/${keyspace}/${name}/vdiff`} />
+                    <Tab text="JSON" to={`/workflow/${clusterID}/${keyspace}/${name}/json`} />
+                    <Tab text="JSON Tree" to={`/workflow/${clusterID}/${keyspace}/${name}/json_tree`} />
                 </TabContainer>
 
                 <Routes>


### PR DESCRIPTION
## Description

Cherry-pick of #20410 onto `release-24.0`.

The offending PR that introduced the bug was part of v24, so this fix needs to be backported.

## Original PR

https://github.com/vitessio/vitess/pull/20410

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>