### PR TITLE
vtgate: cross-shard JSON_ARRAYAGG/JSON_OBJECTAGG via merge-only pushdown

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -23,6 +23,7 @@
         - [New controls for cross-keyspace reads](#vtgate-cross-keyspace-reads)
         - [Streaming errors no longer surface as connection loss](#vtgate-streamexecute-real-errors)
         - [SHA256-hashed passwords in the static gRPC auth plugin](#vtgate-grpc-static-auth-sha256)
+        - [Cross-shard `JSON_ARRAYAGG` and `JSON_OBJECTAGG`](#vtgate-cross-shard-json-aggregation)
     - **[VTTablet](#minor-changes-vttablet)**
         - [Consolidator Reject on Waiter Cap](#vttablet-consolidator-reject-on-cap)
     - **[VTTablet](#minor-changes-vttablet)**
@@ -204,6 +205,19 @@ When an entry sets `CachingSha2Password`, it takes precedence over the plaintext
 The hash is validated and hex-decoded once when the plugin loads. An entry whose `CachingSha2Password` is not valid hex, or does not decode to a 32-byte SHA256 digest, causes the plugin to fail to initialize. No new plugin or flag is introduced.
 
 See [#19250](https://github.com/vitessio/vitess/pull/19250) for details.
+
+#### <a id="vtgate-cross-shard-json-aggregation"/>Cross-shard `JSON_ARRAYAGG` and `JSON_OBJECTAGG`</a>
+
+The aggregation functions `JSON_ARRAYAGG(expr)` and `JSON_OBJECTAGG(key, value)` are now supported in cross-shard queries (scatter aggregation, with or without `GROUP BY`, including use in `HAVING` and inside other expressions). Previously these functions were only supported when the whole query could be routed to a single shard, and cross-shard usage failed with `VT12001: unsupported: in scatter query: aggregation function ...`.
+
+Each shard computes the aggregate for its own rows and VTGate merges the shard-level JSON documents. Notes:
+
+- The order of elements produced by `JSON_ARRAYAGG` across shards follows the order in which shard results are merged. MySQL documents the element order of `JSON_ARRAYAGG` as undefined, so results are spec-conforming but may be ordered differently than on an unsharded MySQL.
+- For `JSON_OBJECTAGG`, MySQL's "last duplicate key wins" rule is applied when merging shard results. As in MySQL (where the result "can depend on the order in which the rows are returned, which is not guaranteed"), the surviving value for a key that occurs on several shards is nondeterministic.
+- Member values of a merged `JSON_OBJECTAGG` that are themselves nested JSON objects may be serialized with a different (but semantically equivalent) member order than MySQL produces.
+- Comparing one of these aggregates (or any JSON-typed value derived from them, including via a derived table) against a string or untyped value at the VTGate level — whether written as a comparison operator, `BETWEEN`, a `CASE` operand, or `NULLIF` — is rejected at planning time with `VT12001: unsupported: comparison of a JSON aggregation result with a string or untyped value`, because VTGate's expression engine does not apply MySQL's implicit string-to-JSON-document parse in comparisons. Compare extracted scalars instead (for example `having json_extract(json_arrayagg(a), '$[0]') = 1`). JSON-literal comparands such as `json_array(...)` currently fail with an `UNIMPLEMENTED: unsupported literal kind` error.
+
+Queries where the aggregate cannot be pushed down to MySQL — for example over cross-shard joins — are not supported and now fail with the more precise error `VT12001: unsupported: aggregation function '<expr>' must be pushed down to MySQL`.
 
 ### <a id="minor-changes-vttablet"/>VTTablet</a>
 

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -809,12 +809,11 @@ func (v *Value) MarshalTo(dst []byte) []byte {
 	case TypeBlob, TypeBit:
 		const prefix = "base64:type15:"
 
-		size := 2 + len(prefix) + base64.StdEncoding.EncodedLen(len(v.s))
-		dst := make([]byte, size)
-		dst[0] = '"'
-		copy(dst[1:], prefix)
-		base64.StdEncoding.Encode(dst[len(prefix)+1:], []byte(v.s))
-		dst[size-1] = '"'
+		dst = slices.Grow(dst, 2+len(prefix)+base64.StdEncoding.EncodedLen(len(v.s)))
+		dst = append(dst, '"')
+		dst = append(dst, prefix...)
+		dst = base64.StdEncoding.AppendEncode(dst, []byte(v.s))
+		dst = append(dst, '"')
 		return dst
 	case TypeNumber:
 		if v.NumberType() == NumberTypeFloat {

--- a/go/mysql/json/parser_test.go
+++ b/go/mysql/json/parser_test.go
@@ -524,3 +524,29 @@ func TestParserParse(t *testing.T) {
 		require.Equalf(t, want, v.String(), "unexpected string representation for object")
 	})
 }
+
+// TestMarshalToBlob verifies that marshaling a blob or bit value appends to
+// the caller's buffer instead of discarding previously accumulated output.
+func TestMarshalToBlob(t *testing.T) {
+	// base64("foo") == "Zm9v".
+	const encoded = `"base64:type15:Zm9v"`
+
+	t.Run("bare", func(t *testing.T) {
+		require.Equal(t, encoded, string(NewBlob("foo").MarshalTo(nil)))
+		require.Equal(t, encoded, string(NewBit("foo").MarshalTo(nil)))
+	})
+
+	t.Run("inside-array", func(t *testing.T) {
+		v := NewArray([]*Value{NewString("a"), NewBlob("foo")})
+		require.Equal(t, `["a", `+encoded+`]`, string(v.MarshalTo(nil)))
+
+		v = NewArray([]*Value{NewString("a"), NewBit("foo")})
+		require.Equal(t, `["a", `+encoded+`]`, string(v.MarshalTo(nil)))
+	})
+
+	t.Run("inside-object", func(t *testing.T) {
+		var obj Object
+		obj.Add("k", NewBlob("foo"))
+		require.Equal(t, `{"k": `+encoded+`}`, string(NewObject(obj).MarshalTo(nil)))
+	})
+}

--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package aggregation
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand/v2"
 	"slices"
@@ -816,4 +817,114 @@ func TestJsonAggregation(t *testing.T) {
 
 	mcmp.Exec("select count(1) from t3 where id6 = 2 group by id7 having json_arrayagg(id5+1) = json_array(2, 6)")
 	mcmp.Exec(`select count(1) from t3 where id6 = 2 group by id7 having json_objectagg(id5+1, id7) = json_object("2",1,"6",1)`)
+}
+
+// TestJsonAggregationCrossShard tests json_arrayagg and json_objectagg over
+// scatter queries: each shard computes a complete JSON document for its rows
+// and vtgate merges the shard-level partial documents.
+func TestJsonAggregationCrossShard(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	// id6 = 1 hashes to shard -80 and id6 = 4 hashes to shard 80-, so the
+	// inserted rows genuinely span both shards.
+	mcmp.Exec("insert into t3(id5, id6, id7) values (1,1,10), (2,1,10), (3,1,20), (4,4,30), (5,4,30), (10,4,40)")
+
+	// Check the plan shape once: a scatter route with the merge happening in
+	// a vtgate-level aggregation.
+	res, err := mcmp.VtConn.ExecuteFetch("vexplain plan select id7, json_arrayagg(id5) from t3 group by id7", 100, false)
+	require.NoError(t, err)
+	require.Contains(t, fmt.Sprintf("%v", res.Rows), "json_arrayagg(1) AS json_arrayagg(id5)")
+	require.Contains(t, fmt.Sprintf("%v", res.Rows), "Scatter")
+
+	// Every id7 group lives on a single shard, so the per-group results are
+	// byte-identical to MySQL while the plan is still a scatter with a
+	// vtgate-side merge.
+	mcmp.Exec("select id7, json_arrayagg(id5) from t3 group by id7 order by id7")
+	mcmp.Exec("select id7, json_objectagg(id5, id6) from t3 group by id7 order by id7")
+
+	// The aggregate inside another expression evaluated at the vtgate level.
+	mcmp.Exec("select id7, json_extract(json_arrayagg(id5), '$[0]') from t3 group by id7 order by id7")
+
+	// HAVING over the merged value. JSON-typed comparands such as
+	// json_array(1, 2) constant-fold to a JSON literal that the evalengine
+	// compiler cannot push for cross-shard filters (UNIMPLEMENTED:
+	// unsupported literal kind '*json.Value'), so compare an extracted
+	// scalar instead.
+	mcmp.Exec("select id7 from t3 group by id7 having json_extract(json_arrayagg(id5), '$[0]') = 1 order by id7")
+
+	// Comparing the merged document against a string is rejected at planning
+	// time: the evalengine would treat the string as a JSON string scalar
+	// where MySQL parses it as a JSON document.
+	utils.AssertContainsError(t, mcmp.VtConn,
+		"select id7 from t3 group by id7 having json_arrayagg(id5) = '[1, 2]'",
+		"VT12001")
+
+	// The same applies to constructs the evalengine lowers to comparisons,
+	// such as BETWEEN, a CASE operand, and NULLIF.
+	utils.AssertContainsError(t, mcmp.VtConn,
+		"select id7 from t3 group by id7 having json_arrayagg(id5) between '[]' and '[9]'",
+		"VT12001")
+
+	// A true multi-shard merge: both shards contribute a non-NULL partial.
+	// The cross-shard element order is undefined, so the arrays are compared
+	// as multisets.
+	mQr, vtQr := mcmp.ExecNoCompare("select json_arrayagg(id5) from t3")
+	compareJSONArrayAggRows(t, mQr, vtQr, 0)
+
+	// A true multi-shard json_objectagg merge: the keys are globally unique
+	// and of differing lengths, and the merged object is emitted in MySQL's
+	// key-length-then-bytes member order, so the bytes match MySQL exactly.
+	mcmp.Exec("select json_objectagg(id5, id7) from t3")
+
+	// Wide DECIMAL member values must survive the cross-shard merge verbatim:
+	// re-encoding them through float64 would corrupt the literals. id = 1, 2
+	// hash to shard -80 and id = 4 to 80-.
+	mcmp.Exec("insert into bet_logs(id, merchant_game_id, bet_amount, game_id) values " +
+		"(1, 1, 123456789012.12345678, 1), (2, 1, 1.50000000, 1), (4, 2, 99999999999.00000001, 2)")
+	mcmp.Exec("select json_objectagg(id, bet_amount) from bet_logs")
+
+	// A NULL key makes the shard's MySQL fail the statement; the shard error
+	// is propagated as is.
+	mcmp.AssertContainsError("select json_objectagg(null, id5) from t3", "JSON documents may not contain NULL member names")
+
+	// Aggregation over a cross-shard join would require vtgate to build the
+	// JSON documents from raw values, which is not supported.
+	utils.AssertContainsError(t, mcmp.VtConn, "select json_arrayagg(t3.id5) from t3 join t9",
+		"VT12001: unsupported: aggregation function 'json_arrayagg(t3.id5)' must be pushed down to MySQL")
+
+	// SQL NULL rows are kept as JSON null elements, unlike other aggregates
+	// that skip NULL values. id1 = 1, 2 hash to shard -80 and id1 = 4 to 80-.
+	mcmp.Exec("insert into t9(id1, id2, id3) values (1,'a',null), (2,'b','x'), (4,'c',null)")
+	mQr, vtQr = mcmp.ExecNoCompare("select json_arrayagg(id3) from t9")
+	compareJSONArrayAggRows(t, mQr, vtQr, 0)
+
+	// Shards without rows contribute a SQL NULL partial that the merge must
+	// skip: only shard -80 still has rows, but the plan is still a scatter.
+	mcmp.Exec("delete from t3 where id6 = 4")
+	mcmp.Exec("select json_arrayagg(id7) from t3")
+	mcmp.Exec("select json_objectagg(id5, id7) from t3")
+
+	// Aggregating no rows at all must return SQL NULL, never [] or {}.
+	mcmp.Exec("delete from t3")
+	mcmp.Exec("select json_arrayagg(id7) from t3")
+	mcmp.Exec("select json_objectagg(id5, id7) from t3")
+}
+
+// compareJSONArrayAggRows compares a json_arrayagg column of MySQL and vtgate
+// results as multisets: MySQL documents the element order of json_arrayagg as
+// undefined, and the cross-shard merge order is not reproducible, so the
+// arrays are compared after sorting their elements.
+func compareJSONArrayAggRows(t *testing.T, mRes, vtRes *sqltypes.Result, col int) {
+	t.Helper()
+	require.Len(t, vtRes.Rows, len(mRes.Rows), "mysql and vitess result count does not match")
+	for i, vtRow := range vtRes.Rows {
+		var mElems, vtElems []json.RawMessage
+		require.NoError(t, json.Unmarshal(mRes.Rows[i][col].Raw(), &mElems))
+		require.NoError(t, json.Unmarshal(vtRow[col].Raw(), &vtElems))
+		sortRaw := func(a, b json.RawMessage) int { return strings.Compare(string(a), string(b)) }
+		slices.SortFunc(mElems, sortRaw)
+		slices.SortFunc(vtElems, sortRaw)
+		require.Equal(t, mElems, vtElems, "mysql and vitess arrays contain different elements: vitess:%v, mysql:%v", vtRes.Rows, mRes.Rows)
+	}
 }

--- a/go/vt/vtgate/engine/aggregations.go
+++ b/go/vt/vtgate/engine/aggregations.go
@@ -17,10 +17,14 @@ limitations under the License.
 package engine
 
 import (
+	"cmp"
 	"fmt"
+	"slices"
 	"strconv"
+	"strings"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/json"
 	"vitess.io/vitess/go/slice"
 	"vitess.io/vitess/go/sqltypes"
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
@@ -336,6 +340,174 @@ func (a *aggregatorGroupConcat) reset() {
 	a.concat = nil // not safe to reuse this byte slice as it's returned as MakeTrusted
 }
 
+// aggregatorJSONArrayAgg merges the per-shard results of a pushed-down json_arrayagg
+// into a single JSON array. Every non-NULL input is a complete, MySQL-normalized JSON
+// array computed by one shard (the planner always pushes the whole function into the
+// shard query), so the merge splices the raw element bytes without parsing; MySQL
+// separates array elements with ", ", so the spliced result is byte-identical to what
+// MySQL itself would produce for the combined rows. A NULL input means the shard had
+// no rows for this group (json_arrayagg returns NULL for an empty group) and is
+// skipped; if no shard contributed anything, the result is SQL NULL, matching MySQL's
+// empty-group behavior.
+type aggregatorJSONArrayAgg struct {
+	from     int
+	hasValue bool
+	elems    []byte // merged elements, without the enclosing brackets
+}
+
+func (a *aggregatorJSONArrayAgg) add(row []sqltypes.Value) error {
+	value := row[a.from]
+	if value.IsNull() {
+		return nil
+	}
+	raw := value.Raw()
+	if len(raw) < 2 || raw[0] != '[' || raw[len(raw)-1] != ']' {
+		return vterrors.VT13001(fmt.Sprintf("unexpected json_arrayagg partial: %q", raw))
+	}
+	// The bracket check alone would accept inputs like `[1], [2]` and splice
+	// corrupt JSON; parse the whole partial to validate it, then splice the
+	// original bytes so the merged output stays byte-identical to MySQL's.
+	var p json.Parser
+	parsed, err := p.ParseBytes(raw)
+	if err != nil {
+		return vterrors.VT13001(fmt.Sprintf("unexpected json_arrayagg partial: %v", err))
+	}
+	if _, isArray := parsed.Array(); !isArray {
+		return vterrors.VT13001(fmt.Sprintf("unexpected json_arrayagg partial: %q", raw))
+	}
+	inner := raw[1 : len(raw)-1]
+	if len(a.elems) > 0 && len(inner) > 0 {
+		a.elems = append(a.elems, ", "...)
+	}
+	a.elems = append(a.elems, inner...)
+	a.hasValue = true
+	return nil
+}
+
+func (a *aggregatorJSONArrayAgg) finish(*evalengine.ExpressionEnv, collations.ID) (sqltypes.Value, error) {
+	if !a.hasValue {
+		return sqltypes.NULL, nil
+	}
+	merged := make([]byte, 0, len(a.elems)+2)
+	merged = append(merged, '[')
+	merged = append(merged, a.elems...)
+	merged = append(merged, ']')
+	return sqltypes.MakeTrusted(sqltypes.TypeJSON, merged), nil
+}
+
+func (a *aggregatorJSONArrayAgg) reset() {
+	a.hasValue = false
+	a.elems = a.elems[:0] // safe to reuse: finish copies the bytes before returning them
+}
+
+// aggregatorJSONObjectAgg merges the per-shard results of a pushed-down json_objectagg
+// into a single JSON object. Every non-NULL input is a complete, MySQL-normalized JSON
+// object (duplicate keys within a shard were already resolved by MySQL). Members merge
+// with MySQL's documented "last duplicate key wins" rule, resolved in partial-arrival
+// order — nondeterministic across shards, exactly as MySQL documents for rows without
+// a guaranteed order. A NULL input means the shard had no rows for this group and is
+// skipped. The merged object is emitted with members sorted by key length and then by
+// byte order, matching MySQL's JSON object normalization.
+type aggregatorJSONObjectAgg struct {
+	from     int
+	hasValue bool
+	keys     []string
+	vals     map[string]*json.Value
+}
+
+func (a *aggregatorJSONObjectAgg) add(row []sqltypes.Value) error {
+	value := row[a.from]
+	if value.IsNull() {
+		return nil
+	}
+	// One-shot parser: the returned values keep the parser's private copy of the
+	// input alive, so they remain valid after the parser goes out of scope.
+	var p json.Parser
+	parsed, err := p.ParseBytes(value.Raw())
+	if err != nil {
+		return vterrors.VT13001(fmt.Sprintf("unexpected json_objectagg partial: %v", err))
+	}
+	obj, ok := parsed.Object()
+	if !ok {
+		return vterrors.VT13001(fmt.Sprintf("unexpected json_objectagg partial: %q", value.Raw()))
+	}
+	a.hasValue = true
+	if a.vals == nil {
+		a.vals = make(map[string]*json.Value, obj.Len())
+	}
+	for _, k := range obj.Keys() {
+		if _, seen := a.vals[k]; !seen {
+			a.keys = append(a.keys, k)
+		}
+		a.vals[k] = obj.Get(k)
+	}
+	return nil
+}
+
+func (a *aggregatorJSONObjectAgg) finish(*evalengine.ExpressionEnv, collations.ID) (sqltypes.Value, error) {
+	if !a.hasValue {
+		return sqltypes.NULL, nil
+	}
+	// MySQL normalizes JSON object members by key length first, then by byte order.
+	slices.SortFunc(a.keys, func(x, y string) int {
+		if c := cmp.Compare(len(x), len(y)); c != 0 {
+			return c
+		}
+		return strings.Compare(x, y)
+	})
+	merged := []byte{'{'}
+	for i, k := range a.keys {
+		if i > 0 {
+			merged = append(merged, ',', ' ')
+		}
+		merged = json.NewString(k).MarshalTo(merged)
+		merged = append(merged, ':', ' ')
+		merged = appendJSONPreservingNumbers(merged, a.vals[k])
+	}
+	merged = append(merged, '}')
+	return sqltypes.MakeTrusted(sqltypes.TypeJSON, merged), nil
+}
+
+func (a *aggregatorJSONObjectAgg) reset() {
+	a.hasValue = false
+	a.keys = nil
+	a.vals = nil // not safe to reuse: the merged values alias the parsed partials
+}
+
+// appendJSONPreservingNumbers appends the JSON text of a parsed value, emitting
+// numbers via their raw parsed literal: MarshalTo reformats non-integer numbers
+// through float64, which corrupts wide decimals produced by MySQL.
+func appendJSONPreservingNumbers(dst []byte, v *json.Value) []byte {
+	if obj, ok := v.Object(); ok {
+		dst = append(dst, '{')
+		first := true
+		obj.Visit(func(key string, val *json.Value) {
+			if !first {
+				dst = append(dst, ',', ' ')
+			}
+			first = false
+			dst = json.NewString(key).MarshalTo(dst)
+			dst = append(dst, ':', ' ')
+			dst = appendJSONPreservingNumbers(dst, val)
+		})
+		return append(dst, '}')
+	}
+	if arr, ok := v.Array(); ok {
+		dst = append(dst, '[')
+		for i, el := range arr {
+			if i > 0 {
+				dst = append(dst, ',', ' ')
+			}
+			dst = appendJSONPreservingNumbers(dst, el)
+		}
+		return append(dst, ']')
+	}
+	if v.NumberType() != json.NumberTypeUnknown {
+		return append(dst, v.Raw()...)
+	}
+	return v.MarshalTo(dst)
+}
+
 type aggregatorGtid struct {
 	from   int
 	shards []*binlogdatapb.ShardGtid
@@ -503,6 +675,12 @@ func newAggregation(fields []*querypb.Field, aggregates []*AggregateParams, env 
 				type_:     targetType,
 				separator: separator,
 			}
+
+		case opcode.AggregateJSONArrayAgg:
+			ag = &aggregatorJSONArrayAgg{from: aggr.Col}
+
+		case opcode.AggregateJSONObjectAgg:
+			ag = &aggregatorJSONObjectAgg{from: aggr.Col}
 
 		case opcode.AggregateConstant:
 			ag = &aggregatorConstant{expr: aggr.EExpr}

--- a/go/vt/vtgate/engine/opcode/constants.go
+++ b/go/vt/vtgate/engine/opcode/constants.go
@@ -79,7 +79,9 @@ const (
 	AggregateAvg
 	AggregateUDF      // This is an opcode used to represent UDFs
 	AggregateConstant // This is an opcode used to represent constants that are not grouped
-	_NumOfOpCodes     // This line must be last of the opcodes!
+	AggregateJSONArrayAgg
+	AggregateJSONObjectAgg
+	_NumOfOpCodes // This line must be last of the opcodes!
 )
 
 // SupportedAggregates maps the list of supported aggregate
@@ -99,6 +101,8 @@ var SupportedAggregates = map[string]AggregateOpcode{
 	"any_value":      AggregateAnyValue,
 	"group_concat":   AggregateGroupConcat,
 	"constant_aggr":  AggregateGroupConcat,
+	"json_arrayagg":  AggregateJSONArrayAgg,
+	"json_objectagg": AggregateJSONObjectAgg,
 }
 
 var AggregateName = map[AggregateOpcode]string{
@@ -114,6 +118,8 @@ var AggregateName = map[AggregateOpcode]string{
 	AggregateAnyValue:      "any_value",
 	AggregateAvg:           "avg",
 	AggregateConstant:      "constant_aggr",
+	AggregateJSONArrayAgg:  "json_arrayagg",
+	AggregateJSONObjectAgg: "json_objectagg",
 }
 
 func (code AggregateOpcode) String() string {
@@ -157,6 +163,9 @@ func (code AggregateOpcode) SQLType(typ querypb.Type) querypb.Type {
 		return sqltypes.Int64
 	case AggregateGtid:
 		return sqltypes.VarChar
+	case AggregateJSONArrayAgg, AggregateJSONObjectAgg:
+		// Both functions always return JSON regardless of the input type.
+		return sqltypes.TypeJSON
 	case AggregateUDF, AggregateConstant: // TODO: we can probably figure out the type here
 		return sqltypes.Unknown
 	default:

--- a/go/vt/vtgate/engine/opcode/constants_test.go
+++ b/go/vt/vtgate/engine/opcode/constants_test.go
@@ -52,6 +52,10 @@ func TestType(t *testing.T) {
 		{AggregateCount, sqltypes.Int32, sqltypes.Int64},
 		{AggregateCountStar, sqltypes.Int64, sqltypes.Int64},
 		{AggregateGtid, sqltypes.VarChar, sqltypes.VarChar},
+		{AggregateJSONArrayAgg, sqltypes.VarChar, sqltypes.TypeJSON},
+		{AggregateJSONArrayAgg, sqltypes.Unknown, sqltypes.TypeJSON},
+		{AggregateJSONObjectAgg, sqltypes.Int64, sqltypes.TypeJSON},
+		{AggregateJSONObjectAgg, sqltypes.Unknown, sqltypes.TypeJSON},
 	}
 
 	for _, tc := range tt {
@@ -130,6 +134,8 @@ func TestAggregateOpcode_MarshalJSON(t *testing.T) {
 		{AggregateGroupConcat, "\"group_concat\""},
 		{AggregateAnyValue, "\"any_value\""},
 		{AggregateAvg, "\"avg\""},
+		{AggregateJSONArrayAgg, "\"json_arrayagg\""},
+		{AggregateJSONObjectAgg, "\"json_objectagg\""},
 		{999, "\"ERROR\""},
 	}
 

--- a/go/vt/vtgate/engine/ordered_aggregate_test.go
+++ b/go/vt/vtgate/engine/ordered_aggregate_test.go
@@ -1189,3 +1189,129 @@ func TestGroupConcat(t *testing.T) {
 		})
 	}
 }
+
+// TestJSONArrayAgg tests merging shard-level json_arrayagg partials per group.
+func TestJSONArrayAgg(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"c1|json_arrayagg(c2)",
+		"int64|json",
+	)
+
+	tcases := []struct {
+		name        string
+		inputResult *sqltypes.Result
+		expResult   *sqltypes.Result
+	}{{
+		name: "multiple grouping keys",
+		inputResult: sqltypes.MakeTestResult(fields,
+			`10|[1, 2]`, `10|[3]`,
+			`20|["a"]`,
+			`30|[null]`, `30|null`,
+			`40|null`),
+		expResult: sqltypes.MakeTestResult(fields,
+			`10|[1, 2, 3]`,
+			`20|["a"]`,
+			`30|[null]`,
+			`40|null`),
+	}, {
+		name:        "empty result",
+		inputResult: sqltypes.MakeTestResult(fields),
+		expResult:   sqltypes.MakeTestResult(fields),
+	}}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			fp := &fakePrimitive{results: []*sqltypes.Result{tcase.inputResult}}
+			oa := &OrderedAggregate{
+				Aggregates:  []*AggregateParams{NewAggregateParam(AggregateJSONArrayAgg, 1, nil, "", collations.MySQL8())},
+				GroupByKeys: []*GroupByParams{{KeyCol: 0}},
+				Input:       fp,
+			}
+			qr, err := oa.TryExecute(t.Context(), &noopVCursor{}, nil, false)
+			require.NoError(t, err)
+			if len(qr.Rows) == 0 {
+				qr.Rows = nil // just to make the expectation.
+				// empty slice or nil both are valid and will not cause any issue.
+			}
+			assert.Equal(t, tcase.expResult, qr)
+
+			fp.rewind()
+			results := &sqltypes.Result{}
+			err = oa.TryStreamExecute(t.Context(), &noopVCursor{}, nil, true, func(qr *sqltypes.Result) error {
+				if qr.Fields != nil {
+					results.Fields = qr.Fields
+				}
+				results.Rows = append(results.Rows, qr.Rows...)
+				return nil
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tcase.expResult, results)
+		})
+	}
+}
+
+// TestJSONObjectAgg tests merging shard-level json_objectagg partials per group.
+func TestJSONObjectAgg(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"c1|json_objectagg(c2, c3)",
+		"int64|json",
+	)
+
+	tcases := []struct {
+		name        string
+		inputResult *sqltypes.Result
+		expResult   *sqltypes.Result
+	}{{
+		name: "multiple grouping keys",
+		inputResult: sqltypes.MakeTestResult(fields,
+			`10|{"a": 1}`, `10|{"bb": 2}`,
+			`20|{"a": 5, "b": 6}`,
+			`30|null`,
+			`40|{"k": 1}`, `40|{"k": 2}`),
+		expResult: sqltypes.MakeTestResult(fields,
+			`10|{"a": 1, "bb": 2}`,
+			`20|{"a": 5, "b": 6}`,
+			`30|null`,
+			`40|{"k": 2}`),
+	}, {
+		name: "wide decimal member values are preserved verbatim",
+		inputResult: sqltypes.MakeTestResult(fields,
+			`10|{"a": 123456789012.12345678}`, `10|{"b": 1.230}`),
+		expResult: sqltypes.MakeTestResult(fields,
+			`10|{"a": 123456789012.12345678, "b": 1.230}`),
+	}, {
+		name:        "empty result",
+		inputResult: sqltypes.MakeTestResult(fields),
+		expResult:   sqltypes.MakeTestResult(fields),
+	}}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			fp := &fakePrimitive{results: []*sqltypes.Result{tcase.inputResult}}
+			oa := &OrderedAggregate{
+				Aggregates:  []*AggregateParams{NewAggregateParam(AggregateJSONObjectAgg, 1, nil, "", collations.MySQL8())},
+				GroupByKeys: []*GroupByParams{{KeyCol: 0}},
+				Input:       fp,
+			}
+			qr, err := oa.TryExecute(t.Context(), &noopVCursor{}, nil, false)
+			require.NoError(t, err)
+			if len(qr.Rows) == 0 {
+				qr.Rows = nil // just to make the expectation.
+				// empty slice or nil both are valid and will not cause any issue.
+			}
+			assert.Equal(t, tcase.expResult, qr)
+
+			fp.rewind()
+			results := &sqltypes.Result{}
+			err = oa.TryStreamExecute(t.Context(), &noopVCursor{}, nil, true, func(qr *sqltypes.Result) error {
+				if qr.Fields != nil {
+					results.Fields = qr.Fields
+				}
+				results.Rows = append(results.Rows, qr.Rows...)
+				return nil
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tcase.expResult, results)
+		})
+	}
+}

--- a/go/vt/vtgate/engine/scalar_aggregation_test.go
+++ b/go/vt/vtgate/engine/scalar_aggregation_test.go
@@ -420,3 +420,317 @@ func TestScalarGroupConcat(t *testing.T) {
 		})
 	}
 }
+
+// TestScalarJSONArrayAgg tests merging shard-level json_arrayagg partials
+// without grouping.
+func TestScalarJSONArrayAgg(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"json_arrayagg(c2)",
+		"json",
+	)
+
+	varcharFields := sqltypes.MakeTestFields(
+		"json_arrayagg(c2)",
+		"varchar",
+	)
+
+	tcases := []struct {
+		name        string
+		inputResult *sqltypes.Result
+		expResult   *sqltypes.Result
+	}{{
+		name: "two shard partials",
+		inputResult: sqltypes.MakeTestResult(fields,
+			`["a", "b"]`, `[1, null]`),
+		expResult: sqltypes.MakeTestResult(fields,
+			`["a", "b", 1, null]`),
+	}, {
+		name: "null partials are skipped",
+		inputResult: sqltypes.MakeTestResult(fields,
+			"null", `[{"a": 1}]`, "null"),
+		expResult: sqltypes.MakeTestResult(fields,
+			`[{"a": 1}]`),
+	}, {
+		name: "empty array partials do not add separators",
+		inputResult: sqltypes.MakeTestResult(fields,
+			`[]`, `[1, 2]`, `[]`),
+		expResult: sqltypes.MakeTestResult(fields,
+			`[1, 2]`),
+	}, {
+		name: "all shards empty",
+		inputResult: sqltypes.MakeTestResult(fields,
+			"null", "null"),
+		expResult: sqltypes.MakeTestResult(fields,
+			"null"),
+	}, {
+		name:        "no rows at all",
+		inputResult: sqltypes.MakeTestResult(fields),
+		expResult: sqltypes.MakeTestResult(fields,
+			"null"),
+	}, {
+		name: "single partial is returned verbatim",
+		inputResult: sqltypes.MakeTestResult(fields,
+			`[1, 2, 3]`),
+		expResult: sqltypes.MakeTestResult(fields,
+			`[1, 2, 3]`),
+	}, {
+		name: "output field type is rewritten to json",
+		inputResult: sqltypes.MakeTestResult(varcharFields,
+			`[1]`, `[2]`),
+		expResult: sqltypes.MakeTestResult(fields,
+			`[1, 2]`),
+	}, {
+		name: "wide decimal elements pass through the splice verbatim",
+		inputResult: sqltypes.MakeTestResult(fields,
+			`[123456789012.12345678]`),
+		expResult: sqltypes.MakeTestResult(fields,
+			`[123456789012.12345678]`),
+	}}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			fp := &fakePrimitive{results: []*sqltypes.Result{tcase.inputResult}}
+			oa := &ScalarAggregate{
+				Aggregates: []*AggregateParams{{
+					Opcode: AggregateJSONArrayAgg,
+					Col:    0,
+				}},
+				Input: fp,
+			}
+			qr, err := oa.TryExecute(t.Context(), &noopVCursor{}, nil, false)
+			require.NoError(t, err)
+			assert.Equal(t, tcase.expResult, qr)
+
+			fp.rewind()
+			results := &sqltypes.Result{}
+			err = oa.TryStreamExecute(t.Context(), &noopVCursor{}, nil, true, func(qr *sqltypes.Result) error {
+				if qr.Fields != nil {
+					results.Fields = qr.Fields
+				}
+				results.Rows = append(results.Rows, qr.Rows...)
+				return nil
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tcase.expResult, results)
+		})
+	}
+}
+
+// TestScalarJSONArrayAggMalformedPartial tests that json_arrayagg fails loudly
+// when an input is not a shard-level JSON array partial.
+func TestScalarJSONArrayAggMalformedPartial(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"json_arrayagg(c2)",
+		"json",
+	)
+
+	// `[1], [2]` passes the bracket check but is not a single JSON array; only
+	// the full parse rejects it.
+	for _, partial := range []string{`abc`, `{"a": 1}`, `1`, `[1], [2]`} {
+		t.Run(partial, func(t *testing.T) {
+			fp := &fakePrimitive{results: []*sqltypes.Result{sqltypes.MakeTestResult(fields, partial)}}
+			oa := &ScalarAggregate{
+				Aggregates: []*AggregateParams{{
+					Opcode: AggregateJSONArrayAgg,
+					Col:    0,
+				}},
+				Input: fp,
+			}
+			_, err := oa.TryExecute(t.Context(), &noopVCursor{}, nil, false)
+			require.ErrorContains(t, err, "unexpected json_arrayagg partial")
+
+			fp.rewind()
+			err = oa.TryStreamExecute(t.Context(), &noopVCursor{}, nil, true, func(*sqltypes.Result) error {
+				return nil
+			})
+			require.ErrorContains(t, err, "unexpected json_arrayagg partial")
+		})
+	}
+}
+
+// TestScalarJSONObjectAgg tests merging shard-level json_objectagg partials
+// without grouping.
+func TestScalarJSONObjectAgg(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"json_objectagg(c1, c2)",
+		"json",
+	)
+
+	tcases := []struct {
+		name        string
+		inputResult *sqltypes.Result
+		expResult   *sqltypes.Result
+	}{{
+		name: "last duplicate key wins and members sort by length then bytes",
+		inputResult: sqltypes.MakeTestResult(fields,
+			`{"a": 1, "b": 2}`, `{"b": 3, "ccc": 4}`),
+		expResult: sqltypes.MakeTestResult(fields,
+			`{"a": 1, "b": 3, "ccc": 4}`),
+	}, {
+		name: "shorter keys sort first",
+		inputResult: sqltypes.MakeTestResult(fields,
+			`{"bb": 1}`, `{"a": 2}`, `{"z": 3}`),
+		expResult: sqltypes.MakeTestResult(fields,
+			`{"a": 2, "z": 3, "bb": 1}`),
+	}, {
+		name: "escaped keys round-trip",
+		inputResult: sqltypes.MakeTestResult(fields,
+			`{"a\"b": 1}`, `{"c": 2}`),
+		expResult: sqltypes.MakeTestResult(fields,
+			`{"c": 2, "a\"b": 1}`),
+	}, {
+		name: "null member values are preserved",
+		inputResult: sqltypes.MakeTestResult(fields,
+			`{"k": null}`, `{"m": 1}`),
+		expResult: sqltypes.MakeTestResult(fields,
+			`{"k": null, "m": 1}`),
+	}, {
+		name: "null partials are skipped",
+		inputResult: sqltypes.MakeTestResult(fields,
+			"null", `{"a": 1}`, "null"),
+		expResult: sqltypes.MakeTestResult(fields,
+			`{"a": 1}`),
+	}, {
+		name: "all shards empty",
+		inputResult: sqltypes.MakeTestResult(fields,
+			"null", "null"),
+		expResult: sqltypes.MakeTestResult(fields,
+			"null"),
+	}, {
+		name:        "no rows at all",
+		inputResult: sqltypes.MakeTestResult(fields),
+		expResult: sqltypes.MakeTestResult(fields,
+			"null"),
+	}, {
+		name: "single partial is returned in normalized order",
+		inputResult: sqltypes.MakeTestResult(fields,
+			`{"b": 1, "aa": 2}`),
+		expResult: sqltypes.MakeTestResult(fields,
+			`{"b": 1, "aa": 2}`),
+	}, {
+		name: "wide decimal member values are preserved verbatim",
+		inputResult: sqltypes.MakeTestResult(fields,
+			`{"a": 123456789012.12345678}`),
+		expResult: sqltypes.MakeTestResult(fields,
+			`{"a": 123456789012.12345678}`),
+	}, {
+		name: "numbers wider than uint64 are preserved verbatim",
+		inputResult: sqltypes.MakeTestResult(fields,
+			`{"a": 12345678901234567890123456789}`),
+		expResult: sqltypes.MakeTestResult(fields,
+			`{"a": 12345678901234567890123456789}`),
+	}, {
+		name: "trailing zeros in member values are preserved verbatim",
+		inputResult: sqltypes.MakeTestResult(fields,
+			`{"a": 1.230}`),
+		expResult: sqltypes.MakeTestResult(fields,
+			`{"a": 1.230}`),
+	}, {
+		name: "nested wide decimal member values are preserved verbatim",
+		inputResult: sqltypes.MakeTestResult(fields,
+			`{"a": {"b": 99999999999999999999999999.5}}`),
+		expResult: sqltypes.MakeTestResult(fields,
+			`{"a": {"b": 99999999999999999999999999.5}}`),
+	}, {
+		name: "merged partials preserve number literals",
+		inputResult: sqltypes.MakeTestResult(fields,
+			`{"a": 1.10000000}`, `{"b": 2.20000000}`),
+		expResult: sqltypes.MakeTestResult(fields,
+			`{"a": 1.10000000, "b": 2.20000000}`),
+	}}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			fp := &fakePrimitive{results: []*sqltypes.Result{tcase.inputResult}}
+			oa := &ScalarAggregate{
+				Aggregates: []*AggregateParams{{
+					Opcode: AggregateJSONObjectAgg,
+					Col:    0,
+				}},
+				Input: fp,
+			}
+			qr, err := oa.TryExecute(t.Context(), &noopVCursor{}, nil, false)
+			require.NoError(t, err)
+			assert.Equal(t, tcase.expResult, qr)
+
+			fp.rewind()
+			results := &sqltypes.Result{}
+			err = oa.TryStreamExecute(t.Context(), &noopVCursor{}, nil, true, func(qr *sqltypes.Result) error {
+				if qr.Fields != nil {
+					results.Fields = qr.Fields
+				}
+				results.Rows = append(results.Rows, qr.Rows...)
+				return nil
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tcase.expResult, results)
+		})
+	}
+}
+
+// TestScalarJSONObjectAggMalformedPartial tests that json_objectagg fails
+// loudly when an input is not a shard-level JSON object partial.
+func TestScalarJSONObjectAggMalformedPartial(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"json_objectagg(c1, c2)",
+		"json",
+	)
+
+	for _, partial := range []string{`abc`, `[1]`, `1`} {
+		t.Run(partial, func(t *testing.T) {
+			fp := &fakePrimitive{results: []*sqltypes.Result{sqltypes.MakeTestResult(fields, partial)}}
+			oa := &ScalarAggregate{
+				Aggregates: []*AggregateParams{{
+					Opcode: AggregateJSONObjectAgg,
+					Col:    0,
+				}},
+				Input: fp,
+			}
+			_, err := oa.TryExecute(t.Context(), &noopVCursor{}, nil, false)
+			require.ErrorContains(t, err, "unexpected json_objectagg partial")
+
+			fp.rewind()
+			err = oa.TryStreamExecute(t.Context(), &noopVCursor{}, nil, true, func(*sqltypes.Result) error {
+				return nil
+			})
+			require.ErrorContains(t, err, "unexpected json_objectagg partial")
+		})
+	}
+}
+
+// TestScalarJSONAggMergeAssociativity tests that merging an already-merged
+// partial with further partials gives the same result as merging all the
+// partials at once. This is what makes multi-level vtgate aggregators
+// (e.g. a route split under a subquery split) correct.
+func TestScalarJSONAggMergeAssociativity(t *testing.T) {
+	runMerge := func(t *testing.T, oc AggregateOpcode, partials ...string) string {
+		fields := sqltypes.MakeTestFields("agg", "json")
+		fp := &fakePrimitive{results: []*sqltypes.Result{sqltypes.MakeTestResult(fields, partials...)}}
+		oa := &ScalarAggregate{
+			Aggregates: []*AggregateParams{{
+				Opcode: oc,
+				Col:    0,
+			}},
+			Input: fp,
+		}
+		qr, err := oa.TryExecute(t.Context(), &noopVCursor{}, nil, false)
+		require.NoError(t, err)
+		return qr.Rows[0][0].ToString()
+	}
+
+	t.Run("json_arrayagg", func(t *testing.T) {
+		all := runMerge(t, AggregateJSONArrayAgg, `[1]`, `[2, 3]`, `[4]`)
+		assert.Equal(t, `[1, 2, 3, 4]`, all)
+
+		merged := runMerge(t, AggregateJSONArrayAgg, `[1]`, `[2, 3]`)
+		assert.Equal(t, all, runMerge(t, AggregateJSONArrayAgg, merged, `[4]`))
+	})
+
+	t.Run("json_objectagg", func(t *testing.T) {
+		all := runMerge(t, AggregateJSONObjectAgg, `{"a": 1}`, `{"bb": 2, "a": 9}`, `{"c": 3}`)
+		assert.Equal(t, `{"a": 9, "c": 3, "bb": 2}`, all)
+
+		merged := runMerge(t, AggregateJSONObjectAgg, `{"a": 1}`, `{"bb": 2, "a": 9}`)
+		assert.Equal(t, all, runMerge(t, AggregateJSONObjectAgg, merged, `{"c": 3}`))
+	})
+}

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -32,6 +32,7 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/operators"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+	"vitess.io/vitess/go/vt/vtgate/semantics"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
@@ -344,6 +345,13 @@ func transformAggregator(ctx *plancontext.PlanningContext, op *operators.Aggrega
 		case opcode.AggregateUDF:
 			message := fmt.Sprintf("Aggregate UDF '%s' must be pushed down to MySQL", sqlparser.String(aggr.Original.Expr))
 			return nil, vterrors.VT12001(message)
+		case opcode.AggregateJSONArrayAgg, opcode.AggregateJSONObjectAgg:
+			if !op.Pushed {
+				// The engine can only merge shard-level JSON documents; it cannot
+				// build them from raw values. If the aggregation was not pushed
+				// below (cross-shard join / non-pushable source), reject the plan.
+				return nil, vterrors.VT12001(fmt.Sprintf("aggregation function '%s' must be pushed down to MySQL", sqlparser.String(aggr.Original.Expr)))
+			}
 		case opcode.AggregateConstant:
 			// For AnyValue aggregations (literals, parameters), translate to evalengine
 			// This allows evaluation even when no input rows are present (empty result sets)
@@ -461,6 +469,12 @@ func transformProjection(ctx *plancontext.PlanningContext, op *operators.Project
 		return nil, err
 	}
 
+	for _, pe := range ap {
+		if err := rejectJSONAggComparisons(ctx, op.Source, pe.EvalExpr); err != nil {
+			return nil, err
+		}
+	}
+
 	var evalengineExprs []evalengine.Expr
 	var columnNames []string
 	for _, pe := range ap {
@@ -510,7 +524,144 @@ func newSimpleProjection(cols []int, colNames []string, src engine.Primitive) en
 	}
 }
 
