### PR TITLE
vttablet: add --filecustomrules-strict to fail fast when custom rules cannot be loaded

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -28,6 +28,7 @@
     - **[VTTablet](#minor-changes-vttablet)**
         - [Schema engine table-count limit is now configurable](#vttablet-schema-max-table-count)
         - [Skip MySQL version check when restoring from a mysql-shell backup](#vttablet-mysql-shell-restore-skip-version-check)
+        - [Optional strict startup for file based custom query rules](#vttablet-filecustomrules-strict)
     - **[Backup/Restore](#minor-changes-backup)**
         - [Chunked backup/restore for the builtinbackupengine](#backup-chunked-builtin)
     - **[General](#minor-changes-general)**
@@ -237,6 +238,14 @@ A new `--mysql-shell-restore-skip-version-check` flag (default `false`) has been
 Because mysql-shell performs a logical restore, its backups are not tied to the on-disk data dictionary format the way physical backups are, so restoring across otherwise-incompatible MySQL versions can be safe. This flag lets operators opt into that behavior.
 
 **Impact**: With this flag set, VTTablet may select and restore a `mysqlshell` backup whose MySQL version would otherwise be rejected as incompatible. Leave it unset to preserve the existing behavior.
+
+#### <a id="vttablet-filecustomrules-strict"/>Optional strict startup for file based custom query rules</a>
+
+Previously, when the file passed via `--filecustomrules` failed to load at startup (missing file, malformed JSON, or an invalid rule), vttablet logged a warning and continued serving with **no** file based custom rules applied. Since custom rules are typically protective, this fail-open behavior could silently disable them.
+
+A new `--filecustomrules-strict` flag (default `false`) makes such a load failure fatal: vttablet exits instead of serving without its configured rules. The default behavior is unchanged, but the load failure is now logged as an error rather than a warning.
+
+See [#20522](https://github.com/vitessio/vitess/issues/20522) for details.
 
 ### <a id="minor-changes-backup"/>Backup/Restore</a>
 

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -162,6 +162,7 @@ Flags:
       --external-decompressor-use-manifest                               allows the decompressor command stored in the backup manifest to be used at restore time. Enabling this is a security risk: an attacker with write access to the backup storage could modify the manifest to execute arbitrary commands on the tablet as the Vitess user. NOT RECOMMENDED.
       --file-backup-storage-root string                                  Root directory for the file backup storage.
       --filecustomrules string                                           file based custom rule path
+      --filecustomrules-strict                                           fail vttablet startup when the file based custom rules cannot be loaded, instead of continuing without them
       --filecustomrules-watch                                            set up a watch on the target file and reload query rules when it changes
       --gc-check-interval duration                                       Interval between garbage collection checks (default 1h0m0s)
       --gc-purge-check-interval duration                                 Interval between purge discovery checks (default 1m0s)

--- a/go/vt/vttablet/customrule/filecustomrule/filecustomrule.go
+++ b/go/vt/vttablet/customrule/filecustomrule/filecustomrule.go
@@ -40,11 +40,17 @@ var (
 	// Commandline flag to specify rule path
 	fileRulePath        string
 	fileRuleShouldWatch bool
+	fileRuleStrict      bool
+
+	// exitFunc is called when a startup rule load failure is fatal.
+	// (it's a var not a call to os.Exit so the test can stub it).
+	exitFunc = os.Exit
 )
 
 func registerFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&fileRulePath, "filecustomrules", fileRulePath, "file based custom rule path")
 	utils.SetFlagBoolVar(fs, &fileRuleShouldWatch, "filecustomrules-watch", fileRuleShouldWatch, "set up a watch on the target file and reload query rules when it changes")
+	utils.SetFlagBoolVar(fs, &fileRuleStrict, "filecustomrules-strict", fileRuleStrict, "fail vttablet startup when the file based custom rules cannot be loaded, instead of continuing without them")
 }
 
 func init() {
@@ -118,7 +124,17 @@ func (fcr *FileCustomRule) GetRules() (qrs *rules.Rules, version int64, err erro
 func ActivateFileCustomRules(qsc tabletserver.Controller) {
 	if fileRulePath != "" {
 		qsc.RegisterQueryRuleSource(FileCustomRuleSource)
-		fileCustomRule.Open(qsc, fileRulePath)
+		if err := fileCustomRule.Open(qsc, fileRulePath); err != nil {
+			// Custom rules are usually protective, so serving without them is a
+			// fail-open worth being loud about. See
+			// https://github.com/vitessio/vitess/issues/20522.
+			if fileRuleStrict {
+				log.Error(fmt.Sprintf("Failed to load custom rules from %q: %v", fileRulePath, err))
+				exitFunc(1)
+				return
+			}
+			log.Error(fmt.Sprintf("Failed to load custom rules from %q, vttablet will serve WITHOUT file based custom rules (pass --filecustomrules-strict to make this error fatal): %v", fileRulePath, err))
+		}
 
 		if !fileRuleShouldWatch {
 			return

--- a/go/vt/vttablet/customrule/filecustomrule/filecustomrule_test.go
+++ b/go/vt/vttablet/customrule/filecustomrule/filecustomrule_test.go
@@ -58,3 +58,59 @@ func TestFileCustomRule(t *testing.T) {
 	qr := qrs.Find("r1")
 	require.NotNilf(t, qr, "Expect custom rule r1 to be found, but got nothing, qrs=%v", qrs)
 }
+
+// TestActivateFileCustomRulesLoadFailure covers what happens at vttablet
+// startup when the custom rules file cannot be loaded: by default the
+// tablet keeps serving without file based custom rules (fail-open), and with
+// --filecustomrules-strict the load error is fatal instead.
+// See https://github.com/vitessio/vitess/issues/20522.
+func TestActivateFileCustomRulesLoadFailure(t *testing.T) {
+	badRulePath := path.Join(t.TempDir(), "bad-customrule.json")
+	err := os.WriteFile(badRulePath, []byte("{ not valid json"), os.FileMode(0o644))
+	require.NoError(t, err)
+
+	goodRulePath := path.Join(t.TempDir(), "good-customrule.json")
+	err = os.WriteFile(goodRulePath, []byte(customRule1), os.FileMode(0o644))
+	require.NoError(t, err)
+
+	// setup points the package-level state at the given rules file and strict
+	// setting, records calls to exitFunc, and restores everything on cleanup.
+	setup := func(t *testing.T, rulePath string, strict bool) (exitCodes *[]int) {
+		origPath, origStrict, origWatch := fileRulePath, fileRuleStrict, fileRuleShouldWatch
+		origExit, origRule := exitFunc, fileCustomRule
+		t.Cleanup(func() {
+			fileRulePath, fileRuleStrict, fileRuleShouldWatch = origPath, origStrict, origWatch
+			exitFunc, fileCustomRule = origExit, origRule
+		})
+
+		var codes []int
+		fileRulePath = rulePath
+		fileRuleStrict = strict
+		fileRuleShouldWatch = false
+		fileCustomRule = NewFileCustomRule()
+		exitFunc = func(code int) { codes = append(codes, code) }
+		return &codes
+	}
+
+	t.Run("load failure without strict keeps serving", func(t *testing.T) {
+		exitCodes := setup(t, badRulePath, false)
+		ActivateFileCustomRules(tabletservermock.NewController())
+		require.Empty(t, *exitCodes)
+	})
+
+	t.Run("load failure with strict is fatal", func(t *testing.T) {
+		exitCodes := setup(t, badRulePath, true)
+		ActivateFileCustomRules(tabletservermock.NewController())
+		require.Equal(t, []int{1}, *exitCodes)
+	})
+
+	t.Run("valid file with strict starts normally", func(t *testing.T) {
+		exitCodes := setup(t, goodRulePath, true)
+		ActivateFileCustomRules(tabletservermock.NewController())
+		require.Empty(t, *exitCodes)
+
+		qrs, _, err := fileCustomRule.GetRules()
+		require.NoError(t, err)
+		require.NotNil(t, qrs.Find("r1"))
+	})
+}


### PR DESCRIPTION
## Description

When the file passed via `--filecustomrules` fails to load at vttablet startup (missing file, malformed JSON, or an invalid rule), the error is silently swallowed: `ActivateFileCustomRules` ignores the return value of `fileCustomRule.Open()`, so the tablet boots and serves traffic with **no** file based custom rules applied, and the only signal is a Warn-level log from deep inside `ParseRules`. Since custom rules are typically protective (blocking dangerous query shapes), this fail-open can silently disable them — the behavior described in #20522.

This PR:

- **Checks the error** from `fileCustomRule.Open()` in `ActivateFileCustomRules`.
- **Adds `--filecustomrules-strict`** (bool, default `false`): when set, a startup load failure is fatal (`log.Error` + exit 1, matching how this same function already treats fsnotify watcher setup failures). When unset, behavior is unchanged except the failure is now logged as a clear **error** stating the tablet is serving without its configured rules and pointing at the flag.
- **Adds unit tests** covering all three cases: load failure without strict (keeps serving), load failure with strict (fatal), valid file with strict (starts normally, rules applied). The exit is stubbed via a package-level `exitFunc` var, following the `sleepDuringTopoFailure` var-for-test precedent in the sibling `topocustomrule` package.
- Updates the `vttablet.txt` flags golden file and the v25.0.0 changelog summary.

**Scoping decisions** (called out for review):

- **Default stays fail-open.** #20522 left open whether the right semantics are fail-closed or opt-in strict. An opt-in flag avoids breaking existing deployments; if maintainers prefer fail-closed by default (now or in a future major), this reduces to flipping the default. Happy to go that way instead if preferred.
- **Startup only.** The fsnotify reload path is untouched: a reload failure on a live tablet already keeps the last good rules (fail-safe), and making it fatal would let a mid-edit typo kill serving tablets.
- **Topo path untouched.** `activateTopoCustomRules` already exits on setup failure, and its watch loop retries transient topo errors — a different (and arguably reasonable) shape; the all-or-nothing `UnmarshalJSON` behavior is also left for a follow-up per the discussion in #20522.

## Related Issue(s)

Related to #20522 (file rules startup path; not marked as closing since the fail-closed-vs-flag design question and the topo/UnmarshalJSON parts remain open)

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches — not needed, new opt-in flag
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI? — no Go toolchain on my dev machine (Vitess targets Linux/macOS); relying on CI
-   [x] Documentation was added or is not required — changelog summary entry + flags golden file updated

## Deployment Notes

No behavior change by default. Operators can opt in with `--filecustomrules-strict` to make vttablet refuse to start when its custom rules file cannot be loaded. In non-strict mode the load failure is now logged at Error level (previously Warn).

### AI Disclosure

This PR was authored with the assistance of Claude Code (Claude Fable 5) and reviewed by me (the author).
