### PR TITLE
vtgate: fix None routing handling when merging unions

### DIFF
--- a/go/test/endtoend/vtgate/queries/union/union_test.go
+++ b/go/test/endtoend/vtgate/queries/union/union_test.go
@@ -67,6 +67,8 @@ func TestUnionDistinct(t *testing.T) {
 			mcmp.AssertMatchesNoOrder("select id1, id2 from t1 union select 827, 452 union select id3,id4 from t2",
 				"[[INT64(4) INT64(4)] [INT64(1) INT64(1)] [INT64(2) INT64(2)] [INT64(3) INT64(3)] [INT64(827) INT64(452)] [INT64(2) INT64(3)] [INT64(3) INT64(4)] [INT64(5) INT64(5)]]")
 			mcmp.AssertMatches("select 1 from dual where 1 IN (select 1 as col union select 2)", "[[INT64(1)]]")
+			mcmp.AssertMatches("select 1 from dual union select id1 from t1 where id1 in (null)", "[[INT64(1)]]")
+			mcmp.AssertMatches("select id1 from t1 where id1 in (null) union select 1 from dual", "[[INT64(1)]]")
 			mcmp.AssertMatches(`SELECT 1 from t1 UNION SELECT 2 from t1`, `[[INT64(1)] [INT64(2)]]`)
 			mcmp.AssertMatches(`SELECT 5 from t1 UNION SELECT 6 from t1`, `[[INT64(5)] [INT64(6)]]`)
 			mcmp.AssertMatchesNoOrder(`SELECT id1 from t1 UNION SELECT id2 from t1`, `[[INT64(1)] [INT64(2)] [INT64(3)] [INT64(4)]]`)

--- a/go/vt/vtgate/planbuilder/operators/misc_routing.go
+++ b/go/vt/vtgate/planbuilder/operators/misc_routing.go
@@ -29,6 +29,11 @@ type (
 	// Can be merged with any other route going to the same keyspace
 	NoneRouting struct {
 		keyspace *vindexes.Keyspace
+
+		// inferredKeyspace is set when the routing this replaced had no keyspace
+		// of its own (information_schema, dual): keyspace is then only a
+		// placeholder giving the engine route a target, not a genuine read.
+		inferredKeyspace bool
 	}
 
 	// TargetedRouting is used when the user has used syntax to target the

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -118,15 +118,23 @@ type (
 
 // UpdateRoutingLogic first checks if we are dealing with a predicate that
 func UpdateRoutingLogic(ctx *plancontext.PlanningContext, in sqlparser.Expr, r Routing) Routing {
+	if nr, ok := r.(*NoneRouting); ok {
+		// a none routing stays none no matter what further predicates say, and
+		// returning it as-is keeps its inferred-keyspace marker intact.
+		return nr
+	}
+
 	ks := r.Keyspace()
+	inferred := false
 	if ks == nil {
 		var err error
 		ks, err = ctx.VSchema.AnyKeyspace()
 		if err != nil {
 			panic(err)
 		}
+		inferred = true
 	}
-	nr := &NoneRouting{keyspace: ks}
+	nr := &NoneRouting{keyspace: ks, inferredKeyspace: inferred}
 
 	expr := in
 	// If we have a JoinPredicate, let's get the inner expression

--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -332,7 +332,8 @@ func mergeOrJoin(ctx *plancontext.PlanningContext, lhs, rhs Operator, joinPredic
 
 // checkCrossKeyspaceOp checks if the given operators would create a cross-keyspace operation
 // and if cross-keyspace joins are denied for any involved keyspace. Fast path for direct
-// Route/Route comparisons (no allocations), falls back to collecting all keyspaces from
+// Route/Route comparisons (no allocations unless an inferred none routing
+// needs its real tables checked), falls back to collecting all keyspaces from
 // both operator trees to handle composite operators spanning multiple keyspaces.
 //
 // Panics via checkCrossKeyspacePair if the operation is denied — this follows the
@@ -341,8 +342,8 @@ func checkCrossKeyspaceOp(ctx *plancontext.PlanningContext, lhs, rhs Operator, o
 	// Fast path: both sides are direct *Route — two type assertions + pointer comparison, no allocations.
 	if lRoute, ok := lhs.(*Route); ok {
 		if rRoute, ok := rhs.(*Route); ok {
-			lhsKs := lRoute.Routing.Keyspace()
-			rhsKs := rRoute.Routing.Keyspace()
+			lhsKs := crossKeyspaceAccountable(lRoute)
+			rhsKs := crossKeyspaceAccountable(rRoute)
 			if lhsKs == nil || rhsKs == nil || lhsKs == rhsKs {
 				return
 			}
@@ -397,9 +398,12 @@ func checkCrossKeyspacePair(ctx *plancontext.PlanningContext, lhs, rhs Operator,
 	}
 }
 
-// hasAlternateInKeyspace checks if op is a direct *Route with an AnyShardRouting alternate
-// in the given keyspace. Only checks direct routes because mergeJoinInputs (via operatorsToRoutes)
-// only uses alternates for direct *Route operators — wrapped routes won't be merged.
+// hasAlternateInKeyspace checks if op is a direct *Route whose tables also live
+// in the given keyspace: through an AnyShardRouting alternate, or — for a route
+// degraded to NoneRouting, where the alternates were discarded — by checking
+// every real table's reference-copy placements in the vschema. Only checks
+// direct routes because mergeJoinInputs (via operatorsToRoutes) only uses
+// alternates for direct *Route operators — wrapped routes won't be merged.
 func hasAlternateInKeyspace(ctx *plancontext.PlanningContext, op Operator, ks *vindexes.Keyspace) bool {
 	route, ok := op.(*Route)
 	if !ok {
@@ -408,11 +412,77 @@ func hasAlternateInKeyspace(ctx *plancontext.PlanningContext, op Operator, ks *v
 	if !ctx.SemTable.DMLTargets.IsEmpty() && TableID(route).IsOverlapping(ctx.SemTable.DMLTargets) {
 		return false
 	}
-	ref, ok := route.Routing.(*AnyShardRouting)
-	if !ok {
+	switch routing := route.Routing.(type) {
+	case *AnyShardRouting:
+		return routing.AlternateInKeyspace(ks) != nil
+	case *NoneRouting:
+		return allRealTablesHaveCopyIn(ctx, route.Source, ks)
+	}
+	return false
+}
+
+// allRealTablesHaveCopyIn reports whether the operator tree has at least one
+// real table and every one of them also lives in ks: as the table's own
+// keyspace, through a reference copy recorded in ReferencedBy, or as the
+// source of a reference table. This only makes a cross-keyspace exemption
+// safe; it does not make the query text runnable in ks, since physical table
+// names can differ between keyspaces.
+func allRealTablesHaveCopyIn(ctx *plancontext.PlanningContext, op Operator, ks *vindexes.Keyspace) bool {
+	if op == nil {
 		return false
 	}
-	return ref.AlternateInKeyspace(ks) != nil
+	found := false
+	covered := true
+	_ = Visit(op, func(this Operator) error {
+		tbl, isTable := this.(*Table)
+		if !isTable || tbl.VTable == nil {
+			return nil
+		}
+		if tbl.QTable != nil && tbl.QTable.IsInfSchema {
+			// information_schema is present on every shard
+			return nil
+		}
+		found = true
+		if tableHasCopyIn(ctx, tbl.VTable, ks) {
+			return nil
+		}
+		covered = false
+		return io.EOF
+	})
+	return found && covered
+}
+
+func tableHasCopyIn(ctx *plancontext.PlanningContext, vt *vindexes.BaseTable, ks *vindexes.Keyspace) bool {
+	if vt.Keyspace == ks {
+		return true
+	}
+	if _, referenced := vt.ReferencedBy[ks.Name]; referenced {
+		return true
+	}
+	if vt.Source == nil {
+		return false
+	}
+	if qualifier := vt.Source.TableName.Qualifier.String(); qualifier != "" {
+		return qualifier == ks.Name
+	}
+	// an unqualified source declaration resolves through the vschema
+	src, _, _, _, _, err := ctx.VSchema.FindTableOrVindex(vt.Source.TableName)
+	return err == nil && src != nil && src.Keyspace == ks
+}
+
+// crossKeyspaceAccountable returns the keyspace the route genuinely reads
+// from. A none routing with an inferred keyspace (information_schema, dual)
+// reads from no keyspace — unless a merge absorbed real tables under it, in
+// which case the placeholder keyspace is where those tables live.
+func crossKeyspaceAccountable(route *Route) *vindexes.Keyspace {
+	nr, ok := route.Routing.(*NoneRouting)
+	if !ok || !nr.inferredKeyspace {
+		return route.Routing.Keyspace()
+	}
+	if len(realTableKeyspaces(route.Source)) == 0 {
+		return nil
+	}
+	return nr.keyspace
 }
 
 // operatorKeyspaces collects all unique keyspaces from an operator tree by recursively
@@ -430,7 +500,7 @@ func collectOperatorKeyspaces(op Operator, result *[]*vindexes.Keyspace) {
 		return
 	}
 	if route, ok := op.(*Route); ok {
-		addOperatorKeyspace(result, route.Routing.Keyspace())
+		addOperatorKeyspace(result, crossKeyspaceAccountable(route))
 		return
 	}
 	for _, input := range op.Inputs() {
@@ -446,6 +516,45 @@ func addOperatorKeyspace(result *[]*vindexes.Keyspace, ks *vindexes.Keyspace) {
 		return
 	}
 	*result = append(*result, ks)
+}
+
+// realTableKeyspaces collects the distinct keyspaces of the real tables under
+// op. Virtual tables (dual, recursive CTE references) have no vschema table
+// behind them, and information_schema tables only get a synthetic VTable in an
+// arbitrary keyspace (createInfSchemaRoute), so neither contributes anything.
+// Unlike operatorKeyspaces, this reflects where the referenced tables actually
+// live rather than where a routing points.
+func realTableKeyspaces(op Operator) []*vindexes.Keyspace {
+	if op == nil {
+		return nil
+	}
+	var result []*vindexes.Keyspace
+	_ = Visit(op, func(this Operator) error {
+		tbl, ok := this.(*Table)
+		if !ok || tbl.VTable == nil {
+			return nil
+		}
+		if tbl.QTable != nil && tbl.QTable.IsInfSchema {
+			return nil
+		}
+		addOperatorKeyspace(&result, tbl.VTable.Keyspace)
+		return nil
+	})
+	return result
+}
+
+// hasInfoSchemaTables reports whether any table under op reads from
+// information_schema.
+func hasInfoSchemaTables(op Operator) bool {
+	var found bool
+	_ = Visit(op, func(this Operator) error {
+		if tbl, ok := this.(*Table); ok && tbl.QTable != nil && tbl.QTable.IsInfSchema {
+			found = true
+			return io.EOF
+		}
+		return nil
+	})
+	return found
 }
 
 func operatorsToRoutes(a, b Operator) (*Route, *Route) {

--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -332,7 +332,8 @@ func mergeOrJoin(ctx *plancontext.PlanningContext, lhs, rhs Operator, joinPredic
 
 // checkCrossKeyspaceOp checks if the given operators would create a cross-keyspace operation
 // and if cross-keyspace joins are denied for any involved keyspace. Fast path for direct
-// Route/Route comparisons (no allocations), falls back to collecting all keyspaces from
+// Route/Route comparisons (no allocations unless an inferred none routing
+// needs its real tables checked), falls back to collecting all keyspaces from
 // both operator trees to handle composite operators spanning multiple keyspaces.
 //
 // Panics via checkCrossKeyspacePair if the operation is denied — this follows the
@@ -341,8 +342,8 @@ func checkCrossKeyspaceOp(ctx *plancontext.PlanningContext, lhs, rhs Operator, o
 	// Fast path: both sides are direct *Route — two type assertions + pointer comparison, no allocations.
 	if lRoute, ok := lhs.(*Route); ok {
 		if rRoute, ok := rhs.(*Route); ok {
-			lhsKs := lRoute.Routing.Keyspace()
-			rhsKs := rRoute.Routing.Keyspace()
+			lhsKs := crossKeyspaceAccountable(lRoute)
+			rhsKs := crossKeyspaceAccountable(rRoute)
 			if lhsKs == nil || rhsKs == nil || lhsKs == rhsKs {
 				return
 			}
@@ -397,9 +398,12 @@ func checkCrossKeyspacePair(ctx *plancontext.PlanningContext, lhs, rhs Operator,
 	}
 }
 
-// hasAlternateInKeyspace checks if op is a direct *Route with an AnyShardRouting alternate
-// in the given keyspace. Only checks direct routes because mergeJoinInputs (via operatorsToRoutes)
-// only uses alternates for direct *Route operators — wrapped routes won't be merged.
+// hasAlternateInKeyspace checks if op is a direct *Route whose tables also live
+// in the given keyspace: through an AnyShardRouting alternate, or — for a route
+// degraded to NoneRouting, where the alternates were discarded — by checking
+// every real table's reference-copy placements in the vschema. Only checks
+// direct routes because mergeJoinInputs (via operatorsToRoutes) only uses
+// alternates for direct *Route operators — wrapped routes won't be merged.
 func hasAlternateInKeyspace(ctx *plancontext.PlanningContext, op Operator, ks *vindexes.Keyspace) bool {
 	route, ok := op.(*Route)
 	if !ok {
@@ -408,11 +412,77 @@ func hasAlternateInKeyspace(ctx *plancontext.PlanningContext, op Operator, ks *v
 	if !ctx.SemTable.DMLTargets.IsEmpty() && TableID(route).IsOverlapping(ctx.SemTable.DMLTargets) {
 		return false
 	}
-	ref, ok := route.Routing.(*AnyShardRouting)
-	if !ok {
+	switch routing := route.Routing.(type) {
+	case *AnyShardRouting:
+		return routing.AlternateInKeyspace(ks) != nil
+	case *NoneRouting:
+		return allRealTablesHaveCopyIn(ctx, route.Source, ks)
+	}
+	return false
+}
+
+// allRealTablesHaveCopyIn reports whether the operator tree has at least one
+// real table and every one of them also lives in ks: as the table's own
+// keyspace, through a reference copy recorded in ReferencedBy, or as the
+// source of a reference table. This only makes a cross-keyspace exemption
+// safe; it does not make the query text runnable in ks, since physical table
+// names can differ between keyspaces.
+func allRealTablesHaveCopyIn(ctx *plancontext.PlanningContext, op Operator, ks *vindexes.Keyspace) bool {
+	if op == nil {
 		return false
 	}
-	return ref.AlternateInKeyspace(ks) != nil
+	found := false
+	covered := true
+	_ = Visit(op, func(this Operator) error {
+		tbl, isTable := this.(*Table)
+		if !isTable || tbl.VTable == nil {
+			return nil
+		}
+		if tbl.QTable != nil && tbl.QTable.IsInfSchema {
+			// information_schema is present on every shard
+			return nil
+		}
+		found = true
+		if tableHasCopyIn(ctx, tbl.VTable, ks) {
+			return nil
+		}
+		covered = false
+		return io.EOF
+	})
+	return found && covered
+}
+
+func tableHasCopyIn(ctx *plancontext.PlanningContext, vt *vindexes.BaseTable, ks *vindexes.Keyspace) bool {
+	if vt.Keyspace == ks {
+		return true
+	}
+	if _, referenced := vt.ReferencedBy[ks.Name]; referenced {
+		return true
+	}
+	if vt.Source == nil {
+		return false
+	}
+	if qualifier := vt.Source.Qualifier.String(); qualifier != "" {
+		return qualifier == ks.Name
+	}
+	// an unqualified source declaration resolves through the vschema
+	src, _, _, _, _, err := ctx.VSchema.FindTableOrVindex(vt.Source.TableName)
+	return err == nil && src != nil && src.Keyspace == ks
+}
+
+// crossKeyspaceAccountable returns the keyspace the route genuinely reads
+// from. A none routing with an inferred keyspace (information_schema, dual)
+// reads from no keyspace — unless a merge absorbed real tables under it, in
+// which case the placeholder keyspace is where those tables live.
+func crossKeyspaceAccountable(route *Route) *vindexes.Keyspace {
+	nr, ok := route.Routing.(*NoneRouting)
+	if !ok || !nr.inferredKeyspace {
+		return route.Routing.Keyspace()
+	}
+	if len(realTableKeyspaces(route.Source)) == 0 {
+		return nil
+	}
+	return nr.keyspace
 }
 
 // operatorKeyspaces collects all unique keyspaces from an operator tree by recursively
@@ -430,7 +500,7 @@ func collectOperatorKeyspaces(op Operator, result *[]*vindexes.Keyspace) {
 		return
 	}
 	if route, ok := op.(*Route); ok {
-		addOperatorKeyspace(result, route.Routing.Keyspace())
+		addOperatorKeyspace(result, crossKeyspaceAccountable(route))
 		return
 	}
 	for _, input := range op.Inputs() {
@@ -446,6 +516,45 @@ func addOperatorKeyspace(result *[]*vindexes.Keyspace, ks *vindexes.Keyspace) {
 		return
 	}
 	*result = append(*result, ks)
+}
+
+// realTableKeyspaces collects the distinct keyspaces of the real tables under
+// op. Virtual tables (dual, recursive CTE references) have no vschema table
+// behind them, and information_schema tables only get a synthetic VTable in an
+// arbitrary keyspace (createInfSchemaRoute), so neither contributes anything.
+// Unlike operatorKeyspaces, this reflects where the referenced tables actually
+// live rather than where a routing points.
+func realTableKeyspaces(op Operator) []*vindexes.Keyspace {
+	if op == nil {
+		return nil
+	}
+	var result []*vindexes.Keyspace
+	_ = Visit(op, func(this Operator) error {
+		tbl, ok := this.(*Table)
+		if !ok || tbl.VTable == nil {
+			return nil
+		}
+		if tbl.QTable != nil && tbl.QTable.IsInfSchema {
+			return nil
+		}
+		addOperatorKeyspace(&result, tbl.VTable.Keyspace)
+		return nil
+	})
+	return result
+}
+
+// hasInfoSchemaTables reports whether any table under op reads from
+// information_schema.
+func hasInfoSchemaTables(op Operator) bool {
+	var found bool
+	_ = Visit(op, func(this Operator) error {
+		if tbl, ok := this.(*Table); ok && tbl.QTable != nil && tbl.QTable.IsInfSchema {
+			found = true
+			return io.EOF
+		}
+		return nil
+	})
+	return found
 }
 
 func operatorsToRoutes(a, b Operator) (*Route, *Route) {

--- a/go/vt/vtgate/planbuilder/operators/route_planning_test.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning_test.go
@@ -23,7 +23,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/vt/key"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtenv"
+	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 	"vitess.io/vitess/go/vt/vtgate/semantics"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
@@ -32,6 +37,7 @@ import (
 type mockVSchema struct {
 	plancontext.VSchema
 	preventCrossKeyspaceReads map[string]bool
+	tables                    map[string]*vindexes.BaseTable
 }
 
 func (m *mockVSchema) AllowCrossKeyspaceReads(keyspace string) (bool, error) {
@@ -41,12 +47,60 @@ func (m *mockVSchema) AllowCrossKeyspaceReads(keyspace string) (bool, error) {
 	return !m.preventCrossKeyspaceReads[keyspace], nil
 }
 
+func (m *mockVSchema) FindTableOrVindex(tab sqlparser.TableName) (*vindexes.BaseTable, vindexes.Vindex, string, topodatapb.TabletType, key.ShardDestination, error) {
+	tbl, found := m.tables[tab.Name.String()]
+	if !found {
+		return nil, nil, "", topodatapb.TabletType_PRIMARY, nil, vterrors.VT05004(tab.Name.String())
+	}
+	return tbl, nil, tbl.Keyspace.Name, topodatapb.TabletType_PRIMARY, nil, nil
+}
+
+func (m *mockVSchema) Environment() *vtenv.Environment {
+	return vtenv.NewTestEnv()
+}
+
+func (m *mockVSchema) ConnCollation() collations.ID {
+	return collations.CollationUtf8mb4ID
+}
+
 func TestCheckCrossKeyspaceJoin(t *testing.T) {
 	ks1 := &vindexes.Keyspace{Name: "ks1"}
 	ks2 := &vindexes.Keyspace{Name: "ks2"}
 
 	makeRoute := func(ks *vindexes.Keyspace) *Route {
 		return &Route{Routing: &NoneRouting{keyspace: ks}}
+	}
+	plainTable := func(ks *vindexes.Keyspace) *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("t")},
+			VTable: &vindexes.BaseTable{Name: sqlparser.NewIdentifierCS("t"), Keyspace: ks},
+		}
+	}
+	refTable := func(ks *vindexes.Keyspace, copyKs string) *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("ref")},
+			VTable: &vindexes.BaseTable{
+				Name:         sqlparser.NewIdentifierCS("ref"),
+				Keyspace:     ks,
+				ReferencedBy: map[string]*vindexes.BaseTable{copyKs: {}},
+			},
+		}
+	}
+	sourcedTable := func(ks *vindexes.Keyspace, sourceKs string) *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("ref")},
+			VTable: &vindexes.BaseTable{
+				Name:     sqlparser.NewIdentifierCS("ref"),
+				Keyspace: ks,
+				Source: &vindexes.Source{
+					Qualifier: sqlparser.NewIdentifierCS(sourceKs),
+					Name:      sqlparser.NewIdentifierCS("src"),
+				},
+			},
+		}
+	}
+	noneRouteOver := func(ks *vindexes.Keyspace, src Operator) *Route {
+		return &Route{unaryOperator: newUnaryOp(src), Routing: &NoneRouting{keyspace: ks}}
 	}
 
 	tests := []struct {
@@ -209,6 +263,84 @@ func TestCheckCrossKeyspaceJoin(t *testing.T) {
 				preventCrossKeyspaceReads: map[string]bool{"ks1": false, "ks2": false},
 			},
 		},
+		{
+			name: "inferred none keyspace does not create a cross-keyspace pair",
+			lhs:  &Route{Routing: &NoneRouting{keyspace: ks1, inferredKeyspace: true}},
+			rhs:  makeRoute(ks2),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+			},
+		},
+		{
+			name: "inferred none keyspace wrapped in a non-route is also skipped",
+			lhs: &Projection{
+				unaryOperator: newUnaryOp(&Route{Routing: &NoneRouting{keyspace: ks1, inferredKeyspace: true}}),
+			},
+			rhs: makeRoute(ks2),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+			},
+		},
+		{
+			name: "cross-keyspace denied but the lhs none branch's table has a reference copy on the rhs",
+			lhs:  noneRouteOver(ks1, refTable(ks1, "ks2")),
+			rhs:  makeRoute(ks2),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+			},
+		},
+		{
+			name: "cross-keyspace denied but the rhs none branch's table is sourced from the lhs keyspace",
+			lhs:  makeRoute(ks1),
+			rhs:  noneRouteOver(ks2, sourcedTable(ks2, "ks1")),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+			},
+		},
+		{
+			name: "cross-keyspace denied but the rhs none branch's table has an unqualified source resolving to the lhs keyspace",
+			lhs:  makeRoute(ks1),
+			rhs: noneRouteOver(ks2, &Table{
+				QTable: &QueryTable{Table: sqlparser.NewTableName("ref")},
+				VTable: &vindexes.BaseTable{
+					Name:     sqlparser.NewIdentifierCS("ref"),
+					Keyspace: ks2,
+					Source: &vindexes.Source{
+						Name: sqlparser.NewIdentifierCS("src"),
+					},
+				},
+			}),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+				tables: map[string]*vindexes.BaseTable{
+					"src": {Name: sqlparser.NewIdentifierCS("src"), Keyspace: ks1},
+				},
+			},
+		},
+		{
+			name: "a none branch that absorbed a table without a copy on the rhs stays denied",
+			lhs: noneRouteOver(ks1, &Join{
+				LHS: refTable(ks1, "ks2"),
+				RHS: plainTable(ks1),
+			}),
+			rhs: makeRoute(ks2),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+			},
+			expectPanic: true,
+		},
+		{
+			name: "an inferred none keyspace over a real table stays accountable",
+			lhs: &Route{
+				unaryOperator: newUnaryOp(plainTable(ks1)),
+				Routing:       &NoneRouting{keyspace: ks1, inferredKeyspace: true},
+			},
+			rhs: makeRoute(ks2),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+			},
+			expectPanic: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -289,6 +421,150 @@ func TestOperatorKeyspaces(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, operatorKeyspaces(tt.op))
+		})
+	}
+}
+
+func TestRealTableKeyspaces(t *testing.T) {
+	ks1 := &vindexes.Keyspace{Name: "ks1"}
+	ks2 := &vindexes.Keyspace{Name: "ks2"}
+
+	makeTable := func(ks *vindexes.Keyspace) *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("t")},
+			VTable: &vindexes.BaseTable{Name: sqlparser.NewIdentifierCS("t"), Keyspace: ks},
+		}
+	}
+	makeInfSchemaTable := func(ks *vindexes.Keyspace) *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("tables"), IsInfSchema: true},
+			VTable: &vindexes.BaseTable{Name: sqlparser.NewIdentifierCS("tables"), Keyspace: ks},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		op       Operator
+		expected []*vindexes.Keyspace
+	}{
+		{
+			name:     "real table",
+			op:       makeTable(ks1),
+			expected: []*vindexes.Keyspace{ks1},
+		},
+		{
+			name:     "virtual dual table has no keyspace",
+			op:       &Table{},
+			expected: nil,
+		},
+		{
+			name:     "table nested under a projection",
+			op:       &Projection{unaryOperator: newUnaryOp(makeTable(ks1))},
+			expected: []*vindexes.Keyspace{ks1},
+		},
+		{
+			name:     "same keyspace tables are deduplicated",
+			op:       &Join{LHS: makeTable(ks1), RHS: makeTable(ks1)},
+			expected: []*vindexes.Keyspace{ks1},
+		},
+		{
+			name:     "tables from different keyspaces",
+			op:       &Join{LHS: makeTable(ks1), RHS: makeTable(ks2)},
+			expected: []*vindexes.Keyspace{ks1, ks2},
+		},
+		{
+			name:     "real table joined with a virtual dual",
+			op:       &Join{LHS: makeTable(ks1), RHS: &Table{}},
+			expected: []*vindexes.Keyspace{ks1},
+		},
+		{
+			name:     "information_schema table with a synthetic vtable contributes nothing",
+			op:       makeInfSchemaTable(ks1),
+			expected: nil,
+		},
+		{
+			name:     "information_schema table joined with a real table",
+			op:       &Join{LHS: makeInfSchemaTable(ks1), RHS: makeTable(ks2)},
+			expected: []*vindexes.Keyspace{ks2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, realTableKeyspaces(tt.op))
+		})
+	}
+}
+
+func TestUpdateRoutingLogicKeepsNoneRouting(t *testing.T) {
+	ks := &vindexes.Keyspace{Name: "ks1"}
+	ctx := &plancontext.PlanningContext{
+		SemTable: &semantics.SemTable{},
+		VSchema:  &mockVSchema{},
+	}
+	orig := &NoneRouting{keyspace: ks, inferredKeyspace: true}
+	falseCmp := &sqlparser.ComparisonExpr{
+		Operator: sqlparser.EqualOp,
+		Left:     sqlparser.NewIntLiteral("1"),
+		Right:    sqlparser.NewIntLiteral("2"),
+	}
+
+	got := UpdateRoutingLogic(ctx, falseCmp, orig)
+
+	assert.Same(t, orig, got)
+}
+
+func TestHasInfoSchemaTables(t *testing.T) {
+	ks1 := &vindexes.Keyspace{Name: "ks1"}
+
+	makeTable := func() *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("t")},
+			VTable: &vindexes.BaseTable{Name: sqlparser.NewIdentifierCS("t"), Keyspace: ks1},
+		}
+	}
+	makeInfSchemaTable := func() *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("tables"), IsInfSchema: true},
+			VTable: &vindexes.BaseTable{Name: sqlparser.NewIdentifierCS("tables"), Keyspace: ks1},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		op       Operator
+		expected bool
+	}{
+		{
+			name:     "real table",
+			op:       makeTable(),
+			expected: false,
+		},
+		{
+			name:     "information_schema table",
+			op:       makeInfSchemaTable(),
+			expected: true,
+		},
+		{
+			name:     "virtual dual table",
+			op:       &Table{},
+			expected: false,
+		},
+		{
+			name:     "information_schema table nested under a projection",
+			op:       &Projection{unaryOperator: newUnaryOp(makeInfSchemaTable())},
+			expected: true,
+		},
+		{
+			name:     "information_schema table joined with a real table",
+			op:       &Join{LHS: makeTable(), RHS: makeInfSchemaTable()},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, hasInfoSchemaTables(tt.op))
 		})
 	}
 }

