### PR TITLE
evalengine, sqlparser: MySQL comparison domains; nested BETWEEN parentheses

### DIFF
--- a/go/mysql/json/clone.go
+++ b/go/mysql/json/clone.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package json
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Clone returns a deep copy of v: arrays and objects are copied recursively,
+// so in-place updates on one value never affect the other. Leaf payloads are
+// shared, except raw strings not yet unescaped: Type rewrites their backing
+// bytes in place, so they are copied. The lazily cached number type needs no
+// copy, since NumberType writes it to a field each clone owns; a value cloned
+// while other goroutines can reach it must have had its number types resolved
+// first (ResolveNumberTypes), since Clone reads the field that NumberType's
+// lazy classification writes.
+func (v *Value) Clone() *Value {
+	switch v.t {
+	case TypeObject:
+		kvs := make([]kv, len(v.o.kvs))
+		for i, item := range v.o.kvs {
+			kvs[i] = kv{k: item.k, v: item.v.Clone()}
+		}
+		return &Value{o: Object{kvs: kvs}, t: TypeObject}
+	case TypeArray:
+		a := make([]*Value, len(v.a))
+		for i, item := range v.a {
+			a[i] = item.Clone()
+		}
+		return &Value{a: a, t: TypeArray}
+	case TypeBoolean, TypeNull:
+		// ValueTrue, ValueFalse and ValueNull are immutable singletons
+		// whose pointer identity is meaningful.
+		return v
+	case typeRawString:
+		return &Value{s: strings.Clone(v.s), t: typeRawString}
+	case TypeString, TypeNumber, TypeDate, TypeTime, TypeDateTime, TypeOpaque, TypeBit, TypeBlob:
+		return &Value{s: v.s, t: v.t, n: v.n}
+	default:
+		panic(fmt.Errorf("BUG: unexpected Value type: %d", v.t))
+	}
+}

--- a/go/mysql/json/clone.go
+++ b/go/mysql/json/clone.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package json
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Clone returns a deep copy of v: arrays and objects are copied recursively,
+// so in-place updates on one value never affect the other. Leaf payloads are
+// shared, except raw strings not yet unescaped: Type rewrites their backing
+// bytes in place, so they are copied. The lazily cached number type needs no
+// copy, since NumberType writes it to a field each clone owns.
+func (v *Value) Clone() *Value {
+	switch v.t {
+	case TypeObject:
+		kvs := make([]kv, len(v.o.kvs))
+		for i, item := range v.o.kvs {
+			kvs[i] = kv{k: item.k, v: item.v.Clone()}
+		}
+		return &Value{o: Object{kvs: kvs}, t: TypeObject}
+	case TypeArray:
+		a := make([]*Value, len(v.a))
+		for i, item := range v.a {
+			a[i] = item.Clone()
+		}
+		return &Value{a: a, t: TypeArray}
+	case TypeBoolean, TypeNull:
+		// ValueTrue, ValueFalse and ValueNull are immutable singletons
+		// whose pointer identity is meaningful.
+		return v
+	case typeRawString:
+		return &Value{s: strings.Clone(v.s), t: typeRawString}
+	case TypeString, TypeNumber, TypeDate, TypeTime, TypeDateTime, TypeOpaque, TypeBit, TypeBlob:
+		return &Value{s: v.s, t: v.t, n: v.n}
+	default:
+		panic(fmt.Errorf("BUG: unexpected Value type: %d", v.t))
+	}
+}

--- a/go/mysql/json/clone_test.go
+++ b/go/mysql/json/clone_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package json
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloneSingletons(t *testing.T) {
+	// The boolean and null singletons are compared by pointer identity,
+	// so Clone must preserve them.
+	assert.Same(t, ValueTrue, ValueTrue.Clone())
+	assert.Same(t, ValueFalse, ValueFalse.Clone())
+	assert.Same(t, ValueNull, ValueNull.Clone())
+}
+
+func TestCloneMutationIndependence(t *testing.T) {
+	t.Run("mutating the clone does not affect the original", func(t *testing.T) {
+		original := MustParse(`{"a": [1, 2, 3], "o": {"x": [4, 5]}, "s": "keep"}`)
+		want := original.String()
+
+		clone := original.Clone()
+		require.Equal(t, want, clone.String())
+
+		obj, ok := clone.Object()
+		require.True(t, ok)
+		obj.Get("a").DelArrayItem(0)
+		obj.Get("a").SetArrayItem(1, MustParse(`42`), Set)
+		nested, ok := obj.Get("o").Object()
+		require.True(t, ok)
+		nested.Del("x")
+		nested.Set("y", MustParse(`"new"`), Set)
+		obj.Del("s")
+
+		assert.Equal(t, `{"a": [2, 42], "o": {"y": "new"}}`, clone.String())
+		assert.Equal(t, want, original.String())
+	})
+
+	t.Run("mutating the original does not affect the clone", func(t *testing.T) {
+		original := MustParse(`{"a": [1, 2, 3], "o": {"x": [4, 5]}}`)
+		clone := original.Clone()
+		want := clone.String()
+
+		obj, ok := original.Object()
+		require.True(t, ok)
+		obj.Get("a").DelArrayItem(2)
+		obj.Set("b", MustParse(`[6]`), Set)
+		nested, ok := obj.Get("o").Object()
+		require.True(t, ok)
+		nested.Set("x", MustParse(`7`), Replace)
+
+		assert.Equal(t, `{"a": [1, 2], "b": [6], "o": {"x": 7}}`, original.String())
+		assert.Equal(t, want, clone.String())
+	})
+}
+
+func TestCloneKindPreservation(t *testing.T) {
+	values := []*Value{
+		NewNumber("1.5", NumberTypeDecimal),
+		NewNumber("18446744073709551615", NumberTypeUnsigned),
+		NewNumber("-42", NumberTypeSigned),
+		NewNumber("1.5e10", NumberTypeFloat),
+		NewString("foo"),
+		NewBlob("\x00\x01"),
+		NewBit("\x81"),
+		NewDate("2023-10-12"),
+		NewTime("14:35:02"),
+		NewDateTime("2023-10-12 14:35:02"),
+		NewOpaqueValue("opaque"),
+		ValueTrue,
+		ValueFalse,
+		ValueNull,
+	}
+	original := NewArray(values)
+	clone := original.Clone()
+
+	cloned, ok := clone.Array()
+	require.True(t, ok)
+	require.Len(t, cloned, len(values))
+	for i, v := range values {
+		assert.Equal(t, v.Type(), cloned[i].Type())
+		assert.Equal(t, v.NumberType(), cloned[i].NumberType())
+		assert.Equal(t, v.Raw(), cloned[i].Raw())
+	}
+}
+
+func TestCloneRawStrings(t *testing.T) {
+	// Type lazily unescapes raw strings by rewriting their backing bytes in
+	// place; the clone must own its bytes so that unescaping one value
+	// cannot corrupt the other.
+	original := MustParse(`["fo\no"]`)
+	clone := original.Clone()
+
+	cloned, ok := clone.Array()
+	require.True(t, ok)
+	s, ok := cloned[0].StringBytes()
+	require.True(t, ok)
+	assert.Equal(t, "fo\no", string(s))
+
+	arr, ok := original.Array()
+	require.True(t, ok)
+	s, ok = arr[0].StringBytes()
+	require.True(t, ok)
+	assert.Equal(t, "fo\no", string(s))
+}

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -1334,6 +1334,27 @@ func parseNumberType(ns string) NumberType {
 	return NumberTypeUnknown
 }
 
+// ResolveNumberTypes classifies every number in the document, in place.
+// Parsed numbers are classified lazily: the first NumberType call writes the
+// classification back to the value. A document that will be shared between
+// goroutines — such as a constant folded into a cached plan — must resolve
+// its number types first, while a single goroutine still owns it, so that
+// concurrent readers never race that write.
+func (v *Value) ResolveNumberTypes() {
+	switch v.t {
+	case TypeObject:
+		for _, item := range v.o.kvs {
+			item.v.ResolveNumberTypes()
+		}
+	case TypeArray:
+		for _, item := range v.a {
+			item.ResolveNumberTypes()
+		}
+	case TypeNumber:
+		v.NumberType()
+	}
+}
+
 func (v *Value) Int64() (int64, bool) {
 	i, err := fastparse.ParseInt64(v.s, 10)
 	if err != nil {

--- a/go/mysql/json/parser_test.go
+++ b/go/mysql/json/parser_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/hack"
@@ -808,5 +809,55 @@ func TestMarshalToBlob(t *testing.T) {
 		var obj Object
 		obj.Add("k", NewBlob("foo"))
 		require.Equal(t, `{"k": `+encoded+`}`, string(NewObject(obj).MarshalTo(nil)))
+	})
+}
+
+// TestResolveNumberTypes verifies that resolving a parsed document classifies
+// every nested number in place, so a later NumberType call never has to write,
+// and that explicitly constructed numbers keep their declared type.
+func TestResolveNumberTypes(t *testing.T) {
+	t.Run("parsed", func(t *testing.T) {
+		v := MustParse(`{"i": -1, "u": 18446744073709551615, "f": 1.5e300, "a": [7, {"n": 2.5}], "s": "no number"}`)
+
+		var rawNumbers func(v *Value) int
+		rawNumbers = func(v *Value) int {
+			switch v.t {
+			case TypeObject:
+				var raw int
+				for _, item := range v.o.kvs {
+					raw += rawNumbers(item.v)
+				}
+				return raw
+			case TypeArray:
+				var raw int
+				for _, item := range v.a {
+					raw += rawNumbers(item)
+				}
+				return raw
+			case TypeNumber:
+				if v.n == numberTypeRaw {
+					return 1
+				}
+				return 0
+			default:
+				return 0
+			}
+		}
+		require.Equal(t, 5, rawNumbers(v), "parsed numbers must start out lazily classified")
+
+		v.ResolveNumberTypes()
+		assert.Zero(t, rawNumbers(v))
+
+		obj, ok := v.Object()
+		require.True(t, ok)
+		assert.Equal(t, NumberTypeSigned, obj.Get("i").NumberType())
+		assert.Equal(t, NumberTypeUnsigned, obj.Get("u").NumberType())
+		assert.Equal(t, NumberTypeFloat, obj.Get("f").NumberType())
+	})
+
+	t.Run("constructed", func(t *testing.T) {
+		v := NewArray([]*Value{NewNumber("1.5", NumberTypeDecimal)})
+		v.ResolveNumberTypes()
+		assert.Equal(t, NumberTypeDecimal, v.a[0].NumberType())
 	})
 }

--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -1544,10 +1544,12 @@ func (node *ComparisonExpr) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node *BetweenExpr) Format(buf *TrackedBuffer) {
+	// BETWEEN is ternary and non-associative: no operand position may drop
+	// the parentheses of an equal-precedence child.
 	if node.IsBetween {
-		buf.astPrintf(node, "%v between %l and %r", node.Left, node.From, node.To)
+		buf.astPrintf(node, "%r between %r and %r", node.Left, node.From, node.To)
 	} else {
-		buf.astPrintf(node, "%v not between %l and %r", node.Left, node.From, node.To)
+		buf.astPrintf(node, "%r not between %r and %r", node.Left, node.From, node.To)
 	}
 }
 

