### PR TITLE
test: remove and consolidate ERS end-to-end tests

### DIFF
--- a/go/test/endtoend/reparent/emergencyreparent/ers_test.go
+++ b/go/test/endtoend/reparent/emergencyreparent/ers_test.go
@@ -365,7 +365,10 @@ func TestERSPromoteRdonly(t *testing.T) {
 	// Confirm that replication is still working as intended
 	utils.ConfirmReplication(t, tablets[0], tablets[1:])
 
-	t.Run("fail fast when no tablet can be safely promoted", func(t *testing.T) {
+	// The fail-fast ERS runs in a goroutine so we can bound it with a test-side deadline; on the
+	// timeout path that goroutine is left running the (non-cancelable) ERS against the shared cluster,
+	// so skip the second scenario if this one fails rather than let the leaked ERS corrupt its state.
+	if !t.Run("fail fast when no tablet can be safely promoted", func(t *testing.T) {
 		// Context to be used in the go-routine to cleanly exit it after the test ends
 		ctx := t.Context()
 		strChan := make(chan string)
@@ -383,11 +386,13 @@ func TestERSPromoteRdonly(t *testing.T) {
 
 		select {
 		case out := <-strChan:
-			require.Contains(t, out, "proposed primary zone1-0000000103 will not be able to make forward progress on being promoted")
+			require.Contains(t, out, fmt.Sprintf("proposed primary %s will not be able to make forward progress on being promoted", tablets[2].Alias))
 		case <-time.After(60 * time.Second):
 			require.Fail(t, "Emergency Reparent Shard did not fail in 60 seconds")
 		}
-	})
+	}) {
+		return
+	}
 
 	t.Run("never promote a rdonly tablet", func(t *testing.T) {
 		err := clusterInstance.VtctldClientProcess.ExecuteCommand("ChangeTabletType", tablets[2].Alias, "rdonly")
@@ -599,6 +604,10 @@ func TestERSForInitialization(t *testing.T) {
 	utils.ConfirmReplication(t, tablets[0], tablets[1:])
 }
 
+// TestRecoverWithMultipleFailures tests that ERS succeeds with the default values even when there
+// are multiple vttablet failures. It uses the semi_sync policy to allow multiple failures to happen
+// and still be recoverable, and runs ERS with the default remote-operation-timeout, lock-timeout and
+// wait_replicas_timeout values so a regression in those defaults is caught (see #11881).
 func TestRecoverWithMultipleFailures(t *testing.T) {
 	clusterInstance := utils.SetupReparentCluster(t, policy.DurabilitySemiSync)
 	defer utils.TeardownCluster(clusterInstance)
@@ -617,7 +626,7 @@ func TestRecoverWithMultipleFailures(t *testing.T) {
 	utils.StopTablet(t, tablets[0], true)
 
 	// We expect this to succeed since we only have 1 primary eligible tablet which is down
-	out, err := utils.Ers(clusterInstance, nil, "30s", "10s")
+	out, err := utils.Ers(clusterInstance, nil, "", "")
 	require.NoError(t, err, out)
 
 	newPrimary := utils.GetNewPrimary(t, clusterInstance)

--- a/go/test/endtoend/reparent/emergencyreparent/ers_test.go
+++ b/go/test/endtoend/reparent/emergencyreparent/ers_test.go
@@ -50,13 +50,6 @@ func TestTrivialERS(t *testing.T) {
 		require.NoError(t, err)
 		time.Sleep(5 * time.Second)
 	}
-	// We should do the same for vtctl binary
-	for i := 1; i <= 4; i++ {
-		out, err := utils.ErsWithVtctldClient(clusterInstance)
-		log.Info(fmt.Sprintf("ERS-vtctldclient loop %d.  EmergencyReparentShard Output: %v", i, out))
-		require.NoError(t, err)
-		time.Sleep(5 * time.Second)
-	}
 }
 
 func TestReparentIgnoreReplicas(t *testing.T) {
@@ -355,31 +348,65 @@ func TestSemiSyncSetupCorrectly(t *testing.T) {
 	})
 }
 
-// TestERSPromoteRdonly tests that we never end up promoting a rdonly instance as the primary
+// TestERSPromoteRdonly tests that we never end up promoting a rdonly instance as the primary,
+// and that ERS fails fast when it cannot find any tablet which can be safely promoted instead
+// of promoting a tablet and hanging while inserting a row in the reparent journal on getting
+// semi-sync ACKs. Both scenarios share one cluster; the fail-fast one runs first because it
+// leaves the cluster untouched.
 func TestERSPromoteRdonly(t *testing.T) {
 	clusterInstance := utils.SetupReparentCluster(t, policy.DurabilitySemiSync)
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
-	var err error
 
-	err = clusterInstance.VtctldClientProcess.ExecuteCommand("ChangeTabletType", tablets[1].Alias, "rdonly")
+	// make tablets[1] a rdonly tablet.
+	err := clusterInstance.VtctldClientProcess.ExecuteCommand("ChangeTabletType", tablets[1].Alias, "rdonly")
 	require.NoError(t, err)
 
-	err = clusterInstance.VtctldClientProcess.ExecuteCommand("ChangeTabletType", tablets[2].Alias, "rdonly")
-	require.NoError(t, err)
-
+	// Confirm that replication is still working as intended
 	utils.ConfirmReplication(t, tablets[0], tablets[1:])
 
-	// Make the current primary agent and database unavailable.
-	utils.StopTablet(t, tablets[0], true)
+	t.Run("fail fast when no tablet can be safely promoted", func(t *testing.T) {
+		// Context to be used in the go-routine to cleanly exit it after the test ends
+		ctx := t.Context()
+		strChan := make(chan string)
+		go func() {
+			// We expect this to fail since we have ignored all replica tablets and only the rdonly is left, which is not capable of sending semi-sync ACKs
+			out, err := utils.ErsIgnoreTablet(clusterInstance, tablets[2], "240s", "90s", []*cluster.Vttablet{tablets[0], tablets[3]}, false)
+			assert.Error(t, err)
+			select {
+			case strChan <- out:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}()
 
-	// We expect this one to fail because we have ignored all the replicas and have only the rdonly's which should not be promoted
-	out, err := utils.ErsIgnoreTablet(clusterInstance, nil, "30s", "30s", []*cluster.Vttablet{tablets[3]}, false)
-	require.Error(t, err, out)
+		select {
+		case out := <-strChan:
+			require.Contains(t, out, "proposed primary zone1-0000000103 will not be able to make forward progress on being promoted")
+		case <-time.After(60 * time.Second):
+			require.Fail(t, "Emergency Reparent Shard did not fail in 60 seconds")
+		}
+	})
 
-	out, err = clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("GetShard", utils.KeyspaceShard)
-	require.NoError(t, err)
-	require.Contains(t, out, `"uid": 101`, "the primary should still be 101 in the shard info")
+	t.Run("never promote a rdonly tablet", func(t *testing.T) {
+		err := clusterInstance.VtctldClientProcess.ExecuteCommand("ChangeTabletType", tablets[2].Alias, "rdonly")
+		require.NoError(t, err)
+
+		// Confirm the cluster recovered from the failed ERS above and replication still works
+		utils.ConfirmReplication(t, tablets[0], tablets[1:])
+
+		// Make the current primary agent and database unavailable.
+		utils.StopTablet(t, tablets[0], true)
+
+		// We expect this one to fail because we have ignored all the replicas and have only the rdonly's which should not be promoted
+		out, err := utils.ErsIgnoreTablet(clusterInstance, nil, "30s", "30s", []*cluster.Vttablet{tablets[3]}, false)
+		require.Error(t, err, out)
+
+		out, err = clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput("GetShard", utils.KeyspaceShard)
+		require.NoError(t, err)
+		require.Contains(t, out, `"uid": 101`, "the primary should still be 101 in the shard info")
+	})
 }
 
 // TestERSPreventCrossCellPromotion tests that we promote a replica in the same cell as the previous primary if prevent cross cell promotion flag is set
@@ -595,44 +622,6 @@ func TestRecoverWithMultipleFailures(t *testing.T) {
 
 	newPrimary := utils.GetNewPrimary(t, clusterInstance)
 	utils.ConfirmReplication(t, newPrimary, []*cluster.Vttablet{tablets[2], tablets[3]})
-}
-
-// TestERSFailFast tests that ERS will fail fast if it cannot find any tablet which can be safely promoted instead of promoting
-// a tablet and hanging while inserting a row in the reparent journal on getting semi-sync ACKs
-func TestERSFailFast(t *testing.T) {
-	clusterInstance := utils.SetupReparentCluster(t, policy.DurabilitySemiSync)
-	defer utils.TeardownCluster(clusterInstance)
-	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
-	utils.ConfirmReplication(t, tablets[0], []*cluster.Vttablet{tablets[1], tablets[2], tablets[3]})
-
-	// make tablets[1] a rdonly tablet.
-	err := clusterInstance.VtctldClientProcess.ExecuteCommand("ChangeTabletType", tablets[1].Alias, "rdonly")
-	require.NoError(t, err)
-
-	// Confirm that replication is still working as intended
-	utils.ConfirmReplication(t, tablets[0], tablets[1:])
-
-	// Context to be used in the go-routine to cleanly exit it after the test ends
-	ctx := t.Context()
-	strChan := make(chan string)
-	go func() {
-		// We expect this to fail since we have ignored all replica tablets and only the rdonly is left, which is not capable of sending semi-sync ACKs
-		out, err := utils.ErsIgnoreTablet(clusterInstance, tablets[2], "240s", "90s", []*cluster.Vttablet{tablets[0], tablets[3]}, false)
-		assert.Error(t, err)
-		select {
-		case strChan <- out:
-			return
-		case <-ctx.Done():
-			return
-		}
-	}()
-
-	select {
-	case out := <-strChan:
-		require.Contains(t, out, "proposed primary zone1-0000000103 will not be able to make forward progress on being promoted")
-	case <-time.After(60 * time.Second):
-		require.Fail(t, "Emergency Reparent Shard did not fail in 60 seconds")
-	}
 }
 
 // TestReplicationStopped checks that ERS ignores a tablet that has replication fully

--- a/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
+++ b/go/test/endtoend/reparent/newfeaturetest/reparent_test.go
@@ -35,36 +35,6 @@ import (
 	"vitess.io/vitess/go/vt/vtctl/reparentutil/policy"
 )
 
-// TestRecoverWithMultipleVttabletFailures tests that ERS succeeds with the default values
-// even when there are multiple vttablet failures. In this test we use the semi_sync policy
-// to allow multiple failures to happen and still be recoverable.
-// The test takes down the vttablets of the primary and a rdonly tablet and runs ERS with the
-// default values of remote-operation-timeout, lock-timeout flags and wait_replicas_timeout subflag.
-func TestRecoverWithMultipleVttabletFailures(t *testing.T) {
-	clusterInstance := utils.SetupReparentCluster(t, policy.DurabilitySemiSync)
-	defer utils.TeardownCluster(clusterInstance)
-	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
-	utils.ConfirmReplication(t, tablets[0], []*cluster.Vttablet{tablets[1], tablets[2], tablets[3]})
-
-	// make tablets[1] a rdonly tablet.
-	err := clusterInstance.VtctldClientProcess.ExecuteCommand("ChangeTabletType", tablets[1].Alias, "rdonly")
-	require.NoError(t, err)
-
-	// Confirm that replication is still working as intended
-	utils.ConfirmReplication(t, tablets[0], tablets[1:])
-
-	// Make the rdonly and primary tablets and databases unavailable.
-	utils.StopTablet(t, tablets[1], true)
-	utils.StopTablet(t, tablets[0], true)
-
-	// We expect this to succeed since we only have 1 primary eligible tablet which is down
-	out, err := utils.Ers(clusterInstance, nil, "", "")
-	require.NoError(t, err, out)
-
-	newPrimary := utils.GetNewPrimary(t, clusterInstance)
-	utils.ConfirmReplication(t, newPrimary, []*cluster.Vttablet{tablets[2], tablets[3]})
-}
-
 // TetsSingeReplicaERS tests that ERS works even when there is only 1 tablet left
 // as long the durability policy allows this failure. Moreover, this also tests that the
 // replica is one such that it was a primary itself before. This way its executed gtid set

--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -425,12 +425,6 @@ func ErsIgnoreTablet(clusterInstance *cluster.LocalProcessCluster, tab *cluster.
 	return clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput(args...)
 }
 
-// ErsWithVtctldClient runs ERS via a vtctldclient binary.
-func ErsWithVtctldClient(clusterInstance *cluster.LocalProcessCluster) (string, error) {
-	args := []string{"EmergencyReparentShard", fmt.Sprintf("%s/%s", KeyspaceName, ShardName)}
-	return clusterInstance.VtctldClientProcess.ExecuteCommandWithOutput(args...)
-}
-
 // endregion
 
 // region validations


### PR DESCRIPTION
## Description

This PR removes and consolidates some ERS end-to-end tests. Every test in the reparent suites builds its own full cluster _(etcd + vtctld + 4 x mysqld + 4 x vttablet)_, which costs roughly 60-90s of setup/teardown per test, and the `ers_prs_newfeatures_heavy` shard packages are also re-run by 4 x `upgrade_downgrade_test_reparent_*` workflows; each cluster build removed here is saved ~5 times per PR

1. `TestRecoverWithMultipleVttabletFailures` _(newfeaturetest)_ is deleted; it is the same scenario as `TestRecoverWithMultipleFailures` _(emergencyreparent)_, differing only in default vs explicit timeout flags
2. `TestTrivialERS` drops its second loop; since the `vtctl` binary was removed both loops shell out to the same `vtctldclient` binary, so 4 x of the ERS calls and 20s of sleeps test nothing new. The now-unused `ErsWithVtctldClient` helper is deleted too
3. `TestERSFailFast` is folded into `TestERSPromoteRdonly` as a subtest; both prove ERS refuses a rdonly-only candidate pool on the same cluster shape. The fail-fast scenario runs first because its failed ERS leaves the cluster untouched, then the rdonly-promotion scenario stops the primary as before

Measured against the last 3 x runs of these jobs on `main` _(which were stable within ±10s)_, this PR's CI saved roughly 7 minutes of runner time:

| Job | `main` | this PR | saved |
|---|---|---|---|
| Cluster (ers_prs_newfeatures_heavy) | ~25m03s | 20m10s | −4m53s _(~20%)_ |
| Upgrade Downgrade - Reparent Old Vtctl | 18m42s | 17m24s | −1m18s |
| Upgrade Downgrade - Reparent Old VTTablet | 19m06s | 18m16s | −0m50s |

The `Reparent New Vtctl`/`New VTTablet` jobs are currently path-skipping on both `main` and this PR, so they would only add further savings during the release season when a next-release branch exists

## Related Issue(s)

Noticed during work on https://github.com/vitessio/vitess/pull/20578

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

### AI Disclosure

This PR was written primarily by Claude Code, including this PR summary
