### PR TITLE
evalengine: support constant-folded JSON values as literals

### DIFF
--- a/go/mysql/json/clone.go
+++ b/go/mysql/json/clone.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package json
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Clone returns a deep copy of v: arrays and objects are copied recursively,
+// so in-place updates on one value never affect the other. Leaf payloads are
+// shared, except raw strings not yet unescaped: Type rewrites their backing
+// bytes in place, so they are copied. The lazily cached number type needs no
+// copy, since NumberType writes it to a field each clone owns; a value cloned
+// while other goroutines can reach it must have had its number types resolved
+// first (ResolveNumberTypes), since Clone reads the field that NumberType's
+// lazy classification writes.
+func (v *Value) Clone() *Value {
+	switch v.t {
+	case TypeObject:
+		kvs := make([]kv, len(v.o.kvs))
+		for i, item := range v.o.kvs {
+			kvs[i] = kv{k: item.k, v: item.v.Clone()}
+		}
+		return &Value{o: Object{kvs: kvs}, t: TypeObject}
+	case TypeArray:
+		a := make([]*Value, len(v.a))
+		for i, item := range v.a {
+			a[i] = item.Clone()
+		}
+		return &Value{a: a, t: TypeArray}
+	case TypeBoolean, TypeNull:
+		// ValueTrue, ValueFalse and ValueNull are immutable singletons
+		// whose pointer identity is meaningful.
+		return v
+	case typeRawString:
+		return &Value{s: strings.Clone(v.s), t: typeRawString}
+	case TypeString, TypeNumber, TypeDate, TypeTime, TypeDateTime, TypeOpaque, TypeBit, TypeBlob:
+		return &Value{s: v.s, t: v.t, n: v.n}
+	default:
+		panic(fmt.Errorf("BUG: unexpected Value type: %d", v.t))
+	}
+}

--- a/go/mysql/json/clone.go
+++ b/go/mysql/json/clone.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package json
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Clone returns a deep copy of v: arrays and objects are copied recursively,
+// so in-place updates on one value never affect the other. Leaf payloads are
+// shared, except raw strings not yet unescaped: Type rewrites their backing
+// bytes in place, so they are copied. The lazily cached number type needs no
+// copy, since NumberType writes it to a field each clone owns.
+func (v *Value) Clone() *Value {
+	switch v.t {
+	case TypeObject:
+		kvs := make([]kv, len(v.o.kvs))
+		for i, item := range v.o.kvs {
+			kvs[i] = kv{k: item.k, v: item.v.Clone()}
+		}
+		return &Value{o: Object{kvs: kvs}, t: TypeObject}
+	case TypeArray:
+		a := make([]*Value, len(v.a))
+		for i, item := range v.a {
+			a[i] = item.Clone()
+		}
+		return &Value{a: a, t: TypeArray}
+	case TypeBoolean, TypeNull:
+		// ValueTrue, ValueFalse and ValueNull are immutable singletons
+		// whose pointer identity is meaningful.
+		return v
+	case typeRawString:
+		return &Value{s: strings.Clone(v.s), t: typeRawString}
+	case TypeString, TypeNumber, TypeDate, TypeTime, TypeDateTime, TypeOpaque, TypeBit, TypeBlob:
+		return &Value{s: v.s, t: v.t, n: v.n}
+	default:
+		panic(fmt.Errorf("BUG: unexpected Value type: %d", v.t))
+	}
+}

--- a/go/mysql/json/clone_test.go
+++ b/go/mysql/json/clone_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package json
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloneSingletons(t *testing.T) {
+	// The boolean and null singletons are compared by pointer identity,
+	// so Clone must preserve them.
+	assert.Same(t, ValueTrue, ValueTrue.Clone())
+	assert.Same(t, ValueFalse, ValueFalse.Clone())
+	assert.Same(t, ValueNull, ValueNull.Clone())
+}
+
+func TestCloneMutationIndependence(t *testing.T) {
+	t.Run("mutating the clone does not affect the original", func(t *testing.T) {
+		original := MustParse(`{"a": [1, 2, 3], "o": {"x": [4, 5]}, "s": "keep"}`)
+		want := original.String()
+
+		clone := original.Clone()
+		require.Equal(t, want, clone.String())
+
+		obj, ok := clone.Object()
+		require.True(t, ok)
+		obj.Get("a").DelArrayItem(0)
+		obj.Get("a").SetArrayItem(1, MustParse(`42`), Set)
+		nested, ok := obj.Get("o").Object()
+		require.True(t, ok)
+		nested.Del("x")
+		nested.Set("y", MustParse(`"new"`), Set)
+		obj.Del("s")
+
+		assert.Equal(t, `{"a": [2, 42], "o": {"y": "new"}}`, clone.String())
+		assert.Equal(t, want, original.String())
+	})
+
+	t.Run("mutating the original does not affect the clone", func(t *testing.T) {
+		original := MustParse(`{"a": [1, 2, 3], "o": {"x": [4, 5]}}`)
+		clone := original.Clone()
+		want := clone.String()
+
+		obj, ok := original.Object()
+		require.True(t, ok)
+		obj.Get("a").DelArrayItem(2)
+		obj.Set("b", MustParse(`[6]`), Set)
+		nested, ok := obj.Get("o").Object()
+		require.True(t, ok)
+		nested.Set("x", MustParse(`7`), Replace)
+
+		assert.Equal(t, `{"a": [1, 2], "b": [6], "o": {"x": 7}}`, original.String())
+		assert.Equal(t, want, clone.String())
+	})
+}
+
+func TestCloneKindPreservation(t *testing.T) {
+	values := []*Value{
+		NewNumber("1.5", NumberTypeDecimal),
+		NewNumber("18446744073709551615", NumberTypeUnsigned),
+		NewNumber("-42", NumberTypeSigned),
+		NewNumber("1.5e10", NumberTypeFloat),
+		NewString("foo"),
+		NewBlob("\x00\x01"),
+		NewBit("\x81"),
+		NewDate("2023-10-12"),
+		NewTime("14:35:02"),
+		NewDateTime("2023-10-12 14:35:02"),
+		NewOpaqueValue("opaque"),
+		ValueTrue,
+		ValueFalse,
+		ValueNull,
+	}
+	original := NewArray(values)
+	clone := original.Clone()
+
+	cloned, ok := clone.Array()
+	require.True(t, ok)
+	require.Len(t, cloned, len(values))
+	for i, v := range values {
+		assert.Equal(t, v.Type(), cloned[i].Type())
+		assert.Equal(t, v.NumberType(), cloned[i].NumberType())
+		assert.Equal(t, v.Raw(), cloned[i].Raw())
+	}
+}
+
+func TestCloneRawStrings(t *testing.T) {
+	// Type lazily unescapes raw strings by rewriting their backing bytes in
+	// place; the clone must own its bytes so that unescaping one value
+	// cannot corrupt the other.
+	original := MustParse(`["fo\no"]`)
+	clone := original.Clone()
+
+	cloned, ok := clone.Array()
+	require.True(t, ok)
+	s, ok := cloned[0].StringBytes()
+	require.True(t, ok)
+	assert.Equal(t, "fo\no", string(s))
+
+	arr, ok := original.Array()
+	require.True(t, ok)
+	s, ok = arr[0].StringBytes()
+	require.True(t, ok)
+	assert.Equal(t, "fo\no", string(s))
+}

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -1334,6 +1334,27 @@ func parseNumberType(ns string) NumberType {
 	return NumberTypeUnknown
 }
 
