### PR TITLE
tabletserver: de-flake disk health monitor poll-count tests

### DIFF
--- a/go/vt/vttablet/tabletserver/disk_health_monitor_test.go
+++ b/go/vt/vttablet/tabletserver/disk_health_monitor_test.go
@@ -30,9 +30,13 @@ func TestDiskHealthMonitor_noStall(t *testing.T) {
 	mockFileWriter := &sequencedMockWriter{}
 	diskHealthMonitor := newPollingDiskHealthMonitor(ctx, mockFileWriter.mockWriteFunction, 50*time.Millisecond, 25*time.Millisecond)
 
-	time.Sleep(300 * time.Millisecond)
-	totalCreateCalls := mockFileWriter.getTotalCreateCalls()
-	require.Equalf(t, 5, totalCreateCalls, "expected 5 calls to createFile, got %d", totalCreateCalls)
+	// The monitor keeps polling. The exact number of polls in a fixed window is
+	// timing-dependent (each cycle spans the polling interval plus the write
+	// duration), so wait for repeated polls rather than asserting an exact count.
+	require.Eventually(t, func() bool {
+		return mockFileWriter.getTotalCreateCalls() >= 5
+	}, 30*time.Second, 10*time.Millisecond, "expected the monitor to keep polling")
+	// A fast, error-free write is never treated as a stall.
 	require.False(t, diskHealthMonitor.IsDiskStalled(), "expected isStalled to be false")
 }
 
@@ -57,10 +61,12 @@ func TestDiskHealthMonitor_stallDetected(t *testing.T) {
 	mockFileWriter := &sequencedMockWriter{defaultWriteFunction: delayedWriteFunction(10*time.Millisecond, errors.New("test error"))}
 	diskHealthMonitor := newPollingDiskHealthMonitor(ctx, mockFileWriter.mockWriteFunction, 50*time.Millisecond, 25*time.Millisecond)
 
-	time.Sleep(300 * time.Millisecond)
-	totalCreateCalls := mockFileWriter.getTotalCreateCalls()
-	require.Equalf(t, 5, totalCreateCalls, "expected 5 calls to createFile, got %d", totalCreateCalls)
-	require.True(t, diskHealthMonitor.IsDiskStalled(), "expected isStalled to be true")
+	// A write function that always errors is reported as a stall once the monitor
+	// has polled. The exact number of polls in a fixed window is timing-dependent,
+	// so wait for repeated polls and a stall rather than asserting an exact count.
+	require.Eventually(t, func() bool {
+		return mockFileWriter.getTotalCreateCalls() >= 5 && diskHealthMonitor.IsDiskStalled()
+	}, 30*time.Second, 10*time.Millisecond, "expected the monitor to report a stall")
 }
 
 type sequencedMockWriter struct {


### PR DESCRIPTION
## Description

`TestDiskHealthMonitor_noStall` and `TestDiskHealthMonitor_stallDetected` are timing-flaky. Both do `time.Sleep(300ms)` and then assert an **exact** poll count of 5.

The poll loop re-arms its interval timer only *after* each write completes, so the effective period is `interval + write duration + scheduling overhead`, not the interval alone. With the tests' 50ms interval and 10ms write that's ~63ms per cycle, and `300ms / 63ms` rounds down to **4** polls — one short of the hard-coded 5. On hosts with faster/finer timers it lands on 5 and passes, which is why it's environment-dependent (it reproduces reliably in an OrbStack devcontainer, for example).

The fix swaps the `time.Sleep` + exact-count assertion for `require.Eventually`, waiting for repeated polls instead of a precise number. This matches the already-robust `TestDiskHealthMonitor_stallAndRecover`, which uses `GreaterOrEqual`. The production polling code is untouched — only the tests change.

## Related Issue(s)

None.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

This PR was written by Claude Code (Opus 4.8) — I diagnosed the flake with it and it wrote the fix; I reviewed and directed.
