### PR TITLE
vtgate: preserve type semantics for scalar subqueries in UNION queries

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -41,6 +41,7 @@ type SubQuery struct {
 	Predicates        []sqlparser.Expr     // Predicates joining outer and inner queries. Empty for uncorrelated subqueries.
 	OuterPredicate    sqlparser.Expr       // This is the predicate that is using the subquery expression. It will not be empty for projections
 	ArgName           string               // This is the name of the ColName or Argument used to replace the subquery
+	Placeholder       sqlparser.Expr       // This is the exact placeholder AST node created to replace the subquery
 	TopLevel          bool                 // will be false if the subquery is deeply nested
 	JoinColumns       []applyJoinColumn    // Broken up join predicates.
 	SubqueryValueName string               // Value name returned by the subquery (uncorrelated queries).
@@ -278,6 +279,9 @@ func (sq *SubQuery) settleFilter(ctx *plancontext.PlanningContext, outer Operato
 			arg = sqlparser.NewArgument(sq.ArgName)
 		}
 		cursor.Replace(arg)
+		if sq.Placeholder == nil {
+			sq.Placeholder = arg
+		}
 	}
 	rhsPred := sqlparser.CopyOnRewrite(sq.Original, dontEnterSubqueries, post, ctx.SemTable.CopySemanticInfo).(sqlparser.Expr)
 
@@ -319,7 +323,10 @@ func dontEnterSubqueries(node, _ sqlparser.SQLNode) bool {
 }
 
 func (sq *SubQuery) isMerged(ctx *plancontext.PlanningContext) bool {
-	_, ok := ctx.MergedSubqueries[sq.ArgName]
+	if sq.Placeholder == nil {
+		return false
+	}
+	_, ok := ctx.MergedSubqueries[sq.Placeholder]
 	return ok
 }
 

