### PR TITLE
examples,docker: update remaining underscore CLI flags

### DIFF
--- a/docker/mini/vtctld-mini-up.sh
+++ b/docker/mini/vtctld-mini-up.sh
@@ -23,17 +23,16 @@ grpc_port=15999
 
 echo "- Starting vtctld..."
 # shellcheck disable=SC2086
-#TODO: Remove underscore(_) flags in v25, replace them with dashed(-) notation
 vtctld \
  $TOPOLOGY_FLAGS \
- --disable_active_reparents \
+ --disable-active-reparents \
  -cell $cell \
- -service_map 'grpc-vtctl' \
- -backup_storage_implementation file \
- -file_backup_storage_root $VTDATAROOT/backups \
+ -service-map 'grpc-vtctl' \
+ -backup-storage-implementation file \
+ -file-backup-storage-root $VTDATAROOT/backups \
  -log_dir $VTDATAROOT/tmp \
  -port $vtctld_web_port \
- -grpc_port $grpc_port \
- -pid_file $VTDATAROOT/tmp/vtctld.pid \
+ -grpc-port $grpc_port \
+ -pid-file $VTDATAROOT/tmp/vtctld.pid \
   > $VTDATAROOT/tmp/vtctld.out 2>&1 &
 echo "+ started"

--- a/docker/mini/vttablet-mini-up.sh
+++ b/docker/mini/vttablet-mini-up.sh
@@ -39,32 +39,31 @@ echo "> Starting vttablet for server $mysql_host:$mysql_port"
 echo "  - Tablet alias is $alias"
 echo "  - Tablet listens on http://$hostname:$port"
 # shellcheck disable=SC2086
-#TODO: Remove underscore(_) flags in v25, replace them with dashed(-) notation
 vttablet \
  $TOPOLOGY_FLAGS \
  -log_dir $VTDATAROOT/tmp \
- -log_queries_to_file $VTDATAROOT/tmp/$tablet_logfile \
+ -log-queries-to-file $VTDATAROOT/tmp/$tablet_logfile \
  -tablet-path $alias \
- -tablet_hostname "$hostname" \
- -init_db_name_override "$keyspace" \
- -init_keyspace $keyspace \
- -init_shard $shard \
- -init_tablet_type $tablet_type \
- -health_check_interval 5s \
- -enable_replication_reporter \
- -backup_storage_implementation file \
- -file_backup_storage_root $VTDATAROOT/backups \
+ -tablet-hostname "$hostname" \
+ -init-db-name-override "$keyspace" \
+ -init-keyspace $keyspace \
+ -init-shard $shard \
+ -init-tablet-type $tablet_type \
+ -health-check-interval 5s \
+ -enable-replication-reporter \
+ -backup-storage-implementation file \
+ -file-backup-storage-root $VTDATAROOT/backups \
  -port $port \
- -grpc_port $grpc_port \
- -db_host $mysql_host \
- -db_port $mysql_port \
- -db_app_user $TOPOLOGY_USER \
- -db_app_password $TOPOLOGY_PASSWORD \
- -db_dba_user $TOPOLOGY_USER \
- -db_dba_password $TOPOLOGY_PASSWORD \
- -mycnf_mysql_port $mysql_port \
- -service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
- -pid_file $VTDATAROOT/$tablet_dir/vttablet.pid \
+ -grpc-port $grpc_port \
+ -db-host $mysql_host \
+ -db-port $mysql_port \
+ -db-app-user $TOPOLOGY_USER \
+ -db-app-password $TOPOLOGY_PASSWORD \
+ -db-dba-user $TOPOLOGY_USER \
+ -db-dba-password $TOPOLOGY_PASSWORD \
+ -mycnf-mysql-port $mysql_port \
+ -service-map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
+ -pid-file $VTDATAROOT/$tablet_dir/vttablet.pid \
  > $VTDATAROOT/$tablet_dir/vttablet.out 2>&1 &
 
 # Block waiting for the tablet to be listening

--- a/docker/vttestserver/run.sh
+++ b/docker/vttestserver/run.sh
@@ -33,16 +33,16 @@ rm -vf "$VTDATAROOT"/"$tablet_dir"/{mysql.sock,mysql.sock.lock}
 /vt/bin/vttestserver \
 	--port "$PORT" \
 	--keyspaces "$KEYSPACES" \
-	--num_shards "$NUM_SHARDS" \
-	--mysql_bind_host "${MYSQL_BIND_HOST:-127.0.0.1}" \
+	--num-shards "$NUM_SHARDS" \
+	--mysql-bind-host "${MYSQL_BIND_HOST:-127.0.0.1}" \
 	--vtcombo-bind-host "${VTCOMBO_BIND_HOST:-127.0.0.1}" \
 	--mysql-server-version "${MYSQL_SERVER_VERSION:-$1}" \
 	--charset "${CHARSET:-utf8mb4}" \
