### PR TITLE
vtgate: don't panic on recursive CTEs with an unexpandable star seed

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/cte_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/cte_cases.json
@@ -2513,11 +2513,11 @@
   },
   {
     "comment": "Recursive CTE whose seed selects * from a table without authoritative columns",
-    "query": "WITH RECURSIVE x AS (SELECT * FROM user UNION SELECT id + 1 FROM x WHERE id < 10) SELECT id FROM x",
+    "query": "WITH RECURSIVE x AS (SELECT * FROM user_metadata UNION ALL SELECT id + 1 FROM x WHERE id < 10) SELECT id FROM x",
     "plan": {
       "Type": "Scatter",
       "QueryType": "SELECT",
-      "Original": "WITH RECURSIVE x AS (SELECT * FROM user UNION SELECT id + 1 FROM x WHERE id < 10) SELECT id FROM x",
+      "Original": "WITH RECURSIVE x AS (SELECT * FROM user_metadata UNION ALL SELECT id + 1 FROM x WHERE id < 10) SELECT id FROM x",
       "Instructions": {
         "OperatorType": "Route",
         "Variant": "Scatter",
@@ -2525,21 +2525,21 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "with recursive x as (select * from `user` where 1 != 1 union select id + 1 from x where 1 != 1) select id from x where 1 != 1",
-        "Query": "with recursive x as (select * from `user` union select id + 1 from x where id < 10) select id from x"
+        "FieldQuery": "with recursive x as (select * from user_metadata where 1 != 1 union all select id + 1 from x where 1 != 1) select id from x where 1 != 1",
+        "Query": "with recursive x as (select * from user_metadata union all select id + 1 from x where id < 10) select id from x"
       },
       "TablesUsed": [
-        "user.user"
+        "user.user_metadata"
       ]
     }
   },
   {
     "comment": "Recursive CTE with a declared column list whose seed selects * from a table without authoritative columns",
-    "query": "WITH RECURSIVE x(a) AS (SELECT * FROM user UNION SELECT a + 1 FROM x WHERE a < 10) SELECT a FROM x",
+    "query": "WITH RECURSIVE x(a) AS (SELECT * FROM user_metadata UNION ALL SELECT a + 1 FROM x WHERE a < 10) SELECT a FROM x",
     "plan": {
       "Type": "Scatter",
       "QueryType": "SELECT",
-      "Original": "WITH RECURSIVE x(a) AS (SELECT * FROM user UNION SELECT a + 1 FROM x WHERE a < 10) SELECT a FROM x",
+      "Original": "WITH RECURSIVE x(a) AS (SELECT * FROM user_metadata UNION ALL SELECT a + 1 FROM x WHERE a < 10) SELECT a FROM x",
       "Instructions": {
         "OperatorType": "Route",
         "Variant": "Scatter",
@@ -2547,11 +2547,11 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "with recursive x(a) as (select * from `user` where 1 != 1 union select a + 1 from x where 1 != 1) select a from x where 1 != 1",
-        "Query": "with recursive x(a) as (select * from `user` union select a + 1 from x where a < 10) select a from x"
+        "FieldQuery": "with recursive x(a) as (select * from user_metadata where 1 != 1 union all select a + 1 from x where 1 != 1) select a from x where 1 != 1",
+        "Query": "with recursive x(a) as (select * from user_metadata union all select a + 1 from x where a < 10) select a from x"
       },
       "TablesUsed": [
-        "user.user"
+        "user.user_metadata"
       ]
     }
   }