+// ResolveNumberTypes classifies every number in the document, in place.
+// Parsed numbers are classified lazily: the first NumberType call writes the
+// classification back to the value. A document that will be shared between
+// goroutines — such as a constant folded into a cached plan — must resolve
+// its number types first, while a single goroutine still owns it, so that
+// concurrent readers never race that write.
+func (v *Value) ResolveNumberTypes() {
+	switch v.t {
+	case TypeObject:
+		for _, item := range v.o.kvs {
+			item.v.ResolveNumberTypes()
+		}
+	case TypeArray:
+		for _, item := range v.a {
+			item.ResolveNumberTypes()
+		}
+	case TypeNumber:
+		v.NumberType()
+	}
+}
+
 func (v *Value) Int64() (int64, bool) {
 	i, err := fastparse.ParseInt64(v.s, 10)
 	if err != nil {

--- a/go/mysql/json/parser_test.go
+++ b/go/mysql/json/parser_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/hack"
@@ -808,5 +809,55 @@ func TestMarshalToBlob(t *testing.T) {
 		var obj Object
 		obj.Add("k", NewBlob("foo"))
 		require.Equal(t, `{"k": `+encoded+`}`, string(NewObject(obj).MarshalTo(nil)))
+	})
+}
+
+// TestResolveNumberTypes verifies that resolving a parsed document classifies
+// every nested number in place, so a later NumberType call never has to write,
+// and that explicitly constructed numbers keep their declared type.
+func TestResolveNumberTypes(t *testing.T) {
+	t.Run("parsed", func(t *testing.T) {
+		v := MustParse(`{"i": -1, "u": 18446744073709551615, "f": 1.5e300, "a": [7, {"n": 2.5}], "s": "no number"}`)
+
+		var rawNumbers func(v *Value) int
+		rawNumbers = func(v *Value) int {
+			switch v.t {
+			case TypeObject:
+				var raw int
+				for _, item := range v.o.kvs {
+					raw += rawNumbers(item.v)
+				}
+				return raw
+			case TypeArray:
+				var raw int
+				for _, item := range v.a {
+					raw += rawNumbers(item)
+				}
+				return raw
+			case TypeNumber:
+				if v.n == numberTypeRaw {
+					return 1
+				}
+				return 0
+			default:
+				return 0
+			}
+		}
+		require.Equal(t, 5, rawNumbers(v), "parsed numbers must start out lazily classified")
+
+		v.ResolveNumberTypes()
+		assert.Zero(t, rawNumbers(v))
+
+		obj, ok := v.Object()
+		require.True(t, ok)
+		assert.Equal(t, NumberTypeSigned, obj.Get("i").NumberType())
+		assert.Equal(t, NumberTypeUnsigned, obj.Get("u").NumberType())
+		assert.Equal(t, NumberTypeFloat, obj.Get("f").NumberType())
+	})
+
+	t.Run("constructed", func(t *testing.T) {
+		v := NewArray([]*Value{NewNumber("1.5", NumberTypeDecimal)})
+		v.ResolveNumberTypes()
+		assert.Equal(t, NumberTypeDecimal, v.a[0].NumberType())
 	})
 }

--- a/go/vt/vtgate/engine/projection_test.go
+++ b/go/vt/vtgate/engine/projection_test.go
@@ -75,6 +75,41 @@ func TestMultiply(t *testing.T) {
 	assert.Equal(t, "[[UINT64(6)] [UINT64(0)] [UINT64(2)]]", fmt.Sprintf("%v", qr.Rows))
 }
 
