### PR TITLE
dbconnpool: coalesce stream fields into the first data packet

### DIFF
--- a/go/vt/dbconnpool/connection.go
+++ b/go/vt/dbconnpool/connection.go
@@ -93,17 +93,24 @@ func (dbc *DBConnection) ExecuteStreamFetch(query string, callback func(*sqltype
 	}
 	defer dbc.CloseResult()
 
-	// first call the callback with the fields
 	flds, err := dbc.Fields()
 	if err != nil {
 		return err
 	}
-	err = callback(&sqltypes.Result{Fields: flds})
-	if err != nil {
-		return fmt.Errorf("stream send error: %v", err)
+
+	// Coalesce the field metadata into the first data packet instead of sending
+	// it as a separate packet up front: results that fit within a single stream
+	// buffer (the common case) then take one packet instead of two.
+	fieldsSent := false
+	sendResult := func(qr *sqltypes.Result) error {
+		if !fieldsSent {
+			fieldsSent = true
+			qr.Fields = flds
+		}
+		return callback(qr)
 	}
 
-	// then get all the rows, sending them as we reach a decent packet size
+	// get all the rows, sending them as we reach a decent packet size
 	// start with a pre-allocated array of 256 rows capacity
 	qr := alloc()
 	byteCount := 0
@@ -122,9 +129,9 @@ func (dbc *DBConnection) ExecuteStreamFetch(query string, callback func(*sqltype
 		}
 
 		if byteCount >= streamBufferSize {
-			err = callback(qr)
+			err = sendResult(qr)
 			if err != nil {
-				return err
+				return fmt.Errorf("stream send error: %v", err)
 			}
 
 			qr = alloc()
@@ -132,10 +139,12 @@ func (dbc *DBConnection) ExecuteStreamFetch(query string, callback func(*sqltype
 		}
 	}
 
-	if len(qr.Rows) > 0 {
-		err = callback(qr)
+	// Send any leftover rows; if nothing was sent yet, this also delivers the
+	// fields as the sole packet of the stream.
+	if len(qr.Rows) > 0 || !fieldsSent {
+		err = sendResult(qr)
 		if err != nil {
-			return err
+			return fmt.Errorf("stream send error: %v", err)
 		}
 	}
 


### PR DESCRIPTION
## Description

`ExecuteStreamFetch` sent the field metadata as its own packet up front, then streamed row packets. This coalesces the fields into the first data packet instead, so a result that fits within a single stream buffer (the common case) takes one packet instead of two. If the result has no rows, the fields still go out as the sole packet.

Extracted from the streaming work in #20378 so it can land on its own; it's a standalone optimization and not a prerequisite for that PR.

## Related Issue(s)

Extracted from #20378.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

Not marked for backport: it's a performance change to the streaming path, not a fix a patch release needs. (`go/vt/dbconnpool` has no test files today; verified via build and the callers' streaming tests.)

## Deployment Notes

The MySQL/gRPC wire output is unchanged; only the internal packet boundary between fields and the first rows moves. Field metadata is still delivered before any rows.

### AI Disclosure

This PR was written by Claude Code — I provided direction and reviewed the result.