--- a/go/vt/vtgate/planbuilder/operators/route_planning_test.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning_test.go
@@ -23,7 +23,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/vt/key"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtenv"
+	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 	"vitess.io/vitess/go/vt/vtgate/semantics"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
@@ -32,6 +37,7 @@ import (
 type mockVSchema struct {
 	plancontext.VSchema
 	preventCrossKeyspaceReads map[string]bool
+	tables                    map[string]*vindexes.BaseTable
 }
 
 func (m *mockVSchema) AllowCrossKeyspaceReads(keyspace string) (bool, error) {
@@ -41,12 +47,62 @@ func (m *mockVSchema) AllowCrossKeyspaceReads(keyspace string) (bool, error) {
 	return !m.preventCrossKeyspaceReads[keyspace], nil
 }
 
+func (m *mockVSchema) FindTableOrVindex(tab sqlparser.TableName) (*vindexes.BaseTable, vindexes.Vindex, string, topodatapb.TabletType, key.ShardDestination, error) {
+	tbl, found := m.tables[tab.Name.String()]
+	if !found {
+		return nil, nil, "", topodatapb.TabletType_PRIMARY, nil, vterrors.VT05004(tab.Name.String())
+	}
+	return tbl, nil, tbl.Keyspace.Name, topodatapb.TabletType_PRIMARY, nil, nil
+}
+
+func (m *mockVSchema) Environment() *vtenv.Environment {
+	return vtenv.NewTestEnv()
+}
+
+func (m *mockVSchema) ConnCollation() collations.ID {
+	return collations.CollationUtf8mb4ID
+}
+
 func TestCheckCrossKeyspaceJoin(t *testing.T) {
 	ks1 := &vindexes.Keyspace{Name: "ks1"}
 	ks2 := &vindexes.Keyspace{Name: "ks2"}
 
 	makeRoute := func(ks *vindexes.Keyspace) *Route {
 		return &Route{Routing: &NoneRouting{keyspace: ks}}
+	}
+	plainTable := func(ks *vindexes.Keyspace) *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("t")},
+			VTable: &vindexes.BaseTable{Name: sqlparser.NewIdentifierCS("t"), Keyspace: ks},
+		}
+	}
+	refTable := func(ks *vindexes.Keyspace, copyKs string) *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("ref")},
+			VTable: &vindexes.BaseTable{
+				Name:         sqlparser.NewIdentifierCS("ref"),
+				Keyspace:     ks,
+				ReferencedBy: map[string]*vindexes.BaseTable{copyKs: {}},
+			},
+		}
+	}
+	sourcedTable := func(ks *vindexes.Keyspace, sourceKs string) *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("ref")},
+			VTable: &vindexes.BaseTable{
+				Name:     sqlparser.NewIdentifierCS("ref"),
+				Keyspace: ks,
+				Source: &vindexes.Source{
+					TableName: sqlparser.TableName{
+						Qualifier: sqlparser.NewIdentifierCS(sourceKs),
+						Name:      sqlparser.NewIdentifierCS("src"),
+					},
+				},
+			},
+		}
+	}
+	noneRouteOver := func(ks *vindexes.Keyspace, src Operator) *Route {
+		return &Route{unaryOperator: newUnaryOp(src), Routing: &NoneRouting{keyspace: ks}}
 	}
 
 	tests := []struct {
@@ -209,6 +265,84 @@ func TestCheckCrossKeyspaceJoin(t *testing.T) {
 				preventCrossKeyspaceReads: map[string]bool{"ks1": false, "ks2": false},
 			},
 		},
