### PR TITLE
`mysqlctl`: don't fail backups when a clean mysqld shutdown outlives the shutdown timeouts

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -256,7 +256,7 @@ See [#20167](https://github.com/vitessio/vitess/pull/20167) for details.
 
 #### <a id="backup-mysqld-shutdown-timeout"/>Slow clean mysqld shutdowns no longer fail backups</a>
 
-The builtin backup engine's shutdown deadline (`--builtinbackup-mysqld-timeout`) is now raised to the backup request's mysqld shutdown timeout (e.g. vtbackup's `--mysql-shutdown-timeout`) plus a 30 second grace period whenever that is larger, so the two settings can no longer silently conflict.
+The builtin backup engine's shutdown deadline (`--builtinbackup-mysqld-timeout`) is now raised to the backup request's mysqld shutdown timeout (e.g. vtbackup's `--mysql-shutdown-timeout`) plus a 30 second grace period whenever that is larger, so the two settings can no longer silently conflict. The same grace period now pads the shutdown contexts of `mysqlctl`, `mysqlctld` and `vtbackup`, which moves `mysqlctld`'s derived `--onterm-timeout` default from `5m10s` to `5m30s`.
 
 In addition, when `mysqladmin` gives up waiting for mysqld to stop, the shutdown is no longer failed immediately: the `SHUTDOWN` command has already been delivered at that point, so Vitess keeps waiting on the pid/socket files until the caller's deadline expires (or for a 30 second grace period, when the caller has no deadline). Slow-but-clean shutdowns, such as upgrade-safe backups running with `innodb_fast_shutdown=0` on large databases, previously failed with `Aborted waiting on pid file` even though mysqld was stopping normally.
 

--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -30,6 +30,7 @@
         - [Skip MySQL version check when restoring from a mysql-shell backup](#vttablet-mysql-shell-restore-skip-version-check)
     - **[Backup/Restore](#minor-changes-backup)**
         - [Chunked backup/restore for the builtinbackupengine](#backup-chunked-builtin)
+        - [Slow clean mysqld shutdowns no longer fail backups](#backup-mysqld-shutdown-timeout)
     - **[General](#minor-changes-general)**
         - [Build version metadata now sourced from VCS stamping](#build-info-from-vcs)
 
@@ -252,6 +253,12 @@ Two new flags control chunking behavior:
 **Compatibility note:** Backups created with chunking enabled are **not restorable by older Vitess versions** that do not understand the `Chunks` field in the backup MANIFEST. Non-chunked backups (the default) remain fully compatible with older versions.
 
 See [#20167](https://github.com/vitessio/vitess/pull/20167) for details.
+
+#### <a id="backup-mysqld-shutdown-timeout"/>Slow clean mysqld shutdowns no longer fail backups</a>
+
+The builtin backup engine's shutdown deadline (`--builtinbackup-mysqld-timeout`) is now raised to the backup request's mysqld shutdown timeout (e.g. vtbackup's `--mysql-shutdown-timeout`) plus a 30 second grace period whenever that is larger, so the two settings can no longer silently conflict.
+
+In addition, when `mysqladmin` gives up waiting for mysqld to stop, the shutdown is no longer failed immediately: the `SHUTDOWN` command has already been delivered at that point, so Vitess keeps waiting on the pid/socket files for the remaining deadline plus the grace period. Slow-but-clean shutdowns, such as upgrade-safe backups running with `innodb_fast_shutdown=0` on large databases, previously failed with `Aborted waiting on pid file` even though mysqld was stopping normally.
 
 ### <a id="minor-changes-general"/>General</a>
 

--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -258,7 +258,7 @@ See [#20167](https://github.com/vitessio/vitess/pull/20167) for details.
 
 The builtin backup engine's shutdown deadline (`--builtinbackup-mysqld-timeout`) is now raised to the backup request's mysqld shutdown timeout (e.g. vtbackup's `--mysql-shutdown-timeout`) plus a 30 second grace period whenever that is larger, so the two settings can no longer silently conflict.
 
-In addition, when `mysqladmin` gives up waiting for mysqld to stop, the shutdown is no longer failed immediately: the `SHUTDOWN` command has already been delivered at that point, so Vitess keeps waiting on the pid/socket files for the remaining deadline plus the grace period. Slow-but-clean shutdowns, such as upgrade-safe backups running with `innodb_fast_shutdown=0` on large databases, previously failed with `Aborted waiting on pid file` even though mysqld was stopping normally.
+In addition, when `mysqladmin` gives up waiting for mysqld to stop, the shutdown is no longer failed immediately: the `SHUTDOWN` command has already been delivered at that point, so Vitess keeps waiting on the pid/socket files until the caller's deadline expires (or for a 30 second grace period, when the caller has no deadline). Slow-but-clean shutdowns, such as upgrade-safe backups running with `innodb_fast_shutdown=0` on large databases, previously failed with `Aborted waiting on pid file` even though mysqld was stopping normally.
 
 ### <a id="minor-changes-general"/>General</a>
 

--- a/go/cmd/mysqlctl/command/shutdown.go
+++ b/go/cmd/mysqlctl/command/shutdown.go
@@ -51,7 +51,7 @@ func commandShutdown(cmd *cobra.Command, args []string) error {
 	}
 	defer mysqld.Close()
 
-	ctx, cancel := context.WithTimeout(cmd.Context(), shutdownArgs.WaitTime+10*time.Second)
+	ctx, cancel := context.WithTimeout(cmd.Context(), shutdownArgs.WaitTime+mysqlctl.MysqldShutdownGracePeriod)
 	defer cancel()
 	if err := mysqld.Shutdown(ctx, cnf, true, shutdownArgs.WaitTime); err != nil {
 		return fmt.Errorf("failed shutdown mysql: %v", err)

--- a/go/cmd/mysqlctl/command/teardown.go
+++ b/go/cmd/mysqlctl/command/teardown.go
@@ -54,7 +54,7 @@ func commandTeardown(cmd *cobra.Command, args []string) error {
 	}
 	defer mysqld.Close()
 
-	ctx, cancel := context.WithTimeout(cmd.Context(), teardownArgs.WaitTime+10*time.Second)
+	ctx, cancel := context.WithTimeout(cmd.Context(), teardownArgs.WaitTime+mysqlctl.MysqldShutdownGracePeriod)
 	defer cancel()
 	if err := mysqld.Teardown(ctx, cnf, teardownArgs.Force, teardownArgs.WaitTime); err != nil {
 		return fmt.Errorf("failed teardown mysql (forced? %v): %v", teardownArgs.Force, err)

--- a/go/cmd/mysqlctld/cli/mysqlctld.go
+++ b/go/cmd/mysqlctld/cli/mysqlctld.go
@@ -75,7 +75,7 @@ var (
 
 	timeouts = &servenv.TimeoutFlags{
 		LameduckPeriod: 50 * time.Millisecond,
-		OnTermTimeout:  shutdownWaitTime + 10*time.Second,
+		OnTermTimeout:  shutdownWaitTime + mysqlctl.MysqldShutdownGracePeriod,
 		OnCloseTimeout: 10 * time.Second,
 	}
 )
@@ -168,7 +168,7 @@ func run(cmd *cobra.Command, args []string) error {
 	// Take mysqld down with us on SIGTERM before entering lame duck.
 	servenv.OnTermSync(func() {
 		log.Info("mysqlctl received SIGTERM, shutting down mysqld first")
-		ctx, cancel := context.WithTimeout(cmd.Context(), shutdownWaitTime+10*time.Second)
+		ctx, cancel := context.WithTimeout(cmd.Context(), shutdownWaitTime+mysqlctl.MysqldShutdownGracePeriod)
 		defer cancel()
 		if err := mysqld.Shutdown(ctx, cnf, true, shutdownWaitTime); err != nil {
 			log.Error(fmt.Sprintf("failed to shutdown mysqld: %v", err))

--- a/go/cmd/vtbackup/cli/vtbackup.go
+++ b/go/cmd/vtbackup/cli/vtbackup.go
@@ -394,7 +394,7 @@ func takeBackup(ctx context.Context, topoServer *topo.Server, backupStorage back
 	// Shut down mysqld when we're done.
 	defer func() {
 		// Use cleanupCtx here so we still try to clean up even if startup timed out.
-		mysqlShutdownCtx, mysqlShutdownCancel := context.WithTimeout(cleanupCtx, mysqlShutdownTimeout+10*time.Second)
+		mysqlShutdownCtx, mysqlShutdownCancel := context.WithTimeout(cleanupCtx, mysqlShutdownTimeout+mysqlctl.MysqldShutdownGracePeriod)
 		defer mysqlShutdownCancel()
 		if err := mysqld.Shutdown(mysqlShutdownCtx, mycnf, false, mysqlShutdownTimeout); err != nil {
 			log.Error(fmt.Sprintf("failed to shutdown mysqld: %v", err))

--- a/go/cmd/vtbackup/cli/vtbackup.go
+++ b/go/cmd/vtbackup/cli/vtbackup.go
@@ -647,7 +647,9 @@ func runBackup(ctx context.Context, topoServer *topo.Server, mysqld *mysqlctl.My
 		}
 
 		// Shutdown, waiting for it to finish
-		if err := mysqld.Shutdown(ctx, mycnf, true, mysqlShutdownTimeout); err != nil {
+		shutdownCtx, shutdownCancel := context.WithTimeout(ctx, mysqlShutdownTimeout+mysqlctl.MysqldShutdownGracePeriod)
+		defer shutdownCancel()
+		if err := mysqld.Shutdown(shutdownCtx, mycnf, true, mysqlShutdownTimeout); err != nil {
 			return fmt.Errorf("Something went wrong during full MySQL shutdown: %v", err)
 		}
 

--- a/go/cmd/vtcombo/cli/main.go
+++ b/go/cmd/vtcombo/cli/main.go
@@ -227,7 +227,7 @@ func run(cmd *cobra.Command, args []string) (err error) {
 			return err
 		}
 		servenv.OnClose(func() {
-			shutdownCtx, shutdownCancel := context.WithTimeout(cmd.Context(), mysqlctl.DefaultShutdownTimeout+10*time.Second)
+			shutdownCtx, shutdownCancel := context.WithTimeout(cmd.Context(), mysqlctl.DefaultShutdownTimeout+mysqlctl.MysqldShutdownGracePeriod)
 			defer shutdownCancel()
 			mysqld.Shutdown(shutdownCtx, cnf, true, mysqlctl.DefaultShutdownTimeout)
 		})
@@ -251,7 +251,7 @@ func run(cmd *cobra.Command, args []string) (err error) {
 	if err != nil {
 		// ensure we start mysql in the event we fail here
 		if startMysql {
-			startCtx, startCancel := context.WithTimeout(ctx, mysqlctl.DefaultShutdownTimeout+10*time.Second)
+			startCtx, startCancel := context.WithTimeout(ctx, mysqlctl.DefaultShutdownTimeout+mysqlctl.MysqldShutdownGracePeriod)
 			defer startCancel()
 			mysqld.Shutdown(startCtx, cnf, true, mysqlctl.DefaultShutdownTimeout)
 		}
@@ -300,7 +300,7 @@ func run(cmd *cobra.Command, args []string) (err error) {
 		err := topotools.RebuildKeyspace(cmd.Context(), logutil.NewConsoleLogger(), ts, ks.GetName(), tpb.Cells, false)
 		if err != nil {
 			if startMysql {
-				shutdownCtx, shutdownCancel := context.WithTimeout(cmd.Context(), mysqlctl.DefaultShutdownTimeout+10*time.Second)
+				shutdownCtx, shutdownCancel := context.WithTimeout(cmd.Context(), mysqlctl.DefaultShutdownTimeout+mysqlctl.MysqldShutdownGracePeriod)
 				defer shutdownCancel()
 				mysqld.Shutdown(shutdownCtx, cnf, true, mysqlctl.DefaultShutdownTimeout)
 			}

--- a/go/flags/endtoend/mysqlctld.txt
+++ b/go/flags/endtoend/mysqlctld.txt
@@ -104,7 +104,7 @@ Flags:
       --mysqlctl-mycnf-template string                                   template file to use for generating the my.cnf file during server init
       --mysqlctl-socket string                                           socket file to use for remote mysqlctl actions (empty for local actions)
       --onclose-timeout duration                                         wait no more than this for OnClose handlers before stopping (default 10s)
-      --onterm-timeout duration                                          wait no more than this for OnTermSync handlers before stopping (default 5m10s)
+      --onterm-timeout duration                                          wait no more than this for OnTermSync handlers before stopping (default 5m30s)
       --pid-file string                                                  If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool-hostname-resolve-interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --port int                                                         port for the server

--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -66,7 +66,7 @@ Flags:
       --builtinbackup-file-read-buffer-size uint                    read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.
       --builtinbackup-file-write-buffer-size uint                   write files using an IO buffer of this many bytes. Golang defaults are used when set to 0. (default 2097152)
       --builtinbackup-incremental-restore-path string               the directory where incremental restore files, namely binlog files, are extracted to. In k8s environments, this should be set to a directory that is shared between the vttablet and mysqld pods. The path should exist. When empty, the default OS temp dir is assumed.
-      --builtinbackup-mysqld-timeout duration                       how long to wait for mysqld to shutdown at the start of the backup. (default 10m0s)
+      --builtinbackup-mysqld-timeout duration                       how long to wait for mysqld to shutdown at the start of the backup. Raised to the mysqld shutdown timeout of the backup request plus a grace period when that is larger. (default 10m0s)
       --builtinbackup-progress duration                             how often to send progress updates when backing up large files. (default 5s)
       --ceph-backup-storage-config string                           Path to JSON config file for ceph backup storage. (default "ceph_backup_config.json")
       --clone-from-primary                                          Clone data from the primary tablet in the shard using MySQL CLONE REMOTE instead of restoring from backup. Requires MySQL 8.0.17+. Mutually exclusive with --clone-from-tablet.

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -34,7 +34,7 @@ Flags:
       --builtinbackup-file-read-buffer-size uint                         read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.
       --builtinbackup-file-write-buffer-size uint                        write files using an IO buffer of this many bytes. Golang defaults are used when set to 0. (default 2097152)
       --builtinbackup-incremental-restore-path string                    the directory where incremental restore files, namely binlog files, are extracted to. In k8s environments, this should be set to a directory that is shared between the vttablet and mysqld pods. The path should exist. When empty, the default OS temp dir is assumed.
-      --builtinbackup-mysqld-timeout duration                            how long to wait for mysqld to shutdown at the start of the backup. (default 10m0s)
+      --builtinbackup-mysqld-timeout duration                            how long to wait for mysqld to shutdown at the start of the backup. Raised to the mysqld shutdown timeout of the backup request plus a grace period when that is larger. (default 10m0s)
       --builtinbackup-progress duration                                  how often to send progress updates when backing up large files. (default 5s)
       --catch-sigpipe                                                    catch and ignore SIGPIPE on stdout and stderr if specified
       --cell string                                                      cell to use

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -39,7 +39,7 @@ Flags:
       --builtinbackup-file-read-buffer-size uint                         read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.
       --builtinbackup-file-write-buffer-size uint                        write files using an IO buffer of this many bytes. Golang defaults are used when set to 0. (default 2097152)
       --builtinbackup-incremental-restore-path string                    the directory where incremental restore files, namely binlog files, are extracted to. In k8s environments, this should be set to a directory that is shared between the vttablet and mysqld pods. The path should exist. When empty, the default OS temp dir is assumed.
-      --builtinbackup-mysqld-timeout duration                            how long to wait for mysqld to shutdown at the start of the backup. (default 10m0s)
+      --builtinbackup-mysqld-timeout duration                            how long to wait for mysqld to shutdown at the start of the backup. Raised to the mysqld shutdown timeout of the backup request plus a grace period when that is larger. (default 10m0s)
       --builtinbackup-progress duration                                  how often to send progress updates when backing up large files. (default 5s)
       --catch-sigpipe                                                    catch and ignore SIGPIPE on stdout and stderr if specified
       --cell string                                                      cell to use

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -67,7 +67,7 @@ Flags:
       --builtinbackup-file-read-buffer-size uint                         read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.
       --builtinbackup-file-write-buffer-size uint                        write files using an IO buffer of this many bytes. Golang defaults are used when set to 0. (default 2097152)
       --builtinbackup-incremental-restore-path string                    the directory where incremental restore files, namely binlog files, are extracted to. In k8s environments, this should be set to a directory that is shared between the vttablet and mysqld pods. The path should exist. When empty, the default OS temp dir is assumed.
-      --builtinbackup-mysqld-timeout duration                            how long to wait for mysqld to shutdown at the start of the backup. (default 10m0s)
+      --builtinbackup-mysqld-timeout duration                            how long to wait for mysqld to shutdown at the start of the backup. Raised to the mysqld shutdown timeout of the backup request plus a grace period when that is larger. (default 10m0s)
       --builtinbackup-progress duration                                  how often to send progress updates when backing up large files. (default 5s)
       --catch-sigpipe                                                    catch and ignore SIGPIPE on stdout and stderr if specified
       --ceph-backup-storage-config string                                Path to JSON config file for ceph backup storage. (default "ceph_backup_config.json")

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -15,7 +15,7 @@ Flags:
       --builtinbackup-file-read-buffer-size uint                         read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.
       --builtinbackup-file-write-buffer-size uint                        write files using an IO buffer of this many bytes. Golang defaults are used when set to 0. (default 2097152)
       --builtinbackup-incremental-restore-path string                    the directory where incremental restore files, namely binlog files, are extracted to. In k8s environments, this should be set to a directory that is shared between the vttablet and mysqld pods. The path should exist. When empty, the default OS temp dir is assumed.
-      --builtinbackup-mysqld-timeout duration                            how long to wait for mysqld to shutdown at the start of the backup. (default 10m0s)
+      --builtinbackup-mysqld-timeout duration                            how long to wait for mysqld to shutdown at the start of the backup. Raised to the mysqld shutdown timeout of the backup request plus a grace period when that is larger. (default 10m0s)
       --builtinbackup-progress duration                                  how often to send progress updates when backing up large files. (default 5s)
       --catch-sigpipe                                                    catch and ignore SIGPIPE on stdout and stderr if specified
       --cells strings                                                    Comma separated list of cells (default [test])

--- a/go/test/endtoend/mysqlctl/mysqlctl_test.go
+++ b/go/test/endtoend/mysqlctl/mysqlctl_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -154,4 +155,39 @@ func TestAutoDetect(t *testing.T) {
 	// Reparent tablets, which requires flavor detection
 	err = clusterInstance.VtctldClientProcess.InitializeShard(keyspaceName, shardName, cell, primaryTablet.TabletUID)
 	require.NoError(t, err)
+}
+
+// TestShutdownWithTinyWaitTime shuts mysqld down with a wait-time below one
+// second, which makes the mysqladmin invoked by mysqlctl run with
+// --shutdown-timeout=0 and give up waiting immediately, reporting "Aborted
+// waiting on pid file" while mysqld is still exiting. The shutdown must
+// still succeed: the SHUTDOWN command was already delivered, and mysqlctl
+// keeps waiting on the pid/socket files instead of failing. This exercises
+// mysqladminAbortedWaiting's match of the literal mysqladmin message
+// against the real mysqladmin binary of the MySQL version this suite runs.
+func TestShutdownWithTinyWaitTime(t *testing.T) {
+	out, err := exec.Command(replicaTablet.MysqlctlProcess.Binary,
+		"--tablet-uid", strconv.Itoa(replicaTablet.TabletUID),
+		"--log-format", "text",
+		"shutdown",
+		"--wait-time", "500ms",
+	).CombinedOutput()
+	require.NoError(t, err, "mysqlctl shutdown failed, output: %s", out)
+	// The warning proves the mysqladmin aborted-wait branch actually ran,
+	// i.e. mysqladmin emitted the "Aborted waiting on pid file" message this
+	// MySQL version and the shutdown succeeded via the pid/socket file wait.
+	// This assumes mysqld cannot remove its pid file before mysqladmin's
+	// first check, ~1ms after the SHUTDOWN statement is acknowledged; a
+	// clean InnoDB shutdown takes orders of magnitude longer than that.
+	require.Contains(t, string(out), "mysqladmin gave up waiting for mysqld to stop",
+		"expected the mysqladmin aborted-wait fallback to be exercised, output: %s", out)
+
+	// Bring mysqld back up for any tests that follow.
+	out, err = exec.Command(replicaTablet.MysqlctlProcess.Binary,
+		"--tablet-uid", strconv.Itoa(replicaTablet.TabletUID),
+		"--mysql-port", strconv.Itoa(replicaTablet.MysqlctlProcess.MySQLPort),
+		"--log-format", "text",
+		"start",
+	).CombinedOutput()
+	require.NoError(t, err, "mysqlctl start failed, output: %s", out)
 }

--- a/go/test/endtoend/mysqlctl/mysqlctl_test.go
+++ b/go/test/endtoend/mysqlctl/mysqlctl_test.go
@@ -166,6 +166,19 @@ func TestAutoDetect(t *testing.T) {
 // mysqladminAbortedWaiting's match of the literal mysqladmin message
 // against the real mysqladmin binary of the MySQL version this suite runs.
 func TestShutdownWithTinyWaitTime(t *testing.T) {
+	// Restore mysqld for any tests that follow, registered before the
+	// shutdown is issued so a failed assertion below cannot leave the
+	// shared fixture down.
+	t.Cleanup(func() {
+		out, err := exec.Command(replicaTablet.MysqlctlProcess.Binary,
+			"--tablet-uid", strconv.Itoa(replicaTablet.TabletUID),
+			"--mysql-port", strconv.Itoa(replicaTablet.MysqlctlProcess.MySQLPort),
+			"--log-format", "text",
+			"start",
+		).CombinedOutput()
+		require.NoError(t, err, "mysqlctl start failed, output: %s", out)
+	})
+
 	out, err := exec.Command(replicaTablet.MysqlctlProcess.Binary,
 		"--tablet-uid", strconv.Itoa(replicaTablet.TabletUID),
 		"--log-format", "text",
@@ -181,13 +194,4 @@ func TestShutdownWithTinyWaitTime(t *testing.T) {
 	// clean InnoDB shutdown takes orders of magnitude longer than that.
 	require.Contains(t, string(out), "mysqladmin gave up waiting for mysqld to stop",
 		"expected the mysqladmin aborted-wait fallback to be exercised, output: %s", out)
-
-	// Bring mysqld back up for any tests that follow.
-	out, err = exec.Command(replicaTablet.MysqlctlProcess.Binary,
-		"--tablet-uid", strconv.Itoa(replicaTablet.TabletUID),
-		"--mysql-port", strconv.Itoa(replicaTablet.MysqlctlProcess.MySQLPort),
-		"--log-format", "text",
-		"start",
-	).CombinedOutput()
-	require.NoError(t, err, "mysqlctl start failed, output: %s", out)
 }

--- a/go/vt/mysqlctl/blackbox/backup_test.go
+++ b/go/vt/mysqlctl/blackbox/backup_test.go
@@ -176,8 +176,41 @@ func TestExecuteBackup(t *testing.T) {
 	require.Equal(t, 4, sourceOpenStats)
 	require.Equal(t, 4, sourceReadStats)
 
+	// A shutdown that outlives BuiltinBackupMysqldTimeout (1s here) but
+	// completes within MysqlShutdownTimeout plus the grace period must not
+	// fail the backup: the engine deadline is the larger of the two.
 	mysqld.ExpectedExecuteSuperQueryCurrent = 0 // resest the index of what queries we've run
-	mysqld.ShutdownTime = time.Minute           // reminder that shutdownDeadline is 1s
+	mysqld.ShutdownTime = 3 * time.Second
+
+	backupResult, err = be.ExecuteBackup(ctx, mysqlctl.BackupParams{
+		Logger: logutil.NewConsoleLogger(),
+		Mysqld: mysqld,
+		Cnf: &mysqlctl.Mycnf{
+			InnodbDataHomeDir:     path.Join(backupRoot, "innodb"),
+			InnodbLogGroupHomeDir: path.Join(backupRoot, "log"),
+			DataDir:               path.Join(backupRoot, "datadir"),
+		},
+		Concurrency:          2,
+		HookExtraEnv:         map[string]string{},
+		TopoServer:           ts,
+		Keyspace:             keyspace,
+		Shard:                shard,
+		Stats:                backupstats.NewFakeStats(),
+		MysqlShutdownTimeout: MysqlShutdownTimeout,
+	}, filebackupstorage.NewBackupHandle(nil, "", "", false))
+
+	require.NoError(t, err)
+	assert.Equal(t, mysqlctl.BackupUsable, backupResult)
+
+	mysqld.ExpectedExecuteSuperQueryCurrent = 0 // resest the index of what queries we've run
+	mysqld.ShutdownTime = time.Minute           // longer than the shutdown deadline below
+
+	// The engine's shutdown deadline is the larger of
+	// BuiltinBackupMysqldTimeout (1s here) and MysqlShutdownTimeout plus
+	// MysqldShutdownGracePeriod, so both are shrunk to make the deadline
+	// expire quickly while the fake mysqld is still shutting down.
+	oldGracePeriod := SetMysqldShutdownGracePeriod(time.Second)
+	defer SetMysqldShutdownGracePeriod(oldGracePeriod)
 
 	backupResult, err = be.ExecuteBackup(ctx, mysqlctl.BackupParams{
 		Logger: logutil.NewConsoleLogger(),
@@ -191,7 +224,7 @@ func TestExecuteBackup(t *testing.T) {
 		TopoServer:           ts,
 		Keyspace:             keyspace,
 		Shard:                shard,
-		MysqlShutdownTimeout: MysqlShutdownTimeout,
+		MysqlShutdownTimeout: time.Second,
 	}, bh)
 
 	require.Error(t, err)

--- a/go/vt/mysqlctl/blackbox/backup_test.go
+++ b/go/vt/mysqlctl/blackbox/backup_test.go
@@ -207,12 +207,12 @@ func TestExecuteBackup(t *testing.T) {
 
 	// The engine's shutdown deadline is the larger of
 	// BuiltinBackupMysqldTimeout (1s here) and MysqlShutdownTimeout plus
-	// MysqldShutdownGracePeriod, so both are shrunk to make the deadline
-	// expire quickly while the fake mysqld is still shutting down.
-	oldGracePeriod := SetMysqldShutdownGracePeriod(time.Second)
-	defer SetMysqldShutdownGracePeriod(oldGracePeriod)
+	// MysqldShutdownGracePeriod, so a short parent context bounds the
+	// shutdown instead; the engine's child timeout cannot extend it.
+	shortCtx, shortCancel := context.WithTimeout(ctx, 2*time.Second)
+	defer shortCancel()
 
-	backupResult, err = be.ExecuteBackup(ctx, mysqlctl.BackupParams{
+	backupResult, err = be.ExecuteBackup(shortCtx, mysqlctl.BackupParams{
 		Logger: logutil.NewConsoleLogger(),
 		Mysqld: mysqld,
 		Cnf: &mysqlctl.Mycnf{

--- a/go/vt/mysqlctl/blackbox/utils.go
+++ b/go/vt/mysqlctl/blackbox/utils.go
@@ -179,6 +179,13 @@ func SetBuiltinBackupMysqldDeadline(t time.Duration) time.Duration {
 	return old
 }
 
+func SetMysqldShutdownGracePeriod(t time.Duration) time.Duration {
+	old := mysqlctl.MysqldShutdownGracePeriod
+	mysqlctl.MysqldShutdownGracePeriod = t
+
+	return old
+}
+
 func createBackupDir(root string, dirs ...string) error {
 	for _, dir := range dirs {
 		if err := os.MkdirAll(path.Join(root, dir), 0o755); err != nil {

--- a/go/vt/mysqlctl/blackbox/utils.go
+++ b/go/vt/mysqlctl/blackbox/utils.go
@@ -179,13 +179,6 @@ func SetBuiltinBackupMysqldDeadline(t time.Duration) time.Duration {
 	return old
 }
 
-func SetMysqldShutdownGracePeriod(t time.Duration) time.Duration {
-	old := mysqlctl.MysqldShutdownGracePeriod
-	mysqlctl.MysqldShutdownGracePeriod = t
-
-	return old
-}
-
 func createBackupDir(root string, dirs ...string) error {
 	for _, dir := range dirs {
 		if err := os.MkdirAll(path.Join(root, dir), 0o755); err != nil {

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -254,7 +254,7 @@ func init() {
 }
 
 func registerBuiltinBackupEngineFlags(fs *pflag.FlagSet) {
-	utils.SetFlagDurationVar(fs, &BuiltinBackupMysqldTimeout, "builtinbackup-mysqld-timeout", BuiltinBackupMysqldTimeout, "how long to wait for mysqld to shutdown at the start of the backup.")
+	utils.SetFlagDurationVar(fs, &BuiltinBackupMysqldTimeout, "builtinbackup-mysqld-timeout", BuiltinBackupMysqldTimeout, "how long to wait for mysqld to shutdown at the start of the backup. Raised to the mysqld shutdown timeout of the backup request plus a grace period when that is larger.")
 	utils.SetFlagDurationVar(fs, &builtinBackupProgress, "builtinbackup-progress", builtinBackupProgress, "how often to send progress updates when backing up large files.")
 	fs.UintVar(&builtinBackupFileReadBufferSize, "builtinbackup-file-read-buffer-size", builtinBackupFileReadBufferSize, "read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.")
 	fs.UintVar(&builtinBackupFileWriteBufferSize, "builtinbackup-file-write-buffer-size", builtinBackupFileWriteBufferSize, "write files using an IO buffer of this many bytes. Golang defaults are used when set to 0.")
@@ -593,7 +593,10 @@ func (be *BuiltinBackupEngine) executeFullBackup(ctx context.Context, params Bac
 	}
 
 	// shutdown mysqld
-	shutdownCtx, cancel := context.WithTimeout(ctx, BuiltinBackupMysqldTimeout)
+	// The engine timeout must not undercut the shutdown timeout the caller
+	// asked for, otherwise this context expires while mysqld is still
+	// shutting down cleanly and the backup is aborted for no reason.
+	shutdownCtx, cancel := context.WithTimeout(ctx, max(BuiltinBackupMysqldTimeout, params.MysqlShutdownTimeout+MysqldShutdownGracePeriod))
 	err = params.Mysqld.Shutdown(shutdownCtx, params.Cnf, true, params.MysqlShutdownTimeout)
 	defer cancel()
 	if err != nil {

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -30,6 +30,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path"
@@ -80,6 +81,14 @@ const (
 	// mysqld has removed its socket and pid files.
 	mysqldExitPollInterval = 100 * time.Millisecond
 )
+
+// MysqldShutdownGracePeriod is added on top of the requested mysqld
+// shutdown timeout, giving the pid/socket file wait in Mysqld.Shutdown
+// a window to observe the exit after mysqladmin has given up waiting.
+// It also pads the shutdown contexts derived from that timeout by
+// mysqlctl, mysqlctld, vtbackup and the builtin backup engine.
+// Exported for testing.
+var MysqldShutdownGracePeriod = 30 * time.Second
 
 var (
 	// DisableActiveReparents is a flag to disable active
@@ -701,8 +710,27 @@ func (mysqld *Mysqld) Shutdown(ctx context.Context, cnf *Mycnf, waitForMysqld bo
 		if err != nil {
 			return err
 		}
-		if _, _, err = execCmd(name, args, env, dir, nil); err != nil {
-			return err
+		if _, output, err := execCmd(name, args, env, dir, nil); err != nil {
+			// mysqladmin exits non-zero when its --shutdown-timeout expires
+			// while mysqld is still shutting down. The SHUTDOWN command has
+			// already been delivered at that point, so a slow-but-clean
+			// shutdown (e.g. innodb_fast_shutdown=0 purging large undo logs)
+			// should not be treated as a failure here; the pid/socket file
+			// wait below decides the outcome instead. That wait is given a
+			// bounded grace window rather than inheriting ctx alone, so
+			// callers with no ctx deadline still fail in finite time when
+			// mysqld is truly hung rather than shutting down slowly.
+			//
+			// The error is only suppressed when the wait below will run:
+			// for waitForMysqld=false callers a nil return would claim a
+			// shutdown nothing verified, so they get the error as before.
+			if !waitForMysqld || !mysqladminAbortedWaiting(output) {
+				return err
+			}
+			log.Warn("mysqladmin gave up waiting for mysqld to stop, waiting on pid/socket files instead", slog.Any("error", err))
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, MysqldShutdownGracePeriod)
+			defer cancel()
 		}
 	default:
 		// hook failed, we report error
@@ -729,6 +757,22 @@ func (mysqld *Mysqld) StartAfterExit(ctx context.Context, cnf *Mycnf) error {
 		return err
 	}
 	return mysqld.Start(ctx, cnf)
+}
+
+// mysqladminAbortedWaiting reports whether mysqladmin output shows it
+// delivered the SHUTDOWN command but gave up waiting for mysqld to exit,
+// which happens when a clean shutdown outlives mysqladmin's
+// --shutdown-timeout ("Warning; Aborted waiting on pid file: '...' after
+// N seconds").
+//
+// This deliberately couples to mysqladmin's literal message, emitted by
+// wait_pidfile() in client/mysqladmin.cc and unchanged across MySQL 5.7,
+// 8.0 and 8.4. The coupling fails closed: if a future MySQL changes the
+// message, the match returns false and Shutdown reports the mysqladmin
+// error exactly as it did before this check existed. The endtoend mysqlctl
+// suite exercises this match against the real mysqladmin binary.
+func mysqladminAbortedWaiting(output string) bool {
+	return strings.Contains(output, "Aborted waiting on pid file")
 }
 
 // waitForMysqldExit polls until both socketFile and pidFile have been removed,

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -82,11 +82,12 @@ const (
 	mysqldExitPollInterval = 100 * time.Millisecond
 )
 
-// MysqldShutdownGracePeriod is added on top of the requested mysqld
-// shutdown timeout, giving the pid/socket file wait in Mysqld.Shutdown
-// a window to observe the exit after mysqladmin has given up waiting.
-// It also pads the shutdown contexts derived from that timeout by
-// mysqlctl, mysqlctld, vtbackup and the builtin backup engine.
+// MysqldShutdownGracePeriod bounds the pid/socket file wait in
+// Mysqld.Shutdown after mysqladmin has given up waiting, for callers
+// whose context has no deadline. It also pads the shutdown contexts
+// derived from the shutdown timeout by mysqlctl, mysqlctld, vtbackup
+// and the builtin backup engine, giving that wait a window to observe
+// the exit.
 // Exported for testing.
 var MysqldShutdownGracePeriod = 30 * time.Second
 
@@ -716,10 +717,10 @@ func (mysqld *Mysqld) Shutdown(ctx context.Context, cnf *Mycnf, waitForMysqld bo
 			// already been delivered at that point, so a slow-but-clean
 			// shutdown (e.g. innodb_fast_shutdown=0 purging large undo logs)
 			// should not be treated as a failure here; the pid/socket file
-			// wait below decides the outcome instead. That wait is given a
-			// bounded grace window rather than inheriting ctx alone, so
-			// callers with no ctx deadline still fail in finite time when
-			// mysqld is truly hung rather than shutting down slowly.
+			// wait below decides the outcome instead, running to the
+			// caller's deadline. Callers whose ctx has no deadline get a
+			// bounded grace window instead, so a truly hung mysqld still
+			// fails in finite time rather than waiting forever.
 			//
 			// The error is only suppressed when the wait below will run:
 			// for waitForMysqld=false callers a nil return would claim a
@@ -729,7 +730,7 @@ func (mysqld *Mysqld) Shutdown(ctx context.Context, cnf *Mycnf, waitForMysqld bo
 			}
 			log.Warn("mysqladmin gave up waiting for mysqld to stop, waiting on pid/socket files instead", slog.Any("error", err))
 			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, MysqldShutdownGracePeriod)
+			ctx, cancel = boundShutdownWaitContext(ctx)
 			defer cancel()
 		}
 	default:
@@ -757,6 +758,18 @@ func (mysqld *Mysqld) StartAfterExit(ctx context.Context, cnf *Mycnf) error {
 		return err
 	}
 	return mysqld.Start(ctx, cnf)
+}
+
+// boundShutdownWaitContext bounds ctx by MysqldShutdownGracePeriod when it
+// has no deadline, so a truly hung mysqld still fails in finite time after
+// mysqladmin has given up waiting. A caller-supplied deadline is never
+// shortened: the pid/socket file wait runs to it, e.g. to the remainder of
+// the builtin backup engine's --builtinbackup-mysqld-timeout budget.
+func boundShutdownWaitContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, hasDeadline := ctx.Deadline(); hasDeadline {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, MysqldShutdownGracePeriod)
 }
 
 // mysqladminAbortedWaiting reports whether mysqladmin output shows it

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -85,11 +85,10 @@ const (
 // MysqldShutdownGracePeriod bounds the pid/socket file wait in
 // Mysqld.Shutdown after mysqladmin has given up waiting, for callers
 // whose context has no deadline. It also pads the shutdown contexts
-// derived from the shutdown timeout by mysqlctl, mysqlctld, vtbackup
-// and the builtin backup engine, giving that wait a window to observe
-// the exit.
-// Exported for testing.
-var MysqldShutdownGracePeriod = 30 * time.Second
+// derived from the shutdown timeout by mysqlctl, mysqlctld, vtbackup,
+// vtcombo and the builtin backup engine, giving that wait a window to
+// observe the exit.
+const MysqldShutdownGracePeriod = 30 * time.Second
 
 var (
 	// DisableActiveReparents is a flag to disable active

--- a/go/vt/mysqlctl/mysqld_test.go
+++ b/go/vt/mysqlctl/mysqld_test.go
@@ -507,3 +507,32 @@ error: 'Access denied for user 'vt_dba'@'localhost' (using password: NO)'`,
 		})
 	}
 }
+
+// TestBoundShutdownWaitContext pins the contract that surfaced in review of
+// the mysqladmin aborted-wait handling: the pid/socket file wait must run to
+// a caller-supplied deadline (e.g. the remaining --builtinbackup-mysqld-timeout
+// budget) and must never be shortened to the grace period; only callers with
+// no deadline get the grace bound.
+func TestBoundShutdownWaitContext(t *testing.T) {
+	t.Run("caller deadline is preserved", func(t *testing.T) {
+		parent, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+		parentDeadline, ok := parent.Deadline()
+		require.True(t, ok)
+
+		bounded, boundedCancel := boundShutdownWaitContext(parent)
+		defer boundedCancel()
+		deadline, ok := bounded.Deadline()
+		require.True(t, ok)
+		assert.Equal(t, parentDeadline, deadline)
+	})
+
+	t.Run("no deadline gets the grace bound", func(t *testing.T) {
+		before := time.Now()
+		bounded, boundedCancel := boundShutdownWaitContext(context.Background())
+		defer boundedCancel()
+		deadline, ok := bounded.Deadline()
+		require.True(t, ok)
+		assert.WithinDuration(t, before.Add(MysqldShutdownGracePeriod), deadline, 5*time.Second)
+	})
+}

--- a/go/vt/mysqlctl/mysqld_test.go
+++ b/go/vt/mysqlctl/mysqld_test.go
@@ -471,3 +471,39 @@ func TestMysqlbinlogEnvironOverridesExistingTZ(t *testing.T) {
 	require.NotContains(t, got, "TZ=Europe/Berlin")
 	require.Equal(t, baseCopy, base)
 }
+
+// TestMysqladminAbortedWaiting verifies detection of the mysqladmin output
+// emitted when its --shutdown-timeout expires while mysqld is still
+// shutting down cleanly, which must not be treated as a shutdown failure.
+func TestMysqladminAbortedWaiting(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name: "aborted waiting on pid file",
+			output: `mysqladmin: connect to server at 'localhost' failed
+error: 'Can't connect to local MySQL server through socket '/vt/socket/mysql.sock' (2)'
+Check that mysqld is running and that the socket: '/vt/socket/mysql.sock' exists!
+Warning;  Aborted waiting on pid file: '/vt/vtdataroot/vt_0000000101/mysql.pid' after 3600 seconds`,
+			want: true,
+		},
+		{
+			name: "access denied",
+			output: `mysqladmin: connect to server at 'localhost' failed
+error: 'Access denied for user 'vt_dba'@'localhost' (using password: NO)'`,
+			want: false,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, mysqladminAbortedWaiting(tt.output))
+		})
+	}
+}

--- a/go/vt/mysqlctl/mysqld_test.go
+++ b/go/vt/mysqlctl/mysqld_test.go
@@ -515,7 +515,7 @@ error: 'Access denied for user 'vt_dba'@'localhost' (using password: NO)'`,
 // no deadline get the grace bound.
 func TestBoundShutdownWaitContext(t *testing.T) {
 	t.Run("caller deadline is preserved", func(t *testing.T) {
-		parent, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		parent, cancel := context.WithTimeout(t.Context(), 10*time.Minute)
 		defer cancel()
 		parentDeadline, ok := parent.Deadline()
 		require.True(t, ok)
@@ -529,7 +529,7 @@ func TestBoundShutdownWaitContext(t *testing.T) {
 
 	t.Run("no deadline gets the grace bound", func(t *testing.T) {
 		before := time.Now()
-		bounded, boundedCancel := boundShutdownWaitContext(context.Background())
+		bounded, boundedCancel := boundShutdownWaitContext(t.Context())
 		defer boundedCancel()
 		deadline, ok := bounded.Deadline()
 		require.True(t, ok)


### PR DESCRIPTION
## Description

When taking a backup with the builtin engine, mysqld can legitimately take hours to shut down cleanly - for example an upgrade-safe backup sets `innodb_fast_shutdown=0`, which fully purges undo logs before exit on a large, write-heavy instance. Today two separate timeouts fail such a backup even though mysqld is stopping normally:

1. `mysqladmin` exits non-zero when its `--shutdown-timeout` expires _(`Warning; Aborted waiting on pid file`)_ and `Mysqld.Shutdown` returns that as an error, even though the `SHUTDOWN` command was already delivered and mysqld is still stopping
2. The builtin backup engine bounds the shutdown with `--builtinbackup-mysqld-timeout` independently of `--mysql-shutdown-timeout`, so raising one without the other still fails with `gave up waiting for mysqld to stop`

This PR makes two changes:

1. `Mysqld.Shutdown` now treats mysqladmin's aborted-wait as shutdown-in-progress when it will verify the exit itself _(`waitForMysqld=true`)_: it logs a warning and falls through to the existing pid/socket file wait, bounded by a new `MysqldShutdownGracePeriod` (30s) so callers with no context deadline still fail in finite time when mysqld is truly hung. Any other mysqladmin error, or a `waitForMysqld=false` call, returns the error exactly as before. The message match fails closed - if a future MySQL rewords the message, the error is returned as it is today
2. The builtin engine's shutdown context becomes `max(--builtinbackup-mysqld-timeout, MysqlShutdownTimeout + grace)`, so the engine deadline can no longer silently undercut the shutdown timeout the caller explicitly asked for

The grace period replaces the `+10s` pads previously hardcoded in `mysqlctl shutdown`/`teardown`, `mysqlctld` and `vtbackup`, keeping those contexts in lockstep with the fallback wait. As a side effect `mysqlctld`'s derived `--onterm-timeout` default moves from `5m10s` to `5m30s`

A couple of notes for reviewers:

- With these changes `--mysql-shutdown-timeout` becomes the operative knob for how long a backup waits on a clean shutdown; `--builtinbackup-mysqld-timeout` now acts as a floor rather than an independent ceiling
- The aborted-wait branch can't be unit-tested without making `execCmd` injectable, so coverage is: a unit test for the message match, a blackbox case that fails on `main` and passes with this change _(a fake shutdown completing between the old and new deadlines)_, and an endtoend test that runs `mysqlctl shutdown --wait-time=500ms` so the real `mysqladmin` of each CI MySQL version emits the aborted-wait message and asserts the fallback actually ran - guarding the string coupling across the version matrix. The `waitForMysqld=false` cell keeps today's behaviour and is covered by reasoning only

## Related Issue(s)

Resolves https://github.com/vitessio/vitess/issues/20604

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

### AI Disclosure

This PR was assisted by Claude Code, directed and reviewed by a human. The PR summary was also prepared by Claude Code
