### PR TITLE
evalengine: collapse NULL RHS for compiled LIKE expressions

### DIFF
--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -207,6 +207,13 @@ func TestCompilerSingle(t *testing.T) {
 			result:     "INT64(1)",
 		},
 		{
+			// A NULL pattern from a column is not folded away, so this exercises the compiled
+			// program; a leftover operand would make IFNULL overflow the VM stack.
+			expression: "ifnull('foo' like column0, 7)",
+			values:     []sqltypes.Value{sqltypes.NULL},
+			result:     "INT64(7)",
+		},
+		{
 			expression: "1 + column0",
 			values:     []sqltypes.Value{sqltypes.NewFloat64(1)},
 			result:     "FLOAT64(2)",

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -202,6 +202,11 @@ func TestCompilerSingle(t *testing.T) {
 			result:     "INT64(2)",
 		},
 		{
+			// LIKE must collapse a NULL right operand before outer expressions consume the result.
+			expression: "null <=> ('foo' like null)",
+			result:     "INT64(1)",
+		},
+		{
 			expression: "1 + column0",
 			values:     []sqltypes.Value{sqltypes.NewFloat64(1)},
 			result:     "FLOAT64(2)",

--- a/go/vt/vtgate/evalengine/expr_compare.go
+++ b/go/vt/vtgate/evalengine/expr_compare.go
@@ -643,7 +643,7 @@ func (expr *LikeExpr) compile(c *compiler) (ctype, error) {
 		return ctype{}, err
 	}
 
-	skip2 := c.compileNullCheck1(rt)
+	skip2 := c.compileNullCheck1r(rt)
 
 	if !lt.isTextual() {
 		c.asm.Convert_xc(2, sqltypes.VarChar, c.collation, nil)


### PR DESCRIPTION
## Description

The compiled EvalEngine used the single-operand null check for the right-hand side of `LIKE`. When the pattern evaluated to `NULL`, that check jumped without collapsing the two operands on the VM stack. An enclosing expression could then consume the leftover left-hand value and return an incorrect result.

For example, MySQL and the interpreted EvalEngine return `1` for:

```sql
NULL <=> ('foo' LIKE NULL)
```

Before this change, the compiled EvalEngine returned `0`.

This change uses `compileNullCheck1r` for the right operand so the stack contains one `NULL` result before execution continues. The regression test compares the interpreted and compiled paths.

No backport is requested. EvalEngine evaluation of `LIKE` is uncommon, and this small compatibility fix can ride the next release unless maintainers prefer otherwise.

### Tests

```sh
go test ./go/vt/vtgate/evalengine -run 'TestCompilerSingle/null_<=>' -count=10
go test ./go/vt/vtgate/evalengine -count=1
go test ./go/vt/vtgate/engine -run 'Test(FilterPass|FilterStreaming|ProjectionStreaming)$' -count=1
go test ./go/vt/vtgate/planbuilder/... -count=1
```

I also compared the expression against a local MySQL 9.6.0 instance. MySQL returned `1`, matching the interpreted EvalEngine and the compiled result after this change.

## Related Issue(s)

Fixes #20623

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

This PR was AI-assisted. The contributor directed the investigation and inspected the result; GPT-5 Codex helped investigate the root cause, write the code and test, and draft the issue and PR.
