### PR TITLE
endtoend: run the utils package in CI and fix its broken tests

### DIFF
--- a/go/test/endtoend/utils/mysql.go
+++ b/go/test/endtoend/utils/mysql.go
@@ -75,6 +75,9 @@ func CreateMysqldAndMycnf(tabletUID uint32, mysqlSocket string, mysqlPort int) (
 	var cfg dbconfigs.DBConfigs
 	// ensure the DBA username is 'root' instead of the system's default username so that mysqladmin can shutdown
 	cfg.Dba.User = "root"
+	// use the replication user created by createInitSQLFile: replicating with an
+	// empty username makes the IO thread fail on MySQL 8.0.24+
+	cfg.Repl.User = "vt_repl"
 	cfg.InitWithSocket(mycnf.SocketFile, collations.MySQL8())
 	return mysqlctl.NewMysqld(&cfg), mycnf, nil
 }
@@ -139,6 +142,11 @@ func createInitSQLFile(mysqlDir, ksName string) (string, error) {
 		return "", err
 	}
 	_, err = fmt.Fprintf(f, "CREATE DATABASE IF NOT EXISTS %s;", ksName)
+	if err != nil {
+		return "", err
+	}
+	// create the replication user the same way config/init_db.sql does
+	_, err = f.WriteString("CREATE USER 'vt_repl'@'%';GRANT REPLICATION SLAVE ON *.* TO 'vt_repl'@'%';")
 	if err != nil {
 		return "", err
 	}