--- a/go/vt/vtgate/planbuilder/testdata/cte_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/cte_cases.json
@@ -2513,11 +2513,11 @@
   },
   {
     "comment": "Recursive CTE whose seed selects * from a table without authoritative columns",
-    "query": "WITH RECURSIVE x AS (SELECT * FROM user_metadata UNION ALL SELECT id + 1 FROM x WHERE id < 10) SELECT id FROM x",
+    "query": "WITH RECURSIVE x AS (SELECT * FROM user_metadata UNION ALL SELECT user_id + 1, email, address, md5, non_planable FROM x WHERE user_id < 10) SELECT user_id FROM x",
     "plan": {
       "Type": "Scatter",
       "QueryType": "SELECT",
-      "Original": "WITH RECURSIVE x AS (SELECT * FROM user_metadata UNION ALL SELECT id + 1 FROM x WHERE id < 10) SELECT id FROM x",
+      "Original": "WITH RECURSIVE x AS (SELECT * FROM user_metadata UNION ALL SELECT user_id + 1, email, address, md5, non_planable FROM x WHERE user_id < 10) SELECT user_id FROM x",
       "Instructions": {
         "OperatorType": "Route",
         "Variant": "Scatter",
@@ -2525,30 +2525,8 @@
           "Name": "user",
           "Sharded": true
         },
-        "FieldQuery": "with recursive x as (select * from user_metadata where 1 != 1 union all select id + 1 from x where 1 != 1) select id from x where 1 != 1",
-        "Query": "with recursive x as (select * from user_metadata union all select id + 1 from x where id < 10) select id from x"
-      },
-      "TablesUsed": [
-        "user.user_metadata"
-      ]
-    }
-  },
-  {
-    "comment": "Recursive CTE with a declared column list whose seed selects * from a table without authoritative columns",
-    "query": "WITH RECURSIVE x(a) AS (SELECT * FROM user_metadata UNION ALL SELECT a + 1 FROM x WHERE a < 10) SELECT a FROM x",
-    "plan": {
-      "Type": "Scatter",
-      "QueryType": "SELECT",
-      "Original": "WITH RECURSIVE x(a) AS (SELECT * FROM user_metadata UNION ALL SELECT a + 1 FROM x WHERE a < 10) SELECT a FROM x",
-      "Instructions": {
-        "OperatorType": "Route",
-        "Variant": "Scatter",
-        "Keyspace": {
-          "Name": "user",
-          "Sharded": true
-        },
-        "FieldQuery": "with recursive x(a) as (select * from user_metadata where 1 != 1 union all select a + 1 from x where 1 != 1) select a from x where 1 != 1",
-        "Query": "with recursive x(a) as (select * from user_metadata union all select a + 1 from x where a < 10) select a from x"
+        "FieldQuery": "with recursive x as (select * from user_metadata where 1 != 1 union all select user_id + 1, email, address, md5, non_planable from x where 1 != 1) select user_id from x where 1 != 1",
+        "Query": "with recursive x as (select * from user_metadata union all select user_id + 1, email, address, md5, non_planable from x where user_id < 10) select user_id from x"
       },
       "TablesUsed": [
         "user.user_metadata"

--- a/go/vt/vtgate/planbuilder/testdata/cte_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/cte_cases.json
@@ -2510,5 +2510,49 @@
         "Query": "select a from (select 1 from dual union all select 2 from dual) as dt(a) where exists (with recursive qn as (select a * 0 as b from dual union all select b + 1 from qn where b = 0) select 1 from qn where b = a)"
       }
     }
+  },
+  {
+    "comment": "Recursive CTE whose seed selects * from a table without authoritative columns",
+    "query": "WITH RECURSIVE x AS (SELECT * FROM user UNION SELECT id + 1 FROM x WHERE id < 10) SELECT id FROM x",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "WITH RECURSIVE x AS (SELECT * FROM user UNION SELECT id + 1 FROM x WHERE id < 10) SELECT id FROM x",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "with recursive x as (select * from `user` where 1 != 1 union select id + 1 from x where 1 != 1) select id from x where 1 != 1",
+        "Query": "with recursive x as (select * from `user` union select id + 1 from x where id < 10) select id from x"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "Recursive CTE with a declared column list whose seed selects * from a table without authoritative columns",
+    "query": "WITH RECURSIVE x(a) AS (SELECT * FROM user UNION SELECT a + 1 FROM x WHERE a < 10) SELECT a FROM x",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "WITH RECURSIVE x(a) AS (SELECT * FROM user UNION SELECT a + 1 FROM x WHERE a < 10) SELECT a FROM x",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "with recursive x(a) as (select * from `user` where 1 != 1 union select a + 1 from x where 1 != 1) select a from x where 1 != 1",
+        "Query": "with recursive x(a) as (select * from `user` union select a + 1 from x where a < 10) select a from x"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -248,6 +248,26 @@ func TestRecursiveCTEChecking(t *testing.T) {
 	}
 }
 
