### PR TITLE
evalengine: stop the binary bitwise operators writing over and marking their result

### DIFF
--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -1017,6 +1017,10 @@ func (v *Value) Array() ([]*Value, bool) {
 }
 
 // StringBytes returns the underlying JSON string for the v.
+//
+// The returned slice aliases the string inside v and must not be written to. v
+// can outlive the caller by a long way — a document folded into a query plan
+// lives as long as the plan is cached, and is shared by concurrent queries.
 func (v *Value) StringBytes() ([]byte, bool) {
 	if v.Type() != TypeString {
 		return nil, false

--- a/go/vt/vtgate/evalengine/arena.go
+++ b/go/vt/vtgate/evalengine/arena.go
@@ -36,6 +36,10 @@ type Arena struct {
 	aSet     []evalSet
 }
 
+// reset returns every value the arena has handed out, to be handed out again by
+// the next evaluation. The constructors below are what make an entry safe to
+// reuse, so each one has to set or clear every field of the type it returns and
+// not only the fields it takes an argument for.
 func (a *Arena) reset() {
 	a.aInt64 = a.aInt64[:0]
 	a.aUint64 = a.aUint64[:0]
@@ -106,6 +110,7 @@ func (a *Arena) newEvalInt64(i int64) *evalInt64 {
 	}
 	val := &a.aInt64[len(a.aInt64)-1]
 	val.i = i
+	val.bitLiteral = false
 	return val
 }
 
@@ -139,11 +144,7 @@ func (a *Arena) newEvalBytesEmpty() *evalBytes {
 		a.aBytes = append(a.aBytes, evalBytes{})
 	}
 	b := &a.aBytes[len(a.aBytes)-1]
-	// reset() hands the same entries out again on the next evaluation, and the
-	// constructors below only set the type, the collation and the bytes: an
-	// entry that is not cleared here keeps the flags of whatever value used it
-	// last.
-	*b = evalBytes{}
+	b.flag = 0
 	return b
 }
 

--- a/go/vt/vtgate/evalengine/arena.go
+++ b/go/vt/vtgate/evalengine/arena.go
@@ -138,7 +138,13 @@ func (a *Arena) newEvalBytesEmpty() *evalBytes {
 	} else {
 		a.aBytes = append(a.aBytes, evalBytes{})
 	}
-	return &a.aBytes[len(a.aBytes)-1]
+	b := &a.aBytes[len(a.aBytes)-1]
+	// reset() hands the same entries out again on the next evaluation, and the
+	// constructors below only set the type, the collation and the bytes: an
+	// entry that is not cleared here keeps the flags of whatever value used it
+	// last.
+	*b = evalBytes{}
+	return b
 }
 
 func (a *Arena) newEvalBinary(raw []byte) *evalBytes {

--- a/go/vt/vtgate/evalengine/arena_test.go
+++ b/go/vt/vtgate/evalengine/arena_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package evalengine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+)
+
+// TestArenaReusedBytesEntriesAreCleared tests that a value handed out by the
+// arena carries nothing over from the value that used the same entry before it.
+// An arena is reset once per evaluation and then hands the same entries out
+// again, while the constructors set only the type, the collation and the bytes,
+// so anything else has to be cleared for the caller to get the value it asked
+// for.
+func TestArenaReusedBytesEntriesAreCleared(t *testing.T) {
+	var a Arena
+
+	// A hex literal is pushed onto the stack by copying the whole literal, which
+	// is how an entry ends up holding flags at all.
+	stale := a.newEvalBytesEmpty()
+	*stale = *newEvalBytesHex([]byte("A")).(*evalBytes)
+	require.True(t, stale.isHexLiteral())
+
+	a.reset()
+
+	fresh := a.newEvalBinary([]byte("A"))
+	require.Same(t, stale, fresh, "the entry must be reused for this test to mean anything")
+	require.False(t, fresh.isHexLiteral())
+	require.False(t, fresh.isBitLiteral())
+	require.Equal(t, sqltypes.VarBinary, fresh.SQLType())
+	require.Equal(t, collationBinary, fresh.col)
+}