--- a/go/vt/sqlparser/ast_format_fast.go
+++ b/go/vt/sqlparser/ast_format_fast.go
@@ -1983,16 +1983,18 @@ func (node *ComparisonExpr) FormatFast(buf *TrackedBuffer) {
 
 // FormatFast formats the node.
 func (node *BetweenExpr) FormatFast(buf *TrackedBuffer) {
+	// BETWEEN is ternary and non-associative: no operand position may drop
+	// the parentheses of an equal-precedence child.
 	if node.IsBetween {
-		buf.printExpr(node, node.Left, true)
+		buf.printExpr(node, node.Left, false)
 		buf.WriteString(" between ")
-		buf.printExpr(node, node.From, true)
+		buf.printExpr(node, node.From, false)
 		buf.WriteString(" and ")
 		buf.printExpr(node, node.To, false)
 	} else {
-		buf.printExpr(node, node.Left, true)
+		buf.printExpr(node, node.Left, false)
 		buf.WriteString(" not between ")
-		buf.printExpr(node, node.From, true)
+		buf.printExpr(node, node.From, false)
 		buf.WriteString(" and ")
 		buf.printExpr(node, node.To, false)
 	}

--- a/go/vt/sqlparser/precedence_test.go
+++ b/go/vt/sqlparser/precedence_test.go
@@ -132,6 +132,9 @@ func TestParens(t *testing.T) {
 		{in: "(a) between (5) and (7)", expected: "a between 5 and 7"},
 		{in: "(a | b) between (5) and (7)", expected: "a | b between 5 and 7"},
 		{in: "(a and b) between (5) and (7)", expected: "(a and b) between 5 and 7"},
+		{in: "(5 between 0 and 10) between 0 and 1", expected: "(5 between 0 and 10) between 0 and 1"},
+		{in: "1 between (0 between 0 and 1) and 2", expected: "1 between (0 between 0 and 1) and 2"},
+		{in: "1 not between (0 between 0 and 1) and 2", expected: "1 not between (0 between 0 and 1) and 2"},
 		{in: "(true is true) is null", expected: "(true is true) is null"},
 		{in: "3 * (100 div 3)", expected: "3 * (100 div 3)"},
 		{in: "100 div 2 div 2", expected: "100 div 2 div 2"},
@@ -208,4 +211,33 @@ func TestPrecedenceOfMemberOfWithAndWithoutParser(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, expression, String(ast2))
+}
+
+func TestNestedBetweenRoundTrip(t *testing.T) {
+	// BETWEEN is ternary and non-associative: a nested BETWEEN keeps its
+	// parentheses in every operand position, so the formatted SQL reparses
+	// to the same tree through both formatter paths.
+	tests := []string{
+		"(5 between 0 and 10) between 0 and 1",
+		"1 between (0 between 0 and 1) and 2",
+		"1 not between (0 between 0 and 1) and 2",
+		"1 between 0 and (2 between 1 and 3)",
+	}
+	parser := NewTestParser()
+	for _, in := range tests {
+		t.Run(in, func(t *testing.T) {
+			stmt, err := parser.Parse("select " + in)
+			require.NoError(t, err)
+
+			formatted := String(stmt)
+			reparsed, err := parser.Parse(formatted)
+			require.NoError(t, err, "formatted SQL must reparse: %s", formatted)
+			require.True(t, Equals.SQLNode(stmt, reparsed), "%q reparses to a different tree", formatted)
+
+			canonical := CanonicalString(stmt)
+			reparsed, err = parser.Parse(canonical)
+			require.NoError(t, err, "canonical SQL must reparse: %s", canonical)
+			require.Equal(t, canonical, CanonicalString(reparsed), "canonical formatting is not a fixed point")
+		})
+	}
 }

--- a/go/vt/sqlparser/testdata/select_cases.txt
+++ b/go/vt/sqlparser/testdata/select_cases.txt
@@ -5528,7 +5528,7 @@ INPUT
 select 5 between 0 and 10 between 0 and 1,(5 between 0 and 10) between 0 and 1;
 END
 OUTPUT
-select 5 between 0 and (10 between 0 and 1), 5 between 0 and 10 between 0 and 1 from dual
+select 5 between 0 and (10 between 0 and 1), (5 between 0 and 10) between 0 and 1 from dual
 END
 INPUT
 select * from (t1 join t2 on t1.b=t2.b) natural join (t3 natural join t4);

--- a/go/vt/vtgate/engine/projection_test.go
+++ b/go/vt/vtgate/engine/projection_test.go
@@ -75,6 +75,41 @@ func TestMultiply(t *testing.T) {
 	assert.Equal(t, "[[UINT64(6)] [UINT64(0)] [UINT64(2)]]", fmt.Sprintf("%v", qr.Rows))
 }
 
+// TestProjectionFoldedJSONLiteral processes several rows through a Projection
+// whose expression contains a constant-folded JSON literal; JSON_REMOVE
+// mutates in place, so every row must see the pristine literal.
+func TestProjectionFoldedJSONLiteral(t *testing.T) {
+	fields := evalengine.FieldResolver([]*querypb.Field{
+		{Name: "p", Type: sqltypes.VarChar, Charset: collations.CollationUtf8mb4ID},
+	})
+	astExpr, err := sqlparser.NewTestParser().ParseExpr(`json_remove(json_array(1, 2, 3), p)`)
+	require.NoError(t, err)
+	evalExpr, err := evalengine.Translate(astExpr, &evalengine.Config{
+		ResolveColumn: fields.Column,
+		ResolveType:   fields.Type,
+		Environment:   vtenv.NewTestEnv(),
+		Collation:     collations.MySQL8().DefaultConnectionCharset(),
+	})
+	require.NoError(t, err)
+	fp := &fakePrimitive{
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(
+			sqltypes.MakeTestFields("p", "varchar"),
+			"$[0]",
+			"$[1]",
+			"$[2]",
+		)},
+	}
+	proj := &Projection{
+		Cols:       []string{"j"},
+		Exprs:      []evalengine.Expr{evalExpr},
+		Input:      fp,
+		noTxNeeded: noTxNeeded{},
+	}
+	qr, err := proj.TryExecute(t.Context(), &noopVCursor{}, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+	assert.Equal(t, `[[JSON("[2, 3]")] [JSON("[1, 3]")] [JSON("[1, 2]")]]`, fmt.Sprintf("%v", qr.Rows))
+}
+
 func TestProjectionStreaming(t *testing.T) {
 	expr := &sqlparser.BinaryExpr{
 		Operator: sqlparser.MultOp,

--- a/go/vt/vtgate/evalengine/cached_size.go
+++ b/go/vt/vtgate/evalengine/cached_size.go
@@ -40,6 +40,29 @@ func (cached *ArithmeticExpr) CachedSize(alloc bool) int64 {
 	return size
 }
 
+func (cached *BetweenExpr) CachedSize(alloc bool) int64 {
+	if cached == nil {
+		return int64(0)
+	}
+	size := int64(0)
+	if alloc {
+		size += int64(64)
+	}
+	// field Left vitess.io/vitess/go/vt/vtgate/evalengine.IR
+	if cc, ok := cached.Left.(cachedObject); ok {
+		size += cc.CachedSize(true)
+	}
+	// field From vitess.io/vitess/go/vt/vtgate/evalengine.IR
+	if cc, ok := cached.From.(cachedObject); ok {
+		size += cc.CachedSize(true)
+	}
+	// field To vitess.io/vitess/go/vt/vtgate/evalengine.IR
+	if cc, ok := cached.To.(cachedObject); ok {
+		size += cc.CachedSize(true)
+	}
+	return size
+}
+
 func (cached *BinaryExpr) CachedSize(alloc bool) int64 {
 	if cached == nil {
 		return int64(0)

--- a/go/vt/vtgate/evalengine/compare.go
+++ b/go/vt/vtgate/evalengine/compare.go
@@ -183,6 +183,30 @@ func compareStrings(l, r eval, env *collations.Environment) (int, error) {
 	return collation.Collate(l.ToRawBytes(), r.ToRawBytes(), false), nil
 }
 
+// evalJSONToText returns the serialized text form of a JSON value, and any
+// other value unchanged.
+func evalJSONToText(e eval) eval {
+	if j, ok := e.(*evalJSON); ok {
+		return newEvalText(j.ToRawBytes(), collationJSON)
+	}
+	return e
+}
+
+// evalCompareCaseJSON compares a (base, WHEN) pair of a simple CASE in which
+// a JSON value participates. MySQL never uses the JSON comparator here: a
+// pair of JSON or textual values compares as strings on the serialized text
+// forms, and any other pair as DOUBLE.
+func evalCompareCaseJSON(l, r eval, collationEnv *collations.Environment) (int, error) {
+	_, lIsJSON := l.(*evalJSON)
+	_, rIsJSON := r.(*evalJSON)
+	if (lIsJSON || typeIsTextual(l.SQLType())) && (rIsJSON || typeIsTextual(r.SQLType())) {
+		return compareStrings(evalJSONToText(l), evalJSONToText(r), collationEnv)
+	}
+	lf, _ := evalToFloat(l)
+	rf, _ := evalToFloat(r)
+	return compareNumeric(lf, rf)
+}
+
 func compareJSON(l, r eval) (int, error) {
 	lj, err := argToJSON(l)
 	if err != nil {

--- a/go/vt/vtgate/evalengine/compiler.go
+++ b/go/vt/vtgate/evalengine/compiler.go
@@ -39,6 +39,11 @@ type compiler struct {
 	asm          assembler
 	sqlmode      SQLMode
 	env          *vtenv.Environment
+	// typeEnv makes this a type-only compile deriving an operand's declared
+	// result type: untyped Column and BindVariable leaves resolve from the
+	// evaluation environment, shapes the VM cannot emit still return their
+	// known result type, and the program is never published for execution.
+	typeEnv *ExpressionEnv
 }
 
 type CompilerLog interface {
@@ -206,6 +211,19 @@ func (c *compiler) unsupported(expr IR) error {
 	buf := sqlparser.NewTrackedBuffer(nil)
 	expr.format(buf)
 	return vterrors.Errorf(vtrpc.Code_UNIMPLEMENTED, "unsupported compilation for IR '%s'", buf.String())
+}
+
+// typeOnlyCall completes a type-only compile of a call whose shape the VM
+// cannot emit: the uncompiled arguments still compile so the stack model
+// stays coherent, and the call contributes its known result type.
+func (c *compiler) typeOnlyCall(args []IR, compiled int, result ctype) (ctype, error) {
+	for _, arg := range args[compiled:] {
+		if _, err := arg.compile(c); err != nil {
+			return ctype{}, err
+		}
+	}
+	c.asm.adjustStack(1 - len(args))
+	return result, nil
 }
 
 func (c *compiler) compile(expr IR) (*CompiledExpr, error) {

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -176,6 +176,22 @@ func (asm *assembler) Add_uu() {
 	}, "ADD UINT64(SP-2), UINT64(SP-1)")
 }
 
+func (asm *assembler) Between(collationEnv *collations.Environment, negate bool, plan betweenPlan) {
+	asm.adjustStack(-2)
+	asm.emit(func(env *ExpressionEnv) int {
+		left := env.vm.stack[env.vm.sp-3]
+		from := env.vm.stack[env.vm.sp-2]
+		to := env.vm.stack[env.vm.sp-1]
+
+		var in boolean
+		in, env.vm.err = evalBetweenExpr(collationEnv, left, from, to, negate, plan, env.now)
+
+		env.vm.stack[env.vm.sp-3] = in.eval()
+		env.vm.sp -= 2
+		return 1
+	}, "BETWEEN (SP-3), (SP-2), (SP-1)")
+}
+
 func (asm *assembler) BitCount_b() {
 	asm.emit(func(env *ExpressionEnv) int {
 		a := env.vm.stack[env.vm.sp-1].(*evalBytes)
@@ -735,6 +751,17 @@ func (asm *assembler) CmpJSON() {
 		env.vm.flags.cmp, env.vm.err = compareJSONValue(l, r)
 		return 1
 	}, "CMP JSON(SP-2), JSON(SP-1)")
+}
+
+func (asm *assembler) CmpCaseJSON(collationEnv *collations.Environment) {
+	asm.adjustStack(-2)
+	asm.emit(func(env *ExpressionEnv) int {
+		l := env.vm.stack[env.vm.sp-2]
+		r := env.vm.stack[env.vm.sp-1]
+		env.vm.sp -= 2
+		env.vm.flags.cmp, env.vm.err = evalCompareCaseJSON(l, r, collationEnv)
+		return 1
+	}, "CMP CASE (SP-2), (SP-1)")
 }
 
 func (asm *assembler) CmpTuple(collationEnv *collations.Environment, fullEquality bool) {
@@ -3231,7 +3258,7 @@ func (asm *assembler) In_table(not bool, table map[vthash.Hash]struct{}) {
 	}
 }
 
-func (asm *assembler) In_slow(collationsEnv *collations.Environment, not bool) {
+func (asm *assembler) In_slow(collationsEnv *collations.Environment, not bool, plan inJSONDomain) {
 	asm.adjustStack(-1)
 
 	if not {
@@ -3240,7 +3267,7 @@ func (asm *assembler) In_slow(collationsEnv *collations.Environment, not bool) {
 			rhs := env.vm.stack[env.vm.sp-1].(*evalTuple)
 
 			var in boolean
-			in, env.vm.err = evalInExpr(collationsEnv, lhs, rhs)
+			in, env.vm.err = evalInExpr(collationsEnv, lhs, rhs, plan)
 
 			env.vm.stack[env.vm.sp-2] = in.not().eval()
 			env.vm.sp -= 1
@@ -3252,7 +3279,7 @@ func (asm *assembler) In_slow(collationsEnv *collations.Environment, not bool) {
 			rhs := env.vm.stack[env.vm.sp-1].(*evalTuple)
 
 			var in boolean
-			in, env.vm.err = evalInExpr(collationsEnv, lhs, rhs)
+			in, env.vm.err = evalInExpr(collationsEnv, lhs, rhs, plan)
 
 			env.vm.stack[env.vm.sp-2] = in.eval()
 			env.vm.sp -= 1

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -176,6 +176,39 @@ func (asm *assembler) Add_uu() {
 	}, "ADD UINT64(SP-2), UINT64(SP-1)")
 }
 
+func (asm *assembler) Between(collationEnv *collations.Environment, negate bool, plan betweenPlan) {
+	asm.adjustStack(-2)
+	asm.emit(func(env *ExpressionEnv) int {
+		left := env.vm.stack[env.vm.sp-3]
+		from := env.vm.stack[env.vm.sp-2]
+		to := env.vm.stack[env.vm.sp-1]
+
+		var in boolean
+		in, env.vm.err = evalBetweenExpr(collationEnv, left, from, to, negate, plan, env.now)
+
+		env.vm.stack[env.vm.sp-3] = in.eval()
+		env.vm.sp -= 2
+		return 1
+	}, "BETWEEN (SP-3), (SP-2), (SP-1)")
+}
+
+func (asm *assembler) BetweenPerExecution(collationEnv *collations.Environment, negate bool, classes [3]cmpClass, leftIR, fromIR, toIR IR) {
+	asm.adjustStack(-2)
+	asm.emit(func(env *ExpressionEnv) int {
+		left := env.vm.stack[env.vm.sp-3]
+		from := env.vm.stack[env.vm.sp-2]
+		to := env.vm.stack[env.vm.sp-1]
+
+		plan := resolveBetweenPlan(classes, leftIR, fromIR, toIR, from, to)
+		var in boolean
+		in, env.vm.err = evalBetweenExpr(collationEnv, left, from, to, negate, plan, env.now)
+
+		env.vm.stack[env.vm.sp-3] = in.eval()
+		env.vm.sp -= 2
+		return 1
+	}, "BETWEEN (SP-3), (SP-2), (SP-1) PER-EXECUTION PLAN")
+}
+
 func (asm *assembler) BitCount_b() {
 	asm.emit(func(env *ExpressionEnv) int {
 		a := env.vm.stack[env.vm.sp-1].(*evalBytes)
@@ -735,6 +768,17 @@ func (asm *assembler) CmpJSON() {
 		env.vm.flags.cmp, env.vm.err = compareJSONValue(l, r)
 		return 1
 	}, "CMP JSON(SP-2), JSON(SP-1)")
+}
+
+func (asm *assembler) CmpCaseJSON(collationEnv *collations.Environment) {
+	asm.adjustStack(-2)
+	asm.emit(func(env *ExpressionEnv) int {
+		l := env.vm.stack[env.vm.sp-2]
+		r := env.vm.stack[env.vm.sp-1]
+		env.vm.sp -= 2
+		env.vm.flags.cmp, env.vm.err = evalCompareCaseJSON(l, r, collationEnv)
+		return 1
+	}, "CMP CASE (SP-2), (SP-1)")
 }
 
 func (asm *assembler) CmpTuple(collationEnv *collations.Environment, fullEquality bool) {
@@ -3231,7 +3275,7 @@ func (asm *assembler) In_table(not bool, table map[vthash.Hash]struct{}) {
 	}
 }
 
-func (asm *assembler) In_slow(collationsEnv *collations.Environment, not bool) {
+func (asm *assembler) In_slow(collationsEnv *collations.Environment, not bool, plan inJSONDomain) {
 	asm.adjustStack(-1)
 
 	if not {
@@ -3240,7 +3284,7 @@ func (asm *assembler) In_slow(collationsEnv *collations.Environment, not bool) {
 			rhs := env.vm.stack[env.vm.sp-1].(*evalTuple)
 
 			var in boolean
-			in, env.vm.err = evalInExpr(collationsEnv, lhs, rhs)
+			in, env.vm.err = evalInExpr(collationsEnv, lhs, rhs, plan)
 
 			env.vm.stack[env.vm.sp-2] = in.not().eval()
 			env.vm.sp -= 1
@@ -3252,7 +3296,7 @@ func (asm *assembler) In_slow(collationsEnv *collations.Environment, not bool) {
 			rhs := env.vm.stack[env.vm.sp-1].(*evalTuple)
 
 			var in boolean
-			in, env.vm.err = evalInExpr(collationsEnv, lhs, rhs)
+			in, env.vm.err = evalInExpr(collationsEnv, lhs, rhs, plan)
 
 			env.vm.stack[env.vm.sp-2] = in.eval()
 			env.vm.sp -= 1

--- a/go/vt/vtgate/evalengine/compiler_asm_push.go
+++ b/go/vt/vtgate/evalengine/compiler_asm_push.go
@@ -589,6 +589,14 @@ func (asm *assembler) PushLiteral(lit eval) error {
 			env.vm.sp++
 			return 1
 		}, "PUSH TIME|DATETIME|DATE(%q)", lit.ToRawBytes())
+	case *evalJSON:
+		asm.emit(func(env *ExpressionEnv) int {
+			// JSON functions mutate documents in place; each execution
+			// of the compiled program must own its copy of the literal.
+			env.vm.stack[env.vm.sp] = lit.Clone()
+			env.vm.sp++
+			return 1
+		}, "PUSH JSON(%s)", lit.ToRawBytes())
 	default:
 		return vterrors.Errorf(vtrpc.Code_UNIMPLEMENTED, "unsupported literal kind '%T'", lit)
 	}

--- a/go/vt/vtgate/evalengine/compiler_asm_push.go
+++ b/go/vt/vtgate/evalengine/compiler_asm_push.go
@@ -589,6 +589,14 @@ func (asm *assembler) PushLiteral(lit eval) error {
 			env.vm.sp++
 			return 1
 		}, "PUSH TIME|DATETIME|DATE(%q)", lit.ToRawBytes())
+	case *evalJSON:
+		asm.emit(func(env *ExpressionEnv) int {
+			// JSON functions mutate documents in place; each execution
+			// of the compiled program must own its copy of the literal.
+			env.vm.stack[env.vm.sp] = lit.Clone()
+			env.vm.sp++
+			return 1
+		}, "PUSH JSON(%q)", lit.ToRawBytes())
 	default:
 		return vterrors.Errorf(vtrpc.Code_UNIMPLEMENTED, "unsupported literal kind '%T'", lit)
 	}

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -890,6 +891,1100 @@ func TestCompilerSingle(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestJSONComparisonDomains checks that IN, BETWEEN and simple CASE match
+// MySQL's comparison-domain coercion when a JSON value participates: IN
+// compares every pair as JSON, while BETWEEN and simple CASE never use the
+// JSON comparator. Non-JSON and NULL rows pin existing behavior.
+func TestJSONComparisonDomains(t *testing.T) {
+	testCases := []struct {
+		expression string
+		values     []sqltypes.Value
+		result     string
+	}{
+		// IN/NOT IN with a JSON value in the comparison domain.
+		{expression: `'[]' IN (JSON_ARRAY(), 0)`, result: `INT64(0)`},
+		{expression: `0 IN (JSON_ARRAY(), '0')`, result: `INT64(0)`},
+		{expression: `1 IN (JSON_ARRAY(), '1')`, result: `INT64(0)`},
+		{expression: `'[]' NOT IN (JSON_ARRAY(), 0)`, result: `INT64(1)`},
+		{expression: `JSON_ARRAY(1) IN ('[1]')`, result: `INT64(0)`},
+		{expression: `0 IN (JSON_EXTRACT('[1]', '$'), '0')`, result: `INT64(0)`},
+		{expression: `0 NOT IN (JSON_ARRAY(), '0')`, result: `INT64(1)`},
+		{expression: `1 NOT IN (JSON_ARRAY(), '1')`, result: `INT64(1)`},
+		{expression: `CAST('[]' AS JSON) IN (JSON_ARRAY(), 0)`, result: `INT64(1)`},
+		{expression: `0 IN (JSON_ARRAY(), 0)`, result: `INT64(1)`},
+		{expression: `'[]' IN (JSON_ARRAY(), '0')`, result: `INT64(0)`},
+		{expression: `'0' IN (CAST('[]' AS JSON), '0')`, result: `INT64(1)`},
+
+		// ENUM and SET values convert to JSON string scalars of their
+		// textual value when a JSON value participates in the IN domain.
+		{
+			expression: `column0 IN ('foo', JSON_ARRAY())`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Enum, []byte(`foo`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 IN (JSON_ARRAY(), 'foo')`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Enum, []byte(`foo`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 NOT IN ('foo', JSON_ARRAY())`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Enum, []byte(`foo`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 NOT IN (JSON_ARRAY(), 'foo')`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Enum, []byte(`foo`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 IN ('foo', JSON_ARRAY())`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Set, []byte(`foo`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 IN (JSON_ARRAY(), 'foo')`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Set, []byte(`foo`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 NOT IN ('foo', JSON_ARRAY())`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Set, []byte(`foo`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 NOT IN (JSON_ARRAY(), 'foo')`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Set, []byte(`foo`))},
+			result:     `INT64(0)`,
+		},
+
+		// BETWEEN/NOT BETWEEN with a JSON value in the comparison domain,
+		// compared as DOUBLE when a non-textual operand participates.
+		{expression: `'[]' BETWEEN JSON_ARRAY() AND 0`, result: `INT64(1)`},
+		{expression: `0 BETWEEN JSON_ARRAY() AND '0'`, result: `INT64(1)`},
+		{expression: `1 BETWEEN JSON_ARRAY() AND '1'`, result: `INT64(1)`},
+		{expression: `JSON_ARRAY() BETWEEN 0 AND '[]'`, result: `INT64(1)`},
+		{expression: `0 BETWEEN 0 AND JSON_ARRAY()`, result: `INT64(1)`},
+		{expression: `'[]' NOT BETWEEN JSON_ARRAY() AND 0`, result: `INT64(0)`},
+		{expression: `1 NOT BETWEEN JSON_ARRAY() AND '1'`, result: `INT64(0)`},
+		{expression: `1 BETWEEN CAST('"1"' AS JSON) AND 2`, result: `INT64(1)`},
+
+		// BETWEEN/NOT BETWEEN with only JSON and textual operands, compared
+		// as strings on the serialized text forms.
+		{expression: `JSON_ARRAY() BETWEEN CAST('0' AS JSON) AND JSON_OBJECT()`, result: `INT64(1)`},
+		{expression: `JSON_OBJECT() BETWEEN JSON_ARRAY() AND JSON_ARRAY()`, result: `INT64(0)`},
+		{expression: `CAST(2 AS JSON) BETWEEN CAST(10 AS JSON) AND CAST(3 AS JSON)`, result: `INT64(1)`},
+		{expression: `'[]' BETWEEN JSON_ARRAY() AND '0'`, result: `INT64(0)`},
+		{expression: `JSON_ARRAY() BETWEEN NULL AND CAST(0 AS JSON)`, result: `INT64(0)`},
+
+		// BETWEEN/NOT BETWEEN with a JSON operand and a statically selected
+		// temporal domain: a DATE/DATETIME/TIMESTAMP participant compares the
+		// whole domain as DATETIME; a TIME column selects the TIME domain,
+		// but a CAST(... AS TIME) expression does not.
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN JSON_ARRAY() AND '2021-01-01'`, result: `INT64(1)`},
+		{expression: `CAST('2020-01-01' AS DATE) NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATETIME) BETWEEN JSON_ARRAY() AND '2021-01-01'`, result: `INT64(1)`},
+		{expression: `CAST('2020-01-01' AS DATETIME) NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`, result: `INT64(0)`},
+		{expression: `'2020-01-01' BETWEEN JSON_ARRAY() AND CAST('2021-01-01' AS DATE)`, result: `INT64(1)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN NULL AND JSON_ARRAY()`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN JSON_ARRAY() AND NULL`, result: `NULL`},
+		{expression: `CAST('12:00:00' AS TIME) BETWEEN JSON_ARRAY() AND '13:00:00'`, result: `INT64(0)`},
+		{expression: `CAST('12:00:00' AS TIME) NOT BETWEEN JSON_ARRAY() AND '13:00:00'`, result: `INT64(1)`},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Datetime, []byte(`2020-01-01 12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Timestamp, []byte(`2020-01-01 12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '13:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 NOT BETWEEN JSON_ARRAY() AND '13:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+
+		// Composite operands whose static result type resolves to DATE select
+		// the DATETIME domain like the column itself would.
+		{
+			expression: `COALESCE(column0, column0) BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `COALESCE(column0, column0) NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `IFNULL(column0, column0) BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `IFNULL(column0, column0) NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `IF(1, column0, column0) BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `IF(1, column0, column0) NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `CASE WHEN 1 THEN column0 ELSE column0 END BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `CASE WHEN 1 THEN column0 ELSE column0 END NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `GREATEST(column0, column0) BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `GREATEST(column0, column0) NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `DATE_ADD(column0, INTERVAL 0 DAY) BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `DATE_ADD(column0, INTERVAL 0 DAY) NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+
+		// Constant composite operands resolve their static type the same way.
+		// 8.0.x constant-folds them before selecting the domain while 8.4.x
+		// does not; we match 8.4.x.
+		{expression: `COALESCE(CAST('2020-01-01' AS DATE), NULL) BETWEEN JSON_ARRAY() AND '2021-01-01'`, result: `INT64(1)`},
+		{expression: `COALESCE(CAST('2020-01-01' AS DATE), NULL) NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`, result: `INT64(0)`},
+		{expression: `GREATEST(CAST('2020-01-01' AS DATE), CAST('2020-06-01' AS DATE)) BETWEEN JSON_ARRAY() AND '2021-01-01'`, result: `INT64(1)`},
+
+		// A TIME-typed composite does not select the TIME domain: COALESCE
+		// over a TIME column falls back to the string domain.
+		{
+			expression: `COALESCE(column0, column0) BETWEEN JSON_ARRAY() AND '13:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `COALESCE(column0, column0) NOT BETWEEN JSON_ARRAY() AND '13:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+
+		// A numeric operand wins over the DATE/DATETIME/TIMESTAMP candidates
+		// unless the left operand is a bare temporal column: the whole
+		// predicate compares as DOUBLE.
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN JSON_ARRAY() AND 99999999`, result: `INT64(1)`},
+		{expression: `CAST('2020-01-01' AS DATE) NOT BETWEEN JSON_ARRAY() AND 99999999`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN 0 AND CAST('"2021-06-06"' AS JSON)`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN CAST(NULL AS SIGNED) AND CAST('"2021-06-06"' AS JSON)`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN 0.5 AND CAST('"2021-06-06"' AS JSON)`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN 0e0 AND CAST('"2021-06-06"' AS JSON)`, result: `INT64(0)`},
+		{expression: `1 BETWEEN CAST('"2"' AS JSON) AND 5`, result: `INT64(0)`},
+		{expression: `0 BETWEEN CAST('true' AS JSON) AND 5`, result: `INT64(0)`},
+		{expression: `2020 BETWEEN CAST(CAST('2020-01-01' AS DATE) AS JSON) AND 99999999`, result: `INT64(1)`},
+
+		// In the DATETIME domain a JSON operand converts from its serialized
+		// text, quotes included: JSON numbers parse, JSON strings and even
+		// JSON date scalars fail to the zero date.
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN JSON_ARRAY() AND CAST('20210101' AS JSON)`, result: `INT64(1)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN CAST('20200606' AS JSON) AND '2021-01-01'`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN JSON_ARRAY() AND CAST(CAST('2021-01-01' AS DATE) AS JSON)`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN JSON_ARRAY() AND CAST('"2021-06-06"' AS JSON)`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN NULL AND CAST('"2021-06-06"' AS JSON)`, result: `INT64(0)`},
+
+		// A declared JSON type participates in domain selection even when
+		// the value is SQL NULL; an untyped NULL stays neutral.
+		{expression: `0 IN (CAST(NULL AS JSON), '0')`, result: `NULL`},
+		{expression: `'a' BETWEEN CAST(NULL AS JSON) AND 'A'`, result: `INT64(0)`},
+		{expression: `'a' BETWEEN NULL AND 'A'`, result: `NULL`},
+		{expression: `'a' BETWEEN CAST(NULL AS CHAR) AND 'A'`, result: `NULL`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN CAST(NULL AS JSON) AND '2021-01-01'`, result: `NULL`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN CAST(NULL AS JSON) AND 0`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) IN (CAST(NULL AS JSON), '2020-01-01')`, result: `NULL`},
+
+		// The IN domain compares every pair with genuine JSON semantics:
+		// strings compare binary and never equal numbers or temporal
+		// scalars, and DATE does not equal DATETIME for the same instant.
+		{expression: `0 IN (JSON_ARRAY(), '0.0')`, result: `INT64(0)`},
+		{expression: `0.0 IN (CAST('0' AS JSON))`, result: `INT64(1)`},
+		{expression: `'2020-1-1' IN (CAST('"2020-1-1"' AS JSON))`, result: `INT64(1)`},
+		{expression: `'B' IN (JSON_ARRAY(), 'b')`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) IN (JSON_ARRAY(), CAST('2020-01-01' AS DATETIME))`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) IN (CAST('2020-01-01' AS DATE), JSON_ARRAY())`, result: `INT64(1)`},
+
+		// Row-valued IN keeps per-column comparisons: JSON inside a row does
+		// not pull the other columns into the JSON domain.
+		{expression: `(JSON_ARRAY(), 0) IN ((JSON_ARRAY(), '0'))`, result: `INT64(1)`},
+
+		// A bare TIME column on the left resolves the comparison per bound
+		// pair when a constant bound activates the conversion; otherwise the
+		// whole predicate compares as strings.
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND 99999999`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN column1 AND '13:00:00'`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)),
+				sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)),
+			},
+			result: `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN '11:00:00' AND column1`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)),
+				sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)),
+			},
+			result: `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN column1 AND '99999999'`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)),
+				sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)),
+			},
+			result: `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN column1 AND 130000`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)),
+				sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)),
+			},
+			result: `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND 'zz'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '25:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '839:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '2021-01-01 13:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND 0.5`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND column1`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)),
+				sqltypes.MakeTrusted(sqltypes.Time, []byte(`13:00:00`)),
+			},
+			result: `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN column1 AND column2`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)),
+				sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)),
+				sqltypes.MakeTrusted(sqltypes.Time, []byte(`13:00:00`)),
+			},
+			result: `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND CAST('130000' AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND CAST('"13:00:00"' AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND CAST(CAST('13:00:00' AS TIME) AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND CAST(CAST('2021-01-01 13:00:00' AS DATETIME) AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			// A typed-NULL JSON constant does not activate the per-pair
+			// paths: the predicate stays on the whole-string fallback.
+			expression: `column0 BETWEEN CAST(NULL AS JSON) AND 'zz'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `NULL`,
+		},
+		{
+			expression: `column0 BETWEEN 'zz' AND CAST(NULL AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN CAST(NULL AS JSON) AND '13:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `NULL`,
+		},
+		{
+			expression: `column0 BETWEEN CAST(NULL AS JSON) AND 99999999`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `NULL`,
+		},
+
+		// A TIME column in a bound position, or wrapped in an expression,
+		// gets no TIME treatment: the domain stays string.
+		{
+			expression: `JSON_ARRAY() BETWEEN column0 AND 'zz'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `'12:00:00' BETWEEN column0 AND JSON_ARRAY()`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `'12:00:00' BETWEEN JSON_ARRAY() AND column0`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `CAST(column0 AS TIME) BETWEEN JSON_ARRAY() AND '13:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+
+		// A bare DATE-family column on the left with a numeric operand also
+		// resolves per bound pair, and only there a JSON string scalar
+		// unquotes and converts while a JSON number is rejected.
+		{
+			expression: `column0 BETWEEN 20200101 AND CAST('"2021-06-06"' AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN CAST('"2020-01-01"' AS JSON) AND 0`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN 0 AND CAST('20210606' AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN 0 AND CAST(CAST('2021-06-06' AS DATE) AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN 0 AND CAST('"zz"' AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND column1`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`)),
+				sqltypes.MakeTrusted(sqltypes.Int64, []byte(`0`)),
+			},
+			result: `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN column1 AND '2021-01-01'`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`)),
+				sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)),
+			},
+			result: `INT64(1)`,
+		},
+		{
+			expression: `20200601 BETWEEN column0 AND CAST('"2021-06-06"' AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+
+		// The string and DOUBLE fallbacks still apply when no operand is
+		// date-carrying.
+		{expression: `'2020-01-01' BETWEEN JSON_ARRAY() AND '2021-01-01'`, result: `INT64(0)`},
+		{expression: `1.5 BETWEEN JSON_ARRAY() AND '2'`, result: `INT64(1)`},
+
+		// JSON-free temporal BETWEEN is unchanged.
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN '2019-01-01' AND '2021-01-01'`, result: `INT64(1)`},
+		{expression: `CAST('2020-01-01' AS DATE) NOT BETWEEN '2019-01-01' AND '2021-01-01'`, result: `INT64(0)`},
+		{expression: `CAST('12:00:00' AS TIME) BETWEEN '11:00:00' AND '13:00:00'`, result: `INT64(1)`},
+		{
+			expression: `column0 BETWEEN '2019-01-01' AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN '11:00:00' AND '13:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+
+		// Simple CASE with a JSON value in a (base, WHEN) pair.
+		{expression: `case JSON_ARRAY() when '[]' then 1 else 0 end`, result: `INT64(1)`},
+		{expression: `case 0 when JSON_ARRAY() then 1 when '0' then 2 else 3 end`, result: `INT64(1)`},
+		{expression: `case '[]' when JSON_ARRAY() then 1 when 0 then 2 else 3 end`, result: `INT64(1)`},
+		{expression: `case JSON_ARRAY() when 0 then 1 when '[]' then 2 else 3 end`, result: `INT64(1)`},
+		{expression: `case when JSON_ARRAY() = '[]' then 1 else 0 end`, result: `INT64(0)`},
+		{expression: `case JSON_ARRAY(1) when CAST('[1]' AS JSON) then 1 else 0 end`, result: `INT64(1)`},
+		{expression: `case JSON_OBJECT() when JSON_ARRAY() then 1 else 0 end`, result: `INT64(0)`},
+		{expression: `case CAST(1 AS JSON) when CAST('1.0' AS JSON) then 1 else 0 end`, result: `INT64(0)`},
+		{expression: `case '[1]' when 3 then 1 when JSON_ARRAY(2) then 2 else 0 end`, result: `INT64(0)`},
+
+		// JSON-free domains are unchanged.
+		{expression: `0 IN ('0', 2)`, result: `INT64(1)`},
+		{expression: `1 BETWEEN 0 AND '2'`, result: `INT64(1)`},
+		{expression: `2 NOT BETWEEN 5 AND 20`, result: `INT64(1)`},
+		{expression: `'b' BETWEEN 'a' AND 'c'`, result: `INT64(1)`},
+		{expression: `case 0 when '0' then 1 else 2 end`, result: `INT64(1)`},
+		{expression: `case 'b' when 'b' then 1 else 2 end`, result: `INT64(1)`},
+
+		// NULL semantics are unchanged, with or without JSON in the domain.
+		{expression: `NULL IN (JSON_ARRAY(), 1)`, result: `NULL`},
+		{expression: `1 IN (NULL, JSON_ARRAY())`, result: `NULL`},
+		{expression: `0 IN (NULL, '0')`, result: `INT64(1)`},
+		{expression: `3 IN (NULL, '0')`, result: `NULL`},
+		{expression: `NULL NOT IN (1, 2)`, result: `NULL`},
+		{expression: `NULL BETWEEN 1 AND 2`, result: `NULL`},
+		{expression: `1 BETWEEN NULL AND 2`, result: `NULL`},
+		{expression: `1 BETWEEN 2 AND NULL`, result: `INT64(0)`},
+		{expression: `1 NOT BETWEEN 2 AND NULL`, result: `INT64(1)`},
+		{expression: `1 BETWEEN NULL AND 0`, result: `INT64(0)`},
+		{expression: `0 BETWEEN NULL AND JSON_ARRAY()`, result: `NULL`},
+		{expression: `NULL BETWEEN JSON_ARRAY() AND 1`, result: `NULL`},
+		{expression: `case NULL when NULL then 1 else 2 end`, result: `INT64(2)`},
+		{expression: `case 1 when NULL then 1 else 2 end`, result: `INT64(2)`},
+		{expression: `case NULL when JSON_ARRAY() then 1 else 2 end`, result: `INT64(2)`},
+
+		// The comparison domain is decided from runtime types.
+		{
+			expression: `0 IN (column0, '0')`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `0 BETWEEN column0 AND '0'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `case column0 when '[]' then 1 else 0 end`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`))},
+			result:     `INT64(1)`,
+		},
+
+		// MySQL's IN type scan stops after the first element that is not
+		// constant for one execution, the stopper included: a JSON element
+		// behind it never selects JSON comparison, while a constant element
+		// never stops the scan.
+		{
+			expression: `'12:00:00' IN (column0, JSON_ARRAY())`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `'12:00:00' IN (JSON_ARRAY(), column0)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `0 IN (column0, '0', JSON_ARRAY())`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Int64, []byte(`1`))},
+			result:     `INT64(1)`,
+		},
+		{expression: `'12:00:00' IN (CAST('12:00:00' AS TIME), JSON_ARRAY())`, result: `INT64(0)`},
+
+		// A temporal column with a nonconstant JSON bound and a numeric
+		// participant compares numerically; a JSON constant keeps the
+		// field-store conversion.
+		{
+			expression: `column0 BETWEEN column1 AND 99999999`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`)),
+				sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`99999999`)),
+			},
+			result: `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN column1 AND 99999999`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)),
+				sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)),
+			},
+			result: `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN CAST('99999999' AS JSON) AND 99999999`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			// The maximum unsigned integer is not TIME-convertible: it must
+			// not wrap into a negative TIME through int64 narrowing.
+			expression: `column0 BETWEEN JSON_ARRAY() AND 18446744073709551615`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+	}
+
+	venv := vtenv.NewTestEnv()
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			expr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+
+			fields := evalengine.FieldResolver(makeFields(tc.values))
+			for _, folding := range []bool{false, true} {
+				cfg := &evalengine.Config{
+					ResolveColumn:     fields.Column,
+					ResolveType:       fields.Type,
+					Collation:         collations.CollationUtf8mb4ID,
+					Environment:       venv,
+					NoConstantFolding: !folding,
+				}
+
+				converted, err := evalengine.Translate(expr, cfg)
+				require.NoError(t, err)
+
+				env := evalengine.EmptyExpressionEnv(venv)
+				env.Row = tc.values
+
+				expected, err := env.EvaluateAST(converted)
+				require.NoError(t, err)
+				require.Equalf(t, tc.result, expected.String(), "bad evaluation from eval engine (folding=%v)", folding)
+
+				res, err := env.Evaluate(converted)
+				require.NoError(t, err)
+				assert.Equalf(t, tc.result, res.String(), "bad evaluation from compiler (folding=%v)", folding)
+			}
+		})
+	}
+}
+
+// TestJSONComparisonDomainsUntypedOperands checks that operand types
+// resolved only at evaluation time — from result fields or bind variable
+// values — select the same comparison domain as statically typed
+// translation, on both the AST and compiled paths.
+func TestJSONComparisonDomainsUntypedOperands(t *testing.T) {
+	type step struct {
+		row    []sqltypes.Value
+		binds  map[string]*querypb.BindVariable
+		result string
+	}
+	bind := func(tt sqltypes.Type, v string) map[string]*querypb.BindVariable {
+		return map[string]*querypb.BindVariable{
+			"v": sqltypes.ValueBindVariable(sqltypes.MakeTrusted(tt, []byte(v))),
+		}
+	}
+	field := func(name string, tt sqltypes.Type) *querypb.Field {
+		charset := uint32(collations.CollationBinaryID)
+		if sqltypes.IsText(tt) {
+			charset = uint32(collations.CollationUtf8mb4ID)
+		}
+		return &querypb.Field{Name: name, Type: tt, Charset: charset}
+	}
+
+	testCases := []struct {
+		expression string
+		fields     []*querypb.Field
+		steps      []step
+		// compileErr asserts that explicit compilation fails while AST
+		// evaluation still resolves the declared comparison plan.
+		compileErr string
+	}{
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Date)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Datetime)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Datetime, []byte(`2020-01-01 12:00:00`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			expression: `:v BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			steps: []step{
+				{binds: bind(sqltypes.Timestamp, `2020-01-01 12:00:00`), result: `INT64(1)`},
+			},
+		},
+		{
+			// One translated expression, re-evaluated with changing bind
+			// types: each evaluation selects its own domain, and the third
+			// one reuses the DATE specialization of the first.
+			expression: `:v BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			steps: []step{
+				{binds: bind(sqltypes.Date, `2020-01-01`), result: `INT64(1)`},
+				{binds: bind(sqltypes.VarChar, `2020-01-01`), result: `INT64(0)`},
+				{binds: bind(sqltypes.Date, `2020-01-01`), result: `INT64(1)`},
+			},
+		},
+		{
+			// A TIME bind is not a column: no TIME treatment, string domain.
+			expression: `:v BETWEEN JSON_ARRAY() AND '13:00:00'`,
+			steps: []step{
+				{binds: bind(sqltypes.Time, `12:00:00`), result: `INT64(0)`},
+			},
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '13:00:00'`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Time)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			expression: `'12:00:00' BETWEEN JSON_ARRAY() AND column0`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Time)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))}, result: `INT64(0)`},
+			},
+		},
+		{
+			expression: `JSON_ARRAY() BETWEEN column0 AND 'zz'`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Time)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			// The declared DATE type of an all-NULL column still selects the
+			// DATETIME domain.
+			expression: `JSON_ARRAY() BETWEEN column0 AND '2021-01-01'`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Date)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.NULL}, result: `NULL`},
+			},
+		},
+		{
+			// The declared JSON type of an all-NULL column still forces the
+			// binary string collation; a VARCHAR column keeps the default
+			// case-insensitive comparison.
+			expression: `'a' BETWEEN column0 AND 'A'`,
+			fields:     []*querypb.Field{field("column0", sqltypes.TypeJSON)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.NULL}, result: `INT64(0)`},
+			},
+		},
+		{
+			expression: `'a' BETWEEN column0 AND 'A'`,
+			fields:     []*querypb.Field{field("column0", sqltypes.VarChar)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.NULL}, result: `NULL`},
+			},
+		},
+		{
+			expression: `0 IN (column0, '0')`,
+			fields:     []*querypb.Field{field("column0", sqltypes.TypeJSON)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`))}, result: `INT64(0)`},
+				{row: []sqltypes.Value{sqltypes.NULL}, result: `NULL`},
+			},
+		},
+		{
+			expression: `0 IN (column0, '0')`,
+			fields:     []*querypb.Field{field("column0", sqltypes.VarChar)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.VarChar, []byte(`0`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			// The DATE-column field path applies with a late-resolved JSON
+			// column whose value is SQL NULL.
+			expression: `column0 BETWEEN column1 AND 99999999`,
+			fields: []*querypb.Field{
+				field("column0", sqltypes.Date),
+				field("column1", sqltypes.TypeJSON),
+			},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`)), sqltypes.NULL}, result: `NULL`},
+			},
+		},
+
+		// A composite operand contributes its declared result type, not the
+		// selected child's runtime representation, including when the value
+		// is SQL NULL.
+		{
+			expression: `0 IN (COALESCE(column0, NULL), '0')`,
+			fields:     []*querypb.Field{field("column0", sqltypes.TypeJSON)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.NULL}, result: `NULL`},
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`))}, result: `INT64(0)`},
+			},
+		},
+		{
+			expression: `'a' BETWEEN COALESCE(column0, NULL) AND 'A'`,
+			fields:     []*querypb.Field{field("column0", sqltypes.TypeJSON)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.NULL}, result: `INT64(0)`},
+			},
+		},
+		{
+			expression: `JSON_ARRAY() BETWEEN COALESCE(column0, NULL) AND '2021-01-01'`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Date)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.NULL}, result: `NULL`},
+			},
+		},
+		{
+			// COALESCE over DATE and VARCHAR declares a string result: the
+			// selected DATE child must not switch the domain.
+			expression: `COALESCE(column0, column1) BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			fields: []*querypb.Field{
+				field("column0", sqltypes.Date),
+				field("column1", sqltypes.VarChar),
+			},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`)), sqltypes.NULL}, result: `INT64(0)`},
+			},
+		},
+		{
+			// COALESCE over JSON and VARCHAR declares a non-JSON result: the
+			// selected JSON child must not re-enable JSON comparison.
+			expression: `0 IN (COALESCE(column0, column1), '0')`,
+			fields: []*querypb.Field{
+				field("column0", sqltypes.TypeJSON),
+				field("column1", sqltypes.VarChar),
+			},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`)), sqltypes.NULL}, result: `INT64(1)`},
+			},
+		},
+		{
+			// The composite's declared type resolves even though this
+			// dynamic JSON_CONTAINS_PATH shape stays VM-unsupported.
+			expression: `0 IN (COALESCE(column0, JSON_CONTAINS_PATH(column0, column1, '$')), '0')`,
+			fields: []*querypb.Field{
+				field("column0", sqltypes.TypeJSON),
+				field("column1", sqltypes.VarChar),
+			},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`)), sqltypes.MakeTrusted(sqltypes.VarChar, []byte(`one`))}, result: `INT64(1)`},
+			},
+			compileErr: `unsupported compilation for IR 'JSON_CONTAINS_PATH`,
+		},
+
+		// MySQL's IN type scan stops after the first element that is not
+		// constant for one execution: a JSON element behind the stopper
+		// never selects JSON comparison.
+		{
+			expression: `'12:00:00' IN (column0, JSON_ARRAY())`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Time)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			expression: `'12:00:00' IN (JSON_ARRAY(), column0)`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Time)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))}, result: `INT64(0)`},
+			},
+		},
+		{
+			// The stopper's own declared type still joins the scan: the
+			// left string converts to DATE for the first comparison.
+			expression: `'2020-1-1' IN (column0, JSON_ARRAY())`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Date)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			expression: `'2020-01-01' IN (JSON_ARRAY(), column0)`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Date)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))}, result: `INT64(0)`},
+			},
+		},
+		{
+			expression: `0 IN (column0, '0', JSON_ARRAY())`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Int64)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Int64, []byte(`1`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			expression: `0 NOT IN (column0, '0', JSON_ARRAY())`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Int64)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Int64, []byte(`1`))}, result: `INT64(0)`},
+			},
+		},
+		{
+			// A bind parameter is constant for one execution: the scan
+			// continues past it and reaches the JSON element.
+			expression: `0 IN (:v, '0', JSON_ARRAY())`,
+			steps: []step{
+				{binds: bind(sqltypes.Int64, `1`), result: `INT64(0)`},
+			},
+		},
+
+		// A temporal column with a nonconstant JSON bound and a numeric
+		// participant compares numerically: the field-store and TIME
+		// conversions apply only to constant bounds.
+		{
+			expression: `column0 BETWEEN column1 AND 99999999`,
+			fields: []*querypb.Field{
+				field("column0", sqltypes.Date),
+				field("column1", sqltypes.TypeJSON),
+			},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`)), sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`99999999`))}, result: `INT64(0)`},
+			},
+		},
+		{
+			expression: `column0 BETWEEN column1 AND column2`,
+			fields: []*querypb.Field{
+				field("column0", sqltypes.Date),
+				field("column1", sqltypes.TypeJSON),
+				field("column2", sqltypes.Int64),
+			},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`)), sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`99999999`)), sqltypes.MakeTrusted(sqltypes.Int64, []byte(`99999999`))}, result: `INT64(0)`},
+			},
+		},
+		{
+			expression: `column0 BETWEEN column1 AND 99999999`,
+			fields: []*querypb.Field{
+				field("column0", sqltypes.Time),
+				field("column1", sqltypes.TypeJSON),
+			},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)), sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			expression: `column0 BETWEEN column1 AND column2`,
+			fields: []*querypb.Field{
+				field("column0", sqltypes.Time),
+				field("column1", sqltypes.TypeJSON),
+				field("column2", sqltypes.Int64),
+			},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)), sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)), sqltypes.MakeTrusted(sqltypes.Int64, []byte(`99999999`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			// The maximum unsigned integer is not TIME-convertible: it must
+			// not wrap into a negative TIME through int64 narrowing.
+			expression: `column0 BETWEEN JSON_ARRAY() AND 18446744073709551615`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Time)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))}, result: `INT64(1)`},
+			},
+		},
+
+		// The reached comparison derives the composite's declared JSON
+		// type — which is what makes the left side false rather than NULL —
+		// while AND keeps the missing bind short-circuited and unresolved.
+		{
+			expression: `('a' BETWEEN COALESCE(column0, NULL) AND 'A') AND :unused`,
+			fields:     []*querypb.Field{field("column0", sqltypes.TypeJSON)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.NULL}, result: `INT64(0)`},
+			},
+			compileErr: `query arguments missing for unused`,
+		},
+	}
+
+	venv := vtenv.NewTestEnv()
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			expr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+
+			for _, folding := range []bool{false, true} {
+				cfg := &evalengine.Config{
+					ResolveColumn:     evalengine.FieldResolver(tc.fields).Column,
+					Collation:         collations.CollationUtf8mb4ID,
+					Environment:       venv,
+					NoConstantFolding: !folding,
+				}
+				translated, err := evalengine.Translate(expr, cfg)
+				require.NoError(t, err)
+				untyped, ok := translated.(*evalengine.UntypedExpr)
+				require.True(t, ok, "expected an untyped translation")
+
+				env := evalengine.EmptyExpressionEnv(venv)
+				env.Fields = tc.fields
+				for i, s := range tc.steps {
+					env.Row = s.row
+					env.BindVars = s.binds
+
+					ast, err := env.EvaluateAST(untyped)
+					require.NoError(t, err)
+					assert.Equalf(t, s.result, ast.String(), "bad evaluation from eval engine (step %d, folding=%v)", i, folding)
+
+					compiled, err := untyped.Compile(env)
+					if tc.compileErr != "" {
+						require.ErrorContains(t, err, tc.compileErr)
+						continue
+					}
+					require.NoError(t, err)
+					vm, err := env.EvaluateVM(compiled)
+					require.NoError(t, err)
+					assert.Equalf(t, s.result, vm.String(), "bad evaluation from compiler (step %d, folding=%v)", i, folding)
+				}
+			}
+		})
+	}
+}
+
+// TestJSONComparisonDomainsConcurrency evaluates one translated comparison
+// from many goroutines with alternating bind types: the JSON-typed bind
+// selects the binary JSON/string domain, the VARCHAR bind the default
+// case-insensitive one. With -race, this catches comparison plans or type
+// specializations shared across evaluations.
+func TestJSONComparisonDomainsConcurrency(t *testing.T) {
+	venv := vtenv.NewTestEnv()
+	expr, err := venv.Parser().ParseExpr(`'a' BETWEEN COALESCE(:w, NULL) AND 'z'`)
+	require.NoError(t, err)
+	translated, err := evalengine.Translate(expr, &evalengine.Config{
+		Collation:   collations.CollationUtf8mb4ID,
+		Environment: venv,
+	})
+	require.NoError(t, err)
+
+	const goroutines, evaluations = 8, 50
+	errs := make([]error, goroutines)
+	observed := make([][]string, goroutines)
+
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		jsonBind := i%2 == 0
+		observed[i] = make([]string, evaluations)
+		wg.Go(func() {
+			bindVar := sqltypes.ValueBindVariable(sqltypes.MakeTrusted(sqltypes.VarChar, []byte(`B`)))
+			if jsonBind {
+				bindVar = sqltypes.ValueBindVariable(sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`"B"`)))
+			}
+			env := evalengine.EmptyExpressionEnv(venv)
+			env.BindVars = map[string]*querypb.BindVariable{"w": bindVar}
+			for n := range evaluations {
+				res, err := env.Evaluate(translated)
+				if err != nil {
+					errs[i] = err
+					return
+				}
+				observed[i][n] = res.String()
+			}
+		})
+	}
+	wg.Wait()
+
+	for i := range goroutines {
+		require.NoErrorf(t, errs[i], "goroutine %d", i)
+		result := `INT64(0)`
+		if i%2 == 0 {
+			result = `INT64(1)`
+		}
+		for _, got := range observed[i] {
+			assert.Equal(t, result, got)
+		}
+	}
+}
+
+// TestJSONComparisonDomainsTupleBind checks that one translated tuple bind,
+// re-executed with changing element declarations, selects the comparison
+// domain from the expanded list's declared element types on every execution.
+func TestJSONComparisonDomainsTupleBind(t *testing.T) {
+	tupleBind := func(vals ...sqltypes.Value) map[string]*querypb.BindVariable {
+		bv := &querypb.BindVariable{Type: querypb.Type_TUPLE}
+		for _, v := range vals {
+			bv.Values = append(bv.Values, sqltypes.ValueToProto(v))
+		}
+		return map[string]*querypb.BindVariable{"vals": bv}
+	}
+
+	venv := vtenv.NewTestEnv()
+	expr, err := venv.Parser().ParseExpr(`0 IN ::vals`)
+	require.NoError(t, err)
+	translated, err := evalengine.Translate(expr, &evalengine.Config{
+		Collation:   collations.CollationUtf8mb4ID,
+		Environment: venv,
+	})
+	require.NoError(t, err)
+
+	steps := []struct {
+		binds  map[string]*querypb.BindVariable
+		result string
+	}{
+		{binds: tupleBind(sqltypes.MakeTrusted(sqltypes.Int64, []byte(`1`)), sqltypes.MakeTrusted(sqltypes.VarChar, []byte(`0`))), result: `INT64(1)`},
+		{binds: tupleBind(sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)), sqltypes.MakeTrusted(sqltypes.VarChar, []byte(`0`))), result: `INT64(0)`},
+		{binds: tupleBind(sqltypes.MakeTrusted(sqltypes.Int64, []byte(`1`)), sqltypes.MakeTrusted(sqltypes.VarChar, []byte(`0`))), result: `INT64(1)`},
+	}
+	env := evalengine.EmptyExpressionEnv(venv)
+	for i, s := range steps {
+		env.BindVars = s.binds
+
+		ast, err := env.EvaluateAST(translated)
+		require.NoError(t, err)
+		assert.Equalf(t, s.result, ast.String(), "bad evaluation from eval engine (step %d)", i)
+
+		res, err := env.Evaluate(translated)
+		require.NoError(t, err)
+		assert.Equalf(t, s.result, res.String(), "bad evaluation from compiler (step %d)", i)
 	}
 }
 

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -1129,3 +1129,69 @@ func TestCompilerNonConstant(t *testing.T) {
 		})
 	}
 }