-	--foreign_key_mode "${FOREIGN_KEY_MODE:-allow}" \
-	--enable_online_ddl="${ENABLE_ONLINE_DDL:-true}" \
-	--enable_direct_ddl="${ENABLE_DIRECT_DDL:-true}" \
+	--foreign-key-mode "${FOREIGN_KEY_MODE:-allow}" \
+	--enable-online-ddl="${ENABLE_ONLINE_DDL:-true}" \
+	--enable-direct-ddl="${ENABLE_DIRECT_DDL:-true}" \
 	--planner-version="${PLANNER_VERSION:-gen4}" \
-	--vschema_ddl_authorized_users=% \
-	--tablet_refresh_interval "${TABLET_REFRESH_INTERVAL:-10s}" \
-	--schema_dir="/vt/schema/"
+	--vschema-ddl-authorized-users=% \
+	--tablet-refresh-interval "${TABLET_REFRESH_INTERVAL:-10s}" \
+	--schema-dir="/vt/schema/"
 

--- a/examples/common/backup-env.sh
+++ b/examples/common/backup-env.sh
@@ -53,8 +53,7 @@ if [ "${TOPO}" = "zk2" ]; then
     # Set topology environment parameters.
     ZK_SERVER="localhost:21811,localhost:21812,localhost:21813"
     # shellcheck disable=SC2034
-    #TODO: Remove underscore(_) flags in v25, replace them with dashed(-) notation
-    TOPOLOGY_FLAGS="--topo_implementation zk2 --topo_global_server_address ${ZK_SERVER} --topo_global_root /vitess/global"
+    TOPOLOGY_FLAGS="--topo-implementation zk2 --topo-global-server-address ${ZK_SERVER} --topo-global-root /vitess/global"
 
     mkdir -p "${VTDATAROOT}/tmp"
 elif [ "${TOPO}" = "consul" ]; then
@@ -62,13 +61,11 @@ elif [ "${TOPO}" = "consul" ]; then
     CONSUL_SERVER=127.0.0.1
     CONSUL_HTTP_PORT=8500
     CONSUL_SERVER_PORT=8300
-    #TODO: Remove underscore(_) flags in v25, replace them with dashed(-) notation
-    TOPOLOGY_FLAGS="--topo_implementation consul --topo_global_server_address ${CONSUL_SERVER}:${CONSUL_HTTP_PORT} --topo_global_root vitess/global/"
+    TOPOLOGY_FLAGS="--topo-implementation consul --topo-global-server-address ${CONSUL_SERVER}:${CONSUL_HTTP_PORT} --topo-global-root vitess/global/"
     mkdir -p "${VTDATAROOT}/consul"
 else
     ETCD_SERVER="localhost:2379"
-    #TODO: Remove underscore(_) flags in v25, replace them with dashed(-) notation
-    TOPOLOGY_FLAGS="--topo_implementation etcd2 --topo_global_server_address $ETCD_SERVER --topo_global_root /vitess/global"
+    TOPOLOGY_FLAGS="--topo-implementation etcd2 --topo-global-server-address $ETCD_SERVER --topo-global-root /vitess/global"
 
     mkdir -p "${VTDATAROOT}/etcd"
 fi

--- a/examples/common/backup-scripts/consul-up.sh
+++ b/examples/common/backup-scripts/consul-up.sh
@@ -43,7 +43,7 @@ sleep 5
 echo "add ${cell} CellInfo"
 set +e
 # shellcheck disable=SC2086
-command vtctldclient --server internal --topo_implementation consul --topo_global_server_address "${CONSUL_SERVER}:${consul_http_port}"  AddCellInfo \
+command vtctldclient --server internal --topo-implementation consul --topo-global-server-address "${CONSUL_SERVER}:${consul_http_port}"  AddCellInfo \
   --root "/vitess/${cell}" \
   --server-address "${CONSUL_SERVER}:${consul_http_port}" \
   "${cell}"

--- a/examples/common/backup-scripts/mysqlctl-down.sh
+++ b/examples/common/backup-scripts/mysqlctl-down.sh
@@ -24,5 +24,5 @@ uid=$TABLET_UID
 printf -v alias '%s-%010d' $cell $uid
 echo "Shutting down MySQL for tablet $alias..."
 
-mysqlctl --tablet_uid $uid shutdown
+mysqlctl --tablet-uid $uid shutdown
 

--- a/examples/common/backup-scripts/mysqlctl-up.sh
+++ b/examples/common/backup-scripts/mysqlctl-up.sh
@@ -37,8 +37,8 @@ fi
 
 mysqlctl \
  --log_dir $VTDATAROOT/tmp \