--- a/go/vt/vtgate/evalengine/arena_test.go
+++ b/go/vt/vtgate/evalengine/arena_test.go
@@ -24,27 +24,56 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 )
 
-// TestArenaReusedBytesEntriesAreCleared tests that a value handed out by the
-// arena carries nothing over from the value that used the same entry before it.
-// An arena is reset once per evaluation and then hands the same entries out
-// again, while the constructors set only the type, the collation and the bytes,
-// so anything else has to be cleared for the caller to get the value it asked
-// for.
-func TestArenaReusedBytesEntriesAreCleared(t *testing.T) {
-	var a Arena
+// TestArenaReusedEntriesAreCleared tests that a value handed out by the arena
+// carries nothing over from the value that used the same entry before it. An
+// arena is reset once per evaluation and then hands the same entries out again,
+// so a field a constructor takes no argument for still has to be cleared for the
+// caller to get the value it asked for.
+func TestArenaReusedEntriesAreCleared(t *testing.T) {
+	t.Run("bytes", func(t *testing.T) {
+		var a Arena
 
-	// A hex literal is pushed onto the stack by copying the whole literal, which
-	// is how an entry ends up holding flags at all.
-	stale := a.newEvalBytesEmpty()
-	*stale = *newEvalBytesHex([]byte("A")).(*evalBytes)
-	require.True(t, stale.isHexLiteral())
+		// A hex literal reaches an entry by having the whole literal copied over
+		// it, which is how an entry ends up holding flags at all.
+		stale := a.newEvalBytesEmpty()
+		*stale = *newEvalBytesHex([]byte("A")).(*evalBytes)
+		require.True(t, stale.isHexLiteral())
 
-	a.reset()
+		a.reset()
 
-	fresh := a.newEvalBinary([]byte("A"))
-	require.Same(t, stale, fresh, "the entry must be reused for this test to mean anything")
-	require.False(t, fresh.isHexLiteral())
-	require.False(t, fresh.isBitLiteral())
-	require.Equal(t, sqltypes.VarBinary, fresh.SQLType())
-	require.Equal(t, collationBinary, fresh.col)
+		fresh := a.newEvalBinary([]byte("A"))
+		require.Same(t, stale, fresh, "the entry must be reused for this test to mean anything")
+		require.False(t, fresh.isHexLiteral())
+		require.False(t, fresh.isBitLiteral())
+		require.Equal(t, sqltypes.VarBinary, fresh.SQLType())
+		require.Equal(t, collationBinary, fresh.col)
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		var a Arena
+
+		stale := a.newEvalInt64(1)
+		stale.bitLiteral = true
+
+		a.reset()
+
+		fresh := a.newEvalInt64(2)
+		require.Same(t, stale, fresh, "the entry must be reused for this test to mean anything")
+		require.False(t, fresh.bitLiteral)
+		require.EqualValues(t, 2, fresh.i)
+	})
+
+	t.Run("uint64", func(t *testing.T) {
+		var a Arena
+
+		stale := a.newEvalUint64(1)
+		stale.hexLiteral = true
+
+		a.reset()
+
+		fresh := a.newEvalUint64(2)
+		require.Same(t, stale, fresh, "the entry must be reused for this test to mean anything")
+		require.False(t, fresh.hexLiteral)
+		require.EqualValues(t, 2, fresh.u)
+	})
 }

--- a/go/vt/vtgate/evalengine/arena_test.go
+++ b/go/vt/vtgate/evalengine/arena_test.go
@@ -33,11 +33,14 @@ func TestArenaReusedEntriesAreCleared(t *testing.T) {
 	t.Run("bytes", func(t *testing.T) {
 		var a Arena
 
-		// A hex literal reaches an entry by having the whole literal copied over
-		// it, which is how an entry ends up holding flags at all.
+		// A literal reaches an entry by having the whole literal copied over it,
+		// which is how an entry ends up holding flags at all. Both markers are
+		// seeded so that clearing only one of them fails the test.
 		stale := a.newEvalBytesEmpty()
 		*stale = *newEvalBytesHex([]byte("A")).(*evalBytes)
+		stale.flag |= flagBit
 		require.True(t, stale.isHexLiteral())
+		require.True(t, stale.isBitLiteral())
 
 		a.reset()
 

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -204,9 +204,13 @@ func (asm *assembler) BitOp_and_bb() {
 			env.vm.err = errBitwiseOperandsLength
 			return 0
 		}
-		for i := range l.bytes {
-			l.bytes[i] = l.bytes[i] & r.bytes[i]
+		// The result needs its own buffer: the operands' bytes are borrowed
+		// from a literal, a bind variable or the input row.
+		out := make([]byte, len(l.bytes))
+		for i := range out {
+			out[i] = l.bytes[i] & r.bytes[i]
 		}
+		l.bytes = out
 		env.vm.sp--
 		return 1
 	}, "AND BINARY(SP-2), BINARY(SP-1)")
@@ -221,9 +225,13 @@ func (asm *assembler) BitOp_or_bb() {
 			env.vm.err = errBitwiseOperandsLength
 			return 0
 		}
-		for i := range l.bytes {
-			l.bytes[i] = l.bytes[i] | r.bytes[i]
+		// The result needs its own buffer: the operands' bytes are borrowed
+		// from a literal, a bind variable or the input row.
+		out := make([]byte, len(l.bytes))
+		for i := range out {
+			out[i] = l.bytes[i] | r.bytes[i]
 		}
+		l.bytes = out
 		env.vm.sp--
 		return 1
 	}, "OR BINARY(SP-2), BINARY(SP-1)")
@@ -238,9 +246,13 @@ func (asm *assembler) BitOp_xor_bb() {
 			env.vm.err = errBitwiseOperandsLength
 			return 0
 		}
-		for i := range l.bytes {
-			l.bytes[i] = l.bytes[i] ^ r.bytes[i]
+		// The result needs its own buffer: the operands' bytes are borrowed
+		// from a literal, a bind variable or the input row.
+		out := make([]byte, len(l.bytes))
+		for i := range out {
+			out[i] = l.bytes[i] ^ r.bytes[i]
 		}
+		l.bytes = out
 		env.vm.sp--
 		return 1
 	}, "XOR BINARY(SP-2), BINARY(SP-1)")
@@ -369,9 +381,13 @@ func (asm *assembler) BitShiftRight_uu() {
 func (asm *assembler) BitwiseNot_b() {
 	asm.emit(func(env *ExpressionEnv) int {
 		a := env.vm.stack[env.vm.sp-1].(*evalBytes)
-		for i := range a.bytes {
-			a.bytes[i] = ^a.bytes[i]
+		// The result needs its own buffer: the operand's bytes are borrowed
+		// from a literal, a bind variable or the input row.
+		out := make([]byte, len(a.bytes))
+		for i := range out {
+			out[i] = ^a.bytes[i]
 		}
+		a.bytes = out
 		return 1
 	}, "BIT_NOT BINARY(SP-1)")
 }

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -204,13 +204,14 @@ func (asm *assembler) BitOp_and_bb() {
 			env.vm.err = errBitwiseOperandsLength
 			return 0
 		}
-		// The result needs its own buffer: the operands' bytes are borrowed
-		// from a literal, a bind variable or the input row.
+		// The result is a plain binary string of its own: the operands' bytes
+		// are borrowed from a literal, a bind variable or the input row, and
+		// their hex or bit literal markers do not carry over to the result.
 		out := make([]byte, len(l.bytes))
 		for i := range out {
 			out[i] = l.bytes[i] & r.bytes[i]
 		}
-		l.bytes = out
+		env.vm.stack[env.vm.sp-2] = env.vm.arena.newEvalBinary(out)
 		env.vm.sp--
 		return 1
 	}, "AND BINARY(SP-2), BINARY(SP-1)")
@@ -225,13 +226,14 @@ func (asm *assembler) BitOp_or_bb() {
 			env.vm.err = errBitwiseOperandsLength
 			return 0
 		}
-		// The result needs its own buffer: the operands' bytes are borrowed
-		// from a literal, a bind variable or the input row.
+		// The result is a plain binary string of its own: the operands' bytes
+		// are borrowed from a literal, a bind variable or the input row, and
+		// their hex or bit literal markers do not carry over to the result.
 		out := make([]byte, len(l.bytes))
 		for i := range out {
 			out[i] = l.bytes[i] | r.bytes[i]
 		}
-		l.bytes = out
+		env.vm.stack[env.vm.sp-2] = env.vm.arena.newEvalBinary(out)
 		env.vm.sp--
 		return 1
 	}, "OR BINARY(SP-2), BINARY(SP-1)")