+// TestProjectionFoldedJSONLiteral processes several rows through a Projection
+// whose expression contains a constant-folded JSON literal; JSON_REMOVE
+// mutates in place, so every row must see the pristine literal.
+func TestProjectionFoldedJSONLiteral(t *testing.T) {
+	fields := evalengine.FieldResolver([]*querypb.Field{
+		{Name: "p", Type: sqltypes.VarChar, Charset: collations.CollationUtf8mb4ID},
+	})
+	astExpr, err := sqlparser.NewTestParser().ParseExpr(`json_remove(json_array(1, 2, 3), p)`)
+	require.NoError(t, err)
+	evalExpr, err := evalengine.Translate(astExpr, &evalengine.Config{
+		ResolveColumn: fields.Column,
+		ResolveType:   fields.Type,
+		Environment:   vtenv.NewTestEnv(),
+		Collation:     collations.MySQL8().DefaultConnectionCharset(),
+	})
+	require.NoError(t, err)
+	fp := &fakePrimitive{
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(
+			sqltypes.MakeTestFields("p", "varchar"),
+			"$[0]",
+			"$[1]",
+			"$[2]",
+		)},
+	}
+	proj := &Projection{
+		Cols:       []string{"j"},
+		Exprs:      []evalengine.Expr{evalExpr},
+		Input:      fp,
+		noTxNeeded: noTxNeeded{},
+	}
+	qr, err := proj.TryExecute(t.Context(), &noopVCursor{}, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+	assert.Equal(t, `[[JSON("[2, 3]")] [JSON("[1, 3]")] [JSON("[1, 2]")]]`, fmt.Sprintf("%v", qr.Rows))
+}
+
 func TestProjectionStreaming(t *testing.T) {
 	expr := &sqlparser.BinaryExpr{
 		Operator: sqlparser.MultOp,

--- a/go/vt/vtgate/evalengine/compiler_asm_push.go
+++ b/go/vt/vtgate/evalengine/compiler_asm_push.go
@@ -589,6 +589,14 @@ func (asm *assembler) PushLiteral(lit eval) error {
 			env.vm.sp++
 			return 1
 		}, "PUSH TIME|DATETIME|DATE(%q)", lit.ToRawBytes())
+	case *evalJSON:
+		asm.emit(func(env *ExpressionEnv) int {
+			// JSON functions mutate documents in place; each execution
+			// of the compiled program must own its copy of the literal.
+			env.vm.stack[env.vm.sp] = lit.Clone()
+			env.vm.sp++
+			return 1
+		}, "PUSH JSON(%s)", lit.ToRawBytes())
 	default:
 		return vterrors.Errorf(vtrpc.Code_UNIMPLEMENTED, "unsupported literal kind '%T'", lit)
 	}

--- a/go/vt/vtgate/evalengine/compiler_asm_push.go
+++ b/go/vt/vtgate/evalengine/compiler_asm_push.go
@@ -589,6 +589,14 @@ func (asm *assembler) PushLiteral(lit eval) error {
 			env.vm.sp++
 			return 1
 		}, "PUSH TIME|DATETIME|DATE(%q)", lit.ToRawBytes())
+	case *evalJSON:
+		asm.emit(func(env *ExpressionEnv) int {
+			// JSON functions mutate documents in place; each execution
+			// of the compiled program must own its copy of the literal.
+			env.vm.stack[env.vm.sp] = lit.Clone()
+			env.vm.sp++
+			return 1
+		}, "PUSH JSON(%q)", lit.ToRawBytes())
 	default:
 		return vterrors.Errorf(vtrpc.Code_UNIMPLEMENTED, "unsupported literal kind '%T'", lit)
 	}

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -1129,3 +1129,69 @@ func TestCompilerNonConstant(t *testing.T) {
 		})
 	}
 }
