### PR TITLE
mysql: honor preferred SSL for replication with Unix sockets

### DIFF
--- a/go/mysql/flavor_mariadb.go
+++ b/go/mysql/flavor_mariadb.go
@@ -30,6 +30,7 @@ import (
 	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/vt/proto/replicationdata"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vttls"
 
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
@@ -205,7 +206,8 @@ func (mariadbFlavor) setReplicationSourceCommand(params *ConnParams, host string
 		fmt.Sprintf("MASTER_PASSWORD = '%s'", params.Pass),
 		fmt.Sprintf("MASTER_CONNECT_RETRY = %d", connectRetry),
 	}
-	if params.SslEnabled() {
+	// Replication connects to the source over TCP, not params.UnixSocket.
+	if params.EffectiveSslMode() != vttls.Disabled {
 		args = append(args, "MASTER_SSL = 1")
 	}
 	if params.SslCa != "" {

--- a/go/mysql/flavor_mariadb_test.go
+++ b/go/mysql/flavor_mariadb_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"vitess.io/vitess/go/vt/vttls"
 )
 
 func TestMariadbSetReplicationSourceCommand(t *testing.T) {
@@ -85,4 +87,27 @@ func TestMariadbSetReplicationSourceCommandSSL(t *testing.T) {
 	conn := &Conn{flavor: mariadbFlavor101{}}
 	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry)
 	assert.Equal(t, want, got, "mariadbFlavor.SetReplicationSourceCommand(%#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, connectRetry, got, want)
+}
+
+// TestMariadbSetReplicationSourceCommandPreferredSSLWithUnixSocket verifies that
+// a Unix socket for direct connections does not disable TLS for TCP replication.
+func TestMariadbSetReplicationSourceCommandPreferredSSLWithUnixSocket(t *testing.T) {
+	params := &ConnParams{
+		Uname:      "username",
+		Pass:       "password",
+		UnixSocket: "/var/run/mysqld/mysqld.sock",
+		SslMode:    vttls.Preferred,
+	}
+	want := `CHANGE MASTER TO
+  MASTER_HOST = 'primary.example.com',
+  MASTER_PORT = 3306,
+  MASTER_USER = 'username',
+  MASTER_PASSWORD = 'password',
+  MASTER_CONNECT_RETRY = 10,
+  MASTER_SSL = 1,
+  MASTER_USE_GTID = current_pos`
+
+	conn := &Conn{flavor: mariadbFlavor101{}}
+	got := conn.SetReplicationSourceCommand(params, "primary.example.com", 3306, 0, 10)
+	assert.Equal(t, want, got)
 }

--- a/go/mysql/flavor_mysql.go
+++ b/go/mysql/flavor_mysql.go
@@ -29,6 +29,7 @@ import (
 	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/vt/proto/replicationdata"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vttls"
 
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
@@ -569,7 +570,8 @@ func (mysqlFlavor) setReplicationSourceCommand(params *ConnParams, host string, 
 		fmt.Sprintf("SOURCE_PASSWORD = '%s'", params.Pass),
 		fmt.Sprintf("SOURCE_CONNECT_RETRY = %d", connectRetry),
 	}
-	if params.SslEnabled() {
+	// Replication connects to the source over TCP, not params.UnixSocket.
+	if params.EffectiveSslMode() != vttls.Disabled {
 		args = append(args, "SOURCE_SSL = 1")
 	} else {
 		args = append(args, "GET_SOURCE_PUBLIC_KEY = 1")

--- a/go/mysql/flavor_mysql_legacy.go
+++ b/go/mysql/flavor_mysql_legacy.go
@@ -23,6 +23,7 @@ import (
 	"vitess.io/vitess/go/mysql/replication"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vttls"
 )
 
 // mysqlFlavorLegacy implements the Flavor interface for Mysql for
@@ -233,7 +234,8 @@ func (mysqlFlavorLegacy) setReplicationSourceCommand(params *ConnParams, host st
 		fmt.Sprintf("MASTER_PASSWORD = '%s'", params.Pass),
 		fmt.Sprintf("MASTER_CONNECT_RETRY = %d", connectRetry),
 	}
-	if params.SslEnabled() {
+	// Replication connects to the source over TCP, not params.UnixSocket.
+	if params.EffectiveSslMode() != vttls.Disabled {
 		args = append(args, "MASTER_SSL = 1")
 	} else {
 		args = append(args, "GET_MASTER_PUBLIC_KEY = 1")

--- a/go/mysql/flavor_mysql_test.go
+++ b/go/mysql/flavor_mysql_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"vitess.io/vitess/go/mysql/replication"
+	"vitess.io/vitess/go/vt/vttls"
 )
 
 func TestMysql8SetReplicationSourceCommand(t *testing.T) {
@@ -89,6 +90,52 @@ func TestMysql8SetReplicationSourceCommandSSL(t *testing.T) {
 	conn := &Conn{flavor: mysqlFlavor8{}}
 	got := conn.SetReplicationSourceCommand(params, host, port, 0, connectRetry)
 	assert.Equal(t, want, got, "mysqlFlavor.SetReplicationSourceCommand(%#v, %#v, %#v, %#v) = %#v, want %#v", params, host, port, connectRetry, got, want)
+}
+
+// TestMysql8SetReplicationSourceCommandPreferredSSLWithUnixSocket verifies that
+// a Unix socket for direct connections does not disable TLS for TCP replication.
+func TestMysql8SetReplicationSourceCommandPreferredSSLWithUnixSocket(t *testing.T) {
+	params := &ConnParams{
+		Uname:      "username",
+		Pass:       "password",
+		UnixSocket: "/var/run/mysqld/mysqld.sock",
+		SslMode:    vttls.Preferred,
+	}
+	want := `CHANGE REPLICATION SOURCE TO
+  SOURCE_HOST = 'primary.example.com',
+  SOURCE_PORT = 3306,
+  SOURCE_USER = 'username',
+  SOURCE_PASSWORD = 'password',
+  SOURCE_CONNECT_RETRY = 10,
+  SOURCE_SSL = 1,
+  SOURCE_AUTO_POSITION = 1`
+
+	conn := &Conn{flavor: mysqlFlavor8{}}
+	got := conn.SetReplicationSourceCommand(params, "primary.example.com", 3306, 0, 10)
+	assert.Equal(t, want, got)
+}
+
+// TestMysqlLegacySetReplicationSourceCommandPreferredSSLWithUnixSocket verifies
+// the same behavior for MySQL versions that use legacy replication terminology.
+func TestMysqlLegacySetReplicationSourceCommandPreferredSSLWithUnixSocket(t *testing.T) {
+	params := &ConnParams{
+		Uname:      "username",
+		Pass:       "password",
+		UnixSocket: "/var/run/mysqld/mysqld.sock",
+		SslMode:    vttls.Preferred,
+	}
+	want := `CHANGE MASTER TO
+  MASTER_HOST = 'primary.example.com',
+  MASTER_PORT = 3306,
+  MASTER_USER = 'username',
+  MASTER_PASSWORD = 'password',
+  MASTER_CONNECT_RETRY = 10,
+  MASTER_SSL = 1,
+  MASTER_AUTO_POSITION = 1`
+
+	conn := &Conn{flavor: mysqlFlavor57{}}
+	got := conn.SetReplicationSourceCommand(params, "primary.example.com", 3306, 0, 10)
+	assert.Equal(t, want, got)
 }
 
 func TestMysql8SetReplicationPositionCommands(t *testing.T) {


### PR DESCRIPTION
## Description

When `vttablet` is configured with both `--db_ssl_mode=preferred` and a Unix socket, `ConnParams.SslEnabled()` correctly disables TLS for direct connections over that local socket. Replication connections are different: replicas connect to the configured source host and port over TCP and never use the local Unix socket.

The replication source command builders were using `SslEnabled()`, so they treated the local socket as if it also applied to replication. For MySQL this emitted `GET_SOURCE_PUBLIC_KEY = 1` or `GET_MASTER_PUBLIC_KEY = 1` instead of enabling replication TLS. For MariaDB it omitted `MASTER_SSL = 1`.

This change checks `EffectiveSslMode()` directly when building replication commands and enables TLS for every mode except `disabled`. It covers modern MySQL, legacy MySQL, and MariaDB. The direct connection behavior of `SslEnabled()` is unchanged.

Regression tests cover `preferred` mode with a configured Unix socket for all three replication command implementations. Existing tests continue to cover disabled/default and required TLS behavior.

This is a good backport candidate for release-23.0 and release-24.0 because the issue affects existing releases and the behavior change is isolated to replication command generation.

## Related Issue(s)

Fixes #17216

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Testing

`go test ./go/mysql/ -run SetReplicationSource -count=1`

The repository pre-commit formatting and lint hooks also pass with zero issues.

## Deployment Notes

After upgrading, configurations that combine `--db_ssl_mode=preferred` with a Unix socket will request TLS for replication over TCP. Operators should ensure the replication source supports TLS, or use `--db_ssl_mode=disabled` if plaintext replication is intended. No schema or data migration is required.

### AI Disclosure

Codex was used to inspect the replication paths, implement the fix, add tests, and draft this description. The changes were validated with targeted tests and the repository's pre-commit formatting and lint hooks.