+		{
+			name: "inferred none keyspace does not create a cross-keyspace pair",
+			lhs:  &Route{Routing: &NoneRouting{keyspace: ks1, inferredKeyspace: true}},
+			rhs:  makeRoute(ks2),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+			},
+		},
+		{
+			name: "inferred none keyspace wrapped in a non-route is also skipped",
+			lhs: &Projection{
+				unaryOperator: newUnaryOp(&Route{Routing: &NoneRouting{keyspace: ks1, inferredKeyspace: true}}),
+			},
+			rhs: makeRoute(ks2),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+			},
+		},
+		{
+			name: "cross-keyspace denied but the lhs none branch's table has a reference copy on the rhs",
+			lhs:  noneRouteOver(ks1, refTable(ks1, "ks2")),
+			rhs:  makeRoute(ks2),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+			},
+		},
+		{
+			name: "cross-keyspace denied but the rhs none branch's table is sourced from the lhs keyspace",
+			lhs:  makeRoute(ks1),
+			rhs:  noneRouteOver(ks2, sourcedTable(ks2, "ks1")),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+			},
+		},
+		{
+			name: "cross-keyspace denied but the rhs none branch's table has an unqualified source resolving to the lhs keyspace",
+			lhs:  makeRoute(ks1),
+			rhs: noneRouteOver(ks2, &Table{
+				QTable: &QueryTable{Table: sqlparser.NewTableName("ref")},
+				VTable: &vindexes.BaseTable{
+					Name:     sqlparser.NewIdentifierCS("ref"),
+					Keyspace: ks2,
+					Source: &vindexes.Source{
+						TableName: sqlparser.TableName{Name: sqlparser.NewIdentifierCS("src")},
+					},
+				},
+			}),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+				tables: map[string]*vindexes.BaseTable{
+					"src": {Name: sqlparser.NewIdentifierCS("src"), Keyspace: ks1},
+				},
+			},
+		},
+		{
+			name: "a none branch that absorbed a table without a copy on the rhs stays denied",
+			lhs: noneRouteOver(ks1, &Join{binaryOperator: binaryOperator{
+				LHS: refTable(ks1, "ks2"),
+				RHS: plainTable(ks1),
+			}}),
+			rhs: makeRoute(ks2),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+			},
+			expectPanic: true,
+		},
+		{
+			name: "an inferred none keyspace over a real table stays accountable",
+			lhs: &Route{
+				unaryOperator: newUnaryOp(plainTable(ks1)),
+				Routing:       &NoneRouting{keyspace: ks1, inferredKeyspace: true},
+			},
+			rhs: makeRoute(ks2),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+			},
+			expectPanic: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -289,6 +423,150 @@ func TestOperatorKeyspaces(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, operatorKeyspaces(tt.op))
+		})
+	}
+}
+
+func TestRealTableKeyspaces(t *testing.T) {
+	ks1 := &vindexes.Keyspace{Name: "ks1"}
+	ks2 := &vindexes.Keyspace{Name: "ks2"}
+
+	makeTable := func(ks *vindexes.Keyspace) *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("t")},
+			VTable: &vindexes.BaseTable{Name: sqlparser.NewIdentifierCS("t"), Keyspace: ks},
+		}
+	}
+	makeInfSchemaTable := func(ks *vindexes.Keyspace) *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("tables"), IsInfSchema: true},
+			VTable: &vindexes.BaseTable{Name: sqlparser.NewIdentifierCS("tables"), Keyspace: ks},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		op       Operator
+		expected []*vindexes.Keyspace
+	}{
+		{
+			name:     "real table",
+			op:       makeTable(ks1),
+			expected: []*vindexes.Keyspace{ks1},
+		},
+		{
+			name:     "virtual dual table has no keyspace",
+			op:       &Table{},
+			expected: nil,
+		},
+		{
+			name:     "table nested under a projection",
+			op:       &Projection{unaryOperator: newUnaryOp(makeTable(ks1))},
+			expected: []*vindexes.Keyspace{ks1},
+		},
+		{
+			name:     "same keyspace tables are deduplicated",
+			op:       &Join{binaryOperator: binaryOperator{LHS: makeTable(ks1), RHS: makeTable(ks1)}},
+			expected: []*vindexes.Keyspace{ks1},
+		},
+		{
+			name:     "tables from different keyspaces",
+			op:       &Join{binaryOperator: binaryOperator{LHS: makeTable(ks1), RHS: makeTable(ks2)}},
+			expected: []*vindexes.Keyspace{ks1, ks2},
+		},
+		{
+			name:     "real table joined with a virtual dual",
+			op:       &Join{binaryOperator: binaryOperator{LHS: makeTable(ks1), RHS: &Table{}}},
+			expected: []*vindexes.Keyspace{ks1},
+		},
+		{
+			name:     "information_schema table with a synthetic vtable contributes nothing",
+			op:       makeInfSchemaTable(ks1),
+			expected: nil,
+		},
+		{
+			name:     "information_schema table joined with a real table",
+			op:       &Join{binaryOperator: binaryOperator{LHS: makeInfSchemaTable(ks1), RHS: makeTable(ks2)}},
+			expected: []*vindexes.Keyspace{ks2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, realTableKeyspaces(tt.op))
+		})
+	}
+}
+
+func TestUpdateRoutingLogicKeepsNoneRouting(t *testing.T) {
+	ks := &vindexes.Keyspace{Name: "ks1"}
+	ctx := &plancontext.PlanningContext{
+		SemTable: &semantics.SemTable{},
+		VSchema:  &mockVSchema{},
+	}
+	orig := &NoneRouting{keyspace: ks, inferredKeyspace: true}
+	falseCmp := &sqlparser.ComparisonExpr{
+		Operator: sqlparser.EqualOp,
+		Left:     sqlparser.NewIntLiteral("1"),
+		Right:    sqlparser.NewIntLiteral("2"),
+	}
+
+	got := UpdateRoutingLogic(ctx, falseCmp, orig)
+
+	assert.Same(t, orig, got)
+}
+
+func TestHasInfoSchemaTables(t *testing.T) {
+	ks1 := &vindexes.Keyspace{Name: "ks1"}
+
+	makeTable := func() *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("t")},
+			VTable: &vindexes.BaseTable{Name: sqlparser.NewIdentifierCS("t"), Keyspace: ks1},
+		}
+	}
+	makeInfSchemaTable := func() *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("tables"), IsInfSchema: true},
+			VTable: &vindexes.BaseTable{Name: sqlparser.NewIdentifierCS("tables"), Keyspace: ks1},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		op       Operator
+		expected bool
+	}{
+		{
+			name:     "real table",
+			op:       makeTable(),
+			expected: false,
+		},
+		{
+			name:     "information_schema table",
+			op:       makeInfSchemaTable(),
+			expected: true,
+		},
+		{
+			name:     "virtual dual table",
+			op:       &Table{},
+			expected: false,
+		},
+		{
+			name:     "information_schema table nested under a projection",
+			op:       &Projection{unaryOperator: newUnaryOp(makeInfSchemaTable())},
+			expected: true,
+		},
+		{
+			name:     "information_schema table joined with a real table",
+			op:       &Join{binaryOperator: binaryOperator{LHS: makeTable(), RHS: makeInfSchemaTable()}},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, hasInfoSchemaTables(tt.op))
 		})
 	}
 }

