### PR TITLE
`resolve-backport` skill: create worktree in-repo so commands match pre-approved permissions

### DIFF
--- a/.agents/skills/resolve-backport/SKILL.md
+++ b/.agents/skills/resolve-backport/SKILL.md
@@ -49,12 +49,16 @@ Follow these steps precisely to resolve merge conflicts in a Vitess backport PR.
   ```
   gh pr view <upstream-number> --repo vitessio/vitess --json files
   ```
-- Check out the backport branch in a worktree to isolate the work from the main checkout:
+- Check out the backport branch in a worktree to isolate the work from the main checkout. Create it under `.claude/worktrees/` (already gitignored) so it stays inside the allowed working directory:
   ```
   git fetch origin <headRefName>
-  git worktree add /tmp/backport-<number> origin/<headRefName>
-  cd /tmp/backport-<number>
+  git worktree add .claude/worktrees/backport-<number> origin/<headRefName>
   ```
+- Then `cd` into the worktree **once, as its own standalone command**:
+  ```
+  cd .claude/worktrees/backport-<number>
+  ```
+  The shell working directory persists between commands, so all subsequent commands (git, go test, make, etc.) must be run plain from the worktree — **never prepend `cd <dir> && ...` to a command**. Compound `cd` prefixes don't match pre-approved permission rules and force a permission prompt on every command.
 
 ## Step 3: Rebase onto latest base branch
 
@@ -191,10 +195,10 @@ The backport branch may be based on a stale version of the release branch. **Alw
     ```
     gh pr merge <number> --repo vitessio/vitess --squash --auto
     ```
-- If we created a git worktree in Step 2, clean it up:
+- If we created a git worktree in Step 2, clean it up. First `cd` back to the main repo root as its own standalone command, then remove the worktree:
   ```
-  cd <original-directory>
-  git worktree remove <worktree-path>
+  cd <main-repo-root>
+  git worktree remove .claude/worktrees/backport-<number>
   ```
 
 ## Handling CI failures


### PR DESCRIPTION
## Description

This PR fixes a permissions annoyance in the `resolve-backport` agent skill. The skill creates its backport worktree at `/tmp/backport-<number>`, which is outside the agent's allowed working directory; this causes the agent to prepend `cd /tmp/backport-<number> && ...` to nearly every command, and those compound commands never match pre-approved `Bash` permission rules, so every step of the skill triggers a permission prompt

The worktree is now created at `.claude/worktrees/backport-<number>` _(already gitignored)_, the skill `cd`s into it once as a standalone command, and it now states explicitly that the shell working directory persists between commands so `cd <dir> && ...` prefixes must never be prepended. The Step 10 cleanup mirrors the same pattern

## Related Issue(s)

Related: https://github.com/vitessio/vitess/pull/19639

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

### AI Disclosure

This PR was written primarily by Claude Code, including this summary