@@ -246,13 +248,14 @@ func (asm *assembler) BitOp_xor_bb() {
 			env.vm.err = errBitwiseOperandsLength
 			return 0
 		}
-		// The result needs its own buffer: the operands' bytes are borrowed
-		// from a literal, a bind variable or the input row.
+		// The result is a plain binary string of its own: the operands' bytes
+		// are borrowed from a literal, a bind variable or the input row, and
+		// their hex or bit literal markers do not carry over to the result.
 		out := make([]byte, len(l.bytes))
 		for i := range out {
 			out[i] = l.bytes[i] ^ r.bytes[i]
 		}
-		l.bytes = out
+		env.vm.stack[env.vm.sp-2] = env.vm.arena.newEvalBinary(out)
 		env.vm.sp--
 		return 1
 	}, "XOR BINARY(SP-2), BINARY(SP-1)")

--- a/go/vt/vtgate/evalengine/expr_bit_test.go
+++ b/go/vt/vtgate/evalengine/expr_bit_test.go
@@ -47,6 +47,8 @@ var bitwiseOperandOwnership = []struct {
 	{name: "literal rhs", expression: `:l ^ _binary'!!'`, result: "`c"},
 }
 
+// bitwiseBindVars returns a fresh set of the operands the cases above use, so
+// that a case which corrupts one of them cannot affect any other case.
 func bitwiseBindVars() map[string]*querypb.BindVariable {
 	return map[string]*querypb.BindVariable{
 		"l": sqltypes.BytesBindVariable([]byte("AB")),

--- a/go/vt/vtgate/evalengine/expr_bit_test.go
+++ b/go/vt/vtgate/evalengine/expr_bit_test.go
@@ -102,7 +102,7 @@ func TestBitwiseBinaryRepeatedEvaluation(t *testing.T) {
 
 // TestBitwiseBinaryResultIsPlainBinary tests that the binary-string form of the
 // bitwise operators returns a plain binary string even when an operand is a hex
-// or bit literal. MySQL reads the result as a binary string, which is only true
+// or bit literal. MySQL 8.0+ reads the result as a binary string, which is only true
 // when its bytes parse as a non-zero number:
 //
 //	SELECT IF(X'FF' & _binary'A', 'true', 'false')  =>  false

--- a/go/vt/vtgate/evalengine/expr_bit_test.go
+++ b/go/vt/vtgate/evalengine/expr_bit_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package evalengine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/vtenv"
+)
+
+// bitwiseOperandOwnership covers the binary-string forms of the bitwise
+// operators, which produce a binary string of the same length as their
+// operands. The operand bytes are borrowed: they can belong to a literal in a
+// translated expression, to a bind variable, or to the input row, so an
+// operator that wrote its result over them would corrupt a value it does not
+// own. Every case uses the operands "AB" and "!!".
+var bitwiseOperandOwnership = []struct {
+	name       string
+	expression string
+	result     string
+}{
+	{name: "not", expression: `~:l`, result: "\xbe\xbd"},
+	{name: "and", expression: `:l & :r`, result: "\x01\x00"},
+	{name: "or", expression: `:l | :r`, result: "ac"},
+	{name: "xor", expression: `:l ^ :r`, result: "`c"},
+	{name: "literal lhs", expression: `_binary'AB' ^ :r`, result: "`c"},
+	{name: "literal rhs", expression: `:l ^ _binary'!!'`, result: "`c"},
+}
+
+func bitwiseBindVars() map[string]*querypb.BindVariable {
+	return map[string]*querypb.BindVariable{
+		"l": sqltypes.BytesBindVariable([]byte("AB")),
+		"r": sqltypes.BytesBindVariable([]byte("!!")),
+	}
+}
+
+// evaluateCompiled evaluates expr through the virtual machine. Translate only
+// returns a *CompiledExpr when it knows the types of the arguments, so an
+// untyped expression is compiled against env first.
+func evaluateCompiled(t *testing.T, env *ExpressionEnv, expr Expr) EvalResult {
+	t.Helper()
+
+	if untyped, ok := expr.(*UntypedExpr); ok {
+		compiled, err := untyped.Compile(env)
+		require.NoError(t, err)
+		expr = compiled
+	}
+	require.IsType(t, &CompiledExpr{}, expr)
+
+	res, err := env.Evaluate(expr)
+	require.NoError(t, err)
+	return res
+}
+
+// TestBitwiseBinaryRepeatedEvaluation evaluates one translated expression
+// several times against one bind variable map, the way a query evaluates an
+// expression once per row. Every evaluation must return the same result: the
+// operands do not change between them, and a translated expression is also
+// shared by concurrent queries through the plan cache.
+func TestBitwiseBinaryRepeatedEvaluation(t *testing.T) {
+	venv := vtenv.NewTestEnv()
+	coll := collations.MySQL8().DefaultConnectionCharset()
+
+	for _, tc := range bitwiseOperandOwnership {
+		t.Run(tc.name, func(t *testing.T) {
+			astExpr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+
+			t.Run("compiled", func(t *testing.T) {
+				translated, err := Translate(astExpr, &Config{Collation: coll, Environment: venv})
+				require.NoError(t, err)
+
+				bindVars := bitwiseBindVars()
+				for i := range 4 {
+					env := EmptyExpressionEnv(venv)
+					env.BindVars = bindVars
+
+					res := evaluateCompiled(t, env, translated)
+					require.Equalf(t, tc.result, res.Value(coll).ToString(), "evaluation %d", i)
+				}
+			})
+
+			t.Run("interpreted", func(t *testing.T) {
+				translated, err := Translate(astExpr, &Config{Collation: coll, Environment: venv})
+				require.NoError(t, err)
+
+				bindVars := bitwiseBindVars()
+				for i := range 4 {
+					env := EmptyExpressionEnv(venv)
+					env.BindVars = bindVars
+
+					res, err := env.EvaluateAST(translated)
+					require.NoError(t, err)
+					require.Equalf(t, tc.result, res.Value(coll).ToString(), "evaluation %d", i)
+				}
+			})
+		})
+	}
+}
+
+// TestBitwiseBinaryPreservesBindVars tests that evaluating a bitwise operator
+// leaves the caller's bind variables untouched. The same bind variable map
+// builds the queries sent to the shards, so writing through it would change the
+// query that is executed.
+func TestBitwiseBinaryPreservesBindVars(t *testing.T) {
+	venv := vtenv.NewTestEnv()
+	coll := collations.MySQL8().DefaultConnectionCharset()
+
+	for _, tc := range bitwiseOperandOwnership {
+		t.Run(tc.name, func(t *testing.T) {
+			astExpr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+			translated, err := Translate(astExpr, &Config{Collation: coll, Environment: venv})
+			require.NoError(t, err)
+
+			t.Run("compiled", func(t *testing.T) {
+				env := EmptyExpressionEnv(venv)
+				env.BindVars = bitwiseBindVars()
+
+				evaluateCompiled(t, env, translated)
+
+				require.Equal(t, []byte("AB"), env.BindVars["l"].Value)
+				require.Equal(t, []byte("!!"), env.BindVars["r"].Value)
+			})
+
+			t.Run("interpreted", func(t *testing.T) {
+				env := EmptyExpressionEnv(venv)
+				env.BindVars = bitwiseBindVars()
+
+				_, err := env.EvaluateAST(translated)
+				require.NoError(t, err)
+
+				require.Equal(t, []byte("AB"), env.BindVars["l"].Value)
+				require.Equal(t, []byte("!!"), env.BindVars["r"].Value)
+			})
+		})
+	}
+}
+
+// TestBitwiseBinaryPreservesRow tests that evaluating a bitwise operator leaves
+// the input row untouched. A row is read once per output column and is owned by
+// the result the input primitive returned, so writing through it would change
+// the values that other columns and later consumers observe.
+func TestBitwiseBinaryPreservesRow(t *testing.T) {
+	venv := vtenv.NewTestEnv()
+	coll := collations.MySQL8().DefaultConnectionCharset()
+	fields := FieldResolver([]*querypb.Field{
+		{Name: "l", Type: sqltypes.VarBinary, Charset: collations.CollationBinaryID},
+		{Name: "r", Type: sqltypes.VarBinary, Charset: collations.CollationBinaryID},
+	})
+
+	for _, expression := range []string{`~l`, `l & r`, `l | r`, `l ^ r`} {
+		t.Run(expression, func(t *testing.T) {
+			astExpr, err := venv.Parser().ParseExpr(expression)
+			require.NoError(t, err)
+			translated, err := Translate(astExpr, &Config{
+				ResolveColumn: fields.Column,
+				ResolveType:   fields.Type,
+				Collation:     coll,
+				Environment:   venv,
+			})
+			require.NoError(t, err)
+
+			newEnv := func() *ExpressionEnv {
+				env := NewExpressionEnv(t.Context(), nil, NewEmptyVCursor(venv, time.Local))
+				env.Row = []sqltypes.Value{
+					sqltypes.MakeTrusted(sqltypes.VarBinary, []byte("AB")),
+					sqltypes.MakeTrusted(sqltypes.VarBinary, []byte("!!")),
+				}
+				return env
+			}
+
+			t.Run("compiled", func(t *testing.T) {
+				env := newEnv()
+				evaluateCompiled(t, env, translated)
+
+				require.Equal(t, "AB", env.Row[0].ToString())
+				require.Equal(t, "!!", env.Row[1].ToString())
+			})
+
+			t.Run("interpreted", func(t *testing.T) {
+				env := newEnv()
+				_, err := env.EvaluateAST(translated)
+				require.NoError(t, err)
+
+				require.Equal(t, "AB", env.Row[0].ToString())
+				require.Equal(t, "!!", env.Row[1].ToString())
+			})
+		})
+	}
+}

--- a/go/vt/vtgate/evalengine/expr_bit_test.go
+++ b/go/vt/vtgate/evalengine/expr_bit_test.go
@@ -85,35 +85,67 @@ func TestBitwiseBinaryRepeatedEvaluation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			astExpr, err := venv.Parser().ParseExpr(tc.expression)
 			require.NoError(t, err)
+			translated, err := Translate(astExpr, &Config{Collation: coll, Environment: venv})
+			require.NoError(t, err)
 
-			t.Run("compiled", func(t *testing.T) {
-				translated, err := Translate(astExpr, &Config{Collation: coll, Environment: venv})
-				require.NoError(t, err)
+			bindVars := bitwiseBindVars()
+			for i := range 4 {
+				env := EmptyExpressionEnv(venv)
+				env.BindVars = bindVars
 
-				bindVars := bitwiseBindVars()
-				for i := range 4 {
-					env := EmptyExpressionEnv(venv)
-					env.BindVars = bindVars
+				res := evaluateCompiled(t, env, translated)
+				require.Equalf(t, tc.result, res.Value(coll).ToString(), "evaluation %d", i)
+			}
+		})
+	}
+}
 
-					res := evaluateCompiled(t, env, translated)
-					require.Equalf(t, tc.result, res.Value(coll).ToString(), "evaluation %d", i)
+// TestBitwiseBinaryResultIsPlainBinary tests that the binary-string form of the
+// bitwise operators returns a plain binary string even when an operand is a hex
+// or bit literal. MySQL reads the result as a binary string, which is only true
+// when its bytes parse as a non-zero number:
+//
+//	SELECT IF(X'FF' & _binary'A', 'true', 'false')  =>  false
+//	SELECT IF(X'41', 'true', 'false')               =>  true
+//
+// A result that carried the operand's hex or bit literal marker would instead be
+// read as the number 65 and come out true.
+func TestBitwiseBinaryResultIsPlainBinary(t *testing.T) {
+	venv := vtenv.NewTestEnv()
+	coll := collations.MySQL8().DefaultConnectionCharset()
+
+	for _, tc := range []struct {
+		expression string
+		result     string
+	}{
+		{expression: `x'ff' & :r`, result: "A"},
+		{expression: `b'11111111' & :r`, result: "A"},
+		{expression: `x'ff' | :r`, result: "\xff"},
+		{expression: `x'ff' ^ :r`, result: "\xbe"},
+	} {
+		t.Run(tc.expression, func(t *testing.T) {
+			astExpr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+			translated, err := Translate(astExpr, &Config{Collation: coll, Environment: venv})
+			require.NoError(t, err)
+
+			newEnv := func() *ExpressionEnv {
+				env := EmptyExpressionEnv(venv)
+				env.BindVars = map[string]*querypb.BindVariable{
+					"r": sqltypes.BytesBindVariable([]byte("A")),
 				}
-			})
+				return env
+			}
 
-			t.Run("interpreted", func(t *testing.T) {
-				translated, err := Translate(astExpr, &Config{Collation: coll, Environment: venv})
-				require.NoError(t, err)
+			interpreted, err := newEnv().EvaluateAST(translated)
+			require.NoError(t, err)
+			compiled := evaluateCompiled(t, newEnv(), translated)
 
-				bindVars := bitwiseBindVars()
-				for i := range 4 {
-					env := EmptyExpressionEnv(venv)
-					env.BindVars = bindVars
+			require.Equal(t, tc.result, interpreted.Value(coll).ToString())
+			require.Equal(t, tc.result, compiled.Value(coll).ToString())
 
-					res, err := env.EvaluateAST(translated)
-					require.NoError(t, err)
-					require.Equalf(t, tc.result, res.Value(coll).ToString(), "evaluation %d", i)
-				}
-			})
+			require.False(t, interpreted.ToBoolean())
+			require.False(t, compiled.ToBoolean())
 		})
 	}
 }


