### PR TITLE
test(vtorc): consolidate redundant unit and e2e tests

### DIFF
--- a/go/test/endtoend/vtorc/api/api_test.go
+++ b/go/test/endtoend/vtorc/api/api_test.go
@@ -52,18 +52,7 @@ func TestAPIEndpoints(t *testing.T) {
 	assert.NotNil(t, primary, "should have elected a primary")
 
 	// find the replica and rdonly tablet
-	var replica, rdonly *cluster.Vttablet
-	for _, tablet := range shard0.Vttablets {
-		// we know we have only two replica type tablets, so the one not the primary must be the replica
-		if tablet.Alias != primary.Alias && tablet.Type == "replica" {
-			replica = tablet
-		}
-		if tablet.Type == "rdonly" {
-			rdonly = tablet
-		}
-	}
-	assert.NotNil(t, replica, "could not find replica tablet")
-	assert.NotNil(t, rdonly, "could not find rdonly tablet")
+	replica, rdonly := utils.FindReplicaAndRdonly(t, shard0, primary)
 
 	// check that the replication is setup correctly before we set read-only
 	utils.CheckReplication(t, clusterInfo, primary, []*cluster.Vttablet{replica, rdonly}, 10*time.Second)

--- a/go/test/endtoend/vtorc/general/vtorc_test.go
+++ b/go/test/endtoend/vtorc/general/vtorc_test.go
@@ -128,40 +128,32 @@ func TestErrantGTIDOnPreviousPrimary(t *testing.T) {
 	utils.WaitForTabletType(t, curPrimary, "drained")
 }
 
-// Cases to test:
-// 1. create cluster with 1 replica and 1 rdonly, let orc choose primary
-// verify rdonly is not elected, only replica
-// verify replication is setup
-func TestSingleKeyspace(t *testing.T) {
-	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 1, 1, []string{"--clusters-to-watch", "ks"}, cluster.VTOrcConfiguration{
-		PreventCrossCellFailover: true,
-	}, cluster.DefaultVtorcsByCell, "")
-	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
-	shard0 := &keyspace.Shards[0]
+// TestClustersToWatch verifies that VTOrc elects a primary and sets up replication when it is
+// told to watch a cluster either by keyspace ("ks") or by keyspace/shard ("ks/0"). It creates a
+// cluster with 1 replica and 1 rdonly and confirms only the replica is elected primary.
+func TestClustersToWatch(t *testing.T) {
+	tests := []struct {
+		name            string
+		clustersToWatch string
+	}{
+		{name: "Keyspace", clustersToWatch: "ks"},
+		{name: "KeyspaceShard", clustersToWatch: "ks/0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
+			utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 1, 1, []string{"--clusters-to-watch", tt.clustersToWatch}, cluster.VTOrcConfiguration{
+				PreventCrossCellFailover: true,
+			}, cluster.DefaultVtorcsByCell, "")
+			keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
+			shard0 := &keyspace.Shards[0]
 
-	utils.CheckPrimaryTablet(t, clusterInfo, shard0.Vttablets[0], true)
-	utils.CheckReplication(t, clusterInfo, shard0.Vttablets[0], shard0.Vttablets[1:], 10*time.Second)
-	utils.WaitForSuccessfulRecoveryCount(t, clusterInfo.ClusterInstance.VTOrcProcesses[0], logic.ElectNewPrimaryRecoveryName, keyspace.Name, shard0.Name, 1)
-	utils.WaitForSuccessfulPRSCount(t, clusterInfo.ClusterInstance.VTOrcProcesses[0], keyspace.Name, shard0.Name, 1)
-}
-
-// Cases to test:
-// 1. create cluster with 1 replica and 1 rdonly, let orc choose primary
-// verify rdonly is not elected, only replica
-// verify replication is setup
-func TestKeyspaceShard(t *testing.T) {
-	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 1, 1, []string{"--clusters-to-watch", "ks/0"}, cluster.VTOrcConfiguration{
-		PreventCrossCellFailover: true,
-	}, cluster.DefaultVtorcsByCell, "")
-	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
-	shard0 := &keyspace.Shards[0]
-
-	utils.CheckPrimaryTablet(t, clusterInfo, shard0.Vttablets[0], true)
-	utils.CheckReplication(t, clusterInfo, shard0.Vttablets[0], shard0.Vttablets[1:], 10*time.Second)
-	utils.WaitForSuccessfulRecoveryCount(t, clusterInfo.ClusterInstance.VTOrcProcesses[0], logic.ElectNewPrimaryRecoveryName, keyspace.Name, shard0.Name, 1)
-	utils.WaitForSuccessfulPRSCount(t, clusterInfo.ClusterInstance.VTOrcProcesses[0], keyspace.Name, shard0.Name, 1)
+			utils.CheckPrimaryTablet(t, clusterInfo, shard0.Vttablets[0], true)
+			utils.CheckReplication(t, clusterInfo, shard0.Vttablets[0], shard0.Vttablets[1:], 10*time.Second)
+			utils.WaitForSuccessfulRecoveryCount(t, clusterInfo.ClusterInstance.VTOrcProcesses[0], logic.ElectNewPrimaryRecoveryName, keyspace.Name, shard0.Name, 1)
+			utils.WaitForSuccessfulPRSCount(t, clusterInfo.ClusterInstance.VTOrcProcesses[0], keyspace.Name, shard0.Name, 1)
+		})
+	}
 }
 
 // Cases to test:
@@ -913,19 +905,7 @@ func TestReplicationStoppedWithSemiSyncBlocked(t *testing.T) {
 
 	// Identify the replica (acker) and rdonly (non-acker).
 	// One of the 2 replicas was elected primary, so 1 replica remains.
-	var replica, rdonly *cluster.Vttablet
-	for _, tablet := range shard0.Vttablets {
-		if tablet.Alias == primary.Alias {
-			continue
-		}
-		if tablet.Type == "rdonly" {
-			rdonly = tablet
-		} else {
-			replica = tablet
-		}
-	}
-	require.NotNil(t, replica, "should have a REPLICA tablet")
-	require.NotNil(t, rdonly, "should have an RDONLY tablet")
+	replica, rdonly := utils.FindReplicaAndRdonly(t, shard0, primary)
 
 	allNonPrimary := []*cluster.Vttablet{replica, rdonly}
 	utils.CheckReplication(t, clusterInfo, primary, allNonPrimary, 15*time.Second)

--- a/go/test/endtoend/vtorc/primaryfailure/primary_failure_test.go
+++ b/go/test/endtoend/vtorc/primaryfailure/primary_failure_test.go
@@ -556,7 +556,7 @@ func TestDownPrimaryPromotionRuleWithLag(t *testing.T) {
 			shard0 := &keyspace.Shards[0]
 			// find primary from topo
 			curPrimary := utils.ShardPrimaryTablet(t, clusterInfo, keyspace, shard0)
-			assert.NotNil(t, curPrimary, "should have elected a primary")
+			require.NotNil(t, curPrimary, "should have elected a primary")
 
 			// find the same-cell replica and rdonly tablets
 			replica, rdonly := utils.FindReplicaAndRdonly(t, shard0, curPrimary)

--- a/go/test/endtoend/vtorc/primaryfailure/primary_failure_test.go
+++ b/go/test/endtoend/vtorc/primaryfailure/primary_failure_test.go
@@ -84,18 +84,7 @@ func TestDownPrimary(t *testing.T) {
 	utils.WaitForSuccessfulPRSCount(t, vtOrcProcess, keyspace.Name, shard0.Name, 1)
 
 	// find the replica and rdonly tablets
-	var replica, rdonly *cluster.Vttablet
-	for _, tablet := range shard0.Vttablets {
-		// we know we have only two replcia tablets, so the one not the primary must be the other replica
-		if tablet.Alias != curPrimary.Alias && tablet.Type == "replica" {
-			replica = tablet
-		}
-		if tablet.Type == "rdonly" {
-			rdonly = tablet
-		}
-	}
-	assert.NotNil(t, replica, "could not find replica tablet")
-	assert.NotNil(t, rdonly, "could not find rdonly tablet")
+	replica, rdonly := utils.FindReplicaAndRdonly(t, shard0, curPrimary)
 
 	// Start a cross-cell replica
 	crossCellReplica := utils.StartVttablet(t, clusterInfo, utils.Cell2, false)
@@ -179,18 +168,7 @@ func TestDownPrimary_KeyspaceEmergencyReparentDisabled(t *testing.T) {
 	utils.WaitForSuccessfulPRSCount(t, vtOrcProcess, keyspace.Name, shard0.Name, 1)
 
 	// find the replica and rdonly tablets
-	var replica, rdonly *cluster.Vttablet
-	for _, tablet := range shard0.Vttablets {
-		// we know we have only two replcia tablets, so the one not the primary must be the other replica
-		if tablet.Alias != curPrimary.Alias && tablet.Type == "replica" {
-			replica = tablet
-		}
-		if tablet.Type == "rdonly" {
-			rdonly = tablet
-		}
-	}
-	assert.NotNil(t, replica, "could not find replica tablet")
-	assert.NotNil(t, rdonly, "could not find rdonly tablet")
+	replica, rdonly := utils.FindReplicaAndRdonly(t, shard0, curPrimary)
 
 	// check that the replication is setup correctly before we failover
 	utils.CheckReplication(t, clusterInfo, curPrimary, []*cluster.Vttablet{rdonly, replica}, 10*time.Second)
@@ -263,18 +241,7 @@ func TestDownPrimaryBeforeVTOrc(t *testing.T) {
 	require.NoError(t, err)
 
 	// find the replica and rdonly tablets
-	var replica, rdonly *cluster.Vttablet
-	for _, tablet := range shard0.Vttablets {
-		// we know we have only two replcia tablets, so the one not the primary must be the other replica
-		if tablet.Alias != curPrimary.Alias && tablet.Type == "replica" {
-			replica = tablet
-		}
-		if tablet.Type == "rdonly" {
-			rdonly = tablet
-		}
-	}
-	assert.NotNil(t, replica, "could not find replica tablet")
-	assert.NotNil(t, rdonly, "could not find rdonly tablet")
+	replica, rdonly := utils.FindReplicaAndRdonly(t, shard0, curPrimary)
 
 	// check that the replication is setup correctly before we failover
 	utils.CheckReplication(t, clusterInfo, curPrimary, []*cluster.Vttablet{rdonly, replica}, 10*time.Second)
@@ -319,18 +286,7 @@ func TestDeletedPrimaryTablet(t *testing.T) {
 	utils.WaitForSuccessfulPRSCount(t, vtOrcProcess, keyspace.Name, shard0.Name, 1)
 
 	// find the replica and rdonly tablets
-	var replica, rdonly *cluster.Vttablet
-	for _, tablet := range shard0.Vttablets {
-		// we know we have only two replcia tablets, so the one not the primary must be the other replica
-		if tablet.Alias != curPrimary.Alias && tablet.Type == "replica" {
-			replica = tablet
-		}
-		if tablet.Type == "rdonly" {
-			rdonly = tablet
-		}
-	}
-	assert.NotNil(t, replica, "could not find replica tablet")
-	assert.NotNil(t, rdonly, "could not find rdonly tablet")
+	replica, rdonly := utils.FindReplicaAndRdonly(t, shard0, curPrimary)
 
 	// check that the replication is setup correctly before we failover
 	utils.CheckReplication(t, clusterInfo, curPrimary, []*cluster.Vttablet{replica, rdonly}, 10*time.Second)
@@ -390,18 +346,7 @@ func TestDeadPrimaryRecoversImmediately(t *testing.T) {
 	utils.WaitForSuccessfulPRSCount(t, vtOrcProcess, keyspace.Name, shard0.Name, 1)
 
 	// find the replica and rdonly tablets
-	var replica, rdonly *cluster.Vttablet
-	for _, tablet := range shard0.Vttablets {
-		// we know we have only two replcia tablets, so the one not the primary must be the other replica
-		if tablet.Alias != curPrimary.Alias && tablet.Type == "replica" {
-			replica = tablet
-		}
-		if tablet.Type == "rdonly" {
-			rdonly = tablet
-		}
-	}
-	assert.NotNil(t, replica, "could not find replica tablet")
-	assert.NotNil(t, rdonly, "could not find rdonly tablet")
+	replica, rdonly := utils.FindReplicaAndRdonly(t, shard0, curPrimary)
 
 	// Start a cross-cell replica
 	crossCellReplica := utils.StartVttablet(t, clusterInfo, utils.Cell2, false)
@@ -451,18 +396,7 @@ func TestCrossDataCenterFailure(t *testing.T) {
 	assert.NotNil(t, curPrimary, "should have elected a primary")
 
 	// find the replica and rdonly tablets
-	var replicaInSameCell, rdonly *cluster.Vttablet
-	for _, tablet := range shard0.Vttablets {
-		// we know we have only two replcia tablets, so the one not the primary must be the other replica
-		if tablet.Alias != curPrimary.Alias && tablet.Type == "replica" {
-			replicaInSameCell = tablet
-		}
-		if tablet.Type == "rdonly" {
-			rdonly = tablet
-		}
-	}
-	assert.NotNil(t, replicaInSameCell, "could not find replica tablet")
-	assert.NotNil(t, rdonly, "could not find rdonly tablet")
+	replicaInSameCell, rdonly := utils.FindReplicaAndRdonly(t, shard0, curPrimary)
 
 	crossCellReplica := utils.StartVttablet(t, clusterInfo, utils.Cell2, false)
 	// newly started tablet does not replicate from anyone yet, we will allow vtorc to fix this too
@@ -524,89 +458,6 @@ func TestCrossDataCenterFailureError(t *testing.T) {
 	utils.CheckPrimaryTablet(t, clusterInfo, curPrimary, false)
 }
 
-// Failover will sometimes lead to a rdonly which can no longer replicate.
-// covers part of the test case master-failover-lost-replicas from orchestrator
-func TestLostRdonlyOnPrimaryFailure(t *testing.T) {
-	// new version of ERS does not check for lost replicas yet
-	// Earlier any replicas that were not able to replicate from the previous primary
-	// were detected by vtorc and could be configured to have their sources detached
-	t.Skip()
-	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 2, nil, cluster.VTOrcConfiguration{
-		PreventCrossCellFailover: true,
-	}, cluster.DefaultVtorcsByCell, "")
-	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
-	shard0 := &keyspace.Shards[0]
-	// find primary from topo
-	curPrimary := utils.ShardPrimaryTablet(t, clusterInfo, keyspace, shard0)
-	assert.NotNil(t, curPrimary, "should have elected a primary")
-
-	// get the tablets
-	var replica, rdonly, aheadRdonly *cluster.Vttablet
-	for _, tablet := range shard0.Vttablets {
-		// find tablets which are not the primary
-		if tablet.Alias != curPrimary.Alias {
-			if tablet.Type == "replica" {
-				replica = tablet
-			} else {
-				if rdonly == nil {
-					rdonly = tablet
-				} else {
-					aheadRdonly = tablet
-				}
-			}
-		}
-	}
-	assert.NotNil(t, replica, "could not find replica tablet")
-	assert.NotNil(t, rdonly, "could not find any rdonly tablet")
-	assert.NotNil(t, aheadRdonly, "could not find both rdonly tablet")
-
-	// check that replication is setup correctly
-	utils.CheckReplication(t, clusterInfo, curPrimary, []*cluster.Vttablet{rdonly, aheadRdonly, replica}, 15*time.Second)
-
-	// disable recoveries on vtorc so that it is unable to repair the replication
-	utils.DisableGlobalRecoveries(t, clusterInfo.ClusterInstance.VTOrcProcesses[0])
-
-	// stop replication on the replica and rdonly.
-	err := clusterInfo.ClusterInstance.VtctldClientProcess.ExecuteCommand("StopReplication", replica.Alias)
-	require.NoError(t, err)
-	err = clusterInfo.ClusterInstance.VtctldClientProcess.ExecuteCommand("StopReplication", rdonly.Alias)
-	require.NoError(t, err)
-
-	// check that aheadRdonly is able to replicate. We also want to add some queries to aheadRdonly which will not be there in replica and rdonly
-	utils.VerifyWritesSucceed(t, clusterInfo, curPrimary, []*cluster.Vttablet{aheadRdonly}, 15*time.Second)
-
-	// assert that the replica and rdonly are indeed lagging and do not have the new insertion by checking the count of rows in the tables
-	out, err := utils.RunSQL(t, "SELECT * FROM vt_insert_test", replica, "vt_ks")
-	require.NoError(t, err)
-	require.Len(t, out.Rows, 1)
-	out, err = utils.RunSQL(t, "SELECT * FROM vt_insert_test", rdonly, "vt_ks")
-	require.NoError(t, err)
-	require.Len(t, out.Rows, 1)
-
-	// Make the current primary database unavailable.
-	err = curPrimary.MysqlctlProcess.Stop()
-	require.NoError(t, err)
-	defer func() {
-		// we remove the tablet from our global list since its mysqlctl process has stopped and cannot be reused for other tests
-		utils.PermanentlyRemoveVttablet(clusterInfo, curPrimary)
-	}()
-
-	// enable recoveries back on vtorc so that it can repair
-	utils.EnableGlobalRecoveries(t, clusterInfo.ClusterInstance.VTOrcProcesses[0])
-
-	// vtorc must promote the lagging replica and not the rdonly, since it has a MustNotPromoteRule promotion rule
-	utils.CheckPrimaryTablet(t, clusterInfo, replica, true)
-
-	// also check that the replication is setup correctly
-	utils.VerifyWritesSucceed(t, clusterInfo, replica, []*cluster.Vttablet{rdonly}, 15*time.Second)
-
-	// check that the rdonly is lost. The lost replica has is detached and its host is prepended with `//`
-	out, err = utils.RunSQL(t, "SELECT HOST FROM performance_schema.replication_connection_configuration", aheadRdonly, "")
-	require.NoError(t, err)
-	require.Equal(t, "//localhost", out.Rows[0][0].ToString())
-}
-
 // This test checks that the promotion of a tablet succeeds if it passes the promotion lag test
 // covers the test case master-failover-fail-promotion-lag-minutes-success from orchestrator
 func TestPromotionLagSuccess(t *testing.T) {
@@ -622,18 +473,7 @@ func TestPromotionLagSuccess(t *testing.T) {
 	assert.NotNil(t, curPrimary, "should have elected a primary")
 
 	// find the replica and rdonly tablets
-	var replica, rdonly *cluster.Vttablet
-	for _, tablet := range shard0.Vttablets {
-		// we know we have only two replcia tablets, so the one not the primary must be the other replica
-		if tablet.Alias != curPrimary.Alias && tablet.Type == "replica" {
-			replica = tablet
-		}
-		if tablet.Type == "rdonly" {
-			rdonly = tablet
-		}
-	}
-	assert.NotNil(t, replica, "could not find replica tablet")
-	assert.NotNil(t, rdonly, "could not find rdonly tablet")
+	replica, rdonly := utils.FindReplicaAndRdonly(t, shard0, curPrimary)
 
 	// check that the replication is setup correctly before we failover
 	utils.CheckReplication(t, clusterInfo, curPrimary, []*cluster.Vttablet{rdonly, replica}, 10*time.Second)
@@ -652,61 +492,6 @@ func TestPromotionLagSuccess(t *testing.T) {
 	utils.VerifyWritesSucceed(t, clusterInfo, replica, []*cluster.Vttablet{rdonly}, 10*time.Second)
 }
 
-// This test checks that the promotion of a tablet succeeds if it passes the promotion lag test
-// covers the test case master-failover-fail-promotion-lag-minutes-failure from orchestrator
-func TestPromotionLagFailure(t *testing.T) {
-	// new version of ERS does not check for promotion lag yet
-	// Earlier vtorc used to check that the promotion lag between the new primary and the old one
-	// was smaller than the configured value, otherwise it would fail the promotion
-	t.Skip()
-	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 3, 1, nil, cluster.VTOrcConfiguration{
-		ReplicationLagQuery:              "select 61",
-		FailPrimaryPromotionOnLagMinutes: 1,
-	}, cluster.DefaultVtorcsByCell, "")
-	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
-	shard0 := &keyspace.Shards[0]
-	// find primary from topo
-	curPrimary := utils.ShardPrimaryTablet(t, clusterInfo, keyspace, shard0)
-	assert.NotNil(t, curPrimary, "should have elected a primary")
-
-	// find the replica and rdonly tablets
-	var replica1, replica2, rdonly *cluster.Vttablet
-	for _, tablet := range shard0.Vttablets {
-		// we know we have only two replcia tablets, so the one not the primary must be the other replica
-		if tablet.Alias != curPrimary.Alias && tablet.Type == "replica" {
-			if replica1 == nil {
-				replica1 = tablet
-			} else {
-				replica2 = tablet
-			}
-		}
-		if tablet.Type == "rdonly" {
-			rdonly = tablet
-		}
-	}
-	assert.NotNil(t, replica1, "could not find replica tablet")
-	assert.NotNil(t, replica2, "could not find second replica tablet")
-	assert.NotNil(t, rdonly, "could not find rdonly tablet")
-
-	// check that the replication is setup correctly before we failover
-	utils.CheckReplication(t, clusterInfo, curPrimary, []*cluster.Vttablet{rdonly, replica1, replica2}, 10*time.Second)
-
-	// Make the current primary database unavailable.
-	err := curPrimary.MysqlctlProcess.Stop()
-	require.NoError(t, err)
-	defer func() {
-		// we remove the tablet from our global list since its mysqlctl process has stopped and cannot be reused for other tests
-		utils.PermanentlyRemoveVttablet(clusterInfo, curPrimary)
-	}()
-
-	// wait for 20 seconds
-	time.Sleep(20 * time.Second)
-
-	// the previous primary should still be the primary since recovery of dead primary should fail
-	utils.CheckPrimaryTablet(t, clusterInfo, curPrimary, false)
-}
-
 // covers the test case master-failover-candidate from orchestrator
 // We explicitly set one of the replicas to Prefer promotion rule.
 // That is the replica which should be promoted in case of primary failure
@@ -722,18 +507,7 @@ func TestDownPrimaryPromotionRule(t *testing.T) {
 	assert.NotNil(t, curPrimary, "should have elected a primary")
 
 	// find the replica and rdonly tablets
-	var replica, rdonly *cluster.Vttablet
-	for _, tablet := range shard0.Vttablets {
-		// we know we have only two replcia tablets, so the one not the primary must be the other replica
-		if tablet.Alias != curPrimary.Alias && tablet.Type == "replica" {
-			replica = tablet
-		}
-		if tablet.Type == "rdonly" {
-			rdonly = tablet
-		}
-	}
-	assert.NotNil(t, replica, "could not find replica tablet")
-	assert.NotNil(t, rdonly, "could not find rdonly tablet")
+	replica, rdonly := utils.FindReplicaAndRdonly(t, shard0, curPrimary)
 
 	crossCellReplica := utils.StartVttablet(t, clusterInfo, utils.Cell2, false)
 	// newly started tablet does not replicate from anyone yet, we will allow vtorc to fix this too
@@ -753,163 +527,98 @@ func TestDownPrimaryPromotionRule(t *testing.T) {
 	utils.VerifyWritesSucceed(t, clusterInfo, crossCellReplica, []*cluster.Vttablet{rdonly, replica}, 10*time.Second)
 }
 
-// covers the test case master-failover-candidate-lag from orchestrator
-// We explicitly set one of the replicas to Prefer promotion rule and make it lag with respect to other replicas.
-// That is the replica which should be promoted in case of primary failure
-// It should also be caught up when it is promoted
+// covers the test cases master-failover-candidate-lag and
+// master-failover-candidate-lag-cross-datacenter from orchestrator.
+// The preferred promotion candidate is made to lag the others; VTOrc must still promote it
+// on primary failure and it must be caught up once promoted.
+//   - SameCell: cross-cell failover is allowed, so the preferred cross-cell replica is
+//     promoted even though it lags.
+//   - CrossCenter: cross-cell failover is prevented, so the preferred cross-cell replica
+//     cannot win and the lagging same-cell replica is promoted instead.
+//
+// Either way, the tablet that is made to lag is the one that ends up promoted.
 func TestDownPrimaryPromotionRuleWithLag(t *testing.T) {
-	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 1, nil, cluster.VTOrcConfiguration{
-		LockShardTimeoutSeconds: 5,
-	}, cluster.DefaultVtorcsByCell, "test")
-	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
-	shard0 := &keyspace.Shards[0]
-	// find primary from topo
-	curPrimary := utils.ShardPrimaryTablet(t, clusterInfo, keyspace, shard0)
-	assert.NotNil(t, curPrimary, "should have elected a primary")
-
-	// get the replicas in the same cell
-	var replica, rdonly *cluster.Vttablet
-	for _, tablet := range shard0.Vttablets {
-		// find tablets which are not the primary
-		if tablet.Alias != curPrimary.Alias {
-			if tablet.Type == "replica" {
-				replica = tablet
-			} else {
-				rdonly = tablet
-			}
-		}
+	tests := []struct {
+		name             string
+		preventCrossCell bool
+	}{
+		{name: "SameCell", preventCrossCell: false},
+		{name: "CrossCenter", preventCrossCell: true},
 	}
-	assert.NotNil(t, replica, "could not find replica tablet")
-	assert.NotNil(t, rdonly, "could not find rdonly tablet")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
+			utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 1, nil, cluster.VTOrcConfiguration{
+				LockShardTimeoutSeconds:  5,
+				PreventCrossCellFailover: tt.preventCrossCell,
+			}, cluster.DefaultVtorcsByCell, "test")
+			keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
+			shard0 := &keyspace.Shards[0]
+			// find primary from topo
+			curPrimary := utils.ShardPrimaryTablet(t, clusterInfo, keyspace, shard0)
+			assert.NotNil(t, curPrimary, "should have elected a primary")
 
-	crossCellReplica := utils.StartVttablet(t, clusterInfo, utils.Cell2, false)
-	// newly started tablet does not replicate from anyone yet, we will allow vtorc to fix this too
-	utils.CheckReplication(t, clusterInfo, curPrimary, []*cluster.Vttablet{crossCellReplica, replica, rdonly}, 25*time.Second)
+			// find the same-cell replica and rdonly tablets
+			replica, rdonly := utils.FindReplicaAndRdonly(t, shard0, curPrimary)
 
-	// disable recoveries for vtorc so that it is unable to repair the replication.
-	utils.DisableGlobalRecoveries(t, clusterInfo.ClusterInstance.VTOrcProcesses[0])
+			crossCellReplica := utils.StartVttablet(t, clusterInfo, utils.Cell2, false)
+			// newly started tablet does not replicate from anyone yet, we will allow vtorc to fix this too
+			utils.CheckReplication(t, clusterInfo, curPrimary, []*cluster.Vttablet{crossCellReplica, replica, rdonly}, 25*time.Second)
 
-	// stop replication on the crossCellReplica.
-	err := clusterInfo.ClusterInstance.VtctldClientProcess.ExecuteCommand("StopReplication", crossCellReplica.Alias)
-	require.NoError(t, err)
-
-	// check that rdonly and replica are able to replicate. We also want to add some queries to replica which will not be there in crossCellReplica
-	utils.VerifyWritesSucceed(t, clusterInfo, curPrimary, []*cluster.Vttablet{replica, rdonly}, 15*time.Second)
-
-	// reset the primary logs so that crossCellReplica can never catch up
-	utils.ResetPrimaryLogs(t, curPrimary)
-
-	// start replication back on the crossCellReplica.
-	err = clusterInfo.ClusterInstance.VtctldClientProcess.ExecuteCommand("StartReplication", crossCellReplica.Alias)
-	require.NoError(t, err)
-
-	// enable recoveries back on vtorc so that it can repair
-	utils.EnableGlobalRecoveries(t, clusterInfo.ClusterInstance.VTOrcProcesses[0])
-
-	// assert that the crossCellReplica is indeed lagging and does not have the new insertion by checking the count of rows in the table
-	out, err := utils.RunSQL(t, "SELECT * FROM vt_insert_test", crossCellReplica, "vt_ks")
-	require.NoError(t, err)
-	require.Len(t, out.Rows, 1)
-
-	// Make the current primary database unavailable.
-	err = curPrimary.MysqlctlProcess.Stop()
-	require.NoError(t, err)
-	defer func() {
-		// we remove the tablet from our global list since its mysqlctl process has stopped and cannot be reused for other tests
-		utils.PermanentlyRemoveVttablet(clusterInfo, curPrimary)
-	}()
-
-	// the crossCellReplica is set to be preferred according to the durability requirements. So it must be promoted
-	utils.CheckPrimaryTablet(t, clusterInfo, crossCellReplica, true)
-
-	// assert that the crossCellReplica has indeed caught up
-	out, err = utils.RunSQL(t, "SELECT * FROM vt_insert_test", crossCellReplica, "vt_ks")
-	require.NoError(t, err)
-	require.Len(t, out.Rows, 2)
-
-	// check that rdonly and replica are able to replicate from the crossCellReplica
-	utils.VerifyWritesSucceed(t, clusterInfo, crossCellReplica, []*cluster.Vttablet{replica, rdonly}, 15*time.Second)
-}
-
-// covers the test case master-failover-candidate-lag-cross-datacenter from orchestrator
-// We explicitly set one of the cross-cell replicas to Prefer promotion rule, but we prevent cross data center promotions.
-// We let a replica in our own cell lag. That is the replica which should be promoted in case of primary failure
-// It should also be caught up when it is promoted
-func TestDownPrimaryPromotionRuleWithLagCrossCenter(t *testing.T) {
-	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
-	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 1, nil, cluster.VTOrcConfiguration{
-		LockShardTimeoutSeconds:  5,
-		PreventCrossCellFailover: true,
-	}, cluster.DefaultVtorcsByCell, "test")
-	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
-	shard0 := &keyspace.Shards[0]
-	// find primary from topo
-	curPrimary := utils.ShardPrimaryTablet(t, clusterInfo, keyspace, shard0)
-	assert.NotNil(t, curPrimary, "should have elected a primary")
-
-	// get the replicas in the same cell
-	var replica, rdonly *cluster.Vttablet
-	for _, tablet := range shard0.Vttablets {
-		// find tablets which are not the primary
-		if tablet.Alias != curPrimary.Alias {
-			if tablet.Type == "replica" {
-				replica = tablet
-			} else {
-				rdonly = tablet
+			// lagged is the tablet we make lag and expect VTOrc to promote anyway; the other
+			// two tablets stay healthy and receive the extra write.
+			lagged := crossCellReplica
+			healthy := []*cluster.Vttablet{replica, rdonly}
+			if tt.preventCrossCell {
+				lagged = replica
+				healthy = []*cluster.Vttablet{crossCellReplica, rdonly}
 			}
-		}
+
+			// disable recoveries for vtorc so that it is unable to repair the replication.
+			utils.DisableGlobalRecoveries(t, clusterInfo.ClusterInstance.VTOrcProcesses[0])
+
+			// stop replication on the lagged tablet.
+			err := clusterInfo.ClusterInstance.VtctldClientProcess.ExecuteCommand("StopReplication", lagged.Alias)
+			require.NoError(t, err)
+
+			// check that the healthy tablets are able to replicate. We also add a write which will not be there in the lagged tablet
+			utils.VerifyWritesSucceed(t, clusterInfo, curPrimary, healthy, 15*time.Second)
+
+			// reset the primary logs so that the lagged tablet can never catch up
+			utils.ResetPrimaryLogs(t, curPrimary)
+
+			// start replication back on the lagged tablet.
+			err = clusterInfo.ClusterInstance.VtctldClientProcess.ExecuteCommand("StartReplication", lagged.Alias)
+			require.NoError(t, err)
+
+			// enable recoveries back on vtorc so that it can repair
+			utils.EnableGlobalRecoveries(t, clusterInfo.ClusterInstance.VTOrcProcesses[0])
+
+			// assert that the lagged tablet is indeed lagging and does not have the new insertion by checking the count of rows in the table
+			out, err := utils.RunSQL(t, "SELECT * FROM vt_insert_test", lagged, "vt_ks")
+			require.NoError(t, err)
+			require.Len(t, out.Rows, 1)
+
+			// Make the current primary database unavailable.
+			err = curPrimary.MysqlctlProcess.Stop()
+			require.NoError(t, err)
+			defer func() {
+				// we remove the tablet from our global list since its mysqlctl process has stopped and cannot be reused for other tests
+				utils.PermanentlyRemoveVttablet(clusterInfo, curPrimary)
+			}()
+
+			// the lagged tablet is preferred according to the durability requirements, so it must be promoted
+			utils.CheckPrimaryTablet(t, clusterInfo, lagged, true)
+
+			// assert that the promoted tablet has indeed caught up
+			out, err = utils.RunSQL(t, "SELECT * FROM vt_insert_test", lagged, "vt_ks")
+			require.NoError(t, err)
+			require.Len(t, out.Rows, 2)
+
+			// check that the healthy tablets are able to replicate from the promoted tablet
+			utils.VerifyWritesSucceed(t, clusterInfo, lagged, healthy, 15*time.Second)
+		})
 	}
-	assert.NotNil(t, replica, "could not find replica tablet")
-	assert.NotNil(t, rdonly, "could not find rdonly tablet")
-
-	crossCellReplica := utils.StartVttablet(t, clusterInfo, utils.Cell2, false)
-	// newly started tablet does not replicate from anyone yet, we will allow vtorc to fix this too
-	utils.CheckReplication(t, clusterInfo, curPrimary, []*cluster.Vttablet{crossCellReplica, replica, rdonly}, 25*time.Second)
-
-	// disable recoveries from vtorc so that it is unable to repair the replication
-	utils.DisableGlobalRecoveries(t, clusterInfo.ClusterInstance.VTOrcProcesses[0])
-
-	// stop replication on the replica.
-	err := clusterInfo.ClusterInstance.VtctldClientProcess.ExecuteCommand("StopReplication", replica.Alias)
-	require.NoError(t, err)
-
-	// check that rdonly and crossCellReplica are able to replicate. We also want to add some queries to crossCenterReplica which will not be there in replica
-	utils.VerifyWritesSucceed(t, clusterInfo, curPrimary, []*cluster.Vttablet{rdonly, crossCellReplica}, 15*time.Second)
-
-	// reset the primary logs so that crossCellReplica can never catch up
-	utils.ResetPrimaryLogs(t, curPrimary)
-
-	// start replication back on the replica.
-	err = clusterInfo.ClusterInstance.VtctldClientProcess.ExecuteCommand("StartReplication", replica.Alias)
-	require.NoError(t, err)
-
-	// enable recoveries back on vtorc so that it can repair
-	utils.EnableGlobalRecoveries(t, clusterInfo.ClusterInstance.VTOrcProcesses[0])
-
-	// assert that the replica is indeed lagging and does not have the new insertion by checking the count of rows in the table
-	out, err := utils.RunSQL(t, "SELECT * FROM vt_insert_test", replica, "vt_ks")
-	require.NoError(t, err)
-	require.Len(t, out.Rows, 1)
-
-	// Make the current primary database unavailable.
-	err = curPrimary.MysqlctlProcess.Stop()
-	require.NoError(t, err)
-	defer func() {
-		// we remove the tablet from our global list since its mysqlctl process has stopped and cannot be reused for other tests
-		utils.PermanentlyRemoveVttablet(clusterInfo, curPrimary)
-	}()
-
-	// the replica should be promoted since we have prevented cross cell promotions
-	utils.CheckPrimaryTablet(t, clusterInfo, replica, true)
-
-	// assert that the replica has indeed caught up
-	out, err = utils.RunSQL(t, "SELECT * FROM vt_insert_test", replica, "vt_ks")
-	require.NoError(t, err)
-	require.Len(t, out.Rows, 2)
-
-	// check that rdonly and crossCellReplica are able to replicate from the replica
-	utils.VerifyWritesSucceed(t, clusterInfo, replica, []*cluster.Vttablet{crossCellReplica, rdonly}, 15*time.Second)
 }
 
 // recoveryDuration returns the duration of the actual recovery execution by parsing VTOrc's log

--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -383,6 +383,24 @@ func ShardPrimaryTablet(t *testing.T, clusterInfo *VTOrcClusterInfo, keyspace *c
 	}
 }
 
+// FindReplicaAndRdonly returns the shard's replica tablet (the "replica"-type tablet that is
+// not the given primary) and its rdonly tablet. It fails the test if either cannot be found.
+func FindReplicaAndRdonly(t *testing.T, shard *cluster.Shard, primary *cluster.Vttablet) (replica, rdonly *cluster.Vttablet) {
+	t.Helper()
+	for _, tablet := range shard.Vttablets {
+		// we know we have only two replica tablets, so the one not the primary must be the other replica
+		if tablet.Alias != primary.Alias && tablet.Type == "replica" {
+			replica = tablet
+		}
+		if tablet.Type == "rdonly" {
+			rdonly = tablet
+		}
+	}
+	require.NotNil(t, replica, "could not find replica tablet")
+	require.NotNil(t, rdonly, "could not find rdonly tablet")
+	return replica, rdonly
+}
+
 // CheckPrimaryTablet waits until the specified tablet becomes the primary tablet
 // Makes sure the tablet type is primary, and its health check agrees.
 func CheckPrimaryTablet(t *testing.T, clusterInfo *VTOrcClusterInfo, tablet *cluster.Vttablet, checkServing bool) {

--- a/go/vt/vtorc/inst/binlog_test.go
+++ b/go/vt/vtorc/inst/binlog_test.go
@@ -53,11 +53,31 @@ func TestDetachedCoordinates2(t *testing.T) {
 }
 
 func TestPreviousFileCoordinates(t *testing.T) {
-	previous, err := testCoordinates.PreviousFileCoordinates()
-
-	require.NoError(t, err)
-	require.Equal(t, "mysql-bin.000009", previous.LogFile)
-	require.Equal(t, uint64(0), previous.LogPos)
+	tests := []struct {
+		name        string
+		coordinates BinlogCoordinates
+		wantLogFile string
+		wantErr     bool
+	}{
+		{name: "standard", coordinates: BinlogCoordinates{LogFile: "mysql-bin.000010", LogPos: 108}, wantLogFile: "mysql-bin.000009"},
+		{name: "five digit suffix", coordinates: BinlogCoordinates{LogFile: "mysql-bin.00017", LogPos: 104}, wantLogFile: "mysql-bin.00016"},
+		{name: "decrement hundreds", coordinates: BinlogCoordinates{LogFile: "mysql-bin.00100", LogPos: 104}, wantLogFile: "mysql-bin.00099"},
+		{name: "dotted hostname prefix", coordinates: BinlogCoordinates{LogFile: "mysql.00.prod.com.00100", LogPos: 104}, wantLogFile: "mysql.00.prod.com.00099"},
+		{name: "underflow errors", coordinates: BinlogCoordinates{LogFile: "mysql.00.prod.com.00000", LogPos: 104}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			previous, err := tt.coordinates.PreviousFileCoordinates()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantLogFile, previous.LogFile)
+			require.Equal(t, tt.coordinates.Type, previous.Type)
+			require.Equal(t, uint64(0), previous.LogPos)
+		})
+	}
 }
 
 func TestNextFileCoordinates(t *testing.T) {
@@ -87,34 +107,6 @@ func TestBinlogCoordinates(t *testing.T) {
 
 	require.True(t, c1.SmallerThanOrEquals(&c2))
 	require.True(t, c1.SmallerThanOrEquals(&c3))
-}
-
-func TestBinlogPrevious(t *testing.T) {
-	c1 := BinlogCoordinates{LogFile: "mysql-bin.00017", LogPos: 104}
-	cres, err := c1.PreviousFileCoordinates()
-
-	require.NoError(t, err)
-	require.Equal(t, c1.Type, cres.Type)
-	require.Equal(t, "mysql-bin.00016", cres.LogFile)
-
-	c2 := BinlogCoordinates{LogFile: "mysql-bin.00100", LogPos: 104}
-	cres, err = c2.PreviousFileCoordinates()
-
-	require.NoError(t, err)
-	require.Equal(t, c1.Type, cres.Type)
-	require.Equal(t, "mysql-bin.00099", cres.LogFile)
-
-	c3 := BinlogCoordinates{LogFile: "mysql.00.prod.com.00100", LogPos: 104}
-	cres, err = c3.PreviousFileCoordinates()
-
-	require.NoError(t, err)
-	require.Equal(t, c1.Type, cres.Type)
-	require.Equal(t, "mysql.00.prod.com.00099", cres.LogFile)
-
-	c4 := BinlogCoordinates{LogFile: "mysql.00.prod.com.00000", LogPos: 104}
-	_, err = c4.PreviousFileCoordinates()
-
-	require.Error(t, err)
 }
 
 func TestBinlogCoordinatesAsKey(t *testing.T) {


### PR DESCRIPTION
## Description

A cleanup pass over the VTOrc tests (`go/vt/vtorc` unit + `go/test/endtoend/vtorc` e2e), in the same spirit as #20690. It removes dead tests, extracts repeated boilerplate into a shared helper, and merges a few near-identical tests into table-driven cases. Test-only: **no production code changes**, and nothing that was actually running lost coverage.

- **Deleted 2 dead e2e tests** — `TestLostRdonlyOnPrimaryFailure` and `TestPromotionLagFailure` were both permanently `t.Skip()`'d because the new ERS no longer checks lost-replicas / promotion-lag. They never ran.
- **New `utils.FindReplicaAndRdonly` helper** — replaces the identical ~13-line "walk the shard to find the replica + rdonly" loop that was copy-pasted across the `primaryfailure`, `api`, and `general` packages.
- **Merged 3 near-identical test pairs into table-driven tests:**
  - `TestDownPrimaryPromotionRuleWithLag` + `TestDownPrimaryPromotionRuleWithLagCrossCenter` → one test (`SameCell` / `CrossCenter`). Both had `lagged == promoted`; the only real differences were `PreventCrossCellFailover` and which replica lags.
  - `TestSingleKeyspace` + `TestKeyspaceShard` → `TestClustersToWatch` (`Keyspace` / `KeyspaceShard`). They differed only by `--clusters-to-watch` (`ks` vs `ks/0`).
  - (unit) `TestBinlogPrevious` → folded into `TestPreviousFileCoordinates` as table rows.

Net: **−312 lines**.

## Related Issue(s)

Follow-up to #20690.

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

### AI Disclosure

This PR was written primarily by Claude Code, including this PR summary.