+
+// TestJSONInStaticTable checks that IN over folded JSON literals does not
+// compile the static hash table: JSON arrays and objects hash by kind and
+// cardinality only, so a hash hit is not equality. Compilation fails until
+// the compiler learns to push JSON literals; the follow-up literal change
+// flips this test to compiled evaluation.
+func TestJSONInStaticTable(t *testing.T) {
+	testCases := []struct {
+		expression string
+		values     []sqltypes.Value
+		result     string
+	}{
+		{
+			expression: `column0 IN (JSON_ARRAY(2))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 IN (JSON_OBJECT('b', 2))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`{"a": 1}`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 IN (JSON_ARRAY(1))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 IN (JSON_OBJECT('a', 1))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`{"a": 1}`))},
+			result:     `INT64(1)`,
+		},
+	}
+
+	venv := vtenv.NewTestEnv()
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			expr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+
+			fields := evalengine.FieldResolver(makeFields(tc.values))
+			cfg := &evalengine.Config{
+				ResolveColumn: fields.Column,
+				Collation:     collations.CollationUtf8mb4ID,
+				Environment:   venv,
+			}
+
+			translated, err := evalengine.Translate(expr, cfg)
+			require.NoError(t, err)
+
+			untyped, ok := translated.(*evalengine.UntypedExpr)
+			require.True(t, ok)
+
+			env := evalengine.EmptyExpressionEnv(venv)
+			env.Row = tc.values
+			env.Fields = makeFields(tc.values)
+
+			res, err := env.EvaluateAST(untyped)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, res.String())
+
+			_, err = untyped.Compile(env)
+			require.ErrorContains(t, err, "unsupported literal kind")
+		})
+	}
+}

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -1102,9 +1102,8 @@ func TestCompilerNonConstant(t *testing.T) {
 
 // TestJSONInStaticTable checks that IN over folded JSON literals does not
 // compile the static hash table: JSON arrays and objects hash by kind and
-// cardinality only, so a hash hit is not equality. Compilation fails until
-// the compiler learns to push JSON literals; the follow-up literal change
-// flips this test to compiled evaluation.
+// cardinality only, so a hash hit is not equality. The compiled comparison
+// must agree with AST evaluation.
 func TestJSONInStaticTable(t *testing.T) {
 	testCases := []struct {
 		expression string
@@ -1160,8 +1159,12 @@ func TestJSONInStaticTable(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tc.result, res.String())
 
-			_, err = untyped.Compile(env)
-			require.ErrorContains(t, err, "unsupported literal kind")
+			compiled, err := untyped.Compile(env)
+			require.NoError(t, err)
+
+			res, err = env.EvaluateVM(compiled)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, res.String())
 		})
 	}
 }

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -1099,3 +1099,69 @@ func TestCompilerNonConstant(t *testing.T) {
 		})
 	}
 }
+
+// TestJSONInStaticTable checks that IN over folded JSON literals does not
+// compile the static hash table: JSON arrays and objects hash by kind and
+// cardinality only, so a hash hit is not equality. Compilation fails until
+// the compiler learns to push JSON literals; the follow-up literal change
+// flips this test to compiled evaluation.
+func TestJSONInStaticTable(t *testing.T) {
+	testCases := []struct {
+		expression string
+		values     []sqltypes.Value
+		result     string
+	}{
+		{
+			expression: `column0 IN (JSON_ARRAY(2))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 IN (JSON_OBJECT('b', 2))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`{"a": 1}`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 IN (JSON_ARRAY(1))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 IN (JSON_OBJECT('a', 1))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`{"a": 1}`))},
+			result:     `INT64(1)`,
+		},
+	}
+
+	venv := vtenv.NewTestEnv()
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			expr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+
+			fields := evalengine.FieldResolver(makeFields(tc.values))
+			cfg := &evalengine.Config{
+				ResolveColumn: fields.Column,
+				Collation:     collations.CollationUtf8mb4ID,
+				Environment:   venv,
+			}
+
+			translated, err := evalengine.Translate(expr, cfg)
+			require.NoError(t, err)
+
+			untyped, ok := translated.(*evalengine.UntypedExpr)
+			require.True(t, ok)
+
+			env := evalengine.EmptyExpressionEnv(venv)
+			env.Row = tc.values
+			env.Fields = makeFields(tc.values)
+
+			res, err := env.EvaluateAST(untyped)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, res.String())
+
+			_, err = untyped.Compile(env)
+			require.ErrorContains(t, err, "unsupported literal kind")
+		})
+	}
+}

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -1132,9 +1132,8 @@ func TestCompilerNonConstant(t *testing.T) {
 
 // TestJSONInStaticTable checks that IN over folded JSON literals does not
 // compile the static hash table: JSON arrays and objects hash by kind and
-// cardinality only, so a hash hit is not equality. Compilation fails until
-// the compiler learns to push JSON literals; the follow-up literal change
-// flips this test to compiled evaluation.
+// cardinality only, so a hash hit is not equality. The compiled comparison
+// must agree with AST evaluation.
 func TestJSONInStaticTable(t *testing.T) {
 	testCases := []struct {
 		expression string
@@ -1190,8 +1189,12 @@ func TestJSONInStaticTable(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tc.result, res.String())
 
-			_, err = untyped.Compile(env)
-			require.ErrorContains(t, err, "unsupported literal kind")
+			compiled, err := untyped.Compile(env)
+			require.NoError(t, err)
+
+			res, err = env.EvaluateVM(compiled)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, res.String())
 		})
 	}
 }

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -920,6 +921,1143 @@ func TestCompilerSingle(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestJSONComparisonDomains checks that IN, BETWEEN and simple CASE match
+// MySQL's comparison-domain coercion when a JSON value participates: IN
+// compares every pair as JSON, while BETWEEN and simple CASE never use the
+// JSON comparator. Non-JSON and NULL rows pin existing behavior.
+func TestJSONComparisonDomains(t *testing.T) {
+	testCases := []struct {
+		expression string
+		values     []sqltypes.Value
+		result     string
+	}{
+		// IN/NOT IN with a JSON value in the comparison domain.
+		{expression: `'[]' IN (JSON_ARRAY(), 0)`, result: `INT64(0)`},
+		{expression: `0 IN (JSON_ARRAY(), '0')`, result: `INT64(0)`},
+		{expression: `1 IN (JSON_ARRAY(), '1')`, result: `INT64(0)`},
+		{expression: `'[]' NOT IN (JSON_ARRAY(), 0)`, result: `INT64(1)`},
+		{expression: `JSON_ARRAY(1) IN ('[1]')`, result: `INT64(0)`},
+		{expression: `0 IN (JSON_EXTRACT('[1]', '$'), '0')`, result: `INT64(0)`},
+		{expression: `0 NOT IN (JSON_ARRAY(), '0')`, result: `INT64(1)`},
+		{expression: `1 NOT IN (JSON_ARRAY(), '1')`, result: `INT64(1)`},
+		{expression: `CAST('[]' AS JSON) IN (JSON_ARRAY(), 0)`, result: `INT64(1)`},
+		{expression: `0 IN (JSON_ARRAY(), 0)`, result: `INT64(1)`},
+		{expression: `'[]' IN (JSON_ARRAY(), '0')`, result: `INT64(0)`},
+		{expression: `'0' IN (CAST('[]' AS JSON), '0')`, result: `INT64(1)`},
+
+		// ENUM and SET values convert to JSON string scalars of their
+		// textual value when a JSON value participates in the IN domain.
+		{
+			expression: `column0 IN ('foo', JSON_ARRAY())`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Enum, []byte(`foo`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 IN (JSON_ARRAY(), 'foo')`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Enum, []byte(`foo`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 NOT IN ('foo', JSON_ARRAY())`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Enum, []byte(`foo`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 NOT IN (JSON_ARRAY(), 'foo')`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Enum, []byte(`foo`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 IN ('foo', JSON_ARRAY())`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Set, []byte(`foo`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 IN (JSON_ARRAY(), 'foo')`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Set, []byte(`foo`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 NOT IN ('foo', JSON_ARRAY())`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Set, []byte(`foo`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 NOT IN (JSON_ARRAY(), 'foo')`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Set, []byte(`foo`))},
+			result:     `INT64(0)`,
+		},
+
+		// BETWEEN/NOT BETWEEN with a JSON value in the comparison domain,
+		// compared as DOUBLE when a non-textual operand participates.
+		{expression: `'[]' BETWEEN JSON_ARRAY() AND 0`, result: `INT64(1)`},
+		{expression: `0 BETWEEN JSON_ARRAY() AND '0'`, result: `INT64(1)`},
+		{expression: `1 BETWEEN JSON_ARRAY() AND '1'`, result: `INT64(1)`},
+		{expression: `JSON_ARRAY() BETWEEN 0 AND '[]'`, result: `INT64(1)`},
+		{expression: `0 BETWEEN 0 AND JSON_ARRAY()`, result: `INT64(1)`},
+		{expression: `'[]' NOT BETWEEN JSON_ARRAY() AND 0`, result: `INT64(0)`},
+		{expression: `1 NOT BETWEEN JSON_ARRAY() AND '1'`, result: `INT64(0)`},
+		{expression: `1 BETWEEN CAST('"1"' AS JSON) AND 2`, result: `INT64(1)`},
+
+		// BETWEEN/NOT BETWEEN with only JSON and textual operands, compared
+		// as strings on the serialized text forms.
+		{expression: `JSON_ARRAY() BETWEEN CAST('0' AS JSON) AND JSON_OBJECT()`, result: `INT64(1)`},
+		{expression: `JSON_OBJECT() BETWEEN JSON_ARRAY() AND JSON_ARRAY()`, result: `INT64(0)`},
+		{expression: `CAST(2 AS JSON) BETWEEN CAST(10 AS JSON) AND CAST(3 AS JSON)`, result: `INT64(1)`},
+		{expression: `'[]' BETWEEN JSON_ARRAY() AND '0'`, result: `INT64(0)`},
+		{expression: `JSON_ARRAY() BETWEEN NULL AND CAST(0 AS JSON)`, result: `INT64(0)`},
+
+		// BETWEEN/NOT BETWEEN with a JSON operand and a statically selected
+		// temporal domain: a DATE/DATETIME/TIMESTAMP participant compares the
+		// whole domain as DATETIME; a TIME column selects the TIME domain,
+		// but a CAST(... AS TIME) expression does not.
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN JSON_ARRAY() AND '2021-01-01'`, result: `INT64(1)`},
+		{expression: `CAST('2020-01-01' AS DATE) NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATETIME) BETWEEN JSON_ARRAY() AND '2021-01-01'`, result: `INT64(1)`},
+		{expression: `CAST('2020-01-01' AS DATETIME) NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`, result: `INT64(0)`},
+		{expression: `'2020-01-01' BETWEEN JSON_ARRAY() AND CAST('2021-01-01' AS DATE)`, result: `INT64(1)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN NULL AND JSON_ARRAY()`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN JSON_ARRAY() AND NULL`, result: `NULL`},
+		{expression: `CAST('12:00:00' AS TIME) BETWEEN JSON_ARRAY() AND '13:00:00'`, result: `INT64(0)`},
+		{expression: `CAST('12:00:00' AS TIME) NOT BETWEEN JSON_ARRAY() AND '13:00:00'`, result: `INT64(1)`},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Datetime, []byte(`2020-01-01 12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Timestamp, []byte(`2020-01-01 12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '13:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 NOT BETWEEN JSON_ARRAY() AND '13:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+
+		// Composite operands whose static result type resolves to DATE select
+		// the DATETIME domain like the column itself would.
+		{
+			expression: `COALESCE(column0, column0) BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `COALESCE(column0, column0) NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `IFNULL(column0, column0) BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `IFNULL(column0, column0) NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `IF(1, column0, column0) BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `IF(1, column0, column0) NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `CASE WHEN 1 THEN column0 ELSE column0 END BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `CASE WHEN 1 THEN column0 ELSE column0 END NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `GREATEST(column0, column0) BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `GREATEST(column0, column0) NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `DATE_ADD(column0, INTERVAL 0 DAY) BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `DATE_ADD(column0, INTERVAL 0 DAY) NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+
+		// Constant composite operands resolve their static type the same way.
+		// 8.0.x constant-folds them before selecting the domain while 8.4.x
+		// does not; we match 8.4.x.
+		{expression: `COALESCE(CAST('2020-01-01' AS DATE), NULL) BETWEEN JSON_ARRAY() AND '2021-01-01'`, result: `INT64(1)`},
+		{expression: `COALESCE(CAST('2020-01-01' AS DATE), NULL) NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`, result: `INT64(0)`},
+		{expression: `GREATEST(CAST('2020-01-01' AS DATE), CAST('2020-06-01' AS DATE)) BETWEEN JSON_ARRAY() AND '2021-01-01'`, result: `INT64(1)`},
+
+		// A TIME-typed composite does not select the TIME domain: COALESCE
+		// over a TIME column falls back to the string domain.
+		{
+			expression: `COALESCE(column0, column0) BETWEEN JSON_ARRAY() AND '13:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `COALESCE(column0, column0) NOT BETWEEN JSON_ARRAY() AND '13:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+
+		// A numeric operand wins over the DATE/DATETIME/TIMESTAMP candidates
+		// unless the left operand is a bare temporal column: the whole
+		// predicate compares as DOUBLE.
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN JSON_ARRAY() AND 99999999`, result: `INT64(1)`},
+		{expression: `CAST('2020-01-01' AS DATE) NOT BETWEEN JSON_ARRAY() AND 99999999`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN 0 AND CAST('"2021-06-06"' AS JSON)`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN CAST(NULL AS SIGNED) AND CAST('"2021-06-06"' AS JSON)`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN 0.5 AND CAST('"2021-06-06"' AS JSON)`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN 0e0 AND CAST('"2021-06-06"' AS JSON)`, result: `INT64(0)`},
+		{expression: `1 BETWEEN CAST('"2"' AS JSON) AND 5`, result: `INT64(0)`},
+		{expression: `0 BETWEEN CAST('true' AS JSON) AND 5`, result: `INT64(0)`},
+		{expression: `2020 BETWEEN CAST(CAST('2020-01-01' AS DATE) AS JSON) AND 99999999`, result: `INT64(1)`},
+
+		// In the DATETIME domain a JSON operand converts from its serialized
+		// text, quotes included: JSON numbers parse, JSON strings and even
+		// JSON date scalars fail to the zero date.
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN JSON_ARRAY() AND CAST('20210101' AS JSON)`, result: `INT64(1)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN CAST('20200606' AS JSON) AND '2021-01-01'`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN JSON_ARRAY() AND CAST(CAST('2021-01-01' AS DATE) AS JSON)`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN JSON_ARRAY() AND CAST('"2021-06-06"' AS JSON)`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN NULL AND CAST('"2021-06-06"' AS JSON)`, result: `INT64(0)`},
+
+		// A declared JSON type participates in domain selection even when
+		// the value is SQL NULL; an untyped NULL stays neutral.
+		{expression: `0 IN (CAST(NULL AS JSON), '0')`, result: `NULL`},
+		{expression: `'a' BETWEEN CAST(NULL AS JSON) AND 'A'`, result: `INT64(0)`},
+		{expression: `'a' BETWEEN NULL AND 'A'`, result: `NULL`},
+		{expression: `'a' BETWEEN CAST(NULL AS CHAR) AND 'A'`, result: `NULL`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN CAST(NULL AS JSON) AND '2021-01-01'`, result: `NULL`},
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN CAST(NULL AS JSON) AND 0`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) IN (CAST(NULL AS JSON), '2020-01-01')`, result: `NULL`},
+
+		// The IN domain compares every pair with genuine JSON semantics:
+		// strings compare binary and never equal numbers or temporal
+		// scalars, and DATE does not equal DATETIME for the same instant.
+		{expression: `0 IN (JSON_ARRAY(), '0.0')`, result: `INT64(0)`},
+		{expression: `0.0 IN (CAST('0' AS JSON))`, result: `INT64(1)`},
+		{expression: `'2020-1-1' IN (CAST('"2020-1-1"' AS JSON))`, result: `INT64(1)`},
+		{expression: `'B' IN (JSON_ARRAY(), 'b')`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) IN (JSON_ARRAY(), CAST('2020-01-01' AS DATETIME))`, result: `INT64(0)`},
+		{expression: `CAST('2020-01-01' AS DATE) IN (CAST('2020-01-01' AS DATE), JSON_ARRAY())`, result: `INT64(1)`},
+
+		// Row-valued IN keeps per-column comparisons: JSON inside a row does
+		// not pull the other columns into the JSON domain.
+		{expression: `(JSON_ARRAY(), 0) IN ((JSON_ARRAY(), '0'))`, result: `INT64(1)`},
+
+		// A bare TIME column on the left resolves the comparison per bound
+		// pair when a constant bound activates the conversion; otherwise the
+		// whole predicate compares as strings.
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND 99999999`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN column1 AND '13:00:00'`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)),
+				sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)),
+			},
+			result: `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN '11:00:00' AND column1`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)),
+				sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)),
+			},
+			result: `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN column1 AND '99999999'`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)),
+				sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)),
+			},
+			result: `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN column1 AND 130000`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)),
+				sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)),
+			},
+			result: `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND 'zz'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '25:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '839:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '2021-01-01 13:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND 0.5`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND column1`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)),
+				sqltypes.MakeTrusted(sqltypes.Time, []byte(`13:00:00`)),
+			},
+			result: `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN column1 AND column2`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)),
+				sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)),
+				sqltypes.MakeTrusted(sqltypes.Time, []byte(`13:00:00`)),
+			},
+			result: `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND CAST('130000' AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND CAST('"13:00:00"' AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND CAST(CAST('13:00:00' AS TIME) AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND CAST(CAST('2021-01-01 13:00:00' AS DATETIME) AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			// A typed-NULL JSON constant does not activate the per-pair
+			// paths: the predicate stays on the whole-string fallback.
+			expression: `column0 BETWEEN CAST(NULL AS JSON) AND 'zz'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `NULL`,
+		},
+		{
+			expression: `column0 BETWEEN 'zz' AND CAST(NULL AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN CAST(NULL AS JSON) AND '13:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `NULL`,
+		},
+		{
+			expression: `column0 BETWEEN CAST(NULL AS JSON) AND 99999999`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `NULL`,
+		},
+
+		// A TIME column in a bound position, or wrapped in an expression,
+		// gets no TIME treatment: the domain stays string.
+		{
+			expression: `JSON_ARRAY() BETWEEN column0 AND 'zz'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `'12:00:00' BETWEEN column0 AND JSON_ARRAY()`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `'12:00:00' BETWEEN JSON_ARRAY() AND column0`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `CAST(column0 AS TIME) BETWEEN JSON_ARRAY() AND '13:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+
+		// A bare DATE-family column on the left with a numeric operand also
+		// resolves per bound pair, and only there a JSON string scalar
+		// unquotes and converts while a JSON number is rejected.
+		{
+			expression: `column0 BETWEEN 20200101 AND CAST('"2021-06-06"' AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN CAST('"2020-01-01"' AS JSON) AND 0`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN 0 AND CAST('20210606' AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN 0 AND CAST(CAST('2021-06-06' AS DATE) AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN 0 AND CAST('"zz"' AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND column1`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`)),
+				sqltypes.MakeTrusted(sqltypes.Int64, []byte(`0`)),
+			},
+			result: `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN column1 AND '2021-01-01'`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`)),
+				sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)),
+			},
+			result: `INT64(1)`,
+		},
+		{
+			expression: `20200601 BETWEEN column0 AND CAST('"2021-06-06"' AS JSON)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(0)`,
+		},
+
+		// The string and DOUBLE fallbacks still apply when no operand is
+		// date-carrying.
+		{expression: `'2020-01-01' BETWEEN JSON_ARRAY() AND '2021-01-01'`, result: `INT64(0)`},
+		{expression: `1.5 BETWEEN JSON_ARRAY() AND '2'`, result: `INT64(1)`},
+
+		// JSON-free temporal BETWEEN is unchanged.
+		{expression: `CAST('2020-01-01' AS DATE) BETWEEN '2019-01-01' AND '2021-01-01'`, result: `INT64(1)`},
+		{expression: `CAST('2020-01-01' AS DATE) NOT BETWEEN '2019-01-01' AND '2021-01-01'`, result: `INT64(0)`},
+		{expression: `CAST('12:00:00' AS TIME) BETWEEN '11:00:00' AND '13:00:00'`, result: `INT64(1)`},
+		{
+			expression: `column0 BETWEEN '2019-01-01' AND '2021-01-01'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN '11:00:00' AND '13:00:00'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+
+		// Simple CASE with a JSON value in a (base, WHEN) pair.
+		{expression: `case JSON_ARRAY() when '[]' then 1 else 0 end`, result: `INT64(1)`},
+		{expression: `case 0 when JSON_ARRAY() then 1 when '0' then 2 else 3 end`, result: `INT64(1)`},
+		{expression: `case '[]' when JSON_ARRAY() then 1 when 0 then 2 else 3 end`, result: `INT64(1)`},
+		{expression: `case JSON_ARRAY() when 0 then 1 when '[]' then 2 else 3 end`, result: `INT64(1)`},
+		{expression: `case when JSON_ARRAY() = '[]' then 1 else 0 end`, result: `INT64(0)`},
+		{expression: `case JSON_ARRAY(1) when CAST('[1]' AS JSON) then 1 else 0 end`, result: `INT64(1)`},
+		{expression: `case JSON_OBJECT() when JSON_ARRAY() then 1 else 0 end`, result: `INT64(0)`},
+		{expression: `case CAST(1 AS JSON) when CAST('1.0' AS JSON) then 1 else 0 end`, result: `INT64(0)`},
+		{expression: `case '[1]' when 3 then 1 when JSON_ARRAY(2) then 2 else 0 end`, result: `INT64(0)`},
+
+		// JSON-free domains are unchanged.
+		{expression: `0 IN ('0', 2)`, result: `INT64(1)`},
+		{expression: `1 BETWEEN 0 AND '2'`, result: `INT64(1)`},
+		{expression: `2 NOT BETWEEN 5 AND 20`, result: `INT64(1)`},
+		{expression: `'b' BETWEEN 'a' AND 'c'`, result: `INT64(1)`},
+		{expression: `case 0 when '0' then 1 else 2 end`, result: `INT64(1)`},
+		{expression: `case 'b' when 'b' then 1 else 2 end`, result: `INT64(1)`},
+
+		// NULL semantics are unchanged, with or without JSON in the domain.
+		{expression: `NULL IN (JSON_ARRAY(), 1)`, result: `NULL`},
+		{expression: `1 IN (NULL, JSON_ARRAY())`, result: `NULL`},
+		{expression: `0 IN (NULL, '0')`, result: `INT64(1)`},
+		{expression: `3 IN (NULL, '0')`, result: `NULL`},
+		{expression: `NULL NOT IN (1, 2)`, result: `NULL`},
+		{expression: `NULL BETWEEN 1 AND 2`, result: `NULL`},
+		{expression: `1 BETWEEN NULL AND 2`, result: `NULL`},
+		{expression: `1 BETWEEN 2 AND NULL`, result: `INT64(0)`},
+		{expression: `1 NOT BETWEEN 2 AND NULL`, result: `INT64(1)`},
+		{expression: `1 BETWEEN NULL AND 0`, result: `INT64(0)`},
+		{expression: `0 BETWEEN NULL AND JSON_ARRAY()`, result: `NULL`},
+		{expression: `NULL BETWEEN JSON_ARRAY() AND 1`, result: `NULL`},
+		{expression: `case NULL when NULL then 1 else 2 end`, result: `INT64(2)`},
+		{expression: `case 1 when NULL then 1 else 2 end`, result: `INT64(2)`},
+		{expression: `case NULL when JSON_ARRAY() then 1 else 2 end`, result: `INT64(2)`},
+
+		// The comparison domain is decided from runtime types.
+		{
+			expression: `0 IN (column0, '0')`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `0 BETWEEN column0 AND '0'`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `case column0 when '[]' then 1 else 0 end`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`))},
+			result:     `INT64(1)`,
+		},
+
+		// MySQL's IN type scan stops after the first element that is not
+		// constant for one execution, the stopper included: a JSON element
+		// behind it never selects JSON comparison, while a constant element
+		// never stops the scan.
+		{
+			expression: `'12:00:00' IN (column0, JSON_ARRAY())`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `'12:00:00' IN (JSON_ARRAY(), column0)`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `0 IN (column0, '0', JSON_ARRAY())`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Int64, []byte(`1`))},
+			result:     `INT64(1)`,
+		},
+		{expression: `'12:00:00' IN (CAST('12:00:00' AS TIME), JSON_ARRAY())`, result: `INT64(0)`},
+
+		// A temporal column with a nonconstant JSON bound and a numeric
+		// participant compares numerically; a JSON constant keeps the
+		// field-store conversion.
+		{
+			expression: `column0 BETWEEN column1 AND 99999999`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`)),
+				sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`99999999`)),
+			},
+			result: `INT64(0)`,
+		},
+		{
+			expression: `column0 BETWEEN column1 AND 99999999`,
+			values: []sqltypes.Value{
+				sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)),
+				sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)),
+			},
+			result: `INT64(1)`,
+		},
+		{
+			expression: `column0 BETWEEN CAST('99999999' AS JSON) AND 99999999`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))},
+			result:     `INT64(1)`,
+		},
+		{
+			// The maximum unsigned integer is not TIME-convertible: it must
+			// not wrap into a negative TIME through int64 narrowing.
+			expression: `column0 BETWEEN JSON_ARRAY() AND 18446744073709551615`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))},
+			result:     `INT64(1)`,
+		},
+	}
+
+	venv := vtenv.NewTestEnv()
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			expr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+
+			fields := evalengine.FieldResolver(makeFields(tc.values))
+			for _, folding := range []bool{false, true} {
+				cfg := &evalengine.Config{
+					ResolveColumn:     fields.Column,
+					ResolveType:       fields.Type,
+					Collation:         collations.CollationUtf8mb4ID,
+					Environment:       venv,
+					NoConstantFolding: !folding,
+				}
+
+				converted, err := evalengine.Translate(expr, cfg)
+				require.NoError(t, err)
+
+				env := evalengine.EmptyExpressionEnv(venv)
+				env.Row = tc.values
+
+				expected, err := env.EvaluateAST(converted)
+				require.NoError(t, err)
+				require.Equalf(t, tc.result, expected.String(), "bad evaluation from eval engine (folding=%t)", folding)
+
+				res, err := env.Evaluate(converted)
+				require.NoError(t, err)
+				assert.Equalf(t, tc.result, res.String(), "bad evaluation from compiler (folding=%t)", folding)
+			}
+		})
+	}
+}
+
+// TestJSONComparisonDomainsUntypedOperands checks that operand types
+// resolved only at evaluation time — from result fields or bind variable
+// values — select the same comparison domain as statically typed
+// translation, on both the AST and compiled paths.
+func TestJSONComparisonDomainsUntypedOperands(t *testing.T) {
+	type step struct {
+		row    []sqltypes.Value
+		binds  map[string]*querypb.BindVariable
+		result string
+	}
+	bind := func(tt sqltypes.Type, v string) map[string]*querypb.BindVariable {
+		return map[string]*querypb.BindVariable{
+			"v": sqltypes.ValueBindVariable(sqltypes.MakeTrusted(tt, []byte(v))),
+		}
+	}
+	field := func(name string, tt sqltypes.Type) *querypb.Field {
+		charset := uint32(collations.CollationBinaryID)
+		if sqltypes.IsText(tt) {
+			charset = uint32(collations.CollationUtf8mb4ID)
+		}
+		return &querypb.Field{Name: name, Type: tt, Charset: charset}
+	}
+
+	testCases := []struct {
+		expression string
+		fields     []*querypb.Field
+		steps      []step
+		// compileErr asserts that explicit compilation fails while AST
+		// evaluation still resolves the declared comparison plan.
+		compileErr string
+	}{
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Date)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Datetime)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Datetime, []byte(`2020-01-01 12:00:00`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			expression: `:v BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			steps: []step{
+				{binds: bind(sqltypes.Timestamp, `2020-01-01 12:00:00`), result: `INT64(1)`},
+			},
+		},
+		{
+			// One translated expression, re-evaluated with changing bind
+			// types: each evaluation selects its own domain, and the third
+			// one reuses the DATE specialization of the first.
+			expression: `:v BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			steps: []step{
+				{binds: bind(sqltypes.Date, `2020-01-01`), result: `INT64(1)`},
+				{binds: bind(sqltypes.VarChar, `2020-01-01`), result: `INT64(0)`},
+				{binds: bind(sqltypes.Date, `2020-01-01`), result: `INT64(1)`},
+			},
+		},
+		{
+			// A TIME bind is not a column: no TIME treatment, string domain.
+			expression: `:v BETWEEN JSON_ARRAY() AND '13:00:00'`,
+			steps: []step{
+				{binds: bind(sqltypes.Time, `12:00:00`), result: `INT64(0)`},
+			},
+		},
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND '13:00:00'`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Time)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			expression: `'12:00:00' BETWEEN JSON_ARRAY() AND column0`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Time)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))}, result: `INT64(0)`},
+			},
+		},
+		{
+			expression: `JSON_ARRAY() BETWEEN column0 AND 'zz'`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Time)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			// The declared DATE type of an all-NULL column still selects the
+			// DATETIME domain.
+			expression: `JSON_ARRAY() BETWEEN column0 AND '2021-01-01'`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Date)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.NULL}, result: `NULL`},
+			},
+		},
+		{
+			// The declared JSON type of an all-NULL column still forces the
+			// binary string collation; a VARCHAR column keeps the default
+			// case-insensitive comparison.
+			expression: `'a' BETWEEN column0 AND 'A'`,
+			fields:     []*querypb.Field{field("column0", sqltypes.TypeJSON)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.NULL}, result: `INT64(0)`},
+			},
+		},
+		{
+			expression: `'a' BETWEEN column0 AND 'A'`,
+			fields:     []*querypb.Field{field("column0", sqltypes.VarChar)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.NULL}, result: `NULL`},
+			},
+		},
+		{
+			expression: `0 IN (column0, '0')`,
+			fields:     []*querypb.Field{field("column0", sqltypes.TypeJSON)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`))}, result: `INT64(0)`},
+				{row: []sqltypes.Value{sqltypes.NULL}, result: `NULL`},
+			},
+		},
+		{
+			expression: `0 IN (column0, '0')`,
+			fields:     []*querypb.Field{field("column0", sqltypes.VarChar)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.VarChar, []byte(`0`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			// The DATE-column field path applies with a late-resolved JSON
+			// column whose value is SQL NULL.
+			expression: `column0 BETWEEN column1 AND 99999999`,
+			fields: []*querypb.Field{
+				field("column0", sqltypes.Date),
+				field("column1", sqltypes.TypeJSON),
+			},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`)), sqltypes.NULL}, result: `NULL`},
+			},
+		},
+
+		// A composite operand contributes its declared result type, not the
+		// selected child's runtime representation, including when the value
+		// is SQL NULL.
+		{
+			expression: `0 IN (COALESCE(column0, NULL), '0')`,
+			fields:     []*querypb.Field{field("column0", sqltypes.TypeJSON)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.NULL}, result: `NULL`},
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`))}, result: `INT64(0)`},
+			},
+		},
+		{
+			expression: `'a' BETWEEN COALESCE(column0, NULL) AND 'A'`,
+			fields:     []*querypb.Field{field("column0", sqltypes.TypeJSON)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.NULL}, result: `INT64(0)`},
+			},
+		},
+		{
+			expression: `JSON_ARRAY() BETWEEN COALESCE(column0, NULL) AND '2021-01-01'`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Date)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.NULL}, result: `NULL`},
+			},
+		},
+		{
+			// COALESCE over DATE and VARCHAR declares a string result: the
+			// selected DATE child must not switch the domain.
+			expression: `COALESCE(column0, column1) BETWEEN JSON_ARRAY() AND '2021-01-01'`,
+			fields: []*querypb.Field{
+				field("column0", sqltypes.Date),
+				field("column1", sqltypes.VarChar),
+			},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`)), sqltypes.NULL}, result: `INT64(0)`},
+			},
+		},
+		{
+			// COALESCE over JSON and VARCHAR declares a non-JSON result: the
+			// selected JSON child must not re-enable JSON comparison.
+			expression: `0 IN (COALESCE(column0, column1), '0')`,
+			fields: []*querypb.Field{
+				field("column0", sqltypes.TypeJSON),
+				field("column1", sqltypes.VarChar),
+			},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`)), sqltypes.NULL}, result: `INT64(1)`},
+			},
+		},
+		{
+			// The composite's declared type resolves even though this
+			// dynamic JSON_CONTAINS_PATH shape stays VM-unsupported.
+			expression: `0 IN (COALESCE(column0, JSON_CONTAINS_PATH(column0, column1, '$')), '0')`,
+			fields: []*querypb.Field{
+				field("column0", sqltypes.TypeJSON),
+				field("column1", sqltypes.VarChar),
+			},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`)), sqltypes.MakeTrusted(sqltypes.VarChar, []byte(`one`))}, result: `INT64(1)`},
+			},
+			compileErr: `unsupported compilation for IR 'JSON_CONTAINS_PATH`,
+		},
+
+		// MySQL's IN type scan stops after the first element that is not
+		// constant for one execution: a JSON element behind the stopper
+		// never selects JSON comparison.
+		{
+			expression: `'12:00:00' IN (column0, JSON_ARRAY())`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Time)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			expression: `'12:00:00' IN (JSON_ARRAY(), column0)`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Time)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))}, result: `INT64(0)`},
+			},
+		},
+		{
+			// The stopper's own declared type still joins the scan: the
+			// left string converts to DATE for the first comparison.
+			expression: `'2020-1-1' IN (column0, JSON_ARRAY())`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Date)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			expression: `'2020-01-01' IN (JSON_ARRAY(), column0)`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Date)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`))}, result: `INT64(0)`},
+			},
+		},
+		{
+			expression: `0 IN (column0, '0', JSON_ARRAY())`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Int64)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Int64, []byte(`1`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			expression: `0 NOT IN (column0, '0', JSON_ARRAY())`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Int64)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Int64, []byte(`1`))}, result: `INT64(0)`},
+			},
+		},
+		{
+			// A bind parameter is constant for one execution: the scan
+			// continues past it and reaches the JSON element.
+			expression: `0 IN (:v, '0', JSON_ARRAY())`,
+			steps: []step{
+				{binds: bind(sqltypes.Int64, `1`), result: `INT64(0)`},
+			},
+		},
+
+		// A temporal column with a row-dependent JSON bound and a numeric
+		// participant compares numerically: the field-store and TIME
+		// conversions apply only to bounds that are constant for one
+		// execution, never to column bounds.
+		{
+			expression: `column0 BETWEEN column1 AND 99999999`,
+			fields: []*querypb.Field{
+				field("column0", sqltypes.Date),
+				field("column1", sqltypes.TypeJSON),
+			},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`)), sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`99999999`))}, result: `INT64(0)`},
+			},
+		},
+		{
+			expression: `column0 BETWEEN column1 AND column2`,
+			fields: []*querypb.Field{
+				field("column0", sqltypes.Date),
+				field("column1", sqltypes.TypeJSON),
+				field("column2", sqltypes.Int64),
+			},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`)), sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`99999999`)), sqltypes.MakeTrusted(sqltypes.Int64, []byte(`99999999`))}, result: `INT64(0)`},
+			},
+		},
+		{
+			expression: `column0 BETWEEN column1 AND 99999999`,
+			fields: []*querypb.Field{
+				field("column0", sqltypes.Time),
+				field("column1", sqltypes.TypeJSON),
+			},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)), sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			expression: `column0 BETWEEN column1 AND column2`,
+			fields: []*querypb.Field{
+				field("column0", sqltypes.Time),
+				field("column1", sqltypes.TypeJSON),
+				field("column2", sqltypes.Int64),
+			},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)), sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)), sqltypes.MakeTrusted(sqltypes.Int64, []byte(`99999999`))}, result: `INT64(1)`},
+			},
+		},
+		{
+			// The maximum unsigned integer is not TIME-convertible: it must
+			// not wrap into a negative TIME through int64 narrowing.
+			expression: `column0 BETWEEN JSON_ARRAY() AND 18446744073709551615`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Time)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))}, result: `INT64(1)`},
+			},
+		},
+
+		// An execution-constant bound of a TIME column resolves its TIME
+		// convertibility from the per-execution value, like the literal it
+		// was normalized from. The compiled plan resolves at runtime: the
+		// three steps below share one VARCHAR specialization across a
+		// convertible and an unconvertible value.
+		{
+			expression: `column0 BETWEEN JSON_ARRAY() AND :v`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Time)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))}, binds: bind(sqltypes.VarChar, `13:00:00`), result: `INT64(1)`},
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))}, binds: bind(sqltypes.VarChar, `zz`), result: `INT64(0)`},
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))}, binds: bind(sqltypes.VarChar, `13:00:00`), result: `INT64(1)`},
+			},
+		},
+		{
+			expression: `column0 NOT BETWEEN JSON_ARRAY() AND :v`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Time)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))}, binds: bind(sqltypes.VarChar, `13:00:00`), result: `INT64(0)`},
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))}, binds: bind(sqltypes.VarChar, `zz`), result: `INT64(1)`},
+			},
+		},
+		{
+			// A NULL bind bound keeps the NULL comparison result.
+			expression: `column0 BETWEEN JSON_ARRAY() AND :v`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Time)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`))}, binds: bind(sqltypes.Null, ``), result: `NULL`},
+			},
+		},
+		{
+			// A JSON-typed execution-constant bound of a DATE column selects
+			// the field-store conversion; normalization never produces a
+			// JSON-typed bind, so only an explicit client bind reaches this
+			// shape.
+			expression: `column0 BETWEEN :v AND 99999999`,
+			fields:     []*querypb.Field{field("column0", sqltypes.Date)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-07-01`))}, binds: bind(sqltypes.TypeJSON, `"2020-12-01"`), result: `INT64(0)`},
+			},
+		},
+
+		// The reached comparison derives the composite's declared JSON
+		// type — which is what makes the left side false rather than NULL —
+		// while AND keeps the missing bind short-circuited and unresolved.
+		{
+			expression: `('a' BETWEEN COALESCE(column0, NULL) AND 'A') AND :unused`,
+			fields:     []*querypb.Field{field("column0", sqltypes.TypeJSON)},
+			steps: []step{
+				{row: []sqltypes.Value{sqltypes.NULL}, result: `INT64(0)`},
+			},
+			compileErr: `query arguments missing for unused`,
+		},
+	}
+
+	venv := vtenv.NewTestEnv()
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			expr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+
+			for _, folding := range []bool{false, true} {
+				cfg := &evalengine.Config{
+					ResolveColumn:     evalengine.FieldResolver(tc.fields).Column,
+					Collation:         collations.CollationUtf8mb4ID,
+					Environment:       venv,
+					NoConstantFolding: !folding,
+				}
+				translated, err := evalengine.Translate(expr, cfg)
+				require.NoError(t, err)
+				untyped, ok := translated.(*evalengine.UntypedExpr)
+				require.True(t, ok, "expected an untyped translation")
+
+				env := evalengine.EmptyExpressionEnv(venv)
+				env.Fields = tc.fields
+				for i, s := range tc.steps {
+					env.Row = s.row
+					env.BindVars = s.binds
+
+					ast, err := env.EvaluateAST(untyped)
+					require.NoError(t, err)
+					assert.Equalf(t, s.result, ast.String(), "bad evaluation from eval engine (step %d, folding=%t)", i, folding)
+
+					compiled, err := untyped.Compile(env)
+					if tc.compileErr != "" {
+						require.ErrorContains(t, err, tc.compileErr)
+						continue
+					}
+					require.NoError(t, err)
+					vm, err := env.EvaluateVM(compiled)
+					require.NoError(t, err)
+					assert.Equalf(t, s.result, vm.String(), "bad evaluation from compiler (step %d, folding=%t)", i, folding)
+				}
+			}
+		})
+	}
+}
+
+// TestJSONComparisonDomainsConcurrency evaluates one translated comparison
+// from many goroutines with alternating bind types: the JSON-typed bind
+// selects the binary JSON/string domain, the VARCHAR bind the default
+// case-insensitive one. With -race, this catches comparison plans or type
+// specializations shared across evaluations.
+func TestJSONComparisonDomainsConcurrency(t *testing.T) {
+	venv := vtenv.NewTestEnv()
+	expr, err := venv.Parser().ParseExpr(`'a' BETWEEN COALESCE(:w, NULL) AND 'z'`)
+	require.NoError(t, err)
+	translated, err := evalengine.Translate(expr, &evalengine.Config{
+		Collation:   collations.CollationUtf8mb4ID,
+		Environment: venv,
+	})
+	require.NoError(t, err)
+
+	const goroutines, evaluations = 8, 50
+	errs := make([]error, goroutines)
+	observed := make([][]string, goroutines)
+
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		jsonBind := i%2 == 0
+		observed[i] = make([]string, evaluations)
+		wg.Go(func() {
+			bindVar := sqltypes.ValueBindVariable(sqltypes.MakeTrusted(sqltypes.VarChar, []byte(`B`)))
+			if jsonBind {
+				bindVar = sqltypes.ValueBindVariable(sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`"B"`)))
+			}
+			env := evalengine.EmptyExpressionEnv(venv)
+			env.BindVars = map[string]*querypb.BindVariable{"w": bindVar}
+			for n := range evaluations {
+				res, err := env.Evaluate(translated)
+				if err != nil {
+					errs[i] = err
+					return
+				}
+				observed[i][n] = res.String()
+			}
+		})
+	}
+	wg.Wait()
+
+	for i := range goroutines {
+		require.NoErrorf(t, errs[i], "goroutine %d", i)
+		result := `INT64(0)`
+		if i%2 == 0 {
+			result = `INT64(1)`
+		}
+		for _, got := range observed[i] {
+			assert.Equal(t, result, got)
+		}
+	}
+}
+
+// TestJSONComparisonDomainsTupleBind checks that one translated tuple bind,
+// re-executed with changing element declarations, selects the comparison
+// domain from the expanded list's declared element types on every execution.
+func TestJSONComparisonDomainsTupleBind(t *testing.T) {
+	tupleBind := func(vals ...sqltypes.Value) map[string]*querypb.BindVariable {
+		bv := &querypb.BindVariable{Type: querypb.Type_TUPLE}
+		for _, v := range vals {
+			bv.Values = append(bv.Values, sqltypes.ValueToProto(v))
+		}
+		return map[string]*querypb.BindVariable{"vals": bv}
+	}
+
+	venv := vtenv.NewTestEnv()
+	expr, err := venv.Parser().ParseExpr(`0 IN ::vals`)
+	require.NoError(t, err)
+	translated, err := evalengine.Translate(expr, &evalengine.Config{
+		Collation:   collations.CollationUtf8mb4ID,
+		Environment: venv,
+	})
+	require.NoError(t, err)
+
+	steps := []struct {
+		binds  map[string]*querypb.BindVariable
+		result string
+	}{
+		{binds: tupleBind(sqltypes.MakeTrusted(sqltypes.Int64, []byte(`1`)), sqltypes.MakeTrusted(sqltypes.VarChar, []byte(`0`))), result: `INT64(1)`},
+		{binds: tupleBind(sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)), sqltypes.MakeTrusted(sqltypes.VarChar, []byte(`0`))), result: `INT64(0)`},
+		{binds: tupleBind(sqltypes.MakeTrusted(sqltypes.Int64, []byte(`1`)), sqltypes.MakeTrusted(sqltypes.VarChar, []byte(`0`))), result: `INT64(1)`},
+	}
+	env := evalengine.EmptyExpressionEnv(venv)
+	for i, s := range steps {
+		env.BindVars = s.binds
+
+		ast, err := env.EvaluateAST(translated)
+		require.NoError(t, err)
+		assert.Equalf(t, s.result, ast.String(), "bad evaluation from eval engine (step %d)", i)
+
+		res, err := env.Evaluate(translated)
+		require.NoError(t, err)
+		assert.Equalf(t, s.result, res.String(), "bad evaluation from compiler (step %d)", i)
 	}
 }
 

--- a/go/vt/vtgate/evalengine/eval_json.go
+++ b/go/vt/vtgate/evalengine/eval_json.go
@@ -154,6 +154,12 @@ func argToJSON(e eval) (*evalJSON, error) {
 			return evalConvert_bj(e), nil
 		}
 		return evalConvertArg_cj(e)
+	case *evalEnum:
+		// An ENUM converts to a JSON string of its textual value, not its ordinal.
+		return json.NewString(e.string), nil
+	case *evalSet:
+		// A SET converts to a JSON string of its textual value, not its bitmask.
+		return json.NewString(e.string), nil
 	case *evalTemporal:
 		return e.toJSON(), nil
 	default:

--- a/go/vt/vtgate/evalengine/expr.go
+++ b/go/vt/vtgate/evalengine/expr.go
@@ -36,6 +36,7 @@ type (
 		eval(env *ExpressionEnv) (eval, error)
 		format(buf *sqlparser.TrackedBuffer)
 		constant() bool
+		constForExecution() bool
 		simplify(env *ExpressionEnv) error
 		compile(c *compiler) (ctype, error)
 	}

--- a/go/vt/vtgate/evalengine/expr_bvar.go
+++ b/go/vt/vtgate/evalengine/expr_bvar.go
@@ -121,6 +121,12 @@ func (bvar *BindVariable) compile(c *compiler) (ctype, error) {
 		typ.Col = typedCoercionCollation(bvar.Type, collations.CollationForType(bvar.Type, bvar.Collation))
 	} else if c.dynamicTypes != nil {
 		typ = c.dynamicTypes[bvar.dynamicTypeOffset]
+	} else if c.typeEnv != nil {
+		t, err := bvar.typeof(c.typeEnv)
+		if err != nil {
+			return ctype{}, err
+		}
+		typ = t
 	} else {
 		return ctype{}, c.unsupported(bvar)
 	}

--- a/go/vt/vtgate/evalengine/expr_column.go
+++ b/go/vt/vtgate/evalengine/expr_column.go
@@ -105,6 +105,12 @@ func (column *Column) compile(c *compiler) (ctype, error) {
 		typ.Values = column.Values
 	} else if c.dynamicTypes != nil {
 		typ = c.dynamicTypes[column.dynamicTypeOffset]
+	} else if c.typeEnv != nil {
+		t, err := column.typeof(c.typeEnv)
+		if err != nil {
+			return ctype{}, err
+		}
+		typ = t
 	} else {
 		return ctype{}, c.unsupported(column)
 	}

--- a/go/vt/vtgate/evalengine/expr_compare.go
+++ b/go/vt/vtgate/evalengine/expr_compare.go
@@ -18,9 +18,17 @@ package evalengine
 
 import (
 	"bytes"
+	"math"
+	"slices"
+	"strings"
+	"time"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/collations/charset"
 	"vitess.io/vitess/go/mysql/collations/colldata"
+	"vitess.io/vitess/go/mysql/datetime"
+	"vitess.io/vitess/go/mysql/fastparse"
+	"vitess.io/vitess/go/mysql/json"
 	"vitess.io/vitess/go/sqltypes"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -48,8 +56,90 @@ type (
 	InExpr struct {
 		BinaryExpr
 		Negate bool
+		// PrefixJSON aggregates the declared-JSON tri-state over the left
+		// operand and the RHS prefix MySQL's type scan inspects, proved at
+		// translation time before constant folding can erase a typed SQL
+		// NULL. Row elements never contribute.
+		PrefixJSON inJSONDomain
+		// JSONScanRHS counts the leading RHS elements of that scan:
+		// everything up to and including the first element that is not
+		// constant for one execution.
+		JSONScanRHS int
 	}
 
+	BetweenExpr struct {
+		Left   IR
+		From   IR
+		To     IR
+		Negate bool
+		// StaticClasses are the comparison classes of (Left, From, To) proved
+		// at translation time, before constant folding can erase a typed SQL
+		// NULL; classUnknown when the type resolves only at evaluation time.
+		StaticClasses [3]cmpClass
+	}
+
+	// cmpClass is the comparison result class of an operand's declared type,
+	// deciding the comparison domain of IN and BETWEEN when a JSON operand
+	// participates.
+	cmpClass uint8
+
+	// inJSONDomain is the declared-JSON comparison plan of a scalar IN:
+	// definitely JSON, definitely not, or resolvable only from the element
+	// types of an execution-expanded tuple bind.
+	inJSONDomain uint8
+
+	// betweenPair is the comparator selected for one bound pair of a
+	// JSON-participating BETWEEN.
+	betweenPair uint8
+
+	// betweenPlan is the comparison plan of a BETWEEN: the legacy pairwise
+	// comparison without a JSON operand, or one comparator per bound pair.
+	// Plans are captured by value, never stored on shared IR.
+	betweenPlan struct {
+		legacy bool
+		pairs  [2]betweenPair
+	}
+)
+
+const (
+	inJSONUnknown inJSONDomain = iota
+	inJSONNo
+	inJSONYes
+)
+
+const (
+	classUnknown cmpClass = iota
+	classNull             // untyped SQL NULL: neutral for domain selection
+	classJSON
+	classDateLike // DATE, DATETIME, TIMESTAMP
+	classTime
+	classString  // textual, binary, ENUM, SET
+	classNumeric // integral, decimal, float, YEAR, BIT
+)
+
+const (
+	// pairString compares the serialized text forms under the collation
+	// aggregated across all three operands; only ever set for both pairs.
+	pairString betweenPair = iota
+	// pairNumeric compares as DOUBLE; it is also the integer fallback of the
+	// TIME column branch.
+	pairNumeric
+	// pairDatetimeText compares as DATETIME, converting operands from their
+	// text forms: a JSON operand converts from its serialized text, quotes
+	// included, so JSON strings and temporal scalars fail to the zero date.
+	pairDatetimeText
+	// pairDatetimeField compares as DATETIME through the field-store
+	// conversion MySQL applies to a constant bound of a DATE-family column:
+	// JSON strings unquote and JSON date scalars convert natively, while
+	// other JSON values fail to the zero date.
+	pairDatetimeField
+	// pairTime compares as packed TIME against a bare TIME column: a JSON
+	// string unquotes and a JSON TIME scalar converts natively, while other
+	// JSON values fail to the zero time.
+	pairTime
+)
+
+type (
 	ComparisonOp interface {
 		String() string
 		compare(collationEnv *collations.Environment, left, right eval) (boolean, error)
@@ -62,11 +152,17 @@ type (
 	compareGT         struct{}
 	compareGE         struct{}
 	compareNullSafeEQ struct{}
+
+	// compareCaseEQ is the equality between the base operand of a simple
+	// CASE and its WHEN operands: like MySQL, it never uses the JSON
+	// comparator.
+	compareCaseEQ struct{}
 )
 
 var (
 	_ IR = (*ComparisonExpr)(nil)
 	_ IR = (*InExpr)(nil)
+	_ IR = (*BetweenExpr)(nil)
 	_ IR = (*LikeExpr)(nil)
 )
 
@@ -113,6 +209,12 @@ func (compareNullSafeEQ) String() string { return "<=>" }
 func (compareNullSafeEQ) compare(collationEnv *collations.Environment, left, right eval) (boolean, error) {
 	cmp, err := evalCompareNullSafe(left, right, collationEnv)
 	return makeboolean(cmp == 0), err
+}
+
+func (compareCaseEQ) String() string { return "=" }
+func (compareCaseEQ) compare(collationEnv *collations.Environment, left, right eval) (boolean, error) {
+	cmp, isNull, err := evalCompareCase(left, right, collationEnv)
+	return makeboolean2(cmp == 0, isNull), err
 }
 
 func typeIsTextual(tt sqltypes.Type) bool {
@@ -224,6 +326,24 @@ func evalCompareAll(lVal, rVal eval, fulleq bool, collationEnv *collations.Envir
 	return n, false, err
 }
 
+// evalCompareCase compares the base operand of a simple CASE with a WHEN
+// operand: it matches evalCompareAll except that JSON pairs go through
+// evalCompareCaseJSON, as MySQL never uses the JSON comparator here.
+func evalCompareCase(lVal, rVal eval, collationEnv *collations.Environment) (int, bool, error) {
+	if lVal == nil || rVal == nil {
+		return 0, true, nil
+	}
+	if left, right, ok := compareAsTuples(lVal, rVal); ok {
+		return evalCompareMany(left.t, right.t, true, collationEnv)
+	}
+	if compareAsJSON(lVal.SQLType(), rVal.SQLType()) {
+		n, err := evalCompareCaseJSON(lVal, rVal, collationEnv)
+		return n, false, err
+	}
+	n, err := evalCompare(lVal, rVal, collationEnv)
+	return n, false, err
+}
+
 // For more details on comparison expression evaluation and type conversion:
 //   - https://dev.mysql.com/doc/refman/8.0/en/type-conversion.html
 func evalCompare(left, right eval, collationEnv *collations.Environment) (comp int, err error) {
@@ -328,7 +448,7 @@ func (expr *ComparisonExpr) compileAsTuple(c *compiler) (ctype, error) {
 	case compareNullSafeEQ:
 		c.asm.CmpTupleNullsafe(c.env.CollationEnv())
 		return ctype{Type: sqltypes.Int64, Col: collationNumeric, Flag: flagIsBoolean}, nil
-	case compareEQ:
+	case compareEQ, compareCaseEQ:
 		c.asm.CmpTuple(c.env.CollationEnv(), true)
 		c.asm.Cmp_eq_n()
 	case compareNE:
@@ -422,7 +542,9 @@ func (expr *ComparisonExpr) compile(c *compiler) (ctype, error) {
 		}
 		swapped = c.compareNumericTypes(lt, rt)
 	case compareAsJSON(lt.Type, rt.Type):
-		if err := c.compareAsJSON(lt, rt); err != nil {
+		if _, ok := expr.Op.(compareCaseEQ); ok {
+			c.asm.CmpCaseJSON(c.env.CollationEnv())
+		} else if err := c.compareAsJSON(lt, rt); err != nil {
 			return ctype{}, err
 		}
 
@@ -438,7 +560,7 @@ func (expr *ComparisonExpr) compile(c *compiler) (ctype, error) {
 	}
 
 	switch expr.Op.(type) {
-	case compareEQ:
+	case compareEQ, compareCaseEQ:
 		c.asm.Cmp_eq()
 	case compareNE:
 		c.asm.Cmp_ne()
@@ -479,14 +601,40 @@ func (expr *ComparisonExpr) compile(c *compiler) (ctype, error) {
 	return cmptype, nil
 }
 
-func evalInExpr(collationEnv *collations.Environment, lhs eval, rhs *evalTuple) (boolean, error) {
+func evalInExpr(collationEnv *collations.Environment, lhs eval, rhs *evalTuple, plan inJSONDomain) (boolean, error) {
 	if lhs == nil {
 		return boolNULL, nil
 	}
 
+	// When a JSON operand participates in IN — by declared type, even when
+	// the value is SQL NULL — MySQL compares every pair as JSON, converting
+	// the non-JSON operands to JSON scalars (strings become string scalars,
+	// not parsed documents). Row (tuple) operands keep their per-column
+	// comparisons. An unresolved plan is the execution-expanded tuple bind,
+	// whose element values carry the declared types of the expanded list.
+	asJSON := plan == inJSONYes
+	if plan == inJSONUnknown {
+		for _, rtuple := range rhs.t {
+			if rtuple != nil && rtuple.SQLType() == sqltypes.TypeJSON {
+				asJSON = true
+				break
+			}
+		}
+	}
+
 	var foundNull, found bool
 	for _, rtuple := range rhs.t {
-		numeric, isNull, err := evalCompareAll(lhs, rtuple, true, collationEnv)
+		var numeric int
+		var isNull bool
+		var err error
+		switch {
+		case asJSON && rtuple == nil:
+			isNull = true
+		case asJSON:
+			numeric, err = compareJSON(lhs, rtuple)
+		default:
+			numeric, isNull, err = evalCompareAll(lhs, rtuple, true, collationEnv)
+		}
 		if err != nil {
 			return boolNULL, err
 		}
@@ -510,6 +658,50 @@ func evalInExpr(collationEnv *collations.Environment, lhs eval, rhs *evalTuple) 
 	}
 }
 
+// resolvePrefixJSON resolves an unknown declared-JSON plan during
+// evaluation: the classes of the left operand and the scanned RHS prefix,
+// late-resolved from their declared types. An execution-expanded tuple bind
+// stays unresolved unless the left operand declares JSON: its element types
+// are inspected on the expanded values.
+func (i *InExpr) resolvePrefixJSON(env *ExpressionEnv, lhs eval, rtuple *evalTuple) inJSONDomain {
+	tuple, ok := i.Right.(TupleExpr)
+	if !ok {
+		class, provisional := evalCmpClass(env, classUnknown, i.Left, lhs)
+		if class == classJSON && provisional {
+			if declared, ok := declaredCmpClass(env, i.Left); ok {
+				class = declared
+			}
+		}
+		if class == classJSON {
+			return inJSONYes
+		}
+		return inJSONUnknown
+	}
+
+	ops := make([]IR, 1, i.JSONScanRHS+1)
+	vals := make([]eval, 1, i.JSONScanRHS+1)
+	ops[0], vals[0] = i.Left, lhs
+	for idx := 0; idx < i.JSONScanRHS && idx < len(tuple); idx++ {
+		var val eval
+		if idx < len(rtuple.t) {
+			val = rtuple.t[idx]
+		}
+		ops = append(ops, tuple[idx])
+		vals = append(vals, val)
+	}
+
+	classes := make([]cmpClass, len(ops))
+	provisional := make([]bool, len(ops))
+	for k := range ops {
+		classes[k], provisional[k] = evalCmpClass(env, classUnknown, ops[k], vals[k])
+	}
+	resolveJSONCmpClasses(env, classes, provisional, ops)
+	if slices.Contains(classes, classJSON) {
+		return inJSONYes
+	}
+	return inJSONNo
+}
+
 // eval implements the ComparisonOp interface
 func (i *InExpr) eval(env *ExpressionEnv) (eval, error) {
 	left, right, err := i.arguments(env)
@@ -520,7 +712,11 @@ func (i *InExpr) eval(env *ExpressionEnv) (eval, error) {
 	if !ok {
 		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "rhs of an In operation should be a tuple")
 	}
-	in, err := evalInExpr(env.collationEnv, left, rtuple)
+	plan := i.PrefixJSON
+	if plan == inJSONUnknown {
+		plan = i.resolvePrefixJSON(env, left, rtuple)
+	}
+	in, err := evalInExpr(env.collationEnv, left, rtuple, plan)
 	if err != nil {
 		return nil, err
 	}
@@ -571,7 +767,12 @@ func (i *InExpr) compileTable(lhs ctype, rhs TupleExpr) map[vthash.Hash]struct{}
 func (expr *InExpr) compile(c *compiler) (ctype, error) {
 	lhs, err := expr.Left.compile(c)
 	if err != nil {
-		return ctype{}, nil
+		return ctype{}, err
+	}
+
+	plan := expr.PrefixJSON
+	if plan == inJSONUnknown && lhs.Type == sqltypes.TypeJSON {
+		plan = inJSONYes
 	}
 
 	switch rhs := expr.Right.(type) {
@@ -580,11 +781,22 @@ func (expr *InExpr) compile(c *compiler) (ctype, error) {
 		if table := expr.compileTable(lhs, rhs); table != nil {
 			c.asm.In_table(expr.Negate, table)
 		} else {
-			rt, err = rhs.compile(c)
-			if err != nil {
-				return ctype{}, err
+			// Compile the elements individually instead of through
+			// TupleExpr.compile, which discards the element types.
+			for idx, el := range rhs {
+				et, err := el.compile(c)
+				if err != nil {
+					return ctype{}, err
+				}
+				if plan == inJSONUnknown && idx < expr.JSONScanRHS && et.Type == sqltypes.TypeJSON {
+					plan = inJSONYes
+				}
 			}
-			c.asm.In_slow(c.env.CollationEnv(), expr.Negate)
+			if plan == inJSONUnknown {
+				plan = inJSONNo
+			}
+			c.asm.PackTuple(len(rhs))
+			c.asm.In_slow(c.env.CollationEnv(), expr.Negate, plan)
 		}
 
 		return ctype{Type: sqltypes.Int64, Col: collationNumeric, Flag: flagIsBoolean | (nullableFlags(lhs.Flag) | (rt.Flag & flagNullable))}, nil
@@ -599,11 +811,517 @@ func (expr *InExpr) compile(c *compiler) (ctype, error) {
 			return ctype{}, err
 		}
 
-		c.asm.In_slow(c.env.CollationEnv(), expr.Negate)
+		// The expanded list's element declarations resolve at execution.
+		if plan == inJSONNo {
+			plan = inJSONUnknown
+		}
+		c.asm.In_slow(c.env.CollationEnv(), expr.Negate, plan)
 		return ctype{Type: sqltypes.Int64, Col: collationNumeric, Flag: flagIsBoolean | (nullableFlags(lhs.Flag) | (rt.Flag & flagNullable))}, nil
 	default:
 		panic("unreachable")
 	}
+}
+
+// classFromType maps a declared SQL type onto its comparison class.
+func classFromType(tt sqltypes.Type) cmpClass {
+	switch {
+	case tt == sqltypes.Null:
+		return classNull
+	case tt == sqltypes.TypeJSON:
+		return classJSON
+	case tt == sqltypes.Date, tt == sqltypes.Datetime, tt == sqltypes.Timestamp:
+		return classDateLike
+	case tt == sqltypes.Time:
+		return classTime
+	case sqltypes.IsNumber(tt), tt == sqltypes.Year, tt == sqltypes.Bit:
+		return classNumeric
+	case sqltypes.IsTextOrBinary(tt), tt == sqltypes.Enum, tt == sqltypes.Set:
+		return classString
+	default:
+		return classUnknown
+	}
+}
+
+// mergeCmpClass merges the translation-time class with the operand's
+// late-resolved type. The static class wins: constant folding erases typed
+// SQL NULLs.
+func mergeCmpClass(static cmpClass, tt sqltypes.Type) cmpClass {
+	if static != classUnknown && static != classNull {
+		return static
+	}
+	if c := classFromType(tt); c != classUnknown {
+		return c
+	}
+	return static
+}
+
+// evalCmpClass resolves an operand's comparison class during evaluation:
+// the translation-time class, the type of the evaluated value, or the type
+// the operand declares in the evaluation environment when the value is SQL
+// NULL. provisional marks a composite classified from its runtime value,
+// whose declared type may still disagree with the selected child's
+// representation.
+func evalCmpClass(env *ExpressionEnv, static cmpClass, op IR, val eval) (cmpClass, bool) {
+	if static != classUnknown && static != classNull {
+		return static, false
+	}
+	if val != nil {
+		return mergeCmpClass(static, val.SQLType()), compositeIR(op)
+	}
+	if typed, ok := op.(typedIR); ok {
+		if ct, err := typed.typeof(env); err == nil {
+			return mergeCmpClass(static, ct.Type), false
+		}
+		return static, false
+	}
+	if compositeIR(op) {
+		if class, ok := declaredCmpClass(env, op); ok {
+			return class, false
+		}
+	}
+	return static, false
+}
+
+// compositeIR reports whether op is a composite whose runtime value may not
+// carry its declared result type: SQL NULL erases it, and an evaluator may
+// return a selected child's internal representation unchanged.
+func compositeIR(op IR) bool {
+	switch op.(type) {
+	case *Literal, *Column, *BindVariable, *TupleBindVariable, TupleExpr:
+		return false
+	}
+	return true
+}
+
+// declaredCmpClass derives a composite operand's declared comparison class
+// through the compiler's type aggregation, resolving untyped leaves from the
+// evaluation environment; the type-only program is discarded.
+func declaredCmpClass(env *ExpressionEnv, op IR) (cmpClass, bool) {
+	venv := env.VCursor().Environment()
+	comp := compiler{
+		env:       venv,
+		collation: venv.CollationEnv().DefaultConnectionCharset(),
+		sqlmode:   env.sqlmode,
+		typeEnv:   env,
+	}
+	typ, err := op.compile(&comp)
+	if err != nil {
+		return classUnknown, false
+	}
+	if class := classFromType(typ.Type); class != classUnknown {
+		return class, true
+	}
+	return classUnknown, false
+}
+
+// resolveJSONCmpClasses re-resolves provisional composite classes from their
+// declared types once a JSON operand participates: the declaration wins over
+// the selected child's runtime representation.
+func resolveJSONCmpClasses(env *ExpressionEnv, classes []cmpClass, provisional []bool, ops []IR) {
+	if !slices.Contains(classes, classJSON) {
+		return
+	}
+	for k, prov := range provisional {
+		if !prov {
+			continue
+		}
+		if class, ok := declaredCmpClass(env, ops[k]); ok {
+			classes[k] = class
+		}
+	}
+}
+
+// betweenToFloat coerces a numeric-domain BETWEEN operand: a JSON temporal
+// scalar converts from the numeric prefix of its unquoted text, like a JSON
+// string; everything else uses the standard DOUBLE coercion.
+func betweenToFloat(e eval) *evalFloat {
+	if j, ok := e.(*evalJSON); ok {
+		switch j.Type() {
+		case json.TypeDate, json.TypeDateTime, json.TypeTime:
+			f, _ := fastparse.ParseFloat64(j.Raw())
+			return &evalFloat{f: f}
+		}
+	}
+	f, _ := evalToFloat(e)
+	return f
+}
+
+// betweenToDateTime coerces a datetime-domain BETWEEN operand from its text
+// form, quotes included for JSON, so JSON strings and temporal scalars fail
+// while JSON numbers parse; failures truncate to the zero DATETIME, never
+// NULL or an error.
+func betweenToDateTime(e eval, now time.Time) datetime.DateTime {
+	if t := evalToDateTime(evalJSONToText(e), -1, now, true); t != nil {
+		return t.dt
+	}
+	return datetime.DateTime{}
+}
+
+// betweenFieldToDateTime coerces a constant bound of a DATE-family column
+// pair through MySQL's field-store conversion: a JSON date-carrying scalar
+// converts natively and a JSON string unquotes, while other JSON values
+// fail; failures truncate to the zero DATETIME.
+func betweenFieldToDateTime(e eval, now time.Time) datetime.DateTime {
+	j, ok := e.(*evalJSON)
+	if !ok {
+		return betweenToDateTime(e, now)
+	}
+	switch j.Type() {
+	case json.TypeDate, json.TypeDateTime:
+		if dt, ok := j.DateTime(); ok {
+			return dt
+		}
+	case json.TypeString:
+		if t := evalToDateTime(newEvalText([]byte(j.Raw()), collationJSON), -1, now, true); t != nil {
+			return t.dt
+		}
+	}
+	return datetime.DateTime{}
+}
+
+// betweenToTime coerces a bound of a TIME-column pair: a JSON TIME scalar
+// converts natively and a JSON string unquotes, while other JSON values
+// fail; failures truncate to the zero TIME.
+func betweenToTime(e eval) datetime.Time {
+	if j, ok := e.(*evalJSON); ok {
+		switch j.Type() {
+		case json.TypeTime:
+			if t, ok := j.Time(); ok {
+				return t
+			}
+		case json.TypeString:
+			if t, ok := parseTimeConstant(j.Raw()); ok {
+				return t
+			}
+		}
+		return datetime.Time{}
+	}
+	if t := evalToTime(e, -1); t != nil {
+		return t.dt.Time
+	}
+	return datetime.Time{}
+}
+
+// parseTimeConstant parses a string as a TIME under MySQL's constant
+// conversion: overflow does not clamp and a date-only string does not
+// convert, but a full datetime literal contributes its time part.
+func parseTimeConstant(s string) (datetime.Time, bool) {
+	if t, _, state := datetime.ParseTime(s, -1); state == datetime.TimeOK {
+		return t, true
+	}
+	if strings.ContainsAny(s, " T") {
+		if dt, _, ok := datetime.ParseDateTime(s, -1); ok {
+			return dt.Time, true
+		}
+	}
+	return datetime.Time{}, false
+}
+
+// betweenTimeConvertible reports whether a constant bound converts to TIME
+// under MySQL's strict constant conversion.
+func betweenTimeConvertible(e eval) bool {
+	switch e := e.(type) {
+	case *evalTemporal:
+		return true
+	case *evalBytes:
+		_, ok := parseTimeConstant(e.string())
+		return ok
+	case *evalInt64:
+		return timeConvertibleInt64(e.i)
+	case *evalUint64:
+		return e.u <= math.MaxInt64 && timeConvertibleInt64(int64(e.u))
+	case *evalFloat:
+		_, _, ok := datetime.ParseTimeFloat(e.f, -1)
+		return ok
+	case *evalDecimal:
+		_, _, ok := datetime.ParseTimeDecimal(e.dec, e.length, -1)
+		return ok
+	}
+	return false
+}
+
+func timeConvertibleInt64(i int64) bool {
+	if _, ok := datetime.ParseTimeInt64(i); ok {
+		return true
+	}
+	_, ok := datetime.ParseDateTimeInt64(i)
+	return ok
+}
+
+// resolveBetweenPlan selects the comparison plan of a BETWEEN. MySQL never
+// compares BETWEEN operands as JSON: numerics win over the temporal domains,
+// a DATE-family operand selects DATETIME in any position, only a bare TIME
+// column on the left selects TIME, and strings otherwise. fromVal and toVal
+// carry the bound values when known: always during evaluation and inside a
+// per-execution compiled plan, constants during compilation.
+func resolveBetweenPlan(classes [3]cmpClass, left, from, to IR, fromVal, toVal eval) betweenPlan {
+	if classes[0] != classJSON && classes[1] != classJSON && classes[2] != classJSON {
+		return betweenPlan{legacy: true}
+	}
+
+	hasNumeric := classes[0] == classNumeric || classes[1] == classNumeric || classes[2] == classNumeric
+	hasDateLike := classes[0] == classDateLike || classes[1] == classDateLike || classes[2] == classDateLike
+	_, leftIsColumn := left.(*Column)
+
+	if hasNumeric && !(leftIsColumn && (classes[0] == classDateLike || classes[0] == classTime)) {
+		return betweenPlan{pairs: [2]betweenPair{pairNumeric, pairNumeric}}
+	}
+	if leftIsColumn && classes[0] == classDateLike && hasNumeric {
+		pair := func(class cmpClass, op IR) betweenPair {
+			switch {
+			case class == classNumeric:
+				return pairNumeric
+			case class == classJSON && op.constForExecution():
+				return pairDatetimeField
+			case class == classJSON:
+				// The field-store conversion applies only to bounds that
+				// are constant for one execution: a row-dependent JSON
+				// bound stays numeric.
+				return pairNumeric
+			default:
+				return pairDatetimeText
+			}
+		}
+		return betweenPlan{pairs: [2]betweenPair{pair(classes[1], from), pair(classes[2], to)}}
+	}
+	if hasDateLike {
+		return betweenPlan{pairs: [2]betweenPair{pairDatetimeText, pairDatetimeText}}
+	}
+	if leftIsColumn && classes[0] == classTime {
+		// A bound that is constant for one execution replays the constant
+		// conversion rule from its per-execution value: normalization
+		// rewrites literal bounds into bind variables, so this keeps
+		// normalized queries matching MySQL's literal behavior. For a bound
+		// that does not convert, this deliberately diverges from MySQL's
+		// prepared-parameter semantics (NULL through a failed field
+		// conversion) and keeps the literal rule's numeric fallback.
+		fromConv := from.constForExecution() && fromVal != nil && betweenTimeConvertible(fromVal)
+		toConv := to.constForExecution() && toVal != nil && betweenTimeConvertible(toVal)
+		// A typed-NULL JSON constant does not activate the per-pair paths:
+		// the predicate stays on the whole-string fallback, unless a numeric
+		// participant keeps the aggregate domain numeric.
+		fromJSONConst := classes[1] == classJSON && from.constForExecution() && fromVal != nil
+		toJSONConst := classes[2] == classJSON && to.constForExecution() && toVal != nil
+		if !fromConv && !toConv && !fromJSONConst && !toJSONConst {
+			if hasNumeric {
+				return betweenPlan{pairs: [2]betweenPair{pairNumeric, pairNumeric}}
+			}
+			return betweenPlan{pairs: [2]betweenPair{pairString, pairString}}
+		}
+		pair := func(class cmpClass, jsonConst, conv bool) betweenPair {
+			if jsonConst || conv || class == classTime {
+				return pairTime
+			}
+			// Unconvertible constants and non-TIME columns compare on their
+			// numeric forms.
+			return pairNumeric
+		}
+		return betweenPlan{pairs: [2]betweenPair{
+			pair(classes[1], fromJSONConst, fromConv),
+			pair(classes[2], toJSONConst, toConv),
+		}}
+	}
+	return betweenPlan{pairs: [2]betweenPair{pairString, pairString}}
+}
+
+// betweenPlanPerExecution reports whether the comparison plan depends on the
+// per-execution value of a bound that is constant for one execution: only
+// the TIME column branch of resolveBetweenPlan consults bound values, so a
+// compiled BETWEEN with such a bound re-resolves its plan on every execution
+// instead of baking one value into the type-keyed program.
+func betweenPlanPerExecution(classes [3]cmpClass, left, from, to IR) bool {
+	if classes[0] != classJSON && classes[1] != classJSON && classes[2] != classJSON {
+		return false
+	}
+	if classes[0] == classDateLike || classes[1] == classDateLike || classes[2] == classDateLike {
+		return false
+	}
+	if _, leftIsColumn := left.(*Column); !leftIsColumn || classes[0] != classTime {
+		return false
+	}
+	perExecution := func(op IR) bool {
+		return op.constForExecution() && !op.constant()
+	}
+	return perExecution(from) || perExecution(to)
+}
+
+// evalBetweenExpr evaluates `left [NOT] BETWEEN from AND to` under the
+// resolved comparison plan.
+func evalBetweenExpr(collationEnv *collations.Environment, left, from, to eval, negate bool, plan betweenPlan, now time.Time) (boolean, error) {
+	if left == nil {
+		return boolNULL, nil
+	}
+
+	var cmp func(pair betweenPair, r eval) (int, bool, error)
+	switch {
+	case plan.legacy:
+		cmp = func(_ betweenPair, r eval) (int, bool, error) {
+			return evalCompareAll(left, r, false, collationEnv)
+		}
+	case plan.pairs[0] == pairString:
+		// MySQL aggregates a single collation across the whole operand set:
+		// the JSON operands make utf8mb4_bin win. Seeding it unconditionally
+		// keeps a declared JSON operand whose value is SQL NULL in the
+		// aggregation.
+		var ca collationAggregation
+		if err := ca.add(collationJSON, collationEnv); err != nil {
+			return boolNULL, err
+		}
+		for _, e := range [3]eval{left, from, to} {
+			if e == nil {
+				continue
+			}
+			if err := ca.add(evalCollation(e), collationEnv); err != nil {
+				return boolNULL, err
+			}
+		}
+		col := colldata.Lookup(ca.result().Collation)
+		toMerged := func(e eval) ([]byte, error) {
+			return charset.Convert(nil, col.Charset(), e.ToRawBytes(), colldata.Lookup(evalCollation(e).Collation).Charset())
+		}
+		leftBytes, err := toMerged(left)
+		if err != nil {
+			return boolNULL, err
+		}
+		cmp = func(_ betweenPair, r eval) (int, bool, error) {
+			if r == nil {
+				return 0, true, nil
+			}
+			rightBytes, err := toMerged(r)
+			if err != nil {
+				return 0, false, err
+			}
+			return col.Collate(leftBytes, rightBytes, false), false, nil
+		}
+	default:
+		cmp = func(pair betweenPair, r eval) (int, bool, error) {
+			if r == nil {
+				return 0, true, nil
+			}
+			switch pair {
+			case pairNumeric:
+				n, err := compareNumeric(betweenToFloat(left), betweenToFloat(r))
+				return n, false, err
+			case pairDatetimeText:
+				return betweenToDateTime(left, now).Compare(betweenToDateTime(r, now)), false, nil
+			case pairDatetimeField:
+				return betweenToDateTime(left, now).Compare(betweenFieldToDateTime(r, now)), false, nil
+			default: // pairTime
+				return betweenToTime(left).Compare(betweenToTime(r)), false, nil
+			}
+		}
+	}
+
+	n, isNull, err := cmp(plan.pairs[0], from)
+	if err != nil {
+		return boolNULL, err
+	}
+	cmpFrom := makeboolean2(n >= 0, isNull)
+	if cmpFrom == boolFalse {
+		// The result is decided: skip the upper-bound comparison, like the
+		// equivalent `left >= from AND left <= to` conjunction would.
+		return makeboolean(negate), nil
+	}
+	n, isNull, err = cmp(plan.pairs[1], to)
+	if err != nil {
+		return boolNULL, err
+	}
+	cmpTo := makeboolean2(n <= 0, isNull)
+
+	// Combine both comparisons like the AND operator would; cmpFrom is either
+	// true or NULL here.
+	var result boolean
+	switch {
+	case cmpTo == boolFalse:
+		result = boolFalse
+	case cmpFrom == boolTrue && cmpTo == boolTrue:
+		result = boolTrue
+	default:
+		result = boolNULL
+	}
+	if negate {
+		result = result.not()
+	}
+	return result, nil
+}
+
+// eval implements the expression interface
+func (b *BetweenExpr) eval(env *ExpressionEnv) (eval, error) {
+	left, err := b.Left.eval(env)
+	if err != nil || left == nil {
+		return nil, err
+	}
+	from, err := b.From.eval(env)
+	if err != nil {
+		return nil, err
+	}
+	to, err := b.To.eval(env)
+	if err != nil {
+		return nil, err
+	}
+	ops := [3]IR{b.Left, b.From, b.To}
+	vals := [3]eval{left, from, to}
+	var classes [3]cmpClass
+	var provisional [3]bool
+	for k := range ops {
+		classes[k], provisional[k] = evalCmpClass(env, b.StaticClasses[k], ops[k], vals[k])
+	}
+	resolveJSONCmpClasses(env, classes[:], provisional[:], ops[:])
+	plan := resolveBetweenPlan(classes, b.Left, b.From, b.To, from, to)
+	in, err := evalBetweenExpr(env.collationEnv, left, from, to, b.Negate, plan, env.now)
+	if err != nil {
+		return nil, err
+	}
+	return in.eval(), nil
+}
+
+// compileBoundVal evaluates a constant bound so the plan resolver can test
+// its TIME convertibility, exactly like constant folding would.
+func compileBoundVal(c *compiler, op IR) eval {
+	if lit, ok := op.(*Literal); ok {
+		return lit.inner
+	}
+	if !op.constant() {
+		return nil
+	}
+	v, err := op.eval(EmptyExpressionEnv(c.env))
+	if err != nil {
+		return nil
+	}
+	return v
+}
+
+func (expr *BetweenExpr) compile(c *compiler) (ctype, error) {
+	lt, err := expr.Left.compile(c)
+	if err != nil {
+		return ctype{}, err
+	}
+
+	skip := c.compileNullCheck1(lt)
+
+	ft, err := expr.From.compile(c)
+	if err != nil {
+		return ctype{}, err
+	}
+	tt, err := expr.To.compile(c)
+	if err != nil {
+		return ctype{}, err
+	}
+
+	classes := [3]cmpClass{
+		mergeCmpClass(expr.StaticClasses[0], lt.Type),
+		mergeCmpClass(expr.StaticClasses[1], ft.Type),
+		mergeCmpClass(expr.StaticClasses[2], tt.Type),
+	}
+	if betweenPlanPerExecution(classes, expr.Left, expr.From, expr.To) {
+		c.asm.BetweenPerExecution(c.env.CollationEnv(), expr.Negate, classes, expr.Left, expr.From, expr.To)
+	} else {
+		plan := resolveBetweenPlan(classes, expr.Left, expr.From, expr.To,
+			compileBoundVal(c, expr.From), compileBoundVal(c, expr.To))
+		c.asm.Between(c.env.CollationEnv(), expr.Negate, plan)
+	}
+	c.asm.jumpDestination(skip)
+	return ctype{Type: sqltypes.Int64, Col: collationNumeric, Flag: flagIsBoolean | nullableFlags(lt.Flag|ft.Flag|tt.Flag)}, nil
 }
 
 func (l *LikeExpr) matchWildcard(left, right []byte, coll collations.ID) bool {

--- a/go/vt/vtgate/evalengine/expr_compare.go
+++ b/go/vt/vtgate/evalengine/expr_compare.go
@@ -18,9 +18,17 @@ package evalengine
 
 import (
 	"bytes"
+	"math"
+	"slices"
+	"strings"
+	"time"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/collations/charset"
 	"vitess.io/vitess/go/mysql/collations/colldata"
+	"vitess.io/vitess/go/mysql/datetime"
+	"vitess.io/vitess/go/mysql/fastparse"
+	"vitess.io/vitess/go/mysql/json"
 	"vitess.io/vitess/go/sqltypes"
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -48,8 +56,90 @@ type (
 	InExpr struct {
 		BinaryExpr
 		Negate bool
+		// PrefixJSON aggregates the declared-JSON tri-state over the left
+		// operand and the RHS prefix MySQL's type scan inspects, proved at
+		// translation time before constant folding can erase a typed SQL
+		// NULL. Row elements never contribute.
+		PrefixJSON inJSONDomain
+		// JSONScanRHS counts the leading RHS elements of that scan:
+		// everything up to and including the first element that is not
+		// constant for one execution.
+		JSONScanRHS int
 	}
 
+	BetweenExpr struct {
+		Left   IR
+		From   IR
+		To     IR
+		Negate bool
+		// StaticClasses are the comparison classes of (Left, From, To) proved
+		// at translation time, before constant folding can erase a typed SQL
+		// NULL; classUnknown when the type resolves only at evaluation time.
+		StaticClasses [3]cmpClass
+	}
+
+	// cmpClass is the comparison result class of an operand's declared type,
+	// deciding the comparison domain of IN and BETWEEN when a JSON operand
+	// participates.
+	cmpClass uint8
+
+	// inJSONDomain is the declared-JSON comparison plan of a scalar IN:
+	// definitely JSON, definitely not, or resolvable only from the element
+	// types of an execution-expanded tuple bind.
+	inJSONDomain uint8
+
+	// betweenPair is the comparator selected for one bound pair of a
+	// JSON-participating BETWEEN.
+	betweenPair uint8
+
+	// betweenPlan is the comparison plan of a BETWEEN: the legacy pairwise
+	// comparison without a JSON operand, or one comparator per bound pair.
+	// Plans are captured by value, never stored on shared IR.
+	betweenPlan struct {
+		legacy bool
+		pairs  [2]betweenPair
+	}
+)
+
+const (
+	inJSONUnknown inJSONDomain = iota
+	inJSONNo
+	inJSONYes
+)
+
+const (
+	classUnknown cmpClass = iota
+	classNull             // untyped SQL NULL: neutral for domain selection
+	classJSON
+	classDateLike // DATE, DATETIME, TIMESTAMP
+	classTime
+	classString  // textual, binary, ENUM, SET
+	classNumeric // integral, decimal, float, YEAR, BIT
+)
+
+const (
+	// pairString compares the serialized text forms under the collation
+	// aggregated across all three operands; only ever set for both pairs.
+	pairString betweenPair = iota
+	// pairNumeric compares as DOUBLE; it is also the integer fallback of the
+	// TIME column branch.
+	pairNumeric
+	// pairDatetimeText compares as DATETIME, converting operands from their
+	// text forms: a JSON operand converts from its serialized text, quotes
+	// included, so JSON strings and temporal scalars fail to the zero date.
+	pairDatetimeText
+	// pairDatetimeField compares as DATETIME through the field-store
+	// conversion MySQL applies to a constant bound of a DATE-family column:
+	// JSON strings unquote and JSON date scalars convert natively, while
+	// other JSON values fail to the zero date.
+	pairDatetimeField
+	// pairTime compares as packed TIME against a bare TIME column: a JSON
+	// string unquotes and a JSON TIME scalar converts natively, while other
+	// JSON values fail to the zero time.
+	pairTime
+)
+
+type (
 	ComparisonOp interface {
 		String() string
 		compare(collationEnv *collations.Environment, left, right eval) (boolean, error)
@@ -62,11 +152,17 @@ type (
 	compareGT         struct{}
 	compareGE         struct{}
 	compareNullSafeEQ struct{}
+
+	// compareCaseEQ is the equality between the base operand of a simple
+	// CASE and its WHEN operands: like MySQL, it never uses the JSON
+	// comparator.
+	compareCaseEQ struct{}
 )
 
 var (
 	_ IR = (*ComparisonExpr)(nil)
 	_ IR = (*InExpr)(nil)
+	_ IR = (*BetweenExpr)(nil)
 	_ IR = (*LikeExpr)(nil)
 )
 
@@ -113,6 +209,12 @@ func (compareNullSafeEQ) String() string { return "<=>" }
 func (compareNullSafeEQ) compare(collationEnv *collations.Environment, left, right eval) (boolean, error) {
 	cmp, err := evalCompareNullSafe(left, right, collationEnv)
 	return makeboolean(cmp == 0), err
+}
+
+func (compareCaseEQ) String() string { return "=" }
+func (compareCaseEQ) compare(collationEnv *collations.Environment, left, right eval) (boolean, error) {
+	cmp, isNull, err := evalCompareCase(left, right, collationEnv)
+	return makeboolean2(cmp == 0, isNull), err
 }
 
 func typeIsTextual(tt sqltypes.Type) bool {
@@ -224,6 +326,24 @@ func evalCompareAll(lVal, rVal eval, fulleq bool, collationEnv *collations.Envir
 	return n, false, err
 }
 
+// evalCompareCase compares the base operand of a simple CASE with a WHEN
+// operand: it matches evalCompareAll except that JSON pairs go through
+// evalCompareCaseJSON, as MySQL never uses the JSON comparator here.
+func evalCompareCase(lVal, rVal eval, collationEnv *collations.Environment) (int, bool, error) {
+	if lVal == nil || rVal == nil {
+		return 0, true, nil
+	}
+	if left, right, ok := compareAsTuples(lVal, rVal); ok {
+		return evalCompareMany(left.t, right.t, true, collationEnv)
+	}
+	if compareAsJSON(lVal.SQLType(), rVal.SQLType()) {
+		n, err := evalCompareCaseJSON(lVal, rVal, collationEnv)
+		return n, false, err
+	}
+	n, err := evalCompare(lVal, rVal, collationEnv)
+	return n, false, err
+}
+
 // For more details on comparison expression evaluation and type conversion:
 //   - https://dev.mysql.com/doc/refman/8.0/en/type-conversion.html
 func evalCompare(left, right eval, collationEnv *collations.Environment) (comp int, err error) {
@@ -328,7 +448,7 @@ func (expr *ComparisonExpr) compileAsTuple(c *compiler) (ctype, error) {
 	case compareNullSafeEQ:
 		c.asm.CmpTupleNullsafe(c.env.CollationEnv())
 		return ctype{Type: sqltypes.Int64, Col: collationNumeric, Flag: flagIsBoolean}, nil
-	case compareEQ:
+	case compareEQ, compareCaseEQ:
 		c.asm.CmpTuple(c.env.CollationEnv(), true)
 		c.asm.Cmp_eq_n()
 	case compareNE:
@@ -422,7 +542,9 @@ func (expr *ComparisonExpr) compile(c *compiler) (ctype, error) {
 		}
 		swapped = c.compareNumericTypes(lt, rt)
 	case compareAsJSON(lt.Type, rt.Type):
-		if err := c.compareAsJSON(lt, rt); err != nil {
+		if _, ok := expr.Op.(compareCaseEQ); ok {
+			c.asm.CmpCaseJSON(c.env.CollationEnv())
+		} else if err := c.compareAsJSON(lt, rt); err != nil {
 			return ctype{}, err
 		}
 
@@ -438,7 +560,7 @@ func (expr *ComparisonExpr) compile(c *compiler) (ctype, error) {
 	}
 
 	switch expr.Op.(type) {
-	case compareEQ:
+	case compareEQ, compareCaseEQ:
 		c.asm.Cmp_eq()
 	case compareNE:
 		c.asm.Cmp_ne()
@@ -479,14 +601,40 @@ func (expr *ComparisonExpr) compile(c *compiler) (ctype, error) {
 	return cmptype, nil
 }
 
-func evalInExpr(collationEnv *collations.Environment, lhs eval, rhs *evalTuple) (boolean, error) {
+func evalInExpr(collationEnv *collations.Environment, lhs eval, rhs *evalTuple, plan inJSONDomain) (boolean, error) {
 	if lhs == nil {
 		return boolNULL, nil
 	}
 
+	// When a JSON operand participates in IN — by declared type, even when
+	// the value is SQL NULL — MySQL compares every pair as JSON, converting
+	// the non-JSON operands to JSON scalars (strings become string scalars,
+	// not parsed documents). Row (tuple) operands keep their per-column
+	// comparisons. An unresolved plan is the execution-expanded tuple bind,
+	// whose element values carry the declared types of the expanded list.
+	asJSON := plan == inJSONYes
+	if plan == inJSONUnknown {
+		for _, rtuple := range rhs.t {
+			if rtuple != nil && rtuple.SQLType() == sqltypes.TypeJSON {
+				asJSON = true
+				break
+			}
+		}
+	}
+
 	var foundNull, found bool
 	for _, rtuple := range rhs.t {
-		numeric, isNull, err := evalCompareAll(lhs, rtuple, true, collationEnv)
+		var numeric int
+		var isNull bool
+		var err error
+		switch {
+		case asJSON && rtuple == nil:
+			isNull = true
+		case asJSON:
+			numeric, err = compareJSON(lhs, rtuple)
+		default:
+			numeric, isNull, err = evalCompareAll(lhs, rtuple, true, collationEnv)
+		}
 		if err != nil {
 			return boolNULL, err
 		}
@@ -510,6 +658,50 @@ func evalInExpr(collationEnv *collations.Environment, lhs eval, rhs *evalTuple) 
 	}
 }
 
+// resolvePrefixJSON resolves an unknown declared-JSON plan during
+// evaluation: the classes of the left operand and the scanned RHS prefix,
+// late-resolved from their declared types. An execution-expanded tuple bind
+// stays unresolved unless the left operand declares JSON: its element types
+// are inspected on the expanded values.
+func (i *InExpr) resolvePrefixJSON(env *ExpressionEnv, lhs eval, rtuple *evalTuple) inJSONDomain {
+	tuple, ok := i.Right.(TupleExpr)
+	if !ok {
+		class, provisional := evalCmpClass(env, classUnknown, i.Left, lhs)
+		if class == classJSON && provisional {
+			if declared, ok := declaredCmpClass(env, i.Left); ok {
+				class = declared
+			}
+		}
+		if class == classJSON {
+			return inJSONYes
+		}
+		return inJSONUnknown
+	}
+
+	ops := make([]IR, 1, i.JSONScanRHS+1)
+	vals := make([]eval, 1, i.JSONScanRHS+1)
+	ops[0], vals[0] = i.Left, lhs
+	for idx := 0; idx < i.JSONScanRHS && idx < len(tuple); idx++ {
+		var val eval
+		if idx < len(rtuple.t) {
+			val = rtuple.t[idx]
+		}
+		ops = append(ops, tuple[idx])
+		vals = append(vals, val)
+	}
+
+	classes := make([]cmpClass, len(ops))
+	provisional := make([]bool, len(ops))
+	for k := range ops {
+		classes[k], provisional[k] = evalCmpClass(env, classUnknown, ops[k], vals[k])
+	}
+	resolveJSONCmpClasses(env, classes, provisional, ops)
+	if slices.Contains(classes, classJSON) {
+		return inJSONYes
+	}
+	return inJSONNo
+}
+
 // eval implements the ComparisonOp interface
 func (i *InExpr) eval(env *ExpressionEnv) (eval, error) {
 	left, right, err := i.arguments(env)
@@ -520,7 +712,11 @@ func (i *InExpr) eval(env *ExpressionEnv) (eval, error) {
 	if !ok {
 		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "rhs of an In operation should be a tuple")
 	}
-	in, err := evalInExpr(env.collationEnv, left, rtuple)
+	plan := i.PrefixJSON
+	if plan == inJSONUnknown {
+		plan = i.resolvePrefixJSON(env, left, rtuple)
+	}
+	in, err := evalInExpr(env.collationEnv, left, rtuple, plan)
 	if err != nil {
 		return nil, err
 	}
@@ -571,7 +767,12 @@ func (i *InExpr) compileTable(lhs ctype, rhs TupleExpr) map[vthash.Hash]struct{}
 func (expr *InExpr) compile(c *compiler) (ctype, error) {
 	lhs, err := expr.Left.compile(c)
 	if err != nil {
-		return ctype{}, nil
+		return ctype{}, err
+	}
+
+	plan := expr.PrefixJSON
+	if plan == inJSONUnknown && lhs.Type == sqltypes.TypeJSON {
+		plan = inJSONYes
 	}
 
 	switch rhs := expr.Right.(type) {
@@ -580,11 +781,22 @@ func (expr *InExpr) compile(c *compiler) (ctype, error) {
 		if table := expr.compileTable(lhs, rhs); table != nil {
 			c.asm.In_table(expr.Negate, table)
 		} else {
-			rt, err = rhs.compile(c)
-			if err != nil {
-				return ctype{}, err
+			// Compile the elements individually instead of through
+			// TupleExpr.compile, which discards the element types.
+			for idx, el := range rhs {
+				et, err := el.compile(c)
+				if err != nil {
+					return ctype{}, err
+				}
+				if plan == inJSONUnknown && idx < expr.JSONScanRHS && et.Type == sqltypes.TypeJSON {
+					plan = inJSONYes
+				}
 			}
-			c.asm.In_slow(c.env.CollationEnv(), expr.Negate)
+			if plan == inJSONUnknown {
+				plan = inJSONNo
+			}
+			c.asm.PackTuple(len(rhs))
+			c.asm.In_slow(c.env.CollationEnv(), expr.Negate, plan)
 		}
 
 		return ctype{Type: sqltypes.Int64, Col: collationNumeric, Flag: flagIsBoolean | (nullableFlags(lhs.Flag) | (rt.Flag & flagNullable))}, nil
@@ -599,11 +811,485 @@ func (expr *InExpr) compile(c *compiler) (ctype, error) {
 			return ctype{}, err
 		}
 
-		c.asm.In_slow(c.env.CollationEnv(), expr.Negate)
+		// The expanded list's element declarations resolve at execution.
+		if plan == inJSONNo {
+			plan = inJSONUnknown
+		}
+		c.asm.In_slow(c.env.CollationEnv(), expr.Negate, plan)
 		return ctype{Type: sqltypes.Int64, Col: collationNumeric, Flag: flagIsBoolean | (nullableFlags(lhs.Flag) | (rt.Flag & flagNullable))}, nil
 	default:
 		panic("unreachable")
 	}
+}
+
+// classFromType maps a declared SQL type onto its comparison class.
+func classFromType(tt sqltypes.Type) cmpClass {
+	switch {
+	case tt == sqltypes.Null:
+		return classNull
+	case tt == sqltypes.TypeJSON:
+		return classJSON
+	case tt == sqltypes.Date, tt == sqltypes.Datetime, tt == sqltypes.Timestamp:
+		return classDateLike
+	case tt == sqltypes.Time:
+		return classTime
+	case sqltypes.IsNumber(tt), tt == sqltypes.Year, tt == sqltypes.Bit:
+		return classNumeric
+	case sqltypes.IsTextOrBinary(tt), tt == sqltypes.Enum, tt == sqltypes.Set:
+		return classString
+	default:
+		return classUnknown
+	}
+}
+
+// mergeCmpClass merges the translation-time class with the operand's
+// late-resolved type. The static class wins: constant folding erases typed
+// SQL NULLs.
+func mergeCmpClass(static cmpClass, tt sqltypes.Type) cmpClass {
+	if static != classUnknown && static != classNull {
+		return static
+	}
+	if c := classFromType(tt); c != classUnknown {
+		return c
+	}
+	return static
+}
+
+// evalCmpClass resolves an operand's comparison class during evaluation:
+// the translation-time class, the type of the evaluated value, or the type
+// the operand declares in the evaluation environment when the value is SQL
+// NULL. provisional marks a composite classified from its runtime value,
+// whose declared type may still disagree with the selected child's
+// representation.
+func evalCmpClass(env *ExpressionEnv, static cmpClass, op IR, val eval) (cmpClass, bool) {
+	if static != classUnknown && static != classNull {
+		return static, false
+	}
+	if val != nil {
+		return mergeCmpClass(static, val.SQLType()), compositeIR(op)
+	}
+	if typed, ok := op.(typedIR); ok {
+		if ct, err := typed.typeof(env); err == nil {
+			return mergeCmpClass(static, ct.Type), false
+		}
+		return static, false
+	}
+	if compositeIR(op) {
+		if class, ok := declaredCmpClass(env, op); ok {
+			return class, false
+		}
+	}
+	return static, false
+}
+
+// compositeIR reports whether op is a composite whose runtime value may not
+// carry its declared result type: SQL NULL erases it, and an evaluator may
+// return a selected child's internal representation unchanged.
+func compositeIR(op IR) bool {
+	switch op.(type) {
+	case *Literal, *Column, *BindVariable, *TupleBindVariable, TupleExpr:
+		return false
+	}
+	return true
+}
+
+// declaredCmpClass derives a composite operand's declared comparison class
+// through the compiler's type aggregation, resolving untyped leaves from the
+// evaluation environment; the type-only program is discarded.
+func declaredCmpClass(env *ExpressionEnv, op IR) (cmpClass, bool) {
+	venv := env.VCursor().Environment()
+	comp := compiler{
+		env:       venv,
+		collation: venv.CollationEnv().DefaultConnectionCharset(),
+		sqlmode:   env.sqlmode,
+		typeEnv:   env,
+	}
+	typ, err := op.compile(&comp)
+	if err != nil {
+		return classUnknown, false
+	}
+	if class := classFromType(typ.Type); class != classUnknown {
+		return class, true
+	}
+	return classUnknown, false
+}
+
+// resolveJSONCmpClasses re-resolves provisional composite classes from their
+// declared types once a JSON operand participates: the declaration wins over
+// the selected child's runtime representation.
+func resolveJSONCmpClasses(env *ExpressionEnv, classes []cmpClass, provisional []bool, ops []IR) {
+	if !slices.Contains(classes, classJSON) {
+		return
+	}
+	for k, prov := range provisional {
+		if !prov {
+			continue
+		}
+		if class, ok := declaredCmpClass(env, ops[k]); ok {
+			classes[k] = class
+		}
+	}
+}
+
+// betweenToFloat coerces a numeric-domain BETWEEN operand: a JSON temporal
+// scalar converts from the numeric prefix of its unquoted text, like a JSON
+// string; everything else uses the standard DOUBLE coercion.
+func betweenToFloat(e eval) *evalFloat {
+	if j, ok := e.(*evalJSON); ok {
+		switch j.Type() {
+		case json.TypeDate, json.TypeDateTime, json.TypeTime:
+			f, _ := fastparse.ParseFloat64(j.Raw())
+			return &evalFloat{f: f}
+		}
+	}
+	f, _ := evalToFloat(e)
+	return f
+}
+
+// betweenToDateTime coerces a datetime-domain BETWEEN operand from its text
+// form, quotes included for JSON, so JSON strings and temporal scalars fail
+// while JSON numbers parse; failures truncate to the zero DATETIME, never
+// NULL or an error.
+func betweenToDateTime(e eval, now time.Time) datetime.DateTime {
+	if t := evalToDateTime(evalJSONToText(e), -1, now, true); t != nil {
+		return t.dt
+	}
+	return datetime.DateTime{}
+}
+
+// betweenFieldToDateTime coerces a constant bound of a DATE-family column
+// pair through MySQL's field-store conversion: a JSON date-carrying scalar
+// converts natively and a JSON string unquotes, while other JSON values
+// fail; failures truncate to the zero DATETIME.
+func betweenFieldToDateTime(e eval, now time.Time) datetime.DateTime {
+	j, ok := e.(*evalJSON)
+	if !ok {
+		return betweenToDateTime(e, now)
+	}
+	switch j.Type() {
+	case json.TypeDate, json.TypeDateTime:
+		if dt, ok := j.DateTime(); ok {
+			return dt
+		}
+	case json.TypeString:
+		if t := evalToDateTime(newEvalText([]byte(j.Raw()), collationJSON), -1, now, true); t != nil {
+			return t.dt
+		}
+	}
+	return datetime.DateTime{}
+}
+
+// betweenToTime coerces a bound of a TIME-column pair: a JSON TIME scalar
+// converts natively and a JSON string unquotes, while other JSON values
+// fail; failures truncate to the zero TIME.
+func betweenToTime(e eval) datetime.Time {
+	if j, ok := e.(*evalJSON); ok {
+		switch j.Type() {
+		case json.TypeTime:
+			if t, ok := j.Time(); ok {
+				return t
+			}
+		case json.TypeString:
+			if t, ok := parseTimeConstant(j.Raw()); ok {
+				return t
+			}
+		}
+		return datetime.Time{}
+	}
+	if t := evalToTime(e, -1); t != nil {
+		return t.dt.Time
+	}
+	return datetime.Time{}
+}
+
+// parseTimeConstant parses a string as a TIME under MySQL's constant
+// conversion: overflow does not clamp and a date-only string does not
+// convert, but a full datetime literal contributes its time part.
+func parseTimeConstant(s string) (datetime.Time, bool) {
+	if t, _, state := datetime.ParseTime(s, -1); state == datetime.TimeOK {
+		return t, true
+	}
+	if strings.ContainsAny(s, " T") {
+		if dt, _, ok := datetime.ParseDateTime(s, -1); ok {
+			return dt.Time, true
+		}
+	}
+	return datetime.Time{}, false
+}
+
+// betweenTimeConvertible reports whether a constant bound converts to TIME
+// under MySQL's strict constant conversion.
+func betweenTimeConvertible(e eval) bool {
+	switch e := e.(type) {
+	case *evalTemporal:
+		return true
+	case *evalBytes:
+		_, ok := parseTimeConstant(e.string())
+		return ok
+	case *evalInt64:
+		return timeConvertibleInt64(e.i)
+	case *evalUint64:
+		return e.u <= math.MaxInt64 && timeConvertibleInt64(int64(e.u))
+	case *evalFloat:
+		_, _, ok := datetime.ParseTimeFloat(e.f, -1)
+		return ok
+	case *evalDecimal:
+		_, _, ok := datetime.ParseTimeDecimal(e.dec, e.length, -1)
+		return ok
+	}
+	return false
+}
+
+func timeConvertibleInt64(i int64) bool {
+	if _, ok := datetime.ParseTimeInt64(i); ok {
+		return true
+	}
+	_, ok := datetime.ParseDateTimeInt64(i)
+	return ok
+}
+
+// resolveBetweenPlan selects the comparison plan of a BETWEEN. MySQL never
+// compares BETWEEN operands as JSON: numerics win over the temporal domains,
+// a DATE-family operand selects DATETIME in any position, only a bare TIME
+// column on the left selects TIME, and strings otherwise. fromVal and toVal
+// carry the bound values when known: always during evaluation, constants
+// during compilation.
+func resolveBetweenPlan(classes [3]cmpClass, left, from, to IR, fromVal, toVal eval) betweenPlan {
+	if classes[0] != classJSON && classes[1] != classJSON && classes[2] != classJSON {
+		return betweenPlan{legacy: true}
+	}
+
+	hasNumeric := classes[0] == classNumeric || classes[1] == classNumeric || classes[2] == classNumeric
+	hasDateLike := classes[0] == classDateLike || classes[1] == classDateLike || classes[2] == classDateLike
+	_, leftIsColumn := left.(*Column)
+
+	if hasNumeric && !(leftIsColumn && (classes[0] == classDateLike || classes[0] == classTime)) {
+		return betweenPlan{pairs: [2]betweenPair{pairNumeric, pairNumeric}}
+	}
+	if leftIsColumn && classes[0] == classDateLike && hasNumeric {
+		pair := func(class cmpClass, op IR) betweenPair {
+			switch {
+			case class == classNumeric:
+				return pairNumeric
+			case class == classJSON && op.constant():
+				return pairDatetimeField
+			case class == classJSON:
+				// The field-store conversion applies only to constant
+				// bounds: a row-dependent JSON bound stays numeric.
+				return pairNumeric
+			default:
+				return pairDatetimeText
+			}
+		}
+		return betweenPlan{pairs: [2]betweenPair{pair(classes[1], from), pair(classes[2], to)}}
+	}
+	if hasDateLike {
+		return betweenPlan{pairs: [2]betweenPair{pairDatetimeText, pairDatetimeText}}
+	}
+	if leftIsColumn && classes[0] == classTime {
+		fromConv := from.constant() && fromVal != nil && betweenTimeConvertible(fromVal)
+		toConv := to.constant() && toVal != nil && betweenTimeConvertible(toVal)
+		// A typed-NULL JSON constant does not activate the per-pair paths:
+		// the predicate stays on the whole-string fallback, unless a numeric
+		// participant keeps the aggregate domain numeric.
+		fromJSONConst := classes[1] == classJSON && from.constant() && fromVal != nil
+		toJSONConst := classes[2] == classJSON && to.constant() && toVal != nil
+		if !fromConv && !toConv && !fromJSONConst && !toJSONConst {
+			if hasNumeric {
+				return betweenPlan{pairs: [2]betweenPair{pairNumeric, pairNumeric}}
+			}
+			return betweenPlan{pairs: [2]betweenPair{pairString, pairString}}
+		}
+		pair := func(class cmpClass, jsonConst, conv bool) betweenPair {
+			if jsonConst || conv || class == classTime {
+				return pairTime
+			}
+			// Unconvertible constants and non-TIME columns compare on their
+			// numeric forms.
+			return pairNumeric
+		}
+		return betweenPlan{pairs: [2]betweenPair{
+			pair(classes[1], fromJSONConst, fromConv),
+			pair(classes[2], toJSONConst, toConv),
+		}}
+	}
+	return betweenPlan{pairs: [2]betweenPair{pairString, pairString}}
+}
+
+// evalBetweenExpr evaluates `left [NOT] BETWEEN from AND to` under the
+// resolved comparison plan.
+func evalBetweenExpr(collationEnv *collations.Environment, left, from, to eval, negate bool, plan betweenPlan, now time.Time) (boolean, error) {
+	if left == nil {
+		return boolNULL, nil
+	}
+
+	var cmp func(pair betweenPair, r eval) (int, bool, error)
+	switch {
+	case plan.legacy:
+		cmp = func(_ betweenPair, r eval) (int, bool, error) {
+			return evalCompareAll(left, r, false, collationEnv)
+		}
+	case plan.pairs[0] == pairString:
+		// MySQL aggregates a single collation across the whole operand set:
+		// the JSON operands make utf8mb4_bin win. Seeding it unconditionally
+		// keeps a declared JSON operand whose value is SQL NULL in the
+		// aggregation.
+		var ca collationAggregation
+		if err := ca.add(collationJSON, collationEnv); err != nil {
+			return boolNULL, err
+		}
+		for _, e := range [3]eval{left, from, to} {
+			if e == nil {
+				continue
+			}
+			if err := ca.add(evalCollation(e), collationEnv); err != nil {
+				return boolNULL, err
+			}
+		}
+		col := colldata.Lookup(ca.result().Collation)
+		toMerged := func(e eval) ([]byte, error) {
+			return charset.Convert(nil, col.Charset(), e.ToRawBytes(), colldata.Lookup(evalCollation(e).Collation).Charset())
+		}
+		leftBytes, err := toMerged(left)
+		if err != nil {
+			return boolNULL, err
+		}
+		cmp = func(_ betweenPair, r eval) (int, bool, error) {
+			if r == nil {
+				return 0, true, nil
+			}
+			rightBytes, err := toMerged(r)
+			if err != nil {
+				return 0, false, err
+			}
+			return col.Collate(leftBytes, rightBytes, false), false, nil
+		}
+	default:
+		cmp = func(pair betweenPair, r eval) (int, bool, error) {
+			if r == nil {
+				return 0, true, nil
+			}
+			switch pair {
+			case pairNumeric:
+				n, err := compareNumeric(betweenToFloat(left), betweenToFloat(r))
+				return n, false, err
+			case pairDatetimeText:
+				return betweenToDateTime(left, now).Compare(betweenToDateTime(r, now)), false, nil
+			case pairDatetimeField:
+				return betweenToDateTime(left, now).Compare(betweenFieldToDateTime(r, now)), false, nil
+			default: // pairTime
+				return betweenToTime(left).Compare(betweenToTime(r)), false, nil
+			}
+		}
+	}
+
+	n, isNull, err := cmp(plan.pairs[0], from)
+	if err != nil {
+		return boolNULL, err
+	}
+	cmpFrom := makeboolean2(n >= 0, isNull)
+	if cmpFrom == boolFalse {
+		// The result is decided: skip the upper-bound comparison, like the
+		// equivalent `left >= from AND left <= to` conjunction would.
+		return makeboolean(negate), nil
+	}
+	n, isNull, err = cmp(plan.pairs[1], to)
+	if err != nil {
+		return boolNULL, err
+	}
+	cmpTo := makeboolean2(n <= 0, isNull)
+
+	// Combine both comparisons like the AND operator would; cmpFrom is either
+	// true or NULL here.
+	var result boolean
+	switch {
+	case cmpTo == boolFalse:
+		result = boolFalse
+	case cmpFrom == boolTrue && cmpTo == boolTrue:
+		result = boolTrue
+	default:
+		result = boolNULL
+	}
+	if negate {
+		result = result.not()
+	}
+	return result, nil
+}
+
+// eval implements the expression interface
+func (b *BetweenExpr) eval(env *ExpressionEnv) (eval, error) {
+	left, err := b.Left.eval(env)
+	if err != nil || left == nil {
+		return nil, err
+	}
+	from, err := b.From.eval(env)
+	if err != nil {
+		return nil, err
+	}
+	to, err := b.To.eval(env)
+	if err != nil {
+		return nil, err
+	}
+	ops := [3]IR{b.Left, b.From, b.To}
+	vals := [3]eval{left, from, to}
+	var classes [3]cmpClass
+	var provisional [3]bool
+	for k := range ops {
+		classes[k], provisional[k] = evalCmpClass(env, b.StaticClasses[k], ops[k], vals[k])
+	}
+	resolveJSONCmpClasses(env, classes[:], provisional[:], ops[:])
+	plan := resolveBetweenPlan(classes, b.Left, b.From, b.To, from, to)
+	in, err := evalBetweenExpr(env.collationEnv, left, from, to, b.Negate, plan, env.now)
+	if err != nil {
+		return nil, err
+	}
+	return in.eval(), nil
+}
+
+// compileBoundVal evaluates a constant bound so the plan resolver can test
+// its TIME convertibility, exactly like constant folding would.
+func compileBoundVal(c *compiler, op IR) eval {
+	if lit, ok := op.(*Literal); ok {
+		return lit.inner
+	}
+	if !op.constant() {
+		return nil
+	}
+	v, err := op.eval(EmptyExpressionEnv(c.env))
+	if err != nil {
+		return nil
+	}
+	return v
+}
+
+func (expr *BetweenExpr) compile(c *compiler) (ctype, error) {
+	lt, err := expr.Left.compile(c)
+	if err != nil {
+		return ctype{}, err
+	}
+
+	skip := c.compileNullCheck1(lt)
+
+	ft, err := expr.From.compile(c)
+	if err != nil {
+		return ctype{}, err
+	}
+	tt, err := expr.To.compile(c)
+	if err != nil {
+		return ctype{}, err
+	}
+
+	classes := [3]cmpClass{
+		mergeCmpClass(expr.StaticClasses[0], lt.Type),
+		mergeCmpClass(expr.StaticClasses[1], ft.Type),
+		mergeCmpClass(expr.StaticClasses[2], tt.Type),
+	}
+	plan := resolveBetweenPlan(classes, expr.Left, expr.From, expr.To,
+		compileBoundVal(c, expr.From), compileBoundVal(c, expr.To))
+
+	c.asm.Between(c.env.CollationEnv(), expr.Negate, plan)
+	c.asm.jumpDestination(skip)
+	return ctype{Type: sqltypes.Int64, Col: collationNumeric, Flag: flagIsBoolean | nullableFlags(lt.Flag|ft.Flag|tt.Flag)}, nil
 }
 
 func (l *LikeExpr) matchWildcard(left, right []byte, coll collations.ID) bool {

--- a/go/vt/vtgate/evalengine/expr_compare.go
+++ b/go/vt/vtgate/evalengine/expr_compare.go
@@ -531,6 +531,13 @@ func (i *InExpr) eval(env *ExpressionEnv) (eval, error) {
 }
 
 func (i *InExpr) compileTable(lhs ctype, rhs TupleExpr) map[vthash.Hash]struct{} {
+	// JSON hashes fingerprint arrays and objects by kind and cardinality
+	// only: a hash hit is not equality, so JSON stays on the comparing
+	// slow path.
+	if lhs.Type == sqltypes.TypeJSON {
+		return nil
+	}
+
 	var (
 		table  = make(map[vthash.Hash]struct{})
 		hasher = vthash.New()

--- a/go/vt/vtgate/evalengine/expr_literal.go
+++ b/go/vt/vtgate/evalengine/expr_literal.go
@@ -41,7 +41,17 @@ func (l *Literal) IsExpr() {}
 
 // eval implements the expression interface
 func (l *Literal) eval(_ *ExpressionEnv) (eval, error) {
-	return l.inner, nil
+	return cloneJSONLiteral(l.inner), nil
+}
+
+// cloneJSONLiteral returns e with a JSON document deep-cloned: JSON functions
+// mutate documents in place, and a Literal is shared by every evaluation of a
+// translated expression.
+func cloneJSONLiteral(e eval) eval {
+	if j, ok := e.(*evalJSON); ok {
+		return j.Clone()
+	}
+	return e
 }
 
 // typeof implements the Expr interface

--- a/go/vt/vtgate/evalengine/expr_logical.go
+++ b/go/vt/vtgate/evalengine/expr_logical.go
@@ -654,6 +654,18 @@ func (c *CaseExpr) constant() bool {
 	return true
 }
 
+func (c *CaseExpr) constForExecution() bool {
+	if c.Else != nil && !c.Else.constForExecution() {
+		return false
+	}
+	for _, then := range c.cases {
+		if !then.when.constForExecution() || !then.then.constForExecution() {
+			return false
+		}
+	}
+	return true
+}
+
 func (c *CaseExpr) simplify(env *ExpressionEnv) error {
 	var err error
 	for i := range c.cases {

--- a/go/vt/vtgate/evalengine/fn_crypto.go
+++ b/go/vt/vtgate/evalengine/fn_crypto.go
@@ -225,6 +225,10 @@ func (call *builtinRandomBytes) constant() bool {
 	return false
 }
 
+func (call *builtinRandomBytes) constForExecution() bool {
+	return false
+}
+
 func (call *builtinRandomBytes) compile(c *compiler) (ctype, error) {
 	arg, err := call.Arguments[0].compile(c)
 	if err != nil {

--- a/go/vt/vtgate/evalengine/fn_json.go
+++ b/go/vt/vtgate/evalengine/fn_json.go
@@ -404,7 +404,10 @@ func (call *builtinJSONDepth) eval(env *ExpressionEnv) (eval, error) {
 }
 
 func (call *builtinJSONDepth) compile(c *compiler) (ctype, error) {
-	return ctype{}, c.unsupported(call)
+	if c.typeEnv == nil {
+		return ctype{}, c.unsupported(call)
+	}
+	return c.typeOnlyCall(call.Arguments, 0, ctype{Type: sqltypes.Int64, Col: collationNumeric, Flag: flagNullable})
 }
 
 func (call *builtinJSONLength) eval(env *ExpressionEnv) (eval, error) {
@@ -446,7 +449,10 @@ func (call *builtinJSONLength) eval(env *ExpressionEnv) (eval, error) {
 }
 
 func (call *builtinJSONLength) compile(c *compiler) (ctype, error) {
-	return ctype{}, c.unsupported(call)
+	if c.typeEnv == nil {
+		return ctype{}, c.unsupported(call)
+	}
+	return c.typeOnlyCall(call.Arguments, 0, ctype{Type: sqltypes.Int64, Col: collationNumeric, Flag: flagNullable})
 }
 
 func (call *builtinJSONContainsPath) eval(env *ExpressionEnv) (eval, error) {
@@ -494,10 +500,16 @@ func (call *builtinJSONContainsPath) compile(c *compiler) (ctype, error) {
 	}
 
 	if !call.Arguments[1].constant() {
+		if c.typeEnv != nil {
+			return c.typeOnlyCall(call.Arguments, 1, ctype{Type: sqltypes.Int64, Col: collationNumeric, Flag: flagIsBoolean | flagNullable})
+		}
 		return ctype{}, c.unsupported(call)
 	}
 
 	if !slice.All(call.Arguments[2:], func(expr IR) bool { return expr.constant() }) {
+		if c.typeEnv != nil {
+			return c.typeOnlyCall(call.Arguments, 1, ctype{Type: sqltypes.Int64, Col: collationNumeric, Flag: flagIsBoolean | flagNullable})
+		}
 		return ctype{}, c.unsupported(call)
 	}
 

--- a/go/vt/vtgate/evalengine/fn_misc.go
+++ b/go/vt/vtgate/evalengine/fn_misc.go
@@ -576,6 +576,10 @@ func (call *builtinUUID) constant() bool {
 	return false
 }
 
+func (call *builtinUUID) constForExecution() bool {
+	return false
+}
+
 func (call *builtinUUIDToBin) eval(env *ExpressionEnv) (eval, error) {
 	arg, err := call.arg1(env)
 	if arg == nil || err != nil {

--- a/go/vt/vtgate/evalengine/fn_time.go
+++ b/go/vt/vtgate/evalengine/fn_time.go
@@ -273,6 +273,10 @@ func (call *builtinSysdate) constant() bool {
 	return false
 }
 
+func (call *builtinSysdate) constForExecution() bool {
+	return false
+}
+
 func (call *builtinCurdate) eval(env *ExpressionEnv) (eval, error) {
 	now := env.time(false)
 	return newEvalDate(now.Date, false), nil

--- a/go/vt/vtgate/evalengine/format.go
+++ b/go/vt/vtgate/evalengine/format.go
@@ -127,13 +127,27 @@ func (l *Literal) format(buf *sqlparser.TrackedBuffer) {
 			if i > 0 {
 				buf.WriteString(", ")
 			}
-			evalToSQLValue(val).EncodeSQLStringBuilder(buf.Builder)
+			formatEvalLiteral(buf, val)
 		}
 		buf.WriteByte(')')
 
 	default:
-		evalToSQLValue(l.inner).EncodeSQLStringBuilder(buf.Builder)
+		formatEvalLiteral(buf, l.inner)
 	}
+}
+
+// formatEvalLiteral formats e as a SQL literal. JSON values are wrapped in
+// CAST(... AS JSON) to keep their document semantics.
+func formatEvalLiteral(buf *sqlparser.TrackedBuffer, e eval) {
+	if _, ok := e.(*evalJSON); ok {
+		buf.WriteLiteral("cast(")
+		evalToSQLValue(e).EncodeSQLStringBuilder(buf.Builder)
+		buf.WriteLiteral(" as ")
+		buf.WriteLiteral("json")
+		buf.WriteByte(')')
+		return
+	}
+	evalToSQLValue(e).EncodeSQLStringBuilder(buf.Builder)
 }
 
 func (bv *BindVariable) Format(buf *sqlparser.TrackedBuffer) {

--- a/go/vt/vtgate/evalengine/format.go
+++ b/go/vt/vtgate/evalengine/format.go
@@ -37,6 +37,8 @@ func precedenceFor(in IR) sqlparser.Precendence {
 		}
 	case *NotExpr:
 		return sqlparser.P13
+	case *BetweenExpr:
+		return sqlparser.P12
 	case *ComparisonExpr:
 		return sqlparser.P11
 	case *IsExpr:
@@ -216,6 +218,20 @@ func (c *InExpr) format(buf *sqlparser.TrackedBuffer) {
 		op = "not in"
 	}
 	formatBinary(buf, c, c.Left, op, c.Right)
+}
+
+func (b *BetweenExpr) format(buf *sqlparser.TrackedBuffer) {
+	// BETWEEN is ternary and non-associative: no operand position may drop
+	// the parentheses of an equal-precedence child.
+	formatExpr(buf, b, b.Left, false)
+	if b.Negate {
+		buf.WriteLiteral(" not between ")
+	} else {
+		buf.WriteLiteral(" between ")
+	}
+	formatExpr(buf, b, b.From, false)
+	buf.WriteLiteral(" and ")
+	formatExpr(buf, b, b.To, false)
 }
 
 func (tuple TupleExpr) format(buf *sqlparser.TrackedBuffer) {

--- a/go/vt/vtgate/evalengine/integration/fuzz_test.go
+++ b/go/vt/vtgate/evalengine/integration/fuzz_test.go
@@ -166,6 +166,9 @@ func evaluateLocalEvalengine(env *evalengine.ExpressionEnv, query string, fields
 				err = fmt.Errorf("PANIC: %v", r)
 			}
 		}()
+		// Evaluation sees the same column declarations as translation and
+		// the remote table: a SQL NULL row value carries no type of its own.
+		env.Fields = fields
 		eval, err = env.Evaluate(local)
 		return
 	}()

--- a/go/vt/vtgate/evalengine/perf_test.go
+++ b/go/vt/vtgate/evalengine/perf_test.go
@@ -36,6 +36,8 @@ func BenchmarkCompilerExpressions(b *testing.B) {
 		{"comparison_u64", "column0 = 12", []sqltypes.Value{sqltypes.NewUint64(666)}},
 		{"comparison_dec", "column0 = 12", []sqltypes.Value{sqltypes.NewDecimal("420")}},
 		{"comparison_f", "column0 = 12", []sqltypes.Value{sqltypes.NewFloat64(420.0)}},
+		{"json_literal_small", "column0 = cast('[1, 2, 3]' as json)", []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`))}},
+		{"json_literal_nested", `column0 = cast('{"a": [1, 2, {"b": ["x", 4.5, true]}], "c": "foo bar baz", "d": {"e": [6, 7, 8, 9]}}' as json)`, []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`{"a": 1}`))}},
 	}
 
 	venv := vtenv.NewTestEnv()

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 
+	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
@@ -67,6 +68,11 @@ var Cases = []TestCase{
 	{Run: TupleComparisons},
 	{Run: Comparisons},
 	{Run: InStatement},
+	{Run: JSONComparisonDomains},
+	{Run: JSONComparisonDomainsTemporal},
+	{Run: JSONComparisonDomainsColumns, Schema: JSONComparisonDomainsColumns_Schema},
+	{Run: JSONComparisonDomainsNullColumns, Schema: JSONComparisonDomainsNullColumns_Schema},
+	{Run: JSONComparisonDomainsCompositeColumns, Schema: JSONComparisonDomainsCompositeColumns_Schema},
 	{Run: FnField},
 	{Run: FnElt},
 	{Run: FnInsert},
@@ -1921,6 +1927,232 @@ func InStatement(yield Query) {
 		yield(fmt.Sprintf("%s NOT IN (%s, %s)", inputs[1], inputs[0], inputs[2]), nil, false)
 		yield(fmt.Sprintf("%s NOT IN (%s, %s, %s)", inputs[0], inputs[1], inputs[2], inputs[0]), nil, false)
 	})