### PR DESCRIPTION
## Description

The compiled instructions for `&`, `|`, `^` and `~` over binary strings wrote their result over the left operand's bytes:

```go
for i := range l.bytes {
    l.bytes[i] = l.bytes[i] ^ r.bytes[i]
}
```

The virtual machine only borrows those bytes, so the instructions corrupt values they don't own. Three ways this shows up today, all on the compiled path only — the interpreted implementations already build the result in a fresh buffer:

| expression | what gets corrupted |
| --- | --- |
| `_binary'AB' ^ :r` | the literal inside the translated expression, so results alternate from row to row, and concurrent queries sharing the cached plan race on it |
| `~:l` | the caller's bind variable, which is also what builds the queries sent to the shards |
| `~c` | the input row, which later output columns and consumers still read |

Each operator now builds its result in its own buffer and swaps it in, the same way the neighbouring `BitShiftLeft_bu` and `BitShiftRight_bu` instructions already do. That costs one allocation per operation, which the interpreted path already pays and which the semantics require anyway — the result is a new value, not an update of the operand.

## The result was also inheriting the operand's literal marker

Reusing the left operand didn't just share its buffer, it kept its `flagHex`/`flagBit` — and those decide how a value converts to a boolean (`evalIsTruthy`). For `&`, `|` and `^` a hex or bit literal on the left reaches the binary-string path whenever the right operand is an ordinary binary string, so the marker carried over to a result that is a plain binary string, and the two evaluation paths disagreed:

