### PR TITLE
vtgate: track per-source copies of pushed join predicates so merges skip them

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -616,7 +616,7 @@ func buildProjection(op *Projection, qb *queryBuilder) {
 func buildApplyJoin(op *ApplyJoin, qb *queryBuilder) {
 	preds := slice.Map(op.JoinPredicates.columns, func(jc applyJoinColumn) sqlparser.Expr {
 		if jc.JoinPredicateID != nil {
-			qb.ctx.PredTracker.Skip(*jc.JoinPredicateID)
+			qb.ctx.PredTracker.SkipWithDescendants(*jc.JoinPredicateID)
 		}
 		return jc.Original
 	})

--- a/go/vt/vtgate/planbuilder/operators/cte_merging.go
+++ b/go/vt/vtgate/planbuilder/operators/cte_merging.go
@@ -84,7 +84,7 @@ func mergeCTE(ctx *plancontext.PlanningContext, seed, term *Route, r Routing, in
 	newTerm, _ := expandHorizon(ctx, hz)
 	for _, predicate := range in.Predicates {
 		if predicate.JoinPredicateID != nil {
-			ctx.PredTracker.Set(*predicate.JoinPredicateID, predicate.Original)
+			ctx.PredTracker.ResetToOriginal(*predicate.JoinPredicateID, predicate.Original)
 		}
 	}
 

--- a/go/vt/vtgate/planbuilder/operators/predicates/predicate.go
+++ b/go/vt/vtgate/planbuilder/operators/predicates/predicate.go
@@ -59,10 +59,14 @@ func (j *JoinPredicate) Current() sqlparser.Expr {
 func (j *JoinPredicate) IsExpr() {}
 
 func (j *JoinPredicate) Format(buf *sqlparser.TrackedBuffer) {
-	j.Current().Format(buf)
+	if expr := j.Current(); expr != nil {
+		expr.Format(buf)
+	}
 }
 
 func (j *JoinPredicate) FormatFast(buf *sqlparser.TrackedBuffer) {
 	fmt.Fprintf(buf, "JP(%d):", j.ID)
-	j.Current().FormatFast(buf)
+	if expr := j.Current(); expr != nil {
+		expr.FormatFast(buf)
+	}
 }

--- a/go/vt/vtgate/planbuilder/operators/predicates/tracker.go
+++ b/go/vt/vtgate/planbuilder/operators/predicates/tracker.go
@@ -17,9 +17,10 @@ limitations under the License.
 package predicates
 
 import (
-	"vitess.io/vitess/go/vt/vterrors"
+	"maps"
 
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 type (
@@ -29,15 +30,27 @@ type (
 	Tracker struct {
 		lastID      ID
 		expressions map[ID]sqlparser.Expr
+
+		// children tracks per-source copies of a predicate, such as the copies
+		// created when a predicate is pushed into every source of a UNION.
+		// When the original predicate is restored or skipped, the copies must
+		// be skipped as well - they cannot be restored to column form inside
+		// their source, and after a merge no one produces their arguments.
+		children map[ID][]ID
 	}
 
 	// ID is a unique key that references the current expression a join predicate represents.
 	ID int
+
+	// Snapshot holds the previous expressions of a predicate and its copies,
+	// captured by ResetToOriginal so an abandoned rewrite can be rolled back.
+	Snapshot map[ID]sqlparser.Expr
 )
 
 func NewTracker() *Tracker {
 	return &Tracker{
 		expressions: make(map[ID]sqlparser.Expr),
+		children:    make(map[ID][]ID),
 	}
 }
 
@@ -48,6 +61,24 @@ func (t *Tracker) NewJoinPredicate(org sqlparser.Expr) *JoinPredicate {
 		ID:      nextID,
 		tracker: t,
 	}
+}
+
+// NewChildJoinPredicate creates a new JoinPredicate that is tracked as a copy of the
+// given parent predicate, so that Skip/restore operations on the parent cascade to it.
+func (t *Tracker) NewChildJoinPredicate(parent *JoinPredicate, org sqlparser.Expr) *JoinPredicate {
+	jp := t.NewJoinPredicate(org)
+	t.children[parent.ID] = append(t.children[parent.ID], jp.ID)
+	return jp
+}
+
+// DescendantIDs returns the IDs of all transitive copies of the given predicate.
+func (t *Tracker) DescendantIDs(id ID) []ID {
+	ids := make([]ID, 0, len(t.children[id]))
+	for _, child := range t.children[id] {
+		ids = append(ids, child)
+		ids = append(ids, t.DescendantIDs(child)...)
+	}
+	return ids
 }
 
 func (t *Tracker) nextID() ID {
@@ -70,4 +101,32 @@ func (t *Tracker) Get(id ID) (sqlparser.Expr, error) {
 
 func (t *Tracker) Skip(id ID) {
 	t.expressions[id] = nil
+}
+
+// SkipWithDescendants skips the given predicate and all its transitive copies.
+func (t *Tracker) SkipWithDescendants(id ID) {
+	t.Skip(id)
+	for _, child := range t.children[id] {
+		t.SkipWithDescendants(child)
+	}
+}
+
+// ResetToOriginal returns the predicate to its pre-push expression and skips
+// all of its transitive copies: they cannot be restored to column form inside
+// their source, and once the parent is restored nothing produces their
+// arguments. It returns a Snapshot of the previous state so callers that may
+// abandon the rewrite can undo it with Rollback.
+func (t *Tracker) ResetToOriginal(id ID, expr sqlparser.Expr) Snapshot {
+	snapshot := Snapshot{id: t.expressions[id]}
+	t.expressions[id] = expr
+	for _, child := range t.DescendantIDs(id) {
+		snapshot[child] = t.expressions[child]
+		t.Skip(child)
+	}
+	return snapshot
+}
+
+// Rollback puts back the expressions captured in a Snapshot.
+func (t *Tracker) Rollback(s Snapshot) {
+	maps.Copy(t.expressions, s)
 }

--- a/go/vt/vtgate/planbuilder/operators/predicates/tracker.go
+++ b/go/vt/vtgate/planbuilder/operators/predicates/tracker.go
@@ -17,9 +17,10 @@ limitations under the License.
 package predicates
 
 import (
-	"vitess.io/vitess/go/vt/vterrors"
+	"maps"
 
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 type (
@@ -29,15 +30,27 @@ type (
 	Tracker struct {
 		lastID      ID
 		expressions map[ID]sqlparser.Expr
+
+		// children tracks per-source copies of a predicate, such as the copies
+		// created when a predicate is pushed into every source of a UNION.
+		// When the original predicate is restored or skipped, the copies must
+		// be skipped as well - they cannot be restored to column form inside
+		// their source, and after a merge no one produces their arguments.
+		children map[ID][]ID
 	}
 
 	// ID is a unique key that references the current expression a join predicate represents.
 	ID int
+
+	// Snapshot holds the previous expressions of a predicate and its copies,
+	// captured by ResetToOriginal so an abandoned rewrite can be rolled back.
+	Snapshot map[ID]sqlparser.Expr
 )
 
 func NewTracker() *Tracker {
 	return &Tracker{
 		expressions: make(map[ID]sqlparser.Expr),
+		children:    make(map[ID][]ID),
 	}
 }
 
@@ -48,6 +61,24 @@ func (t *Tracker) NewJoinPredicate(org sqlparser.Expr) *JoinPredicate {
 		ID:      nextID,
 		tracker: t,
 	}
+}
+
+// NewChildJoinPredicate creates a new JoinPredicate that is tracked as a copy of the
+// given parent predicate, so that Skip/restore operations on the parent cascade to it.
+func (t *Tracker) NewChildJoinPredicate(parent *JoinPredicate, org sqlparser.Expr) *JoinPredicate {
+	jp := t.NewJoinPredicate(org)
+	t.children[parent.ID] = append(t.children[parent.ID], jp.ID)
+	return jp
+}
+
+// DescendantIDs returns the IDs of all transitive copies of the given predicate.
+func (t *Tracker) DescendantIDs(id ID) []ID {
+	var ids []ID
+	for _, child := range t.children[id] {
+		ids = append(ids, child)
+		ids = append(ids, t.DescendantIDs(child)...)
+	}
+	return ids
 }
 
 func (t *Tracker) nextID() ID {
@@ -70,4 +101,32 @@ func (t *Tracker) Get(id ID) (sqlparser.Expr, error) {
 
 func (t *Tracker) Skip(id ID) {
 	t.expressions[id] = nil
+}
+
+// SkipWithDescendants skips the given predicate and all its transitive copies.
+func (t *Tracker) SkipWithDescendants(id ID) {
+	t.Skip(id)
+	for _, child := range t.children[id] {
+		t.SkipWithDescendants(child)
+	}
+}
+
+// ResetToOriginal returns the predicate to its pre-push expression and skips
+// all of its transitive copies: they cannot be restored to column form inside
+// their source, and once the parent is restored nothing produces their
+// arguments. It returns a Snapshot of the previous state so callers that may
+// abandon the rewrite can undo it with Rollback.
+func (t *Tracker) ResetToOriginal(id ID, expr sqlparser.Expr) Snapshot {
+	snapshot := Snapshot{id: t.expressions[id]}
+	t.expressions[id] = expr
+	for _, child := range t.DescendantIDs(id) {
+		snapshot[child] = t.expressions[child]
+		t.Skip(child)
+	}
+	return snapshot
+}
+
+// Rollback puts back the expressions captured in a Snapshot.
+func (t *Tracker) Rollback(s Snapshot) {
+	maps.Copy(t.expressions, s)
 }

--- a/go/vt/vtgate/planbuilder/operators/predicates/tracker_test.go
+++ b/go/vt/vtgate/planbuilder/operators/predicates/tracker_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+func TestSkipWithDescendantsCascadesToChildren(t *testing.T) {
+	tracker := NewTracker()
+	parent := tracker.NewJoinPredicate(sqlparser.NewIntLiteral("1"))
+	childA := tracker.NewChildJoinPredicate(parent, sqlparser.NewIntLiteral("2"))
+	childB := tracker.NewChildJoinPredicate(parent, sqlparser.NewIntLiteral("3"))
+
+	tracker.SkipWithDescendants(parent.ID)
+
+	require.Nil(t, parent.Current())
+	require.Nil(t, childA.Current())
+	require.Nil(t, childB.Current())
+}
+
+func TestSkipWithDescendantsCascadesTransitively(t *testing.T) {
+	tracker := NewTracker()
+	parent := tracker.NewJoinPredicate(sqlparser.NewIntLiteral("1"))
+	child := tracker.NewChildJoinPredicate(parent, sqlparser.NewIntLiteral("2"))
+	grandchild := tracker.NewChildJoinPredicate(child, sqlparser.NewIntLiteral("3"))
+
+	tracker.SkipWithDescendants(parent.ID)
+
+	require.Nil(t, parent.Current())
+	require.Nil(t, child.Current())
+	require.Nil(t, grandchild.Current())
+}
+
+func TestSkipWithDescendantsLeavesUnrelatedPredicates(t *testing.T) {
+	tracker := NewTracker()
+	parent := tracker.NewJoinPredicate(sqlparser.NewIntLiteral("1"))
+	child := tracker.NewChildJoinPredicate(parent, sqlparser.NewIntLiteral("2"))
+	other := tracker.NewJoinPredicate(sqlparser.NewIntLiteral("3"))
+
+	tracker.SkipWithDescendants(parent.ID)
+
+	require.Nil(t, parent.Current())
+	require.Nil(t, child.Current())
+	require.NotNil(t, other.Current())
+}
+
+func TestDescendantIDsReturnsTransitiveClosure(t *testing.T) {
+	tracker := NewTracker()
+	parent := tracker.NewJoinPredicate(sqlparser.NewIntLiteral("1"))
+	childA := tracker.NewChildJoinPredicate(parent, sqlparser.NewIntLiteral("2"))
+	childB := tracker.NewChildJoinPredicate(parent, sqlparser.NewIntLiteral("3"))
+	grandchild := tracker.NewChildJoinPredicate(childA, sqlparser.NewIntLiteral("4"))
+
+	require.ElementsMatch(t, []ID{childA.ID, childB.ID, grandchild.ID}, tracker.DescendantIDs(parent.ID))
+	require.Empty(t, tracker.DescendantIDs(childB.ID))
+}
+
+func TestResetToOriginalRestoresParentAndSkipsDescendants(t *testing.T) {
+	tracker := NewTracker()
+	parent := tracker.NewJoinPredicate(sqlparser.NewIntLiteral("1"))
+	child := tracker.NewChildJoinPredicate(parent, sqlparser.NewIntLiteral("2"))
+	grandchild := tracker.NewChildJoinPredicate(child, sqlparser.NewIntLiteral("3"))
+	original := sqlparser.NewIntLiteral("42")
+
+	snapshot := tracker.ResetToOriginal(parent.ID, original)
+
+	require.Same(t, original, parent.Current())
+	require.Nil(t, child.Current())
+	require.Nil(t, grandchild.Current())
+	require.Len(t, snapshot, 3)
+}
+
+func TestRollbackRestoresSnapshotState(t *testing.T) {
+	tracker := NewTracker()
+	parent := tracker.NewJoinPredicate(sqlparser.NewIntLiteral("1"))
+	child := tracker.NewChildJoinPredicate(parent, sqlparser.NewIntLiteral("2"))
+	pushed := parent.Current()
+	copied := child.Current()
+
+	snapshot := tracker.ResetToOriginal(parent.ID, sqlparser.NewIntLiteral("42"))
+	tracker.Rollback(snapshot)
+
+	require.Same(t, pushed, parent.Current())
+	require.Same(t, copied, child.Current())
+}

--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -19,6 +19,7 @@ package operators
 import (
 	"fmt"
 	"io"
+	"maps"
 	"strconv"
 
 	"vitess.io/vitess/go/slice"
@@ -151,26 +152,18 @@ func tryMergeApplyJoin(in *ApplyJoin, ctx *plancontext.PlanningContext) (_ Opera
 
 	//  - Rewrite join predicates already pushed down &&
 	//  - Save original join predicates if we have to bail out of the rewrite
-	original := map[predicates.ID]sqlparser.Expr{}
+	original := predicates.Snapshot{}
 	for _, col := range aj.JoinPredicates.columns {
 		if col.JoinPredicateID != nil {
 			// if we have pushed down a join predicate, we need to restore it to its original shape, without the argument from the LHS
-			id := *col.JoinPredicateID
-			oldExpr, err := ctx.PredTracker.Get(id)
-			if err != nil {
-				panic(err)
-			}
-			original[id] = oldExpr
-			ctx.PredTracker.Set(id, col.Original)
+			maps.Copy(original, ctx.PredTracker.ResetToOriginal(*col.JoinPredicateID, col.Original))
 		}
 	}
 
 	// Defer restoration of original predicates if no successful rewrite happens.
 	defer func() {
 		if res == NoRewrite {
-			for id, expr := range original {
-				ctx.PredTracker.Set(id, expr)
-			}
+			ctx.PredTracker.Rollback(original)
 		}
 	}()
 

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -133,6 +133,11 @@ func UpdateRoutingLogic(ctx *plancontext.PlanningContext, in sqlparser.Expr, r R
 	pred, isJP := in.(*predicates.JoinPredicate)
 	if isJP {
 		expr = pred.Current()
+		if expr == nil {
+			// the predicate has been skipped - the join it belonged to has been
+			// merged away, so it no longer applies and must not influence routing
+			return r
+		}
 	}
 
 	if b := ctx.IsConstantBool(expr); b != nil && !*b {

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -124,6 +124,18 @@ func UpdateRoutingLogic(ctx *plancontext.PlanningContext, in sqlparser.Expr, r R
 		return nr
 	}
 
+	expr := in
+	// If we have a JoinPredicate, let's get the inner expression
+	pred, isJP := in.(*predicates.JoinPredicate)
+	if isJP {
+		expr = pred.Current()
+		if expr == nil {
+			// the predicate has been skipped - the join it belonged to has been
+			// merged away, so it no longer applies and must not influence routing
+			return r
+		}
+	}
+
 	ks := r.Keyspace()
 	inferred := false
 	if ks == nil {
@@ -135,13 +147,6 @@ func UpdateRoutingLogic(ctx *plancontext.PlanningContext, in sqlparser.Expr, r R
 		inferred = true
 	}
 	nr := &NoneRouting{keyspace: ks, inferredKeyspace: inferred}
-
-	expr := in
-	// If we have a JoinPredicate, let's get the inner expression
-	pred, isJP := in.(*predicates.JoinPredicate)
-	if isJP {
-		expr = pred.Current()
-	}
 
 	if b := ctx.IsConstantBool(expr); b != nil && !*b {
 		return nr

--- a/go/vt/vtgate/planbuilder/operators/union.go
+++ b/go/vt/vtgate/planbuilder/operators/union.go
@@ -122,8 +122,12 @@ func (u *Union) predicatePerSource(ctx *plancontext.PlanningContext, expr sqlpar
 		if jp, ok := predicate.(*predicates.JoinPredicate); ok {
 			// Create a new JoinPredicate for each source to keep tracking working
 			// We can't use `*JoinPredicate.Clone` here as that would update the tracker and overwrite
-			// the expression for the original predicate
-			predicate = ctx.PredTracker.NewJoinPredicate(jp.Current())
+			// the expression for the original predicate.
+			// The copy is registered as a child of the original so that skipping the
+			// original (when the join it belongs to is merged into a single route)
+			// cascades to the per-source copies, whose arguments would otherwise
+			// have no producer left in the plan.
+			predicate = ctx.PredTracker.NewChildJoinPredicate(jp, jp.Current())
 		}
 
 		predicate = sqlparser.CopyOnRewrite(predicate, nil, func(cursor *sqlparser.CopyOnWriteCursor) {


### PR DESCRIPTION
## Description

This prepares for https://github.com/vitessio/vitess/pull/20630, which merges joins over derived-table unions into single routes. That merge is unsafe today. Pushing a join predicate into a union mints a copy for each leg, and those copies are registered in the predicate tracker under fresh IDs that the join's cleanup machinery cannot see, because both the restore on merge and the skip at SQL build time key off the outer predicate's ID alone. Merging such a join bakes the argument form into every leg while removing the Join primitive that would have bound it, so the emitted query references a bind variable that nothing produces and fails at execution.

This change records each copy's ID against its originating predicate so that restores and skips cascade to the copies. On merge the copies are dropped rather than restored, because inside a non-LATERAL derived table the column form would reference a sibling FROM item, and the restored outer predicate already applies the same filter to the union's output. The restore is itself a tracker operation, ResetToOriginal, which skips the copies and returns a snapshot that Rollback puts back if the merge is abandoned, so every restore site cascades the same way, including the recursive CTE merge. The defective path is unreachable on main, which is why there are no golden plan changes. The planner currently refuses exactly these merges, but that protection is an accidental invariant, and any merge-enabling change would arm the defect. Unit tests pin the tracker lifecycle so it cannot regress silently.

## Related Issue(s)

https://github.com/vitessio/vitess/pull/20630 depends on this change.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

There are no user-visible behavior changes. No migrations or configuration changes.

### AI Disclosure

This PR was written primarily by Fable with review from GPT 5.6 Sol.

---

```mermaid
graph LR
    subgraph json [JSON support]
        direction TB
        PR20625["#20625 (merged)<br>mysql/json: fix MarshalTo discarding accumulated output for nested blob and bit values"]
        PR20632["#20632<br>vtgate: preserve IN value lists in complex aggregate projections"]
        PRA["#20691<br>evalengine: disable the static IN hash table for JSON operands"]
        PR20682["#20682 (draft)<br>evalengine: support constant-folded JSON values as literals"]
        PR20683["#20683 (draft)<br>evalengine, sqlparser: MySQL comparison domains; nested BETWEEN parentheses"]
        PR20626["#20626 (draft)<br>vtgate: support cross-shard JSON_ARRAYAGG and JSON_OBJECTAGG"]
        PR20625 --> PR20682
        PRA --> PR20682
        PR20682 --> PR20683
        PR20632 --> PR20626
        PR20683 --> PR20626
    end

    subgraph union [Union routing]
        direction TB
        PR20628["#20628<br>vtgate: track per-source copies of pushed join predicates so merges skip them"]
        PR20629["#20629 (merged)<br>vtgate: fix None routing handling when merging unions"]
        PR20630["#20630 (draft)<br>vtgate: merge unions on join-predicate-free routings when all sources agree"]
        PR20755["#20755<br>vtgate: fix union merging through reference-table alternates"]
        PR20756["#20756 (draft)<br>vtgate: merge empty reference branches through rewritten copies"]
        PR20628 --> PR20630
        PR20629 --> PR20630
        PR20630 --> PR20756
        PR20755 --> PR20756
    end

    subgraph cte [Recursive CTEs]
        direction TB
        PR20759["#20759<br>vtgate: expand qualified stars without JOIN USING coalescing"]
        PR20633["#20633 (draft)<br>vtgate: validate the declared column list length of CTEs and derived tables"]
        PR20631["#20631 (draft)<br>vtgate: bind recursive CTE column filters as arguments in unmerged term queries"]
        PR20759 --> PR20633
        PR20633 --> PR20631
    end

    json ~~~ union ~~~ cte
```

