### PR TITLE
Hard-bound the super_read_only reset cleanup

### DIFF
--- a/go/vt/mysqlctl/query.go
+++ b/go/vt/mysqlctl/query.go
@@ -168,6 +168,45 @@ func (mysqld *Mysqld) executeFetchContext(ctx context.Context, conn *dbconnpool.
 	}
 }
 
+// execBounded runs query on conn. If ctx expires first, it closes conn so the
+// blocked ExecuteFetch fails fast, joins the worker, and returns ctx.Err() —
+// nothing is left running on the connection when it returns.
+func execBounded(ctx context.Context, conn *dbconnpool.DBConnection, query string) error {
+	done := make(chan error, 1)
+	go func() {
+		_, err := conn.ExecuteFetch(query, 10000, false)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		// Prefer the query result if it raced with the deadline.
+		select {
+		case err := <-done:
+			return err
+		default:
+		}
+		conn.Close()
+		<-done
+		return ctx.Err()
+	}
+}
+
+// killConnectionBounded issues a KILL for connID on a dedicated connection,
+// bounding both the connect and the KILL itself so it cannot block past
+// timeout even when the server is unresponsive.
+func (mysqld *Mysqld) killConnectionBounded(timeout time.Duration, connID int64) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	conn, err := mysqld.GetDbaConnection(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	return execBounded(ctx, conn, fmt.Sprintf("kill %d", connID))
+}
+
 // killConnection issues a MySQL KILL command for the given connection ID.
 func (mysqld *Mysqld) killConnection(connID int64) error {
 	// There's no other interface that both types of connection implement.

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -319,7 +319,17 @@ func (mysqld *Mysqld) SetSuperReadOnly(ctx context.Context, on bool) (ResetSuper
 	resetSuperReadOnly := func(value string) error {
 		resetCtx, cancel := context.WithTimeout(context.Background(), superReadOnlyResetTimeout)
 		defer cancel()
-		return mysqld.ExecuteSuperQuery(resetCtx, "SET GLOBAL super_read_only = '"+value+"'")
+
+		done := make(chan error, 1)
+		go func() {
+			done <- mysqld.ExecuteSuperQuery(resetCtx, "SET GLOBAL super_read_only = '"+value+"'")
+		}()
+		select {
+		case err := <-done:
+			return err
+		case <-resetCtx.Done():
+			return vterrors.Errorf(vtrpcpb.Code_DEADLINE_EXCEEDED, "timed out resetting super_read_only to '%s'", value)
+		}
 	}
 
 	//  return function for switching `OFF` super_read_only

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"strconv"
 	"strings"
@@ -320,16 +321,30 @@ func (mysqld *Mysqld) SetSuperReadOnly(ctx context.Context, on bool) (ResetSuper
 		resetCtx, cancel := context.WithTimeout(context.Background(), superReadOnlyResetTimeout)
 		defer cancel()
 
-		done := make(chan error, 1)
-		go func() {
-			done <- mysqld.ExecuteSuperQuery(resetCtx, "SET GLOBAL super_read_only = '"+value+"'")
-		}()
-		select {
-		case err := <-done:
-			return err
-		case <-resetCtx.Done():
-			return vterrors.Errorf(vtrpcpb.Code_DEADLINE_EXCEEDED, "timed out resetting super_read_only to '%s'", value)
+		// Use a dedicated connection so every step honors the context: the
+		// connect is bounded by resetCtx, and on timeout execBounded closes
+		// the connection and joins its worker, so nothing is left running or
+		// held when this returns.
+		conn, err := mysqld.GetDbaConnection(resetCtx)
+		if err != nil {
+			return vterrors.Wrapf(err, "failed to get a connection to reset super_read_only to '%s'", value)
 		}
+		defer conn.Close()
+
+		err = execBounded(resetCtx, conn, "SET GLOBAL super_read_only = '"+value+"'")
+		if !errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		// The statement may still be pending server-side; a best-effort KILL
+		// makes a recovering server abort it instead of applying it later.
+		if killErr := mysqld.killConnectionBounded(superReadOnlyResetTimeout, conn.ID()); killErr != nil {
+			log.Warn(
+				"failed to kill the timed-out super_read_only reset query",
+				slog.Int64("conn_id", conn.ID()),
+				slog.Any("error", killErr),
+			)
+		}
+		return vterrors.Errorf(vtrpcpb.Code_DEADLINE_EXCEEDED, "timed out resetting super_read_only to '%s'", value)
 	}
 
 	//  return function for switching `OFF` super_read_only

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -46,6 +46,8 @@ const (
 	getGlobalStatusQuery = "SELECT variable_name, variable_value FROM performance_schema.global_status"
 )
 
+var superReadOnlyResetTimeout = 15 * time.Second
+
 type ResetSuperReadOnlyFunc func() error
 
 // WaitForReplicationStart waits until the deadline for replication to start.
@@ -314,19 +316,21 @@ func (mysqld *Mysqld) SetReadOnly(ctx context.Context, on bool) error {
 // SetSuperReadOnly set/unset the super_read_only flag.
 // Returns a function which is called to set super_read_only back to its original value.
 func (mysqld *Mysqld) SetSuperReadOnly(ctx context.Context, on bool) (ResetSuperReadOnlyFunc, error) {
+	resetSuperReadOnly := func(value string) error {
+		resetCtx, cancel := context.WithTimeout(context.Background(), superReadOnlyResetTimeout)
+		defer cancel()
+		return mysqld.ExecuteSuperQuery(resetCtx, "SET GLOBAL super_read_only = '"+value+"'")
+	}
+
 	//  return function for switching `OFF` super_read_only
 	var resetFunc ResetSuperReadOnlyFunc
 	disableFunc := func() error {
-		query := "SET GLOBAL super_read_only = 'OFF'"
-		err := mysqld.ExecuteSuperQuery(context.Background(), query)
-		return err
+		return resetSuperReadOnly("OFF")
 	}
 
 	//  return function for switching `ON` super_read_only.
 	enableFunc := func() error {
-		query := "SET GLOBAL super_read_only = 'ON'"
-		err := mysqld.ExecuteSuperQuery(context.Background(), query)
-		return err
+		return resetSuperReadOnly("ON")
 	}
 
 	superReadOnlyEnabled, err := mysqld.IsSuperReadOnly(ctx)

--- a/go/vt/mysqlctl/replication_test.go
+++ b/go/vt/mysqlctl/replication_test.go
@@ -862,6 +862,46 @@ func TestSetSuperReadOnlyResetTimesOut(t *testing.T) {
 	}
 }
 
+func TestSetSuperReadOnlyResetBoundedWhenKillFails(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+
+	params := db.ConnParams()
+	cp := *params
+	dbc := dbconfigs.NewTestDBConfigs(cp, cp, "fakesqldb")
+
+	withTestSuperReadOnlyResetTimeout(t, 100*time.Millisecond)
+
+	db.AddQuery("SELECT 1", &sqltypes.Result{})
+	db.AddQuery("SELECT @@global.super_read_only", sqltypes.MakeTestResult(sqltypes.MakeTestFields("sro", "int64"), "0"))
+	db.AddQuery("SET GLOBAL super_read_only = 'ON'", &sqltypes.Result{})
+	db.AddQuery("SET GLOBAL super_read_only = 'OFF'", &sqltypes.Result{})
+
+	// Block the reset query and register no KILL handler: cancellation cannot
+	// be delivered, so the inner execution path never unblocks on its own.
+	unblock := make(chan struct{})
+	db.SetBeforeFunc("SET GLOBAL super_read_only = 'OFF'", func() { <-unblock })
+
+	testMysqld := NewMysqld(dbc)
+	defer testMysqld.Close()
+	// Release the blocked handler before pool close so teardown does not hang.
+	defer close(unblock)
+
+	resetFunc, err := testMysqld.SetSuperReadOnly(t.Context(), true)
+	require.NoError(t, err)
+	require.NotNil(t, resetFunc)
+
+	done := make(chan error, 1)
+	go func() { done <- resetFunc() }()
+
+	select {
+	case err := <-done:
+		require.ErrorContains(t, err, "timed out")
+	case <-time.After(30 * time.Second):
+		require.Fail(t, "resetFunc did not return; reset is not hard-bounded when KILL cannot be delivered")
+	}
+}
+
 func TestSetSuperReadOnlyResetDetachedFromParentContext(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()

--- a/go/vt/mysqlctl/replication_test.go
+++ b/go/vt/mysqlctl/replication_test.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -838,12 +839,17 @@ func TestSetSuperReadOnlyResetTimesOut(t *testing.T) {
 	db.AddQuery("SET GLOBAL super_read_only = 'ON'", &sqltypes.Result{})
 	db.AddQuery("SET GLOBAL super_read_only = 'OFF'", &sqltypes.Result{})
 
+	// Block the reset query; the KILL aborts it, as a healthy server would.
 	unblock := make(chan struct{})
 	var once sync.Once
 	release := func() { once.Do(func() { close(unblock) }) }
 	t.Cleanup(release)
 	db.SetBeforeFunc("SET GLOBAL super_read_only = 'OFF'", func() { <-unblock })
-	db.AddQueryPatternWithCallback("kill.*", &sqltypes.Result{}, func(string) { release() })
+	var killed atomic.Bool
+	db.AddQueryPatternWithCallback("kill.*", &sqltypes.Result{}, func(string) {
+		killed.Store(true)
+		release()
+	})
 
 	testMysqld := NewMysqld(dbc)
 	defer testMysqld.Close()
@@ -856,10 +862,14 @@ func TestSetSuperReadOnlyResetTimesOut(t *testing.T) {
 	go func() { done <- resetFunc() }()
 
 	select {
-	case <-done:
+	case err := <-done:
+		require.ErrorContains(t, err, "timed out")
 	case <-time.After(30 * time.Second):
-		require.Fail(t, "resetFunc did not return; the reset context is not bounded")
+		require.Fail(t, "resetFunc did not return; the reset is not bounded")
 	}
+	// The stuck statement must be killed so a recovering server aborts it
+	// instead of applying it later.
+	assert.Eventually(t, killed.Load, 30*time.Second, 10*time.Millisecond)
 }
 
 func TestSetSuperReadOnlyResetBoundedWhenKillFails(t *testing.T) {
@@ -877,10 +887,12 @@ func TestSetSuperReadOnlyResetBoundedWhenKillFails(t *testing.T) {
 	db.AddQuery("SET GLOBAL super_read_only = 'ON'", &sqltypes.Result{})
 	db.AddQuery("SET GLOBAL super_read_only = 'OFF'", &sqltypes.Result{})
 
-	// Block the reset query and register no KILL handler: cancellation cannot
-	// be delivered, so the inner execution path never unblocks on its own.
+	// Block both the reset query and the KILL: cancellation cannot be
+	// delivered, mimicking a fully unresponsive server, so nothing on the
+	// server side ever unblocks on its own.
 	unblock := make(chan struct{})
 	db.SetBeforeFunc("SET GLOBAL super_read_only = 'OFF'", func() { <-unblock })
+	db.AddQueryPatternWithCallback("kill.*", &sqltypes.Result{}, func(string) { <-unblock })
 
 	testMysqld := NewMysqld(dbc)
 	defer testMysqld.Close()

--- a/go/vt/mysqlctl/replication_test.go
+++ b/go/vt/mysqlctl/replication_test.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -768,4 +769,122 @@ func TestSemiSyncExtensionLoaded(t *testing.T) {
 	res, err = testMysqld.SemiSyncExtensionLoaded(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, mysql.SemiSyncTypeOff, res)
+}
+
+func withTestSuperReadOnlyResetTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := superReadOnlyResetTimeout
+	superReadOnlyResetTimeout = d
+	t.Cleanup(func() { superReadOnlyResetTimeout = orig })
+}
+
+func TestSetSuperReadOnly(t *testing.T) {
+	tests := []struct {
+		name       string
+		on         bool
+		current    string
+		wantReset  bool
+		resetQuery string
+	}{
+		{name: "enable when disabled returns reset", on: true, current: "0", wantReset: true, resetQuery: "SET GLOBAL super_read_only = 'OFF'"},
+		{name: "disable when enabled returns reset", on: false, current: "1", wantReset: true, resetQuery: "SET GLOBAL super_read_only = 'ON'"},
+		{name: "enable when already enabled is a no-op", on: true, current: "1", wantReset: false},
+		{name: "disable when already disabled is a no-op", on: false, current: "0", wantReset: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := fakesqldb.New(t)
+			defer db.Close()
+
+			params := db.ConnParams()
+			cp := *params
+			dbc := dbconfigs.NewTestDBConfigs(cp, cp, "fakesqldb")
+
+			db.AddQuery("SELECT 1", &sqltypes.Result{})
+			db.AddQuery("SELECT @@global.super_read_only", sqltypes.MakeTestResult(sqltypes.MakeTestFields("sro", "int64"), tt.current))
+			db.AddQuery("SET GLOBAL super_read_only = 'ON'", &sqltypes.Result{})
+			db.AddQuery("SET GLOBAL super_read_only = 'OFF'", &sqltypes.Result{})
+
+			testMysqld := NewMysqld(dbc)
+			defer testMysqld.Close()
+
+			resetFunc, err := testMysqld.SetSuperReadOnly(t.Context(), tt.on)
+			require.NoError(t, err)
+
+			if !tt.wantReset {
+				assert.Nil(t, resetFunc)
+				return
+			}
+
+			require.NotNil(t, resetFunc)
+			require.NoError(t, resetFunc())
+			assert.NotZero(t, db.GetQueryCalledNum(tt.resetQuery))
+		})
+	}
+}
+
+func TestSetSuperReadOnlyResetTimesOut(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+
+	params := db.ConnParams()
+	cp := *params
+	dbc := dbconfigs.NewTestDBConfigs(cp, cp, "fakesqldb")
+
+	withTestSuperReadOnlyResetTimeout(t, 100*time.Millisecond)
+
+	db.AddQuery("SELECT 1", &sqltypes.Result{})
+	db.AddQuery("SELECT @@global.super_read_only", sqltypes.MakeTestResult(sqltypes.MakeTestFields("sro", "int64"), "0"))
+	db.AddQuery("SET GLOBAL super_read_only = 'ON'", &sqltypes.Result{})
+	db.AddQuery("SET GLOBAL super_read_only = 'OFF'", &sqltypes.Result{})
+
+	unblock := make(chan struct{})
+	var once sync.Once
+	release := func() { once.Do(func() { close(unblock) }) }
+	t.Cleanup(release)
+	db.SetBeforeFunc("SET GLOBAL super_read_only = 'OFF'", func() { <-unblock })
+	db.AddQueryPatternWithCallback("kill.*", &sqltypes.Result{}, func(string) { release() })
+
+	testMysqld := NewMysqld(dbc)
+	defer testMysqld.Close()
+
+	resetFunc, err := testMysqld.SetSuperReadOnly(t.Context(), true)
+	require.NoError(t, err)
+	require.NotNil(t, resetFunc)
+
+	done := make(chan error, 1)
+	go func() { done <- resetFunc() }()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		require.Fail(t, "resetFunc did not return; the reset context is not bounded")
+	}
+}
+
+func TestSetSuperReadOnlyResetDetachedFromParentContext(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+
+	params := db.ConnParams()
+	cp := *params
+	dbc := dbconfigs.NewTestDBConfigs(cp, cp, "fakesqldb")
+
+	db.AddQuery("SELECT 1", &sqltypes.Result{})
+	db.AddQuery("SELECT @@global.super_read_only", sqltypes.MakeTestResult(sqltypes.MakeTestFields("sro", "int64"), "0"))
+	db.AddQuery("SET GLOBAL super_read_only = 'ON'", &sqltypes.Result{})
+	db.AddQuery("SET GLOBAL super_read_only = 'OFF'", &sqltypes.Result{})
+
+	testMysqld := NewMysqld(dbc)
+	defer testMysqld.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	resetFunc, err := testMysqld.SetSuperReadOnly(ctx, true)
+	require.NoError(t, err)
+	require.NotNil(t, resetFunc)
+
+	cancel()
+
+	require.NoError(t, resetFunc())
+	assert.NotZero(t, db.GetQueryCalledNum("SET GLOBAL super_read_only = 'OFF'"))
 }


### PR DESCRIPTION
## Description

The reset function returned by `Mysqld.SetSuperReadOnly` ran on `context.Background()`, which has no deadline, so cleanup could block indefinitely if MySQL was unresponsive. Since the reset runs from a `defer` while `actionMutex` is held, a stall there can wedge the tablet and leave a reparent holding the shard lock.

`context.Background()` is intentional and kept: the reset is usually called when the caller's context is already cancelled, so using that context would skip the cleanup entirely. The fix keeps it detached but bounds it.

After AI review feedback, a plain `context.WithTimeout` turned out not to be enough  parts of the execution path ignore the context (the pool health check, KILL delivery, and the unconditional wait for a killed query), and a bare watchdog would abandon an in-flight `SET GLOBAL` that a recovering server could apply later, after the state had been changed by a subsequent reparent. The reset now:

- runs on a dedicated DBA connection, so every step (connect, execute) honors the deadline
- on timeout, closes the connection and joins the worker **before returning** — nothing is left running and no connection or goroutine is retained
- then issues a best-effort KILL on a second dedicated connection (itself bounded the same way), so a recovering server aborts the pending statement instead of applying it later


## Related Issue(s)

Fixes #20586

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

No configuration change. A stalled reset now fails after a 15s timeout (with a best-effort KILL of the stuck statement) and logs an error instead of blocking forever.

### AI Disclosure

The tests and the follow-up hardening commits (the bounded execution and KILL handling) were written by Claude Code, with direction and review from me.
