### PR TITLE
vtgate: prefer shard-computed values for ungrouped constant aggregations

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -27,6 +27,7 @@
         - [PREPARE statements no longer report the prepared statement's tables](#vtgate-prepare-tables-used)
         - [Preparing a statement no longer starts an implicit transaction](#vtgate-prepare-no-implicit-tx)
         - [Stricter validation of SQL-level PREPARE statements](#vtgate-prepare-stricter-validation)
+        - [Constant expressions in cross-shard aggregations return shard-computed values](#vtgate-constant-aggregation-shard-values)
     - **[VTTablet](#minor-changes-vttablet)**
         - [Consolidator Reject on Waiter Cap](#vttablet-consolidator-reject-on-cap)
         - [Query timeout for state-changing statements on the streaming path](#vttablet-stream-query-timeout)
@@ -246,6 +247,10 @@ SQL-level `PREPARE` and binary-protocol `COM_STMT_PREPARE` now reject statement 
 Additionally, `PREPARE ... FROM ?` is now a syntax error, matching MySQL: the grammar accidentally accepted a positional parameter as the statement text, but no value could ever reach it and the statement always failed. This also affects programs that parse SQL using the `go/vt/sqlparser` package directly.
 
 See [#20562](https://github.com/vitessio/vitess/pull/20562) for details.
+
+#### <a id="vtgate-constant-aggregation-shard-values"/>Constant expressions in cross-shard aggregations return shard-computed values</a>
+
+When a cross-shard aggregation query selects a constant expression alongside aggregate functions (e.g. `select count(*), <constant-expression> from t`), VTGate previously re-evaluated the constant expression itself, even though the expression is also computed by MySQL on every shard. For the rare expressions where VTGate's evaluation engine and MySQL disagree, this silently returned a different value than every shard computed. VTGate now returns the value computed by the shards, and only evaluates the expression itself when the input is empty — where a scalar aggregate must still produce a row containing the constant.
 
 ### <a id="minor-changes-vttablet"/>VTTablet</a>
 

--- a/go/vt/vtgate/engine/aggregations.go
+++ b/go/vt/vtgate/engine/aggregations.go
@@ -280,16 +280,35 @@ func (a *aggregatorScalar) reset() {
 	a.hasValue = false
 }
 
+// aggregatorConstant returns the value the shards computed for a constant expression,
+// captured from the first input row. The expression is only evaluated at the vtgate
+// level when no input row arrived, so that a scalar aggregate over an empty input
+// still produces a row containing the constant.
 type aggregatorConstant struct {
-	expr evalengine.Expr
+	from     int
+	expr     evalengine.Expr
+	current  sqltypes.Value
+	hasValue bool
 }
 
-func (*aggregatorConstant) add([]sqltypes.Value) error {
+func (a *aggregatorConstant) add(row []sqltypes.Value) error {
+	if !a.hasValue {
+		a.current = row[a.from]
+		a.hasValue = true
+	}
 	return nil
 }
 
 func (a *aggregatorConstant) finish(env *evalengine.ExpressionEnv, coll collations.ID) (sqltypes.Value, error) {
+	if a.hasValue {
+		return a.current, nil
+	}
 	return eval(env, a.expr, coll)
+}
+
+func (a *aggregatorConstant) reset() {
+	a.current = sqltypes.NULL
+	a.hasValue = false
 }
 
 func eval(env *evalengine.ExpressionEnv, eexpr evalengine.Expr, coll collations.ID) (sqltypes.Value, error) {
@@ -300,8 +319,6 @@ func eval(env *evalengine.ExpressionEnv, eexpr evalengine.Expr, coll collations.
 
 	return v.Value(coll), nil
 }
-
-func (*aggregatorConstant) reset() {}
 
 type aggregatorGroupConcat struct {
 	from      int
@@ -505,7 +522,7 @@ func newAggregation(fields []*querypb.Field, aggregates []*AggregateParams, env 
 			}
 
 		case opcode.AggregateConstant:
-			ag = &aggregatorConstant{expr: aggr.EExpr}
+			ag = &aggregatorConstant{from: aggr.Col, expr: aggr.EExpr}
 
 		default:
 			panic("BUG: unexpected Aggregation opcode")

--- a/go/vt/vtgate/engine/ordered_aggregate_test.go
+++ b/go/vt/vtgate/engine/ordered_aggregate_test.go
@@ -109,6 +109,50 @@ func TestOrderedAggregateExecuteTruncate(t *testing.T) {
 	utils.MustMatch(t, wantResult, result)
 }
 
+// TestOrderedAggregateConstantAggrPerGroup checks that a grouped constant aggregation captures
+// the first-row value of each group, with the captured value reset between groups.
+func TestOrderedAggregateConstantAggrPerGroup(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"col|count(*)|const",
+		"varbinary|int64|int64",
+	)
+	fp := &fakePrimitive{
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(fields,
+			"a|1|10",
+			"a|2|10",
+			"b|5|20",
+		)},
+	}
+
+	countAggr := NewAggregateParam(AggregateSum, 1, nil, "", collations.MySQL8())
+	countAggr.OrigOpcode = AggregateCountStar
+	// the expression deliberately evaluates to a different value than the ones returned by the
+	// shards, to prove that each group returns its own captured shard value
+	constAggr := NewAggregateParam(AggregateConstant, 2, evalengine.NewLiteralInt(99), "", collations.MySQL8())
+
+	oa := &OrderedAggregate{
+		Aggregates:  []*AggregateParams{countAggr, constAggr},
+		GroupByKeys: []*GroupByParams{{KeyCol: 0}},
+		Input:       fp,
+	}
+
+	result, err := oa.TryExecute(t.Context(), &noopVCursor{}, nil, false)
+	require.NoError(t, err)
+	assert.Equal(t, `[[VARBINARY("a") INT64(3) INT64(10)] [VARBINARY("b") INT64(5) INT64(20)]]`, fmt.Sprintf("%v", result.Rows))
+
+	fp.rewind()
+	results := &sqltypes.Result{}
+	err = oa.TryStreamExecute(t.Context(), &noopVCursor{}, nil, true, func(qr *sqltypes.Result) error {
+		if qr.Fields != nil {
+			results.Fields = qr.Fields
+		}
+		results.Rows = append(results.Rows, qr.Rows...)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, `[[VARBINARY("a") INT64(3) INT64(10)] [VARBINARY("b") INT64(5) INT64(20)]]`, fmt.Sprintf("%v", results.Rows))
+}
+
 func TestMinMaxFailsCorrectly(t *testing.T) {
 	fp := &fakePrimitive{
 		results: []*sqltypes.Result{sqltypes.MakeTestResult(

--- a/go/vt/vtgate/engine/scalar_aggregation_test.go
+++ b/go/vt/vtgate/engine/scalar_aggregation_test.go
@@ -29,6 +29,7 @@ import (
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/sqlparser"
 	. "vitess.io/vitess/go/vt/vtgate/engine/opcode"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
 )
 
 func TestEmptyRows(outer *testing.T) {
@@ -141,6 +142,122 @@ func TestScalarAggregateStreamExecute(t *testing.T) {
 
 	got := fmt.Sprintf("%v", results[1].Rows)
 	assert.Equal(t, "[[DECIMAL(4)]]", got)
+}
+
+// TestScalarConstantAggrPrefersShardValue checks that a constant aggregation returns the value
+// computed by the shards instead of re-evaluating the expression at the vtgate level.
+func TestScalarConstantAggrPrefersShardValue(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"count(*)|const",
+		"int64|int64",
+	)
+	fp := &fakePrimitive{
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(fields,
+			"1|5",
+			"3|5",
+		)},
+	}
+
+	countAggr := NewAggregateParam(AggregateSum, 0, nil, "count(*)", collations.MySQL8())
+	countAggr.OrigOpcode = AggregateCountStar
+	// the expression deliberately evaluates to a different value than the one returned by the
+	// shards, to prove that the shard value is the one returned
+	constAggr := NewAggregateParam(AggregateConstant, 1, evalengine.NewLiteralInt(2), "const", collations.MySQL8())
+
+	oa := &ScalarAggregate{
+		Aggregates: []*AggregateParams{countAggr, constAggr},
+		Input:      fp,
+	}
+
+	qr, err := oa.TryExecute(t.Context(), &noopVCursor{}, nil, false)
+	require.NoError(t, err)
+	assert.Equal(t, `[[INT64(4) INT64(5)]]`, fmt.Sprintf("%v", qr.Rows))
+}
+
+// TestScalarConstantAggrEmptyInput checks that a constant aggregation falls back to evaluating
+// the expression when the input has no rows.
+func TestScalarConstantAggrEmptyInput(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"const",
+		"int64",
+	)
+	fp := &fakePrimitive{
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(fields)},
+	}
+
+	oa := &ScalarAggregate{
+		Aggregates: []*AggregateParams{
+			NewAggregateParam(AggregateConstant, 0, evalengine.NewLiteralInt(2), "const", collations.MySQL8()),
+		},
+		Input: fp,
+	}
+
+	qr, err := oa.TryExecute(t.Context(), &noopVCursor{}, nil, false)
+	require.NoError(t, err)
+	assert.Equal(t, `[[INT64(2)]]`, fmt.Sprintf("%v", qr.Rows))
+}
+
+// TestScalarConstantAggrNullShardValue checks that a NULL returned by the shards is a legitimate
+// captured value for a constant aggregation and does not trigger expression evaluation.
+func TestScalarConstantAggrNullShardValue(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"const",
+		"int64",
+	)
+	fp := &fakePrimitive{
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(fields,
+			"null",
+		)},
+	}
+
+	oa := &ScalarAggregate{
+		Aggregates: []*AggregateParams{
+			NewAggregateParam(AggregateConstant, 0, evalengine.NewLiteralInt(2), "const", collations.MySQL8()),
+		},
+		Input: fp,
+	}
+
+	qr, err := oa.TryExecute(t.Context(), &noopVCursor{}, nil, false)
+	require.NoError(t, err)
+	assert.Equal(t, `[[NULL]]`, fmt.Sprintf("%v", qr.Rows))
+}
+
+// TestScalarConstantAggrStreamExecute checks that a constant aggregation returns the value
+// computed by the shards on the streaming path.
+func TestScalarConstantAggrStreamExecute(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"count(*)|const",
+		"int64|int64",
+	)
+	fp := &fakePrimitive{
+		allResultsInOneCall: true,
+		results: []*sqltypes.Result{
+			sqltypes.MakeTestResult(fields,
+				"1|5",
+			), sqltypes.MakeTestResult(fields,
+				"3|5",
+			),
+		},
+	}
+
+	countAggr := NewAggregateParam(AggregateSum, 0, nil, "count(*)", collations.MySQL8())
+	countAggr.OrigOpcode = AggregateCountStar
+	constAggr := NewAggregateParam(AggregateConstant, 1, evalengine.NewLiteralInt(2), "const", collations.MySQL8())
+
+	oa := &ScalarAggregate{
+		Aggregates: []*AggregateParams{countAggr, constAggr},
+		Input:      fp,
+	}
+
+	var results []*sqltypes.Result
+	err := oa.TryStreamExecute(t.Context(), &noopVCursor{}, nil, true, func(qr *sqltypes.Result) error {
+		results = append(results, qr)
+		return nil
+	})
+	require.NoError(t, err)
+	// one for the fields, and one for the actual aggregation result
+	require.Len(t, results, 2, "number of results")
+	assert.Equal(t, `[[INT64(4) INT64(5)]]`, fmt.Sprintf("%v", results[1].Rows))
 }
 
 // TestScalarAggregateExecuteTruncate checks if truncate works


### PR DESCRIPTION
## Description

When a scatter query selects a constant expression next to an aggregate, for example `select count(*), <constant> from user`, the constant becomes an `AggregateConstant` aggregation. The expression is pushed into every shard query, so MySQL computes it with real MySQL semantics, but the vtgate aggregation layer then throws those shard values away and re-evaluates the expression with the evalengine. Wherever the evalengine and MySQL disagree, vtgate silently returns a value that no shard computed. A concrete case verified against MySQL 8.0.34, 8.4.6 and 8.4.10: `select count(*), case 0 when json_array() then 1 when '0' then 2 else 3 end from user` on a sharded keyspace returns 2 from vtgate where every MySQL shard computes 1, because the evalengine does not reproduce MySQL's comparison-domain coercion for simple CASE.

This PR makes `AggregateConstant` capture the value from the first input row, the way ANY_VALUE would, and return that at finish. The expression is only evaluated at the vtgate level when no input row arrived at all, preserving the empty-input semantics where a scalar aggregate query with no rows must still produce one row containing the constant. A captured NULL counts as a value, and grouped aggregation resets the capture per group on both the execute and streaming paths. Plan shapes are unchanged, so no golden files move, and the divergence class disappears for any query that returns at least one row.

## Related Issue(s)

The underlying evalengine comparison-domain divergence will be reported separately; this change removes the constant-aggregation path's exposure to it independently of that fix.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Constant select expressions in cross-shard aggregation queries now return the value the shards computed instead of a vtgate re-evaluation. For the small class of expressions where the two engines disagree, results change to match MySQL whenever at least one row is aggregated. No migrations or configuration changes.

### AI Disclosure

This PR was written primarily by Fable with review from GPT 5.6 Sol.