+
+// TestJSONInStaticTable checks that IN over folded JSON literals does not
+// compile the static hash table: JSON arrays and objects hash by kind and
+// cardinality only, so a hash hit is not equality. Compilation fails until
+// the compiler learns to push JSON literals; the follow-up literal change
+// flips this test to compiled evaluation.
+func TestJSONInStaticTable(t *testing.T) {
+	testCases := []struct {
+		expression string
+		values     []sqltypes.Value
+		result     string
+	}{
+		{
+			expression: `column0 IN (JSON_ARRAY(2))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 IN (JSON_OBJECT('b', 2))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`{"a": 1}`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 IN (JSON_ARRAY(1))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 IN (JSON_OBJECT('a', 1))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`{"a": 1}`))},
+			result:     `INT64(1)`,
+		},
+	}
+
+	venv := vtenv.NewTestEnv()
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			expr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+
+			fields := evalengine.FieldResolver(makeFields(tc.values))
+			cfg := &evalengine.Config{
+				ResolveColumn: fields.Column,
+				Collation:     collations.CollationUtf8mb4ID,
+				Environment:   venv,
+			}
+
+			translated, err := evalengine.Translate(expr, cfg)
+			require.NoError(t, err)
+
+			untyped, ok := translated.(*evalengine.UntypedExpr)
+			require.True(t, ok)
+
+			env := evalengine.EmptyExpressionEnv(venv)
+			env.Row = tc.values
+			env.Fields = makeFields(tc.values)
+
+			res, err := env.EvaluateAST(untyped)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, res.String())
+
+			_, err = untyped.Compile(env)
+			require.ErrorContains(t, err, "unsupported literal kind")
+		})
+	}
+}

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -1102,9 +1102,8 @@ func TestCompilerNonConstant(t *testing.T) {
 
 // TestJSONInStaticTable checks that IN over folded JSON literals does not
 // compile the static hash table: JSON arrays and objects hash by kind and
-// cardinality only, so a hash hit is not equality. Compilation fails until
-// the compiler learns to push JSON literals; the follow-up literal change
-// flips this test to compiled evaluation.
+// cardinality only, so a hash hit is not equality. The compiled comparison
+// must agree with AST evaluation.
 func TestJSONInStaticTable(t *testing.T) {
 	testCases := []struct {
 		expression string
@@ -1160,8 +1159,12 @@ func TestJSONInStaticTable(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tc.result, res.String())
 
-			_, err = untyped.Compile(env)
-			require.ErrorContains(t, err, "unsupported literal kind")
+			compiled, err := untyped.Compile(env)
+			require.NoError(t, err)
+
+			res, err = env.EvaluateVM(compiled)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, res.String())
 		})
 	}
 }

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -1099,3 +1099,69 @@ func TestCompilerNonConstant(t *testing.T) {
 		})
 	}
 }
+
+// TestJSONInStaticTable checks that IN over folded JSON literals does not
+// compile the static hash table: JSON arrays and objects hash by kind and
+// cardinality only, so a hash hit is not equality. Compilation fails until
+// the compiler learns to push JSON literals; the follow-up literal change
+// flips this test to compiled evaluation.
+func TestJSONInStaticTable(t *testing.T) {
+	testCases := []struct {
+		expression string
+		values     []sqltypes.Value
+		result     string
+	}{
+		{
+			expression: `column0 IN (JSON_ARRAY(2))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 IN (JSON_OBJECT('b', 2))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`{"a": 1}`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 IN (JSON_ARRAY(1))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 IN (JSON_OBJECT('a', 1))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`{"a": 1}`))},
+			result:     `INT64(1)`,
+		},
+	}
+
+	venv := vtenv.NewTestEnv()
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			expr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+
+			fields := evalengine.FieldResolver(makeFields(tc.values))
+			cfg := &evalengine.Config{
+				ResolveColumn: fields.Column,
+				Collation:     collations.CollationUtf8mb4ID,
+				Environment:   venv,
+			}
+
+			translated, err := evalengine.Translate(expr, cfg)
+			require.NoError(t, err)
+
+			untyped, ok := translated.(*evalengine.UntypedExpr)
+			require.True(t, ok)
+
+			env := evalengine.EmptyExpressionEnv(venv)
+			env.Row = tc.values
+			env.Fields = makeFields(tc.values)
+
+			res, err := env.EvaluateAST(untyped)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, res.String())
+
+			_, err = untyped.Compile(env)
+			require.ErrorContains(t, err, "unsupported literal kind")
+		})
+	}
+}

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -1132,9 +1132,8 @@ func TestCompilerNonConstant(t *testing.T) {
 
 // TestJSONInStaticTable checks that IN over folded JSON literals does not
 // compile the static hash table: JSON arrays and objects hash by kind and
-// cardinality only, so a hash hit is not equality. Compilation fails until
-// the compiler learns to push JSON literals; the follow-up literal change
-// flips this test to compiled evaluation.
+// cardinality only, so a hash hit is not equality. The compiled comparison
+// must agree with AST evaluation.
 func TestJSONInStaticTable(t *testing.T) {
 	testCases := []struct {
 		expression string
@@ -1190,8 +1189,12 @@ func TestJSONInStaticTable(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tc.result, res.String())
 
-			_, err = untyped.Compile(env)
-			require.ErrorContains(t, err, "unsupported literal kind")
+			compiled, err := untyped.Compile(env)
+			require.NoError(t, err)
+
+			res, err = env.EvaluateVM(compiled)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, res.String())
 		})
 	}
 }

