### PR TITLE
vtgate: fix column truncation in Aggregator for reordered GROUP BY keys with HAVING

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/aggregator.go
+++ b/go/vt/vtgate/planbuilder/operators/aggregator.go
@@ -91,6 +91,9 @@ func createNonGroupingAggr(expr *sqlparser.AliasedExpr) Aggr {
 
 func (a *Aggregator) addColumnWithoutPushing(ctx *plancontext.PlanningContext, expr *sqlparser.AliasedExpr, addToGroupBy bool) int {
 	offset := len(a.Columns)
+	defer func() {
+		a.checkOffset(offset)
+	}()
 	a.Columns = append(a.Columns, expr)
 
 	if addToGroupBy {

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -7408,5 +7408,81 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "distinct count and having with group by col1, col2",
+    "query": "select col1, col2, count(distinct val2) from user group by col1, col2 having min(val1) >= 'a'",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select col1, col2, count(distinct val2) from user group by col1, col2 having min(val1) >= 'a'",
+      "Instructions": {
+        "OperatorType": "Filter",
+        "Predicate": "min(val1) >= 'a'",
+        "ResultColumns": 3,
+        "Inputs": [
+          {
+            "OperatorType": "Aggregate",
+            "Variant": "Ordered",
+            "Aggregates": "count_distinct(2|6) AS count(distinct val2), min(3|7) AS min(val1)",
+            "GroupBy": "(0|4), (1|5)",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select col1, col2, val2, min(val1), weight_string(col1), weight_string(col2), weight_string(val2), weight_string(min(val1)) from `user` where 1 != 1 group by col1, col2, val2, weight_string(col1), weight_string(col2), weight_string(val2)",
+                "OrderBy": "(0|4) ASC, (1|5) ASC, (2|6) ASC",
+                "Query": "select col1, col2, val2, min(val1), weight_string(col1), weight_string(col2), weight_string(val2), weight_string(min(val1)) from `user` group by col1, col2, val2, weight_string(col1), weight_string(col2), weight_string(val2) order by col1 asc, col2 asc, val2 asc"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "distinct count and having with group by col2, col1 (reordered)",
+    "query": "select col1, col2, count(distinct val2) from user group by col2, col1 having min(val1) >= 'a'",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select col1, col2, count(distinct val2) from user group by col2, col1 having min(val1) >= 'a'",
+      "Instructions": {
+        "OperatorType": "Filter",
+        "Predicate": "min(val1) >= 'a'",
+        "ResultColumns": 3,
+        "Inputs": [
+          {
+            "OperatorType": "Aggregate",
+            "Variant": "Ordered",
+            "Aggregates": "count_distinct(2|6) AS count(distinct val2), min(3|7) AS min(val1)",
+            "GroupBy": "(1|4), (0|5)",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select col1, col2, val2, min(val1), weight_string(col2), weight_string(col1), weight_string(val2), weight_string(min(val1)) from `user` where 1 != 1 group by col2, col1, val2, weight_string(col2), weight_string(col1), weight_string(val2)",
+                "OrderBy": "(1|4) ASC, (0|5) ASC, (2|6) ASC",
+                "Query": "select col1, col2, val2, min(val1), weight_string(col2), weight_string(col1), weight_string(val2), weight_string(min(val1)) from `user` group by col2, col1, val2, weight_string(col2), weight_string(col1), weight_string(val2) order by col2 asc, col1 asc, val2 asc"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Fixes an issue where reordering `GROUP BY` keys in queries with `COUNT(DISTINCT)` and `HAVING` filters led to result mismatches due to premature column truncation in `Aggregator.addColumnWithoutPushing`.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Fixes #20620.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->

This PR was written by me, with assistance from Claude Mythos 5 for generating test cases.