- --tablet_uid $uid \
- --mysql_port $mysql_port \
+ --tablet-uid $uid \
+ --mysql-port $mysql_port \
  $action
 
 echo -e "MySQL for tablet $alias is running!"

--- a/examples/common/backup-scripts/vtctld-up.sh
+++ b/examples/common/backup-scripts/vtctld-up.sh
@@ -26,13 +26,13 @@ echo "Starting vtctld..."
 vtctld \
  $TOPOLOGY_FLAGS \
  --cell $cell \
- --service_map 'grpc-vtctl,grpc-vtctld' \
- --backup_storage_implementation file \
- --file_backup_storage_root $VTDATAROOT/backups \
+ --service-map 'grpc-vtctl,grpc-vtctld' \
+ --backup-storage-implementation file \
+ --file-backup-storage-root $VTDATAROOT/backups \
  --log_dir $VTDATAROOT/tmp \
  --port $vtctld_web_port \
- --grpc_port $grpc_port \
- --pid_file $VTDATAROOT/tmp/vtctld.pid \
+ --grpc-port $grpc_port \
+ --pid-file $VTDATAROOT/tmp/vtctld.pid \
  --pprof-http \
   > $VTDATAROOT/tmp/vtctld.out 2>&1 &
 

--- a/examples/common/backup-scripts/vtgate-up.sh
+++ b/examples/common/backup-scripts/vtgate-up.sh
@@ -29,18 +29,18 @@ echo "Starting vtgate..."
 vtgate \
   $TOPOLOGY_FLAGS \
   --log_dir $VTDATAROOT/tmp \
-  --log_queries_to_file $VTDATAROOT/tmp/vtgate_querylog.txt \
+  --log-queries-to-file $VTDATAROOT/tmp/vtgate_querylog.txt \
   --port $web_port \
-  --grpc_port $grpc_port \
-  --mysql_server_port $mysql_server_port \
-  --mysql_server_socket_path $mysql_server_socket_path \
+  --grpc-port $grpc_port \
+  --mysql-server-port $mysql_server_port \
+  --mysql-server-socket-path $mysql_server_socket_path \
   --cell $cell \
-  --cells_to_watch $cell \
-  --tablet_types_to_wait PRIMARY,REPLICA \
-  --service_map 'grpc-vtgateservice' \
-  --pid_file $VTDATAROOT/tmp/vtgate.pid \
-  --enable_buffer \
-  --mysql_auth_server_impl none \
+  --cells-to-watch $cell \
+  --tablet-types-to-wait PRIMARY,REPLICA \
+  --service-map 'grpc-vtgateservice' \
+  --pid-file $VTDATAROOT/tmp/vtgate.pid \
+  --enable-buffer \
+  --mysql-auth-server-impl none \
   --pprof-http \
   > $VTDATAROOT/tmp/vtgate.out 2>&1 &
 

--- a/examples/common/backup-scripts/vttablet-up.sh
+++ b/examples/common/backup-scripts/vttablet-up.sh
@@ -33,11 +33,10 @@ if [[ "${uid: -1}" -gt 1 ]]; then
  tablet_type=rdonly
 fi
 
-# Additional logging and explicit topology flags for vttablet for the backup local example
-# to ensure it uses the underscored topology flags that are required for older vttablet versions.
+# Additional logging and explicit topology flags for vttablet for the backup local example.
 echo "Starting backup vttablet for $alias..."
 echo "Topology flags inherited at start of backup vttablet: $TOPOLOGY_FLAGS"
-export TOPOLOGY_FLAGS="--topo_implementation etcd2 --topo_global_server_address $ETCD_SERVER --topo_global_root /vitess/global"
+export TOPOLOGY_FLAGS="--topo-implementation etcd2 --topo-global-server-address $ETCD_SERVER --topo-global-root /vitess/global"
 echo "Topology flags at start of backup vttablet, after explicitly setting: $TOPOLOGY_FLAGS"
 
 
@@ -45,21 +44,21 @@ echo "Topology flags at start of backup vttablet, after explicitly setting: $TOP
 vttablet \
  $TOPOLOGY_FLAGS \
  --log_dir $VTDATAROOT/tmp \
- --log_queries_to_file $VTDATAROOT/tmp/$tablet_logfile \
+ --log-queries-to-file $VTDATAROOT/tmp/$tablet_logfile \
  --tablet-path $alias \
- --tablet_hostname "$tablet_hostname" \
- --init_keyspace $keyspace \
- --init_shard $shard \
- --init_tablet_type $tablet_type \
- --health_check_interval 5s \
- --backup_storage_implementation file \
- --file_backup_storage_root $VTDATAROOT/backups \
- --restore_from_backup \
+ --tablet-hostname "$tablet_hostname" \
+ --init-keyspace $keyspace \
+ --init-shard $shard \
+ --init-tablet-type $tablet_type \
+ --health-check-interval 5s \
+ --backup-storage-implementation file \
+ --file-backup-storage-root $VTDATAROOT/backups \
+ --restore-from-backup \
  --port $port \
