### PR TITLE
evalengine: stop RPAD growing its operand in place

### DIFF
--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -30,6 +30,7 @@ import (
 	"math"
 	"math/bits"
 	"net/netip"
+	"slices"
 	"strconv"
 	"time"
 
@@ -3020,10 +3021,13 @@ func (asm *assembler) Fn_RPAD(col collations.TypedCollation) {
 		repeat := (l - strLen) / runeLen
 		remainder := (l - strLen) % runeLen
 
-		str.bytes = append(str.bytes, bytes.Repeat(pad.bytes, repeat)...)
+		padding := bytes.Repeat(pad.bytes, repeat)
 		if remainder > 0 {
-			str.bytes = append(str.bytes, charset.Slice(cs, pad.bytes, 0, remainder)...)
+			padding = append(padding, charset.Slice(cs, pad.bytes, 0, remainder)...)
 		}
+		// The result needs its own buffer: str.bytes is borrowed from the input
+		// row or a bind variable, where the next value follows it in memory.
+		str.bytes = slices.Concat(str.bytes, padding)
 
 		env.vm.sp -= 2
 		return 1

--- a/go/vt/vtgate/evalengine/fn_string.go
+++ b/go/vt/vtgate/evalengine/fn_string.go
@@ -19,6 +19,7 @@ package evalengine
 import (
 	"bytes"
 	"math"
+	"slices"
 
 	"vitess.io/vitess/go/mysql/capabilities"
 	"vitess.io/vitess/go/mysql/collations"
@@ -1267,7 +1268,10 @@ func (call *builtinPad) eval(env *ExpressionEnv) (eval, error) {
 
 	var res []byte
 	if !call.left {
-		res = text.bytes
+		// The result needs its own buffer: text.bytes is borrowed from the
+		// input row or a bind variable, where the next value follows it in
+		// memory.
+		res = slices.Clone(text.bytes)
 	}
 
 	res = append(res, bytes.Repeat(pad.bytes, repeat)...)

--- a/go/vt/vtgate/evalengine/fn_string.go
+++ b/go/vt/vtgate/evalengine/fn_string.go
@@ -1266,21 +1266,19 @@ func (call *builtinPad) eval(env *ExpressionEnv) (eval, error) {
 	repeat := (int(length) - strLen) / runeLen
 	remainder := (int(length) - strLen) % runeLen
 
+	padding := bytes.Repeat(pad.bytes, repeat)
+	if remainder > 0 {
+		padding = append(padding, charset.Slice(cs, pad.bytes, 0, remainder)...)
+	}
+
 	var res []byte
-	if !call.left {
+	if call.left {
+		res = append(padding, text.bytes...)
+	} else {
 		// The result needs its own buffer: text.bytes is borrowed from the
 		// input row or a bind variable, where the next value follows it in
 		// memory.
-		res = slices.Clone(text.bytes)
-	}
-
-	res = append(res, bytes.Repeat(pad.bytes, repeat)...)
-	if remainder > 0 {
-		res = append(res, charset.Slice(cs, pad.bytes, 0, remainder)...)
-	}
-
-	if call.left {
-		res = append(res, text.bytes...)
+		res = slices.Concat(text.bytes, padding)
 	}
 
 	return newEvalText(res, text.col), nil

--- a/go/vt/vtgate/evalengine/fn_string_test.go
+++ b/go/vt/vtgate/evalengine/fn_string_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package evalengine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/vtenv"
+)
+
+// TestPadPreservesRow tests that LPAD and RPAD leave the input row untouched.
+// The values of a row share one buffer, so every value but the last is followed
+// in memory by the next one: padding that grew its operand in place would write
+// over the column that comes after it.
+func TestPadPreservesRow(t *testing.T) {
+	venv := vtenv.NewTestEnv()
+	coll := collations.MySQL8().DefaultConnectionCharset()
+	fields := []*querypb.Field{
+		{Name: "l", Type: sqltypes.VarChar, Charset: collations.CollationUtf8mb4ID},
+		{Name: "r", Type: sqltypes.VarChar, Charset: collations.CollationUtf8mb4ID},
+	}
+	resolver := FieldResolver(fields)
+
+	testCases := []struct {
+		expression string
+		result     string
+	}{
+		{expression: `rpad(l, 4, 'x')`, result: "ABxx"},
+		{expression: `rpad(l, 5, 'xy')`, result: "ABxyx"},
+		{expression: `lpad(l, 4, 'x')`, result: "xxAB"},
+		{expression: `lpad(l, 5, 'xy')`, result: "xyxAB"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.expression, func(t *testing.T) {
+			astExpr, err := venv.Parser().ParseExpr(tc.expression)
+			require.NoError(t, err)
+			translated, err := Translate(astExpr, &Config{
+				ResolveColumn: resolver.Column,
+				ResolveType:   resolver.Type,
+				Collation:     coll,
+				Environment:   venv,
+			})
+			require.NoError(t, err)
+
+			// A row as it arrives from a shard: one buffer holding every value,
+			// so "AB" is backed by spare capacity that runs into "CD".
+			newEnv := func() *ExpressionEnv {
+				env := NewExpressionEnv(t.Context(), nil, NewEmptyVCursor(venv, time.Local))
+				env.Row = sqltypes.MakeRowTrusted(fields, &querypb.Row{
+					Lengths: []int64{2, 2},
+					Values:  []byte("ABCD"),
+				})
+				return env
+			}
+
+			t.Run("compiled", func(t *testing.T) {
+				env := newEnv()
+				require.IsType(t, &CompiledExpr{}, translated)
+
+				res, err := env.Evaluate(translated)
+				require.NoError(t, err)
+
+				require.Equal(t, tc.result, res.Value(coll).ToString())
+				require.Equal(t, "AB", env.Row[0].ToString())
+				require.Equal(t, "CD", env.Row[1].ToString())
+			})
+
+			t.Run("interpreted", func(t *testing.T) {
+				env := newEnv()
+
+				res, err := env.EvaluateAST(translated)
+				require.NoError(t, err)
+
+				require.Equal(t, tc.result, res.Value(coll).ToString())
+				require.Equal(t, "AB", env.Row[0].ToString())
+				require.Equal(t, "CD", env.Row[1].ToString())
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Description

`RPAD` appended its padding to the string it was handed:

```go
str.bytes = append(str.bytes, bytes.Repeat(pad.bytes, repeat)...)
```

The evalengine only borrows those bytes, and when they come from a result row they have the next column sitting right behind them — `MakeRowTrusted` hands every value of a row a slice of one shared buffer, so all but the last have spare capacity that runs into their neighbour. Appending in place therefore writes the padding over the following column.

With a row holding `"AB"` and `"CD"`, `rpad(l, 4, 'x')` returns `"ABxx"` and leaves the second column reading `"xx"` instead of `"CD"`.

Both implementations had this: the compiled `Fn_RPAD` and the interpreted `builtinPad.eval`, so there was no safe path to fall back to. `LPAD` was never affected — it builds the padding first and appends the operand onto it. `RPAD` now does the same, which also makes the two symmetric, at the same allocation cost `LPAD` already paid.

I swept the rest of the evalengine for the same shape — anything appending onto, or copying into, bytes it borrows rather than owns — and `RPAD` was the only one.

The test builds its row with `MakeRowTrusted` from a `querypb.Row` rather than hand-rolling a subslice, so it reproduces the layout rows actually arrive in. It covers `RPAD` and `LPAD` with single- and multi-byte padding across both evaluation paths. On `main` the four `RPAD` cases fail and the four `LPAD` cases pass.

### Left alone

When the string is already at least as long as the requested length, `RPAD` returns `charset.Slice(cs, str.bytes, 0, l)`, which aliases the input row. That is a read-only alias and nothing writes through it once the append is fixed, so making it copy would only add cost to the common truncating path.

## Related Issue(s)

Fixes #20699

Found while auditing the evalengine for in-place writes over borrowed memory, alongside #20696. The two are independent — different functions, different mechanism (`append` into spare capacity rather than writing through an index) — and neither depends on the other.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

Backport justification: this needs nothing but an `RPAD` over a column evaluated at VTGate, so it is reachable on the release branches as they stand. It silently returns wrong data for a column the query did not even apply a function to, and both evaluation paths are affected, so there is no configuration that avoids it.

## Deployment Notes

Queries that apply `RPAD` to a column at VTGate — rather than pushing it down to MySQL — could return corrupted values for the columns selected after it. No migrations or configuration changes.

### AI Disclosure

Claude Code found the bug while auditing the evalengine for writes over borrowed memory, wrote the fix and the tests, and confirmed the failure reproduces on `main` for `RPAD` and not for `LPAD`. I provided direction and reviewed the result.