+}
+
+func JSONComparisonDomains(yield Query) {
+	domain := make([]string, 0, len(inputJSONComparisonDomainJSON)+len(inputJSONComparisonDomainScalars))
+	domain = append(domain, inputJSONComparisonDomainJSON...)
+	domain = append(domain, inputJSONComparisonDomainScalars...)
+
+	for i, l := range domain {
+		for j, a := range domain {
+			for k, b := range domain {
+				// Only yield combinations in which a JSON value participates:
+				// the JSON-free ones are covered by the other generators.
+				jsons := len(inputJSONComparisonDomainJSON)
+				if i >= jsons && j >= jsons && k >= jsons {
+					continue
+				}
+				yield(fmt.Sprintf("%s IN (%s, %s)", l, a, b), nil, false)
+				yield(fmt.Sprintf("%s NOT IN (%s, %s)", l, a, b), nil, false)
+				// MySQL versions disagree on BETWEEN with equal bounds and a
+				// JSON participant: 8.0.34 and 8.4.10 fold it into a
+				// JSON-comparator equality, the latest 8.0.x does not.
+				if a != b {
+					yield(fmt.Sprintf("%s BETWEEN %s AND %s", l, a, b), nil, false)
+					yield(fmt.Sprintf("%s NOT BETWEEN %s AND %s", l, a, b), nil, false)
+				}
+				yield(fmt.Sprintf("CASE %s WHEN %s THEN 1 WHEN %s THEN 2 ELSE 3 END", l, a, b), nil, false)
+			}
+		}
+	}
+}
+
+func JSONComparisonDomainsTemporal(yield Query) {
+	// Only constant operands here; JSONComparisonDomainsColumns covers the
+	// column-position rules with a schema.
+	dates := []string{
+		`CAST('2020-01-01' AS DATE)`,
+		`CAST('2020-01-01 12:00:00' AS DATETIME)`,
+	}
+	jsons := []string{`JSON_ARRAY()`, `JSON_OBJECT()`, `CAST('[]' AS JSON)`}
+
+	for _, l := range dates {
+		for _, j := range jsons {
+			yield(fmt.Sprintf("%s BETWEEN %s AND '2021-01-01'", l, j), nil, false)
+			yield(fmt.Sprintf("%s NOT BETWEEN %s AND '2021-01-01'", l, j), nil, false)
+			yield(fmt.Sprintf("%s BETWEEN '2019-01-01' AND %s", l, j), nil, false)
+			yield(fmt.Sprintf("'2020-01-01' BETWEEN %s AND %s", j, l), nil, false)
+		}
+		// Without a JSON participant, the pairwise comparisons apply.
+		yield(l+" BETWEEN '2019-01-01' AND '2021-01-01'", nil, false)
+
+		// A numeric operand moves the whole comparison off the DATETIME
+		// domain onto DOUBLE, in any position.
+		yield(l+" BETWEEN JSON_ARRAY() AND 99999999", nil, false)
+		yield(l+" NOT BETWEEN JSON_ARRAY() AND 99999999", nil, false)
+		yield(l+` BETWEEN 0 AND CAST('"2021-06-06"' AS JSON)`, nil, false)
+		yield(l+` BETWEEN CAST(NULL AS SIGNED) AND CAST('"2021-06-06"' AS JSON)`, nil, false)
+		yield(l+` BETWEEN 0.5 AND CAST('"2021-06-06"' AS JSON)`, nil, false)
+		yield(l+` BETWEEN 0e0 AND CAST('"2021-06-06"' AS JSON)`, nil, false)
+	}
+	yield(`1 BETWEEN CAST('"2"' AS JSON) AND 5`, nil, false)
+	yield(`0 BETWEEN CAST('true' AS JSON) AND 5`, nil, false)
+	yield(`2020 BETWEEN CAST(CAST('2020-01-01' AS DATE) AS JSON) AND 99999999`, nil, false)
+
+	// In the DATETIME domain a JSON operand converts from its serialized
+	// text, quotes included: JSON numbers parse, JSON strings and JSON date
+	// scalars fail to the zero date.
+	yield(`CAST('2020-01-01' AS DATE) BETWEEN JSON_ARRAY() AND CAST('20210101' AS JSON)`, nil, false)
+	yield(`CAST('2020-01-01' AS DATE) BETWEEN CAST('20200606' AS JSON) AND '2021-01-01'`, nil, false)
+	yield(`CAST('2020-01-01' AS DATE) BETWEEN JSON_ARRAY() AND CAST(CAST('2021-01-01' AS DATE) AS JSON)`, nil, false)
+	yield(`CAST('2020-01-01' AS DATE) BETWEEN JSON_ARRAY() AND CAST('"2021-06-06"' AS JSON)`, nil, false)
+
+	// A declared JSON type participates in domain selection even when the
+	// value is SQL NULL; an untyped NULL stays neutral. A DATE left operand
+	// with a NULL bound is absent here: 8.0.28 answers it differently from
+	// 8.0.34+, and TestJSONComparisonDomains pins the modern behavior.
+	yield(`0 IN (CAST(NULL AS JSON), '0')`, nil, false)
+	yield(`'a' BETWEEN CAST(NULL AS JSON) AND 'A'`, nil, false)
+	yield(`'a' BETWEEN NULL AND 'A'`, nil, false)
+	yield(`'a' BETWEEN CAST(NULL AS CHAR) AND 'A'`, nil, false)
+	yield(`CAST('2020-01-01' AS DATE) BETWEEN CAST(NULL AS JSON) AND 0`, nil, false)
+	yield(`CAST('2020-01-01' AS DATE) IN (CAST(NULL AS JSON), '2020-01-01')`, nil, false)
+
+	// The IN domain compares every pair with genuine JSON semantics.
+	yield(`0 IN (JSON_ARRAY(), '0.0')`, nil, false)
+	yield(`0.0 IN (CAST('0' AS JSON))`, nil, false)
+	yield(`'2020-1-1' IN (CAST('"2020-1-1"' AS JSON))`, nil, false)
+	yield(`'B' IN (JSON_ARRAY(), 'b')`, nil, false)
+	yield(`CAST('2020-01-01' AS DATE) IN (JSON_ARRAY(), CAST('2020-01-01' AS DATETIME))`, nil, false)
+	yield(`CAST('2020-01-01' AS DATE) IN (CAST('2020-01-01' AS DATE), JSON_ARRAY())`, nil, false)
+	yield(`(JSON_ARRAY(), 0) IN ((JSON_ARRAY(), '0'))`, nil, false)
+
+	// A DATE-typed composite operand selects the DATETIME domain. Only
+	// DATE_ADD is exercised here: 8.0.x constant-folds COALESCE/IF/CASE/
+	// GREATEST composites before selecting the domain while 8.4.x does not;
+	// TestJSONComparisonDomains pins those to the 8.4.x behavior.
+	yield(`DATE_ADD(CAST('2020-01-01' AS DATE), INTERVAL 0 DAY) BETWEEN JSON_ARRAY() AND '2021-01-01'`, nil, false)
+	yield(`DATE_ADD(CAST('2020-01-01' AS DATE), INTERVAL 0 DAY) NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`, nil, false)
+
+	// A TIME expression does not select a temporal domain: with only JSON
+	// and textual participants left, the domain falls back to strings.
+	for _, j := range jsons {
+		yield(fmt.Sprintf("CAST('12:00:00' AS TIME) BETWEEN %s AND '13:00:00'", j), nil, false)
+		yield(fmt.Sprintf("CAST('12:00:00' AS TIME) NOT BETWEEN %s AND '13:00:00'", j), nil, false)
+	}
+	yield(`CAST('12:00:00' AS TIME) BETWEEN '11:00:00' AND '13:00:00'`, nil, false)
+
+	// TIME-typed composites do not select a temporal domain either.
+	yield(`COALESCE(CAST('12:00:00' AS TIME), NULL) BETWEEN JSON_ARRAY() AND '13:00:00'`, nil, false)
+	yield(`COALESCE(CAST('12:00:00' AS TIME), NULL) NOT BETWEEN JSON_ARRAY() AND '13:00:00'`, nil, false)
+	yield(`GREATEST(CAST('12:00:00' AS TIME), CAST('11:00:00' AS TIME)) BETWEEN JSON_ARRAY() AND '13:00:00'`, nil, false)
+	yield(`DATE_ADD(CAST('12:00:00' AS TIME), INTERVAL 0 SECOND) BETWEEN JSON_ARRAY() AND '13:00:00'`, nil, false)
+}
+
+// JSONComparisonDomainsColumns exercises the column-position rules of the
+// comparison domains. The JSON participants are columns too: a standalone
+// JSON constant does not survive constant folding next to a column operand
+// yet.
+func JSONComparisonDomainsColumns(yield Query) {
+	row := []sqltypes.Value{
+		sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)),
+		sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)),
+		sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`)),
+		sqltypes.MakeTrusted(sqltypes.VarChar, []byte(`12:00:00`)),
+		sqltypes.MakeTrusted(sqltypes.Int64, []byte(`0`)),
+		sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`99999999`)),
+		sqltypes.MakeTrusted(sqltypes.Int64, []byte(`99999999`)),
+	}
+
+	// A convertible constant bound activates the TIME column's per-pair
+	// paths; without one the whole predicate compares as strings.
+	yield(`column0 BETWEEN column1 AND '13:00:00'`, row, false)
+	yield(`column0 NOT BETWEEN column1 AND '13:00:00'`, row, false)
+	yield(`column0 BETWEEN column1 AND '99999999'`, row, false)
+	yield(`column0 BETWEEN '11:00:00' AND column1`, row, false)
+	yield(`column0 BETWEEN column1 AND 130000`, row, false)
+	yield(`column0 BETWEEN 'zz' AND column1`, row, false)
+	yield(`column0 BETWEEN column3 AND column1`, row, false)
+
+	// A TIME column in a bound position gets no TIME treatment.
+	yield(`column3 BETWEEN column1 AND column0`, row, false)
+
+	// A DATE column selects the DATETIME domain for all pairs without a
+	// numeric operand, and the per-pair field path with one.
+	yield(`column2 BETWEEN column1 AND '2021-01-01'`, row, false)
+	yield(`column2 NOT BETWEEN column1 AND '2021-01-01'`, row, false)
+	yield(`column2 BETWEEN column1 AND 99999999`, row, false)
+	yield(`column2 BETWEEN column1 AND column4`, row, false)
+
+	// A temporal column with a nonconstant JSON bound and a numeric
+	// participant compares numerically: the field-store and TIME
+	// conversions apply only to constant bounds.
+	yield(`column2 BETWEEN column5 AND 99999999`, row, false)
+	yield(`column2 BETWEEN column5 AND column6`, row, false)
+	yield(`column0 BETWEEN column1 AND 99999999`, row, false)
+	yield(`column0 BETWEEN column1 AND column6`, row, false)
+	yield(`column0 BETWEEN JSON_ARRAY() AND 18446744073709551615`, row, false)
+
+	// IN with a JSON column compares every pair with JSON semantics.
+	yield(`column4 IN (column1, '0')`, row, false)
+	yield(`column2 IN (column1, '2020-1-1')`, row, false)
+	yield(`column0 IN (column1, '12:00:00.0')`, row, false)
+	yield(`column3 IN (column1, '12:00:00')`, row, false)
+
+	// The IN type scan stops at the first element that is not constant for
+	// one execution: a JSON element behind the stopper never selects JSON
+	// comparison, and the stopper's own type still joins the scan.
+	yield(`'12:00:00' IN (column0, JSON_ARRAY())`, row, false)
+	yield(`'12:00:00' IN (JSON_ARRAY(), column0)`, row, false)
+	yield(`'2020-1-1' IN (column2, JSON_ARRAY())`, row, false)
+	yield(`'2020-01-01' IN (JSON_ARRAY(), column2)`, row, false)
+	yield(`0 IN (column6, '0', JSON_ARRAY())`, row, false)
+
+	// A typed JSON SQL NULL keeps steering the domain when child folding
+	// erases the cast.
+	yield(`column0 IN (CAST(NULL AS JSON), '0')`, row, false)
+	yield(`column0 BETWEEN CAST(NULL AS JSON) AND 'A'`, row, false)
+}
+
+// JSONComparisonDomainsNullColumns exercises declared types of columns and
+// composites whose row values are SQL NULL: only the declaration can steer
+// the comparison domain.
+func JSONComparisonDomainsNullColumns(yield Query) {
+	row := []sqltypes.Value{sqltypes.NULL, sqltypes.NULL}
+
+	yield(`0 IN (column0, '0')`, row, false)
+	yield(`'a' BETWEEN column0 AND 'A'`, row, false)
+	yield(`0 IN (COALESCE(column0, NULL), '0')`, row, false)
+	yield(`'a' BETWEEN COALESCE(column0, NULL) AND 'A'`, row, false)
+	yield(`JSON_ARRAY() BETWEEN COALESCE(column1, NULL) AND '2021-01-01'`, row, false)
+}
+
+var JSONComparisonDomainsNullColumns_Schema = []*querypb.Field{
+	{Name: "column0", Type: sqltypes.TypeJSON, ColumnType: "JSON"},
+	{Name: "column1", Type: sqltypes.Date, ColumnType: "DATE"},
+}
+
+// JSONComparisonDomainsCompositeColumns exercises composites whose declared
+// result type differs from the selected child's runtime representation.
+func JSONComparisonDomainsCompositeColumns(yield Query) {
+	row := []sqltypes.Value{
+		sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`)),
+		sqltypes.NULL,
+		sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`)),
+		sqltypes.MakeTrusted(sqltypes.VarChar, []byte(`one`)),
+	}
+
+	yield(`0 IN (COALESCE(column0, column1), '0')`, row, false)
+	yield(`COALESCE(column2, column1) BETWEEN JSON_ARRAY() AND '2021-01-01'`, row, false)
+	yield(`0 IN (COALESCE(column0, JSON_CONTAINS_PATH(column0, column3, '$')), '0')`, row, false)
+}
+
+var JSONComparisonDomainsCompositeColumns_Schema = []*querypb.Field{
+	{Name: "column0", Type: sqltypes.TypeJSON, ColumnType: "JSON"},
+	{Name: "column1", Type: sqltypes.VarChar, ColumnType: "VARCHAR(64)", Charset: uint32(collations.CollationUtf8mb4ID)},
+	{Name: "column2", Type: sqltypes.Date, ColumnType: "DATE"},
+	{Name: "column3", Type: sqltypes.VarChar, ColumnType: "VARCHAR(16)", Charset: uint32(collations.CollationUtf8mb4ID)},
+}
+
+var JSONComparisonDomainsColumns_Schema = []*querypb.Field{
+	{Name: "column0", Type: sqltypes.Time, ColumnType: "TIME"},
+	{Name: "column1", Type: sqltypes.TypeJSON, ColumnType: "JSON"},
+	{Name: "column2", Type: sqltypes.Date, ColumnType: "DATE"},
+	{Name: "column3", Type: sqltypes.VarChar, ColumnType: "VARCHAR(64)", Charset: uint32(collations.CollationUtf8mb4ID)},
+	{Name: "column4", Type: sqltypes.Int64, ColumnType: "BIGINT"},
+	{Name: "column5", Type: sqltypes.TypeJSON, ColumnType: "JSON"},
+	{Name: "column6", Type: sqltypes.Int64, ColumnType: "BIGINT"},
 }
 
 func FnNow(yield Query) {

--- a/go/vt/vtgate/evalengine/testcases/cases.go
+++ b/go/vt/vtgate/evalengine/testcases/cases.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 
+	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 )
@@ -67,6 +68,11 @@ var Cases = []TestCase{
 	{Run: TupleComparisons},
 	{Run: Comparisons},
 	{Run: InStatement},
+	{Run: JSONComparisonDomains},
+	{Run: JSONComparisonDomainsTemporal},
+	{Run: JSONComparisonDomainsColumns, Schema: JSONComparisonDomainsColumns_Schema},
+	{Run: JSONComparisonDomainsNullColumns, Schema: JSONComparisonDomainsNullColumns_Schema},
+	{Run: JSONComparisonDomainsCompositeColumns, Schema: JSONComparisonDomainsCompositeColumns_Schema},
 	{Run: FnField},
 	{Run: FnElt},
 	{Run: FnInsert},
@@ -1921,6 +1927,233 @@ func InStatement(yield Query) {
 		yield(fmt.Sprintf("%s NOT IN (%s, %s)", inputs[1], inputs[0], inputs[2]), nil, false)
 		yield(fmt.Sprintf("%s NOT IN (%s, %s, %s)", inputs[0], inputs[1], inputs[2], inputs[0]), nil, false)
 	})
+}
+
+func JSONComparisonDomains(yield Query) {
+	domain := make([]string, 0, len(inputJSONComparisonDomainJSON)+len(inputJSONComparisonDomainScalars))
+	domain = append(domain, inputJSONComparisonDomainJSON...)
+	domain = append(domain, inputJSONComparisonDomainScalars...)
+
+	for i, l := range domain {
+		for j, a := range domain {
+			for k, b := range domain {
+				// Only yield combinations in which a JSON value participates:
+				// the JSON-free ones are covered by the other generators.
+				jsons := len(inputJSONComparisonDomainJSON)
+				if i >= jsons && j >= jsons && k >= jsons {
+					continue
+				}
+				yield(fmt.Sprintf("%s IN (%s, %s)", l, a, b), nil, false)
+				yield(fmt.Sprintf("%s NOT IN (%s, %s)", l, a, b), nil, false)
+				// MySQL versions disagree on BETWEEN with equal bounds and a
+				// JSON participant: 8.0.34 and 8.4.10 fold it into a
+				// JSON-comparator equality, the latest 8.0.x does not.
+				if a != b {
+					yield(fmt.Sprintf("%s BETWEEN %s AND %s", l, a, b), nil, false)
+					yield(fmt.Sprintf("%s NOT BETWEEN %s AND %s", l, a, b), nil, false)
+				}
+				yield(fmt.Sprintf("CASE %s WHEN %s THEN 1 WHEN %s THEN 2 ELSE 3 END", l, a, b), nil, false)
+			}
+		}
+	}
+}
+
+func JSONComparisonDomainsTemporal(yield Query) {
+	// Only constant operands here; JSONComparisonDomainsColumns covers the
+	// column-position rules with a schema.
+	dates := []string{
+		`CAST('2020-01-01' AS DATE)`,
+		`CAST('2020-01-01 12:00:00' AS DATETIME)`,
+	}
+	jsons := []string{`JSON_ARRAY()`, `JSON_OBJECT()`, `CAST('[]' AS JSON)`}
+
+	for _, l := range dates {
+		for _, j := range jsons {
+			yield(fmt.Sprintf("%s BETWEEN %s AND '2021-01-01'", l, j), nil, false)
+			yield(fmt.Sprintf("%s NOT BETWEEN %s AND '2021-01-01'", l, j), nil, false)
+			yield(fmt.Sprintf("%s BETWEEN '2019-01-01' AND %s", l, j), nil, false)
+			yield(fmt.Sprintf("'2020-01-01' BETWEEN %s AND %s", j, l), nil, false)
+		}
+		// Without a JSON participant, the pairwise comparisons apply.
+		yield(l+" BETWEEN '2019-01-01' AND '2021-01-01'", nil, false)
+
+		// A numeric operand moves the whole comparison off the DATETIME
+		// domain onto DOUBLE, in any position.
+		yield(l+" BETWEEN JSON_ARRAY() AND 99999999", nil, false)
+		yield(l+" NOT BETWEEN JSON_ARRAY() AND 99999999", nil, false)
+		yield(l+` BETWEEN 0 AND CAST('"2021-06-06"' AS JSON)`, nil, false)
+		yield(l+` BETWEEN CAST(NULL AS SIGNED) AND CAST('"2021-06-06"' AS JSON)`, nil, false)
+		yield(l+` BETWEEN 0.5 AND CAST('"2021-06-06"' AS JSON)`, nil, false)
+		yield(l+` BETWEEN 0e0 AND CAST('"2021-06-06"' AS JSON)`, nil, false)
+	}
+	yield(`1 BETWEEN CAST('"2"' AS JSON) AND 5`, nil, false)
+	yield(`0 BETWEEN CAST('true' AS JSON) AND 5`, nil, false)
+	yield(`2020 BETWEEN CAST(CAST('2020-01-01' AS DATE) AS JSON) AND 99999999`, nil, false)
+
+	// In the DATETIME domain a JSON operand converts from its serialized
+	// text, quotes included: JSON numbers parse, JSON strings and JSON date
+	// scalars fail to the zero date.
+	yield(`CAST('2020-01-01' AS DATE) BETWEEN JSON_ARRAY() AND CAST('20210101' AS JSON)`, nil, false)
+	yield(`CAST('2020-01-01' AS DATE) BETWEEN CAST('20200606' AS JSON) AND '2021-01-01'`, nil, false)
+	yield(`CAST('2020-01-01' AS DATE) BETWEEN JSON_ARRAY() AND CAST(CAST('2021-01-01' AS DATE) AS JSON)`, nil, false)
+	yield(`CAST('2020-01-01' AS DATE) BETWEEN JSON_ARRAY() AND CAST('"2021-06-06"' AS JSON)`, nil, false)
+
+	// A declared JSON type participates in domain selection even when the
+	// value is SQL NULL; an untyped NULL stays neutral. A DATE left operand
+	// with a NULL bound is absent here: 8.0.28 answers it differently from
+	// 8.0.34+, and TestJSONComparisonDomains pins the modern behavior.
+	yield(`0 IN (CAST(NULL AS JSON), '0')`, nil, false)
+	yield(`'a' BETWEEN CAST(NULL AS JSON) AND 'A'`, nil, false)
+	yield(`'a' BETWEEN NULL AND 'A'`, nil, false)
+	yield(`'a' BETWEEN CAST(NULL AS CHAR) AND 'A'`, nil, false)
+	yield(`CAST('2020-01-01' AS DATE) BETWEEN CAST(NULL AS JSON) AND 0`, nil, false)
+	yield(`CAST('2020-01-01' AS DATE) IN (CAST(NULL AS JSON), '2020-01-01')`, nil, false)
+
+	// The IN domain compares every pair with genuine JSON semantics.
+	yield(`0 IN (JSON_ARRAY(), '0.0')`, nil, false)
+	yield(`0.0 IN (CAST('0' AS JSON))`, nil, false)
+	yield(`'2020-1-1' IN (CAST('"2020-1-1"' AS JSON))`, nil, false)
+	yield(`'B' IN (JSON_ARRAY(), 'b')`, nil, false)
+	yield(`CAST('2020-01-01' AS DATE) IN (JSON_ARRAY(), CAST('2020-01-01' AS DATETIME))`, nil, false)
+	yield(`CAST('2020-01-01' AS DATE) IN (CAST('2020-01-01' AS DATE), JSON_ARRAY())`, nil, false)
+	yield(`(JSON_ARRAY(), 0) IN ((JSON_ARRAY(), '0'))`, nil, false)
+
+	// A DATE-typed composite operand selects the DATETIME domain. Only
+	// DATE_ADD is exercised here: 8.0.x constant-folds COALESCE/IF/CASE/
+	// GREATEST composites before selecting the domain while 8.4.x does not;
+	// TestJSONComparisonDomains pins those to the 8.4.x behavior.
+	yield(`DATE_ADD(CAST('2020-01-01' AS DATE), INTERVAL 0 DAY) BETWEEN JSON_ARRAY() AND '2021-01-01'`, nil, false)
+	yield(`DATE_ADD(CAST('2020-01-01' AS DATE), INTERVAL 0 DAY) NOT BETWEEN JSON_ARRAY() AND '2021-01-01'`, nil, false)
+
+	// A TIME expression does not select a temporal domain: with only JSON
+	// and textual participants left, the domain falls back to strings.
+	for _, j := range jsons {
+		yield(fmt.Sprintf("CAST('12:00:00' AS TIME) BETWEEN %s AND '13:00:00'", j), nil, false)
+		yield(fmt.Sprintf("CAST('12:00:00' AS TIME) NOT BETWEEN %s AND '13:00:00'", j), nil, false)
+	}
+	yield(`CAST('12:00:00' AS TIME) BETWEEN '11:00:00' AND '13:00:00'`, nil, false)
+
+	// TIME-typed composites do not select a temporal domain either.
+	yield(`COALESCE(CAST('12:00:00' AS TIME), NULL) BETWEEN JSON_ARRAY() AND '13:00:00'`, nil, false)
+	yield(`COALESCE(CAST('12:00:00' AS TIME), NULL) NOT BETWEEN JSON_ARRAY() AND '13:00:00'`, nil, false)
+	yield(`GREATEST(CAST('12:00:00' AS TIME), CAST('11:00:00' AS TIME)) BETWEEN JSON_ARRAY() AND '13:00:00'`, nil, false)
+	yield(`DATE_ADD(CAST('12:00:00' AS TIME), INTERVAL 0 SECOND) BETWEEN JSON_ARRAY() AND '13:00:00'`, nil, false)
+}
+
+// JSONComparisonDomainsColumns exercises the column-position rules of the
+// comparison domains. The JSON participants are columns too: a standalone
+// JSON constant does not survive constant folding next to a column operand
+// yet.
+func JSONComparisonDomainsColumns(yield Query) {
+	row := []sqltypes.Value{
+		sqltypes.MakeTrusted(sqltypes.Time, []byte(`12:00:00`)),
+		sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[]`)),
+		sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`)),
+		sqltypes.MakeTrusted(sqltypes.VarChar, []byte(`12:00:00`)),
+		sqltypes.MakeTrusted(sqltypes.Int64, []byte(`0`)),
+		sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`99999999`)),
+		sqltypes.MakeTrusted(sqltypes.Int64, []byte(`99999999`)),
+	}
+
+	// A convertible constant bound activates the TIME column's per-pair
+	// paths; without one the whole predicate compares as strings.
+	yield(`column0 BETWEEN column1 AND '13:00:00'`, row, false)
+	yield(`column0 NOT BETWEEN column1 AND '13:00:00'`, row, false)
+	yield(`column0 BETWEEN column1 AND '99999999'`, row, false)
+	yield(`column0 BETWEEN '11:00:00' AND column1`, row, false)
+	yield(`column0 BETWEEN column1 AND 130000`, row, false)
+	yield(`column0 BETWEEN 'zz' AND column1`, row, false)
+	yield(`column0 BETWEEN column3 AND column1`, row, false)
+
+	// A TIME column in a bound position gets no TIME treatment.
+	yield(`column3 BETWEEN column1 AND column0`, row, false)
+
+	// A DATE column selects the DATETIME domain for all pairs without a
+	// numeric operand, and the per-pair field path with one.
+	yield(`column2 BETWEEN column1 AND '2021-01-01'`, row, false)
+	yield(`column2 NOT BETWEEN column1 AND '2021-01-01'`, row, false)
+	yield(`column2 BETWEEN column1 AND 99999999`, row, false)
+	yield(`column2 BETWEEN column1 AND column4`, row, false)
+
+	// A temporal column with a row-dependent JSON bound and a numeric
+	// participant compares numerically: the field-store and TIME
+	// conversions apply only to bounds that are constant for one
+	// execution, never to column bounds.
+	yield(`column2 BETWEEN column5 AND 99999999`, row, false)
+	yield(`column2 BETWEEN column5 AND column6`, row, false)
+	yield(`column0 BETWEEN column1 AND 99999999`, row, false)
+	yield(`column0 BETWEEN column1 AND column6`, row, false)
+	yield(`column0 BETWEEN JSON_ARRAY() AND 18446744073709551615`, row, false)
+
+	// IN with a JSON column compares every pair with JSON semantics.
+	yield(`column4 IN (column1, '0')`, row, false)
+	yield(`column2 IN (column1, '2020-1-1')`, row, false)
+	yield(`column0 IN (column1, '12:00:00.0')`, row, false)
+	yield(`column3 IN (column1, '12:00:00')`, row, false)
+
+	// The IN type scan stops at the first element that is not constant for
+	// one execution: a JSON element behind the stopper never selects JSON
+	// comparison, and the stopper's own type still joins the scan.
+	yield(`'12:00:00' IN (column0, JSON_ARRAY())`, row, false)
+	yield(`'12:00:00' IN (JSON_ARRAY(), column0)`, row, false)
+	yield(`'2020-1-1' IN (column2, JSON_ARRAY())`, row, false)
+	yield(`'2020-01-01' IN (JSON_ARRAY(), column2)`, row, false)
+	yield(`0 IN (column6, '0', JSON_ARRAY())`, row, false)
+
+	// A typed JSON SQL NULL keeps steering the domain when child folding
+	// erases the cast.
+	yield(`column0 IN (CAST(NULL AS JSON), '0')`, row, false)
+	yield(`column0 BETWEEN CAST(NULL AS JSON) AND 'A'`, row, false)
+}
+
+// JSONComparisonDomainsNullColumns exercises declared types of columns and
+// composites whose row values are SQL NULL: only the declaration can steer
+// the comparison domain.
+func JSONComparisonDomainsNullColumns(yield Query) {
+	row := []sqltypes.Value{sqltypes.NULL, sqltypes.NULL}
+
+	yield(`0 IN (column0, '0')`, row, false)
+	yield(`'a' BETWEEN column0 AND 'A'`, row, false)
+	yield(`0 IN (COALESCE(column0, NULL), '0')`, row, false)
+	yield(`'a' BETWEEN COALESCE(column0, NULL) AND 'A'`, row, false)
+	yield(`JSON_ARRAY() BETWEEN COALESCE(column1, NULL) AND '2021-01-01'`, row, false)
+}
+
+var JSONComparisonDomainsNullColumns_Schema = []*querypb.Field{
+	{Name: "column0", Type: sqltypes.TypeJSON, ColumnType: "JSON"},
+	{Name: "column1", Type: sqltypes.Date, ColumnType: "DATE"},
+}
+
+// JSONComparisonDomainsCompositeColumns exercises composites whose declared
+// result type differs from the selected child's runtime representation.
+func JSONComparisonDomainsCompositeColumns(yield Query) {
+	row := []sqltypes.Value{
+		sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`)),
+		sqltypes.NULL,
+		sqltypes.MakeTrusted(sqltypes.Date, []byte(`2020-01-01`)),
+		sqltypes.MakeTrusted(sqltypes.VarChar, []byte(`one`)),
+	}
+
+	yield(`0 IN (COALESCE(column0, column1), '0')`, row, false)
+	yield(`COALESCE(column2, column1) BETWEEN JSON_ARRAY() AND '2021-01-01'`, row, false)
+	yield(`0 IN (COALESCE(column0, JSON_CONTAINS_PATH(column0, column3, '$')), '0')`, row, false)
+}
+
+var JSONComparisonDomainsCompositeColumns_Schema = []*querypb.Field{
+	{Name: "column0", Type: sqltypes.TypeJSON, ColumnType: "JSON"},
+	{Name: "column1", Type: sqltypes.VarChar, ColumnType: "VARCHAR(64)", Charset: uint32(collations.CollationUtf8mb4ID)},
+	{Name: "column2", Type: sqltypes.Date, ColumnType: "DATE"},
+	{Name: "column3", Type: sqltypes.VarChar, ColumnType: "VARCHAR(16)", Charset: uint32(collations.CollationUtf8mb4ID)},
+}
+
+var JSONComparisonDomainsColumns_Schema = []*querypb.Field{
+	{Name: "column0", Type: sqltypes.Time, ColumnType: "TIME"},
+	{Name: "column1", Type: sqltypes.TypeJSON, ColumnType: "JSON"},
+	{Name: "column2", Type: sqltypes.Date, ColumnType: "DATE"},
+	{Name: "column3", Type: sqltypes.VarChar, ColumnType: "VARCHAR(64)", Charset: uint32(collations.CollationUtf8mb4ID)},
+	{Name: "column4", Type: sqltypes.Int64, ColumnType: "BIGINT"},
+	{Name: "column5", Type: sqltypes.TypeJSON, ColumnType: "JSON"},
+	{Name: "column6", Type: sqltypes.Int64, ColumnType: "BIGINT"},
 }
 
 func FnNow(yield Query) {

--- a/go/vt/vtgate/evalengine/testcases/inputs.go
+++ b/go/vt/vtgate/evalengine/testcases/inputs.go
@@ -53,6 +53,17 @@ var inputJSONBinaryValues = []string{
 	`CAST('foo' AS BINARY)`, `b'1010'`,
 }
 
+// inputJSONComparisonDomainJSON are JSON values that force MySQL to aggregate
+// the comparison domain of IN, BETWEEN and simple CASE;
+// inputJSONComparisonDomainScalars are the SQL scalars they coerce against.
+var inputJSONComparisonDomainJSON = []string{
+	`JSON_ARRAY()`, `JSON_OBJECT()`, `JSON_EXTRACT('[1]', '$')`, `CAST('[]' AS JSON)`,
+}
+
+var inputJSONComparisonDomainScalars = []string{
+	`0`, `1`, `'0'`, `'1'`, `'[]'`, `'{}'`, `NULL`,
+}
+
 var inputBitwise = []string{
 	"0", "1", "0xFF", "255", "1.0", "1.1", "-1", "-255", "7", "9", "13", "1.5", "-1.5", "'1.5'", "'-1.5'",
 	"0.0e0", "1.0e0", "255.0", "1.5e0", "-1.5e0", "1.1e0", "-1e0", "-255e0", "7e0", "9e0", "13e0",

--- a/go/vt/vtgate/evalengine/translate.go
+++ b/go/vt/vtgate/evalengine/translate.go
@@ -55,10 +55,42 @@ func (ast *astCompiler) translateComparisonExpr2(op sqlparser.ComparisonExprOper
 	}
 
 	if op == sqlparser.InOp || op == sqlparser.NotInOp {
-		return &InExpr{
+		in := &InExpr{
 			BinaryExpr: binaryExpr,
 			Negate:     op == sqlparser.NotInOp,
-		}, nil
+		}
+		tuple, ok := right.(TupleExpr)
+		if !ok {
+			if ast.staticCmpClass(left) == classJSON {
+				in.PrefixJSON = inJSONYes
+			}
+			return in, nil
+		}
+		// MySQL's type scan inspects the RHS elements in order and stops
+		// after the first one that is not constant for one execution: a
+		// JSON element behind that stopper never selects JSON comparison.
+		in.JSONScanRHS = len(tuple)
+		for idx, el := range tuple {
+			if !el.constForExecution() {
+				in.JSONScanRHS = idx + 1
+				break
+			}
+		}
+		in.PrefixJSON = inJSONNo
+		for _, op := range append([]IR{left}, tuple[:in.JSONScanRHS]...) {
+			switch ast.staticCmpClass(op) {
+			case classJSON:
+				in.PrefixJSON = inJSONYes
+			case classUnknown:
+				if in.PrefixJSON == inJSONNo {
+					in.PrefixJSON = inJSONUnknown
+				}
+			}
+			if in.PrefixJSON == inJSONYes {
+				break
+			}
+		}
+		return in, nil
 	}
 
 	switch op {
@@ -456,9 +488,11 @@ func (ast *astCompiler) translateCaseExpr(node *sqlparser.CaseExpr) (IR, error) 
 		}
 
 		if cmpbase != nil {
-			cond, err = ast.translateComparisonExpr2(sqlparser.EqualOp, cmpbase, cond)
-			if err != nil {
-				return nil, err
+			// Unlike the `=` operator, MySQL never uses the JSON comparator
+			// between the base operand of a simple CASE and its WHEN operands.
+			cond = &ComparisonExpr{
+				Left: cmpbase, Right: cond,
+				Op: compareCaseEQ{},
 			}
 		}
 
@@ -471,27 +505,54 @@ func (ast *astCompiler) translateCaseExpr(node *sqlparser.CaseExpr) (IR, error) 
 	return &result, nil
 }
 
+// staticCmpClass resolves the comparison class of an operand at translation
+// time, before constant folding, by compiling it into a throwaway compiler;
+// classUnknown when the type resolves only at evaluation time.
+func (ast *astCompiler) staticCmpClass(op IR) cmpClass {
+	if lit, ok := op.(*Literal); ok {
+		if lit.inner == nil {
+			return classNull
+		}
+		return classFromType(lit.inner.SQLType())
+	}
+	comp := compiler{
+		collation: ast.cfg.Collation,
+		env:       ast.cfg.Environment,
+		sqlmode:   ast.cfg.SQLMode,
+	}
+	typ, err := op.compile(&comp)
+	if err != nil {
+		return classUnknown
+	}
+	return classFromType(typ.Type)
+}
+
 func (ast *astCompiler) translateBetweenExpr(node *sqlparser.BetweenExpr) (IR, error) {
-	// x BETWEEN a AND b => x >= a AND x <= b
-	from := &sqlparser.ComparisonExpr{
-		Operator: sqlparser.GreaterEqualOp,
-		Left:     node.Left,
-		Right:    node.From,
+	// BETWEEN is not lowered to `x >= a AND x <= b`: MySQL decides the
+	// comparison domain across all three operands when JSON participates.
+	left, err := ast.translateExpr(node.Left)
+	if err != nil {
+		return nil, err
 	}
-	to := &sqlparser.ComparisonExpr{
-		Operator: sqlparser.LessEqualOp,
-		Left:     node.Left,
-		Right:    node.To,
+	from, err := ast.translateExpr(node.From)
+	if err != nil {
+		return nil, err
 	}
-
-	if !node.IsBetween {
-		// x NOT BETWEEN a AND b  => x < a OR x > b
-		from.Operator = sqlparser.LessThanOp
-		to.Operator = sqlparser.GreaterThanOp
-		return ast.translateExpr(&sqlparser.OrExpr{Left: from, Right: to})
+	to, err := ast.translateExpr(node.To)
+	if err != nil {
+		return nil, err
 	}
-
-	return ast.translateExpr(sqlparser.AndExpressions(from, to))
+	return &BetweenExpr{
+		Left:   left,
+		From:   from,
+		To:     to,
+		Negate: !node.IsBetween,
+		StaticClasses: [3]cmpClass{
+			ast.staticCmpClass(left),
+			ast.staticCmpClass(from),
+			ast.staticCmpClass(to),
+		},
+	}, nil
 }
 
 func translateExprNotSupported(e sqlparser.Expr) error {

--- a/go/vt/vtgate/evalengine/translate.go
+++ b/go/vt/vtgate/evalengine/translate.go
@@ -55,10 +55,42 @@ func (ast *astCompiler) translateComparisonExpr2(op sqlparser.ComparisonExprOper
 	}
 
 	if op == sqlparser.InOp || op == sqlparser.NotInOp {
-		return &InExpr{
+		in := &InExpr{
 			BinaryExpr: binaryExpr,
 			Negate:     op == sqlparser.NotInOp,
-		}, nil
+		}
+		tuple, ok := right.(TupleExpr)
+		if !ok {
+			if ast.staticCmpClass(left) == classJSON {
+				in.PrefixJSON = inJSONYes
+			}
+			return in, nil
+		}
+		// MySQL's type scan inspects the RHS elements in order and stops
+		// after the first one that is not constant for one execution: a
+		// JSON element behind that stopper never selects JSON comparison.
+		in.JSONScanRHS = len(tuple)
+		for idx, el := range tuple {
+			if !el.constForExecution() {
+				in.JSONScanRHS = idx + 1
+				break
+			}
+		}
+		in.PrefixJSON = inJSONNo
+		for _, op := range append([]IR{left}, tuple[:in.JSONScanRHS]...) {
+			switch ast.staticCmpClass(op) {
+			case classJSON:
+				in.PrefixJSON = inJSONYes
+			case classUnknown:
+				if in.PrefixJSON == inJSONNo {
+					in.PrefixJSON = inJSONUnknown
+				}
+			}
+			if in.PrefixJSON == inJSONYes {
+				break
+			}
+		}
+		return in, nil
 	}
 
 	switch op {
@@ -460,9 +492,11 @@ func (ast *astCompiler) translateCaseExpr(node *sqlparser.CaseExpr) (IR, error) 
 		}
 
 		if cmpbase != nil {
-			cond, err = ast.translateComparisonExpr2(sqlparser.EqualOp, cmpbase, cond)
-			if err != nil {
-				return nil, err
+			// Unlike the `=` operator, MySQL never uses the JSON comparator
+			// between the base operand of a simple CASE and its WHEN operands.
+			cond = &ComparisonExpr{
+				BinaryExpr: BinaryExpr{Left: cmpbase, Right: cond},
+				Op:         compareCaseEQ{},
 			}
 		}
 
@@ -475,27 +509,54 @@ func (ast *astCompiler) translateCaseExpr(node *sqlparser.CaseExpr) (IR, error) 
 	return &result, nil
 }
 
+// staticCmpClass resolves the comparison class of an operand at translation
+// time, before constant folding, by compiling it into a throwaway compiler;
+// classUnknown when the type resolves only at evaluation time.
+func (ast *astCompiler) staticCmpClass(op IR) cmpClass {
+	if lit, ok := op.(*Literal); ok {
+		if lit.inner == nil {
+			return classNull
+		}
+		return classFromType(lit.inner.SQLType())
+	}
+	comp := compiler{
+		collation: ast.cfg.Collation,
+		env:       ast.cfg.Environment,
+		sqlmode:   ast.cfg.SQLMode,
+	}
+	typ, err := op.compile(&comp)
+	if err != nil {
+		return classUnknown
+	}
+	return classFromType(typ.Type)
+}
+
 func (ast *astCompiler) translateBetweenExpr(node *sqlparser.BetweenExpr) (IR, error) {
-	// x BETWEEN a AND b => x >= a AND x <= b
-	from := &sqlparser.ComparisonExpr{
-		Operator: sqlparser.GreaterEqualOp,
-		Left:     node.Left,
-		Right:    node.From,
+	// BETWEEN is not lowered to `x >= a AND x <= b`: MySQL decides the
+	// comparison domain across all three operands when JSON participates.
+	left, err := ast.translateExpr(node.Left)
+	if err != nil {
+		return nil, err
 	}
-	to := &sqlparser.ComparisonExpr{
-		Operator: sqlparser.LessEqualOp,
-		Left:     node.Left,
-		Right:    node.To,
+	from, err := ast.translateExpr(node.From)
+	if err != nil {
+		return nil, err
 	}
-
-	if !node.IsBetween {
-		// x NOT BETWEEN a AND b  => x < a OR x > b
-		from.Operator = sqlparser.LessThanOp
-		to.Operator = sqlparser.GreaterThanOp
-		return ast.translateExpr(&sqlparser.OrExpr{Left: from, Right: to})
+	to, err := ast.translateExpr(node.To)
+	if err != nil {
+		return nil, err
 	}
-
-	return ast.translateExpr(sqlparser.AndExpressions(from, to))
+	return &BetweenExpr{
+		Left:   left,
+		From:   from,
+		To:     to,
+		Negate: !node.IsBetween,
+		StaticClasses: [3]cmpClass{
+			ast.staticCmpClass(left),
+			ast.staticCmpClass(from),
+			ast.staticCmpClass(to),
+		},
+	}, nil
 }
 
 func translateExprNotSupported(e sqlparser.Expr) error {

--- a/go/vt/vtgate/evalengine/translate_card.go
+++ b/go/vt/vtgate/evalengine/translate_card.go
@@ -149,6 +149,11 @@ func (ast *astCompiler) cardExpr(expr IR) error {
 		return ast.cardBinary(expr.Left, expr.Right)
 	case *ComparisonExpr:
 		return ast.cardComparison(expr.Left, expr.Right)
+	case *BetweenExpr:
+		if err := ast.cardComparison(expr.Left, expr.From); err != nil {
+			return err
+		}
+		return ast.cardComparison(expr.Left, expr.To)
 	case *InExpr:
 		if err := ast.cardExpr(expr.Left); err != nil {
 			return err

--- a/go/vt/vtgate/evalengine/translate_simplify.go
+++ b/go/vt/vtgate/evalengine/translate_simplify.go
@@ -51,6 +51,45 @@ func (expr *UnaryExpr) constant() bool {
 	return expr.Inner.constant()
 }
 
+// constForExecution mirrors MySQL's const_for_execution() property: whether
+// the value is stable once execution parameters are assigned. It is distinct
+// from constant(): bind parameters and statement-stable functions such as
+// NOW are constant for one execution without being foldable at translation,
+// while columns and volatile functions are neither.
+
+func (expr *Literal) constForExecution() bool {
+	return true
+}
+
+func (expr *BindVariable) constForExecution() bool {
+	return true
+}
+
+func (expr *TupleBindVariable) constForExecution() bool {
+	return true
+}
+
+func (expr *Column) constForExecution() bool {
+	return false
+}
+
+func (expr *BinaryExpr) constForExecution() bool {
+	return expr.Left.constForExecution() && expr.Right.constForExecution()
+}
+
+func (tuple TupleExpr) constForExecution() bool {
+	for _, subexpr := range tuple {
+		if !subexpr.constForExecution() {
+			return false
+		}
+	}
+	return true
+}
+
+func (expr *UnaryExpr) constForExecution() bool {
+	return expr.Inner.constForExecution()
+}
+
 func (expr *Literal) simplify(_ *ExpressionEnv) error {
 	return nil
 }
@@ -95,6 +134,26 @@ func (expr *LikeExpr) simplify(env *ExpressionEnv) error {
 	return nil
 }
 
+func (b *BetweenExpr) constant() bool {
+	return b.Left.constant() && b.From.constant() && b.To.constant()
+}
+
+func (b *BetweenExpr) constForExecution() bool {
+	return b.Left.constForExecution() && b.From.constForExecution() && b.To.constForExecution()
+}
+
+func (b *BetweenExpr) simplify(env *ExpressionEnv) error {
+	var err error
+	if b.Left, err = simplifyExpr(env, b.Left); err != nil {
+		return err
+	}
+	if b.From, err = simplifyExpr(env, b.From); err != nil {
+		return err
+	}
+	b.To, err = simplifyExpr(env, b.To)
+	return err
+}
+
 func (inexpr *InExpr) simplify(env *ExpressionEnv) error {
 	if err := inexpr.BinaryExpr.simplify(env); err != nil {
 		return err
@@ -126,6 +185,10 @@ func (expr *UnaryExpr) simplify(env *ExpressionEnv) error {
 
 func (c *CallExpr) constant() bool {
 	return c.Arguments.constant()
+}
+
+func (c *CallExpr) constForExecution() bool {
+	return c.Arguments.constForExecution()
 }
 
 func (c *CallExpr) simplify(env *ExpressionEnv) error {

--- a/go/vt/vtgate/evalengine/translate_simplify.go
+++ b/go/vt/vtgate/evalengine/translate_simplify.go
@@ -157,5 +157,12 @@ func evalToIR(simplified eval) IR {
 		}
 		return te
 	}
+	if j, ok := simplified.(*evalJSON); ok {
+		// The literal is shared by every evaluation of the translated
+		// expression: resolve the document's lazy number classification
+		// now, while this goroutine still owns it, so that concurrent
+		// evaluations only ever read the shared value.
+		j.ResolveNumberTypes()
+	}
 	return &Literal{inner: simplified}
 }

--- a/go/vt/vtgate/evalengine/translate_test.go
+++ b/go/vt/vtgate/evalengine/translate_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package evalengine
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -156,6 +157,220 @@ func TestTranslateSimplification(t *testing.T) {
 			}
 			assert.Equal(t, tc.simplified.literal, sqlparser.String(simplified))
 		})
+	}
+}
+
+// TestTranslateFoldedJSONLiterals tests that JSON values produced by constant
+// folding compile, evaluate and format as CAST('<json>' AS JSON) literals; a
+// bare string literal would compare as a JSON string scalar, not a document.
+func TestTranslateFoldedJSONLiterals(t *testing.T) {
+	testCases := []struct {
+		expression string
+		simplified string
+		row        sqltypes.Value
+		result     sqltypes.Value
+	}{{
+		expression: `j = json_array(1)`,
+		simplified: `j = cast('[1]' as json)`,
+		row:        sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`)),
+		result:     sqltypes.NewInt64(1),
+	}, {
+		expression: `coalesce(j, json_array(1, 2))`,
+		simplified: `coalesce(j, cast('[1, 2]' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1, 2]`)),
+	}, {
+		expression: `coalesce(j, json_object('a', 1))`,
+		simplified: `coalesce(j, cast('{"a": 1}' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`{"a": 1}`)),
+	}, {
+		expression: `coalesce(j, cast('"foo"' as json))`,
+		simplified: `coalesce(j, cast('"foo"' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`"foo"`)),
+	}, {
+		// wide decimals must keep their exact serialization and not
+		// round-trip through float64
+		expression: `coalesce(j, json_array(123456789012.12345678))`,
+		simplified: `coalesce(j, cast('[123456789012.12345678]' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[123456789012.12345678]`)),
+	}, {
+		// a JSON null literal is a JSON value, not a SQL NULL
+		expression: `coalesce(j, cast('null' as json))`,
+		simplified: `coalesce(j, cast('null' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`null`)),
+	}, {
+		expression: `coalesce(j, null)`,
+		simplified: `coalesce(j, null)`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.NULL,
+	}}
+
+	venv := vtenv.NewTestEnv()
+	fields := FieldResolver([]*querypb.Field{
+		{Name: "j", Type: sqltypes.TypeJSON, Charset: collations.CollationUtf8mb4ID},
+	})
+
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			astExpr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+
+			translated, err := Translate(astExpr, &Config{
+				ResolveColumn: fields.Column,
+				ResolveType:   fields.Type,
+				Collation:     venv.CollationEnv().DefaultConnectionCharset(),
+				Environment:   venv,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.simplified, sqlparser.String(translated))
+
+			env := NewExpressionEnv(t.Context(), nil, NewEmptyVCursor(venv, time.Local))
+			env.Row = []sqltypes.Value{tc.row}
+
+			compiled, err := env.Evaluate(translated)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, compiled.Value(collations.MySQL8().DefaultConnectionCharset()))
+
+			interpreted, err := env.EvaluateAST(translated)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, interpreted.Value(collations.MySQL8().DefaultConnectionCharset()))
+		})
+	}
+}
+
+// TestTranslateFoldedJSONLiteralOwnership tests that evaluating a translated
+// expression never mutates a folded JSON literal: JSON_REMOVE updates its
+// input in place, and translated expressions are reused across evaluations.
+func TestTranslateFoldedJSONLiteralOwnership(t *testing.T) {
+	testCases := []struct {
+		expression string
+		paths      []string
+		results    []string
+	}{{
+		expression: `json_remove(json_array(1, 2, 3), :p)`,
+		paths:      []string{`$[0]`, `$[1]`, `$[2]`},
+		results:    []string{`[2, 3]`, `[1, 3]`, `[1, 2]`},
+	}, {
+		expression: `json_remove(json_object('a', json_array(1, 2, 3)), :p)`,
+		paths:      []string{`$.a[0]`, `$.a[1]`, `$.a[2]`},
+		results:    []string{`{"a": [2, 3]}`, `{"a": [1, 3]}`, `{"a": [1, 2]}`},
+	}}
+
+	venv := vtenv.NewTestEnv()
+	coll := collations.MySQL8().DefaultConnectionCharset()
+
+	translate := func(t *testing.T, expression string) *UntypedExpr {
+		astExpr, err := venv.Parser().ParseExpr(expression)
+		require.NoError(t, err)
+		translated, err := Translate(astExpr, &Config{
+			Collation:   coll,
+			Environment: venv,
+		})
+		require.NoError(t, err)
+		untyped, ok := translated.(*UntypedExpr)
+		require.True(t, ok, "expected *UntypedExpr, got %T", translated)
+		return untyped
+	}
+	newEnv := func(path string) *ExpressionEnv {
+		env := EmptyExpressionEnv(venv)
+		env.BindVars = map[string]*querypb.BindVariable{
+			"p": sqltypes.StringBindVariable(path),
+		}
+		return env
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			t.Run("interpreted", func(t *testing.T) {
+				translated := translate(t, tc.expression)
+				for i, path := range tc.paths {
+					env := newEnv(path)
+					res, err := env.EvaluateAST(translated)
+					require.NoError(t, err)
+					assert.Equal(t, tc.results[i], res.Value(coll).ToString())
+				}
+			})
+			t.Run("compiled", func(t *testing.T) {
+				translated := translate(t, tc.expression)
+				for i, path := range tc.paths {
+					env := newEnv(path)
+					compiled, err := translated.Compile(env)
+					require.NoError(t, err)
+					res, err := env.Evaluate(compiled)
+					require.NoError(t, err)
+					assert.Equal(t, tc.results[i], res.Value(coll).ToString())
+				}
+			})
+		})
+	}
+}
+
+// TestTranslateFoldedJSONLiteralConcurrency evaluates a single translated
+// expression containing a folded JSON literal from multiple goroutines; with
+// -race, this catches evaluations sharing the literal's document.
+func TestTranslateFoldedJSONLiteralConcurrency(t *testing.T) {
+	venv := vtenv.NewTestEnv()
+	coll := collations.MySQL8().DefaultConnectionCharset()
+
+	astExpr, err := venv.Parser().ParseExpr(`json_remove(json_array(1, 2, 3), :p)`)
+	require.NoError(t, err)
+	translated, err := Translate(astExpr, &Config{
+		Collation:   coll,
+		Environment: venv,
+	})
+	require.NoError(t, err)
+	untyped, ok := translated.(*UntypedExpr)
+	require.True(t, ok, "expected *UntypedExpr, got %T", translated)
+
+	paths := []string{`$[0]`, `$[1]`, `$[2]`}
+	results := []string{`[2, 3]`, `[1, 3]`, `[1, 2]`}
+
+	const goroutines, evaluations = 8, 100
+	errs := make([]error, goroutines)
+	observed := make([][]string, goroutines)
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		observed[g] = make([]string, evaluations)
+		wg.Go(func() {
+			for i := range evaluations {
+				n := (g + i) % len(paths)
+
+				env := EmptyExpressionEnv(venv)
+				env.BindVars = map[string]*querypb.BindVariable{
+					"p": sqltypes.StringBindVariable(paths[n]),
+				}
+
+				var res EvalResult
+				var err error
+				if g%2 == 0 {
+					res, err = env.EvaluateAST(untyped)
+				} else {
+					var compiled *CompiledExpr
+					compiled, err = untyped.Compile(env)
+					if err == nil {
+						res, err = env.Evaluate(compiled)
+					}
+				}
+				if err != nil {
+					errs[g] = err
+					return
+				}
+				observed[g][i] = res.Value(coll).ToString()
+			}
+		})
+	}
+	wg.Wait()
+
+	for g := range goroutines {
+		require.NoErrorf(t, errs[g], "goroutine %d", g)
+		for i, got := range observed[g] {
+			assert.Equal(t, results[(g+i)%len(paths)], got)
+		}
 	}
 }
 

--- a/go/vt/vtgate/evalengine/translate_test.go
+++ b/go/vt/vtgate/evalengine/translate_test.go
@@ -110,9 +110,9 @@ func TestTranslateSimplification(t *testing.T) {
 		{"ifnull(null, 23)", ok(`case when null is null then 23 else null`), ok(`23`)},
 		{"nullif(1, 1)", ok(`case when 1 = 1 then null else 1`), ok(`null`)},
 		{"nullif(1, 2)", ok(`case when 1 = 2 then null else 1`), ok(`1`)},
-		{"12 between 5 and 20", ok("12 >= 5 and 12 <= 20"), ok(`1`)},
-		{"12 not between 5 and 20", ok("12 < 5 or 12 > 20"), ok(`0`)},
-		{"2 not between 5 and 20", ok("2 < 5 or 2 > 20"), ok(`1`)},
+		{"12 between 5 and 20", ok("12 between 5 and 20"), ok(`1`)},
+		{"12 not between 5 and 20", ok("12 not between 5 and 20"), ok(`0`)},
+		{"2 not between 5 and 20", ok("2 not between 5 and 20"), ok(`1`)},
 		{"json->\"$.c\"", ok("JSON_EXTRACT(`json`, '$.c')"), ok("JSON_EXTRACT(`json`, '$.c')")},
 		{"json->>\"$.c\"", ok("JSON_UNQUOTE(JSON_EXTRACT(`json`, '$.c'))"), ok("JSON_UNQUOTE(JSON_EXTRACT(`json`, '$.c'))")},
 	}
@@ -697,4 +697,103 @@ func TestBindVarType(t *testing.T) {
 		Environment: venv,
 	})
 	require.NoError(t, err)
+}
+
+// TestInExprJSONScanPrefix pins the translation-time IN type-scan prefix:
+// MySQL inspects RHS elements in order and stops after the first one that is
+// not constant for one execution, the stopper included. Bind parameters and
+// statement-stable functions continue the scan; columns and volatile
+// functions stop it.
+func TestInExprJSONScanPrefix(t *testing.T) {
+	testCases := []struct {
+		expression string
+		prefix     int
+		domain     inJSONDomain
+	}{
+		{`0 IN (1, '0', JSON_ARRAY())`, 3, inJSONYes},
+		{`0 IN (:v, '0', JSON_ARRAY())`, 3, inJSONYes},
+		{`0 IN (:v + 1, '0', JSON_ARRAY())`, 3, inJSONYes},
+		{`0 IN (NOW(), '0', JSON_ARRAY())`, 3, inJSONYes},
+		{`0 IN (CURDATE(), '0', JSON_ARRAY())`, 3, inJSONYes},
+		{`0 IN (USER(), '0', JSON_ARRAY())`, 3, inJSONYes},
+		{`0 IN (DATABASE(), '0', JSON_ARRAY())`, 3, inJSONYes},
+		{`0 IN (column0, '0', JSON_ARRAY())`, 1, inJSONUnknown},
+		{`0 IN (column0 + 1, '0', JSON_ARRAY())`, 1, inJSONUnknown},
+		{`0 IN (SYSDATE(), '0', JSON_ARRAY())`, 1, inJSONNo},
+		{`0 IN (UUID(), '0', JSON_ARRAY())`, 1, inJSONNo},
+		{`0 IN (RANDOM_BYTES(8), '0', JSON_ARRAY())`, 1, inJSONNo},
+		{`0 IN ('0', 1)`, 2, inJSONNo},
+		{`JSON_ARRAY() IN (column0, '0')`, 1, inJSONYes},
+	}
+
+	venv := vtenv.NewTestEnv()
+	fields := []*querypb.Field{{Name: "column0", Type: sqltypes.Int64, ColumnType: "BIGINT"}}
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			expr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+
+			translated, err := Translate(expr, &Config{
+				ResolveColumn:     FieldResolver(fields).Column,
+				Collation:         collations.CollationUtf8mb4ID,
+				Environment:       venv,
+				NoConstantFolding: true,
+				NoCompilation:     true,
+			})
+			require.NoError(t, err)
+
+			in, ok := translated.(*UntypedExpr).ir.(*InExpr)
+			require.True(t, ok, "expected an InExpr translation")
+			assert.Equal(t, tc.prefix, in.JSONScanRHS, "wrong type-scan prefix")
+			assert.Equal(t, tc.domain, in.PrefixJSON, "wrong declared-JSON tri-state")
+		})
+	}
+}
+
+// TestBetweenExprFormatRoundTrip checks that formatting a translated BETWEEN
+// preserves the parentheses of equal- and lower-precedence operands: the
+// formatted SQL must reparse to the same value.
+func TestBetweenExprFormatRoundTrip(t *testing.T) {
+	testCases := []struct {
+		expression string
+		formatted  string
+		result     string
+	}{
+		{`(0 AND 1) BETWEEN 0 AND 0`, `(0 and 1) between 0 and 0`, `INT64(1)`},
+		{`1 BETWEEN (0 BETWEEN 0 AND 1) AND 2`, `1 between (0 between 0 and 1) and 2`, `INT64(1)`},
+		{`5 NOT BETWEEN (0 BETWEEN 0 AND 1) AND 2`, `5 not between (0 between 0 and 1) and 2`, `INT64(1)`},
+	}
+
+	venv := vtenv.NewTestEnv()
+	cfg := &Config{
+		Collation:         collations.CollationUtf8mb4ID,
+		Environment:       venv,
+		NoConstantFolding: true,
+		NoCompilation:     true,
+	}
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			expr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+			translated, err := Translate(expr, cfg)
+			require.NoError(t, err)
+
+			buf := sqlparser.NewTrackedBuffer(nil)
+			translated.(*UntypedExpr).ir.format(buf)
+			require.Equal(t, tc.formatted, buf.String())
+
+			env := EmptyExpressionEnv(venv)
+			res, err := env.Evaluate(translated)
+			require.NoError(t, err)
+			require.Equal(t, tc.result, res.String())
+
+			reparsed, err := venv.Parser().ParseExpr(buf.String())
+			require.NoError(t, err)
+			retranslated, err := Translate(reparsed, cfg)
+			require.NoError(t, err)
+			res, err = env.Evaluate(retranslated)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, res.String())
+		})
+	}
 }