--- a/go/test/endtoend/utils/mysql_test.go
+++ b/go/test/endtoend/utils/mysql_test.go
@@ -29,6 +29,7 @@ import (
 
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/replication"
+	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -112,10 +113,55 @@ func TestCreateMySQL(t *testing.T) {
 	ctx := t.Context()
 	conn, err := mysql.Connect(ctx, &mysqlParams)
 	require.NoError(t, err)
-	AssertMatches(t, conn, "show databases;", `[[VARCHAR("information_schema")] [VARCHAR("ks")] [VARCHAR("mysql")] [VARCHAR("performance_schema")] [VARCHAR("sys")]]`)
-	AssertMatches(t, conn, "show tables;", `[[VARCHAR("t1")]]`)
+	// Compare row values rather than the rendered field types: MySQL reports
+	// the SHOW columns as binary strings when lower_case_table_names=0 (the
+	// Linux default) and as non-binary otherwise, so the type is not portable.
+	assert.Equal(t, []string{"information_schema", "ks", "mysql", "performance_schema", "sys"}, rowStrings(t, Exec(t, conn, "show databases")))
+	assert.Equal(t, []string{"t1"}, rowStrings(t, Exec(t, conn, "show tables")))
 	Exec(t, conn, "insert into t1(id1, id2, id3) values (1, 1, 1), (2, 2, 2), (3, 3, 3)")
 	AssertMatches(t, conn, "select * from t1;", `[[INT64(1) INT64(1) INT64(1)] [INT64(2) INT64(2) INT64(2)] [INT64(3) INT64(3) INT64(3)]]`)
+}
+
+// rowStrings flattens a single-column result into its string values.
+func rowStrings(t *testing.T, qr *sqltypes.Result) []string {
+	t.Helper()
+	rows := make([]string, 0, len(qr.Rows))
+	for _, row := range qr.Rows {
+		require.Len(t, row, 1)
+		rows = append(rows, row[0].ToString())
+	}
+	return rows
+}
+
+// newReplicationSource starts a second mysqld that the shared test mysqld can
+// replicate from, and returns its port. Replicating from the shared mysqld
+// itself can never reach a running state: the IO thread stops because source
+// and replica would have equal server ids.
+//
+// The source's binlog and GTID history are cleared so that an auto-positioned
+// replica does not replay the source's own initialization (database and user
+// creation), which would conflict with the replica's local state.
+func newReplicationSource(t *testing.T) int32 {
+	t.Helper()
+
+	port := clusterInstance.GetAndReservePort()
+	_, sourceMysqld, _, closer, err := NewMySQLWithMysqld(port, clusterInstance.Hostname, "sourceks")
+	require.NoError(t, err)
+	t.Cleanup(closer)
+
+	// Detach the shared mysqld and restore a clean replication state for the
+	// tests that follow. Registered after closer so that it runs before the
+	// source is torn down. t.Context() is already canceled by the time cleanup
+	// runs, so use a fresh context.
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		assert.NoError(t, mysqld.ResetReplication(ctx))
+	})
+
+	err = sourceMysqld.ResetReplication(t.Context())
+	require.NoError(t, err)
+	return int32(port)
 }
 
 func TestSetSuperReadOnlyMySQL(t *testing.T) {
@@ -455,45 +501,46 @@ func TestSemiSyncEnabled(t *testing.T) {
 func TestWaitForReplicationStart(t *testing.T) {
 	require.NotNil(t, mysqld)
 
-	err := mysqlctl.WaitForReplicationStart(t.Context(), mysqld, 1)
-	require.ErrorContains(t, err, "no replication status")
-
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer cancel()
-	port, err := mysqld.GetMysqlPort(ctx)
-	require.NoError(t, err)
-	host := "localhost"
-
-	err = mysqld.SetReplicationSource(t.Context(), host, port, 0, true, true)
+	// Start from a clean state so the assertions below do not depend on what
+	// previous tests left behind.
+	err := mysqld.ResetReplication(t.Context())
 	require.NoError(t, err)
 
 	err = mysqlctl.WaitForReplicationStart(t.Context(), mysqld, 1)
+	require.ErrorContains(t, err, "no replication status")
+
+	sourcePort := newReplicationSource(t)
+
+	err = mysqld.SetReplicationSource(t.Context(), "localhost", sourcePort, 0, true, true)
 	require.NoError(t, err)
 
-	err = mysqld.ResetReplication(t.Context())
+	err = mysqlctl.WaitForReplicationStart(t.Context(), mysqld, 30)
 	require.NoError(t, err)
 }
 
 func TestStartReplication(t *testing.T) {
 	require.NotNil(t, mysqld)
 
-	err := mysqld.StartReplication(t.Context(), map[string]string{})
+	// Start from a clean state so the assertions below do not depend on what
+	// previous tests left behind.
+	err := mysqld.ResetReplication(t.Context())
+	require.NoError(t, err)
+
+	err = mysqld.StartReplication(t.Context(), map[string]string{})
 	require.ErrorContains(t, err, "The server is not configured as replica")
 
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer cancel()
-	port, err := mysqld.GetMysqlPort(ctx)
-	require.NoError(t, err)
-	host := "localhost"
+	sourcePort := newReplicationSource(t)
 
 	// Set startReplicationAfter to false as we want to test StartReplication here
-	err = mysqld.SetReplicationSource(t.Context(), host, port, 0, true, false)
+	err = mysqld.SetReplicationSource(t.Context(), "localhost", sourcePort, 0, true, false)
 	require.NoError(t, err)
 
 	err = mysqld.StartReplication(t.Context(), map[string]string{})
 	require.NoError(t, err)
 
-	err = mysqld.ResetReplication(t.Context())
+	// Replication actually reaches a running state, not just a successful
+	// START REPLICA.
+	err = mysqlctl.WaitForReplicationStart(t.Context(), mysqld, 30)
 	require.NoError(t, err)
 }
 

--- a/go/test/endtoend/utils/mysql_test.go
+++ b/go/test/endtoend/utils/mysql_test.go
@@ -542,6 +542,12 @@ func TestStartReplication(t *testing.T) {
 	// START REPLICA.
 	err = mysqlctl.WaitForReplicationStart(t.Context(), mysqld, 30)
 	require.NoError(t, err)
+
+	// WaitForReplicationStart also returns nil when the threads are stopped
+	// without a recorded error, so check the running state directly.
+	status, err := mysqld.ReplicationStatus(t.Context())
+	require.NoError(t, err)
+	assert.True(t, status.Running(), "replication should be running, got IO state %v and SQL state %v", status.IOState, status.SQLState)
 }
 
 func TestStopReplication(t *testing.T) {

--- a/test/config.json
+++ b/test/config.json
@@ -1180,6 +1180,18 @@
       "Tags": [],
       "Needs": []
     },
+    "mysql_utils": {
+      "File": "unused.go",
+      "Packages": [
+        "vitess.io/vitess/go/test/endtoend/utils"
+      ],
+      "Args": [],
+      "Command": [],
+      "Manual": false,
+      "Shard": "vtgate_queries",
+      "Tags": [],
+      "Needs": []
+    },
     "vtgate_kill": {
       "File": "unused.go",
       "Packages": [


### PR DESCRIPTION
## Description

The tests in `go/test/endtoend/utils` were never registered in `test/config.json`, so nothing in CI ever ran them, and three of them silently broke over time. This registers the package in the `vtgate_queries` shard and fixes those three tests.

What was broken:

- `TestCreateMySQL` expects VARCHAR field types from `show databases` and `show tables`, but MySQL flags those SHOW columns as binary strings when `lower_case_table_names=0`, the Linux default, so on CI they render as VARBINARY. The expectations only held on macOS, where the default is 2.
- `TestWaitForReplicationStart` and `TestStartReplication` replicate the test mysqld from itself with an empty replication username. MySQL 8.0.24+ fast-fails the IO thread with "Invalid (empty) username", and even with valid credentials self-replication can never reach a running state because source and replica have equal server ids.

How it's fixed:

- `TestCreateMySQL` compares row values instead of rendered field types.
- The test harness now creates a `vt_repl` user the same way `config/init_db.sql` does and uses it as the replication user.
- The two replication tests replicate from a second mysqld, and they reset replication state up front and on cleanup so they no longer depend on test order.

Verified by running the full package against MySQL 8.4 on Linux in the `vitess/bootstrap` image, all 20 tests pass.

Split out of #20285.

## Related Issue(s)

- #20261

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

N/A, test-only change.

### AI Disclosure

This PR was written primarily by Claude Code, with human direction and review.