### PR TITLE
vtgate: support prepared statements with a leading WITH clause

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1579,6 +1579,15 @@ func (e *Executor) Prepare(ctx context.Context, method string, safeSession *econ
 
 func (e *Executor) prepare(ctx context.Context, safeSession *econtext.SafeSession, sql string, logStats *logstats.LogStats) ([]*querypb.Field, uint16, error) {
 	stmtType := sqlparser.Preview(sql)
+	if stmtType == sqlparser.StmtUnknown {
+		// Preview only looks at the first keyword, so statements starting with
+		// a WITH clause come back as unknown. Classify those from the AST.
+		stmt, err := e.env.Parser().Parse(sql)
+		if err != nil {
+			return nil, 0, err
+		}
+		stmtType = sqlparser.ASTToStatementType(stmt)
+	}
 	logStats.StmtType = stmtType.String()
 
 	// Mysql warnings are scoped to the current session, but are

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1581,12 +1581,23 @@ func (e *Executor) prepare(ctx context.Context, safeSession *econtext.SafeSessio
 	stmtType := sqlparser.Preview(sql)
 	if stmtType == sqlparser.StmtUnknown {
 		// Preview only looks at the first keyword, so statements starting with
-		// a WITH clause come back as unknown. Classify those from the AST.
+		// a WITH clause come back as unknown. Classify those from the AST, but
+		// only rescue the statements handlePrepare can count parameters for
+		// (WITH ... SELECT/INSERT/REPLACE/UPDATE/DELETE). Anything else stays
+		// unknown and is rejected below, rather than being reported to the
+		// client as a zero-parameter success.
 		stmt, err := e.env.Parser().Parse(sql)
 		if err != nil {
+			// An unparseable statement is never SHOW, so clear warnings to
+			// match the non-SHOW handling below before returning the error.
+			safeSession.ClearWarnings()
 			return nil, 0, err
 		}
-		stmtType = sqlparser.ASTToStatementType(stmt)
+		switch astType := sqlparser.ASTToStatementType(stmt); astType {
+		case sqlparser.StmtSelect, sqlparser.StmtInsert, sqlparser.StmtReplace,
+			sqlparser.StmtUpdate, sqlparser.StmtDelete:
+			stmtType = astType
+		}
 	}
 	logStats.StmtType = stmtType.String()
 

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1588,8 +1588,10 @@ func (e *Executor) prepare(ctx context.Context, safeSession *econtext.SafeSessio
 		// client as a zero-parameter success.
 		stmt, err := e.env.Parser().Parse(sql)
 		if err != nil {
-			// An unparseable statement is never SHOW, so clear warnings to
-			// match the non-SHOW handling below before returning the error.
+			// The statement stays unknown, and an unparseable statement is
+			// never SHOW, so record the type and clear warnings the way the
+			// code below does before returning the syntax error.
+			logStats.StmtType = stmtType.String()
 			safeSession.ClearWarnings()
 			return nil, 0, err
 		}

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -3111,6 +3111,37 @@ func TestSelectBindvarswithPrepare(t *testing.T) {
 	assert.Empty(t, sbc2.Queries)
 }
 
+func TestPrepareWithCTE(t *testing.T) {
+	testcases := []struct {
+		name        string
+		sql         string
+		paramsCount uint16
+	}{{
+		name:        "recursive cte select",
+		sql:         "with recursive rec as (select id from main1 where id = ? union all select id + 1 from rec where id < ?) select id from rec",
+		paramsCount: 2,
+	}, {
+		name:        "cte update",
+		sql:         "with cte as (select id from main1 where id = ?) update simple set name = ? where id in (select id from cte)",
+		paramsCount: 2,
+	}, {
+		name:        "cte delete",
+		sql:         "with cte as (select id from main1 where id = ?) delete from simple where id in (select id from cte)",
+		paramsCount: 1,
+	}}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			executor, _, _, _, ctx := createExecutorEnv(t)
+			session := &vtgatepb.Session{TargetString: KsTestUnsharded}
+
+			_, paramsCount, err := executorPrepare(ctx, executor, session, tc.sql)
+			require.NoError(t, err)
+			require.Equal(t, tc.paramsCount, paramsCount)
+		})
+	}
+}
+
 func assertOptimizedPlanCondition(t *testing.T, executor *Executor, sql string, condition ...engine.Condition) *engine.PlanSwitcher {
 	var plan *engine.Plan
 	executor.ForEachPlan(func(p *engine.Plan) bool {

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -3142,6 +3142,34 @@ func TestPrepareWithCTE(t *testing.T) {
 	}
 }
 
+// A statement whose first keyword Preview does not recognize but that parses to
+// a type prepare cannot count parameters for (DO discards its expression list)
+// must be rejected rather than reported to the client as a zero-parameter
+// success, which would defer a parameter-count mismatch to execution time.
+func TestPrepareUnknownParseableStatementRejected(t *testing.T) {
+	executor, _, _, _, ctx := createExecutorEnv(t)
+	session := &vtgatepb.Session{TargetString: KsTestUnsharded}
+
+	_, paramsCount, err := executorPrepare(ctx, executor, session, "do ?")
+	require.Error(t, err)
+	require.Zero(t, paramsCount)
+}
+
+// Preparing a statement whose first keyword Preview does not recognize and that
+// fails to parse must clear session warnings, like every other non-SHOW
+// statement, so a later SHOW WARNINGS does not report stale warnings.
+func TestPrepareClearsWarningsOnParseError(t *testing.T) {
+	executor, _, _, _, ctx := createExecutorEnv(t)
+	session := econtext.NewSafeSession(&vtgatepb.Session{
+		TargetString: KsTestUnsharded,
+		Warnings:     []*querypb.QueryWarning{{Code: 234, Message: "oh noes"}},
+	})
+
+	_, _, err := executor.Prepare(ctx, "TestExecute", session, "bad select id from t1")
+	require.Error(t, err)
+	require.Empty(t, session.Warnings)
+}
+
 func assertOptimizedPlanCondition(t *testing.T, executor *Executor, sql string, condition ...engine.Condition) *engine.PlanSwitcher {
 	var plan *engine.Plan
 	executor.ForEachPlan(func(p *engine.Plan) bool {

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -3170,6 +3170,24 @@ func TestPrepareClearsWarningsOnParseError(t *testing.T) {
 	require.Empty(t, session.Warnings)
 }
 
+// A statement whose first keyword Preview does not recognize and that fails to
+// parse has no known statement type, so its query log record reports the
+// statement type as unknown rather than leaving the field empty.
+func TestPrepareParseErrorLogsUnknownStatementType(t *testing.T) {
+	executor, _, _, _, ctx := createExecutorEnv(t)
+	session := econtext.NewSafeSession(&vtgatepb.Session{TargetString: KsTestUnsharded})
+
+	logChan := executor.queryLogger.Subscribe("Test")
+	t.Cleanup(func() { executor.queryLogger.Unsubscribe(logChan) })
+
+	_, _, err := executor.Prepare(ctx, "TestExecute", session, "bad select id from t1")
+	require.Error(t, err)
+
+	logStats := getQueryLog(logChan)
+	require.NotNil(t, logStats)
+	require.Equal(t, "UNKNOWN", logStats.StmtType)
+}
+
 func assertOptimizedPlanCondition(t *testing.T, executor *Executor, sql string, condition ...engine.Condition) *engine.PlanSwitcher {
 	var plan *engine.Plan
 	executor.ForEachPlan(func(p *engine.Plan) bool {

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -2960,7 +2960,7 @@ func TestExecutorTruncateErrors(t *testing.T) {
 	require.EqualError(t, err, "syntax error at posi [TRUNCATED]")
 
 	_, _, err = executor.Prepare(t.Context(), "TestExecute", session, "invalid statement")
-	assert.EqualError(t, err, "[BUG] unrecognized p [TRUNCATED]")
+	assert.EqualError(t, err, "syntax error at posi [TRUNCATED]")
 }
 
 func TestPrepareDoesNotStartTransaction(t *testing.T) {

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -169,8 +169,8 @@ func TestVTGatePrepareError(t *testing.T) {
 	require.Nil(t, qr)
 
 	newCounts := errorCounts.Counts()
-	require.Contains(t, newCounts, "Prepare.TestUnsharded.primary.INTERNAL")
-	require.Equal(t, counts["Prepare.TestUnsharded.primary.INTERNAL"]+1, newCounts["Prepare.TestUnsharded.primary.INTERNAL"])
+	require.Contains(t, newCounts, "Prepare.TestUnsharded.primary.INVALID_ARGUMENT")
+	require.Equal(t, counts["Prepare.TestUnsharded.primary.INVALID_ARGUMENT"]+1, newCounts["Prepare.TestUnsharded.primary.INVALID_ARGUMENT"])
 
 	for k, v := range newCounts {
 		if strings.HasPrefix(k, "Execute") {


### PR DESCRIPTION
## Description

Preparing any statement that starts with a `WITH` clause fails with `[BUG] unrecognized prepare statement`, as reported in https://github.com/vitessio/vitess/issues/16415#issuecomment-3260955729 (Grafana prepares all its queries, including recursive CTEs). The prepare path classifies statements with the textual `sqlparser.Preview` heuristic, which only looks at the first keyword and has no case for `with` — the regular execute path classifies from the AST, which is why the same queries work fine outside of PREPARE.

This is the targeted fix, split out of #20535 so it can be backported on its own: when `Preview` returns `StmtUnknown`, parse the statement and, only if it classifies as `SELECT`/`INSERT`/`REPLACE`/`UPDATE`/`DELETE` (the types the prepare path can count parameters for), reclassify from the AST. That lets `WITH ...` CTE statements be prepared while leaving anything else (e.g. `DO ?`) rejected as before — reclassifying those too would report a zero-parameter success and defer the real parameter-count mismatch to execution.

Two side effects, both aligning prepare with Execute/StreamExecute:

- Preparing an unparseable statement now returns a proper syntax error (`INVALID_ARGUMENT`) instead of the internal `[BUG]` error.
- The parse-error path now clears session warnings like every other non-`SHOW` statement, so a later `SHOW WARNINGS` no longer reports stale warnings.

#20535 follows up on main (v25+) only, removing `Preview` from the prepare path entirely — so unknown statements are classified from a single AST parse instead of this fallback's extra parse, and the set of preparable statements is aligned with MySQL.

Backport justification: user-facing bug — clients that prepare their queries (e.g. Grafana over the MySQL protocol) cannot run any CTE query through vtgate. The fix is a small, additive fallback on the prepare path only.

## Related Issue(s)

Part of #16415

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Preparing an invalid (unparseable) statement returns a syntax error instead of an internal `[BUG] unrecognized prepare statement` error; the `Prepare` error metric for such statements moves from `INTERNAL` to `INVALID_ARGUMENT`.

### AI Disclosure

This PR was written by Claude Code — I provided direction and reviewed.