--- a/go/vt/vtgate/evalengine/translate_test.go
+++ b/go/vt/vtgate/evalengine/translate_test.go
@@ -110,9 +110,9 @@ func TestTranslateSimplification(t *testing.T) {
 		{"ifnull(null, 23)", ok(`case when null is null then 23 else null`), ok(`23`)},
 		{"nullif(1, 1)", ok(`case when 1 = 1 then null else 1`), ok(`null`)},
 		{"nullif(1, 2)", ok(`case when 1 = 2 then null else 1`), ok(`1`)},
-		{"12 between 5 and 20", ok("12 >= 5 and 12 <= 20"), ok(`1`)},
-		{"12 not between 5 and 20", ok("12 < 5 or 12 > 20"), ok(`0`)},
-		{"2 not between 5 and 20", ok("2 < 5 or 2 > 20"), ok(`1`)},
+		{"12 between 5 and 20", ok("12 between 5 and 20"), ok(`1`)},
+		{"12 not between 5 and 20", ok("12 not between 5 and 20"), ok(`0`)},
+		{"2 not between 5 and 20", ok("2 not between 5 and 20"), ok(`1`)},
 		{"json->\"$.c\"", ok("JSON_EXTRACT(`json`, '$.c')"), ok("JSON_EXTRACT(`json`, '$.c')")},
 		{"json->>\"$.c\"", ok("JSON_UNQUOTE(JSON_EXTRACT(`json`, '$.c'))"), ok("JSON_UNQUOTE(JSON_EXTRACT(`json`, '$.c'))")},
 	}
