### PR TITLE
ci: use the shared setup-go action in the remaining workflows

### DIFF
--- a/.github/workflows/check_make_vtadmin_authz_testgen.yml
+++ b/.github/workflows/check_make_vtadmin_authz_testgen.yml
@@ -54,14 +54,8 @@ jobs:
       uses: ./.github/actions/tune-os
 
     - name: Set up Go
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      uses: ./.github/actions/setup-go
       if: steps.changes.outputs.vtadmin_changes == 'true'
-      with:
-        go-version-file: go.mod
-        cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
-        cache-dependency-path: |
-          go.sum
-          tools/**/go.sum
 
     - name: Get dependencies
       if: steps.changes.outputs.vtadmin_changes == 'true'

--- a/.github/workflows/check_make_vtadmin_web_proto.yml
+++ b/.github/workflows/check_make_vtadmin_web_proto.yml
@@ -57,11 +57,8 @@ jobs:
             - 'web/vtadmin/package-lock.json'
 
     - name: Set up Go
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      uses: ./.github/actions/setup-go
       if: steps.changes.outputs.proto_changes == 'true'
-      with:
-        go-version-file: go.mod
-        cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
 
     - name: Setup Node
       if: steps.changes.outputs.proto_changes == 'true'

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -132,10 +132,7 @@ jobs:
 
       - name: Set up Go
         if: steps.changes.outputs.end_to_end == 'true'
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
+        uses: ./.github/actions/setup-go
 
       - name: Set up python
         if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/cluster_endtoend_disk_health_monitor.yml
+++ b/.github/workflows/cluster_endtoend_disk_health_monitor.yml
@@ -68,10 +68,7 @@ jobs:
 
       - name: Set up Go
         if: steps.changes.outputs.end_to_end == 'true'
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
+        uses: ./.github/actions/setup-go
 
       - name: Set up python
         if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -62,13 +62,7 @@ jobs:
 
     - name: Set up Go
       if: steps.mode.outputs.is_full_run == 'true' || steps.changes.outputs.changed_files == 'true'
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-      with:
-        go-version-file: go.mod
-        cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
-        cache-dependency-path: |
-          go.sum
-          tools/**/go.sum
+      uses: ./.github/actions/setup-go
 
     - name: Detect changed Go packages
       if: steps.mode.outputs.is_full_run != 'true' && steps.changes.outputs.changed_files == 'true'

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -37,10 +37,7 @@ jobs:
           persist-credentials: 'false'
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
+        uses: ./.github/actions/setup-go
 
       - name: Tune the OS
         timeout-minutes: 5

--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -82,10 +82,7 @@ jobs:
 
       - name: Set up Go
         if: steps.changes.outputs.end_to_end == 'true'
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
+        uses: ./.github/actions/setup-go
 
       - name: Tune the OS
         if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/e2e_race.yml
+++ b/.github/workflows/e2e_race.yml
@@ -61,10 +61,7 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-      with:
-        go-version-file: go.mod
-        cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
+      uses: ./.github/actions/setup-go
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -61,10 +61,7 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-      with:
-        go-version-file: go.mod
-        cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
+      uses: ./.github/actions/setup-go
 
     - name: Tune the OS
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/error_code_docs_generate.yml
+++ b/.github/workflows/error_code_docs_generate.yml
@@ -25,10 +25,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
+        uses: ./.github/actions/setup-go
 
       - name: Generate error codes
         run: |

--- a/.github/workflows/local_example.yml
+++ b/.github/workflows/local_example.yml
@@ -72,10 +72,7 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.examples == 'true'
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-      with:
-        go-version-file: go.mod
-        cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
+      uses: ./.github/actions/setup-go
 
     - name: Tune the OS
       if: steps.changes.outputs.examples == 'true'

--- a/.github/workflows/region_example.yml
+++ b/.github/workflows/region_example.yml
@@ -72,10 +72,7 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.examples == 'true'
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-      with:
-        go-version-file: go.mod
-        cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
+      uses: ./.github/actions/setup-go
 
     - name: Tune the OS
       if: steps.changes.outputs.examples == 'true'

--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -126,13 +126,7 @@ jobs:
 
       - name: Set up Go
         if: (steps.changes.outputs.go_files == 'true' || steps.changes.outputs.parser_changes == 'true' || steps.changes.outputs.proto_changes == 'true')
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
-          cache-dependency-path: |
-            go.sum
-            tools/**/go.sum
+        uses: ./.github/actions/setup-go
 
       - name: Tune the OS
         if: steps.changes.outputs.go_files == 'true'