```
x'ff' & :r       with r = 'A'    compiled=VARBINARY("A") true    interpreted=VARBINARY("A") false
b'11111111' & :r with r = 'A'    compiled=VARBINARY("A") true    interpreted=VARBINARY("A") false
```

MySQL 8.0+ agrees with the interpreted path — the result of a binary-string bitwise operation is a binary string, so it is only true when its bytes parse as a non-zero number:

```
mysql> SELECT IF(X'FF' & _binary'A', 'true', 'false'), IF(X'41', 'true', 'false');
+-----------------------------------------+----------------------------+
| false                                   | true                       |
+-----------------------------------------+----------------------------+
```

It is also what the compiled path already declares: `compileBinary` returns `ctype{Type: VarBinary, Col: collationBinary}` with no flags, so only the runtime value was out of step. Anything *inside* a compiled program picks its boolean conversion from that static type and so behaved correctly; the divergence is visible at the boundary, where `EvalResult.ToBoolean()` reads the runtime value — which is the conversion `Filter` uses to decide which rows survive.

The three instructions now install a fresh binary result rather than reusing the operand's value, which fixes the marker and the buffer in one go. `~` and the shifts need no equivalent change: their compile paths require the operand *not* to be a hex or bit literal, so they can never receive a marked operand.

This half is pre-existing rather than something the aliasing fix introduced — `main` reuses the operand too — but it is the same line of code, so it is fixed here rather than in a third PR.