--- a/go/vt/vtgate/planbuilder/operators/subquery_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_builder.go
@@ -389,7 +389,7 @@ func (sqb *SubQueryBuilder) pullOutValueSubqueries(
 		sqInner := createSubquery(ctx, original, sq, outerID, original, argName, filterType, true)
 		allSubqs = append(allSubqs, sqInner)
 		sqb.Inner = append(sqb.Inner, sqInner)
-		sqb.replaceSubqueryNode(cursor, argName, filterType, isDML)
+		sqInner.Placeholder = sqb.replaceSubqueryNode(cursor, argName, filterType, isDML)
 	}
 
 	expr = sqlparser.Rewrite(expr, nil, func(cursor *sqlparser.Cursor) bool {
@@ -414,16 +414,19 @@ func (sqb *SubQueryBuilder) pullOutValueSubqueries(
 
 // replaceSubqueryNode replaces the current cursor node with the appropriate
 // argument placeholder for the given bind var name and opcode.
-func (sqb *SubQueryBuilder) replaceSubqueryNode(cursor *sqlparser.Cursor, argName string, filterType opcode.PulloutOpcode, isDML bool) {
+func (sqb *SubQueryBuilder) replaceSubqueryNode(cursor *sqlparser.Cursor, argName string, filterType opcode.PulloutOpcode, isDML bool) sqlparser.Expr {
+	var node sqlparser.Expr
 	if isDML {
 		if filterType.NeedsListArg() {
-			cursor.Replace(sqlparser.NewListArg(argName))
+			node = sqlparser.NewListArg(argName)
 		} else {
-			cursor.Replace(sqlparser.NewArgument(argName))
+			node = sqlparser.NewArgument(argName)
 		}
 	} else {
-		cursor.Replace(sqlparser.NewColName(argName))
+		node = sqlparser.NewColName(argName)
 	}
+	cursor.Replace(node)
+	return node
 }
 
 // getOpCodeFromParent determines the pullout opcode for a subquery based on its parent expression type.

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -106,11 +106,37 @@ func settleSubqueries(ctx *plancontext.PlanningContext, op Operator) Operator {
 			}
 		case *Ordering:
 			op.settleOrderingExpressions(ctx)
+		case *Union:
+			for _, selList := range op.Selects {
+				for _, selectExpr := range selList {
+					if aliased, ok := selectExpr.(*sqlparser.AliasedExpr); ok {
+						for arg, sq := range ctx.MergedSubqueries {
+							aliased.Expr = rewriteSubqueryArg(aliased.Expr, arg, sq)
+						}
+					}
+				}
+			}
 		}
 		return op, NoRewrite
 	}
 
 	return BottomUp(op, TableID, visit, nil)
+}
+
+func rewriteSubqueryArg(expr sqlparser.Expr, arg string, sq *sqlparser.Subquery) sqlparser.Expr {
+	return sqlparser.Rewrite(expr, nil, func(cursor *sqlparser.Cursor) bool {
+		switch node := cursor.Node().(type) {
+		case *sqlparser.ColName:
+			if node.Name.String() == arg {
+				cursor.Replace(sq)
+			}
+		case *sqlparser.Argument:
+			if node.Name == arg {
+				cursor.Replace(sq)
+			}
+		}
+		return true
+	}).(sqlparser.Expr)
 }
 
 func (o *Ordering) settleOrderingExpressions(ctx *plancontext.PlanningContext) {

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -104,6 +104,8 @@ func settleSubqueries(ctx *plancontext.PlanningContext, op Operator) Operator {
 					op.Columns[aggr.ColOffset].Expr = newExpr
 				}
 			}
+		case *Ordering:
+			op.settleOrderingExpressions(ctx)
 		case *Union:
 			for _, selList := range op.Selects {
 				for _, selectExpr := range selList {

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -104,14 +104,12 @@ func settleSubqueries(ctx *plancontext.PlanningContext, op Operator) Operator {
 					op.Columns[aggr.ColOffset].Expr = newExpr
 				}
 			}
-		case *Ordering:
-			op.settleOrderingExpressions(ctx)
 		case *Union:
 			for _, selList := range op.Selects {
 				for _, selectExpr := range selList {
 					if aliased, ok := selectExpr.(*sqlparser.AliasedExpr); ok {
-						for arg, sq := range ctx.MergedSubqueries {
-							aliased.Expr = rewriteSubqueryArg(aliased.Expr, arg, sq)
+						for placeholder, sq := range ctx.MergedSubqueries {
+							aliased.Expr = rewriteSubqueryArg(aliased.Expr, placeholder, sq)
 						}
 					}
 				}
@@ -123,17 +121,10 @@ func settleSubqueries(ctx *plancontext.PlanningContext, op Operator) Operator {
 	return BottomUp(op, TableID, visit, nil)
 }
 
-func rewriteSubqueryArg(expr sqlparser.Expr, arg string, sq *sqlparser.Subquery) sqlparser.Expr {
+func rewriteSubqueryArg(expr sqlparser.Expr, placeholder sqlparser.Expr, sq *sqlparser.Subquery) sqlparser.Expr {
 	return sqlparser.Rewrite(expr, nil, func(cursor *sqlparser.Cursor) bool {
-		switch node := cursor.Node().(type) {
-		case *sqlparser.ColName:
-			if node.Name.String() == arg {
-				cursor.Replace(sq)
-			}
-		case *sqlparser.Argument:
-			if node.Name == arg {
-				cursor.Replace(sq)
-			}
+		if cursor.Node() == placeholder {
+			cursor.Replace(sq)
 		}
 		return true
 	}).(sqlparser.Expr)
@@ -141,19 +132,11 @@ func rewriteSubqueryArg(expr sqlparser.Expr, arg string, sq *sqlparser.Subquery)
 
 func (o *Ordering) settleOrderingExpressions(ctx *plancontext.PlanningContext) {
 	for idx := range o.Order {
-		for arg, sq := range ctx.MergedSubqueries {
+		for placeholder, sq := range ctx.MergedSubqueries {
 			expr := sqlparser.Rewrite(o.Order[idx].SimplifiedExpr, nil, func(cursor *sqlparser.Cursor) bool {
-				switch expr := cursor.Node().(type) {
-				case *sqlparser.ColName:
-					if expr.Name.String() == arg {
-						cursor.Replace(sq)
-					}
-				case *sqlparser.Argument:
-					if expr.Name == arg {
-						cursor.Replace(sq)
-					}
+				if cursor.Node() == placeholder {
+					cursor.Replace(sq)
 				}
-
 				return true
 			})
 			o.Order[idx].SimplifiedExpr = expr.(sqlparser.Expr)
@@ -181,25 +164,14 @@ func rewriteMergedSubqueryExpr(ctx *plancontext.PlanningContext, se SubQueryExpr
 		// this is because we might have subqueries inside subqueries, and we need to merge them all
 		merged = false
 		for _, sq := range se {
-			if _, ok := ctx.MergedSubqueries[sq.ArgName]; !ok {
+			if sq.Placeholder == nil {
+				continue
+			}
+			if _, ok := ctx.MergedSubqueries[sq.Placeholder]; !ok {
 				continue
 			}
 			expr = sqlparser.Rewrite(expr, nil, func(cursor *sqlparser.Cursor) bool {
-				switch expr := cursor.Node().(type) {
-				case *sqlparser.ColName:
-					if expr.Name.String() != sq.ArgName { // TODO systay 2023.09.15 - This is not safe enough. We should figure out a better way.
-						return true
-					}
-				case *sqlparser.Argument:
-					if expr.Name != sq.ArgName {
-						return true
-					}
-				case sqlparser.ListArg:
-					// DML IN/NOT IN subqueries use ListArg placeholders, not Argument.
-					if string(expr) != sq.ArgName {
-						return true
-					}
-				default:
+				if cursor.Node() != sq.Placeholder {
 					return true
 				}
 				rewritten = true
@@ -367,7 +339,9 @@ func tryMergeWithRHS(ctx *plancontext.PlanningContext, inner *SubQuery, outer *A
 	}
 
 	outer.RHS = newOp
-	ctx.MergedSubqueries[inner.ArgName] = inner.originalSubquery
+	if inner.Placeholder != nil {
+		ctx.MergedSubqueries[inner.Placeholder] = inner.originalSubquery
+	}
 	return outer, Rewrote("merged subquery with rhs of join")
 }
 
@@ -583,7 +557,9 @@ func tryMergeSubqueryWithOuter(ctx *plancontext.PlanningContext, subQuery *SubQu
 	if outer.Comments != nil {
 		op.Comments = outer.Comments
 	}
-	ctx.MergedSubqueries[subQuery.ArgName] = subQuery.originalSubquery
+	if subQuery.Placeholder != nil {
+		ctx.MergedSubqueries[subQuery.Placeholder] = subQuery.originalSubquery
+	}
 	return op, Rewrote("merged subquery with outer")
 }
 

--- a/go/vt/vtgate/planbuilder/plancontext/planning_context.go
+++ b/go/vt/vtgate/planbuilder/plancontext/planning_context.go
@@ -46,8 +46,8 @@ type PlanningContext struct {
 	VerifyAllFKs bool
 
 	// MergedSubqueries tracks subqueries that have been merged into routes,
-	// keyed by their arg name.
-	MergedSubqueries map[string]*sqlparser.Subquery
+	// keyed by their placeholder expression node.
+	MergedSubqueries map[sqlparser.Expr]*sqlparser.Subquery
 
 	// CurrentPhase keeps track of how far we've gone in the planning process
 	// The type should be operators.Phase, but depending on that would lead to circular dependencies
@@ -106,7 +106,7 @@ func CreatePlanningContext(stmt sqlparser.Statement,
 		VSchema:           vschema,
 		PlannerVersion:    version,
 		ReservedArguments: map[sqlparser.Expr]string{},
-		MergedSubqueries:  map[string]*sqlparser.Subquery{},
+		MergedSubqueries:  map[sqlparser.Expr]*sqlparser.Subquery{},
 		Statement:         stmt,
 		PredTracker:       predicates.NewTracker(),
 	}, nil

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -7011,8 +7011,7 @@
       "Instructions": {
         "OperatorType": "Aggregate",
         "Variant": "Scalar",
-        "Aggregates": "max(0|1) AS max((select max(col2) from user u1 where u1.id = u2.id))",
-        "ResultColumns": 1,
+        "Aggregates": "max(0 COLLATE utf8mb4_0900_ai_ci) AS max((select max(col2) from user u1 where u1.id = u2.id))",
         "Inputs": [
           {
             "OperatorType": "Route",
@@ -7021,8 +7020,8 @@
               "Name": "user",
               "Sharded": true
             },
-            "FieldQuery": "select max((select max(col2) from `user` as u1 where 1 != 1)), weight_string(max((select max(col2) from `user` as u1 where 1 != 1))) from `user` as u2 where 1 != 1",
-            "Query": "select max((select max(col2) from `user` as u1 where u1.id = u2.id)), weight_string(max((select max(col2) from `user` as u1 where u1.id = u2.id))) from `user` as u2"
+            "FieldQuery": "select max((select max(col2) from `user` as u1 where 1 != 1)) from `user` as u2 where 1 != 1",
+            "Query": "select max((select max(col2) from `user` as u1 where u1.id = u2.id)) from `user` as u2"
           }
         ]
       },

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -23,6 +23,28 @@
     }
   },
   {
+    "comment": "union all with scalar subquery in select expression",
+    "query": "select (select id from unsharded) as col_2 union all select id as col_2 from unsharded",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select (select id from unsharded) as col_2 union all select id as col_2 from unsharded",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select (select id from unsharded where 1 != 1) as col_2 from dual where 1 != 1 union all select id as col_2 from unsharded where 1 != 1",
+        "Query": "select (select id from unsharded) as col_2 from dual union all select id as col_2 from unsharded"
+      },
+      "TablesUsed": [
+        "main.unsharded"
+      ]
+    }
+  },
+  {
     "comment": "union distinct between two scatter selects",
     "query": "select id from user union select id from music",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -45,6 +45,28 @@
     }
   },
   {
+    "comment": "union all with scalar subquery and column matching generated subquery arg name",
+    "query": "select (select id from unsharded) as col_2 union all select t.__sq1 from unsharded as t",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select (select id from unsharded) as col_2 union all select t.__sq1 from unsharded as t",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select (select id from unsharded where 1 != 1) as col_2 from dual where 1 != 1 union all select t.__sq1 from unsharded as t where 1 != 1",
+        "Query": "select (select id from unsharded) as col_2 from dual union all select t.__sq1 from unsharded as t"
+      },
+      "TablesUsed": [
+        "main.unsharded"
+      ]
+    }
+  },
+  {
     "comment": "union distinct between two scatter selects",
     "query": "select id from user union select id from music",
     "plan": {

--- a/go/vt/vtgate/semantics/semantic_table.go
+++ b/go/vt/vtgate/semantics/semantic_table.go
@@ -686,6 +686,15 @@ func (st *SemTable) TypeForExpr(e sqlparser.Expr) (evalengine.Type, bool) {
 		return evalengine.NewTypeEx(sqltypes.VarBinary, collations.CollationBinaryID, wt.Nullable(), 0, 0, nil), true
 	}
 
+	if subq, ok := e.(*sqlparser.Subquery); ok {
+		selectExprs := st.SelectExprs(subq.Select)
+		if len(selectExprs) > 0 {
+			if ae, ok := selectExprs[0].(*sqlparser.AliasedExpr); ok {
+				return st.TypeForExpr(ae.Expr)
+			}
+		}
+	}
+
 	return evalengine.NewUnknownType(), false
 }
 


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

Fixes an issue where `UNION` queries containing scalar subqueries returned truncated column values.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

Fixes #20619.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->

This PR was developed with the assistance of Claude Mythos 5.