--- a/go/vt/vtgate/planbuilder/operators/route_test.go
+++ b/go/vt/vtgate/planbuilder/operators/route_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operators
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/vschemawrapper"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtenv"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+)
+
+func TestUpdateRoutingLogicSequenceRouting(t *testing.T) {
+	env := vtenv.NewTestEnv()
+	vs := vindexes.BuildVSchema(&vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{"main": {}},
+	}, sqlparser.NewTestParser())
+	vw, err := vschemawrapper.NewVschemaWrapper(env, vs, nil)
+	require.NoError(t, err)
+
+	stmt, err := sqlparser.NewTestParser().Parse("select 1 from dual")
+	require.NoError(t, err)
+	reservedVars := sqlparser.NewReservedVars("vtg", make(sqlparser.BindVars))
+	ctx, err := plancontext.CreatePlanningContext(stmt, reservedVars, vw, querypb.ExecuteOptions_Gen4)
+	require.NoError(t, err)
+
+	// a sequence routing must pass through predicate handling untouched
+	seq := &SequenceRouting{keyspace: &vindexes.Keyspace{Name: "main"}}
+	assert.Same(t, seq, UpdateRoutingLogic(ctx, sqlparser.NewIntLiteral("1"), seq))
+}

--- a/go/vt/vtgate/planbuilder/operators/union_merging.go
+++ b/go/vt/vtgate/planbuilder/operators/union_merging.go
@@ -17,6 +17,8 @@ limitations under the License.
 package operators
 
 import (
+	"slices"
+
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
@@ -114,6 +116,18 @@ func mergeUnionInputs(
 		return nil, nil
 	}
 
+	// a none routing resolves to no shards at execution time, so its side of the
+	// union contributes no rows. None pairings must be decided before the dual
+	// and anyShard cases below: those would retain the none routing and
+	// incorrectly discard the other side's rows.
+	if a == none || b == none {
+		if op, exprs, merged := tryMergeNoneUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingA, routingB, a, b); merged {
+			return op, exprs
+		}
+		checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
+		return nil, nil
+	}
+
 	switch {
 	// if either side is a dual query, we can always merge them together
 	// an unsharded/reference route can be merged with anything going to that keyspace
@@ -121,11 +135,6 @@ func mergeUnionInputs(
 		return createMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingA, nil)
 	case a == dual || (a == anyShard && sameKeyspace):
 		return createMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingB, nil)