## Clearing arena entries

Installing a fresh result means allocating from `env.vm.arena`, and the arena is reset once per evaluation and then hands the same entries out again. Its constructors set only the fields they take an argument for, so an entry kept the markers of whatever value used it last. Two of them were affected:

- `newEvalBytesEmpty` left `flag` alone while setting the type, the collation and the bytes. `PushLiteral` parks whole literals in these entries (`*b = *lit`), markers included, so this one had a live writer — an entry really could be holding `flagHex` when it was handed out as a plain binary string.
- `newEvalInt64` left `bitLiteral` alone. Its twin `newEvalUint64` already cleared `hexLiteral`, so this was an asymmetry rather than a considered difference.

Both now clear as they hand the entry out, which covers every caller rather than just the instructions touched here, and `reset()` states the constructors' side of the contract.

Neither is reachable through a query as things stand. For `evalBytes` the entry sequence is deterministic for a given program, so it needs two different programs sharing one `ExpressionEnv` and colliding on an index, which I could not construct. For `evalInt64` nothing can set the marker on an arena entry at all: the only writer is `toNumericBit`, which does not allocate from the arena, and the only reader is `negate()` on the interpreted path. They are pinned by unit tests on the arena contract instead. A string-heavy benchmark (`concat`/`substr`/`lpad` over the compiled path) shows no measurable cost and identical allocation counts.

