### PR TITLE
vtgate: preserve IN value lists in complex aggregate projections

### DIFF
--- a/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
+++ b/go/test/endtoend/vtgate/queries/aggregation/aggregation_test.go
@@ -600,6 +600,23 @@ func TestComplexAggregation(t *testing.T) {
 	})
 }
 
+// TestAggregateInValueList tests an aggregate compared against an IN value
+// list, which vtgate evaluates itself over the merged shard results. The
+// comparison must keep MySQL's three-valued logic, so a list containing NULL
+// yields NULL when no other member matches.
+func TestAggregateInValueList(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	mcmp.Exec("insert into aggr_test(id, val1, val2) values(1,'a',1), (2,'b',1), (3,'c',3), (4,'d',null)")
+
+	mcmp.AssertMatches("select count(*) in (3, 4) from aggr_test", `[[INT64(1)]]`)
+	mcmp.AssertMatches("select count(*) in (1, 2) from aggr_test", `[[INT64(0)]]`)
+	mcmp.AssertMatches("select count(val2) in (3, null) from aggr_test", `[[INT64(1)]]`)
+	mcmp.AssertMatches("select count(val2) in (1, null) from aggr_test", `[[NULL]]`)
+	mcmp.AssertMatches("select count(*) not in (1, null) from aggr_test", `[[NULL]]`)
+}
+
 func TestJoinAggregation(t *testing.T) {
 	mcmp, closer := start(t)
 	defer closer()

--- a/go/vt/vtgate/planbuilder/operators/queryprojection.go
+++ b/go/vt/vtgate/planbuilder/operators/queryprojection.go
@@ -481,6 +481,14 @@ func (qp *QueryProjection) extractAggr(
 			makeComplex()
 			return true
 		}
+		switch ex.(type) {
+		case sqlparser.ValTuple, sqlparser.ListArg:
+			// Tuples are structural containers, not values a single input
+			// column could carry: an IN value list must stay a tuple all the
+			// way to the evalengine. Descend so the members become ordinary
+			// inputs; a list bind variable stays in the expression as is.
+			return true
+		}
 		if !qp.isExprInGroupByExprs(ctx, ex) {
 			aggr := createNonGroupingAggr(aeWrap(ex))
 			addAggr(aggr)

--- a/go/vt/vtgate/planbuilder/operators/queryprojection.go
+++ b/go/vt/vtgate/planbuilder/operators/queryprojection.go
@@ -481,6 +481,14 @@ func (qp *QueryProjection) extractAggr(
 			makeComplex()
 			return true
 		}
+		switch ex.(type) {
+		case sqlparser.ValTuple, sqlparser.ListArg:
+			// An IN value list must reach the evalengine as a list, not as a
+			// single input column. A tuple is descended so each member becomes
+			// its own input column and the tuple shape survives; a list bind
+			// variable is a leaf left in place for the evalengine to resolve.
+			return true
+		}
 		if !qp.isExprInGroupByExprs(ctx, ex) {
 			aggr := createNonGroupingAggr(aeWrap(ex))
 			addAggr(aggr)

--- a/go/vt/vtgate/planbuilder/plancontext/planning_context.go
+++ b/go/vt/vtgate/planbuilder/plancontext/planning_context.go
@@ -139,7 +139,13 @@ func (ctx *PlanningContext) TypeForExpr(e sqlparser.Expr) (evalengine.Type, bool
 	if !found {
 		typ := ctx.calculateTypeFor(e)
 		if typ.Valid() {
-			ctx.SemTable.ExprTypes[e] = typ
+			if semantics.ValidAsMapKey(e) {
+				// Expressions of unhashable types, such as the
+				// sqlparser.ValTuple value list of an IN comparison, can
+				// still be typed but cannot be stored in the ExprTypes
+				// cache: using one as a map key panics.
+				ctx.SemTable.ExprTypes[e] = typ
+			}
 			return typ, true
 		}
 		return evalengine.NewUnknownType(), false

--- a/go/vt/vtgate/planbuilder/plancontext/planning_context.go
+++ b/go/vt/vtgate/planbuilder/plancontext/planning_context.go
@@ -139,7 +139,10 @@ func (ctx *PlanningContext) TypeForExpr(e sqlparser.Expr) (evalengine.Type, bool
 	if !found {
 		typ := ctx.calculateTypeFor(e)
 		if typ.Valid() {
-			ctx.SemTable.ExprTypes[e] = typ
+			if semantics.ValidAsMapKey(e) {
+				// Unhashable expressions can still be typed, just not cached.
+				ctx.SemTable.ExprTypes[e] = typ
+			}
 			return typ, true
 		}
 		return evalengine.NewUnknownType(), false

--- a/go/vt/vtgate/planbuilder/plancontext/planning_context_test.go
+++ b/go/vt/vtgate/planbuilder/plancontext/planning_context_test.go
@@ -138,6 +138,20 @@ func TestOuterTableNullability(t *testing.T) {
 	}
 }
 
+// TestTypeForExprTuple tests that a tuple expression is typed by calculation
+// even though it cannot be stored in the ExprTypes cache: sqlparser.ValTuple
+// is a slice type, so using it as a map key would panic.
+func TestTypeForExprTuple(t *testing.T) {
+	ctx := createPlanContext(semantics.EmptySemTable())
+	tuple := sqlparser.ValTuple{sqlparser.NewIntLiteral("1"), sqlparser.NewIntLiteral("2")}
+
+	typ, found := ctx.TypeForExpr(tuple)
+
+	require.True(t, found)
+	assert.Equal(t, sqltypes.Tuple, typ.Type())
+	assert.Empty(t, ctx.SemTable.ExprTypes)
+}
+
 func prepareContextAndFindColumns(t *testing.T, query string) (ctx *PlanningContext, columns []*sqlparser.ColName) {
 	parser := sqlparser.NewTestParser()
 	ast, err := parser.Parse(query)

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -7408,5 +7408,79 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "vtgate-evaluated aggregate compared against a literal IN value list keeps the tuple structure",
+    "query": "select count(foo) in (1, 2) from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select count(foo) in (1, 2) from user",
+      "Instructions": {
+        "OperatorType": "Projection",
+        "Expressions": [
+          "count(foo) in (1, 2) as count(foo) in (1, 2)"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Aggregate",
+            "Variant": "Scalar",
+            "Aggregates": "sum_count(0) AS count(foo), constant_aggr(1) AS 1, constant_aggr(2) AS 2",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select count(foo), 1, 2 from `user` where 1 != 1",
+                "Query": "select count(foo), 1, 2 from `user`"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "vtgate-evaluated aggregate compared against a list bind variable keeps the tuple structure",
+    "query": "select count(foo) in ::vals from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select count(foo) in ::vals from user",
+      "Instructions": {
+        "OperatorType": "Projection",
+        "Expressions": [
+          "count(foo) in ::vals as count(foo) in ::vals"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Aggregate",
+            "Variant": "Scalar",
+            "Aggregates": "sum_count(0) AS count(foo)",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select count(foo) from `user` where 1 != 1",
+                "Query": "select count(foo) from `user`"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/semantics/scoper.go
+++ b/go/vt/vtgate/semantics/scoper.go
@@ -277,7 +277,7 @@ func (s *scoper) up(cursor *sqlparser.Cursor) error {
 }
 
 func ValidAsMapKey(s sqlparser.SQLNode) bool {
-	return reflect.TypeOf(s).Comparable()
+	return s == nil || reflect.TypeOf(s).Comparable()
 }
 
 // createSpecialScopePostProjection is used for the special projection in ORDER BY, GROUP BY and HAVING

--- a/go/vt/vtgate/semantics/semantic_table.go
+++ b/go/vt/vtgate/semantics/semantic_table.go
@@ -673,6 +673,12 @@ func (st *SemTable) AddExprs(tbl *sqlparser.AliasedTableExpr, cols *sqlparser.Se
 // TypeForExpr returns the type of expressions in the query
 // Note that PlanningContext has the same method, and you should use that if you have a PlanningContext
 func (st *SemTable) TypeForExpr(e sqlparser.Expr) (evalengine.Type, bool) {
+	if !ValidAsMapKey(e) {
+		// Expressions of unhashable types, such as the sqlparser.ValTuple
+		// value list of an IN comparison, cannot be stored in ExprTypes and
+		// would panic when used as a map key.
+		return evalengine.NewUnknownType(), false
+	}
 	if typ, found := st.ExprTypes[e]; found {
 		return typ, true
 	}

--- a/go/vt/vtgate/semantics/semantic_table.go
+++ b/go/vt/vtgate/semantics/semantic_table.go
@@ -673,6 +673,10 @@ func (st *SemTable) AddExprs(tbl *sqlparser.AliasedTableExpr, cols *sqlparser.Se
 // TypeForExpr returns the type of expressions in the query
 // Note that PlanningContext has the same method, and you should use that if you have a PlanningContext
 func (st *SemTable) TypeForExpr(e sqlparser.Expr) (evalengine.Type, bool) {
+	if !ValidAsMapKey(e) {
+		// Not all expressions are valid map keys
+		return evalengine.NewUnknownType(), false
+	}
 	if typ, found := st.ExprTypes[e]; found {
 		return typ, true
 	}

--- a/go/vt/vtgate/semantics/semantic_table_test.go
+++ b/go/vt/vtgate/semantics/semantic_table_test.go
@@ -1100,3 +1100,14 @@ func TestCopySemanticInfoIntoColName(t *testing.T) {
 		require.NotContains(t, semTable.Direct, to)
 	})
 }
+
+// TestTypeForExprUnhashable tests that type lookups for expressions of
+// unhashable types, such as the value list of an IN comparison, report no
+// type instead of panicking on the ExprTypes map access.
+func TestTypeForExprUnhashable(t *testing.T) {
+	st := EmptySemTable()
+	tuple := sqlparser.ValTuple{sqlparser.NewIntLiteral("1"), sqlparser.NewIntLiteral("2")}
+	typ, found := st.TypeForExpr(tuple)
+	assert.False(t, found)
+	assert.Equal(t, sqltypes.Unknown, typ.Type())
+}

--- a/go/vt/vtgate/semantics/semantic_table_test.go
+++ b/go/vt/vtgate/semantics/semantic_table_test.go
@@ -1100,3 +1100,19 @@ func TestCopySemanticInfoIntoColName(t *testing.T) {
 		require.NotContains(t, semTable.Direct, to)
 	})
 }
+
+// TestTypeForExprUnhashable tests that type lookups for expressions of
+// unhashable types, such as the value list of an IN comparison, report no
+// type instead of panicking on the ExprTypes map access, and that a nil
+// expression still reports no type rather than panicking in the guard.
+func TestTypeForExprUnhashable(t *testing.T) {
+	st := EmptySemTable()
+	tuple := sqlparser.ValTuple{sqlparser.NewIntLiteral("1"), sqlparser.NewIntLiteral("2")}
+	typ, found := st.TypeForExpr(tuple)
+	assert.False(t, found)
+	assert.Equal(t, sqltypes.Unknown, typ.Type())
+
+	typ, found = st.TypeForExpr(nil)
+	assert.False(t, found)
+	assert.Equal(t, sqltypes.Unknown, typ.Type())
+}


### PR DESCRIPTION
## Description

Planning `select count(foo) in (1, 2) from user` on a sharded keyspace panics with `hash of unhashable type sqlparser.ValTuple`. The bind variable form `select count(foo) in ::vals from user`, which is also what the normalizer rewrites literal IN lists into in production, fails with an internal error saying the rhs of an In operation should be a tuple. Both queries are valid SQL.

The root cause is in aggregate extraction. When a select expression contains an aggregate inside a larger expression, the planner extracts the aggregates and turns each remaining aggregate free subexpression into a single input column. An IN value list was captured whole this way, so offset planning replaced the entire tuple with one column reference, which can only ever carry one value. This PR teaches the extraction to treat value tuples and list bind variables as structural containers instead. Tuple members become ordinary input columns, a list bind variable stays in the expression as is, and the tuple shape survives to the expression engine, which already supports both forms.

The type lookups that panicked are also guarded. `SemTable.TypeForExpr` is a cache lookup and now reports no type for expressions that cannot be used as map keys, while `PlanningContext.TypeForExpr` still calculates the type of such expressions and only skips caching them. Planner goldens pin the literal and bind variable forms, unit tests cover both lookup contracts, and an end-to-end test compares the true, false and NULL outcomes against MySQL.

The same aggregate extraction and unguarded type lookup exist on release-23.0 and release-24.0, and both reproduce the failure: the literal form panics with `hash of unhashable type sqlparser.ValTuple` and the bind variable form fails with `rhs of an In operation should be a tuple, was *evalengine.Column`. Over the MySQL protocol the panic is a `runtime.Error` that `operators.PanicHandler` re-panics and only the per-connection handler in `go/mysql/server.go` recovers, so a client sending valid SQL has its connection closed rather than receiving an error. That makes this worth backporting: the fix is small, self-contained, and covered by planner goldens, unit tests and an end-to-end test against MySQL.

## Related Issue(s)

https://github.com/vitessio/vitess/pull/20626 depends on this change.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

VTGate can now plan aggregate expressions compared against literal or bind variable IN lists. These queries previously failed with a planner panic or an internal error. No migrations or configuration changes.

### AI Disclosure

This PR was written primarily by Fable with review from GPT 5.6 Sol.

---

```mermaid
graph LR
    subgraph json [JSON support]
        direction TB
        PR20625["#20625 (merged)<br>mysql/json: fix MarshalTo discarding accumulated output for nested blob and bit values"]
        PR20632["#20632<br>vtgate: preserve IN value lists in complex aggregate projections"]
        PRA["#20691<br>evalengine: disable the static IN hash table for JSON operands"]
        PR20682["#20682 (draft)<br>evalengine: support constant-folded JSON values as literals"]
        PR20683["#20683 (draft)<br>evalengine, sqlparser: MySQL comparison domains; nested BETWEEN parentheses"]
        PR20626["#20626 (draft)<br>vtgate: support cross-shard JSON_ARRAYAGG and JSON_OBJECTAGG"]
        PR20625 --> PR20682
        PRA --> PR20682
        PR20682 --> PR20683
        PR20632 --> PR20626
        PR20683 --> PR20626
    end

    subgraph union [Union routing]
        direction TB
        PR20628["#20628<br>vtgate: track per-source copies of pushed join predicates so merges skip them"]
        PR20629["#20629 (merged)<br>vtgate: fix None routing handling when merging unions"]
        PR20630["#20630 (draft)<br>vtgate: merge unions on join-predicate-free routings when all sources agree"]
        PR20755["#20755<br>vtgate: fix union merging through reference-table alternates"]
        PR20756["#20756 (draft)<br>vtgate: merge empty reference branches through rewritten copies"]
        PR20628 --> PR20630
        PR20629 --> PR20630
        PR20630 --> PR20756
        PR20755 --> PR20756
    end

    subgraph cte [Recursive CTEs]
        direction TB
        PR20759["#20759<br>vtgate: expand qualified stars without JOIN USING coalescing"]
        PR20633["#20633 (draft)<br>vtgate: validate the declared column list length of CTEs and derived tables"]
        PR20631["#20631 (draft)<br>vtgate: bind recursive CTE column filters as arguments in unmerged term queries"]
        PR20759 --> PR20633
        PR20633 --> PR20631
    end

    json ~~~ union ~~~ cte
```