-
-	case a == none:
-		return createMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingB, nil)
-	case b == none:
-		return createMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingA, nil)
 
 	case a == sharded && b == sharded && sameKeyspace:
 		res, exprs := tryMergeUnionShardedRouting(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct)
@@ -138,6 +147,75 @@ func mergeUnionInputs(
 	checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
 
 	return nil, nil
+}
+
+// tryMergeNoneUnion merges a union pairing in which at least one side has a
+// none routing. The none side contributes no rows, but its query text (and the
+// field query derived from it) still references its tables, so a merge may only
+// adopt a routing whose keyspace holds every real table of the none side.
+func tryMergeNoneUnion(
+	ctx *plancontext.PlanningContext,
+	lhsRoute, rhsRoute *Route,
+	lhsExprs, rhsExprs []sqlparser.SelectExpr,
+	distinct bool,
+	routingA, routingB Routing,
+	a, b routingType,
+) (Operator, []sqlparser.SelectExpr, bool) {
+	otherRouting, otherType := routingB, b
+	noneRoute, otherRoute := lhsRoute, rhsRoute
+	if a != none {
+		otherRouting, otherType = routingA, a
+		noneRoute, otherRoute = rhsRoute, lhsRoute
+	}
+	noneKeyspaces := realTableKeyspaces(noneRoute.Source)
+
+	var routing Routing
+	switch {
+	case otherType == none:
+		// both sides are empty. They can collapse into a single none route as
+		// long as their combined real tables live in one keyspace: the merged
+		// route's field query must be executable on a shard of that keyspace.
+		for _, ks := range realTableKeyspaces(otherRoute.Source) {
+			if !slices.Contains(noneKeyspaces, ks) {
+				noneKeyspaces = append(noneKeyspaces, ks)
+			}
+		}
+		switch len(noneKeyspaces) {
+		case 0:
+			routing = noneRoute.Routing
+		case 1:
+			routing = &NoneRouting{keyspace: noneKeyspaces[0]}
+		default:
+			return nil, nil, false
+		}
+	case hasInfoSchemaTables(noneRoute.Source):
+		// an information_schema comparison may have been rewritten to a
+		// planner-generated argument (e.g. :__vtschemaname) that only a DBA
+		// route binds. Adopting an executable routing would ship that argument
+		// to a shard with no binding for it, so this branch must stay separate.
+		return nil, nil, false
+	case len(noneKeyspaces) == 0:
+		// the none side references no real tables, so its keyspace is only a
+		// placeholder: adopt the other side's routing unconditionally.
+		routing = otherRouting
+	case otherType == dual:
+		// a dual side has no keyspace and no tables of its own, so any shard
+		// in the none side's single keyspace can produce its rows.
+		if len(noneKeyspaces) != 1 {
+			return nil, nil, false
+		}
+		routing = &AnyShardRouting{keyspace: noneKeyspaces[0]}
+	default:
+		// the other side's routing is retained, but only when it targets the
+		// keyspace holding the none side's tables: they exist nowhere else.
+		if len(noneKeyspaces) != 1 || noneKeyspaces[0] != otherRouting.Keyspace() {
+			return nil, nil, false
+		}
+		routing = otherRouting
+	}
+
+	op, exprs := createMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routing, nil)
+	return op, exprs, true
 }
 
 func tryMergeUnionShardedRouting(

--- a/go/vt/vtgate/planbuilder/testdata/dml_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/dml_cases.json
@@ -7255,5 +7255,129 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "a destination-targeted union subquery with an empty same-keyspace branch merges into the destination route",
+    "query": "update `user[-80]`.user_extra set val = 1 where user_id in (select id from `user[-80]`.`user` where id in (null) union select id from `user[-80]`.`user`)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "UPDATE",
+      "Original": "update `user[-80]`.user_extra set val = 1 where user_id in (select id from `user[-80]`.`user` where id in (null) union select id from `user[-80]`.`user`)",
+      "Instructions": {
+        "OperatorType": "UncorrelatedSubquery",
+        "Variant": "PulloutIn",
+        "PulloutVars": [
+          "__sq_has_values",
+          "__sq1"
+        ],
+        "Inputs": [
+          {
+            "InputName": "SubQuery",
+            "OperatorType": "Distinct",
+            "Collations": [
+              "(0:1)"
+            ],
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "ByDestination",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "TargetDestination": "ExactKeyRange(-80)",
+                "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+                "Query": "select id, weight_string(id) from `user` where id in (null) union select id, weight_string(id) from `user`"
+              }
+            ]
+          },
+          {
+            "InputName": "Outer",
+            "OperatorType": "Update",
+            "Variant": "ByDestination",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "Query": "update user_extra set val = 1 where :__sq_has_values and user_id in ::__sq1"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a cross-keyspace empty branch stays separate from a destination-targeted branch",
+    "query": "update `user[-80]`.user_extra set val = 1 where user_id in (select oid from ordering.order_event where oid in (null) union select id from `user[-80]`.`user`)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "UPDATE",
+      "Original": "update `user[-80]`.user_extra set val = 1 where user_id in (select oid from ordering.order_event where oid in (null) union select id from `user[-80]`.`user`)",
+      "Instructions": {
+        "OperatorType": "UncorrelatedSubquery",
+        "Variant": "PulloutIn",
+        "PulloutVars": [
+          "__sq_has_values",
+          "__sq1"
+        ],
+        "Inputs": [
+          {
+            "InputName": "SubQuery",
+            "OperatorType": "Distinct",
+            "Collations": [
+              "(0:1)"
+            ],
+            "Inputs": [
+              {
+                "OperatorType": "Concatenate",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "None",
+                    "Keyspace": {
+                      "Name": "ordering",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select oid, weight_string(oid) from order_event where 1 != 1",
+                    "Query": "select distinct oid, weight_string(oid) from order_event where oid in (null) lock in share mode"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "ByDestination",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "TargetDestination": "ExactKeyRange(-80)",
+                    "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1",
+                    "Query": "select distinct id, weight_string(id) from `user` lock in share mode"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "InputName": "Outer",
+            "OperatorType": "Update",
+            "Variant": "ByDestination",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "Query": "update user_extra set val = 1 where :__sq_has_values and user_id in ::__sq1"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "ordering.order_event",
+        "user.user",
+        "user.user_extra"
+      ]
+    },
+    "skip_e2e": true
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -266,7 +266,7 @@
     }
   },
   {
-    "comment": "union operations in derived table, without star expression (FROM)¡",
+    "comment": "union operations in derived table, without star expression (FROM)\u00a1",
     "query": "select col1,col2 from (select col1, col2 from user union all select col1, col2 from user_extra) as t",
     "plan": {
       "Type": "Scatter",
@@ -452,6 +452,719 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "none routing merged with dual: any shard in the none side's keyspace serves the dual rows",
+    "query": "select id from user where id in (null) union select 1 from dual",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select id from user where id in (null) union select 1 from dual",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from `user` where 1 != 1 union select 1 from dual where 1 != 1",
+        "Query": "select id from `user` where id in (null) union select 1 from dual"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "dual merged with a none routing on the right: any shard in the none side's keyspace serves the dual rows",
+    "query": "select 1 from dual union select id from user where id in (null)",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select 1 from dual union select id from user where id in (null)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select 1 from dual where 1 != 1 union select id from `user` where 1 != 1",
+        "Query": "select 1 from dual union select id from `user` where id in (null)"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "none routings from different keyspaces stay unmerged; the dual leg merges into one none side's keyspace",
+    "query": "select oid from ordering.order_event where oid in (null) union select id from user where id in (null) union select 1 from dual",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select oid from ordering.order_event where oid in (null) union select id from user where id in (null) union select 1 from dual",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Reference",
+                "Keyspace": {
+                  "Name": "ordering",
+                  "Sharded": true
+                },
+                "FieldQuery": "select oid, weight_string(oid) from order_event where 1 != 1 union select 1, weight_string(1) from dual where 1 != 1",
+                "Query": "select oid, weight_string(oid) from order_event where oid in (null) union select 1, weight_string(1) from dual"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user` where id in (null)) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "ordering.order_event",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a none routing only merges with a sharded routing in its own keyspace",
+    "query": "select oid from ordering.order_event where oid in (null) union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select oid from ordering.order_event where oid in (null) union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "ordering",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as oid, weight_string(dt.c0) from (select oid from order_event where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as oid, weight_string(dt.c0) from (select distinct oid from order_event where oid in (null)) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "ordering.order_event",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a none routing only merges with an unsharded routing in its own keyspace",
+    "query": "select oid from ordering.order_event where oid in (null) union select col from unsharded",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select oid from ordering.order_event where oid in (null) union select col from unsharded",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "ordering",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as oid, weight_string(dt.c0) from (select oid from order_event where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as oid, weight_string(dt.c0) from (select distinct oid from order_event where oid in (null)) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as col, weight_string(dt.c0) from (select col from unsharded where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as col, weight_string(dt.c0) from (select distinct col from unsharded) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded",
+        "ordering.order_event"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a none routing merges with a sharded routing in the same keyspace",
+    "query": "select id from user where id in (null) union select id from user_extra",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user where id in (null) union select id from user_extra",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from user_extra where 1 != 1",
+            "Query": "select id, weight_string(id) from `user` where id in (null) union select id, weight_string(id) from user_extra"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "union all keeps cross-keyspace none legs unmerged while the dual leg merges in order",
+    "query": "select oid from ordering.order_event where oid in (null) union all select id from user where id in (null) union all select 1 from dual",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select oid from ordering.order_event where oid in (null) union all select id from user where id in (null) union all select 1 from dual",
+      "Instructions": {
+        "OperatorType": "Concatenate",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "None",
+            "Keyspace": {
+              "Name": "ordering",
+              "Sharded": true
+            },
+            "FieldQuery": "select oid from order_event where 1 != 1",
+            "Query": "select oid from order_event where oid in (null)"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Reference",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id from `user` where 1 != 1 union all select 1 from dual where 1 != 1",
+            "Query": "select id from `user` where id in (null) union all select 1 from dual"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "ordering.order_event",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a dual-derived none routing that absorbed a real table only merges into that table's keyspace",
+    "query": "select u.col from unsharded as u, (select 1 from dual where 1 in (null)) as x union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select u.col from unsharded as u, (select 1 from dual where 1 in (null)) as x union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as col, weight_string(dt.c0) from (select u.col from unsharded as u, (select 1 from dual where 1 != 1) as x where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as col, weight_string(dt.c0) from (select distinct u.col from unsharded as u, (select 1 from dual where 1 in (null)) as x) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "a dual-derived none routing that absorbed a real table merges with a branch in that table's keyspace",
+    "query": "select u.col from unsharded as u, (select 1 from dual where 1 in (null)) as x union select col2 from unsharded_auto",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select u.col from unsharded as u, (select 1 from dual where 1 in (null)) as x union select col2 from unsharded_auto",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select u.col from unsharded as u, (select 1 from dual where 1 != 1) as x where 1 != 1 union select col2 from unsharded_auto where 1 != 1",
+        "Query": "select u.col from unsharded as u, (select 1 from dual where 1 in (null)) as x union select col2 from unsharded_auto"
+      },
+      "TablesUsed": [
+        "main.unsharded",
+        "main.unsharded_auto"
+      ]
+    }
+  },
+  {
+    "comment": "none routings in the same keyspace collapse into a single none route",
+    "query": "select id from user where id in (null) union select id from user_extra where user_id in (null)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user where id in (null) union select id from user_extra where user_id in (null)",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "None",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from user_extra where 1 != 1",
+            "Query": "select id, weight_string(id) from `user` where id in (null) union select id, weight_string(id) from user_extra where user_id in (null)"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "none routings from different keyspaces stay unmerged: no single keyspace could resolve the merged field query",
+    "query": "select id from user where id in (null) union select oid from ordering.order_event where oid in (null)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user where id in (null) union select oid from ordering.order_event where oid in (null)",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user` where id in (null)) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "ordering",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as oid, weight_string(dt.c0) from (select oid from order_event where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as oid, weight_string(dt.c0) from (select distinct oid from order_event where oid in (null)) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "ordering.order_event",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a none routing over a rewritten information_schema branch must not adopt the dual side: only a DBA route binds :__vtschemaname",
+    "query": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select 1 from dual",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select 1 from dual",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0: utf8mb3_general_ci"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+                "Query": "select distinct `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and 0"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Reference",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select 1 from dual where 1 != 1",
+                "Query": "select distinct 1 from dual"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "comment": "the information_schema guard also applies when the other side lands on the inferred keyspace",
+    "query": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select col from unsharded",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select col from unsharded",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as `table_name`, weight_string(dt.c0) from (select `table_name` from information_schema.`tables` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as `table_name`, weight_string(dt.c0) from (select distinct `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and 0) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as col, weight_string(dt.c0) from (select col from unsharded where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as col, weight_string(dt.c0) from (select distinct col from unsharded) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded"
+      ]
+    }
+  },
+  {
+    "comment": "a degraded information_schema branch stays separate from a sharded side",
+    "query": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as `table_name`, weight_string(dt.c0) from (select `table_name` from information_schema.`tables` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as `table_name`, weight_string(dt.c0) from (select distinct `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and 0) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "a degraded information_schema branch stays separate from a live DBA route",
+    "query": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select table_name from information_schema.columns",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select table_name from information_schema.columns",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0: utf8mb3_general_ci"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+                "Query": "select distinct `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and 0"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "DBA",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select `table_name` from information_schema.`columns` where 1 != 1",
+                "Query": "select distinct `table_name` from information_schema.`columns`"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a reference-degraded none routing keeps its canonical keyspace and declines a cross-keyspace merge",
+    "query": "select id from ambiguous_ref_with_source where id in (null) union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from ambiguous_ref_with_source where id in (null) union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from ambiguous_ref_with_source where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from ambiguous_ref_with_source where id in (null)) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.ambiguous_ref_with_source",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "differing physical reference names must not merge: the none side's table does not exist in the other keyspace",
+    "query": "select id from source_of_ref where id in (null) union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from source_of_ref where id in (null) union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from source_of_ref where id in (null)) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.source_of_ref",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "a reference-degraded none routing whose keyspace matches the other side still merges",
+    "query": "select id from ref_with_source where id in (null) union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from ref_with_source where id in (null) union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ref_with_source where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ref_with_source where id in (null) union select id, weight_string(id) from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union with the same target shard because of vindex",
@@ -2118,6 +2831,66 @@
       },
       "TablesUsed": [
         "main.unsharded",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "statically false dual branch merges into the other side's keyspace",
+    "query": "select 42 from dual where false union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select 42 from dual where false union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 42 from dual where 1 != 1 union select id from `user` where 1 != 1",
+            "Query": "select 42 from dual where 0 union select id from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "statically false dual branch on the right merges into the other side's keyspace",
+    "query": "select id from user union select 42 from dual where false",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user union select 42 from dual where false",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id from `user` where 1 != 1 union select 42 from dual where 1 != 1",
+            "Query": "select id from `user` union select 42 from dual where 0"
+          }
+        ]
+      },
+      "TablesUsed": [
         "user.user"
       ]
     }

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -266,7 +266,7 @@
     }
   },
   {
-    "comment": "union operations in derived table, without star expression (FROM)¡",
+    "comment": "union operations in derived table, without star expression (FROM)\u00a1",
     "query": "select col1,col2 from (select col1, col2 from user union all select col1, col2 from user_extra) as t",
     "plan": {
       "Type": "Scatter",
@@ -452,6 +452,719 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "none routing merged with dual: any shard in the none side's keyspace serves the dual rows",
+    "query": "select id from user where id in (null) union select 1 from dual",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select id from user where id in (null) union select 1 from dual",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from `user` where 1 != 1 union select 1 from dual where 1 != 1",
+        "Query": "select id from `user` where id in (null) union select 1 from dual"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "dual merged with a none routing on the right: any shard in the none side's keyspace serves the dual rows",
+    "query": "select 1 from dual union select id from user where id in (null)",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select 1 from dual union select id from user where id in (null)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select 1 from dual where 1 != 1 union select id from `user` where 1 != 1",
+        "Query": "select 1 from dual union select id from `user` where id in (null)"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "none routings from different keyspaces stay unmerged; the dual leg merges into one none side's keyspace",
+    "query": "select oid from ordering.order_event where oid in (null) union select id from user where id in (null) union select 1 from dual",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select oid from ordering.order_event where oid in (null) union select id from user where id in (null) union select 1 from dual",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Reference",
+                "Keyspace": {
+                  "Name": "ordering",
+                  "Sharded": true
+                },
+                "FieldQuery": "select oid, weight_string(oid) from order_event where 1 != 1 union select 1, weight_string(1) from dual where 1 != 1",
+                "Query": "select oid, weight_string(oid) from order_event where oid in (null) union select 1, weight_string(1) from dual"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user` where id in (null)) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "ordering.order_event",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a none routing only merges with a sharded routing in its own keyspace",
+    "query": "select oid from ordering.order_event where oid in (null) union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select oid from ordering.order_event where oid in (null) union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "ordering",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as oid, weight_string(dt.c0) from (select oid from order_event where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as oid, weight_string(dt.c0) from (select distinct oid from order_event where oid in (null)) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "ordering.order_event",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a none routing only merges with an unsharded routing in its own keyspace",
+    "query": "select oid from ordering.order_event where oid in (null) union select col from unsharded",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select oid from ordering.order_event where oid in (null) union select col from unsharded",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "ordering",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as oid, weight_string(dt.c0) from (select oid from order_event where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as oid, weight_string(dt.c0) from (select distinct oid from order_event where oid in (null)) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as col, weight_string(dt.c0) from (select col from unsharded where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as col, weight_string(dt.c0) from (select distinct col from unsharded) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded",
+        "ordering.order_event"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a none routing merges with a sharded routing in the same keyspace",
+    "query": "select id from user where id in (null) union select id from user_extra",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user where id in (null) union select id from user_extra",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from user_extra where 1 != 1",
+            "Query": "select id, weight_string(id) from `user` where id in (null) union select id, weight_string(id) from user_extra"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "union all keeps cross-keyspace none legs unmerged while the dual leg merges in order",
+    "query": "select oid from ordering.order_event where oid in (null) union all select id from user where id in (null) union all select 1 from dual",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select oid from ordering.order_event where oid in (null) union all select id from user where id in (null) union all select 1 from dual",
+      "Instructions": {
+        "OperatorType": "Concatenate",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "None",
+            "Keyspace": {
+              "Name": "ordering",
+              "Sharded": true
+            },
+            "FieldQuery": "select oid from order_event where 1 != 1",
+            "Query": "select oid from order_event where oid in (null)"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Reference",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id from `user` where 1 != 1 union all select 1 from dual where 1 != 1",
+            "Query": "select id from `user` where id in (null) union all select 1 from dual"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "ordering.order_event",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a dual-derived none routing that absorbed a real table only merges into that table's keyspace",
+    "query": "select u.col from unsharded as u, (select 1 from dual where 1 in (null)) as x union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select u.col from unsharded as u, (select 1 from dual where 1 in (null)) as x union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as col, weight_string(dt.c0) from (select u.col from unsharded as u, (select 1 from dual where 1 != 1) as x where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as col, weight_string(dt.c0) from (select distinct u.col from unsharded as u, (select 1 from dual where 1 in (null)) as x) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "a dual-derived none routing that absorbed a real table merges with a branch in that table's keyspace",
+    "query": "select u.col from unsharded as u, (select 1 from dual where 1 in (null)) as x union select col2 from unsharded_auto",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select u.col from unsharded as u, (select 1 from dual where 1 in (null)) as x union select col2 from unsharded_auto",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select u.col from unsharded as u, (select 1 from dual where 1 != 1) as x where 1 != 1 union select col2 from unsharded_auto where 1 != 1",
+        "Query": "select u.col from unsharded as u, (select 1 from dual where 1 in (null)) as x union select col2 from unsharded_auto"
+      },
+      "TablesUsed": [
+        "main.unsharded",
+        "main.unsharded_auto"
+      ]
+    }
+  },
+  {
+    "comment": "none routings in the same keyspace collapse into a single none route",
+    "query": "select id from user where id in (null) union select id from user_extra where user_id in (null)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user where id in (null) union select id from user_extra where user_id in (null)",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "None",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from user_extra where 1 != 1",
+            "Query": "select id, weight_string(id) from `user` where id in (null) union select id, weight_string(id) from user_extra where user_id in (null)"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "none routings from different keyspaces stay unmerged: no single keyspace could resolve the merged field query",
+    "query": "select id from user where id in (null) union select oid from ordering.order_event where oid in (null)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user where id in (null) union select oid from ordering.order_event where oid in (null)",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user` where id in (null)) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "ordering",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as oid, weight_string(dt.c0) from (select oid from order_event where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as oid, weight_string(dt.c0) from (select distinct oid from order_event where oid in (null)) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "ordering.order_event",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a none routing over a rewritten information_schema branch must not adopt the dual side: only a DBA route binds :__vtschemaname",
+    "query": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select 1 from dual",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select 1 from dual",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0: utf8mb3_general_ci"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+                "Query": "select distinct `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and 0"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Reference",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select 1 from dual where 1 != 1",
+                "Query": "select distinct 1 from dual"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "comment": "the information_schema guard also applies when the other side lands on the inferred keyspace",
+    "query": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select col from unsharded",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select col from unsharded",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as `table_name`, weight_string(dt.c0) from (select `table_name` from information_schema.`tables` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as `table_name`, weight_string(dt.c0) from (select distinct `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and 0) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as col, weight_string(dt.c0) from (select col from unsharded where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as col, weight_string(dt.c0) from (select distinct col from unsharded) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded"
+      ]
+    }
+  },
+  {
+    "comment": "a degraded information_schema branch stays separate from a sharded side",
+    "query": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as `table_name`, weight_string(dt.c0) from (select `table_name` from information_schema.`tables` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as `table_name`, weight_string(dt.c0) from (select distinct `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and 0) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "a degraded information_schema branch stays separate from a live DBA route",
+    "query": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select table_name from information_schema.columns",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select table_name from information_schema.columns",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0: utf8mb3_general_ci"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+                "Query": "select distinct `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and 0"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "DBA",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select `table_name` from information_schema.`columns` where 1 != 1",
+                "Query": "select distinct `table_name` from information_schema.`columns`"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a reference-degraded none routing keeps its canonical keyspace and declines a cross-keyspace merge",
+    "query": "select id from ambiguous_ref_with_source where id in (null) union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from ambiguous_ref_with_source where id in (null) union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from ambiguous_ref_with_source where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from ambiguous_ref_with_source where id in (null)) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.ambiguous_ref_with_source",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "differing physical reference names must not merge: the none side's table does not exist in the other keyspace",
+    "query": "select id from source_of_ref where id in (null) union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from source_of_ref where id in (null) union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from source_of_ref where id in (null)) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.source_of_ref",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "a reference-degraded none routing whose keyspace matches the other side still merges",
+    "query": "select id from ref_with_source where id in (null) union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from ref_with_source where id in (null) union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ref_with_source where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ref_with_source where id in (null) union select id, weight_string(id) from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union with the same target shard because of vindex",
@@ -2121,5 +2834,112 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "statically false dual branch merges into the other side's keyspace",
+    "query": "select 42 from dual where false union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select 42 from dual where false union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 42 from dual where 1 != 1 union select id from `user` where 1 != 1",
+            "Query": "select 42 from dual where 0 union select id from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "statically false dual branch on the right merges into the other side's keyspace",
+    "query": "select id from user union select 42 from dual where false",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user union select 42 from dual where false",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id from `user` where 1 != 1 union select 42 from dual where 1 != 1",
+            "Query": "select id from `user` union select 42 from dual where 0"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "a none routing over a sharded table stays separate from a live DBA route",
+    "query": "select id from user where id in (null) union select table_name from information_schema.tables",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user where id in (null) union select table_name from information_schema.tables",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user` where id in (null)) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "DBA",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as `table_name`, weight_string(dt.c0) from (select `table_name` from information_schema.`tables` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as `table_name`, weight_string(dt.c0) from (select distinct `table_name` from information_schema.`tables`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -266,7 +266,7 @@
     }
   },
   {
-    "comment": "union operations in derived table, without star expression (FROM)\u00a1",
+    "comment": "union operations in derived table, without star expression (FROM)¡",
     "query": "select col1,col2 from (select col1, col2 from user union all select col1, col2 from user_extra) as t",
     "plan": {
       "Type": "Scatter",
@@ -779,38 +779,6 @@
       "TablesUsed": [
         "main.unsharded",
         "main.unsharded_auto"
-      ]
-    }
-  },
-  {
-    "comment": "none routings in the same keyspace collapse into a single none route",
-    "query": "select id from user where id in (null) union select id from user_extra where user_id in (null)",
-    "plan": {
-      "Type": "Complex",
-      "QueryType": "SELECT",
-      "Original": "select id from user where id in (null) union select id from user_extra where user_id in (null)",
-      "Instructions": {
-        "OperatorType": "Distinct",
-        "Collations": [
-          "(0:1)"
-        ],
-        "ResultColumns": 1,
-        "Inputs": [
-          {
-            "OperatorType": "Route",
-            "Variant": "None",
-            "Keyspace": {
-              "Name": "user",
-              "Sharded": true
-            },
-            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from user_extra where 1 != 1",
-            "Query": "select id, weight_string(id) from `user` where id in (null) union select id, weight_string(id) from user_extra where user_id in (null)"
-          }
-        ]
-      },
-      "TablesUsed": [
-        "user.user",
-        "user.user_extra"
       ]
     }
   },


### PR DESCRIPTION
## Description

On main, a union that combines an empty-shard branch with a non-empty one can return the wrong result. The merge switch checks Dual and AnyShard before None, so `select id from user where id in (null) union select 1 from dual` keeps the None routing, resolves no shards, and returns nothing instead of the dual row. None routings also merge across keyspaces, so `select oid from ordering.order_event where oid in (null) union select id from user` embeds `order_event` in a query scattered to the user keyspace and fails with an unknown-table error.

The fix handles None pairings before the other arms and decides them from the real tables under the None side's route, derived from the operator tree at merge time so the decision cannot go stale when a route absorbs tables through earlier merges. A branch with no real tables, such as a statically false select from dual, adopts the other side's routing unconditionally, and paired with Dual, any shard in the None side's single table keyspace can serve the dual rows. Any other pairing retains the non-None side only when it targets the keyspace holding the None side's tables, and two None sides collapse into one None route only when their combined tables live in one keyspace. The fence is needed because a route that resolves no shards still runs its field query on a shard of its routing's keyspace, so cross-keyspace None pairs stay unmerged rather than embedding tables that fail there at runtime. Two hardening rules complete the fence: a branch whose information_schema comparison was rewritten to a planner-generated argument never adopts an executable routing, since only a DBA route binds `:__vtschemaname`, and for a branch degraded to None the cross-keyspace check validates each real table's reference-copy placements from the vschema at check time, so `PreventCrossKeyspaceReads` no longer rejects a union whose empty branch has a copy on the other side.

Twenty-two planner cases pin the corrected plans: both merge orders of the dual pairing and of a three-source shape, same-keyspace controls that must keep merging, statically false dual branches folding into the other side's keyspace, a dual-derived branch that absorbed a real table through a join, the cross-keyspace None pair, the four information_schema pairings, and the reference-table declines. Two end-to-end assertions check that the dual row survives execution in both orders, and the golden file joins the execution harness when https://github.com/vitessio/vitess/pull/20630 wires it into the plan e2e suite. Since affected unions silently drop rows or fail outright, this is probably worth backporting.

## Related Issue(s)

https://github.com/vitessio/vitess/pull/20630 depends on this change.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Unions with an empty-shard branch previously could return an empty result or fail with unknown-table errors, including when the empty branch came from dual, was joined with a real table, or read from information_schema. They now return the correct rows. No migrations or configuration changes.

### AI Disclosure

This PR was written primarily by Fable with review from GPT 5.6 Sol.

---

```mermaid
graph LR
    subgraph json [JSON support]
        direction TB
        PR20625["#20625 (merged)<br>mysql/json: fix MarshalTo discarding accumulated output for nested blob and bit values"]
        PR20632["#20632<br>vtgate: preserve IN value lists in complex aggregate projections"]
        PRA["#20691<br>evalengine: disable the static IN hash table for JSON operands"]
        PR20682["#20682 (draft)<br>evalengine: support constant-folded JSON values as literals"]
        PR20683["#20683 (draft)<br>evalengine, sqlparser: MySQL comparison domains; nested BETWEEN parentheses"]
        PR20626["#20626 (draft)<br>vtgate: support cross-shard JSON_ARRAYAGG and JSON_OBJECTAGG"]
        PR20625 --> PR20682
        PRA --> PR20682
        PR20682 --> PR20683
        PR20632 --> PR20626
        PR20683 --> PR20626
    end

    subgraph union [Union routing]
        direction TB
        PR20628["#20628<br>vtgate: track per-source copies of pushed join predicates so merges skip them"]
        PR20629["#20629<br>vtgate: fix None routing handling when merging unions"]
        PR20630["#20630 (draft)<br>vtgate: merge unions on join-predicate-free routings when all sources agree"]
        PR20755["#20755<br>vtgate: fix union merging through reference-table alternates"]
        PR20756["#20756 (draft)<br>vtgate: merge empty reference branches through rewritten copies"]
        PR20628 --> PR20630
        PR20629 --> PR20630
        PR20630 --> PR20756
        PR20755 --> PR20756
    end

    subgraph cte [Recursive CTEs]
        direction TB
        PR20759["#20759<br>vtgate: expand qualified stars without JOIN USING coalescing"]
        PR20633["#20633 (draft)<br>vtgate: validate the declared column list length of CTEs and derived tables"]
        PR20631["#20631 (draft)<br>vtgate: bind recursive CTE column filters as arguments in unmerged term queries"]
        PR20759 --> PR20633
        PR20633 --> PR20631
    end

    json ~~~ union ~~~ cte
```



