### PR TITLE
evalengine: collapse the VM stack when a later LOCATE or SUBSTRING operand is NULL

### DIFF
--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -202,6 +202,36 @@ func TestCompilerSingle(t *testing.T) {
 			result:     "INT64(2)",
 		},
 		{
+			// A NULL string operand must collapse both LOCATE operands before outer
+			// expressions consume the result.
+			expression: "null <=> locate('foo', column0)",
+			values:     []sqltypes.Value{sqltypes.NULL},
+			result:     "INT64(1)",
+		},
+		{
+			// A leftover operand would make IFNULL overflow the VM stack.
+			expression: "ifnull(locate('foo', column0), 7)",
+			values:     []sqltypes.Value{sqltypes.NULL},
+			result:     "INT64(7)",
+		},
+		{
+			// A NULL position must collapse all three LOCATE operands.
+			expression: "ifnull(locate('foo', 'foobar', column0), 7)",
+			values:     []sqltypes.Value{sqltypes.NULL},
+			result:     "INT64(7)",
+		},
+		{
+			// A NULL length must collapse all three SUBSTRING operands.
+			expression: "null <=> substring('abc', 1, column0)",
+			values:     []sqltypes.Value{sqltypes.NULL},
+			result:     "INT64(1)",
+		},
+		{
+			expression: "ifnull(substring('abc', 1, column0), 'x')",
+			values:     []sqltypes.Value{sqltypes.NULL},
+			result:     `VARCHAR("x")`,
+		},
+		{
 			expression: "1 + column0",
 			values:     []sqltypes.Value{sqltypes.NewFloat64(1)},
 			result:     "FLOAT64(2)",

--- a/go/vt/vtgate/evalengine/fn_string.go
+++ b/go/vt/vtgate/evalengine/fn_string.go
@@ -1627,7 +1627,7 @@ func (call *builtinSubstring) compile(c *compiler) (ctype, error) {
 		if err != nil {
 			return ctype{}, err
 		}
-		skip2 = c.compileNullCheck2(str, l)
+		skip2 = c.compileNullCheckArg(l, 2)
 		_ = c.compileToInt64(l, 1)
 		c.asm.Fn_SUBSTRING3(tt, cs, col)
 	} else {
@@ -1696,7 +1696,7 @@ func (call *builtinLocate) compile(c *compiler) (ctype, error) {
 		return ctype{}, err
 	}
 
-	skip2 := c.compileNullCheck1(str)
+	skip2 := c.compileNullCheck1r(str)
 	var skip3 *jump
 
 	if !str.isTextual() {
@@ -1724,7 +1724,7 @@ func (call *builtinLocate) compile(c *compiler) (ctype, error) {
 		if err != nil {
 			return ctype{}, err
 		}
-		skip3 = c.compileNullCheck1(l)
+		skip3 = c.compileNullCheckArg(l, 2)
 		_ = c.compileToInt64(l, 1)
 	}
 


### PR DESCRIPTION
## Description

While reviewing #20624 we audited the remaining null-check call sites in the compiled EvalEngine and found two more builtins with the same stack-imbalance bug that PR fixed for `LIKE`: `LOCATE` (second and third operands) and three-argument `SUBSTRING` (length operand).

Their null checks jumped past the consuming instruction without collapsing the operands already on the VM stack, so with a dynamic `NULL` (nullable column or bind variable) an enclosing expression either consumed a stale operand and returned a wrong result, or overflowed the precomputed stack and panicked inside `EvaluateVM` — e.g. `NULL <=> LOCATE('foo', nullable_col)` returned `0` instead of `1`, and `IFNULL(LOCATE('foo', nullable_col), 7)` panicked with `index out of range`.

The fix uses the existing collapsing primitives (`compileNullCheck1r` for the second operand, `compileNullCheckArg` for the third), matching what every other multi-operand builtin already emits. Regression tests compare the interpreted and compiled paths with a `NULL` arriving from a column, so constant folding cannot hide the compiled path.

Since this can panic on the query path, backporting to the supported release branches seems warranted — happy to add the labels if maintainers agree.

## Related Issue(s)

Fixes #20644

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

Investigation, fix, and tests were written by Claude Code under my direction.