@@ -694,4 +694,103 @@ func TestBindVarType(t *testing.T) {
 		Environment: venv,
 	})
 	require.NoError(t, err)
+}
+
+// TestInExprJSONScanPrefix pins the translation-time IN type-scan prefix:
+// MySQL inspects RHS elements in order and stops after the first one that is
+// not constant for one execution, the stopper included. Bind parameters and
+// statement-stable functions continue the scan; columns and volatile
+// functions stop it.
+func TestInExprJSONScanPrefix(t *testing.T) {
+	testCases := []struct {
+		expression string
+		prefix     int
+		domain     inJSONDomain
+	}{
+		{`0 IN (1, '0', JSON_ARRAY())`, 3, inJSONYes},
+		{`0 IN (:v, '0', JSON_ARRAY())`, 3, inJSONYes},
+		{`0 IN (:v + 1, '0', JSON_ARRAY())`, 3, inJSONYes},
+		{`0 IN (NOW(), '0', JSON_ARRAY())`, 3, inJSONYes},
+		{`0 IN (CURDATE(), '0', JSON_ARRAY())`, 3, inJSONYes},
+		{`0 IN (USER(), '0', JSON_ARRAY())`, 3, inJSONYes},
+		{`0 IN (DATABASE(), '0', JSON_ARRAY())`, 3, inJSONYes},
+		{`0 IN (column0, '0', JSON_ARRAY())`, 1, inJSONUnknown},
+		{`0 IN (column0 + 1, '0', JSON_ARRAY())`, 1, inJSONUnknown},
+		{`0 IN (SYSDATE(), '0', JSON_ARRAY())`, 1, inJSONNo},
+		{`0 IN (UUID(), '0', JSON_ARRAY())`, 1, inJSONNo},
+		{`0 IN (RANDOM_BYTES(8), '0', JSON_ARRAY())`, 1, inJSONNo},
+		{`0 IN ('0', 1)`, 2, inJSONNo},
+		{`JSON_ARRAY() IN (column0, '0')`, 1, inJSONYes},
+	}
+
+	venv := vtenv.NewTestEnv()
+	fields := []*querypb.Field{{Name: "column0", Type: sqltypes.Int64, ColumnType: "BIGINT"}}
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			expr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+
+			translated, err := Translate(expr, &Config{
+				ResolveColumn:     FieldResolver(fields).Column,
+				Collation:         collations.CollationUtf8mb4ID,
+				Environment:       venv,
+				NoConstantFolding: true,
+				NoCompilation:     true,
+			})
+			require.NoError(t, err)
+
+			in, ok := translated.(*UntypedExpr).ir.(*InExpr)
+			require.True(t, ok, "expected an InExpr translation")
+			assert.Equal(t, tc.prefix, in.JSONScanRHS, "wrong type-scan prefix")
+			assert.Equal(t, tc.domain, in.PrefixJSON, "wrong declared-JSON tri-state")
+		})
+	}
+}
+
+// TestBetweenExprFormatRoundTrip checks that formatting a translated BETWEEN
+// preserves the parentheses of equal- and lower-precedence operands: the
+// formatted SQL must reparse to the same value.
+func TestBetweenExprFormatRoundTrip(t *testing.T) {
+	testCases := []struct {
+		expression string
+		formatted  string
+		result     string
+	}{
+		{`(0 AND 1) BETWEEN 0 AND 0`, `(0 and 1) between 0 and 0`, `INT64(1)`},
+		{`1 BETWEEN (0 BETWEEN 0 AND 1) AND 2`, `1 between (0 between 0 and 1) and 2`, `INT64(1)`},
+		{`5 NOT BETWEEN (0 BETWEEN 0 AND 1) AND 2`, `5 not between (0 between 0 and 1) and 2`, `INT64(1)`},
+	}
+
+	venv := vtenv.NewTestEnv()
+	cfg := &Config{
+		Collation:         collations.CollationUtf8mb4ID,
+		Environment:       venv,
+		NoConstantFolding: true,
+		NoCompilation:     true,
+	}
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			expr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+			translated, err := Translate(expr, cfg)
+			require.NoError(t, err)
+
+			buf := sqlparser.NewTrackedBuffer(nil)
+			translated.(*UntypedExpr).ir.format(buf)
+			require.Equal(t, tc.formatted, buf.String())
+
+			env := EmptyExpressionEnv(venv)
+			res, err := env.Evaluate(translated)
+			require.NoError(t, err)
+			require.Equal(t, tc.result, res.String())
+
+			reparsed, err := venv.Parser().ParseExpr(buf.String())
+			require.NoError(t, err)
+			retranslated, err := Translate(reparsed, cfg)
+			require.NoError(t, err)
+			res, err = env.Evaluate(retranslated)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, res.String())
+		})
+	}
 }