--- a/go/vt/vtgate/evalengine/expr_compare.go
+++ b/go/vt/vtgate/evalengine/expr_compare.go
@@ -531,6 +531,13 @@ func (i *InExpr) eval(env *ExpressionEnv) (eval, error) {
 }
 
 func (i *InExpr) compileTable(lhs ctype, rhs TupleExpr) map[vthash.Hash]struct{} {
+	// JSON hashes fingerprint arrays and objects by kind and cardinality
+	// only: a hash hit is not equality, so JSON stays on the comparing
+	// slow path.
+	if lhs.Type == sqltypes.TypeJSON {
+		return nil
+	}
+
 	var (
 		table  = make(map[vthash.Hash]struct{})
 		hasher = vthash.New()

--- a/go/vt/vtgate/evalengine/expr_literal.go
+++ b/go/vt/vtgate/evalengine/expr_literal.go
@@ -41,7 +41,17 @@ func (l *Literal) IsExpr() {}
 
 // eval implements the expression interface
 func (l *Literal) eval(_ *ExpressionEnv) (eval, error) {
-	return l.inner, nil
+	return cloneJSONLiteral(l.inner), nil
+}
+
+// cloneJSONLiteral returns e with a JSON document deep-cloned: JSON functions
+// mutate documents in place, and a Literal is shared by every evaluation of a
+// translated expression.
+func cloneJSONLiteral(e eval) eval {
+	if j, ok := e.(*evalJSON); ok {
+		return j.Clone()
+	}
+	return e
 }
 
 // typeof implements the Expr interface

--- a/go/vt/vtgate/evalengine/format.go
+++ b/go/vt/vtgate/evalengine/format.go
@@ -127,13 +127,27 @@ func (l *Literal) format(buf *sqlparser.TrackedBuffer) {
 			if i > 0 {
 				buf.WriteString(", ")
 			}
-			evalToSQLValue(val).EncodeSQLStringBuilder(buf.Builder)
+			formatEvalLiteral(buf, val)
 		}
 		buf.WriteByte(')')
 
 	default:
-		evalToSQLValue(l.inner).EncodeSQLStringBuilder(buf.Builder)
+		formatEvalLiteral(buf, l.inner)
 	}
+}
+
+// formatEvalLiteral formats e as a SQL literal. JSON values are wrapped in
+// CAST(... AS JSON) to keep their document semantics.
+func formatEvalLiteral(buf *sqlparser.TrackedBuffer, e eval) {
+	if _, ok := e.(*evalJSON); ok {
+		buf.WriteLiteral("cast(")
+		evalToSQLValue(e).EncodeSQLStringBuilder(buf.Builder)
+		buf.WriteLiteral(" as ")
+		buf.WriteLiteral("json")
+		buf.WriteByte(')')
+		return
+	}
+	evalToSQLValue(e).EncodeSQLStringBuilder(buf.Builder)
 }
 
 func (bv *BindVariable) Format(buf *sqlparser.TrackedBuffer) {

--- a/go/vt/vtgate/evalengine/perf_test.go
+++ b/go/vt/vtgate/evalengine/perf_test.go
@@ -36,6 +36,8 @@ func BenchmarkCompilerExpressions(b *testing.B) {
 		{"comparison_u64", "column0 = 12", []sqltypes.Value{sqltypes.NewUint64(666)}},
 		{"comparison_dec", "column0 = 12", []sqltypes.Value{sqltypes.NewDecimal("420")}},
 		{"comparison_f", "column0 = 12", []sqltypes.Value{sqltypes.NewFloat64(420.0)}},
+		{"json_literal_small", "column0 = cast('[1, 2, 3]' as json)", []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`))}},
+		{"json_literal_nested", `column0 = cast('{"a": [1, 2, {"b": ["x", 4.5, true]}], "c": "foo bar baz", "d": {"e": [6, 7, 8, 9]}}' as json)`, []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`{"a": 1}`))}},
 	}
 
 	venv := vtenv.NewTestEnv()

--- a/go/vt/vtgate/evalengine/translate_simplify.go
+++ b/go/vt/vtgate/evalengine/translate_simplify.go
@@ -157,5 +157,12 @@ func evalToIR(simplified eval) IR {
 		}
 		return te
 	}
+	if j, ok := simplified.(*evalJSON); ok {
+		// The literal is shared by every evaluation of the translated
+		// expression: resolve the document's lazy number classification
+		// now, while this goroutine still owns it, so that concurrent
+		// evaluations only ever read the shared value.
+		j.ResolveNumberTypes()
+	}
 	return &Literal{inner: simplified}
 }

--- a/go/vt/vtgate/evalengine/translate_test.go
+++ b/go/vt/vtgate/evalengine/translate_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package evalengine
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -156,6 +157,220 @@ func TestTranslateSimplification(t *testing.T) {
 			}
 			assert.Equal(t, tc.simplified.literal, sqlparser.String(simplified))
 		})
+	}
+}
+
+// TestTranslateFoldedJSONLiterals tests that JSON values produced by constant
+// folding compile, evaluate and format as CAST('<json>' AS JSON) literals; a
+// bare string literal would compare as a JSON string scalar, not a document.
+func TestTranslateFoldedJSONLiterals(t *testing.T) {
+	testCases := []struct {
+		expression string
+		simplified string
+		row        sqltypes.Value
+		result     sqltypes.Value
+	}{{
+		expression: `j = json_array(1)`,
+		simplified: `j = cast('[1]' as json)`,
+		row:        sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`)),
+		result:     sqltypes.NewInt64(1),
+	}, {
+		expression: `coalesce(j, json_array(1, 2))`,
+		simplified: `coalesce(j, cast('[1, 2]' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1, 2]`)),
+	}, {
+		expression: `coalesce(j, json_object('a', 1))`,
+		simplified: `coalesce(j, cast('{"a": 1}' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`{"a": 1}`)),
+	}, {
+		expression: `coalesce(j, cast('"foo"' as json))`,
+		simplified: `coalesce(j, cast('"foo"' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`"foo"`)),
+	}, {
+		// wide decimals must keep their exact serialization and not
+		// round-trip through float64
+		expression: `coalesce(j, json_array(123456789012.12345678))`,
+		simplified: `coalesce(j, cast('[123456789012.12345678]' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[123456789012.12345678]`)),
+	}, {
+		// a JSON null literal is a JSON value, not a SQL NULL
+		expression: `coalesce(j, cast('null' as json))`,
+		simplified: `coalesce(j, cast('null' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`null`)),
+	}, {
+		expression: `coalesce(j, null)`,
+		simplified: `coalesce(j, null)`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.NULL,
+	}}
+
+	venv := vtenv.NewTestEnv()
+	fields := FieldResolver([]*querypb.Field{
+		{Name: "j", Type: sqltypes.TypeJSON, Charset: collations.CollationUtf8mb4ID},
+	})
+
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			astExpr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+
+			translated, err := Translate(astExpr, &Config{
+				ResolveColumn: fields.Column,
+				ResolveType:   fields.Type,
+				Collation:     venv.CollationEnv().DefaultConnectionCharset(),
+				Environment:   venv,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.simplified, sqlparser.String(translated))
+
+			env := NewExpressionEnv(t.Context(), nil, NewEmptyVCursor(venv, time.Local))
+			env.Row = []sqltypes.Value{tc.row}
+
+			compiled, err := env.Evaluate(translated)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, compiled.Value(collations.MySQL8().DefaultConnectionCharset()))
+
+			interpreted, err := env.EvaluateAST(translated)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, interpreted.Value(collations.MySQL8().DefaultConnectionCharset()))
+		})
+	}
+}
+
+// TestTranslateFoldedJSONLiteralOwnership tests that evaluating a translated
+// expression never mutates a folded JSON literal: JSON_REMOVE updates its
+// input in place, and translated expressions are reused across evaluations.
+func TestTranslateFoldedJSONLiteralOwnership(t *testing.T) {
+	testCases := []struct {
+		expression string
+		paths      []string
+		results    []string
+	}{{
+		expression: `json_remove(json_array(1, 2, 3), :p)`,
+		paths:      []string{`$[0]`, `$[1]`, `$[2]`},
+		results:    []string{`[2, 3]`, `[1, 3]`, `[1, 2]`},
+	}, {
+		expression: `json_remove(json_object('a', json_array(1, 2, 3)), :p)`,
+		paths:      []string{`$.a[0]`, `$.a[1]`, `$.a[2]`},
+		results:    []string{`{"a": [2, 3]}`, `{"a": [1, 3]}`, `{"a": [1, 2]}`},
+	}}
+
+	venv := vtenv.NewTestEnv()
+	coll := collations.MySQL8().DefaultConnectionCharset()
+
+	translate := func(t *testing.T, expression string) *UntypedExpr {
+		astExpr, err := venv.Parser().ParseExpr(expression)
+		require.NoError(t, err)
+		translated, err := Translate(astExpr, &Config{
+			Collation:   coll,
+			Environment: venv,
+		})
+		require.NoError(t, err)
+		untyped, ok := translated.(*UntypedExpr)
+		require.True(t, ok, "expected *UntypedExpr, got %T", translated)
+		return untyped
+	}
+	newEnv := func(path string) *ExpressionEnv {
+		env := EmptyExpressionEnv(venv)
+		env.BindVars = map[string]*querypb.BindVariable{
+			"p": sqltypes.StringBindVariable(path),
+		}
+		return env
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			t.Run("interpreted", func(t *testing.T) {
+				translated := translate(t, tc.expression)
+				for i, path := range tc.paths {
+					env := newEnv(path)
+					res, err := env.EvaluateAST(translated)
+					require.NoError(t, err)
+					assert.Equal(t, tc.results[i], res.Value(coll).ToString())
+				}
+			})
+			t.Run("compiled", func(t *testing.T) {
+				translated := translate(t, tc.expression)
+				for i, path := range tc.paths {
+					env := newEnv(path)
+					compiled, err := translated.Compile(env)
+					require.NoError(t, err)
+					res, err := env.Evaluate(compiled)
+					require.NoError(t, err)
+					assert.Equal(t, tc.results[i], res.Value(coll).ToString())
+				}
+			})
+		})
+	}
+}
+
+// TestTranslateFoldedJSONLiteralConcurrency evaluates a single translated
+// expression containing a folded JSON literal from multiple goroutines; with
+// -race, this catches evaluations sharing the literal's document.
+func TestTranslateFoldedJSONLiteralConcurrency(t *testing.T) {
+	venv := vtenv.NewTestEnv()
+	coll := collations.MySQL8().DefaultConnectionCharset()
+
+	astExpr, err := venv.Parser().ParseExpr(`json_remove(json_array(1, 2, 3), :p)`)
+	require.NoError(t, err)
+	translated, err := Translate(astExpr, &Config{
+		Collation:   coll,
+		Environment: venv,
+	})
+	require.NoError(t, err)
+	untyped, ok := translated.(*UntypedExpr)
+	require.True(t, ok, "expected *UntypedExpr, got %T", translated)
+
+	paths := []string{`$[0]`, `$[1]`, `$[2]`}
+	results := []string{`[2, 3]`, `[1, 3]`, `[1, 2]`}
+
+	const goroutines, evaluations = 8, 100
+	errs := make([]error, goroutines)
+	observed := make([][]string, goroutines)
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		observed[g] = make([]string, evaluations)
+		wg.Go(func() {
+			for i := range evaluations {
+				n := (g + i) % len(paths)
+
+				env := EmptyExpressionEnv(venv)
+				env.BindVars = map[string]*querypb.BindVariable{
+					"p": sqltypes.StringBindVariable(paths[n]),
+				}
+
+				var res EvalResult
+				var err error
+				if g%2 == 0 {
+					res, err = env.EvaluateAST(untyped)
+				} else {
+					var compiled *CompiledExpr
+					compiled, err = untyped.Compile(env)
+					if err == nil {
+						res, err = env.Evaluate(compiled)
+					}
+				}
+				if err != nil {
+					errs[g] = err
+					return
+				}
+				observed[g][i] = res.Value(coll).ToString()
+			}
+		})
+	}
+	wg.Wait()
+
+	for g := range goroutines {
+		require.NoErrorf(t, errs[g], "goroutine %d", g)
+		for i, got := range observed[g] {
+			assert.Equal(t, results[(g+i)%len(paths)], got)
+		}
 	}
 }
 

--- a/go/vt/vtgate/evalengine/translate_test.go
+++ b/go/vt/vtgate/evalengine/translate_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package evalengine
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -156,6 +157,223 @@ func TestTranslateSimplification(t *testing.T) {
 			}
 			assert.Equal(t, tc.simplified.literal, sqlparser.String(simplified))
 		})
+	}
+}
+
+// TestTranslateFoldedJSONLiterals tests that JSON values produced by constant
+// folding compile, evaluate and format as CAST('<json>' AS JSON) literals; a
+// bare string literal would compare as a JSON string scalar, not a document.
+func TestTranslateFoldedJSONLiterals(t *testing.T) {
+	testCases := []struct {
+		expression string
+		simplified string
+		row        sqltypes.Value
+		result     sqltypes.Value
+	}{{
+		expression: `j = json_array(1)`,
+		simplified: `j = cast('[1]' as json)`,
+		row:        sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`)),
+		result:     sqltypes.NewInt64(1),
+	}, {
+		expression: `coalesce(j, json_array(1, 2))`,
+		simplified: `coalesce(j, cast('[1, 2]' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1, 2]`)),
+	}, {
+		expression: `coalesce(j, json_object('a', 1))`,
+		simplified: `coalesce(j, cast('{"a": 1}' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`{"a": 1}`)),
+	}, {
+		expression: `coalesce(j, cast('"foo"' as json))`,
+		simplified: `coalesce(j, cast('"foo"' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`"foo"`)),
+	}, {
+		// wide decimals must keep their exact serialization and not
+		// round-trip through float64
+		expression: `coalesce(j, json_array(123456789012.12345678))`,
+		simplified: `coalesce(j, cast('[123456789012.12345678]' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[123456789012.12345678]`)),
+	}, {
+		// a JSON null literal is a JSON value, not a SQL NULL
+		expression: `coalesce(j, cast('null' as json))`,
+		simplified: `coalesce(j, cast('null' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`null`)),
+	}, {
+		expression: `coalesce(j, null)`,
+		simplified: `coalesce(j, null)`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.NULL,
+	}}
+
+	venv := vtenv.NewTestEnv()
+	fields := FieldResolver([]*querypb.Field{
+		{Name: "j", Type: sqltypes.TypeJSON, Charset: collations.CollationUtf8mb4ID},
+	})
+
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			astExpr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+
+			translated, err := Translate(astExpr, &Config{
+				ResolveColumn: fields.Column,
+				ResolveType:   fields.Type,
+				Collation:     venv.CollationEnv().DefaultConnectionCharset(),
+				Environment:   venv,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.simplified, sqlparser.String(translated))
+
+			env := NewExpressionEnv(t.Context(), nil, NewEmptyVCursor(venv, time.Local))
+			env.Row = []sqltypes.Value{tc.row}
+
+			compiled, err := env.Evaluate(translated)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, compiled.Value(collations.MySQL8().DefaultConnectionCharset()))
+
+			interpreted, err := env.EvaluateAST(translated)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, interpreted.Value(collations.MySQL8().DefaultConnectionCharset()))
+		})
+	}
+}
+
+// TestTranslateFoldedJSONLiteralOwnership tests that evaluating a translated
+// expression never mutates a folded JSON literal: JSON_REMOVE updates its
+// input in place, and translated expressions are reused across evaluations.
+func TestTranslateFoldedJSONLiteralOwnership(t *testing.T) {
+	testCases := []struct {
+		expression string
+		paths      []string
+		results    []string
+	}{{
+		expression: `json_remove(json_array(1, 2, 3), :p)`,
+		paths:      []string{`$[0]`, `$[1]`, `$[2]`},
+		results:    []string{`[2, 3]`, `[1, 3]`, `[1, 2]`},
+	}, {
+		expression: `json_remove(json_object('a', json_array(1, 2, 3)), :p)`,
+		paths:      []string{`$.a[0]`, `$.a[1]`, `$.a[2]`},
+		results:    []string{`{"a": [2, 3]}`, `{"a": [1, 3]}`, `{"a": [1, 2]}`},
+	}}
+
+	venv := vtenv.NewTestEnv()
+	coll := collations.MySQL8().DefaultConnectionCharset()
+
+	translate := func(t *testing.T, expression string) *UntypedExpr {
+		astExpr, err := venv.Parser().ParseExpr(expression)
+		require.NoError(t, err)
+		translated, err := Translate(astExpr, &Config{
+			Collation:   coll,
+			Environment: venv,
+		})
+		require.NoError(t, err)
+		untyped, ok := translated.(*UntypedExpr)
+		require.True(t, ok, "expected *UntypedExpr, got %T", translated)
+		return untyped
+	}
+	newEnv := func(path string) *ExpressionEnv {
+		env := EmptyExpressionEnv(venv)
+		env.BindVars = map[string]*querypb.BindVariable{
+			"p": sqltypes.StringBindVariable(path),
+		}
+		return env
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			t.Run("interpreted", func(t *testing.T) {
+				translated := translate(t, tc.expression)
+				for i, path := range tc.paths {
+					env := newEnv(path)
+					res, err := env.EvaluateAST(translated)
+					require.NoError(t, err)
+					assert.Equal(t, tc.results[i], res.Value(coll).ToString())
+				}
+			})
+			t.Run("compiled", func(t *testing.T) {
+				translated := translate(t, tc.expression)
+				for i, path := range tc.paths {
+					env := newEnv(path)
+					compiled, err := translated.Compile(env)
+					require.NoError(t, err)
+					res, err := env.Evaluate(compiled)
+					require.NoError(t, err)
+					assert.Equal(t, tc.results[i], res.Value(coll).ToString())
+				}
+			})
+		})
+	}
+}
+
+// TestTranslateFoldedJSONLiteralConcurrency evaluates a single translated
+// expression containing a folded JSON literal from multiple goroutines; with
+// -race, this catches evaluations sharing the literal's document. The
+// document is folded from a CAST of JSON text: only parsed numbers carry the
+// lazy number classification whose in-place write must not race the reads of
+// concurrent evaluations and lazy compilations.
+func TestTranslateFoldedJSONLiteralConcurrency(t *testing.T) {
+	venv := vtenv.NewTestEnv()
+	coll := collations.MySQL8().DefaultConnectionCharset()
+
+	astExpr, err := venv.Parser().ParseExpr(`json_remove(cast('[1, 2, 3]' as json), :p)`)
+	require.NoError(t, err)
+	translated, err := Translate(astExpr, &Config{
+		Collation:   coll,
+		Environment: venv,
+	})
+	require.NoError(t, err)
+	untyped, ok := translated.(*UntypedExpr)
+	require.True(t, ok, "expected *UntypedExpr, got %T", translated)
+
+	paths := []string{`$[0]`, `$[1]`, `$[2]`}
+	results := []string{`[2, 3]`, `[1, 3]`, `[1, 2]`}
+
+	const goroutines, evaluations = 8, 100
+	errs := make([]error, goroutines)
+	observed := make([][]string, goroutines)
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		observed[g] = make([]string, evaluations)
+		wg.Go(func() {
+			for i := range evaluations {
+				n := (g + i) % len(paths)
+
+				env := EmptyExpressionEnv(venv)
+				env.BindVars = map[string]*querypb.BindVariable{
+					"p": sqltypes.StringBindVariable(paths[n]),
+				}
+
+				var res EvalResult
+				var err error
+				if g%2 == 0 {
+					res, err = env.EvaluateAST(untyped)
+				} else {
+					var compiled *CompiledExpr
+					compiled, err = untyped.Compile(env)
+					if err == nil {
+						res, err = env.Evaluate(compiled)
+					}
+				}
+				if err != nil {
+					errs[g] = err
+					return
+				}
+				observed[g][i] = res.Value(coll).ToString()
+			}
+		})
+	}
+	wg.Wait()
+
+	for g := range goroutines {
+		require.NoErrorf(t, errs[g], "goroutine %d", g)
+		for i, got := range observed[g] {
+			assert.Equal(t, results[(g+i)%len(paths)], got)
+		}
 	}
 }
 

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -3167,6 +3167,44 @@
     }
   },
   {
+    "comment": "having predicate with a constant-folded json value is evaluated at the vtgate level",
+    "query": "select foo, count(*) from user group by foo having min(textcol1) = json_array(1)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select foo, count(*) from user group by foo having min(textcol1) = json_array(1)",
+      "Instructions": {
+        "OperatorType": "Filter",
+        "Predicate": "min(textcol1) = json_array(1)",
+        "ResultColumns": 2,
+        "Inputs": [
+          {
+            "OperatorType": "Aggregate",
+            "Variant": "Ordered",
+            "Aggregates": "sum_count_star(1) AS count(*), min(2 COLLATE latin1_swedish_ci) AS min(textcol1)",
+            "GroupBy": "(0|3)",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select foo, count(*), min(textcol1), weight_string(foo) from `user` where 1 != 1 group by foo, weight_string(foo)",
+                "OrderBy": "(0|3) ASC",
+                "Query": "select foo, count(*), min(textcol1), weight_string(foo) from `user` group by foo, weight_string(foo) order by foo asc"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
     "comment": "find aggregation expression and use column offset in filter times two",
     "query": "select foo, sum(foo), sum(bar) from user group by foo having sum(foo)+sum(bar) = 42",
     "plan": {


### PR DESCRIPTION
## Description

A comparison operand that constant-folds to a JSON value fails translation with `unsupported literal kind '*json.Value'`, reachable from plain HAVING queries on aggregates. Folded JSON documents are now supported as literals: the compiler pushes them, and each evaluation receives a deep clone of the document, since JSON functions mutate documents in place, lazily unescaped payloads rewrite themselves on first access, and a literal in a cached plan is shared by every execution, including concurrent ones. `json.Value` gains the `Clone` method that backs this; it shares immutable leaf payloads, copies the raw strings whose backing bytes rewrite on first access, and panics on an unknown type exactly as `MarshalTo` does. Formatting wraps such literals in `CAST(... AS JSON)` through the buffer's literal casing so they round-trip with document semantics, and compiler benchmark cases put the per-evaluation clone at roughly half a microsecond for a small document and about a microsecond for a nested one.

This sits on top of the merged #20696 and #20697 operand-mutation fixes, which keep compiled opcodes from writing through a shared document, and on https://github.com/vitessio/vitess/pull/20691, whose IN-table test it flips to compiled evaluation now that JSON literals push.

## Related Issue(s)

Builds on https://github.com/vitessio/vitess/pull/20625 and https://github.com/vitessio/vitess/pull/20691. https://github.com/vitessio/vitess/pull/20683 builds on this change.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Comparisons whose operands constant-fold to JSON values now translate and compile instead of failing with an unsupported-literal error. Formatted plans render such literals as `cast('...' as json)`. No migrations or configuration changes.

### AI Disclosure

This PR was written primarily by Fable with review from GPT 5.6 Sol.

---

```mermaid
graph LR
    subgraph json [JSON support]
        direction TB
        PR20625["#20625 (merged)<br>mysql/json: fix MarshalTo discarding accumulated output for nested blob and bit values"]
        PR20632["#20632<br>vtgate: preserve IN value lists in complex aggregate projections"]
        PRA["#20691<br>evalengine: disable the static IN hash table for JSON operands"]
        PR20682["#20682 (draft)<br>evalengine: support constant-folded JSON values as literals"]
        PR20683["#20683 (draft)<br>evalengine, sqlparser: MySQL comparison domains; nested BETWEEN parentheses"]
        PR20626["#20626 (draft)<br>vtgate: support cross-shard JSON_ARRAYAGG and JSON_OBJECTAGG"]
        PR20625 --> PR20682
        PRA --> PR20682
        PR20682 --> PR20683
        PR20632 --> PR20626
        PR20683 --> PR20626
    end

    subgraph union [Union routing]
        direction TB
        PR20628["#20628<br>vtgate: track per-source copies of pushed join predicates so merges skip them"]
        PR20629["#20629 (merged)<br>vtgate: fix None routing handling when merging unions"]
        PR20630["#20630 (draft)<br>vtgate: merge unions on join-predicate-free routings when all sources agree"]
        PR20755["#20755<br>vtgate: fix union merging through reference-table alternates"]
        PR20756["#20756 (draft)<br>vtgate: merge empty reference branches through rewritten copies"]
        PR20628 --> PR20630
        PR20629 --> PR20630
        PR20630 --> PR20756
        PR20755 --> PR20756
    end

    subgraph cte [Recursive CTEs]
        direction TB
        PR20759["#20759<br>vtgate: expand qualified stars without JOIN USING coalescing"]
        PR20633["#20633 (draft)<br>vtgate: validate the declared column list length of CTEs and derived tables"]
        PR20631["#20631 (draft)<br>vtgate: bind recursive CTE column filters as arguments in unmerged term queries"]
        PR20759 --> PR20633
        PR20633 --> PR20631
    end

    json ~~~ union ~~~ cte
```

