### PR TITLE
vtgate: re-chunk gRPC streaming responses at the service boundary

### DIFF
--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -364,7 +364,7 @@ Flags:
       --stats-common-tags strings                                        Comma-separated list of common tags for the stats backend. It provides both label and values. Example: label1:value1,label2:value2
       --stats-drop-variables string                                      Variables to be dropped from the list of exported variables.
       --stats-emit-period duration                                       Interval between emitting stats to all registered backends (default 1m0s)
-      --stream-buffer-size int                                           the number of bytes sent from vtgate for each stream call. It's recommended to keep this value in sync with vttablet's query-server-config-stream-buffer-size. (default 32768)
+      --stream-buffer-size int                                           the number of bytes sent in each gRPC streaming API response. (default 32768)
       --stream-health-buffer-size uint                                   max streaming health entries to buffer per streaming health client (default 20)
       --table-gc-lifecycle string                                        States for a DROP TABLE garbage collection cycle. Default is 'hold,purge,evac,drop', use any subset ('drop' implicitly always included) (default "hold,purge,evac,drop")
       --table-refresh-interval int                                       interval in milliseconds to refresh tables in status page with refreshRequired class

--- a/go/flags/endtoend/vtgate.txt
+++ b/go/flags/endtoend/vtgate.txt
@@ -204,7 +204,7 @@ Flags:
       --stats-emit-period duration                                       Interval between emitting stats to all registered backends (default 1m0s)
       --statsd-address string                                            Address for statsd client
       --statsd-sample-rate float                                         Sample rate for statsd metrics (default 1)
-      --stream-buffer-size int                                           the number of bytes sent from vtgate for each stream call. It's recommended to keep this value in sync with vttablet's query-server-config-stream-buffer-size. (default 32768)
+      --stream-buffer-size int                                           the number of bytes sent in each gRPC streaming API response. (default 32768)
       --table-refresh-interval int                                       interval in milliseconds to refresh tables in status page with refreshRequired class
       --tablet-filter-tags StringMap                                     Specifies a comma-separated list of tablet tags (as key:value pairs) to filter the tablets to watch.
       --tablet-filters strings                                           Specifies a comma-separated list of 'keyspace|shard_name or keyrange' values to filter the tablets to watch.

--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -69,14 +69,12 @@ func (vte *VTExplain) initVtgateExecutor(ctx context.Context, ts *topo.Server, v
 		vte.vtgateSession.Options.PlannerVersion = opts.PlannerVersion
 	}
 