## Tests

The new tests cover all four operators: repeated evaluation against a single bind variable map, the way a query evaluates an expression once per row, plus explicit assertions that the bind variables and the input row are unchanged, and that a binary-string bitwise result converts to a boolean as a plain binary string. They all fail on `main`.

`json.Value.StringBytes` also grew a note that its result aliases the document and must not be written to. That method is how a JSON document's bytes reach a mutable `evalBytes` (via `JSON_UNQUOTE`), and it was the route by which these instructions could reach a folded JSON document, so the constraint is worth stating where the slice is handed out.

## Related Issue(s)

Fixes #20698

Found while reviewing #20682. That change makes constant-folded JSON documents reachable from the compiled path, at which point `~cast(json_unquote(json_extract(json_array('AB'), :p)) as binary(2))` corrupts the folded literal too. With this fix in place that no longer happens, so #20682 needs no change of its own for it.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

Backport justification: the bind variable and input row corruption need nothing but a binary-string bitwise operator on the compiled path, so both are reachable on the release branches as they stand. They produce wrong results silently and race across concurrent queries, with no workaround other than avoiding the operators. The literal-marker divergence needs only a hex or bit literal on the left of `&`, `|` or `^`, and changes which rows a filter keeps.

## Deployment Notes

Queries using `&`, `|`, `^` or `~` on binary strings at VTGate can have been returning wrong values for rows after the first, and can have altered the queries sent to the shards. A binary-string `&`, `|` or `^` with a hex or bit literal on the left can also have been treated as true where MySQL 8.0+ treats it as false, which changes which rows a `WHERE` clause keeps. No migrations or configuration changes.

### AI Disclosure

Claude Code found the bugs while reviewing #20682, wrote the fixes and the tests, and verified each case reproduces on `main` and against MySQL. I provided direction and reviewed the result. The literal-marker bug came out of @GrahamCampbell's review, and the arena entries were audited field by field from there.

