### PR TITLE
test: fix TestVreplicationCopyThrottling flakiness

### DIFF
--- a/go/test/endtoend/vreplication/vreplication_test.go
+++ b/go/test/endtoend/vreplication/vreplication_test.go
@@ -228,10 +228,17 @@ func TestVreplicationCopyThrottling(t *testing.T) {
 	defaultCell := vc.Cells[cell]
 	// To test vstreamer source throttling for the MoveTables operation
 	maxSourceTrxHistory := int64(5)
+	// The throttle is held engaged by an open transaction that pins the InnoDB
+	// history list length above the threshold. That transaction must outlive
+	// everything the test waits on afterwards, otherwise the tablet's transaction
+	// reaper releases it, the history list drains, and the copy phase proceeds
+	// before we observe it throttled. The reaper timeout is therefore set above
+	// the sum of the wait budgets that run while the transaction is open
+	// (waitForInnoDBHistoryLength + waitForWorkflowState + confirmWorkflowHasCopiedNoData),
+	// with headroom for workflow creation and polling overhead on a slow runner.
+	sourceTrxTimeout := (defaultTimeout + workflowStateTimeout + defaultTimeout) * 2
 	extraVTTabletArgs = []string{
-		// We rely on holding open transactions to generate innodb history so extend the timeout
-		// to avoid flakiness when the CI is very slow.
-		"--queryserver-config-transaction-timeout=" + (defaultTimeout * 3).String(),
+		"--queryserver-config-transaction-timeout=" + sourceTrxTimeout.String(),
 		fmt.Sprintf("%s=%d", "--vreplication-copy-phase-max-innodb-history-list-length", maxSourceTrxHistory),
 		parallelInsertWorkers,
 	}


### PR DESCRIPTION
## Description

`TestVreplicationCopyThrottling` is flaky on slow CI runners. It failed this way on an unrelated PR: https://github.com/vitessio/vitess/actions/runs/29754826138/job/88394971597

The test keeps the copy phase throttled by holding an open transaction whose read view pins the source's InnoDB history list length above the configured threshold (`--vreplication-copy-phase-max-innodb-history-list-length=5`). While that transaction stays open, the vstreamer's `waitForMySQL` check keeps the stream parked in `Copying`.

The problem is the tablet's transaction reaper. It was set to a fixed `defaultTimeout*3` (180s), but the held-open transaction has to survive the *entire* wait budget the test runs while it's open:

- `waitForInnoDBHistoryLength` — up to 60s
- `waitForWorkflowState(Copying)` — up to 90s
- `confirmWorkflowHasCopiedNoData` — the full 60s, and it also needs the throttle held the whole time

That's ~210s+ before you even count workflow creation and polling overhead — already above the 180s reaper. On a resource-starved runner the reaper fires mid-wait, the history list drains, the copy phase completes, and the stream flips to `Running` before the test ever observes `Copying`, so `waitForWorkflowState` times out (last-seen state `Running`, position advanced).

The fix derives the reaper timeout from the sum of those wait budgets with headroom, instead of a magic multiplier, so it can't silently drift below the test's own runtime again:

```go
sourceTrxTimeout := (defaultTimeout + workflowStateTimeout + defaultTimeout) * 2
```

This is a test-only tablet flag, reset via `extraVTTabletArgs` after the test.

## Related Issue(s)

n/a

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — test-only change.

### AI Disclosure

This PR was written by Claude Code, with direction and review from me.