- --grpc_port $grpc_port \
- --service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
- --pid_file $VTDATAROOT/$tablet_dir/vttablet.pid \
- --heartbeat_on_demand_duration=5s \
+ --grpc-port $grpc_port \
+ --service-map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
+ --pid-file $VTDATAROOT/$tablet_dir/vttablet.pid \
+ --heartbeat-on-demand-duration=5s \
  --pprof-http \
  > $VTDATAROOT/$tablet_dir/vttablet.out 2>&1 &
 

--- a/examples/common/backup-scripts/zk-up.sh
+++ b/examples/common/backup-scripts/zk-up.sh
@@ -51,7 +51,7 @@ echo "Started zk servers."
 # Add the CellInfo description for the $CELL cell.
 # If the node already exists, it's fine, means we used existing data.
 set +e
-command vtctldclient --server internal --topo_implementation zk2 --topo_global_server_address "${ZK_SERVER}" AddCellInfo \
+command vtctldclient --server internal --topo-implementation zk2 --topo-global-server-address "${ZK_SERVER}" AddCellInfo \
   --root "/vitess/${cell}" \
   --server-address "${ZK_SERVER}" \
   "${cell}"

--- a/examples/common/env.sh
+++ b/examples/common/env.sh
@@ -53,7 +53,6 @@ if [ "${TOPO}" = "zk2" ]; then
     # Set topology environment parameters.
     ZK_SERVER="localhost:21811,localhost:21812,localhost:21813"
     # shellcheck disable=SC2034
-    #TODO: Remove underscore(_) flags in v25, replace them with dashed(-) notation
     TOPOLOGY_FLAGS="--topo-implementation zk2 --topo-global-server-address ${ZK_SERVER} --topo-global-root /vitess/global"
 
     mkdir -p "${VTDATAROOT}/tmp"
@@ -62,12 +61,10 @@ elif [ "${TOPO}" = "consul" ]; then
     CONSUL_SERVER=127.0.0.1
     CONSUL_HTTP_PORT=8500
     CONSUL_SERVER_PORT=8300
-    #TODO: Remove underscore(_) flags in v25, replace them with dashed(-) notation
     TOPOLOGY_FLAGS="--topo-implementation consul --topo-global-server-address ${CONSUL_SERVER}:${CONSUL_HTTP_PORT} --topo-global-root vitess/global/"
     mkdir -p "${VTDATAROOT}/consul"
 else
     ETCD_SERVER="localhost:2379"
-    #TODO: Remove underscore(_) flags in v25, replace them with dashed(-) notation
     TOPOLOGY_FLAGS="--topo-implementation etcd2 --topo-global-server-address $ETCD_SERVER --topo-global-root /vitess/global"
 
     mkdir -p "${VTDATAROOT}/etcd"


### PR DESCRIPTION
## Description

The underscore→dash flag deprecation (removal is slated for v25, and we're on `25.0.0-SNAPSHOT`) still fires from a handful of shell scripts. The Go test helpers and the local example scripts were already migrated (#19974, #18629), but the backup local example and the docker run scripts got missed.

This dashes them:
- `examples/common/backup-env.sh` + `examples/common/backup-scripts/*` — these were deliberately left on underscores back in #18629 for the upgrade/downgrade backup tests, since the N-1 vttablet predated the dash flags. On the v25 branch N-1 is v24, which takes both, so the old `#TODO: Remove ... in v25` markers are now safe to action.
- `docker/vttestserver/run.sh`, `docker/mini/vtctld-mini-up.sh` and `docker/mini/vttablet-mini-up.sh`. `docker-entry` runs both mini scripts, so migrating only vtctld would have left MiniVitess failing at vttablet start once the normalizer is gone (thanks @copilot for catching that).
- `examples/common/env.sh` — the `TOPOLOGY_FLAGS` there were already dashed, so this just drops the three now-dead `#TODO: Remove ... in v25` comments.

A couple of things left alone on purpose:
- `--log_dir` stays as-is. glog owns it, the normalizer exempts it, and `--log-dir` would be an unknown flag.
- `test/vtop_example.sh` isn't touched. Those `LegacyVtctlCommand -- MoveTables/Reshard` flags go through the legacy parser, so they never warned, and the legacy command registers the names with underscores anyway, so dashing them would just break the script.

## Related Issue(s)

<!-- none that I know of — happy to link one if there's a v25 flag-removal tracking issue -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None. Operators copying these example/docker scripts just get clean, forward-compatible flag names ahead of the v25 underscore removal.

### AI Disclosure

Written by Claude Code — I gave the direction and reviewed the result.