### PR TITLE
test: let a second topo server start next to a suite's shared one

### DIFF
--- a/go/test/endtoend/cluster/topo_process.go
+++ b/go/test/endtoend/cluster/topo_process.go
@@ -171,6 +171,12 @@ func (topo *TopoProcess) SetupZookeeper(cluster *LocalProcessCluster) error {
 	topo.proc = exec.Command(
 		topo.Binary,
 		"--zk.cfg", fmt.Sprintf("1@%v:%s", host, topo.ZKPorts),
+		// The ZooKeeper AdminServer listens on a fixed default port (8080)
+		// that is not covered by the reserved ports above, so a second
+		// ZooKeeper started by a test next to the suite's shared one fails
+		// with ERROR_STARTING_ADMIN_SERVER (exit code 4). Nothing in these
+		// tests uses the AdminServer, so disable it.
+		"--zk.extra", "admin.enableServer=false",
 		"init",
 	)
 
@@ -205,6 +211,8 @@ type PortsInfo struct {
 	SerfLan int `json:"serf_lan"`
 	SerfWan int `json:"serf_wan"`
 	Server  int `json:"server"`
+	GRPC    int `json:"grpc"`
+	GRPCTLS int `json:"grpc_tls"`
 }
 
 // SetupConsul spawns a new consul service and initializes it with the defaults.
@@ -240,6 +248,13 @@ func (topo *TopoProcess) SetupConsul(cluster *LocalProcessCluster) (err error) {
 			SerfLan: cluster.GetAndReservePort(),
 			SerfWan: cluster.GetAndReservePort(),
 			Server:  cluster.GetAndReservePort(),
+			// Consul 1.14+ binds the gRPC TLS listener on a fixed default
+			// port (8503) even without TLS configured, so a second consul
+			// started by a test next to the suite's shared one exits with
+			// "bind: address already in use". Vitess only talks to consul
+			// over HTTP, so disable both gRPC listeners.
+			GRPC:    -1,
+			GRPCTLS: -1,
 		},
 		DataDir: topo.DataDirectory,
 		LogFile: logFile,


### PR DESCRIPTION
## Description

The e2e cluster harness reserves every port it configures for the topo server, but ZooKeeper and consul both listen on additional **fixed default ports** the harness never configures. A test that brings up its own cluster (and its own topo server) next to its suite's shared one therefore fails deterministically on those flavors, while working fine under etcd. This surfaced in #20016, whose new `TestChangeTypePrimaryCompletesWithBlockedCommit` starts a dedicated cluster inside the tabletmanager suite and fails on the `tabletmanager_consul` and `tabletmanager_zk2` (Docker Test Cluster) shards at `StartTopo()`.

Two separate collisions, both reproduced locally:

- **ZooKeeper**: the AdminServer binds port **8080** by default (`admin.serverPort` is not set in `config/zkcfg/zoo.cfg`). The second ZK exits with code 4 (`ERROR_STARTING_ADMIN_SERVER`) and `zkctl init` spins ~30s dialing the client port before giving up — matching the ~30s CI failure. Fixed by passing `--zk.extra admin.enableServer=false`; nothing in the tests uses the AdminServer. (`go/vt/zkctl/zkctl_test.go` already works around the same collision by overriding `admin.serverPort`.)

- **consul**: consul 2.0.1 (pinned in `build.env` since #20351) binds the gRPC TLS listener on port **8503** even without TLS configured, so the second agent exits immediately with `bind: address already in use`. Fixed by disabling both gRPC listeners (`ports.grpc = -1`, `ports.grpc_tls = -1`); Vitess only talks to consul over HTTP.

Verified locally with a two-cluster harness test (not included): without the fix it fails with the exact CI errors on both flavors; with the fix it passes under consul 2.0.1, zk2, and etcd2.

One caveat: consul 1.11.4 and older reject `ports.grpc_tls` as an unknown config key. `build.env` has pinned consul 2.0.1 since #20351, but a stale local install from before that bump will need a re-bootstrap.

## Related Issue(s)

- Unblocks the new e2e test in #20016, which is the first test to start its own topo server inside a shared suite.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] Tests were added or are not required (test-infra-only change; exercised by every consul/zk2 e2e shard, and by #20016's new test once it lands)
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — test infrastructure only.

### AI Disclosure

This PR was investigated and written by Claude Code; I provided direction and reviewed the changes.
