### PR TITLE
mysql/json: fix MarshalTo discarding accumulated output for nested blob and bit values

### DIFF
--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -809,12 +809,11 @@ func (v *Value) MarshalTo(dst []byte) []byte {
 	case TypeBlob, TypeBit:
 		const prefix = "base64:type15:"
 
-		size := 2 + len(prefix) + base64.StdEncoding.EncodedLen(len(v.s))
-		dst := make([]byte, size)
-		dst[0] = '"'
-		copy(dst[1:], prefix)
-		base64.StdEncoding.Encode(dst[len(prefix)+1:], []byte(v.s))
-		dst[size-1] = '"'
+		dst = slices.Grow(dst, 2+len(prefix)+base64.StdEncoding.EncodedLen(len(v.s)))
+		dst = append(dst, '"')
+		dst = append(dst, prefix...)
+		dst = base64.StdEncoding.AppendEncode(dst, hack.StringBytes(v.s))
+		dst = append(dst, '"')
 		return dst
 	case TypeNumber:
 		if v.NumberType() == NumberTypeFloat {

--- a/go/mysql/json/parser_test.go
+++ b/go/mysql/json/parser_test.go
@@ -524,3 +524,29 @@ func TestParserParse(t *testing.T) {
 		require.Equalf(t, want, v.String(), "unexpected string representation for object")
 	})
 }
+
+// TestMarshalToBlob verifies that marshaling a blob or bit value appends to
+// the caller's buffer instead of discarding previously accumulated output.
+func TestMarshalToBlob(t *testing.T) {
+	// base64("foo") == "Zm9v".
+	const encoded = `"base64:type15:Zm9v"`
+
+	t.Run("bare", func(t *testing.T) {
+		require.Equal(t, encoded, string(NewBlob("foo").MarshalTo(nil)))
+		require.Equal(t, encoded, string(NewBit("foo").MarshalTo(nil)))
+	})
+
+	t.Run("inside-array", func(t *testing.T) {
+		v := NewArray([]*Value{NewString("a"), NewBlob("foo")})
+		require.Equal(t, `["a", `+encoded+`]`, string(v.MarshalTo(nil)))
+
+		v = NewArray([]*Value{NewString("a"), NewBit("foo")})
+		require.Equal(t, `["a", `+encoded+`]`, string(v.MarshalTo(nil)))
+	})
+
+	t.Run("inside-object", func(t *testing.T) {
+		var obj Object
+		obj.Add("k", NewBlob("foo"))
+		require.Equal(t, `{"k": `+encoded+`}`, string(NewObject(obj).MarshalTo(nil)))
+	})
+}

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -267,6 +267,10 @@ func JSONArray(yield Query) {
 			yield(fmt.Sprintf("JSON_ARRAY(%s, %s)", a, b), nil, false)
 		}
 	}
+	for _, b := range inputJSONBinaryValues {
+		yield(fmt.Sprintf("JSON_ARRAY(%s)", b), nil, false)
+		yield(fmt.Sprintf("JSON_ARRAY('a', %s)", b), nil, false)
+	}
 	yield("JSON_ARRAY()", nil, false)
 }
 
@@ -275,6 +279,9 @@ func JSONObject(yield Query) {
 		for _, b := range inputJSONPrimitives {
 			yield(fmt.Sprintf("JSON_OBJECT(%s, %s)", a, b), nil, false)
 		}
+	}
+	for _, b := range inputJSONBinaryValues {
+		yield(fmt.Sprintf("JSON_OBJECT('k', %s)", b), nil, false)
 	}
 	yield("JSON_OBJECT()", nil, false)
 }

--- a/go/vt/vtgate/evalengine/testcases/inputs.go
+++ b/go/vt/vtgate/evalengine/testcases/inputs.go
@@ -46,6 +46,13 @@ var inputJSONPrimitives = []string{
 	`'foobar'`, `'foo\nbar'`, `'a'`, `JSON_OBJECT()`,
 }
 
