### PR TITLE
test: replace dead waits in the onlineddl scheduler suite

### DIFF
--- a/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
+++ b/go/test/endtoend/onlineddl/scheduler/onlineddl_scheduler_test.go
@@ -2365,7 +2365,10 @@ DROP TABLE IF EXISTS stress_test
 
 	var openEndedUUID string
 	t.Run("open ended migration", func(t *testing.T) {
-		openEndedUUID = testOnlineDDLStatement(t, createParams(alterTableThrottlingStatement, "vitess --singleton --postpone-completion", "vtgate", "", "hint_col", "", false))
+		// A --postpone-completion migration never reaches a terminal state on its
+		// own, so skip the terminal-state wait and wait for Running instead.
+		openEndedUUID = testOnlineDDLStatement(t, createParams(alterTableThrottlingStatement, "vitess --singleton --postpone-completion", "vtgate", "", "hint_col", "", true))
+		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, openEndedUUID, normalWaitTime, schema.OnlineDDLStatusRunning)
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, openEndedUUID, schema.OnlineDDLStatusRunning)
 	})
 	t.Run("failed singleton migration, vtgate", func(t *testing.T) {
@@ -2423,7 +2426,9 @@ DROP TABLE IF EXISTS stress_test
 		onlineddl.CheckCancelAllMigrations(t, &vtParams, 1)
 	})
 	t.Run("fail singleton-table same table multi submission", func(t *testing.T) {
-		uuid := testOnlineDDLStatement(t, createParams(alterTableThrottlingStatement, "vitess --singleton-table --postpone-completion", "vtctl", "", "hint_col", "", false))
+		// skipWait: a --postpone-completion migration never reaches a terminal
+		// state on its own; the wait for Running below is the one that matters.
+		uuid := testOnlineDDLStatement(t, createParams(alterTableThrottlingStatement, "vitess --singleton-table --postpone-completion", "vtctl", "", "hint_col", "", true))
 		uuids = append(uuids, uuid)
 		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalWaitTime, schema.OnlineDDLStatusRunning)
 
@@ -2434,7 +2439,9 @@ DROP TABLE IF EXISTS stress_test
 	var throttledUUIDs []string
 	// singleton-context
 	t.Run("postponed migrations, singleton-context", func(t *testing.T) {
-		uuidList := testOnlineDDLStatement(t, createParams(multiAlterTableThrottlingStatement, "vitess --singleton-context --postpone-completion", "vtctl", "", "hint_col", "", false))
+		// skipWait: --postpone-completion migrations never reach a terminal state
+		// on their own; the status checks below accept Queued/Ready/Running.
+		uuidList := testOnlineDDLStatement(t, createParams(multiAlterTableThrottlingStatement, "vitess --singleton-context --postpone-completion", "vtctl", "", "hint_col", "", true))
 		throttledUUIDs = strings.Split(uuidList, "\n")
 		assert.Len(t, throttledUUIDs, 3)
 		for _, uuid := range throttledUUIDs {
@@ -2492,7 +2499,9 @@ DROP TABLE IF EXISTS stress_test
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, uuid, schema.OnlineDDLStatusComplete)
 	})
 	t.Run("fail concurrent singleton-context with revert", func(t *testing.T) {
-		revertUUID := testRevertMigration(t, createRevertParams(uuids[len(uuids)-1], "vitess --allow-concurrent --postpone-completion --singleton-context", "vtctl", "rev:ctx", "", false))
+		// skipWait: a --postpone-completion revert never reaches a terminal state
+		// on its own; the wait for Running below is the one that matters.
+		revertUUID := testRevertMigration(t, createRevertParams(uuids[len(uuids)-1], "vitess --allow-concurrent --postpone-completion --singleton-context", "vtctl", "rev:ctx", "", true))
 		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, revertUUID, normalWaitTime, schema.OnlineDDLStatusRunning)
 		// revert is running
 		_ = testOnlineDDLStatement(t, createParams(dropNonexistentTableStatement, "vitess --allow-concurrent --singleton-context", "vtctl", "migrate:ctx", "", "rejected", true))
@@ -2502,7 +2511,9 @@ DROP TABLE IF EXISTS stress_test
 		onlineddl.CheckMigrationStatus(t, &vtParams, shards, revertUUID, schema.OnlineDDLStatusCancelled)
 	})
 	t.Run("success concurrent singleton-context with no-context revert", func(t *testing.T) {
-		revertUUID := testRevertMigration(t, createRevertParams(uuids[len(uuids)-1], "vitess --allow-concurrent --postpone-completion", "vtctl", "rev:ctx", "", false))
+		// skipWait: a --postpone-completion revert never reaches a terminal state
+		// on its own; the wait for Running below is the one that matters.
+		revertUUID := testRevertMigration(t, createRevertParams(uuids[len(uuids)-1], "vitess --allow-concurrent --postpone-completion", "vtctl", "rev:ctx", "", true))
 		onlineddl.WaitForMigrationStatus(t, &vtParams, shards, revertUUID, normalWaitTime, schema.OnlineDDLStatusRunning)
 		// revert is running but has no --singleton-context. Our next migration should be able to run.
 		uuid := testOnlineDDLStatement(t, createParams(dropNonexistentTableStatement, "vitess --allow-concurrent --singleton-context", "vtctl", "migrate:ctx", "", "", false))
@@ -3648,8 +3659,16 @@ func testOnlineDDLStatement(t *testing.T, params *testOnlineDDLStatementParams) 
 	fmt.Printf("<%s>\n", uuid)
 
 	if !strategySetting.Strategy.IsDirect() && !params.skipWait && uuid != "" {
-		status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalWaitTime, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
-		fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
+		// A multi-statement migration returns one UUID per statement, newline
+		// separated; wait for each of them to reach a terminal state.
+		for migrationUUID := range strings.SplitSeq(uuid, "\n") {
+			migrationUUID = strings.TrimSpace(migrationUUID)
+			if migrationUUID == "" {
+				continue
+			}
+			status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, migrationUUID, normalWaitTime, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
+			fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
+		}
 	}
 
 	if params.expectError == "" && params.expectHint != "" {
@@ -3686,8 +3705,9 @@ func testRevertMigration(t *testing.T, params *testRevertMigrationParams) (uuid 
 		fmt.Println("# Generated UUID (for debug purposes):")
 		fmt.Printf("<%s>\n", uuid)
 	}
-	if !params.skipWait {
-		time.Sleep(time.Second * 20)
+	if !params.skipWait && uuid != "" {
+		status := onlineddl.WaitForMigrationStatus(t, &vtParams, shards, uuid, normalWaitTime, schema.OnlineDDLStatusComplete, schema.OnlineDDLStatusFailed)
+		fmt.Printf("# Migration status (for debug purposes): <%s>\n", status)
 	}
 	return uuid
 }


### PR DESCRIPTION
## Description

Extracted from #20552 so it can land on its own.

`TestSchedulerSchemaChanges` — the dominant test in the `onlineddl_scheduler` CI shard (~1083s) — spends 41% of its time (441s) in waits that provably cannot succeed:

- `testRevertMigration` unconditionally slept 20s after every revert (17 executions = 340s), even though every caller immediately checks for a terminal status. It now waits for `Complete`/`Failed`, which returns in a couple of scheduler ticks and also catches reverts slower than 20s that previously failed the follow-up check.
- Multi-statement migrations return newline-separated UUIDs, so the terminal-status wait in `testOnlineDDLStatement` matched nothing and silently burned its full 20s timeout. It now waits per UUID.
- `--postpone-completion` migrations can never reach a terminal state, so their terminal-status waits were guaranteed 20s timeouts. They're now submitted with `skipWait` and wait for `Running` where the follow-up assertions need it.

`TestSchedulerSchemaChanges` drops from ~18 to ~11 minutes locally with all subtests passing.

## Related Issue(s)

Part of the CI e2e-runtime work in #20552.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches (not applicable)
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — test-only change, no production code.

### AI Disclosure

Extracted by Claude Code from #20552 — I provided direction and reviewed it.