-	streamSize := 10
 	var schemaTracker vtgate.SchemaInfo // no schema tracker for these tests
 	queryLogBufferSize := 10
 	plans := theine.NewStore[vtgate.PlanCacheKey, *engine.Plan](4*1024*1024, false)
 	eConfig := vtgate.ExecutorConfig{
 		Name:         "TestExecutor",
 		Normalize:    opts.Normalize,
-		StreamSize:   streamSize,
 		AllowScatter: true,
 	}
 	vte.vtgateExecutor = vtgate.NewExecutor(ctx, vte.env, vte.explainTopo, Cell, resolver, eConfig, false, plans, schemaTracker, opts.PlannerVersion, vtgate.NewDynamicViperConfig())

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -112,9 +112,8 @@ func init() {
 // the abilities of the underlying vttablets.
 type (
 	ExecutorConfig struct {
-		Name       string
-		Normalize  bool
-		StreamSize int
+		Name      string
+		Normalize bool
 		// AllowScatter will fail planning if set to false and a plan contains any scatter queries
 		AllowScatter bool
 		// PreventCrossKeyspaceReads will fail planning if set to true and a plan contains any cross-keyspace joins or UNIONs.
@@ -335,41 +334,22 @@ func (e *Executor) StreamExecute(
 	resultHandler := func(ctx context.Context, plan *engine.Plan, vc *econtext.VCursorImpl, bindVars map[string]*querypb.BindVariable, execStart time.Time) error {
 		var seenResults atomic.Bool
 		var resultMu sync.Mutex
-		result := &sqltypes.Result{}
 		if canReturnRows(plan.QueryType) {
 			srr.callback = func(qr *sqltypes.Result) error {
 				resultMu.Lock()
 				defer resultMu.Unlock()
-				// If the row has field info, send it separately.
-				// TODO(sougou): this behavior is for handling tests because
-				// the framework currently sends all results as one packet.
-				byteCount := 0
-				if len(qr.Fields) > 0 {
-					result.Fields = qr.Fields
-					if err := callback(qr.Metadata()); err != nil {
-						return err
-					}
-					seenResults.Store(true)
+				// Forward each tablet packet to the client as it arrives, without
+				// re-chunking to a fixed packet size: the gRPC streaming API
+				// re-chunks to --stream-buffer-size at the service boundary
+				// (grpcvtgateservice), and the MySQL protocol path streams the
+				// tablet packets verbatim. An OK-only packet (no fields, no rows)
+				// carries no result-set data the streaming path delivers, so it is
+				// left alone, unchanged from before.
+				if len(qr.Fields) == 0 && len(qr.Rows) == 0 {
+					return nil
 				}
-
-				for _, row := range qr.Rows {
-					result.Rows = append(result.Rows, row)
-
-					for _, col := range row {
-						byteCount += col.Len()
-					}
-
-					if byteCount >= e.config.StreamSize {
-						err := callback(result)
-						seenResults.Store(true)
-						result = &sqltypes.Result{}
-						byteCount = 0
-						if err != nil {
-							return err
-						}
-					}
-				}
-				return nil
+				seenResults.Store(true)
+				return callback(qr)
 			}
 		}
 
@@ -410,9 +390,11 @@ func (e *Executor) StreamExecute(
 			return nil
 		}
 
-		// Send left-over rows if there is no error on execution.
-		if len(result.Rows) > 0 || !seenResults.Load() {
-			if err := callback(result); err != nil {
+		// Packets are forwarded to the client as they arrive, so there are no
+		// left-over rows to flush here. If the primitive produced no packets at
+		// all, still emit one empty result so the client sees a response.
+		if !seenResults.Load() {
+			if err := callback(&sqltypes.Result{}); err != nil {
 				return err
 			}
 		}

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -248,7 +248,6 @@ func createCustomExecutor(t testing.TB, vschema string, mysqlVersion string) (ex
 func createExecutorConfig() ExecutorConfig {
 	return ExecutorConfig{
 		Name:         "TestExecutor",
-		StreamSize:   10,
 		AllowScatter: true,
 	}
 }
@@ -256,7 +255,6 @@ func createExecutorConfig() ExecutorConfig {
 func createExecutorConfigWithNormalizer() ExecutorConfig {
 	return ExecutorConfig{
 		Name:         "TestExecutor",
-		StreamSize:   10,
 		AllowScatter: true,
 		Normalize:    true,
 	}

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -643,11 +643,12 @@ func TestStreamUnsharded(t *testing.T) {
 	testQueryLog(t, executor, logChan, "TestExecuteStream", "SELECT", sql, 1)
 }
 
-func TestStreamBuffering(t *testing.T) {
+func TestStreamPassthrough(t *testing.T) {
 	executor, _, _, sbclookup, _ := createExecutorEnv(t)
 
-	// This test is similar to TestStreamUnsharded except that it returns a Result > 10 bytes,
-	// such that the splitting of the Result into multiple Result responses gets tested.
+	// This test is similar to TestStreamUnsharded except that it verifies that
+	// packets are forwarded to the callback exactly as the tablet sent them,
+	// without any re-chunking in the executor.
 	sbclookup.SetResults([]*sqltypes.Result{{
 		Fields: []*querypb.Field{
 			{Name: "id", Type: sqltypes.Int32, Charset: collations.CollationBinaryID, Flags: uint32(querypb.MySqlFlag_NUM_FLAG)},
@@ -670,7 +671,7 @@ func TestStreamBuffering(t *testing.T) {
 	err := executor.StreamExecute(
 		t.Context(),
 		nil,
-		"TestStreamBuffering",
+		"TestStreamPassthrough",
 		econtext.NewSafeSession(session),
 		"select id from music_user_map where id = 1",
 		nil,
@@ -686,17 +687,10 @@ func TestStreamBuffering(t *testing.T) {
 			{Name: "id", Type: sqltypes.Int32, Charset: collations.CollationBinaryID, Flags: uint32(querypb.MySqlFlag_NUM_FLAG)},
 			{Name: "col", Type: sqltypes.VarChar, Charset: uint32(collations.MySQL8().DefaultConnectionCharset())},
 		},
-	}, {
-		Fields: []*querypb.Field{
-			{Name: "id", Type: sqltypes.Int32, Charset: collations.CollationBinaryID, Flags: uint32(querypb.MySqlFlag_NUM_FLAG)},
-			{Name: "col", Type: sqltypes.VarChar, Charset: uint32(collations.MySQL8().DefaultConnectionCharset())},
-		},
 		Rows: [][]sqltypes.Value{{
 			sqltypes.NewInt32(1),
 			sqltypes.NewVarChar("01234567890123456789"),
-		}},
-	}, {
-		Rows: [][]sqltypes.Value{{
+		}, {
 			sqltypes.NewInt32(2),
 			sqltypes.NewVarChar("12345678901234567890"),
 		}},

--- a/go/vt/vtgate/grpcvtgateservice/server.go
+++ b/go/vt/vtgate/grpcvtgateservice/server.go
@@ -185,7 +185,10 @@ func (vtg *VTGate) StreamExecuteMulti(request *vtgatepb.StreamExecuteMultiReques
 		session = &vtgatepb.Session{Autocommit: true}
 	}
 
-	session, vtgErr := vtg.server.StreamExecuteMulti(ctx, nil, session, request.Sql, func(qr sqltypes.QueryResponse, more bool, firstPacket bool) error {
+	// Split oversized result packets to --stream-buffer-size so response
+	// message sizes stay independent of how the underlying primitives chunk
+	// their output.
+	callback := vtgate.NewStreamExecuteMultiChunker(func(qr sqltypes.QueryResponse, more bool, firstPacket bool) error {
 		// Send is not safe to call concurrently, but vtgate
 		// guarantees that it's not.
 		return stream.Send(&vtgatepb.StreamExecuteMultiResponse{
@@ -194,6 +197,7 @@ func (vtg *VTGate) StreamExecuteMulti(request *vtgatepb.StreamExecuteMultiReques
 			NewResult:   firstPacket,
 		})
 	})
+	session, vtgErr := vtg.server.StreamExecuteMulti(ctx, nil, session, request.Sql, callback)
 
 	var errs []error
 	if vtgErr != nil {
@@ -247,14 +251,18 @@ func (vtg *VTGate) StreamExecute(request *vtgatepb.StreamExecuteRequest, stream 
 		session = &vtgatepb.Session{Autocommit: true}
 	}
 
-	// The streaming gRPC API has no prepared-statement field, so prepared is always false here.
-	session, vtgErr := vtg.server.StreamExecute(ctx, nil, session, request.Query.Sql, request.Query.BindVariables, false, func(value *sqltypes.Result) error {
+	// Split oversized result packets to --stream-buffer-size so response
+	// message sizes stay independent of how the underlying primitives chunk
+	// their output.
+	chunked := vtgate.NewStreamResponseChunker(func(value *sqltypes.Result) error {
 		// Send is not safe to call concurrently, but vtgate
 		// guarantees that it's not.
 		return stream.Send(&vtgatepb.StreamExecuteResponse{
 			Result: sqltypes.ResultToProto3(value),
 		})
 	})
+	// The streaming gRPC API has no prepared-statement field, so prepared is always false here.
+	session, vtgErr := vtg.server.StreamExecute(ctx, nil, session, request.Query.Sql, request.Query.BindVariables, false, chunked)
 
 	var errs []error
 	if vtgErr != nil {

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -637,19 +637,6 @@ func TestComQueryMulti(t *testing.T) {
 								Charset: collations.CollationBinaryID,
 							},
 						},
-					},
-					QueryError: nil,
-				},
-				{
-					QueryResult: &sqltypes.Result{
-						Fields: []*querypb.Field{
-							{
-								Name:    "1",
-								Type:    sqltypes.Int64,
-								Flags:   uint32(querypb.MySqlFlag_NUM_FLAG | querypb.MySqlFlag_NOT_NULL_FLAG),
-								Charset: collations.CollationBinaryID,
-							},
-						},
 						Rows: [][]sqltypes.Value{
 							{
 								sqltypes.NewInt64(1),
@@ -659,8 +646,8 @@ func TestComQueryMulti(t *testing.T) {
 					QueryError: nil,
 				},
 			},
-			more:        []bool{false, false, false},
-			firstPacket: []bool{true, false, false},
+			more:        []bool{false, false},
+			firstPacket: []bool{true, false},
 			errExpected: false,
 		}, {
 			name: "Multiple queries - olap - success",
@@ -690,35 +677,9 @@ func TestComQueryMulti(t *testing.T) {
 								Charset: collations.CollationBinaryID,
 							},
 						},
-					},
-					QueryError: nil,
-				},
-				{
-					QueryResult: &sqltypes.Result{
-						Fields: []*querypb.Field{
-							{
-								Name:    "1",
-								Type:    sqltypes.Int64,
-								Flags:   uint32(querypb.MySqlFlag_NUM_FLAG | querypb.MySqlFlag_NOT_NULL_FLAG),
-								Charset: collations.CollationBinaryID,
-							},
-						},
 						Rows: [][]sqltypes.Value{
 							{
 								sqltypes.NewInt64(1),
-							},
-						},
-					},
-					QueryError: nil,
-				},
-				{
-					QueryResult: &sqltypes.Result{
-						Fields: []*querypb.Field{
-							{
-								Name:    "2",
-								Type:    sqltypes.Int64,
-								Flags:   uint32(querypb.MySqlFlag_NUM_FLAG | querypb.MySqlFlag_NOT_NULL_FLAG),
-								Charset: collations.CollationBinaryID,
 							},
 						},
 					},
@@ -778,19 +739,6 @@ func TestComQueryMulti(t *testing.T) {
 								Charset: collations.CollationBinaryID,
 							},
 						},
-					},
-					QueryError: nil,
-				},
-				{
-					QueryResult: &sqltypes.Result{
-						Fields: []*querypb.Field{
-							{
-								Name:    "3",
-								Type:    sqltypes.Int64,
-								Flags:   uint32(querypb.MySqlFlag_NUM_FLAG | querypb.MySqlFlag_NOT_NULL_FLAG),
-								Charset: collations.CollationBinaryID,
-							},
-						},
 						Rows: [][]sqltypes.Value{
 							{
 								sqltypes.NewInt64(3),
@@ -800,8 +748,8 @@ func TestComQueryMulti(t *testing.T) {
 					QueryError: nil,
 				},
 			},
-			more:        []bool{true, true, true, true, true, true, false, false, false},
-			firstPacket: []bool{true, false, false, true, false, false, true, false, false},
+			more:        []bool{true, true, true, true, false, false},
+			firstPacket: []bool{true, false, true, false, true, false},
 			errExpected: false,
 		}, {
 			name: "Multiple queries - olap - failure",
@@ -831,35 +779,9 @@ func TestComQueryMulti(t *testing.T) {
 								Charset: collations.CollationBinaryID,
 							},
 						},
-					},
-					QueryError: nil,
-				},
-				{
-					QueryResult: &sqltypes.Result{
-						Fields: []*querypb.Field{
-							{
-								Name:    "1",
-								Type:    sqltypes.Int64,
-								Flags:   uint32(querypb.MySqlFlag_NUM_FLAG | querypb.MySqlFlag_NOT_NULL_FLAG),
-								Charset: collations.CollationBinaryID,
-							},
-						},
 						Rows: [][]sqltypes.Value{
 							{
 								sqltypes.NewInt64(1),
-							},
-						},
-					},
-					QueryError: nil,
-				},
-				{
-					QueryResult: &sqltypes.Result{
-						Fields: []*querypb.Field{
-							{
-								Name:    "2",
-								Type:    sqltypes.Int64,
-								Flags:   uint32(querypb.MySqlFlag_NUM_FLAG | querypb.MySqlFlag_NOT_NULL_FLAG),
-								Charset: collations.CollationBinaryID,
 							},
 						},
 					},
@@ -901,8 +823,8 @@ func TestComQueryMulti(t *testing.T) {
 					QueryError:  errors.New("syntax error at position 8 near 'parsing' (errno 1105) (sqlstate HY000)"),
 				},
 			},
-			more:        []bool{true, true, true, true, true, true, false},
-			firstPacket: []bool{true, false, false, true, false, false, true},
+			more:        []bool{true, true, true, true, false},
+			firstPacket: []bool{true, false, true, false, true},
 			errExpected: false,
 		},
 	}

--- a/go/vt/vtgate/stream_chunker.go
+++ b/go/vt/vtgate/stream_chunker.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"vitess.io/vitess/go/sqltypes"
+)
+
+// NewStreamResponseChunker wraps a streaming callback so that row-returning
+// result packets larger than --stream-buffer-size are split into
+// --stream-buffer-size'd packets, and repeated field metadata (each shard of
+// a scatter query leads with its own fields) is forwarded only once. This
+// keeps the packet sizes of the gRPC streaming API independent of primitives
+// that emit their complete result as one packet (e.g. an in-memory sort).
+//
+// Packets are never buffered across callbacks: everything a packet carries is
+// delivered to the callback before the wrapper returns. Tailing streams (e.g.
+// a message stream, which trickles rows for the lifetime of the stream) and
+// streams that end in an error therefore deliver every row they produced.
+// Streams whose first packet has no fields carry OK packets (e.g. DML) and
+// pass through unchanged.
+//
+// The returned callback is not safe for concurrent use; the executor already
+// serializes streaming callbacks.
+func NewStreamResponseChunker(callback func(*sqltypes.Result) error) func(*sqltypes.Result) error {
+	return newStreamResponseChunker(streamBufferSize, callback)
+}
+
+func newStreamResponseChunker(size int, callback func(*sqltypes.Result) error) func(*sqltypes.Result) error {
+	firstPacket := true
+	okOnly := false
+	fieldsSent := false
+
+	return func(qr *sqltypes.Result) error {
+		if firstPacket {
+			firstPacket = false
+			okOnly = len(qr.Fields) == 0
+		}
+		if okOnly {
+			return callback(qr)
+		}
+
+		// Forward the field metadata once per stream. The packet is copied
+		// before stripping repeated fields: it belongs to the producing
+		// stream, which may reuse it.
+		if len(qr.Fields) > 0 {
+			if fieldsSent {
+				stripped := *qr
+				stripped.Fields = nil
+				qr = &stripped
+			}
+			fieldsSent = true
+		}
+
+		total := 0
+		for _, row := range qr.Rows {
+			for _, col := range row {
+				total += col.Len()
+			}
+		}
+		if total <= size {
+			return callback(qr)
+		}
+
+		// Split the oversized packet. The first chunk carries the packet's
+		// fields and OK data (RowsAffected, InsertID, Info, ...), the rest
+		// carry rows only.
+		head := *qr
+		emitted := false
+		emit := func(rows []sqltypes.Row) error {
+			if !emitted {
+				emitted = true
+				head.Rows = rows
+				return callback(&head)
+			}
+			return callback(&sqltypes.Result{Rows: rows})
+		}
+		var rows []sqltypes.Row
+		byteCount := 0
+		for _, row := range qr.Rows {
+			rows = append(rows, row)
+			for _, col := range row {
+				byteCount += col.Len()
+			}
+			if byteCount >= size {
+				if err := emit(rows); err != nil {
+					return err
+				}
+				rows = nil
+				byteCount = 0
+			}
+		}
+		if len(rows) > 0 {
+			return emit(rows)
+		}
+		return nil
+	}
+}
+
+// NewStreamExecuteMultiChunker applies NewStreamResponseChunker to each
+// statement's result stream of a StreamExecuteMulti call. When a source
+// packet is split, only the first chunk of a statement's first packet keeps
+// firstPacket set, and every chunk carries the statement's more flag. Error
+// responses pass through unchanged.
+func NewStreamExecuteMultiChunker(send func(qr sqltypes.QueryResponse, more bool, firstPacket bool) error) func(qr sqltypes.QueryResponse, more bool, firstPacket bool) error {
+	return newStreamExecuteMultiChunker(streamBufferSize, send)
+}
+
+func newStreamExecuteMultiChunker(size int, send func(qr sqltypes.QueryResponse, more bool, firstPacket bool) error) func(qr sqltypes.QueryResponse, more bool, firstPacket bool) error {
+	var chunked func(*sqltypes.Result) error
+	var more bool
+	first := true
+
+	forward := func(result *sqltypes.Result) error {
+		isFirst := first
+		first = false
+		return send(sqltypes.QueryResponse{QueryResult: result}, more, isFirst)
+	}
+
+	return func(qr sqltypes.QueryResponse, qrMore bool, firstPacket bool) error {
+		if firstPacket {
+			first = true
+			chunked = newStreamResponseChunker(size, forward)
+		}
+		more = qrMore
+		if qr.QueryError != nil {
+			isFirst := first
+			first = false
+			return send(qr, qrMore, isFirst)
+		}
+		return chunked(qr.QueryResult)
+	}
+}

--- a/go/vt/vtgate/stream_chunker_test.go
+++ b/go/vt/vtgate/stream_chunker_test.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/test/utils"
+
+	querypb "vitess.io/vitess/go/vt/proto/query"
+)
+
+var chunkerFields = []*querypb.Field{
+	{Name: "col", Type: sqltypes.VarChar},
+}
+
+func row(val string) []sqltypes.Value {
+	return []sqltypes.Value{sqltypes.NewVarChar(val)}
+}
+
+func collectChunker(size int) (chunked func(*sqltypes.Result) error, results *[]*sqltypes.Result) {
+	results = &[]*sqltypes.Result{}
+	chunked = newStreamResponseChunker(size, func(qr *sqltypes.Result) error {
+		*results = append(*results, qr)
+		return nil
+	})
+	return chunked, results
+}
+
+func TestStreamResponseChunkerForwardsPacketsImmediately(t *testing.T) {
+	// Packets that fit the chunk size are forwarded as-is from within the
+	// callback. Nothing may be buffered across callbacks: a message stream
+	// (stream * from msg) trickles rows for the lifetime of the stream, and a
+	// buffered row would not be delivered until the buffer fills, which for a
+	// message stream is never.
+	chunked, results := collectChunker(1000)
+
+	require.NoError(t, chunked(&sqltypes.Result{Fields: chunkerFields}))
+	utils.MustMatch(t, []*sqltypes.Result{{Fields: chunkerFields}}, *results)
+
+	require.NoError(t, chunked(&sqltypes.Result{Rows: [][]sqltypes.Value{row("a")}}))
+	utils.MustMatch(t, []*sqltypes.Result{
+		{Fields: chunkerFields},
+		{Rows: [][]sqltypes.Value{row("a")}},
+	}, *results)
+
+	require.NoError(t, chunked(&sqltypes.Result{Rows: [][]sqltypes.Value{row("b")}}))
+	utils.MustMatch(t, []*sqltypes.Result{
+		{Fields: chunkerFields},
+		{Rows: [][]sqltypes.Value{row("a")}},
+		{Rows: [][]sqltypes.Value{row("b")}},
+	}, *results)
+}
+
+func TestStreamResponseChunkerSplitsLargePackets(t *testing.T) {
+	// A single oversized packet, as emitted by an in-memory sort, is split at
+	// the chunk size instead of being forwarded as one giant gRPC message. The
+	// packet's fields and OK data ride on the first chunk only.
+	chunked, results := collectChunker(8)
+
+	require.NoError(t, chunked(&sqltypes.Result{
+		Fields:       chunkerFields,
+		Rows:         [][]sqltypes.Value{row("aaaa"), row("bbbb"), row("cccc"), row("dddd"), row("eeee")},
+		RowsAffected: 5,
+	}))
+
+	want := []*sqltypes.Result{
+		{Fields: chunkerFields, Rows: [][]sqltypes.Value{row("aaaa"), row("bbbb")}, RowsAffected: 5},
+		{Rows: [][]sqltypes.Value{row("cccc"), row("dddd")}},
+		{Rows: [][]sqltypes.Value{row("eeee")}},
+	}
+	utils.MustMatch(t, want, *results)
+}
+
+func TestStreamResponseChunkerDedupsScatterFields(t *testing.T) {
+	// In a scatter query every shard stream leads with its own fields packet,
+	// and with the coalesced tablet stream format the rows ride along in it;
+	// only the first stream's fields are forwarded.
+	chunked, results := collectChunker(1000)
+
+	require.NoError(t, chunked(&sqltypes.Result{Fields: chunkerFields, Rows: [][]sqltypes.Value{row("a")}}))
+	require.NoError(t, chunked(&sqltypes.Result{Fields: chunkerFields, Rows: [][]sqltypes.Value{row("b")}}))
+
+	want := []*sqltypes.Result{
+		{Fields: chunkerFields, Rows: [][]sqltypes.Value{row("a")}},
+		{Rows: [][]sqltypes.Value{row("b")}},
+	}
+	utils.MustMatch(t, want, *results)
+}
+
+func TestStreamResponseChunkerOKPacketPassthrough(t *testing.T) {
+	// A stream whose first packet has no fields carries OK packets (e.g.
+	// DML); those pass through unchanged, keeping fields like
+	// SessionStateChanges intact.
+	chunked, results := collectChunker(1000)
+
+	ok := &sqltypes.Result{
+		RowsAffected:        3,
+		InsertID:            42,
+		SessionStateChanges: "state",
+	}
+	require.NoError(t, chunked(ok))
+
+	utils.MustMatch(t, []*sqltypes.Result{ok}, *results)
+}
+
+func TestStreamResponseChunkerDoesNotMutateSource(t *testing.T) {
+	// Stripping duplicate fields and splitting must not modify the caller's
+	// result: the result belongs to the producing stream, which may reuse it.
+	chunked, _ := collectChunker(8)
+
+	first := &sqltypes.Result{Fields: chunkerFields, Rows: [][]sqltypes.Value{row("a")}}
+	require.NoError(t, chunked(first))
+
+	second := &sqltypes.Result{
+		Fields: chunkerFields,
+		Rows:   [][]sqltypes.Value{row("aaaa"), row("bbbb"), row("cccc")},
+	}
+	require.NoError(t, chunked(second))
+
+	utils.MustMatch(t, &sqltypes.Result{Fields: chunkerFields, Rows: [][]sqltypes.Value{row("a")}}, first)
+	utils.MustMatch(t, &sqltypes.Result{
+		Fields: chunkerFields,
+		Rows:   [][]sqltypes.Value{row("aaaa"), row("bbbb"), row("cccc")},
+	}, second)
+}
+
+type multiPacket struct {
+	qr          sqltypes.QueryResponse
+	more        bool
+	firstPacket bool
+}
+
+func TestStreamExecuteMultiChunker(t *testing.T) {
+	var got []multiPacket
+	callback := NewStreamExecuteMultiChunker(func(qr sqltypes.QueryResponse, more bool, firstPacket bool) error {
+		got = append(got, multiPacket{qr: qr, more: more, firstPacket: firstPacket})
+		return nil
+	})
+
+	// Statement 1: fields, then a row.
+	require.NoError(t, callback(sqltypes.QueryResponse{QueryResult: &sqltypes.Result{Fields: chunkerFields}}, true, true))
+	require.NoError(t, callback(sqltypes.QueryResponse{QueryResult: &sqltypes.Result{Rows: [][]sqltypes.Value{row("a")}}}, true, false))
+	// Statement 2: a single combined packet; its fields are forwarded again
+	// because it is a new statement.
+	require.NoError(t, callback(sqltypes.QueryResponse{QueryResult: &sqltypes.Result{Fields: chunkerFields, Rows: [][]sqltypes.Value{row("b")}}}, false, true))
+
+	want := []multiPacket{
+		{qr: sqltypes.QueryResponse{QueryResult: &sqltypes.Result{Fields: chunkerFields}}, more: true, firstPacket: true},
+		{qr: sqltypes.QueryResponse{QueryResult: &sqltypes.Result{Rows: [][]sqltypes.Value{row("a")}}}, more: true, firstPacket: false},
+		{qr: sqltypes.QueryResponse{QueryResult: &sqltypes.Result{Fields: chunkerFields, Rows: [][]sqltypes.Value{row("b")}}}, more: false, firstPacket: true},
+	}
+	utils.MustMatch(t, want, got)
+}
+
+func TestStreamExecuteMultiChunkerSplitKeepsFlags(t *testing.T) {
+	// When one source packet splits into several chunks, only the first chunk
+	// of the statement's first packet keeps firstPacket=true, and all chunks
+	// carry the statement's more flag.
+	var got []multiPacket
+	callback := newStreamExecuteMultiChunker(8, func(qr sqltypes.QueryResponse, more bool, firstPacket bool) error {
+		got = append(got, multiPacket{qr: qr, more: more, firstPacket: firstPacket})
+		return nil
+	})
+
+	require.NoError(t, callback(sqltypes.QueryResponse{QueryResult: &sqltypes.Result{
+		Fields: chunkerFields,
+		Rows:   [][]sqltypes.Value{row("aaaa"), row("bbbb"), row("cccc")},
+	}}, true, true))
+
+	want := []multiPacket{
+		{qr: sqltypes.QueryResponse{QueryResult: &sqltypes.Result{Fields: chunkerFields, Rows: [][]sqltypes.Value{row("aaaa"), row("bbbb")}}}, more: true, firstPacket: true},
+		{qr: sqltypes.QueryResponse{QueryResult: &sqltypes.Result{Rows: [][]sqltypes.Value{row("cccc")}}}, more: true, firstPacket: false},
+	}
+	utils.MustMatch(t, want, got)
+}
+
+func TestStreamExecuteMultiChunkerError(t *testing.T) {
+	var got []multiPacket
+	callback := NewStreamExecuteMultiChunker(func(qr sqltypes.QueryResponse, more bool, firstPacket bool) error {
+		got = append(got, multiPacket{qr: qr, more: more, firstPacket: firstPacket})
+		return nil
+	})
+
+	// Statement 1 succeeds, statement 2 fails before producing results. The
+	// error passes through unchanged and statement 1's rows were already
+	// delivered from within their callback.
+	require.NoError(t, callback(sqltypes.QueryResponse{QueryResult: &sqltypes.Result{Fields: chunkerFields, Rows: [][]sqltypes.Value{row("a")}}}, true, true))
+	queryErr := sqltypes.QueryResponse{QueryError: sqltypes.ErrIncompatibleTypeCast}
+	require.NoError(t, callback(queryErr, false, true))
+
+	want := []multiPacket{
+		{qr: sqltypes.QueryResponse{QueryResult: &sqltypes.Result{Fields: chunkerFields, Rows: [][]sqltypes.Value{row("a")}}}, more: true, firstPacket: true},
+		{qr: queryErr, more: false, firstPacket: true},
+	}
+	utils.MustMatch(t, want, got)
+}

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -191,7 +191,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	utils.SetFlagBoolVar(fs, &normalizeQueries, "normalize-queries", normalizeQueries, "Rewrite queries with bind vars. Turn this off if the app itself sends normalized queries with bind vars.")
 	fs.BoolVar(&terseErrors, "vtgate-config-terse-errors", terseErrors, "prevent bind vars from escaping in returned errors")
 	fs.IntVar(&truncateErrorLen, "truncate-error-len", truncateErrorLen, "truncate errors sent to client if they are longer than this value (0 means do not truncate)")
-	utils.SetFlagIntVar(fs, &streamBufferSize, "stream-buffer-size", streamBufferSize, "the number of bytes sent from vtgate for each stream call. It's recommended to keep this value in sync with vttablet's query-server-config-stream-buffer-size.")
+	utils.SetFlagIntVar(fs, &streamBufferSize, "stream-buffer-size", streamBufferSize, "the number of bytes sent in each gRPC streaming API response.")
 	utils.SetFlagInt64Var(fs, &queryPlanCacheMemory, "gate-query-cache-memory", queryPlanCacheMemory, "gate server query cache size in bytes, maximum amount of memory to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache.")
 	utils.SetFlagIntVar(fs, &maxMemoryRows, "max-memory-rows", maxMemoryRows, "Maximum number of rows that will be held in memory for intermediate results as well as the final result.")
 	utils.SetFlagIntVar(fs, &warnMemoryRows, "warn-memory-rows", warnMemoryRows, "Warning threshold for in-memory results. A row count higher than this amount will cause the VtGateWarnings.ResultsExceeded counter to be incremented.")
@@ -412,7 +412,6 @@ func Init(
 
 	eConfig := ExecutorConfig{
 		Normalize:                 normalizeQueries,
-		StreamSize:                streamBufferSize,
 		AllowScatter:              !noScatter,
 		PreventCrossKeyspaceReads: preventCrossKeyspaceReads,
 		WarmingReadsPercent:       warmingReadsPercent,

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -263,8 +263,6 @@ func TestVTGateStreamExecute(t *testing.T) {
 	require.NoError(t, err)
 	want := []*sqltypes.Result{{
 		Fields: sandboxconn.StreamRowResult.Fields,
-	}, {
-		Fields: sandboxconn.StreamRowResult.Fields,
 		Rows:   sandboxconn.StreamRowResult.Rows,
 	}}
 	utils.MustMatch(t, want, qrs)


### PR DESCRIPTION
## Description

`Executor.StreamExecute` used to re-buffer every streamed packet: it split fields into a separate metadata packet, copied each row into an accumulator, counted bytes per column, and flushed on the vtgate-side `--stream-buffer-size`. The tablet already batches rows into packets, so this was redundant work on the streaming hot path, and it coupled vtgate's packet sizing to a flag that really only matters to gRPC streaming API consumers.

This forwards each tablet packet to the client callback as it arrives instead. The MySQL protocol layer writes fields from the first packet and rows from every packet, so its wire output is unchanged; gRPC `StreamExecute` API clients now receive packets in the shape the tablet sent them. OK-only packets carry no result-set data the streaming path delivers today, so they're left alone.

Re-chunking to `--stream-buffer-size` now happens only where it's actually needed: at the gRPC service boundary (`grpcvtgateservice`), via a new `StreamResponseChunker` that splits oversized row packets and forwards repeated scatter field metadata only once. The `--stream-buffer-size` flag is rescoped accordingly, and the now-unused `ExecutorConfig.StreamSize` plumbing is removed.

Extracted from the streaming-delivery work in #20378 so it can land on its own.

## Related Issue(s)

Part of #20378.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

Not marked for backport: this changes observable gRPC streaming packet shapes and a flag's meaning, which isn't something a patch release should do.

## Deployment Notes

- `--stream-buffer-size` now means "bytes per gRPC streaming API response" and no longer affects the MySQL protocol path (which streams tablet packets verbatim). Its default is unchanged.
- gRPC `StreamExecute`/`StreamExecuteMulti` clients now receive result packets in the shape the tablet produced them (still bounded by `--stream-buffer-size` at the boundary), rather than vtgate-side re-chunked packets.

### AI Disclosure

This PR was written by Claude Code — I provided direction and reviewed the result.