--- a/go/vt/vtgate/evalengine/translate_test.go
+++ b/go/vt/vtgate/evalengine/translate_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package evalengine
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -156,6 +157,223 @@ func TestTranslateSimplification(t *testing.T) {
 			}
 			assert.Equal(t, tc.simplified.literal, sqlparser.String(simplified))
 		})
+	}
+}
+
+// TestTranslateFoldedJSONLiterals tests that JSON values produced by constant
+// folding compile, evaluate and format as CAST('<json>' AS JSON) literals; a
+// bare string literal would compare as a JSON string scalar, not a document.
+func TestTranslateFoldedJSONLiterals(t *testing.T) {
+	testCases := []struct {
+		expression string
+		simplified string
+		row        sqltypes.Value
+		result     sqltypes.Value
+	}{{
+		expression: `j = json_array(1)`,
+		simplified: `j = cast('[1]' as json)`,
+		row:        sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`)),
+		result:     sqltypes.NewInt64(1),
+	}, {
+		expression: `coalesce(j, json_array(1, 2))`,
+		simplified: `coalesce(j, cast('[1, 2]' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1, 2]`)),
+	}, {
+		expression: `coalesce(j, json_object('a', 1))`,
+		simplified: `coalesce(j, cast('{"a": 1}' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`{"a": 1}`)),
+	}, {
+		expression: `coalesce(j, cast('"foo"' as json))`,
+		simplified: `coalesce(j, cast('"foo"' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`"foo"`)),
+	}, {
+		// wide decimals must keep their exact serialization and not
+		// round-trip through float64
+		expression: `coalesce(j, json_array(123456789012.12345678))`,
+		simplified: `coalesce(j, cast('[123456789012.12345678]' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[123456789012.12345678]`)),
+	}, {
+		// a JSON null literal is a JSON value, not a SQL NULL
+		expression: `coalesce(j, cast('null' as json))`,
+		simplified: `coalesce(j, cast('null' as json))`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`null`)),
+	}, {
+		expression: `coalesce(j, null)`,
+		simplified: `coalesce(j, null)`,
+		row:        sqltypes.NULL,
+		result:     sqltypes.NULL,
+	}}
+
+	venv := vtenv.NewTestEnv()
+	fields := FieldResolver([]*querypb.Field{
+		{Name: "j", Type: sqltypes.TypeJSON, Charset: collations.CollationUtf8mb4ID},
+	})
+
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			astExpr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+
+			translated, err := Translate(astExpr, &Config{
+				ResolveColumn: fields.Column,
+				ResolveType:   fields.Type,
+				Collation:     venv.CollationEnv().DefaultConnectionCharset(),
+				Environment:   venv,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.simplified, sqlparser.String(translated))
+
+			env := NewExpressionEnv(t.Context(), nil, NewEmptyVCursor(venv, time.Local))
+			env.Row = []sqltypes.Value{tc.row}
+
+			compiled, err := env.Evaluate(translated)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, compiled.Value(collations.MySQL8().DefaultConnectionCharset()))
+
+			interpreted, err := env.EvaluateAST(translated)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, interpreted.Value(collations.MySQL8().DefaultConnectionCharset()))
+		})
+	}
+}
+
+// TestTranslateFoldedJSONLiteralOwnership tests that evaluating a translated
+// expression never mutates a folded JSON literal: JSON_REMOVE updates its
+// input in place, and translated expressions are reused across evaluations.
+func TestTranslateFoldedJSONLiteralOwnership(t *testing.T) {
+	testCases := []struct {
+		expression string
+		paths      []string
+		results    []string
+	}{{
+		expression: `json_remove(json_array(1, 2, 3), :p)`,
+		paths:      []string{`$[0]`, `$[1]`, `$[2]`},
+		results:    []string{`[2, 3]`, `[1, 3]`, `[1, 2]`},
+	}, {
+		expression: `json_remove(json_object('a', json_array(1, 2, 3)), :p)`,
+		paths:      []string{`$.a[0]`, `$.a[1]`, `$.a[2]`},
+		results:    []string{`{"a": [2, 3]}`, `{"a": [1, 3]}`, `{"a": [1, 2]}`},
+	}}
+
+	venv := vtenv.NewTestEnv()
+	coll := collations.MySQL8().DefaultConnectionCharset()
+
+	translate := func(t *testing.T, expression string) *UntypedExpr {
+		astExpr, err := venv.Parser().ParseExpr(expression)
+		require.NoError(t, err)
+		translated, err := Translate(astExpr, &Config{
+			Collation:   coll,
+			Environment: venv,
+		})
+		require.NoError(t, err)
+		untyped, ok := translated.(*UntypedExpr)
+		require.True(t, ok, "expected *UntypedExpr, got %T", translated)
+		return untyped
+	}
+	newEnv := func(path string) *ExpressionEnv {
+		env := EmptyExpressionEnv(venv)
+		env.BindVars = map[string]*querypb.BindVariable{
+			"p": sqltypes.StringBindVariable(path),
+		}
+		return env
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			t.Run("interpreted", func(t *testing.T) {
+				translated := translate(t, tc.expression)
+				for i, path := range tc.paths {
+					env := newEnv(path)
+					res, err := env.EvaluateAST(translated)
+					require.NoError(t, err)
+					assert.Equal(t, tc.results[i], res.Value(coll).ToString())
+				}
+			})
+			t.Run("compiled", func(t *testing.T) {
+				translated := translate(t, tc.expression)
+				for i, path := range tc.paths {
+					env := newEnv(path)
+					compiled, err := translated.Compile(env)
+					require.NoError(t, err)
+					res, err := env.Evaluate(compiled)
+					require.NoError(t, err)
+					assert.Equal(t, tc.results[i], res.Value(coll).ToString())
+				}
+			})
+		})
+	}
+}
+
+// TestTranslateFoldedJSONLiteralConcurrency evaluates a single translated
+// expression containing a folded JSON literal from multiple goroutines; with
+// -race, this catches evaluations sharing the literal's document. The
+// document is folded from a CAST of JSON text: only parsed numbers carry the
+// lazy number classification whose in-place write must not race the reads of
+// concurrent evaluations and lazy compilations.
+func TestTranslateFoldedJSONLiteralConcurrency(t *testing.T) {
+	venv := vtenv.NewTestEnv()
+	coll := collations.MySQL8().DefaultConnectionCharset()
+
+	astExpr, err := venv.Parser().ParseExpr(`json_remove(cast('[1, 2, 3]' as json), :p)`)
+	require.NoError(t, err)
+	translated, err := Translate(astExpr, &Config{
+		Collation:   coll,
+		Environment: venv,
+	})
+	require.NoError(t, err)
+	untyped, ok := translated.(*UntypedExpr)
+	require.True(t, ok, "expected *UntypedExpr, got %T", translated)
+
+	paths := []string{`$[0]`, `$[1]`, `$[2]`}
+	results := []string{`[2, 3]`, `[1, 3]`, `[1, 2]`}
+
+	const goroutines, evaluations = 8, 100
+	errs := make([]error, goroutines)
+	observed := make([][]string, goroutines)
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		observed[g] = make([]string, evaluations)
+		wg.Go(func() {
+			for i := range evaluations {
+				n := (g + i) % len(paths)
+
+				env := EmptyExpressionEnv(venv)
+				env.BindVars = map[string]*querypb.BindVariable{
+					"p": sqltypes.StringBindVariable(paths[n]),
+				}
+
+				var res EvalResult
+				var err error
+				if g%2 == 0 {
+					res, err = env.EvaluateAST(untyped)
+				} else {
+					var compiled *CompiledExpr
+					compiled, err = untyped.Compile(env)
+					if err == nil {
+						res, err = env.Evaluate(compiled)
+					}
+				}
+				if err != nil {
+					errs[g] = err
+					return
+				}
+				observed[g][i] = res.Value(coll).ToString()
+			}
+		})
+	}
+	wg.Wait()
+
+	for g := range goroutines {
+		require.NoErrorf(t, errs[g], "goroutine %d", g)
+		for i, got := range observed[g] {
+			assert.Equal(t, results[(g+i)%len(paths)], got)
+		}
 	}
 }
 

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -3167,6 +3167,44 @@
     }
   },
   {
+    "comment": "having predicate with a constant-folded json value is evaluated at the vtgate level",
+    "query": "select foo, count(*) from user group by foo having min(textcol1) = json_array(1)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select foo, count(*) from user group by foo having min(textcol1) = json_array(1)",
+      "Instructions": {
+        "OperatorType": "Filter",
+        "Predicate": "min(textcol1) = json_array(1)",
+        "ResultColumns": 2,
+        "Inputs": [
+          {
+            "OperatorType": "Aggregate",
+            "Variant": "Ordered",
+            "Aggregates": "sum_count_star(1) AS count(*), min(2 COLLATE latin1_swedish_ci) AS min(textcol1)",
+            "GroupBy": "(0|3)",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select foo, count(*), min(textcol1), weight_string(foo) from `user` where 1 != 1 group by foo, weight_string(foo)",
+                "OrderBy": "(0|3) ASC",
+                "Query": "select foo, count(*), min(textcol1), weight_string(foo) from `user` group by foo, weight_string(foo) order by foo asc"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
     "comment": "find aggregation expression and use column offset in filter times two",
     "query": "select foo, sum(foo), sum(bar) from user group by foo having sum(foo)+sum(bar) = 42",
     "plan": {


### PR DESCRIPTION
## Description

The evalengine evaluates mixed-operand IN, BETWEEN and simple CASE with per-pair coercion, diverging from MySQL whenever a JSON value participates. Differential testing against MySQL 8.0.28 through 8.4.10 shows `0 IN (JSON_ARRAY(), '0')` returning 1 where MySQL returns 0 and `0 BETWEEN JSON_ARRAY() AND '0'` returning 0 where MySQL returns 1. The root cause is the same in all three: MySQL aggregates a comparison domain across the operands, while the evalengine compared each pair independently.

This implements MySQL's domain semantics. IN runs every pairwise comparison in the JSON domain when MySQL's ordered type scan sees a JSON operand; BETWEEN gets a dedicated IR node instead of the `>= AND <=` lowering, resolving MySQL's verified comparison plan from declared operand types — composites and SQL NULLs included; simple CASE compares each base/WHEN pair under a per-pair aggregated domain. Compiled and interpreted paths share the same helpers, late-resolved types select the same plan as static ones, bind-parameter bounds resolve their value-dependent conversions per execution rather than being baked into cached programs, and behavior without JSON operands is unchanged.

BETWEEN's serializers get the matching correctness fix: the parser's formatters (and the new IR node's) treated the left operand and lower bound as safe positions for equal-precedence children, so a nested BETWEEN lost its parentheses and reparsed with different grouping — or, in the lower bound, into a parse error. Every operand position now keeps them.

## Related Issue(s)

Builds on https://github.com/vitessio/vitess/pull/20682. https://github.com/vitessio/vitess/pull/20626 depends on this change.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

VTGate-evaluated IN, BETWEEN and simple CASE expressions with a JSON operand now return the same values as MySQL, resolving bind-parameter bounds from their per-execution values, and serialized SQL keeps the parentheses of a BETWEEN nested inside another BETWEEN's operands. One deliberate divergence remains: a TIME-column BETWEEN with a bind-parameter bound that does not convert to TIME follows MySQL's literal-conversion rule and returns 0 or 1 where MySQL's prepared-statement parameter semantics would yield NULL, which keeps normalized literal queries matching direct MySQL. Other expressions are unaffected. No migrations or configuration changes.

### AI Disclosure

This PR was written primarily by Fable with review from GPT 5.6 Sol.

---

```mermaid
graph LR
    subgraph json [JSON support]
        direction TB
        PR20625["#20625 (merged)<br>mysql/json: fix MarshalTo discarding accumulated output for nested blob and bit values"]
        PR20632["#20632<br>vtgate: preserve IN value lists in complex aggregate projections"]
        PRA["#20691<br>evalengine: disable the static IN hash table for JSON operands"]
        PR20682["#20682 (draft)<br>evalengine: support constant-folded JSON values as literals"]
        PR20683["#20683 (draft)<br>evalengine, sqlparser: MySQL comparison domains; nested BETWEEN parentheses"]
        PR20626["#20626 (draft)<br>vtgate: support cross-shard JSON_ARRAYAGG and JSON_OBJECTAGG"]
        PR20625 --> PR20682
        PRA --> PR20682
        PR20682 --> PR20683
        PR20632 --> PR20626
        PR20683 --> PR20626
    end

    subgraph union [Union routing]
        direction TB
        PR20628["#20628<br>vtgate: track per-source copies of pushed join predicates so merges skip them"]
        PR20629["#20629 (merged)<br>vtgate: fix None routing handling when merging unions"]
        PR20630["#20630 (draft)<br>vtgate: merge unions on join-predicate-free routings when all sources agree"]
        PR20755["#20755<br>vtgate: fix union merging through reference-table alternates"]
        PR20756["#20756 (draft)<br>vtgate: merge empty reference branches through rewritten copies"]
        PR20628 --> PR20630
        PR20629 --> PR20630
        PR20630 --> PR20756
        PR20755 --> PR20756
    end

    subgraph cte [Recursive CTEs]
        direction TB
        PR20759["#20759<br>vtgate: expand qualified stars without JOIN USING coalescing"]
        PR20633["#20633 (draft)<br>vtgate: validate the declared column list length of CTEs and derived tables"]
        PR20631["#20631 (draft)<br>vtgate: bind recursive CTE column filters as arguments in unmerged term queries"]
        PR20759 --> PR20633
        PR20633 --> PR20631
    end

    json ~~~ union ~~~ cte
```


