### PR TITLE
Keep the surrounding predicate when pulling out EXISTS

### DIFF
--- a/go/vt/vtgate/engine/opcode/constants.go
+++ b/go/vt/vtgate/engine/opcode/constants.go
@@ -54,6 +54,12 @@ func (code PulloutOpcode) NeedsListArg() bool {
 	return code == PulloutIn || code == PulloutNotIn
 }
 
+// NeedsExistsArg reports whether the pullout replaces an EXISTS predicate,
+// in which case the whole ExistsExpr is substituted by the has-values argument.
+func (code PulloutOpcode) NeedsExistsArg() bool {
+	return code == PulloutExists || code == PulloutNotExists
+}
+
 // MarshalJSON serializes the PulloutOpcode as a JSON string.
 // It's used for testing and diagnostics.
 func (code PulloutOpcode) MarshalJSON() ([]byte, error) {

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -267,6 +267,14 @@ func (sq *SubQuery) settleFilter(ctx *plancontext.PlanningContext, outer Operato
 				}
 			}
 		}
+		// EXISTS is a predicate in its own right, so the has-values argument
+		// replaces the whole ExistsExpr. Replacing only the inner Subquery
+		// would leave an EXISTS around a bind variable behind.
+		if _, isExists := node.(*sqlparser.ExistsExpr); isExists && sq.FilterType.NeedsExistsArg() {
+			cursor.Replace(sqlparser.NewArgument(hasValuesArg()))
+			return
+		}
+
 		if _, ok := node.(*sqlparser.Subquery); !ok {
 			return
 		}
