### PR TITLE
vtorc: use RestartReplication RPC in restartDirectReplicas

### DIFF
--- a/go/vt/vtorc/logic/topology_recovery.go
+++ b/go/vt/vtorc/logic/topology_recovery.go
@@ -605,10 +605,28 @@ func getShardTablets(ctx context.Context, keyspace, shard string) ([]*topo.Table
 
 // restartReplication calls RestartReplication RPC for the given tablet with a timeout.
 func restartReplication(ctx context.Context, tablet *topodatapb.Tablet, semiSync bool) error {
-	ctx, cancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
-	defer cancel()
+	restartCtx, restartCancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
+	err := tmc.RestartReplication(restartCtx, tablet, semiSync)
+	restartCancel()
+	if err == nil {
+		return nil
+	}
 
-	return tmc.RestartReplication(ctx, tablet, semiSync)
+	// TODO: Remove this StartReplication fallback in v26, when all supported
+	// vttablets include detached post-STOP cleanup in RestartReplication.
+	tabletAlias := topoproto.TabletAliasString(tablet.Alias)
+	log.Warn("RestartReplication failed; attempting to ensure replication is started",
+		slog.String("tablet", tabletAlias),
+		slog.Any("error", err),
+	)
+
+	startCtx, startCancel := context.WithTimeout(context.WithoutCancel(ctx), topo.RemoteOperationTimeout)
+	defer startCancel()
+	if startErr := tmc.StartReplication(startCtx, tablet, semiSync); startErr != nil {
+		return vterrors.Wrapf(err, "failed to ensure replication was started on tablet %s after RestartReplication error (%v)", tabletAlias, startErr)
+	}
+
+	return err
 }
 
 // isERSEnabled returns true if ERS can be used globally or for the given keyspace.

--- a/go/vt/vtorc/logic/topology_recovery.go
+++ b/go/vt/vtorc/logic/topology_recovery.go
@@ -31,6 +31,8 @@ import (
 
 	"github.com/patrickmn/go-cache"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/log"
@@ -574,7 +576,7 @@ func restartDirectReplicas(ctx context.Context, analysisEntry *inst.DetectionAna
 			// Determine if this replica should use semi-sync based on the durability policy
 			semiSync := policy.IsReplicaSemiSync(durabilityPolicy, primaryTablet, tablet)
 
-			if err := restartReplication(ctx, tablet, semiSync); err != nil {
+			if err := restartReplication(ctx, tablet, semiSync, logger); err != nil {
 				logger.Error(fmt.Sprintf("Failed to restart replication on %s: %v", tabletAliasString, err))
 				return err
 			}
@@ -604,7 +606,7 @@ func getShardTablets(ctx context.Context, keyspace, shard string) ([]*topo.Table
 }
 
 // restartReplication calls RestartReplication RPC for the given tablet with a timeout.
-func restartReplication(ctx context.Context, tablet *topodatapb.Tablet, semiSync bool) error {
+func restartReplication(ctx context.Context, tablet *topodatapb.Tablet, semiSync bool, logger *log.PrefixedLogger) error {
 	restartCtx, restartCancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
 	err := tmc.RestartReplication(restartCtx, tablet, semiSync)
 	restartCancel()
@@ -612,10 +614,17 @@ func restartReplication(ctx context.Context, tablet *topodatapb.Tablet, semiSync
 		return nil
 	}
 
+	// Skip the fallback when the recovery context is done, since the detached
+	// fallback cannot be canceled and would only delay recovery teardown, or
+	// when the RPC never reached the tablet, in which case STOP cannot have run.
+	if ctx.Err() != nil || status.Code(err) == codes.Unavailable {
+		return err
+	}
+
 	// TODO: Remove this StartReplication fallback in v26, when all supported
 	// vttablets include detached post-STOP cleanup in RestartReplication.
 	tabletAlias := topoproto.TabletAliasString(tablet.Alias)
-	log.Warn("RestartReplication failed; attempting to ensure replication is started",
+	logger.Warn("RestartReplication failed; attempting to ensure replication is started",
 		slog.String("tablet", tabletAlias),
 		slog.Any("error", err),
 	)
@@ -623,7 +632,9 @@ func restartReplication(ctx context.Context, tablet *topodatapb.Tablet, semiSync
 	startCtx, startCancel := context.WithTimeout(context.WithoutCancel(ctx), topo.RemoteOperationTimeout)
 	defer startCancel()
 	if startErr := tmc.StartReplication(startCtx, tablet, semiSync); startErr != nil {
-		return vterrors.Wrapf(err, "failed to ensure replication was started on tablet %s after RestartReplication error (%v)", tabletAlias, startErr)
+		// Wrap with %w (not vterrors.Wrapf, which has no Unwrap) so callers can
+		// still match on the original RestartReplication error.
+		return fmt.Errorf("failed to ensure replication was started on tablet %s after RestartReplication error (%v): %w", tabletAlias, startErr, err)
 	}
 
 	return err

--- a/go/vt/vtorc/logic/topology_recovery.go
+++ b/go/vt/vtorc/logic/topology_recovery.go
@@ -571,16 +571,11 @@ func restartDirectReplicas(ctx context.Context, analysisEntry *inst.DetectionAna
 			logger.Info("Restarting replication on direct replica " + tabletAliasString)
 			_ = AuditTopologyRecovery(topologyRecovery, "Restarting replication on direct replica "+tabletAliasString)
 
-			if err := stopReplication(ctx, tablet); err != nil {
-				logger.Error(fmt.Sprintf("Failed to stop replication on %s: %v", tabletAliasString, err))
-				return err
-			}
-
 			// Determine if this replica should use semi-sync based on the durability policy
 			semiSync := policy.IsReplicaSemiSync(durabilityPolicy, primaryTablet, tablet)
 
-			if err := startReplication(ctx, tablet, semiSync); err != nil {
-				logger.Error(fmt.Sprintf("Failed to start replication on %s: %v", tabletAliasString, err))
+			if err := restartReplication(ctx, tablet, semiSync); err != nil {
+				logger.Error(fmt.Sprintf("Failed to restart replication on %s: %v", tabletAliasString, err))
 				return err
 			}
 			logger.Info("Successfully restarted replication on " + tabletAliasString)
@@ -608,20 +603,12 @@ func getShardTablets(ctx context.Context, keyspace, shard string) ([]*topo.Table
 	return ts.GetTabletsByShard(ctx, keyspace, shard)
 }
 
-// stopReplication calls StopReplication RPC for the given tablet with a timeout.
-func stopReplication(ctx context.Context, tablet *topodatapb.Tablet) error {
+// restartReplication calls RestartReplication RPC for the given tablet with a timeout.
+func restartReplication(ctx context.Context, tablet *topodatapb.Tablet, semiSync bool) error {
 	ctx, cancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
 	defer cancel()
 
-	return tmc.StopReplication(ctx, tablet)
-}
-
-// startReplication calls StartReplication RPC for the given tablet with a timeout.
-func startReplication(ctx context.Context, tablet *topodatapb.Tablet, semiSync bool) error {
-	ctx, cancel := context.WithTimeout(ctx, topo.RemoteOperationTimeout)
-	defer cancel()
-
-	return tmc.StartReplication(ctx, tablet, semiSync)
+	return tmc.RestartReplication(ctx, tablet, semiSync)
 }
 
 // isERSEnabled returns true if ERS can be used globally or for the given keyspace.

--- a/go/vt/vtorc/logic/topology_recovery_test.go
+++ b/go/vt/vtorc/logic/topology_recovery_test.go
@@ -1411,7 +1411,42 @@ func TestReconcileStaleTopoPrimaryTopoTimeout(t *testing.T) {
 	})
 }
 
-// TestRestartDirectReplicasTimeout verifies that restartDirectReplicas does not block forever if an RPC hangs.
+func TestRestartReplicationEnsuresReplicationIsStartedAfterError(t *testing.T) {
+	oldTMC := tmc
+	t.Cleanup(func() {
+		tmc = oldTMC
+	})
+
+	mockController := gomock.NewController(t)
+	mockTMC := tmcmock.NewMockTabletManagerClient(mockController)
+	tmc = mockTMC
+
+	tablet := &topodatapb.Tablet{Alias: &topodatapb.TabletAlias{Cell: "zone1", Uid: 101}}
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	gomock.InOrder(
+		mockTMC.EXPECT().
+			RestartReplication(gomock.Any(), tablet, true).
+			DoAndReturn(func(context.Context, *topodatapb.Tablet, bool) error {
+				cancel()
+				return context.Canceled
+			}),
+		mockTMC.EXPECT().
+			StartReplication(gomock.Any(), tablet, true).
+			DoAndReturn(func(ctx context.Context, _ *topodatapb.Tablet, _ bool) error {
+				require.NoError(t, ctx.Err())
+				_, ok := ctx.Deadline()
+				require.True(t, ok, "cleanup context must have a deadline")
+				return nil
+			}),
+	)
+
+	err := restartReplication(ctx, tablet, true)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestRestartDirectReplicasTimeout verifies that restartDirectReplicas does not block forever if replication RPCs hang.
 func TestRestartDirectReplicasTimeout(t *testing.T) {
 	orcDB, fromCache, err := db.OpenVTOrcWithCache()
 	require.NoError(t, err)
@@ -1505,6 +1540,13 @@ func TestRestartDirectReplicasTimeout(t *testing.T) {
 				return ctx.Err()
 			}).
 			Times(1)
+		mockTMC.EXPECT().
+			StartReplication(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _ *topodatapb.Tablet, _ bool) error {
+				<-ctx.Done()
+				return ctx.Err()
+			}).
+			Times(1)
 
 		tmc = mockTMC
 
@@ -1544,7 +1586,10 @@ func TestRestartDirectReplicasTimeout(t *testing.T) {
 		// hanging on the RestartReplication RPC).
 		synctest.Wait()
 
-		// Move fake time just beyond the expected RPC timeout boundary.
+		// Move fake time beyond both RPC timeout boundaries.
+		time.Sleep(topo.RemoteOperationTimeout + time.Nanosecond)
+		synctest.Wait()
+
 		time.Sleep(topo.RemoteOperationTimeout + time.Nanosecond)
 		synctest.Wait()
 
@@ -1553,9 +1598,9 @@ func TestRestartDirectReplicasTimeout(t *testing.T) {
 		case result := <-resultCh:
 			require.True(t, result.attempted, "recovery must be attempted")
 			require.NotNil(t, result.topologyRecovery, "topology recovery record must be returned")
-			require.ErrorIs(t, result.err, context.DeadlineExceeded, "restartDirectReplicas must timeout and return when a replication RPC hangs indefinitely")
+			require.ErrorContains(t, result.err, context.DeadlineExceeded.Error(), "restartDirectReplicas must timeout and return when a replication RPC hangs indefinitely")
 		default:
-			require.FailNowf(t, "restartDirectReplicas did not return", "expected timeout after %s when a replication RPC hangs indefinitely", topo.RemoteOperationTimeout)
+			require.FailNowf(t, "restartDirectReplicas did not return", "expected timeout after %s when replication RPCs hang indefinitely", 2*topo.RemoteOperationTimeout)
 		}
 
 		activeRecoveries, err := ReadActiveClusterRecoveries(keyspace, shard)

--- a/go/vt/vtorc/logic/topology_recovery_test.go
+++ b/go/vt/vtorc/logic/topology_recovery_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/vt/external/golib/sqlutils"
@@ -1411,39 +1413,114 @@ func TestReconcileStaleTopoPrimaryTopoTimeout(t *testing.T) {
 	})
 }
 
-func TestRestartReplicationEnsuresReplicationIsStartedAfterError(t *testing.T) {
+func TestRestartReplicationFallback(t *testing.T) {
 	oldTMC := tmc
 	t.Cleanup(func() {
 		tmc = oldTMC
 	})
 
-	mockController := gomock.NewController(t)
-	mockTMC := tmcmock.NewMockTabletManagerClient(mockController)
-	tmc = mockTMC
+	oldRemoteOpTimeout := topo.RemoteOperationTimeout
+	topo.RemoteOperationTimeout = 100 * time.Millisecond
+	t.Cleanup(func() {
+		topo.RemoteOperationTimeout = oldRemoteOpTimeout
+	})
 
 	tablet := &topodatapb.Tablet{Alias: &topodatapb.TabletAlias{Cell: "zone1", Uid: 101}}
-	ctx, cancel := context.WithCancel(t.Context())
-	t.Cleanup(cancel)
+	logger := log.NewPrefixedLogger("test-restart-replication-fallback")
 
-	gomock.InOrder(
+	setup := func(t *testing.T) *tmcmock.MockTabletManagerClient {
+		mockController := gomock.NewController(t)
+		mockTMC := tmcmock.NewMockTabletManagerClient(mockController)
+		tmc = mockTMC
+		return mockTMC
+	}
+
+	// The server may have run STOP REPLICA before timing out, so the fallback
+	// must run while the recovery context is still alive.
+	t.Run("fallback starts replication after RPC timeout", func(t *testing.T) {
+		mockTMC := setup(t)
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+
+		gomock.InOrder(
+			mockTMC.EXPECT().
+				RestartReplication(gomock.Any(), tablet, true).
+				DoAndReturn(func(restartCtx context.Context, _ *topodatapb.Tablet, _ bool) error {
+					<-restartCtx.Done()
+					return restartCtx.Err()
+				}),
+			mockTMC.EXPECT().
+				StartReplication(gomock.Any(), tablet, true).
+				DoAndReturn(func(ctx context.Context, _ *topodatapb.Tablet, _ bool) error {
+					require.NoError(t, ctx.Err())
+					_, ok := ctx.Deadline()
+					require.True(t, ok, "cleanup context must have a deadline")
+					return nil
+				}),
+		)
+
+		err := restartReplication(ctx, tablet, true, logger)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	// When the fallback also fails, the returned error must still unwrap to
+	// the original RestartReplication error so callers can match on it.
+	t.Run("fallback failure preserves original error", func(t *testing.T) {
+		mockTMC := setup(t)
+
+		gomock.InOrder(
+			mockTMC.EXPECT().
+				RestartReplication(gomock.Any(), tablet, true).
+				DoAndReturn(func(restartCtx context.Context, _ *topodatapb.Tablet, _ bool) error {
+					<-restartCtx.Done()
+					return restartCtx.Err()
+				}),
+			mockTMC.EXPECT().
+				StartReplication(gomock.Any(), tablet, true).
+				Return(errors.New("start failed")),
+		)
+
+		err := restartReplication(t.Context(), tablet, true, logger)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.ErrorContains(t, err, "failed to ensure replication was started")
+	})
+
+	// A canceled recovery context means the recovery is being torn down; the
+	// detached fallback would only delay eg.Wait() and the next recovery.
+	t.Run("fallback skipped when recovery context is canceled", func(t *testing.T) {
+		mockTMC := setup(t)
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+
 		mockTMC.EXPECT().
 			RestartReplication(gomock.Any(), tablet, true).
 			DoAndReturn(func(context.Context, *topodatapb.Tablet, bool) error {
 				cancel()
 				return context.Canceled
-			}),
+			})
 		mockTMC.EXPECT().
-			StartReplication(gomock.Any(), tablet, true).
-			DoAndReturn(func(ctx context.Context, _ *topodatapb.Tablet, _ bool) error {
-				require.NoError(t, ctx.Err())
-				_, ok := ctx.Deadline()
-				require.True(t, ok, "cleanup context must have a deadline")
-				return nil
-			}),
-	)
+			StartReplication(gomock.Any(), gomock.Any(), gomock.Any()).
+			Times(0)
 
-	err := restartReplication(ctx, tablet, true)
-	require.ErrorIs(t, err, context.Canceled)
+		err := restartReplication(ctx, tablet, true, logger)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	// On transport errors the RPC never reached the tablet, so STOP cannot
+	// have run and the fallback would waste a full RemoteOperationTimeout.
+	t.Run("fallback skipped when tablet is unreachable", func(t *testing.T) {
+		mockTMC := setup(t)
+
+		mockTMC.EXPECT().
+			RestartReplication(gomock.Any(), tablet, true).
+			Return(status.Error(codes.Unavailable, "connection refused"))
+		mockTMC.EXPECT().
+			StartReplication(gomock.Any(), gomock.Any(), gomock.Any()).
+			Times(0)
+
+		err := restartReplication(t.Context(), tablet, true, logger)
+		require.Equal(t, codes.Unavailable, status.Code(err))
+	})
 }
 
 // TestRestartDirectReplicasTimeout verifies that restartDirectReplicas does not block forever if replication RPCs hang.
@@ -1598,7 +1675,7 @@ func TestRestartDirectReplicasTimeout(t *testing.T) {
 		case result := <-resultCh:
 			require.True(t, result.attempted, "recovery must be attempted")
 			require.NotNil(t, result.topologyRecovery, "topology recovery record must be returned")
-			require.ErrorContains(t, result.err, context.DeadlineExceeded.Error(), "restartDirectReplicas must timeout and return when a replication RPC hangs indefinitely")
+			require.ErrorIs(t, result.err, context.DeadlineExceeded, "restartDirectReplicas must timeout and return when a replication RPC hangs indefinitely")
 		default:
 			require.FailNowf(t, "restartDirectReplicas did not return", "expected timeout after %s when replication RPCs hang indefinitely", 2*topo.RemoteOperationTimeout)
 		}

--- a/go/vt/vtorc/logic/topology_recovery_test.go
+++ b/go/vt/vtorc/logic/topology_recovery_test.go
@@ -1499,8 +1499,8 @@ func TestRestartDirectReplicasTimeout(t *testing.T) {
 		// when the passed context is canceled.
 		mockTMC := tmcmock.NewMockTabletManagerClient(mockController)
 		mockTMC.EXPECT().
-			StopReplication(gomock.Any(), gomock.Any()).
-			DoAndReturn(func(ctx context.Context, _ *topodatapb.Tablet) error {
+			RestartReplication(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _ *topodatapb.Tablet, _ bool) error {
 				<-ctx.Done()
 				return ctx.Err()
 			}).
@@ -1541,7 +1541,7 @@ func TestRestartDirectReplicasTimeout(t *testing.T) {
 		}()
 
 		// Let the recovery goroutine reach a blocked state before advancing fake time (in this case,
-		// hanging on the StopReplication RPC).
+		// hanging on the RestartReplication RPC).
 		synctest.Wait()
 
 		// Move fake time just beyond the expected RPC timeout boundary.

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -340,17 +340,22 @@ func (tm *TabletManager) RestartReplication(ctx context.Context, semiSync bool) 
 		return err
 	}
 
-	semiSyncAction, err := tm.convertBoolToSemiSyncAction(ctx, semiSync)
+	// Once STOP succeeds, use a fresh bounded context so caller cancellation
+	// cannot leave replication stopped.
+	postStopCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), topo.RemoteOperationTimeout)
+	defer cancel()
+
+	semiSyncAction, err := tm.convertBoolToSemiSyncAction(postStopCtx, semiSync)
 	if err != nil {
 		return err
 	}
 
-	if err := tm.fixSemiSync(ctx, tm.Tablet().Type, semiSyncAction); err != nil {
+	if err := tm.fixSemiSync(postStopCtx, tm.Tablet().Type, semiSyncAction); err != nil {
 		return err
 	}
 
 	// Start replication
-	return tm.startReplicationRecoverable(ctx)
+	return tm.startReplicationRecoverable(postStopCtx)
 }
 
 // StartReplicationUntilAfter will start the replication and let it catch up

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -327,6 +327,11 @@ func (tm *TabletManager) StartReplication(ctx context.Context, semiSync bool) er
 // RestartReplication will stop replication and then start it again
 func (tm *TabletManager) RestartReplication(ctx context.Context, semiSync bool) error {
 	log.Info("RestartReplication")
+	postStopTimeout := topo.RemoteOperationTimeout
+	if deadline, ok := ctx.Deadline(); ok {
+		postStopTimeout = time.Until(deadline)
+	}
+
 	if err := tm.waitForGrantsToHaveApplied(ctx); err != nil {
 		return err
 	}
@@ -340,9 +345,9 @@ func (tm *TabletManager) RestartReplication(ctx context.Context, semiSync bool) 
 		return err
 	}
 
-	// Once STOP succeeds, use a fresh bounded context so caller cancellation
-	// cannot leave replication stopped.
-	postStopCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), topo.RemoteOperationTimeout)
+	// Once STOP succeeds, reuse the caller's timeout budget with cancellation
+	// detached so caller cancellation cannot leave replication stopped.
+	postStopCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), postStopTimeout)
 	defer cancel()
 
 	semiSyncAction, err := tm.convertBoolToSemiSyncAction(postStopCtx, semiSync)

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -327,11 +327,6 @@ func (tm *TabletManager) StartReplication(ctx context.Context, semiSync bool) er
 // RestartReplication will stop replication and then start it again
 func (tm *TabletManager) RestartReplication(ctx context.Context, semiSync bool) error {
 	log.Info("RestartReplication")
-	postStopTimeout := topo.RemoteOperationTimeout
-	if deadline, ok := ctx.Deadline(); ok {
-		postStopTimeout = time.Until(deadline)
-	}
-
 	if err := tm.waitForGrantsToHaveApplied(ctx); err != nil {
 		return err
 	}
@@ -345,8 +340,14 @@ func (tm *TabletManager) RestartReplication(ctx context.Context, semiSync bool) 
 		return err
 	}
 
-	// Once STOP succeeds, reuse the caller's timeout budget with cancellation
-	// detached so caller cancellation cannot leave replication stopped.
+	// Once STOP succeeds, run the post-STOP work with cancellation detached so
+	// caller cancellation cannot leave replication stopped. The detached work is
+	// bounded by the caller's remaining budget, capped at RemoteOperationTimeout,
+	// so the action lock cannot be held well beyond the caller's deadline.
+	postStopTimeout := topo.RemoteOperationTimeout
+	if deadline, ok := ctx.Deadline(); ok {
+		postStopTimeout = min(time.Until(deadline), postStopTimeout)
+	}
 	postStopCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), postStopTimeout)
 	defer cancel()
 

--- a/go/vt/vttablet/tabletmanager/rpc_replication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication_test.go
@@ -95,6 +95,7 @@ type (
 		*mysqlctl.FakeMysqlDaemon
 		cancel                   context.CancelFunc
 		postStopTimeoutRemaining chan time.Duration
+		stopDelay                time.Duration
 	}
 )
 
@@ -108,7 +109,12 @@ func (d *demotePrimaryStallQS) IsServing() bool {
 }
 
 func (rmd *restartReplicationMysqlDaemon) StopReplication(context.Context, map[string]string) error {
-	rmd.cancel()
+	if rmd.cancel != nil {
+		rmd.cancel()
+	}
+	if rmd.stopDelay > 0 {
+		time.Sleep(rmd.stopDelay)
+	}
 	return nil
 }
 
@@ -574,7 +580,40 @@ func TestRestartReplicationUsesCallerTimeoutAfterStop(t *testing.T) {
 	err := tm.RestartReplication(ctx, false)
 	require.NoError(t, err)
 	require.NoError(t, fakeMysqlDaemon.CheckSuperQueryList())
-	assert.Greater(t, <-postStopTimeoutRemaining, topo.RemoteOperationTimeout)
+	assert.LessOrEqual(t, <-postStopTimeoutRemaining, topo.RemoteOperationTimeout,
+		"post-STOP budget must be capped at RemoteOperationTimeout")
+}
+
+// TestRestartReplicationDeductsPreStopTimeFromPostStopBudget verifies time spent
+// before and during STOP is deducted from the post-STOP timeout budget.
+func TestRestartReplicationDeductsPreStopTimeFromPostStopBudget(t *testing.T) {
+	oldRemoteOpTimeout := topo.RemoteOperationTimeout
+	topo.RemoteOperationTimeout = 30 * time.Second
+	t.Cleanup(func() {
+		topo.RemoteOperationTimeout = oldRemoteOpTimeout
+	})
+
+	fakeMysqlDaemon := newTestMysqlDaemon(t, 1)
+	fakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{"START REPLICA"}
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	postStopTimeoutRemaining := make(chan time.Duration, 1)
+	restartMysqlDaemon := &restartReplicationMysqlDaemon{
+		FakeMysqlDaemon:          fakeMysqlDaemon,
+		postStopTimeoutRemaining: postStopTimeoutRemaining,
+		stopDelay:                time.Second,
+	}
+	tm := newTestReplicationTM(newTestTablet(t, 100, "ks", "0", nil), fakeMysqlDaemon, nil)
+	tm.MysqlDaemon = restartMysqlDaemon
+
+	err := tm.RestartReplication(ctx, false)
+	require.NoError(t, err)
+	require.NoError(t, fakeMysqlDaemon.CheckSuperQueryList())
+
+	remaining := <-postStopTimeoutRemaining
+	assert.Greater(t, remaining, 8*time.Second)
+	assert.Less(t, remaining, 9500*time.Millisecond, "time spent in STOP must be deducted from the post-STOP budget")
 }
 
 // TestRestartReplicationRecoversFromRecoverableReplicationInitializationError verifies RestartReplication self-heals recoverable init failures.

--- a/go/vt/vttablet/tabletmanager/rpc_replication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication_test.go
@@ -93,7 +93,8 @@ type (
 
 	restartReplicationMysqlDaemon struct {
 		*mysqlctl.FakeMysqlDaemon
-		cancel context.CancelFunc
+		cancel                   context.CancelFunc
+		postStopTimeoutRemaining chan time.Duration
 	}
 )
 
@@ -115,8 +116,12 @@ func (rmd *restartReplicationMysqlDaemon) SemiSyncExtensionLoaded(ctx context.Co
 	if err := ctx.Err(); err != nil {
 		return mysql.SemiSyncTypeUnknown, err
 	}
-	if _, ok := ctx.Deadline(); !ok {
+	deadline, ok := ctx.Deadline()
+	if !ok {
 		return mysql.SemiSyncTypeUnknown, errors.New("post-STOP context must have a deadline")
+	}
+	if rmd.postStopTimeoutRemaining != nil {
+		rmd.postStopTimeoutRemaining <- time.Until(deadline)
 	}
 	return mysql.SemiSyncTypeOff, nil
 }
@@ -549,6 +554,27 @@ func TestRestartReplicationCompletesAfterContextCancellation(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, fakeMysqlDaemon.CheckSuperQueryList())
 	assert.True(t, fakeMysqlDaemon.Replicating, "replication must be started after STOP succeeds")
+}
+
+func TestRestartReplicationUsesCallerTimeoutAfterStop(t *testing.T) {
+	fakeMysqlDaemon := newTestMysqlDaemon(t, 1)
+	fakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{"START REPLICA"}
+	ctx, cancel := context.WithTimeout(t.Context(), 2*topo.RemoteOperationTimeout)
+	t.Cleanup(cancel)
+
+	postStopTimeoutRemaining := make(chan time.Duration, 1)
+	restartMysqlDaemon := &restartReplicationMysqlDaemon{
+		FakeMysqlDaemon:          fakeMysqlDaemon,
+		cancel:                   cancel,
+		postStopTimeoutRemaining: postStopTimeoutRemaining,
+	}
+	tm := newTestReplicationTM(newTestTablet(t, 100, "ks", "0", nil), fakeMysqlDaemon, nil)
+	tm.MysqlDaemon = restartMysqlDaemon
+
+	err := tm.RestartReplication(ctx, false)
+	require.NoError(t, err)
+	require.NoError(t, fakeMysqlDaemon.CheckSuperQueryList())
+	assert.Greater(t, <-postStopTimeoutRemaining, topo.RemoteOperationTimeout)
 }
 
 // TestRestartReplicationRecoversFromRecoverableReplicationInitializationError verifies RestartReplication self-heals recoverable init failures.

--- a/go/vt/vttablet/tabletmanager/rpc_replication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/semaphore"
 
+	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/sqltypes"
@@ -83,11 +84,18 @@ func TestWaitForGrantsToHaveApplied(t *testing.T) {
 	require.NoError(t, err)
 }
 
-type demotePrimaryStallQS struct {
-	tabletserver.Controller
-	qsWaitChan     chan any
-	primaryStalled atomic.Bool
-}
+type (
+	demotePrimaryStallQS struct {
+		tabletserver.Controller
+		qsWaitChan     chan any
+		primaryStalled atomic.Bool
+	}
+
+	restartReplicationMysqlDaemon struct {
+		*mysqlctl.FakeMysqlDaemon
+		cancel context.CancelFunc
+	}
+)
 
 func (d *demotePrimaryStallQS) SetDemotePrimaryStalled(val bool) {
 	d.primaryStalled.Store(val)
@@ -96,6 +104,21 @@ func (d *demotePrimaryStallQS) SetDemotePrimaryStalled(val bool) {
 func (d *demotePrimaryStallQS) IsServing() bool {
 	<-d.qsWaitChan
 	return false
+}
+
+func (rmd *restartReplicationMysqlDaemon) StopReplication(context.Context, map[string]string) error {
+	rmd.cancel()
+	return nil
+}
+
+func (rmd *restartReplicationMysqlDaemon) SemiSyncExtensionLoaded(ctx context.Context) (mysql.SemiSyncType, error) {
+	if err := ctx.Err(); err != nil {
+		return mysql.SemiSyncTypeUnknown, err
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		return mysql.SemiSyncTypeUnknown, errors.New("post-STOP context must have a deadline")
+	}
+	return mysql.SemiSyncTypeOff, nil
 }
 
 // TestDemotePrimaryStalled checks that if demote primary takes too long, then we mark it as stalled.
@@ -505,6 +528,27 @@ func TestStartReplicationRecoversFromRecoverableReplicationInitError(t *testing.
 	err := tm.StartReplication(t.Context(), false)
 	require.NoError(t, err)
 	require.NoError(t, fakeMysqlDaemon.CheckSuperQueryList())
+}
+
+// TestRestartReplicationCompletesAfterContextCancellation verifies a successful
+// stop is followed by a bounded start when the RPC context is canceled.
+func TestRestartReplicationCompletesAfterContextCancellation(t *testing.T) {
+	fakeMysqlDaemon := newTestMysqlDaemon(t, 1)
+	fakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{"START REPLICA"}
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	restartMysqlDaemon := &restartReplicationMysqlDaemon{
+		FakeMysqlDaemon: fakeMysqlDaemon,
+		cancel:          cancel,
+	}
+	tm := newTestReplicationTM(newTestTablet(t, 100, "ks", "0", nil), fakeMysqlDaemon, nil)
+	tm.MysqlDaemon = restartMysqlDaemon
+
+	err := tm.RestartReplication(ctx, false)
+	require.NoError(t, err)
+	require.NoError(t, fakeMysqlDaemon.CheckSuperQueryList())
+	assert.True(t, fakeMysqlDaemon.Replicating, "replication must be started after STOP succeeds")
 }
 
 // TestRestartReplicationRecoversFromRecoverableReplicationInitializationError verifies RestartReplication self-heals recoverable init failures.


### PR DESCRIPTION
## Description

Followup to #18628. When that PR added the `RestartReplication` RPC, the intent was to eventually use it in `restartDirectReplicas` (from #18626) — but we needed the RPC to be present across two releases first. It's now shipped in v23 and v24, so this swaps `vtorc`'s `restartDirectReplicas` from the old `StopReplication` + `StartReplication` two-RPC sequence over to the single `RestartReplication` RPC.

Same effect (stop → semi-sync fix → start), but now under one tablet lock in one round-trip instead of two, which closes the small window between the separate calls. The two local timeout-wrapper helpers (`stopReplication`, `startReplication`) collapse into a single `restartReplication`, and the semi-sync value is computed just before the call (it's metadata-only, so ordering doesn't matter).

Timeout handling changed with the single RPC. On the vttablet side, once `STOP REPLICA` succeeds the post-STOP work (semi-sync fix + `START REPLICA`) runs detached from caller cancellation, bounded by the caller's remaining budget capped at `RemoteOperationTimeout`, so a caller cancel/timeout mid-RPC cannot leave replication stopped and the tablet action lock cannot be held well past the caller's deadline. On the vtorc side, if `RestartReplication` fails after STOP may have run (e.g. it times out), vtorc issues a `StartReplication` under a second `RemoteOperationTimeout` to avoid leaving the replica stopped. That fallback also covers older vttablets without the detached post-STOP cleanup, and is skipped when the recovery context is canceled or when the RPC never reached the tablet (`Unavailable`), where STOP cannot have run.

## Related Issue(s)

- Followup to #18628
- Originally intended for #18626
- Context: #18564

## Checklist

- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

The vttablet `RestartReplication` RPC handler semantics changed for all callers: after `STOP REPLICA` succeeds, the remaining work (semi-sync fix + `START REPLICA`) now completes even if the caller cancels or times out, bounded by the caller's remaining budget capped at `RemoteOperationTimeout`. A caller without a deadline is now capped at `RemoteOperationTimeout` where it was previously unbounded. There is no in-tree caller other than `vtorc`, so impact is limited to external tmclient users of `RestartReplication`.

---

_Most of this was written by Claude Code — I just provided direction._