+// inputJSONBinaryValues are JSON-able values that MySQL stores as opaque
+// binary values inside a JSON document. They are only valid in value
+// position: MySQL rejects binary-charset strings as JSON object keys.
+var inputJSONBinaryValues = []string{
+	`CAST('foo' AS BINARY)`, `b'1010'`,
+}
+
 var inputBitwise = []string{
 	"0", "1", "0xFF", "255", "1.0", "1.1", "-1", "-255", "7", "9", "13", "1.5", "-1.5", "'1.5'", "'-1.5'",
 	"0.0e0", "1.0e0", "255.0", "1.5e0", "-1.5e0", "1.1e0", "-1e0", "-255e0", "7e0", "9e0", "13e0",

--- a/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/vstreamer_test.go
@@ -2210,6 +2210,39 @@ func TestJSON(t *testing.T) {
 	ts.Run()
 }
 
+// TestJSONNestedOpaque verifies that JSON documents containing binary and bit
+// values nested inside arrays and objects stream with the surrounding document
+// intact, since those values take a separate marshaling path from other JSON
+// scalars.
+func TestJSONNestedOpaque(t *testing.T) {
+	execStatements(t, []string{
+		"create table vitess_json_opaque(id int, val json, primary key(id))",
+	})
+	t.Cleanup(func() {
+		execStatements(t, []string{
+			"drop table vitess_json_opaque",
+		})
+	})
+
+	testcases := []testcase{{
+		input: []string{
+			"begin",
+			"insert into vitess_json_opaque values(1, JSON_OBJECT('k', CAST('foo' AS BINARY)))",
+			"insert into vitess_json_opaque values(2, JSON_ARRAY('a', b'1010'))",
+			"commit",
+		},
+		output: [][]string{{
+			"begin",
+			`type:FIELD field_event:{table_name:"vitess_json_opaque" fields:{name:"id" type:INT32 table:"vitess_json_opaque" org_table:"vitess_json_opaque" database:"vttest" org_name:"id" column_length:11 charset:63 column_type:"int(11)"} fields:{name:"val" type:JSON table:"vitess_json_opaque" org_table:"vitess_json_opaque" database:"vttest" org_name:"val" column_length:4294967295 charset:63 column_type:"json"}}`,
+			`type:ROW row_event:{table_name:"vitess_json_opaque" row_changes:{after:{lengths:1 lengths:27 values:"1{\"k\": \"base64:type15:Zm9v\"}"}}}`,
+			`type:ROW row_event:{table_name:"vitess_json_opaque" row_changes:{after:{lengths:1 lengths:27 values:"2[\"a\", \"base64:type15:Cg==\"]"}}}`,
+			"gtid",
+			"commit",
+		}},
+	}}
+	runCases(t, nil, testcases, "", nil)
+}
+
 func TestExternalTable(t *testing.T) {
 	execStatements(t, []string{
 		"create database external",


### PR DESCRIPTION
## Description

`Value.MarshalTo` in `go/mysql/json` takes a destination buffer and appends the marshaled value to it. The arm that handles blob and bit values accidentally declares a fresh buffer instead of appending to the one the caller passed in. As a result, whenever a blob or bit value appears inside an array or object, everything marshaled before it is thrown away. Marshaling an array such as `["a", <blob>]` comes back as just the blob token, with the opening bracket and every preceding element missing.

This PR fixes the arm to append the quoted `base64:type15:` token to the incoming buffer like every other arm does. The encoded bytes for the value itself are unchanged, and the destination is presized in one step so the fix does not add allocations on the common path. A regression test covers bare and in-array marshaling for both blob and bit values and in-object marshaling for blob, and it fails with the exact truncation symptom on the old code. The bug silently corrupts output for any caller passing a non-empty buffer, so it is probably worth backporting to the release branches.

## Related Issue(s)

https://github.com/vitessio/vitess/pull/20682 depends on this change.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

JSON marshaling of blob and bit values nested inside arrays or objects no longer truncates the preceding output. No migrations or configuration changes.

### AI Disclosure

This PR was written primarily by Fable with review from GPT 5.6 Sol.


