### PR TITLE
evalengine: disable the static IN hash table for JSON operands

### DIFF
--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -1129,3 +1129,69 @@ func TestCompilerNonConstant(t *testing.T) {
 		})
 	}
 }
+
+// TestJSONInStaticTable checks that IN over folded JSON literals does not
+// compile the static hash table: JSON arrays and objects hash by kind and
+// cardinality only, so a hash hit is not equality. Compilation fails until
+// the compiler learns to push JSON literals; the follow-up literal change
+// flips this test to compiled evaluation.
+func TestJSONInStaticTable(t *testing.T) {
+	testCases := []struct {
+		expression string
+		values     []sqltypes.Value
+		result     string
+	}{
+		{
+			expression: `column0 IN (JSON_ARRAY(2))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 IN (JSON_OBJECT('b', 2))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`{"a": 1}`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 IN (JSON_ARRAY(1))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 IN (JSON_OBJECT('a', 1))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`{"a": 1}`))},
+			result:     `INT64(1)`,
+		},
+	}
+
+	venv := vtenv.NewTestEnv()
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			expr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+
+			fields := evalengine.FieldResolver(makeFields(tc.values))
+			cfg := &evalengine.Config{
+				ResolveColumn: fields.Column,
+				Collation:     collations.CollationUtf8mb4ID,
+				Environment:   venv,
+			}
+
+			translated, err := evalengine.Translate(expr, cfg)
+			require.NoError(t, err)
+
+			untyped, ok := translated.(*evalengine.UntypedExpr)
+			require.True(t, ok)
+
+			env := evalengine.EmptyExpressionEnv(venv)
+			env.Row = tc.values
+			env.Fields = makeFields(tc.values)
+
+			res, err := env.EvaluateAST(untyped)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, res.String())
+
+			_, err = untyped.Compile(env)
+			require.ErrorContains(t, err, "unsupported literal kind")
+		})
+	}
+}

--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -1099,3 +1099,69 @@ func TestCompilerNonConstant(t *testing.T) {
 		})
 	}
 }
+
+// TestJSONInStaticTable checks that IN over folded JSON literals does not
+// compile the static hash table: JSON arrays and objects hash by kind and
+// cardinality only, so a hash hit is not equality. Compilation fails until
+// the compiler learns to push JSON literals; the follow-up literal change
+// flips this test to compiled evaluation.
+func TestJSONInStaticTable(t *testing.T) {
+	testCases := []struct {
+		expression string
+		values     []sqltypes.Value
+		result     string
+	}{
+		{
+			expression: `column0 IN (JSON_ARRAY(2))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 IN (JSON_OBJECT('b', 2))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`{"a": 1}`))},
+			result:     `INT64(0)`,
+		},
+		{
+			expression: `column0 IN (JSON_ARRAY(1))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`[1]`))},
+			result:     `INT64(1)`,
+		},
+		{
+			expression: `column0 IN (JSON_OBJECT('a', 1))`,
+			values:     []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(`{"a": 1}`))},
+			result:     `INT64(1)`,
+		},
+	}
+
+	venv := vtenv.NewTestEnv()
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			expr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+
+			fields := evalengine.FieldResolver(makeFields(tc.values))
+			cfg := &evalengine.Config{
+				ResolveColumn: fields.Column,
+				Collation:     collations.CollationUtf8mb4ID,
+				Environment:   venv,
+			}
+
+			translated, err := evalengine.Translate(expr, cfg)
+			require.NoError(t, err)
+
+			untyped, ok := translated.(*evalengine.UntypedExpr)
+			require.True(t, ok)
+
+			env := evalengine.EmptyExpressionEnv(venv)
+			env.Row = tc.values
+			env.Fields = makeFields(tc.values)
+
+			res, err := env.EvaluateAST(untyped)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, res.String())
+
+			_, err = untyped.Compile(env)
+			require.ErrorContains(t, err, "unsupported literal kind")
+		})
+	}
+}

--- a/go/vt/vtgate/evalengine/expr_compare.go
+++ b/go/vt/vtgate/evalengine/expr_compare.go
@@ -531,6 +531,13 @@ func (i *InExpr) eval(env *ExpressionEnv) (eval, error) {
 }
 
 func (i *InExpr) compileTable(lhs ctype, rhs TupleExpr) map[vthash.Hash]struct{} {
+	// JSON hashes fingerprint arrays and objects by kind and cardinality
+	// only: a hash hit is not equality, so JSON stays on the comparing
+	// slow path.
+	if lhs.Type == sqltypes.TypeJSON {
+		return nil
+	}
+
 	var (
 		table  = make(map[vthash.Hash]struct{})
 		hasher = vthash.New()


### PR DESCRIPTION
## Description

The compiled IN fast path builds a static hash table from an all-literal list and treats a hash hit as equality without comparing the candidate. JSON values hash through their MySQL-style ordering weights, which fingerprint arrays and objects by kind and cardinality only, so any two arrays of the same length collide, as do any two objects with the same member count: with a JSON column containing `[1]`, the compiled `json_col IN (JSON_ARRAY(2))` returns 1 where the interpreter and MySQL return 0. JSON operands now stay on the slow path, which performs real comparisons. The weight strings themselves are unchanged, since their shape is intentional for ordering; the defect was treating their hash as proof of equality.

This leads the JSON chain, so the fast-path fix merges before anything widens its reach. At this position the compiler cannot yet push a constant-folded JSON literal, so an IN list over folded JSON documents fails to compile instead of building the table: it is pushed down to MySQL or evaluated by the interpreter where possible, and errors where a compiled program is required, which is the correct direction of failure; the test pins exactly that, and https://github.com/vitessio/vitess/pull/20682 flips the same test to compiled evaluation once literal pushing exists.

## Related Issue(s)

https://github.com/vitessio/vitess/pull/20682 builds on this change.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Compiled IN comparisons over JSON arrays and objects no longer report false matches for same-cardinality values. Until the follow-up JSON literal change lands, IN over a list of constant-folded JSON documents does not compile: it is pushed down to MySQL or evaluated by the interpreter where possible, and errors where a compiled program is required, instead of returning wrong matches. No migrations or configuration changes.

### AI Disclosure

This PR was written primarily by Fable with review from GPT 5.6 Sol.

---

```mermaid
graph LR
    subgraph json [JSON support]
        direction TB
        PR20625["#20625 (merged)<br>mysql/json: fix MarshalTo discarding accumulated output for nested blob and bit values"]
        PR20632["#20632<br>vtgate: preserve IN value lists in complex aggregate projections"]
        PRA["#20691<br>evalengine: disable the static IN hash table for JSON operands"]
        PR20682["#20682 (draft)<br>evalengine: support constant-folded JSON values as literals"]
        PR20683["#20683 (draft)<br>evalengine, sqlparser: MySQL comparison domains; nested BETWEEN parentheses"]
        PR20626["#20626 (draft)<br>vtgate: support cross-shard JSON_ARRAYAGG and JSON_OBJECTAGG"]
        PR20625 --> PR20682
        PRA --> PR20682
        PR20682 --> PR20683
        PR20632 --> PR20626
        PR20683 --> PR20626
    end

    subgraph union [Union routing]
        direction TB
        PR20628["#20628<br>vtgate: track per-source copies of pushed join predicates so merges skip them"]
        PR20629["#20629 (merged)<br>vtgate: fix None routing handling when merging unions"]
        PR20630["#20630 (draft)<br>vtgate: merge unions on join-predicate-free routings when all sources agree"]
        PR20755["#20755<br>vtgate: fix union merging through reference-table alternates"]
        PR20756["#20756 (draft)<br>vtgate: merge empty reference branches through rewritten copies"]
        PR20628 --> PR20630
        PR20629 --> PR20630
        PR20630 --> PR20756
        PR20755 --> PR20756
    end

    subgraph cte [Recursive CTEs]
        direction TB
        PR20759["#20759<br>vtgate: expand qualified stars without JOIN USING coalescing"]
        PR20633["#20633 (draft)<br>vtgate: validate the declared column list length of CTEs and derived tables"]
        PR20631["#20631 (draft)<br>vtgate: bind recursive CTE column filters as arguments in unmerged term queries"]
        PR20759 --> PR20633
        PR20633 --> PR20631
    end

    json ~~~ union ~~~ cte
```

