### PR TITLE
ci: stop PR runs from saving Go caches, split module and build caches

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -1,30 +1,62 @@
 name: "Set up Go"
-description: "Set up Go with shared module caching"
+description: "Set up Go with shared module and build caching"
 inputs:
   cache:
-    description: "Whether to cache Go modules"
+    description: "Whether to restore and save the Go module and build caches"
     default: "true"
 runs:
   using: "composite"
   steps:
     - name: Set up Go
       id: setup-go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version-file: go.mod
-        # Disable built-in caching; its key includes ImageOS which
-        # creates duplicate cache entries across runner types.
+        # Disable built-in caching: its key includes ImageOS, which duplicates
+        # entries across runner types, it stores the platform-independent
+        # module cache once per platform, and it saves from pull request runs,
+        # which crowds the branch-scoped entries pull requests restore from
+        # out of the repository cache quota.
         cache: false
 
+    # Runs that are not branch pushes only restore. A cache saved from a pull
+    # request run is scoped to that pull request and can only be reused by its
+    # own re-runs, while it still counts against the repository quota and
+    # evicts the shared branch-scoped entries.
+    - name: Restore Go module cache
+      if: inputs.cache == 'true' && (github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/'))
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ~/go/pkg/mod
+        key: go-mod-${{ hashFiles('go.sum', 'tools/**/go.sum') }}
+        restore-keys: |
+          go-mod-
+
+    - name: Restore Go build cache
+      if: inputs.cache == 'true' && (github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/'))
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ~/.cache/go-build
+        key: go-build-${{ toLower(runner.os) }}-${{ toLower(runner.arch) }}-go${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum', 'tools/**/go.sum') }}
+        restore-keys: |
+          go-build-${{ toLower(runner.os) }}-${{ toLower(runner.arch) }}-go${{ steps.setup-go.outputs.go-version }}-
+
+    # Branch pushes save the entries every other run restores from. The saves
+    # deliberately start from an empty cache instead of a restored one, so a
+    # go.sum change produces a minimal entry without stale module versions or
+    # dead build cache contents. actions/cache saves in its post step, after
+    # the job has populated the caches, and only when the job succeeds and the
+    # key does not exist yet.
     - name: Cache Go modules
-      if: inputs.cache == 'true' && (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main'))
+      if: inputs.cache == 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
-        # Same paths cached by actions/setup-go internally.
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        # Cache by version/arch/hash. Construct hash using same method as actions/setup-go.
-        key: go-${{ steps.setup-go.outputs.go-version }}-${{ toLower(runner.os) }}-${{ toLower(runner.arch) }}-${{ hashFiles('go.sum', 'tools/**/go.sum') }}
-        restore-keys: |
-          go-${{ steps.setup-go.outputs.go-version }}-${{ toLower(runner.os) }}-${{ toLower(runner.arch) }}-
+        path: ~/go/pkg/mod
+        key: go-mod-${{ hashFiles('go.sum', 'tools/**/go.sum') }}
+
+    - name: Cache Go build cache
+      if: inputs.cache == 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ~/.cache/go-build
+        key: go-build-${{ toLower(runner.os) }}-${{ toLower(runner.arch) }}-go${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum', 'tools/**/go.sum') }}

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -67,3 +67,31 @@ runs:
       with:
         path: ~/.cache/go-build
         key: go-build-${{ runner.os }}-${{ runner.arch }}-go${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum', 'tools/**/go.sum') }}
+
+    # Download the root module and every tool module, so a saved module cache
+    # always contains the full dependency set its key covers, no matter which
+    # job saves it first; the tool modules are otherwise only fetched on first
+    # use. On a cache hit this is a fast no-op. Retried because
+    # proxy.golang.org occasionally drops connections mid-download.
+    - name: Download Go modules
+      shell: bash
+      run: |
+        download() {
+          go mod download || return 1
+          local modfile
+          for modfile in tools/*/go.mod; do
+            go mod download -modfile="${modfile}" || return 1
+          done
+        }
+
+        for attempt in 1 2 3; do
+          if download; then
+            break
+          fi
+          if [ "${attempt}" = 3 ]; then
+            echo "go mod download failed after ${attempt} attempts"
+            exit 1
+          fi
+          echo "go mod download failed (attempt ${attempt}); retrying"
+          sleep 10
+        done

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -32,7 +32,7 @@ runs:
 
     - name: Restore Go module cache
       if: inputs.cache == 'true' && steps.cache-mode.outputs.save == 'false'
-      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/go/pkg/mod
         key: go-mod-${{ hashFiles('go.sum', 'tools/**/go.sum') }}
@@ -41,7 +41,7 @@ runs:
 
     - name: Restore Go build cache
       if: inputs.cache == 'true' && steps.cache-mode.outputs.save == 'false'
-      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.cache/go-build
         key: go-build-${{ runner.os }}-${{ runner.arch }}-go${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum', 'tools/**/go.sum') }}
@@ -56,14 +56,14 @@ runs:
     # the job succeeds and the key does not exist yet.
     - name: Cache Go modules
       if: inputs.cache == 'true' && steps.cache-mode.outputs.save == 'true'
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/go/pkg/mod
         key: go-mod-${{ hashFiles('go.sum', 'tools/**/go.sum') }}
 
     - name: Cache Go build cache
       if: inputs.cache == 'true' && steps.cache-mode.outputs.save == 'true'
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.cache/go-build
         key: go-build-${{ runner.os }}-${{ runner.arch }}-go${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum', 'tools/**/go.sum') }}

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -44,9 +44,9 @@ runs:
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/.cache/go-build
-        key: go-build-${{ toLower(runner.os) }}-${{ toLower(runner.arch) }}-go${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum', 'tools/**/go.sum') }}
+        key: go-build-${{ runner.os }}-${{ runner.arch }}-go${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum', 'tools/**/go.sum') }}
         restore-keys: |
-          go-build-${{ toLower(runner.os) }}-${{ toLower(runner.arch) }}-go${{ steps.setup-go.outputs.go-version }}-
+          go-build-${{ runner.os }}-${{ runner.arch }}-go${{ steps.setup-go.outputs.go-version }}-
 
     # Pushes to main and the release branches save the entries every other run
     # restores from. The saves deliberately start from an empty cache instead
@@ -66,4 +66,4 @@ runs:
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/.cache/go-build
-        key: go-build-${{ toLower(runner.os) }}-${{ toLower(runner.arch) }}-go${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum', 'tools/**/go.sum') }}
+        key: go-build-${{ runner.os }}-${{ runner.arch }}-go${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum', 'tools/**/go.sum') }}

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -19,12 +19,19 @@ runs:
         # out of the repository cache quota.
         cache: false
 
-    # Runs that are not branch pushes only restore. A cache saved from a pull
-    # request run is scoped to that pull request and can only be reused by its
-    # own re-runs, while it still counts against the repository quota and
-    # evicts the shared branch-scoped entries.
+    # Only pushes to main and the release branches save caches; everything
+    # else restores. Caches saved from any other run are scoped to a ref that
+    # pull requests do not restore from, while still counting against the
+    # repository quota and evicting the shared entries.
+    - name: Determine cache mode
+      id: cache-mode
+      shell: bash
+      env:
+        SAVE: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-')) }}
+      run: echo "save=${SAVE}" >> "${GITHUB_OUTPUT}"
+
     - name: Restore Go module cache
-      if: inputs.cache == 'true' && (github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/'))
+      if: inputs.cache == 'true' && steps.cache-mode.outputs.save == 'false'
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/go/pkg/mod
@@ -33,7 +40,7 @@ runs:
           go-mod-
 
     - name: Restore Go build cache
-      if: inputs.cache == 'true' && (github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/'))
+      if: inputs.cache == 'true' && steps.cache-mode.outputs.save == 'false'
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/.cache/go-build
@@ -41,21 +48,21 @@ runs:
         restore-keys: |
           go-build-${{ toLower(runner.os) }}-${{ toLower(runner.arch) }}-go${{ steps.setup-go.outputs.go-version }}-
 
-    # Branch pushes save the entries every other run restores from. The saves
-    # deliberately start from an empty cache instead of a restored one, so a
-    # go.sum change produces a minimal entry without stale module versions or
-    # dead build cache contents. actions/cache saves in its post step, after
-    # the job has populated the caches, and only when the job succeeds and the
-    # key does not exist yet.
+    # Pushes to main and the release branches save the entries every other run
+    # restores from. The saves deliberately start from an empty cache instead
+    # of a restored one, so a go.sum change produces a minimal entry without
+    # stale module versions or dead build cache contents. actions/cache saves
+    # in its post step, after the job has populated the caches, and only when
+    # the job succeeds and the key does not exist yet.
     - name: Cache Go modules
-      if: inputs.cache == 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
+      if: inputs.cache == 'true' && steps.cache-mode.outputs.save == 'true'
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/go/pkg/mod
         key: go-mod-${{ hashFiles('go.sum', 'tools/**/go.sum') }}
 
     - name: Cache Go build cache
-      if: inputs.cache == 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
+      if: inputs.cache == 'true' && steps.cache-mode.outputs.save == 'true'
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/.cache/go-build

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -116,18 +116,12 @@ jobs:
           predicate-quantifier: 'every'
           filters: |
             unit_tests:
-              - '{test/config.json,go/**,test.go,Makefile,build.env,go.sum,go.mod,proto/*.proto,tools/**,config/**,bootstrap.sh,.github/workflows/unit_test.yml,.github/actions/setup-mysql/action.yml}'
+              - '{test/config.json,go/**,test.go,Makefile,build.env,go.sum,go.mod,proto/*.proto,tools/**,config/**,bootstrap.sh,.github/workflows/unit_test.yml,.github/actions/setup-mysql/action.yml,.github/actions/setup-go/action.yml}'
               - '!{go/test/endtoend,go/flags/endtoend,go/mysql/endtoend,go/vt/vtctl/endtoend,go/vt/vtctl/grpcvtctldserver/endtoend,go/vt/vtgate/endtoend,go/vt/vttablet/endtoend}/**/*_test.go'
 
       - name: Set up Go
         if: steps.changes.outputs.unit_tests == 'true'
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
-          cache-dependency-path: |
-            go.sum
-            tools/**/go.sum
+        uses: ./.github/actions/setup-go
 
       - name: Set up python
         if: steps.changes.outputs.unit_tests == 'true'
@@ -160,7 +154,18 @@ jobs:
           export DEBIAN_FRONTEND="noninteractive"
           sudo apt-get install -y make unzip g++ curl git wget ${{ matrix.java && 'ant default-jre-headless' || '' }}
 
-          go mod download
+          # proxy.golang.org occasionally drops connections mid-download.
+          for attempt in 1 2 3; do
+            if go mod download; then
+              break
+            fi
+            if [ "$attempt" = 3 ]; then
+              echo "go mod download failed after $attempt attempts"
+              exit 1
+            fi
+            echo "go mod download failed (attempt $attempt); retrying"
+            sleep 10
+          done
 
       - name: Run make tools
         if: steps.changes.outputs.unit_tests == 'true'

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -154,19 +154,6 @@ jobs:
           export DEBIAN_FRONTEND="noninteractive"
           sudo apt-get install -y make unzip g++ curl git wget ${{ matrix.java && 'ant default-jre-headless' || '' }}
 
-          # proxy.golang.org occasionally drops connections mid-download.
-          for attempt in 1 2 3; do
-            if go mod download; then
-              break
-            fi
-            if [ "$attempt" = 3 ]; then
-              echo "go mod download failed after $attempt attempts"
-              exit 1
-            fi
-            echo "go mod download failed (attempt $attempt); retrying"
-            sleep 10
-          done
-
       - name: Run make tools
         if: steps.changes.outputs.unit_tests == 'true'
         timeout-minutes: 10


### PR DESCRIPTION
## Description

The repository's Actions cache pool is over the 10GB quota (~12GB across 58 entries right now), so GitHub's LRU eviction continuously flushes the ~1GB Go caches. In practice no populated setup-go entry for the current `go.sum` hash survives more than a few hours, `Cache is not found` is the norm, and every unit test job downloads the full module graph from `proxy.golang.org` — which occasionally flakes mid-download and fails the run (see the `Get dependencies` failure on https://github.com/vitessio/vitess/actions/runs/29835633875/job/88658901571).

The bulk of the pressure is self-inflicted duplication: caches saved from pull request runs are scoped to that PR's merge ref and can only ever be reused by re-runs of the same PR, yet each active PR was saving its own ~1.1GB × 3 runner-variant copies — evicting the branch-scoped entries that all PRs fall back to.

This reworks the `setup-go` composite action (added in #19784 but never wired into any workflow) and switches `unit_test.yml` to it:

- **Pull request runs only restore, branch pushes save.** PRs restore from the base branch's entries; saves happen on pushes to `main`/`release-*` only (tags excluded — nothing can restore from a tag's scope), and only when the job succeeds, which also stops half-downloaded module caches from being saved.
- **The module cache is stored once, not per platform.** `GOMODCACHE` contents are platform-independent, so it gets a shared `go-mod-<hash>` key instead of three per-variant copies.
- **The build cache stays per platform/Go version**, with a prefix `restore-keys` fallback so a `go.sum` bump warm-starts from the previous entry. Within a key's lifetime the third-party half of the build cache stays fully valid (Go's build cache is content-addressed and deps can't drift without changing the key).
- **The action downloads the root module and every `tools/*/go.mod` module itself, retried up to 3 times** to ride out transient proxy errors. The download makes saved entries deterministic: the module cache key hashes every `tools/*/go.sum`, but tool modules are otherwise only fetched on first use, so the saved contents would depend on which job saves first.

Saves intentionally have no `restore-keys`: the first push after a `go.sum` change runs cold and seeds the new key from a clean download, so entries never accumulate stale module versions (there is no way to prune unused modules from `GOMODCACHE`). Every subsequent push restores on the exact key as usual.

Steady state drops from ~8–9GB of setup-go entries to roughly 3–4GB (one module cache plus per-platform build caches per active branch), comfortably inside the quota — which is what actually fixes the hit rate, since entries stop being evicted between runs.

This intentionally only converts `unit_test.yml` for now; once it holds up we can switch the remaining workflows that use `actions/setup-go` directly, and backport to the active release branches so their PRs get cache coverage under their own `go.sum` keys.

## Related Issue(s)

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — CI-only change.

### AI Disclosure

Investigation and implementation by Claude Code, directed and reviewed by me.