+// sourceHasJSONAgg reports whether the operator tree contains a JSON
+// aggregation that is merged at the vtgate level. It does not look inside
+// Routes: aggregations under a Route are fully evaluated by MySQL.
+func sourceHasJSONAgg(op operators.Operator) bool {
+	if _, isRoute := op.(*operators.Route); isRoute {
+		return false
+	}
+	if agg, isAggr := op.(*operators.Aggregator); isAggr {
+		for _, a := range agg.Aggregations {
+			switch a.OpCode {
+			case opcode.AggregateJSONArrayAgg, opcode.AggregateJSONObjectAgg:
+				return true
+			}
+		}
+	}
+	for _, in := range op.Inputs() {
+		if sourceHasJSONAgg(in) {
+			return true
+		}
+	}
+	return false
+}
+
+// rejectJSONAggComparisons fails planning when a comparison evaluated at the
+// vtgate level could involve a JSON aggregation result and a string or untyped
+// operand: the evalengine compares such operands as JSON string scalars, while
+// MySQL parses them as JSON documents, silently producing different results.
+func rejectJSONAggComparisons(ctx *plancontext.PlanningContext, source operators.Operator, exprs ...sqlparser.Expr) error {
+	if !sourceHasJSONAgg(source) {
+		return nil
+	}
+	unwrap := func(e sqlparser.Expr) sqlparser.Expr {
+		if offset, ok := e.(*sqlparser.Offset); ok {
+			return offset.Original
+		}
+		return e
+	}
+	isJSON := func(e sqlparser.Expr) bool {
+		if !semantics.ValidAsMapKey(e) {
+			return false
+		}
+		typ, ok := ctx.TypeForExpr(e)
+		return ok && typ.Type() == sqltypes.TypeJSON
+	}
+	isStringOrUntyped := func(e sqlparser.Expr) bool {
+		if !semantics.ValidAsMapKey(e) {
+			return true
+		}
+		typ, ok := ctx.TypeForExpr(e)
+		return !ok || typ.Type() == sqltypes.Unknown || sqltypes.IsText(typ.Type())
+	}
+	divergent := func(a, b sqlparser.Expr) bool {
+		aJSON, bJSON := isJSON(a), isJSON(b)
+		if aJSON == bJSON {
+			return false
+		}
+		other := b
+		if bJSON {
+			other = a
+		}
+		return isStringOrUntyped(other)
+	}
+	reject := func(node sqlparser.Expr) (bool, error) {
+		return false, vterrors.VT12001(fmt.Sprintf("comparison of a JSON aggregation result with a string or untyped value: %s", sqlparser.String(node)))
+	}
+	for _, expr := range exprs {
+		err := sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+			switch node := node.(type) {
+			case *sqlparser.ComparisonExpr:
+				left, right := unwrap(node.Left), unwrap(node.Right)
+				if !divergent(left, right) {
+					return true, nil
+				}
+				printable := *node
+				printable.Left, printable.Right = left, right
+				return reject(&printable)
+			case *sqlparser.BetweenExpr:
+				// The evalengine desugars BETWEEN into ordered comparisons
+				// of the operand with each bound.
+				left, from, to := unwrap(node.Left), unwrap(node.From), unwrap(node.To)
+				if !divergent(left, from) && !divergent(left, to) {
+					return true, nil
+				}
+				printable := *node
+				printable.Left, printable.From, printable.To = left, from, to
+				return reject(&printable)
+			case *sqlparser.CaseExpr:
+				// A CASE with an operand compares the operand with each
+				// WHEN value for equality in the evalengine.
+				if node.Expr == nil {
+					return true, nil
+				}
+				operand := unwrap(node.Expr)
+				found := false
+				for _, when := range node.Whens {
+					if divergent(operand, unwrap(when.Cond)) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return true, nil
+				}
+				printable := *node
+				printable.Expr = operand
+				printable.Whens = make([]*sqlparser.When, 0, len(node.Whens))
+				for _, when := range node.Whens {
+					printable.Whens = append(printable.Whens, &sqlparser.When{Cond: unwrap(when.Cond), Val: when.Val})
+				}
+				return reject(&printable)
+			case *sqlparser.FuncExpr:
+				// The evalengine rewrites NULLIF(a, b) into
+				// CASE WHEN a = b THEN NULL ELSE a END.
+				if node.Name.Lowered() != "nullif" || len(node.Exprs) != 2 {
+					return true, nil
+				}
+				left, right := unwrap(node.Exprs[0]), unwrap(node.Exprs[1])
+				if !divergent(left, right) {
+					return true, nil
+				}
+				printable := *node
+				printable.Exprs = []sqlparser.Expr{left, right}
+				return reject(&printable)
+			}
+			return true, nil
+		}, expr)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func transformFilter(ctx *plancontext.PlanningContext, op *operators.Filter) (engine.Primitive, error) {
+	if err := rejectJSONAggComparisons(ctx, op.Source, op.Predicates...); err != nil {
+		return nil, err
+	}
+
 	src, err := transformToPrimitive(ctx, op.Source)
 	if err != nil {
 		return nil, err

--- a/go/vt/vtgate/planbuilder/operators/aggregation_pushing_helper.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregation_pushing_helper.go
@@ -141,6 +141,12 @@ func (ab *aggBuilder) handleAggr(ctx *plancontext.PlanningContext, aggr Aggr) er
 		// and later will try pushing the column instead.
 		// TODO: this should be handled better by pushing the function down.
 		return errAbortAggrPushing
+	case opcode.AggregateJSONArrayAgg, opcode.AggregateJSONObjectAgg:
+		// JSON aggregation cannot be pushed under a join: merging shard-level
+		// documents is only valid when the whole function was pushed down, and
+		// the vtgate engine cannot build JSON documents from raw values.
+		// Abort the push; transformAggregator rejects the resulting shape.
+		return errAbortAggrPushing
 	case opcode.AggregateUnassigned:
 		panic(vterrors.VT12001(fmt.Sprintf("in scatter query: aggregation function '%s'", sqlparser.String(aggr.Original))))
 	case opcode.AggregateGtid:

--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -436,6 +436,12 @@ func (aggr Aggr) getPushColumn() sqlparser.Expr {
 			panic(vterrors.VT12001("group_concat with more than 1 column"))
 		}
 		return aggr.Func.GetArg()
+	case opcode.AggregateJSONObjectAgg:
+		// Two-argument aggregate: there is no single column to push on the
+		// not-pushed path, and the engine cannot build JSON objects from raw
+		// values. transformAggregator would reject this shape anyway; fail
+		// here with the same message.
+		panic(vterrors.VT12001(fmt.Sprintf("aggregation function '%s' must be pushed down to MySQL", sqlparser.String(aggr.Original.Expr))))
 	default:
 		if len(aggr.Func.GetArgs()) > 1 {
 			panic(vterrors.VT03001(sqlparser.String(aggr.Func)))

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -7408,5 +7408,343 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "json_arrayagg on scatter query",
+    "query": "select json_arrayagg(foo) from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select json_arrayagg(foo) from user",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Scalar",
+        "Aggregates": "json_arrayagg(0) AS json_arrayagg(foo)",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select json_arrayagg(foo) from `user` where 1 != 1",
+            "Query": "select json_arrayagg(foo) from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "json_arrayagg aggregation on top of route",
+    "query": "select intcol, json_arrayagg(foo) from user group by intcol",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select intcol, json_arrayagg(foo) from user group by intcol",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Ordered",
+        "Aggregates": "json_arrayagg(1) AS json_arrayagg(foo)",
+        "GroupBy": "0",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select intcol, json_arrayagg(foo) from `user` where 1 != 1 group by intcol",
+            "OrderBy": "0 ASC",
+            "Query": "select intcol, json_arrayagg(foo) from `user` group by intcol order by intcol asc"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "json_objectagg on scatter query",
+    "query": "select json_objectagg(name, foo) from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select json_objectagg(name, foo) from user",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Scalar",
+        "Aggregates": "json_objectagg(0) AS json_objectagg(name, foo)",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select json_objectagg(`name`, foo) from `user` where 1 != 1",
+            "Query": "select json_objectagg(`name`, foo) from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "json_objectagg aggregation on top of route",
+    "query": "select intcol, json_objectagg(name, foo) from user group by intcol",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select intcol, json_objectagg(name, foo) from user group by intcol",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Ordered",
+        "Aggregates": "json_objectagg(1) AS json_objectagg(name, foo)",
+        "GroupBy": "0",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select intcol, json_objectagg(`name`, foo) from `user` where 1 != 1 group by intcol",
+            "OrderBy": "0 ASC",
+            "Query": "select intcol, json_objectagg(`name`, foo) from `user` group by intcol order by intcol asc"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "json_arrayagg grouped on unique vindex is pushed down entirely",
+    "query": "select id, json_arrayagg(foo) from user group by id",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select id, json_arrayagg(foo) from user group by id",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id, json_arrayagg(foo) from `user` where 1 != 1 group by id",
+        "Query": "select id, json_arrayagg(foo) from `user` group by id"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "json_arrayagg in having",
+    "query": "select intcol from user group by intcol having json_arrayagg(foo) = '[1]'",
+    "plan": "VT12001: unsupported: comparison of a JSON aggregation result with a string or untyped value: json_arrayagg(foo) = '[1]'"
+  },
+  {
+    "comment": "json_arrayagg in having compared via an extracted scalar",
+    "query": "select intcol from user group by intcol having json_extract(json_arrayagg(foo), '$[0]') = 1",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select intcol from user group by intcol having json_extract(json_arrayagg(foo), '$[0]') = 1",
+      "Instructions": {
+        "OperatorType": "Filter",
+        "Predicate": "json_extract(json_arrayagg(foo), '$[0]') = 1",
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Aggregate",
+            "Variant": "Ordered",
+            "Aggregates": "json_arrayagg(1) AS json_arrayagg(foo)",
+            "GroupBy": "0",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select intcol, json_arrayagg(foo) from `user` where 1 != 1 group by intcol",
+                "OrderBy": "0 ASC",
+                "Query": "select intcol, json_arrayagg(foo) from `user` group by intcol order by intcol asc"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "json_arrayagg inside another expression",
+    "query": "select json_extract(json_arrayagg(foo), '$[0]') from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select json_extract(json_arrayagg(foo), '$[0]') from user",
+      "Instructions": {
+        "OperatorType": "Projection",
+        "Expressions": [
+          "JSON_EXTRACT(json_arrayagg(foo), '$[0]') as json_extract(json_arrayagg(foo), '$[0]')"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Aggregate",
+            "Variant": "Scalar",
+            "Aggregates": "json_arrayagg(0) AS json_arrayagg(foo), constant_aggr('$[0]') AS $[0]",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select json_arrayagg(foo), '$[0]' from `user` where 1 != 1",
+                "Query": "select json_arrayagg(foo), '$[0]' from `user`"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "json_arrayagg in derived table",
+    "query": "select t.a from (select intcol, json_arrayagg(foo) a from user group by intcol) t",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select t.a from (select intcol, json_arrayagg(foo) a from user group by intcol) t",
+      "Instructions": {
+        "OperatorType": "SimpleProjection",
+        "Columns": "1",
+        "Inputs": [
+          {
+            "OperatorType": "Aggregate",
+            "Variant": "Ordered",
+            "Aggregates": "json_arrayagg(1) AS a",
+            "GroupBy": "0",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select intcol, json_arrayagg(foo) as a from `user` where 1 != 1 group by intcol",
+                "OrderBy": "0 ASC",
+                "Query": "select intcol, json_arrayagg(foo) as a from `user` group by intcol order by intcol asc"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "json_arrayagg mixed with other aggregations",
+    "query": "select count(*), json_arrayagg(foo) from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select count(*), json_arrayagg(foo) from user",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Scalar",
+        "Aggregates": "sum_count_star(0) AS count(*), json_arrayagg(1) AS json_arrayagg(foo)",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select count(*), json_arrayagg(foo) from `user` where 1 != 1",
+            "Query": "select count(*), json_arrayagg(foo) from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "json_arrayagg mixed with distinct aggregation",
+    "query": "select count(distinct col), json_arrayagg(intcol) from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select count(distinct col), json_arrayagg(intcol) from user",
+      "Instructions": {
+        "OperatorType": "Aggregate",
+        "Variant": "Scalar",
+        "Aggregates": "count_distinct(0) AS count(distinct col), json_arrayagg(1) AS json_arrayagg(intcol)",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select col, json_arrayagg(intcol) from `user` where 1 != 1 group by col",
+            "OrderBy": "0 ASC",
+            "Query": "select col, json_arrayagg(intcol) from `user` group by col order by col asc"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "json_arrayagg on cross-shard join is not supported",
+    "query": "select json_arrayagg(u.foo) from user u join user_extra e on u.col = e.col",
+    "plan": "VT12001: unsupported: aggregation function 'json_arrayagg(u.foo)' must be pushed down to MySQL"
+  },
+  {
+    "comment": "json_objectagg on cross-shard join is not supported",
+    "query": "select json_objectagg(u.name, u.foo) from user u join user_extra e on u.col = e.col",
+    "plan": "VT12001: unsupported: aggregation function 'json_objectagg(u.`name`, u.foo)' must be pushed down to MySQL"
+  },
+  {
+    "comment": "json_arrayagg over limit is not supported",
+    "query": "select json_arrayagg(foo) from (select foo from user limit 3) t",
+    "plan": "VT12001: unsupported: aggregation function 'json_arrayagg(foo)' must be pushed down to MySQL"
+  },
+  {
+    "comment": "json_objectagg over limit is not supported",
+    "query": "select json_objectagg(col, foo) from (select col, foo from user limit 3) t",
+    "plan": "VT12001: unsupported: aggregation function 'json_objectagg(col, foo)' must be pushed down to MySQL"
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -555,9 +555,9 @@
     "skip_e2e": true
   },
   {
-    "comment": "unsupported json aggregation expressions in scatter query",
+    "comment": "unsupported json aggregation comparison in scatter query",
     "query": "select count(1) from user where cola = 'abc' group by n_id having json_arrayagg(a_id) = '[]'",
-    "plan": "VT12001: unsupported: in scatter query: aggregation function 'json_arrayagg(a_id)'",
+    "plan": "VT12001: unsupported: comparison of a JSON aggregation result with a string or untyped value: json_arrayagg(a_id) = '[]'",
     "skip_e2e": true
   },
   {

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -443,5 +443,45 @@
     "comment": "window function in derived table on scatter route",
     "query": "select * from (select rank() over (partition by col) as r from user) as t",
     "plan": "VT12001: unsupported: window functions are only supported for single-shard queries"
+  },
+  {
+    "comment": "json_arrayagg as window function on scatter query",
+    "query": "select json_arrayagg(foo) over () from user",
+    "plan": "VT12001: unsupported: window functions are only supported for single-shard queries"
+  },
+  {
+    "comment": "json aggregation compared with a string in the select list",
+    "query": "select json_arrayagg(intcol) = '[]' from user",
+    "plan": "VT12001: unsupported: comparison of a JSON aggregation result with a string or untyped value: json_arrayagg(intcol) = '[]'"
+  },
+  {
+    "comment": "json aggregation compared with a string through a derived table",
+    "query": "select * from (select json_arrayagg(intcol) as j from user) t where t.j = '[]'",
+    "plan": "VT12001: unsupported: comparison of a JSON aggregation result with a string or untyped value: t.j = '[]'"
+  },
+  {
+    "comment": "json aggregation compared with a list of strings",
+    "query": "select intcol from user group by intcol having json_arrayagg(a_id) in ('[]', '[1]')",
+    "plan": "VT12001: unsupported: comparison of a JSON aggregation result with a string or untyped value: json_arrayagg(a_id) in ('[]', '[1]')"
+  },
+  {
+    "comment": "json aggregation compared with a JSON literal comparand",
+    "query": "select intcol from user group by intcol having json_arrayagg(foo) = json_array(1)",
+    "plan": "unsupported literal kind '*json.Value'"
+  },
+  {
+    "comment": "merged json_arrayagg compared with string bounds using BETWEEN",
+    "query": "select intcol from user group by intcol having json_arrayagg(foo) between '[]' and '[1]'",
+    "plan": "VT12001: unsupported: comparison of a JSON aggregation result with a string or untyped value: json_arrayagg(foo) between '[]' and '[1]'"
+  },
+  {
+    "comment": "merged json_arrayagg compared with a string through a CASE operand",
+    "query": "select intcol from user group by intcol having case json_arrayagg(foo) when '[]' then 1 else 0 end = 1",
+    "plan": "VT12001: unsupported: comparison of a JSON aggregation result with a string or untyped value: case json_arrayagg(foo) when '[]' then 1 else 0 end"
+  },
+  {
+    "comment": "merged json_arrayagg compared with a string through NULLIF",
+    "query": "select intcol from user group by intcol having nullif(json_arrayagg(foo), '[]') is null",
+    "plan": "VT12001: unsupported: comparison of a JSON aggregation result with a string or untyped value: nullif(json_arrayagg(foo), '[]')"
   }
 ]


### PR DESCRIPTION
## Description

Today Vitess only plans `JSON_ARRAYAGG` and `JSON_OBJECTAGG` when the whole query lands on a single shard; anything cross-shard fails with VT12001. This change adds cross-shard support for both functions.

The approach follows the `GROUP_CONCAT` pattern: the aggregate is pushed unchanged into the shard SQL, so MySQL itself handles value-to-JSON conversion, NULL rows, and the NULL-key error, and two new vtgate opcodes merge the per-shard JSON partials. Arrays merge by splicing the partial texts byte-for-byte; objects are parsed and unioned with MySQL's last-duplicate-key-wins rule, then written back out in MySQL's length-then-bytes member order.

Shapes where the aggregate cannot be pushed (joins, non-pushable sources) are rejected at planning time with a clearer VT12001, and as a safety net the engine validates that every input it merges is a well-formed JSON array or object, so a raw value can never be silently spliced into a result. Cross-shard element order and which duplicate key wins are nondeterministic (MySQL documents both as undefined for these functions), and nested-object key order can differ from MySQL's serialization — all noted in the changelog. Tests cover the engine merge paths, planner plans (including converting the previously pinned unsupported cases), and end-to-end comparisons against real MySQL with fixtures verified to actually span shards.

## Related Issue(s)

This PR depends on https://github.com/vitessio/vitess/pull/20625 being merge first. This is an alternative approach to https://github.com/vitessio/vitess/pull/20626 for the same feature.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Queries using `JSON_ARRAYAGG`/`JSON_OBJECTAGG` across shards now succeed instead of returning VT12001. The VT12001 message for shapes that still cannot be planned (joins, non-pushable sources) changed from "in scatter query: aggregation function" to "aggregation function '<expr>' must be pushed down to MySQL". Cross-shard element ordering and duplicate-key winners are nondeterministic, matching MySQL's documented undefined ordering. No migrations or configuration changes.

### AI Disclosure

This PR was written primarily by Claude Code.
