### PR TITLE
sqlparser: keep nested BETWEEN parenthesized in all operand positions

### DIFF
--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -1544,10 +1544,12 @@ func (node *ComparisonExpr) Format(buf *TrackedBuffer) {
 
 // Format formats the node.
 func (node *BetweenExpr) Format(buf *TrackedBuffer) {
+	// BETWEEN is ternary and non-associative: no operand position may drop
+	// the parentheses of an equal-precedence child.
 	if node.IsBetween {
-		buf.astPrintf(node, "%v between %l and %r", node.Left, node.From, node.To)
+		buf.astPrintf(node, "%r between %r and %r", node.Left, node.From, node.To)
 	} else {
-		buf.astPrintf(node, "%v not between %l and %r", node.Left, node.From, node.To)
+		buf.astPrintf(node, "%r not between %r and %r", node.Left, node.From, node.To)
 	}
 }
 

--- a/go/vt/sqlparser/ast_format_fast.go
+++ b/go/vt/sqlparser/ast_format_fast.go
@@ -1983,16 +1983,18 @@ func (node *ComparisonExpr) FormatFast(buf *TrackedBuffer) {
 
 // FormatFast formats the node.
 func (node *BetweenExpr) FormatFast(buf *TrackedBuffer) {
+	// BETWEEN is ternary and non-associative: no operand position may drop
+	// the parentheses of an equal-precedence child.
 	if node.IsBetween {
-		buf.printExpr(node, node.Left, true)
+		buf.printExpr(node, node.Left, false)
 		buf.WriteString(" between ")
-		buf.printExpr(node, node.From, true)
+		buf.printExpr(node, node.From, false)
 		buf.WriteString(" and ")
 		buf.printExpr(node, node.To, false)
 	} else {
-		buf.printExpr(node, node.Left, true)
+		buf.printExpr(node, node.Left, false)
 		buf.WriteString(" not between ")
-		buf.printExpr(node, node.From, true)
+		buf.printExpr(node, node.From, false)
 		buf.WriteString(" and ")
 		buf.printExpr(node, node.To, false)
 	}

--- a/go/vt/sqlparser/precedence_test.go
+++ b/go/vt/sqlparser/precedence_test.go
@@ -132,6 +132,9 @@ func TestParens(t *testing.T) {
 		{in: "(a) between (5) and (7)", expected: "a between 5 and 7"},
 		{in: "(a | b) between (5) and (7)", expected: "a | b between 5 and 7"},
 		{in: "(a and b) between (5) and (7)", expected: "(a and b) between 5 and 7"},
+		{in: "(5 between 0 and 10) between 0 and 1", expected: "(5 between 0 and 10) between 0 and 1"},
+		{in: "1 between (0 between 0 and 1) and 2", expected: "1 between (0 between 0 and 1) and 2"},
+		{in: "1 not between (0 between 0 and 1) and 2", expected: "1 not between (0 between 0 and 1) and 2"},
 		{in: "(true is true) is null", expected: "(true is true) is null"},
 		{in: "3 * (100 div 3)", expected: "3 * (100 div 3)"},
 		{in: "100 div 2 div 2", expected: "100 div 2 div 2"},
@@ -208,4 +211,33 @@ func TestPrecedenceOfMemberOfWithAndWithoutParser(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, expression, String(ast2))
+}
+
+func TestNestedBetweenRoundTrip(t *testing.T) {
+	// BETWEEN is ternary and non-associative: a nested BETWEEN keeps its
+	// parentheses in every operand position, so the formatted SQL reparses
+	// to the same tree through both formatter paths.
+	tests := []string{
+		"(5 between 0 and 10) between 0 and 1",
+		"1 between (0 between 0 and 1) and 2",
+		"1 not between (0 between 0 and 1) and 2",
+		"1 between 0 and (2 between 1 and 3)",
+	}
+	parser := NewTestParser()
+	for _, in := range tests {
+		t.Run(in, func(t *testing.T) {
+			stmt, err := parser.Parse("select " + in)
+			require.NoError(t, err)
+
+			formatted := String(stmt)
+			reparsed, err := parser.Parse(formatted)
+			require.NoError(t, err, "formatted SQL must reparse: %s", formatted)
+			require.True(t, Equals.SQLNode(stmt, reparsed), "%q reparses to a different tree", formatted)
+
+			canonical := CanonicalString(stmt)
+			reparsed, err = parser.Parse(canonical)
+			require.NoError(t, err, "canonical SQL must reparse: %s", canonical)
+			require.Equal(t, canonical, CanonicalString(reparsed), "canonical formatting is not a fixed point")
+		})
+	}
 }

--- a/go/vt/sqlparser/testdata/select_cases.txt
+++ b/go/vt/sqlparser/testdata/select_cases.txt
@@ -5528,7 +5528,7 @@ INPUT
 select 5 between 0 and 10 between 0 and 1,(5 between 0 and 10) between 0 and 1;
 END
 OUTPUT
-select 5 between 0 and (10 between 0 and 1), 5 between 0 and 10 between 0 and 1 from dual
+select 5 between 0 and (10 between 0 and 1), (5 between 0 and 10) between 0 and 1 from dual
 END
 INPUT
 select * from (t1 join t2 on t1.b=t2.b) natural join (t3 natural join t4);


### PR DESCRIPTION
## Description

BETWEEN is a ternary, non-associative construct, but both formatter paths treated the left operand and the lower bound as safe positions for equal-precedence children. A nested BETWEEN on the left therefore lost its parentheses and reparsed with different grouping — `(5 BETWEEN 0 AND 10) BETWEEN 0 AND 1` formats as `5 between 0 and 10 between 0 and 1`, which reparses as `5 between 0 and (10 between 0 and 1)` and changes the value — and one in the lower bound produced SQL that cannot be parsed back at all. Both the regular formatter and the generated fast formatter now keep every operand position parenthesized at equal precedence, matching the grammar. One serialization test expectation changes accordingly: it pinned the meaning-changing output.

## Related Issue(s)

None.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Serialized SQL with a BETWEEN nested inside another BETWEEN's operands now preserves its parentheses, keeping the original meaning and reparsability. Ordinary BETWEEN output is unchanged. No migrations or configuration changes.

### AI Disclosure

This PR was written primarily by Fable with review from GPT 5.6 Sol.