@@ -285,11 +293,11 @@ func (sq *SubQuery) settleFilter(ctx *plancontext.PlanningContext, outer Operato
 	switch sq.FilterType {
 	case opcode.PulloutExists:
 		sq.addLimit()
-		predicates = append(predicates, sqlparser.NewArgument(hasValuesArg()))
+		predicates = append(predicates, rhsPred)
 	case opcode.PulloutNotExists:
 		sq.addLimit()
 		sq.FilterType = opcode.PulloutExists // it's the same pullout as EXISTS, just with a NOT in front of the predicate
-		predicates = append(predicates, sqlparser.NewNotExpr(sqlparser.NewArgument(hasValuesArg())))
+		predicates = append(predicates, rhsPred)
 	case opcode.PulloutIn:
 		// Because we replace the comparison expression with an AND expression, it might be the top level construct there.
 		// In this case, it is better to send the two sides of the AND expression separately in the predicates because it can

--- a/go/vt/vtgate/planbuilder/operators/subquery.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery.go
@@ -237,6 +237,19 @@ func (sq *SubQuery) addLimit() {
 	sq.Subquery = newLimit(sq.Subquery, &sqlparser.Limit{Rowcount: sqlparser.NewIntLiteral("1")}, true)
 }
 
+// countSubqueries reports how many subqueries a predicate holds. A SubQuery carries a
+// single has-values argument, so a predicate with more than one cannot be rebuilt from it.
+func countSubqueries(expr sqlparser.Expr) (count int) {
+	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+		if _, ok := node.(*sqlparser.Subquery); ok {
+			count++
+			return false, nil
+		}
+		return true, nil
+	}, expr)
+	return count
+}
+
 func (sq *SubQuery) settleFilter(ctx *plancontext.PlanningContext, outer Operator) Operator {
 	if len(sq.Predicates) > 0 {
 		if sq.FilterType != opcode.PulloutExists {
@@ -245,6 +258,10 @@ func (sq *SubQuery) settleFilter(ctx *plancontext.PlanningContext, outer Operato
 		sq.addLimit()
 		return outer
 	}
+
+	// With several subqueries in one predicate there is no single has-values argument to
+	// rebuild it from, so those keep the previous behaviour rather than a broken plan.
+	rebuildPredicate := sq.FilterType.NeedsExistsArg() && countSubqueries(sq.Original) == 1
 
 	hasValuesArg := func() string {
 		s := ctx.ReservedVars.ReserveVariable(string(sqlparser.HasValueSubQueryBaseName))
@@ -270,7 +287,7 @@ func (sq *SubQuery) settleFilter(ctx *plancontext.PlanningContext, outer Operato
 		// EXISTS is a predicate in its own right, so the has-values argument
 		// replaces the whole ExistsExpr. Replacing only the inner Subquery
 		// would leave an EXISTS around a bind variable behind.
-		if _, isExists := node.(*sqlparser.ExistsExpr); isExists && sq.FilterType.NeedsExistsArg() {
+		if _, isExists := node.(*sqlparser.ExistsExpr); isExists && rebuildPredicate {
 			cursor.Replace(sqlparser.NewArgument(hasValuesArg()))
 			return
 		}
@@ -293,11 +310,19 @@ func (sq *SubQuery) settleFilter(ctx *plancontext.PlanningContext, outer Operato
 	switch sq.FilterType {
 	case opcode.PulloutExists:
 		sq.addLimit()
-		predicates = append(predicates, rhsPred)
+		if rebuildPredicate {
+			predicates = append(predicates, rhsPred)
+		} else {
+			predicates = append(predicates, sqlparser.NewArgument(hasValuesArg()))
+		}
 	case opcode.PulloutNotExists:
 		sq.addLimit()
 		sq.FilterType = opcode.PulloutExists // it's the same pullout as EXISTS, just with a NOT in front of the predicate
-		predicates = append(predicates, rhsPred)
+		if rebuildPredicate {
+			predicates = append(predicates, rhsPred)
+		} else {
+			predicates = append(predicates, sqlparser.NewNotExpr(sqlparser.NewArgument(hasValuesArg())))
+		}
 	case opcode.PulloutIn:
 		// Because we replace the comparison expression with an AND expression, it might be the top level construct there.
 		// In this case, it is better to send the two sides of the AND expression separately in the predicates because it can

--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -240,7 +240,10 @@ func tryPushSubQueryInJoin(
 	// we want to push the subquery as close to its needs
 	// as possible, so that we can potentially merge them together
 	// TODO: we need to check dependencies and break apart all expressions in the subquery, not just the merge predicates
-	deps := semantics.EmptyTableSet()
+	// The predicate that gets restored once the subquery is settled needs every table it
+	// mentions, not just the ones in the merge predicates, or it lands on a route that
+	// cannot see them.
+	deps := ctx.SemTable.RecursiveDeps(inner.Original)
 	for _, predicate := range inner.GetMergePredicates() {
 		deps = deps.Merge(ctx.SemTable.RecursiveDeps(predicate))
 	}

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -5120,5 +5120,155 @@
         "user.user_extra"
       ]
     }
+  },
+  {
+    "comment": "EXISTS inside a CASE keeps the rest of the predicate",
+    "query": "select u.col from `user` as u where (case when exists (select 1 from user_extra) then u.col else true end) <=> null",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select u.col from `user` as u where (case when exists (select 1 from user_extra) then u.col else true end) <=> null",
+      "Instructions": {
+        "OperatorType": "UncorrelatedSubquery",
+        "Variant": "PulloutExists",
+        "PulloutVars": [
+          "__sq_has_values"
+        ],
+        "Inputs": [
+          {
+            "InputName": "SubQuery",
+            "OperatorType": "Limit",
+            "Count": "1",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select 1 from user_extra where 1 != 1",
+                "Query": "select 1 from user_extra limit 1"
+              }
+            ]
+          },
+          {
+            "InputName": "Outer",
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select u.col from `user` as u where 1 != 1",
+            "Query": "select u.col from `user` as u where case when :__sq_has_values then u.col else true end <=> null"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "EXISTS on one side of an OR keeps the other side",
+    "query": "select u.col from `user` as u where u.id = 5 or exists (select 1 from user_extra)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select u.col from `user` as u where u.id = 5 or exists (select 1 from user_extra)",
+      "Instructions": {
+        "OperatorType": "UncorrelatedSubquery",
+        "Variant": "PulloutExists",
+        "PulloutVars": [
+          "__sq_has_values"
+        ],
+        "Inputs": [
+          {
+            "InputName": "SubQuery",
+            "OperatorType": "Limit",
+            "Count": "1",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select 1 from user_extra where 1 != 1",
+                "Query": "select 1 from user_extra limit 1"
+              }
+            ]
+          },
+          {
+            "InputName": "Outer",
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select u.col from `user` as u where 1 != 1",
+            "Query": "select u.col from `user` as u where u.id = 5 or :__sq_has_values"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "NOT EXISTS on one side of an OR keeps the other side",
+    "query": "select u.col from `user` as u where u.id = 5 or not exists (select 1 from user_extra)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select u.col from `user` as u where u.id = 5 or not exists (select 1 from user_extra)",
+      "Instructions": {
+        "OperatorType": "UncorrelatedSubquery",
+        "Variant": "PulloutExists",
+        "PulloutVars": [
+          "__sq_has_values"
+        ],
+        "Inputs": [
+          {
+            "InputName": "SubQuery",
+            "OperatorType": "Limit",
+            "Count": "1",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select 1 from user_extra where 1 != 1",
+                "Query": "select 1 from user_extra limit 1"
+              }
+            ]
+          },
+          {
+            "InputName": "Outer",
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select u.col from `user` as u where 1 != 1",
+            "Query": "select u.col from `user` as u where u.id = 5 or not :__sq_has_values"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -5270,5 +5270,83 @@
         "user.user_extra"
       ]
     }
+  },
+  {
+    "comment": "EXISTS in a join condition keeps the filter above the join",
+    "query": "select u.col from `user` as u join music as m on u.id = m.user_id or exists (select 1 from user_extra)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select u.col from `user` as u join music as m on u.id = m.user_id or exists (select 1 from user_extra)",
+      "Instructions": {
+        "OperatorType": "UncorrelatedSubquery",
+        "Variant": "PulloutExists",
+        "PulloutVars": [
+          "__sq_has_values"
+        ],
+        "Inputs": [
+          {
+            "InputName": "SubQuery",
+            "OperatorType": "Limit",
+            "Count": "1",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select 1 from user_extra where 1 != 1",
+                "Query": "select 1 from user_extra limit 1"
+              }
+            ]
+          },
+          {
+            "InputName": "Outer",
+            "OperatorType": "Filter",
+            "Predicate": "u.id = m.user_id or :__sq_has_values",
+            "ResultColumns": 1,
+            "Inputs": [
+              {
+                "OperatorType": "Join",
+                "Variant": "Join",
+                "JoinColumnIndexes": "L:0,L:1,R:0",
+                "JoinVars": {
+                  "u_id": 1
+                },
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select u.col, u.id from `user` as u where 1 != 1",
+                    "Query": "select u.col, u.id from `user` as u"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "Scatter",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select m.user_id from music as m where 1 != 1",
+                    "Query": "select m.user_id from music as m"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user",
+        "user.user_extra"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Description

`settleFilter` builds `rhsPred` by walking `sq.Original` and substituting the subquery placeholders. Every opcode arm uses `rhsPred` except `PulloutExists` and `PulloutNotExists`, which appended a bare `:__sq_has_values` and threw the rest of the predicate away. On a sharded keyspace that silently drops half of a predicate, and vtgate returns the wrong rows:

| query | planned before | planned now |
|---|---|---|
| `WHERE (CASE WHEN EXISTS (…) THEN u.col ELSE true END) <=> NULL` | `WHERE :__sq_has_values` | `WHERE CASE WHEN :__sq_has_values THEN u.col ELSE true END <=> NULL` |
| `WHERE u.id = 5 OR EXISTS (…)` | `WHERE :__sq_has_values` | `WHERE u.id = 5 OR :__sq_has_values` |
| `WHERE u.id = 5 OR NOT EXISTS (…)` | `WHERE NOT :__sq_has_values` | `WHERE u.id = 5 OR NOT :__sq_has_values` |

The `post` callback now replaces the whole `*sqlparser.ExistsExpr` rather than only the inner `Subquery`, so `rhsPred` is well formed for those two opcodes too, and both arms use it. A top-level `EXISTS(...)` reduces `rhsPred` to the bare argument and a top-level `NOT EXISTS(...)` to the negated argument, which is what the arms produced before, so no existing plan changes. The whole planbuilder golden suite passes with no regeneration.

This is the same root cause and essentially the same fix as #20042, which the stale bot closed in July before anyone reviewed it — credit to @arthurschreiber for diagnosing it first. That PR also carried a `subqueryGroup` refactor to coordinate several subqueries extracted from one predicate, and Codecov flagged it at 0% patch coverage. This is the narrow version: three plan tests that fail without it, and no new machinery.

## Known limitation: several subqueries in one predicate

A predicate holding more than one subquery is left planning exactly as it does today. `getSubQuery` returns only the first match and `handleSubquery` runs once per predicate, so in a shape like `u.id = 5 OR EXISTS (q1) OR EXISTS (q2)` there is never an operator for `q2`, and no single has-values argument to rebuild the predicate from. `settleFilter` detects that with `countSubqueries` and keeps the previous bare-argument behaviour rather than substituting into a predicate it cannot complete.

That shape plans to `WHERE :__sq_has_values` both on `main` and with this PR, `u.id = 5` and the second `EXISTS` are dropped, and `music` does not even reach `TablesUsed`:

```sql
select u.col from user u
where u.id = 5
   or exists (select 1 from user_extra ue where ue.col = 1)
   or exists (select 1 from music m where m.col = 2)
```
So it is an untouched pre-existing bug, not a regression, but it is not fixed here either. An earlier version of this description claimed this case planned correctly and used that to argue the #20042 refactor might be unnecessary, that was wrong on both counts. Coordinating sibling subqueries needs that machinery, and I have left it out of scope rather than pretending the narrow fix covers it.

## Related Issue(s)

Fixes #19536

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Queries matching these shapes previously returned wrong rows and will now return correct ones, so results change for affected users. Worth a release-note callout.

### AI Disclosure

AI-assisted: the comments, pr text and its tests were written with Claude Code, from a diagnosis and fix I had worked out beforehand and reviewed afterwards.