### PR TITLE
VDiff: stop pre-seeding a bogus category in TableDiffPhaseTimings

### DIFF
--- a/go/vt/vttablet/tabletmanager/vdiff/controller.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/controller.go
@@ -103,7 +103,7 @@ func newController(row sqltypes.RowNamedValues, dbClientFactory func() binlogpla
 		options:               options,
 		Errors:                stats.NewCountersWithSingleLabel("", "", "Error"),
 		TableDiffRowCounts:    stats.NewCountersWithSingleLabel("", "", "Rows"),
-		TableDiffPhaseTimings: stats.NewTimings("", "", "", "TablePhase"),
+		TableDiffPhaseTimings: stats.NewTimings("", "", ""),
 	}
 	return ct, nil
 }

--- a/go/vt/vttablet/tabletmanager/vdiff/stats_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/stats_test.go
@@ -23,7 +23,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/stats"
+	"vitess.io/vitess/go/vt/vttablet/tmclient"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 )
@@ -43,7 +45,7 @@ func TestVDiffStats(t *testing.T) {
 			uuid:                  uuid.New().String(),
 			Errors:                stats.NewCountersWithSingleLabel("", "", "Error"),
 			TableDiffRowCounts:    stats.NewCountersWithSingleLabel("", "", "Rows"),
-			TableDiffPhaseTimings: stats.NewTimings("", "", "", "TablePhase"),
+			TableDiffPhaseTimings: stats.NewTimings("", "", ""),
 		},
 	}
 
@@ -73,4 +75,16 @@ func TestVDiffStats(t *testing.T) {
 
 	testStats.RowsDiffedCount.Add(512)
 	require.Equal(t, int64(512), testStats.RowsDiffedCount.Get())
+}
+
+func TestControllerPhaseTimingsNotPreseeded(t *testing.T) {
+	row := sqltypes.RowNamedValues{
+		"id":         sqltypes.NewInt64(1),
+		"vdiff_uuid": sqltypes.NewVarChar(uuid.New().String()),
+		"workflow":   sqltypes.NewVarChar("testwf"),
+	}
+	vde := &Engine{tmClientFactory: func() tmclient.TabletManagerClient { return nil }}
+	ct, err := newController(row, nil, nil, vde, nil)
+	require.NoError(t, err)
+	require.Empty(t, ct.TableDiffPhaseTimings.Histograms())
 }


### PR DESCRIPTION
## Description

`newController()` built its phase timings with `stats.NewTimings("", "", "", "TablePhase")`. The 4th argument of `stats.NewTimings` is a pre-seeded category key, not a label name, so every VDiff controller started with a permanent zero-value histogram under the literal key `"TablePhase"`.

The `VDiffPhaseTimings` gauge declares four labels (`{workflow, uuid, table, phase}`) and emits histogram keys as `<workflow>.<uuid>.<table>.<phase>`. The phantom key has too few parts, so the Prometheus backend fails to build the metric and logs

```
Error adding metric: Desc{fqName: "vttablet_v_diff_phase_timings", help: "VDiff phase timings", constLabels: {}, variableLabels: {workflow,uuid,table,phase}}
```

on every scrape, from VDiff creation until the tablet restarts.

This drops the vararg (the label of an unpublished `Timings` is unused), removes the same construct from `stats_test.go`, and adds a regression test asserting a fresh controller's phase-timings histograms start empty.

## Related Issue(s)

Fixes #20712

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

Backport justification: one-line, zero-risk fix for unbounded error-log spam on all release branches that emit VDiff stats via the Prometheus backend.

## Deployment Notes

vttablet stops logging `Error adding metric: Desc{fqName: "vttablet_v_diff_phase_timings", ...}` on every Prometheus scrape while a VDiff controller is loaded. Exported metrics are unchanged: the phantom `TablePhase` key never produced a metric (its export failed with that error), so no series appears or disappears.