+// A recursive CTE whose seed selects * from a table without authoritative column
+// information keeps the star in its projection, so the CTE's column list is not
+// known during analysis. Such a CTE is not authoritative and columns resolved
+// against it are uncertain, which analysis has to report rather than crash on.
+func TestRecursiveCTEWithUnexpandedStar(t *testing.T) {
+	queries := []string{
+		"with recursive x as (select * from t union select id + 1 from x where id < 10) select id from x",
+		"with recursive x(a) as (select * from t union select a + 1 from x where a < 10) select a from x",
+	}
+	for _, query := range queries {
+		t.Run(query, func(t *testing.T) {
+			parse, err := sqlparser.NewTestParser().Parse(query)
+			require.NoError(t, err)
+
+			_, err = AnalyzeStrict(parse, "user", fakeSchemaInfo())
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestBindingMultiAliasedTablePositive(t *testing.T) {
 	type testCase struct {
 		query          string

--- a/go/vt/vtgate/semantics/cte_table.go
+++ b/go/vt/vtgate/semantics/cte_table.go
@@ -97,7 +97,12 @@ func (cte *CTETable) getColumns(bool) []ColumnInfo {
 	for i, selExpr := range selExprs {
 		ae, isAe := selExpr.(*sqlparser.AliasedExpr)
 		if !isAe {
-			panic(vterrors.VT12001("should not be called"))
+			// A star we could not expand hides every column from here on, so this
+			// is as much of the list as we know. newCTETable has already marked the
+			// CTE as not authoritative, which is what makes a partial list safe:
+			// dependencies() falls back to uncertain for anything not found here,
+			// and expandTableColumns() refuses to expand a non-authoritative table.
+			return cols
 		}
 		if len(cte.Columns) == 0 {
 			cols = append(cols, ColumnInfo{Name: ae.ColumnName()})


### PR DESCRIPTION
## Description

`CTETable.getColumns` panicked as soon as it hit a projection entry that wasn't an `AliasedExpr`. That happens whenever a recursive CTE's seed selects `*` from a table without authoritative column information — the star never gets expanded, so it's still sitting in the projection when column resolution reaches it.

```sql
WITH RECURSIVE x AS (SELECT * FROM user_metadata UNION ALL SELECT id + 1 FROM x WHERE id < 10) SELECT id FROM x
```

Semantic analysis runs before `operators.PlanQuery`, so it's outside the planner's `PanicHandler`. The panic went all the way to `VTGate.HandlePanic` and came back to the client as `uncaught panic: ...`, with a stack trace in the vtgate logs. Plain client SQL, no column list needed to trigger it.

The fix returns the columns known so far instead of panicking. `newCTETable` already marks a CTE with an unexpanded star as not authoritative, and that's what makes a partial list safe rather than merely tolerable:

- `dependencies()` falls back to `createUncertain` for anything not found in the list
- `expandTableColumns()` breaks out on `!tbl.authoritative()` before it ever calls `processColumnsFor`, so a partial list can't silently produce a truncated `SELECT *`

`RealTable` already handles the identical situation the same way in `extractSelectExprsFromCTE` — it returns nil rather than panicking — so this brings `CTETable` in line with its sibling.

These queries now plan the same way as the equivalent query with known columns: a single route pushed down to MySQL, which resolves the columns vtgate can't.

## Tests

Two analyzer cases, with and without a declared column list, and one plan case. Reverting just the `cte_table.go` change fails exactly those three and no others.

The plan case has to use a sharded table — against an unsharded keyspace the query is routed without ever resolving the CTE's columns, so it doesn't reach the panic.

It uses `UNION ALL` deliberately. A recursive CTE with `UNION DISTINCT` over a sharded seed is pushed down as a bare scatter with no `Distinct` on top, so each shard computes its own closure and vtgate concatenates them — a value produced on two shards comes back twice. That is pre-existing and unrelated to this fix (the same query with no star plans identically today), filed as #20703, but it isn't behavior worth recording as an expectation. With `UNION ALL` the pushdown is correct: each seed row derives its own chain independently, so per-shard concatenation gives the same multiset as computing the CTE over all rows at once.

The recursive term also spells out all five columns of `user_metadata` rather than using a shorter list, so the query has a column count MySQL would accept.

There is no plan case with a declared column list. Written honestly, as `x(a, b, c, d, e)` against a five-column star, it panics in `extractColumnsFromCTE`, which compares the declared list against the length of the *unexpanded* projection — one `StarExpr`. That is the column-list arity bug #20633 is about, and its `containsStar` skip doesn't catch this shape either. Out of scope here, tracked in https://github.com/vitessio/vitess/issues/20743.

## Related Issue(s)

Part of https://github.com/vitessio/vitess/issues/20743, which tracks both unexpandable-star panic shapes. This PR fixes the shape without a declared column list; the declared-list shape panics in `extractColumnsFromCTE` and remains open there.

https://github.com/vitessio/vitess/issues/20703 is a separate pre-existing bug the plan test cases had to steer around. Not fixed here.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Recursive CTEs whose seed selects `*` from a table without authoritative columns previously returned an `uncaught panic` error. They now plan normally and are pushed down to MySQL. No migrations or configuration changes.

I'd suggest backporting — it's a crash reachable from ordinary client SQL, and the fix is six lines with no behavior change for queries that already worked.

### AI Disclosure

Written by Claude Code — I pointed it at the panic and reviewed the result.