--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -45,10 +45,7 @@ jobs:
           persist-credentials: 'false'
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
+        uses: ./.github/actions/setup-go
 
       - name: Upgrade the Golang Dependencies
         id: detect-and-update

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -46,7 +46,14 @@ jobs:
           ref: ${{ matrix.branch }}
 
       - name: Set up Go
-        uses: ./.github/actions/setup-go
+        # The shared setup-go action is resolved from the matrix.branch
+        # checkout, where it may not exist or may be outdated. This job only
+        # compiles the small go-upgrade tool once a day, so caching is not
+        # worth it anyway.
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
 
       - name: Detect new version and update codebase
         env:

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -46,10 +46,7 @@ jobs:
           ref: ${{ matrix.branch }}
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
+        uses: ./.github/actions/setup-go
 
       - name: Detect new version and update codebase
         env:

--- a/.github/workflows/vitess_tester_vtgate.yml
+++ b/.github/workflows/vitess_tester_vtgate.yml
@@ -69,10 +69,7 @@ jobs:
 
     - name: Set up Go
       if: steps.changes.outputs.end_to_end == 'true'
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-      with:
-        go-version-file: go.mod
-        cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
+      uses: ./.github/actions/setup-go
 
     - name: Set up python
       if: steps.changes.outputs.end_to_end == 'true'

--- a/.github/workflows/vtop_example.yml
+++ b/.github/workflows/vtop_example.yml
@@ -64,10 +64,7 @@ jobs:
 
       - name: Set up Go
         if: steps.changes.outputs.end_to_end == 'true'
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: go.mod
-          cache: ${{ (github.base_ref == 'main' || (github.base_ref == '' && github.ref_name == 'main')) && 'true' || 'false' }}
+        uses: ./.github/actions/setup-go
 
       - name: Tune the OS
         if: steps.changes.outputs.end_to_end == 'true'


### PR DESCRIPTION
## Description

#20646 moved the unit test jobs onto the shared `./.github/actions/setup-go` action, but every other workflow still called `actions/setup-go` directly with its built-in caching left on for `main` and for PRs targeting `main`. So we kept minting `setup-go-*` entries alongside the `go-mod-*` / `go-build-*` ones the shared action manages.

Those aren't cheap. They're currently **5.17 GB across 6 entries** (up to 1.28 GB each) against the repo's 10 GB cache quota — which we're over right now at 10.78 GB, so eviction is actively running. Most of them sit on `refs/pull/*` refs no other run can restore from, so they burn quota without being reusable. Meanwhile the x64 `go-build` entry, the one nearly every job wants, isn't in the cache at all at the moment.

So this points the remaining 17 workflows at `./.github/actions/setup-go`, which disables the built-in cache, keys the module and build caches separately, and only saves from pushes to `main` and the release branches.

Two cleanups fall out incidentally: the two spellings of the dependency hash get unified (some workflows hashed `go.sum` alone, others `go.sum` plus `tools/**/go.sum`), and `ImageOS` leaves the key, so a runner image bump no longer invalidates the build cache.

The `upgrade_downgrade_test_*` workflows and `create_release.yml` already pass `cache: false`, so they never produced these entries and are left alone.

Two behavior changes worth a reviewer's eye, both intentional and both inherited from the shared action:

- These jobs now **restore** caches on every branch and PR, where the old conditional only restored on `main` and PRs targeting `main`. Saving is still limited to `main` and `release-*`.
- Each migrated job now runs the action's `go mod download` step for the root module and every `tools/*/go.mod`. That's new work for `codeql_analysis`, `update_golang_version` and `update_golang_dependencies`, but it's a fast no-op on a cache hit.

One thing this deliberately does *not* fix: build cache warmth. Race and non-race jobs still share one `go-build-*` key and overwrite each other, so which contents survive is down to whichever job saves first. Same for unit vs e2e test objects. Worth doing separately — I'd rather land the quota win first and measure with a healthy cache than tune keys while eviction is thrashing.

## Related Issue(s)

Follow-up to #20646.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None, CI-only change.

### AI Disclosure

Written by Claude Code — I gave the direction and reviewed the result.
