### PR TITLE
mysql/json: read numbers the way MySQL does

### DIFF
--- a/go/mysql/json/LICENSE.rapidjson
+++ b/go/mysql/json/LICENSE.rapidjson
@@ -1,0 +1,37 @@
+Tencent is pleased to support the open source community by making RapidJSON
+available.
+
+Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip.
+
+Parts of parser.go are derived from RapidJSON 1.1.0, the JSON parser MySQL
+parses documents with, so that Vitess accepts exactly the documents MySQL does:
+mysqlNumberFits follows GenericReader::ParseNumber in
+include/rapidjson/reader.h, scaleByPow10 and movePoint follow
+StrtodNormalPrecision and FastPath in include/rapidjson/internal/strtod.h, and
+the pow10 table holds the same values as Pow10 in
+include/rapidjson/internal/pow10.h. No RapidJSON source is included here; the Go
+code was written to reproduce what those functions decide.
+
+RapidJSON is licensed under the MIT License:
+
+The MIT License (MIT)
+
+Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/go/mysql/json/marshal.go
+++ b/go/mysql/json/marshal.go
@@ -491,7 +491,7 @@ func (w *sqlWriter) writeNumber(top bool) error {
 	// Use the parser's readFloat to validate number grammar, rejecting
 	// malformed inputs like "1+2", "1..2", or "1e+" that a simple
 	// character-class loop would accept.
-	n, ok := readFloat(w.data[w.pos:])
+	n, _, ok := readFloat(w.data[w.pos:])
 	if !ok || n == 0 {
 		return fmt.Errorf("invalid number at position %d in JSON", w.pos)
 	}

--- a/go/mysql/json/marshal.go
+++ b/go/mysql/json/marshal.go
@@ -491,7 +491,7 @@ func (w *sqlWriter) writeNumber(top bool) error {
 	// Use the parser's readFloat to validate number grammar, rejecting
 	// malformed inputs like "1+2", "1..2", or "1e+" that a simple
 	// character-class loop would accept.
-	n, _, ok := readFloat(w.data[w.pos:])
+	n, _, _, ok := readFloat(w.data[w.pos:])
 	if !ok || n == 0 {
 		return fmt.Errorf("invalid number at position %d in JSON", w.pos)
 	}

--- a/go/mysql/json/marshal.go
+++ b/go/mysql/json/marshal.go
@@ -491,7 +491,7 @@ func (w *sqlWriter) writeNumber(top bool) error {
 	// Use the parser's readFloat to validate number grammar, rejecting
 	// malformed inputs like "1+2", "1..2", or "1e+" that a simple
 	// character-class loop would accept.
-	n, _, _, ok := readFloat(w.data[w.pos:])
+	n, _, ok := readFloat(w.data[w.pos:])
 	if !ok || n == 0 {
 		return fmt.Errorf("invalid number at position %d in JSON", w.pos)
 	}

--- a/go/mysql/json/marshal_test.go
+++ b/go/mysql/json/marshal_test.go
@@ -128,6 +128,13 @@ func TestAppendMarshalSQLNumberGrammar(t *testing.T) {
 		`1e+`,
 		`1e`,
 		`--1`,
+		// Shapes JSON's grammar does not have: a written plus, an integer
+		// part opening with a zero, and a decimal point with nothing on
+		// one side of it.
+		`+1`,
+		`007`,
+		`.2`,
+		`12.`,
 	}
 	for _, input := range malformed {
 		buf := &bytes2.Buffer{}

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -22,6 +22,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"math"
 	"slices"
 	"strconv"
 	"strings"
@@ -190,7 +191,7 @@ func parseValue(s string, c *cache, depth int) (*Value, string, error) {
 		return ValueNull, s[len("null"):], nil
 	}
 
-	flen, exponent, fraction, ok := readFloat(s)
+	flen, exponent, ok := readFloat(s)
 	if !ok {
 		return nil, s[flen:], fmt.Errorf("invalid number in JSON string: %q", s)
 	}
@@ -199,13 +200,8 @@ func parseValue(s string, c *cache, depth int) (*Value, string, error) {
 	v.t = TypeNumber
 	v.s = s[:flen]
 	v.n = numberTypeRaw
-	if exponent > maxFloat64Digits+fraction {
+	if mayExceedFloat64(v.s, exponent) && !mysqlNumberFits(v.s) {
 		return nil, s, fmt.Errorf("number too big to be stored in double: %q", v.s)
-	}
-	if mayExceedFloat64(v.s, exponent) {
-		if _, err := fastparse.ParseFloat64(v.s); err != nil {
-			return nil, s, fmt.Errorf("number too big to be stored in double: %q", v.s)
-		}
 	}
 	return v, s[flen:], nil
 }
@@ -223,6 +219,209 @@ const maxFloat64Digits = 308
 // only makes the answer yes more often.
 func mayExceedFloat64(num string, exponent int) bool {
 	return len(num)+exponent > maxFloat64Digits
+}
+
+// pow10 holds the powers of ten that a number's digits are scaled by, which is
+// the table RapidJSON scales its significand with. It is built from the decimal
+// spellings rather than from math.Pow10, which multiplies two table entries
+// together and lands a bit away from the spelling for 78 of these exponents.
+var pow10 [maxFloat64Digits + 1]float64
+
+func init() {
+	for i := range pow10 {
+		pow10[i], _ = fastparse.ParseFloat64("1e" + strconv.Itoa(i))
+	}
+}
+
+// mysqlNumberFits reports whether MySQL can store num, which has to already be
+// a grammatically valid JSON number.
+//
+// MySQL parses JSON with RapidJSON, which decides this in two places. While
+// reading the exponent, a written exponent may not move the decimal point more
+// than maxFloat64Digits places past the digits already behind it. After
+// converting, the result may not be larger than the largest double. Neither
+// place catches what the other does: an exponent that lands on zero is refused
+// only as written, and a number written within the bound can still overflow
+// once converted.
+//
+// The conversion below is the one RapidJSON does rather than a correct one. It
+// accumulates the significand into a double and scales that by a power of ten,
+// which lands an ULP or two from the true value, and the boundary sits wherever
+// that lands. A number a hair under the largest double therefore comes down to
+// how it was spelled: 1.7976931348623158e308 does not fit, while writing the
+// same value as 1.79769313486231580e308 does, because the extra digit moves
+// where the significand ends and the scaling begins. Converting the same way is
+// what makes a document valid here exactly when it is valid in MySQL.
+func mysqlNumberFits(num string) bool {
+	i := 0
+	minus := num[i] == '-'
+	if minus {
+		i++
+	}
+
+	var (
+		u32       uint32
+		u64       uint64
+		use64     bool
+		sigDigits int
+		d         float64
+		useDouble bool
+	)
+	digit := func() bool { return i < len(num) && num[i] >= '0' && num[i] <= '9' }
+
+	// The integer part accumulates as an integer for as long as one can hold
+	// it, stepping up in width as it fills. RapidJSON leaves the leading digit
+	// out of sigDigits, and the seventeen-digit cut-off in the fraction below is
+	// measured against that count.
+	if num[i] == '0' {
+		i++
+	} else {
+		u32 = uint32(num[i] - '0')
+		i++
+		for digit() {
+			if minus {
+				if u32 >= 214748364 && (u32 != 214748364 || num[i] > '8') {
+					u64, use64 = uint64(u32), true
+					break
+				}
+			} else if u32 >= 429496729 && (u32 != 429496729 || num[i] > '5') {
+				u64, use64 = uint64(u32), true
+				break
+			}
+			u32 = u32*10 + uint32(num[i]-'0')
+			i++
+			sigDigits++
+		}
+	}
+	if use64 {
+		for digit() {
+			if minus {
+				if u64 >= 0x0CCCCCCCCCCCCCCC && (u64 != 0x0CCCCCCCCCCCCCCC || num[i] > '8') {
+					d, useDouble = float64(u64), true
+					break
+				}
+			} else if u64 >= 0x1999999999999999 && (u64 != 0x1999999999999999 || num[i] > '5') {
+				d, useDouble = float64(u64), true
+				break
+			}
+			u64 = u64*10 + uint64(num[i]-'0')
+			i++
+			sigDigits++
+		}
+	}
+	for useDouble && digit() {
+		d = d*10 + float64(num[i]-'0')
+		i++
+	}
+
+	// Digits behind the decimal point move it left, which is what expFrac
+	// counts. Past seventeen significant digits they stop counting and stop
+	// arriving, so they move it no further.
+	expFrac := 0
+	if i < len(num) && num[i] == '.' {
+		i++
+		if !useDouble {
+			if !use64 {
+				u64 = uint64(u32)
+			}
+			for digit() {
+				if u64 > 0x1FFFFFFFFFFFFF {
+					break
+				}
+				u64 = u64*10 + uint64(num[i]-'0')
+				i++
+				expFrac--
+				if u64 != 0 {
+					sigDigits++
+				}
+			}
+			d = float64(u64)
+			useDouble = true
+		}
+		for digit() {
+			if sigDigits < 17 {
+				d = d*10 + float64(num[i]-'0')
+				expFrac--
+				if d > 0 {
+					sigDigits++
+				}
+			}
+			i++
+		}
+	}
+
+	exp := 0
+	if i < len(num) && (num[i] == 'e' || num[i] == 'E') {
+		i++
+		if !useDouble {
+			if use64 {
+				d = float64(u64)
+			} else {
+				d = float64(u32)
+			}
+			useDouble = true
+		}
+		negative := num[i] == '-'
+		if negative || num[i] == '+' {
+			i++
+		}
+		exp = int(num[i] - '0')
+		i++
+		if negative {
+			// A negative exponent is not bounded, only stopped before it could
+			// overflow the int it accumulates into. Everything out that far has
+			// flushed to zero long before.
+			maxExp := (expFrac + 2147483639) / 10
+			for digit() {
+				exp = exp*10 + int(num[i]-'0')
+				i++
+				if exp > maxExp {
+					for digit() {
+						i++
+					}
+				}
+			}
+			exp = -exp
+		} else {
+			maxExp := maxFloat64Digits - expFrac
+			for digit() {
+				exp = exp*10 + int(num[i]-'0')
+				i++
+				if exp > maxExp {
+					return false
+				}
+			}
+		}
+	}
+
+	// A number that never needed a double is an integer MySQL keeps exact.
+	if !useDouble {
+		return true
+	}
+	return scaleByPow10(d, exp+expFrac) <= math.MaxFloat64
+}
+
+// scaleByPow10 moves d by p decimal places the way RapidJSON does, in one
+// multiplication or division by a power of ten. Anything below the smallest
+// power in the table is moved in two steps so that the table is never indexed
+// past its end.
+func scaleByPow10(d float64, p int) float64 {
+	if p < -maxFloat64Digits {
+		d = movePoint(d, -maxFloat64Digits)
+		return movePoint(d, p+maxFloat64Digits)
+	}
+	return movePoint(d, p)
+}
+
+func movePoint(significand float64, exp int) float64 {
+	switch {
+	case exp < -maxFloat64Digits:
+		return 0
+	case exp >= 0:
+		return significand * pow10[exp]
+	default:
+		return significand / pow10[-exp]
+	}
 }
 
 func parseArray(s string, c *cache, depth int) (*Value, string, error) {
@@ -530,14 +729,14 @@ func parseRawString(s string) (string, string, error) {
 }
 
 // readFloat reads a JSON number off the front of s, returning how much of s it
-// covers, the exponent it was written with, and how many digits it carries
-// after its decimal point. Together those say how far the number's digits sit
-// from where a double keeps them.
+// covers and the exponent it was written with. Whether the number is one a
+// double can hold is mysqlNumberFits's job; the exponent is reported so that
+// question only has to be asked of numbers whose digits could reach that far.
 //
 // What counts as a number is JSON's grammar rather than Go's: a written plus,
 // a missing digit on either side of the decimal point, and an integer part
 // that opens with a zero are all rejected.
-func readFloat[S string | []byte](s S) (i, exponent, fraction int, ok bool) {
+func readFloat[S string | []byte](s S) (i, exponent int, ok bool) {
 	// optional minus. JSON numbers carry no written plus.
 	if i >= len(s) {
 		return
@@ -564,7 +763,6 @@ func readFloat[S string | []byte](s S) (i, exponent, fraction int, ok bool) {
 			return
 		}
 		for ; i < len(s) && '0' <= s[i] && s[i] <= '9'; i++ {
-			fraction++
 		}
 	}
 
@@ -598,7 +796,7 @@ func readFloat[S string | []byte](s S) (i, exponent, fraction int, ok bool) {
 			exponent = -exponent
 		}
 	}
-	return i, exponent, fraction, true
+	return i, exponent, true
 }
 
 // Object represents JSON object.

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -252,6 +252,12 @@ func init() {
 // same value as 1.79769313486231580e308 does, because the extra digit moves
 // where the significand ends and the scaling begins. Converting the same way is
 // what makes a document valid here exactly when it is valid in MySQL.
+//
+// The float64 conversions in the digit loops keep the multiply and the add as
+// two roundings. Without them the compiler is free to fuse both into one FMA
+// on arm64, which rounds once and can land the accumulation one ULP away from
+// where MySQL's builds put it — enough to flip which side of the largest
+// double a number falls on.
 func mysqlNumberFits(num string) bool {
 	i := 0
 	minus := num[i] == '-'
@@ -310,7 +316,7 @@ func mysqlNumberFits(num string) bool {
 		}
 	}
 	for useDouble && digit() {
-		d = d*10 + float64(num[i]-'0')
+		d = float64(d*10) + float64(num[i]-'0')
 		i++
 	}
 
@@ -340,7 +346,7 @@ func mysqlNumberFits(num string) bool {
 		}
 		for digit() {
 			if sigDigits < 17 {
-				d = d*10 + float64(num[i]-'0')
+				d = float64(d*10) + float64(num[i]-'0')
 				expFrac--
 				if d > 0 {
 					sigDigits++

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -1,6 +1,8 @@
 /*
 Copyright 2018 Aliaksandr Valialkin
 Copyright 2023 The Vitess Authors.
+Portions Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip.
+See LICENSE.rapidjson in this directory.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -245,8 +247,11 @@ func init() {
 // mysqlNumberFits reports whether MySQL can store num, which has to already be
 // a grammatically valid JSON number.
 //
-// MySQL parses JSON with RapidJSON, which decides this in two places. While
-// reading the exponent, a written exponent may not move the decimal point more
+// MySQL parses JSON with RapidJSON, and runs its number reader without
+// kParseFullPrecisionFlag — which is what leaves MySQL on the approximate
+// conversion below rather than a correct one, and pins this boundary to that
+// reader. It decides this in two places. While reading the exponent, a written
+// exponent may not move the decimal point more
 // than maxFloat64Digits places past the digits already behind it. After
 // converting, the result may not be larger than the largest double. Neither
 // place catches what the other does: an exponent that lands on zero is refused

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -176,26 +176,26 @@ func parseValue(s string, c *cache, depth int) (*Value, string, error) {
 	}
 	if s[0] == 't' {
 		if len(s) < len("true") || s[:len("true")] != "true" {
-			return nil, s, fmt.Errorf("unexpected value found: %q", s)
+			return nil, s, fmt.Errorf("unexpected value found: %q", startEndString(s))
 		}
 		return ValueTrue, s[len("true"):], nil
 	}
 	if s[0] == 'f' {
 		if len(s) < len("false") || s[:len("false")] != "false" {
-			return nil, s, fmt.Errorf("unexpected value found: %q", s)
+			return nil, s, fmt.Errorf("unexpected value found: %q", startEndString(s))
 		}
 		return ValueFalse, s[len("false"):], nil
 	}
 	if s[0] == 'n' {
 		if len(s) < len("null") || s[:len("null")] != "null" {
-			return nil, s, fmt.Errorf("unexpected value found: %q", s)
+			return nil, s, fmt.Errorf("unexpected value found: %q", startEndString(s))
 		}
 		return ValueNull, s[len("null"):], nil
 	}
 
 	flen, exponent, ok := readFloat(s)
 	if !ok {
-		return nil, s[flen:], fmt.Errorf("invalid number in JSON string: %q", s)
+		return nil, s[flen:], fmt.Errorf("invalid number in JSON string: %q", startEndString(s))
 	}
 
 	v := c.getValue()

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -228,14 +228,17 @@ func mayExceedFloat64(num string, exponent int) bool {
 }
 
 // pow10 holds the powers of ten that a number's digits are scaled by, which is
-// the table RapidJSON scales its significand with. It is built from the decimal
-// spellings rather than from math.Pow10, which multiplies two table entries
-// together and lands a bit away from the spelling for 78 of these exponents.
+// the table RapidJSON scales its significand with. RapidJSON writes its table
+// out as decimal literals, so each entry here is read from the same spelling and
+// lands on the same double. math.Pow10 would not: it multiplies two table entries
+// together and comes out a bit away from the spelling for 78 of these exponents.
 var pow10 [maxFloat64Digits + 1]float64
 
+// The rest of the package reads numbers with fastparse, because that is a hot
+// path. This table is built once at startup, so it uses strconv instead.
 func init() {
 	for i := range pow10 {
-		pow10[i], _ = fastparse.ParseFloat64("1e" + strconv.Itoa(i))
+		pow10[i], _ = strconv.ParseFloat("1e"+strconv.Itoa(i), 64)
 	}
 }
 

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -203,7 +203,7 @@ func parseValue(s string, c *cache, depth int) (*Value, string, error) {
 	v.s = s[:flen]
 	v.n = numberTypeRaw
 	if mayExceedFloat64(v.s, exponent) && !mysqlNumberFits(v.s) {
-		return nil, s, fmt.Errorf("number too big to be stored in double: %q", v.s)
+		return nil, s, fmt.Errorf("number too big to be stored in double: %q", startEndString(v.s))
 	}
 	return v, s[flen:], nil
 }

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -541,44 +541,39 @@ func parseRawString(s string) (string, string, error) {
 // covers, the exponent it was written with, and how many digits it carries
 // after its decimal point. Together those say how far the number's digits sit
 // from where a double keeps them.
+//
+// What counts as a number is JSON's grammar rather than Go's: a written plus,
+// a missing digit on either side of the decimal point, and an integer part
+// that opens with a zero are all rejected.
 func readFloat[S string | []byte](s S) (i, exponent, fraction int, ok bool) {
-	// optional sign
+	// optional minus. JSON numbers carry no written plus.
 	if i >= len(s) {
 		return
 	}
-	if s[i] == '+' || s[i] == '-' {
+	if s[i] == '-' {
 		i++
 	}
 
-	// digits
-	sawdot := false
-	sawdigits := false
-	nd := 0
-loop:
-	for ; i < len(s); i++ {
-		switch c := s[i]; true {
-		case c == '.':
-			if sawdot {
-				break loop
-			}
-			sawdot = true
-			continue
-
-		case '0' <= c && c <= '9':
-			sawdigits = true
-			if sawdot {
-				fraction++
-			}
-			if c == '0' && nd == 0 { // ignore leading zeros
-				continue
-			}
-			nd++
-			continue
-		}
-		break
-	}
-	if !sawdigits {
+	// integer part: either a lone zero, or digits that do not open with one
+	if i >= len(s) || s[i] < '0' || s[i] > '9' {
 		return
+	}
+	if s[i] == '0' {
+		i++
+	} else {
+		for ; i < len(s) && '0' <= s[i] && s[i] <= '9'; i++ {
+		}
+	}
+
+	// optional fraction, which has to carry a digit of its own
+	if i < len(s) && s[i] == '.' {
+		i++
+		if i >= len(s) || s[i] < '0' || s[i] > '9' {
+			return
+		}
+		for ; i < len(s) && '0' <= s[i] && s[i] <= '9'; i++ {
+			fraction++
+		}
 	}
 
 	// optional exponent moves the decimal point. An exponent larger than

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -185,14 +185,6 @@ func parseValue(s string, c *cache, depth int) (*Value, string, error) {
 	}
 	if s[0] == 'n' {
 		if len(s) < len("null") || s[:len("null")] != "null" {
-			// Try parsing NaN
-			if len(s) >= 3 && strings.EqualFold(s[:3], "nan") {
-				v := c.getValue()
-				v.t = TypeNumber
-				v.s = s[:3]
-				v.n = numberTypeRaw
-				return v, s[3:], nil
-			}
 			return nil, s, fmt.Errorf("unexpected value found: %q", s)
 		}
 		return ValueNull, s[len("null"):], nil

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -213,20 +213,42 @@ func parseValue(s string, c *cache, depth int) (*Value, string, error) {
 // 308 always leaves somewhere for the number to land and 309 need not.
 const maxFloat64Digits = 308
 
-// mayExceedFloat64 reports whether num is worth converting to find out whether
-// a double can hold it. It errs towards yes: the job is to keep the conversion
-// off the common path, not to answer the question. A number is below the
-// largest double whenever the digits it is written to, moved by its exponent,
-// stay within the ones that double has — len(num) overcounts the digits, which
-// only makes the answer yes more often.
+// mayExceedFloat64 reports whether num is worth converting to find out whether a
+// double can hold it. It errs towards yes: the job is to keep the conversion off
+// the common path, not to answer the question.
 //
-// Only an exponent that moves the decimal point to the right counts against
-// those digits. A negative one buys nothing back: the digits are read into the
+// What can carry a number that far is the digits in front of its decimal point,
+// moved by its exponent — it stays below 10^309 whenever those two together stay
+// inside the places a double has, whatever it goes on to say after the point.
+// Digits behind the point only ever move it the other way, and they are what buys
+// the written exponent its extra room; nor can they overflow the significand on
+// the way in, since it stops taking them at seventeen.
+//
+// Only an exponent that moves the point to the right counts against those digits.
+// A negative one buys nothing back: the digits in front are read into the
 // significand before the exponent is applied, so a significand that ran out of
 // room on the way in has already gone infinite, and moving the point afterwards
 // leaves it there.
+//
+// Counting those digits means walking them, so len(num) answers first. It counts
+// the fraction and the exponent's own characters too, and so can only say yes too
+// often — which leaves the walk where the conversion it saves is: off the path
+// every ordinary number takes.
 func mayExceedFloat64(num string, exponent int) bool {
-	return len(num)+max(exponent, 0) > maxFloat64Digits
+	room := maxFloat64Digits - max(exponent, 0)
+	if len(num) <= room {
+		return false
+	}
+
+	i := 0
+	if num[0] == '-' {
+		i++
+	}
+	digits := 0
+	for i+digits < len(num) && '0' <= num[i+digits] && num[i+digits] <= '9' {
+		digits++
+	}
+	return digits > room
 }
 
 // pow10 holds the powers of ten that a number's digits are scaled by, which is

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -190,6 +190,7 @@ func parseValue(s string, c *cache, depth int) (*Value, string, error) {
 				v := c.getValue()
 				v.t = TypeNumber
 				v.s = s[:3]
+				v.n = numberTypeRaw
 				return v, s[3:], nil
 			}
 			return nil, s, fmt.Errorf("unexpected value found: %q", s)
@@ -197,7 +198,7 @@ func parseValue(s string, c *cache, depth int) (*Value, string, error) {
 		return ValueNull, s[len("null"):], nil
 	}
 
-	flen, ok := readFloat(s)
+	flen, exponent, ok := readFloat(s)
 	if !ok {
 		return nil, s[flen:], fmt.Errorf("invalid number in JSON string: %q", s)
 	}
@@ -206,7 +207,26 @@ func parseValue(s string, c *cache, depth int) (*Value, string, error) {
 	v.t = TypeNumber
 	v.s = s[:flen]
 	v.n = numberTypeRaw
+	if mayExceedFloat64(v.s, exponent) {
+		if _, err := fastparse.ParseFloat64(v.s); err != nil {
+			return nil, s, fmt.Errorf("number too big to be stored in double: %q", v.s)
+		}
+	}
 	return v, s[flen:], nil
+}
+
+// maxFloat64Digits is the number of digits it takes to write a number that a
+// double cannot hold. The largest double is under 1.8e308, so 308 digits always
+// fit and 309 need not.
+const maxFloat64Digits = 308
+
+// mayExceedFloat64 reports whether num is worth converting to find out whether
+// a double can hold it. It errs towards yes: the job is to keep the conversion
+// off the common path, not to answer the question. Without an exponent a number
+// has to be written out to more digits than the largest double before it can be
+// too big for one.
+func mayExceedFloat64(num string, exponent bool) bool {
+	return exponent || len(num) > maxFloat64Digits
 }
 
 func parseArray(s string, c *cache, depth int) (*Value, string, error) {
@@ -513,7 +533,7 @@ func parseRawString(s string) (string, string, error) {
 	}
 }
 
-func readFloat[S string | []byte](s S) (i int, ok bool) {
+func readFloat[S string | []byte](s S) (i int, exponent bool, ok bool) {
 	// optional sign
 	if i >= len(s) {
 		return
@@ -556,6 +576,7 @@ loop:
 	// a lot (say, 100000).  it doesn't matter if it's
 	// not the exact number.
 	if i < len(s) && (s[i] == 'e' || s[i] == 'E') {
+		exponent = true
 		i++
 		if i >= len(s) {
 			return
@@ -569,7 +590,7 @@ loop:
 		for ; i < len(s) && ('0' <= s[i] && s[i] <= '9'); i++ {
 		}
 	}
-	return i, true
+	return i, exponent, true
 }
 
 // Object represents JSON object.

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -198,7 +198,7 @@ func parseValue(s string, c *cache, depth int) (*Value, string, error) {
 		return ValueNull, s[len("null"):], nil
 	}
 
-	flen, exponent, ok := readFloat(s)
+	flen, exponent, fraction, ok := readFloat(s)
 	if !ok {
 		return nil, s[flen:], fmt.Errorf("invalid number in JSON string: %q", s)
 	}
@@ -207,6 +207,9 @@ func parseValue(s string, c *cache, depth int) (*Value, string, error) {
 	v.t = TypeNumber
 	v.s = s[:flen]
 	v.n = numberTypeRaw
+	if exponent > maxFloat64Digits+fraction {
+		return nil, s, fmt.Errorf("number too big to be stored in double: %q", v.s)
+	}
 	if mayExceedFloat64(v.s, exponent) {
 		if _, err := fastparse.ParseFloat64(v.s); err != nil {
 			return nil, s, fmt.Errorf("number too big to be stored in double: %q", v.s)
@@ -215,18 +218,19 @@ func parseValue(s string, c *cache, depth int) (*Value, string, error) {
 	return v, s[flen:], nil
 }
 
-// maxFloat64Digits is the number of digits it takes to write a number that a
-// double cannot hold. The largest double is under 1.8e308, so 308 digits always
-// fit and 309 need not.
+// maxFloat64Digits is how far a decimal point can travel before a double runs
+// out of room. The largest double is under 1.8e308, so a written exponent of
+// 308 always leaves somewhere for the number to land and 309 need not.
 const maxFloat64Digits = 308
 
 // mayExceedFloat64 reports whether num is worth converting to find out whether
 // a double can hold it. It errs towards yes: the job is to keep the conversion
-// off the common path, not to answer the question. Without an exponent a number
-// has to be written out to more digits than the largest double before it can be
-// too big for one.
-func mayExceedFloat64(num string, exponent bool) bool {
-	return exponent || len(num) > maxFloat64Digits
+// off the common path, not to answer the question. A number is below the
+// largest double whenever the digits it is written to, moved by its exponent,
+// stay within the ones that double has — len(num) overcounts the digits, which
+// only makes the answer yes more often.
+func mayExceedFloat64(num string, exponent int) bool {
+	return len(num)+exponent > maxFloat64Digits
 }
 
 func parseArray(s string, c *cache, depth int) (*Value, string, error) {
@@ -533,7 +537,11 @@ func parseRawString(s string) (string, string, error) {
 	}
 }
 
-func readFloat[S string | []byte](s S) (i int, exponent bool, ok bool) {
+// readFloat reads a JSON number off the front of s, returning how much of s it
+// covers, the exponent it was written with, and how many digits it carries
+// after its decimal point. Together those say how far the number's digits sit
+// from where a double keeps them.
+func readFloat[S string | []byte](s S) (i, exponent, fraction int, ok bool) {
 	// optional sign
 	if i >= len(s) {
 		return
@@ -558,6 +566,9 @@ loop:
 
 		case '0' <= c && c <= '9':
 			sawdigits = true
+			if sawdot {
+				fraction++
+			}
 			if c == '0' && nd == 0 { // ignore leading zeros
 				continue
 			}
@@ -570,27 +581,37 @@ loop:
 		return
 	}
 
-	// optional exponent moves decimal point.
-	// if we read a very large, very long number,
-	// just be sure to move the decimal point by
-	// a lot (say, 100000).  it doesn't matter if it's
-	// not the exact number.
+	// optional exponent moves the decimal point. An exponent larger than
+	// exponentCeiling stops there rather than running on: the ceiling clears
+	// both the largest double and every digit this number could hold after its
+	// decimal point, so a number stopped at it is out of reach either way.
 	if i < len(s) && (s[i] == 'e' || s[i] == 'E') {
-		exponent = true
 		i++
 		if i >= len(s) {
 			return
 		}
+		negative := false
 		if s[i] == '+' || s[i] == '-' {
+			negative = s[i] == '-'
 			i++
 		}
 		if i >= len(s) || s[i] < '0' || s[i] > '9' {
 			return
 		}
+		exponentCeiling := maxFloat64Digits + len(s)
 		for ; i < len(s) && ('0' <= s[i] && s[i] <= '9'); i++ {
+			if exponent <= exponentCeiling {
+				exponent = exponent*10 + int(s[i]-'0')
+			}
+		}
+		if exponent > exponentCeiling {
+			exponent = exponentCeiling
+		}
+		if negative {
+			exponent = -exponent
 		}
 	}
-	return i, exponent, true
+	return i, exponent, fraction, true
 }
 
 // Object represents JSON object.

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -217,8 +217,14 @@ const maxFloat64Digits = 308
 // largest double whenever the digits it is written to, moved by its exponent,
 // stay within the ones that double has — len(num) overcounts the digits, which
 // only makes the answer yes more often.
+//
+// Only an exponent that moves the decimal point to the right counts against
+// those digits. A negative one buys nothing back: the digits are read into the
+// significand before the exponent is applied, so a significand that ran out of
+// room on the way in has already gone infinite, and moving the point afterwards
+// leaves it there.
 func mayExceedFloat64(num string, exponent int) bool {
-	return len(num)+exponent > maxFloat64Digits
+	return len(num)+max(exponent, 0) > maxFloat64Digits
 }
 
 // pow10 holds the powers of ten that a number's digits are scaled by, which is

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -741,9 +741,16 @@ func parseRawString(s string) (string, string, error) {
 }
 
 // readFloat reads a JSON number off the front of s, returning how much of s it
-// covers and the exponent it was written with. Whether the number is one a
-// double can hold is mysqlNumberFits's job; the exponent is reported so that
-// question only has to be asked of numbers whose digits could reach that far.
+// covers and how far its exponent moves the decimal point. Whether the number
+// is one a double can hold is mysqlNumberFits's job; the exponent is reported so
+// that question only has to be asked of numbers whose digits could reach that
+// far.
+//
+// That distance is bounded rather than exact. An exponent can be written to more
+// digits than it takes to leave every double behind, and one that reaches
+// exponentCeiling below is left there instead of read out to the end. So it
+// answers how far is far enough to matter and nothing finer; mysqlNumberFits
+// reads the exponent itself off the number again.
 //
 // What counts as a number is JSON's grammar rather than Go's: a written plus,
 // a missing digit on either side of the decimal point, and an integer part

--- a/go/mysql/json/parser_bench_test.go
+++ b/go/mysql/json/parser_bench_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package json
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// numberArray builds a JSON array of n numbers, each spelled by digits.
+func numberArray(n int, digits func(i int) string) string {
+	var sb strings.Builder
+	sb.WriteByte('[')
+	for i := range n {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(digits(i))
+	}
+	sb.WriteByte(']')
+	return sb.String()
+}
+
+// benchDocs covers the number shapes the parser takes different paths through.
+//
+// The first four are the everyday ones, where the cost is the scan itself. The
+// last three reach the magnitude check, which a number only pays for when its
+// digits and its exponent together could carry it past the largest double:
+// once with an exponent large enough to ask the question of every element, once
+// where the digits alone are enough to ask it, and once for a document the
+// answer rejects.
+var benchDocs = []struct {
+	name     string
+	doc      string
+	rejected bool
+}{
+	{name: "int/1024", doc: numberArray(1024, func(i int) string { return strconv.Itoa(i * 7919) })},
+	{name: "frac/1024", doc: numberArray(1024, func(i int) string { return strconv.Itoa(i) + "." + strconv.Itoa(i*7919) })},
+	{name: "exp/1024", doc: numberArray(1024, func(i int) string { return strconv.Itoa(i) + "." + strconv.Itoa(i*7919) + "e" + strconv.Itoa(i%300) })},
+	{name: "mixed-object", doc: `{"id":38141,"name":"a name","ok":true,"score":-12.5e3,"tags":["x","y"],"meta":null}`},
+
+	{name: "checked/1024", doc: numberArray(1024, func(i int) string { return "1." + strconv.Itoa(i) + "e30" + strconv.Itoa(i%8) })},
+	{name: "checked-long-fraction", doc: "0." + strings.Repeat("0", 400) + "1e-400"},
+	{name: "rejected", doc: strings.Repeat("9", 400) + "e-100", rejected: true},
+}
+
+func BenchmarkParse(b *testing.B) {
+	for _, tc := range benchDocs {
+		b.Run(tc.name, func(b *testing.B) {
+			var p Parser
+
+			// A case that stops early measures the error path instead of the one
+			// it was written for, and reads as a speed-up while doing it.
+			if _, err := p.Parse(tc.doc); (err != nil) != tc.rejected {
+				b.Fatalf("document does not take the path this case measures: err=%v", err)
+			}
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(tc.doc)))
+			for b.Loop() {
+				v, err := p.Parse(tc.doc)
+				if err == nil && v == nil {
+					b.Fatal("parsed to no value")
+				}
+			}
+		})
+	}
+}

--- a/go/mysql/json/parser_bench_test.go
+++ b/go/mysql/json/parser_bench_test.go
@@ -39,14 +39,17 @@ func numberArray(n int, digits func(i int) string) string {
 // benchDocs covers the number shapes the parser takes different paths through.
 //
 // The first four are the everyday ones, where the cost is the scan itself. The
-// last three reach the magnitude check, which a number only pays for when its
-// digits and its exponent together could carry it past the largest double:
-// once with an exponent large enough to ask the question of every element, once
-// where the digits alone are enough to ask it, and once for a document the
-// answer rejects.
+// last three reach the magnitude check, which a number only pays for once it is
+// written to more digits than its exponent leaves a double room for: once with
+// an exponent that shrinks the room to ask the question of every element, once
+// where the digits alone are past what a double has, and once for a document the
+// answer rejects. reachesMagnitudeCheck holds them to that, since a case that
+// falls short of the check goes on measuring the scan and reads as though the
+// check were free.
 var benchDocs = []struct {
 	name     string
 	doc      string
+	checked  bool
 	rejected bool
 }{
 	{name: "int/1024", doc: numberArray(1024, func(i int) string { return strconv.Itoa(i * 7919) })},
@@ -54,9 +57,34 @@ var benchDocs = []struct {
 	{name: "exp/1024", doc: numberArray(1024, func(i int) string { return strconv.Itoa(i) + "." + strconv.Itoa(i*7919) + "e" + strconv.Itoa(i%300) })},
 	{name: "mixed-object", doc: `{"id":38141,"name":"a name","ok":true,"score":-12.5e3,"tags":["x","y"],"meta":null}`},
 
-	{name: "checked/1024", doc: numberArray(1024, func(i int) string { return "1." + strconv.Itoa(i) + "e30" + strconv.Itoa(i%8) })},
-	{name: "checked-long-fraction", doc: "0." + strings.Repeat("0", 400) + "1e-400"},
-	{name: "rejected", doc: strings.Repeat("9", 400) + "e-100", rejected: true},
+	{name: "checked/1024", doc: numberArray(1024, func(i int) string { return "1" + strconv.Itoa(1000000000000000000+i) + "e289" }), checked: true},
+	{name: "checked-long-fraction", doc: "1" + strings.Repeat("0", 308) + "." + strings.Repeat("5", 400), checked: true},
+	{name: "rejected", doc: strings.Repeat("9", 400) + "e-100", checked: true, rejected: true},
+}
+
+// reachesMagnitudeCheck reports whether every number in doc is converted to find
+// out whether a double can hold it, which is what the checked cases are for. A
+// number written to fewer digits than a double has room for answers that question
+// from its digits alone, and a case built out of those measures the scan it shares
+// with every other case instead.
+func reachesMagnitudeCheck(doc string) bool {
+	numbers := 0
+	for i := 0; i < len(doc); {
+		if c := doc[i]; c != '-' && (c < '0' || c > '9') {
+			i++
+			continue
+		}
+		flen, exponent, ok := readFloat(doc[i:])
+		if !ok {
+			return false
+		}
+		if !mayExceedFloat64(doc[i:i+flen], exponent) {
+			return false
+		}
+		numbers++
+		i += flen
+	}
+	return numbers > 0
 }
 
 func BenchmarkParse(b *testing.B) {
@@ -68,6 +96,9 @@ func BenchmarkParse(b *testing.B) {
 			// it was written for, and reads as a speed-up while doing it.
 			if _, err := p.Parse(tc.doc); (err != nil) != tc.rejected {
 				b.Fatalf("document does not take the path this case measures: err=%v", err)
+			}
+			if reachesMagnitudeCheck(tc.doc) != tc.checked {
+				b.Fatalf("document reaches the magnitude check: %v, want %v", !tc.checked, tc.checked)
 			}
 
 			b.ReportAllocs()

--- a/go/mysql/json/parser_test.go
+++ b/go/mysql/json/parser_test.go
@@ -177,20 +177,6 @@ func TestParseNumberTooBigForDouble(t *testing.T) {
 		}
 	})
 
-	// Nothing bounds how long a number may be written, and Parse copies the
-	// message it wraps, so naming the number in full would carry the document
-	// twice over into the error a client is handed. It is abbreviated instead,
-	// as the unparsed tail already is.
-	t.Run("the error abbreviates a long number", func(t *testing.T) {
-		doc := "1" + strings.Repeat("0", 100000)
-
-		var p Parser
-		_, err := p.Parse(doc)
-		require.ErrorContains(t, err, "number too big to be stored in double")
-		require.NotContains(t, err.Error(), strings.Repeat("0", 200),
-			"the error carries the number it is reporting on")
-	})
-
 	// A negative exponent is not bounded, only stopped before it overflows the
 	// int it accumulates into, and what sends a number through the conversion at
 	// all is being written to more digits than a double holds. These cross the
@@ -314,6 +300,35 @@ func TestParseNumberGrammar(t *testing.T) {
 			})
 		}
 	})
+}
+
+// TestParseErrorAbbreviatesTheDocument covers how much of a rejected document
+// its error names. Nothing bounds how long a document may be, and Parse copies
+// the message it wraps, so naming the text in full hands a client its own
+// document back twice over. Each rejection abbreviates what it names, as the
+// unparsed tail alongside it already did.
+func TestParseErrorAbbreviatesTheDocument(t *testing.T) {
+	long := strings.Repeat("9", 100000)
+
+	for _, tc := range []struct {
+		name string
+		doc  string
+	}{
+		{name: "a number too big for a double", doc: "1" + long},
+		{name: "a written plus", doc: "+" + long},
+		{name: "a decimal point with nothing before it", doc: "." + long},
+		{name: "a decimal point with nothing after it", doc: long + "."},
+		{name: "nan", doc: "nan" + long},
+		{name: "nothing the grammar has a shape for", doc: "q" + long},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var p Parser
+			_, err := p.Parse(tc.doc)
+			require.Error(t, err)
+			require.NotContains(t, err.Error(), strings.Repeat("9", 200),
+				"the error carries the document it is reporting on")
+		})
+	}
 }
 
 func TestUnescapeStringBestEffort(t *testing.T) {

--- a/go/mysql/json/parser_test.go
+++ b/go/mysql/json/parser_test.go
@@ -177,6 +177,32 @@ func TestParseNumberTooBigForDouble(t *testing.T) {
 		}
 	})
 
+	// A negative exponent is not bounded, only stopped before it overflows the
+	// int it accumulates into, and what sends a number through the conversion at
+	// all is being written to more digits than a double holds. These cross the
+	// two, so the exponent is read into an int that cannot hold it and then
+	// scales a significand: written past that stop, it lands wherever the
+	// overflow leaves it, which can be a power of ten the table does not go up
+	// to. Each of these stays valid and reads as zero. MySQL 8.0.46 accepts all
+	// three and reads them as zero too.
+	t.Run("a negative exponent written past what an int holds", func(t *testing.T) {
+		for _, doc := range []string{
+			strings.Repeat("9", 400) + "e-" + strings.Repeat("2", 306),
+			"-" + strings.Repeat("9", 400) + "e-" + strings.Repeat("2", 306),
+			strings.Repeat("1", 400) + "." + strings.Repeat("5", 20) + "e-" + strings.Repeat("2", 306),
+		} {
+			t.Run(startEndString(doc), func(t *testing.T) {
+				var p Parser
+				v, err := p.Parse(doc)
+				require.NoError(t, err)
+
+				f, ok := v.Float64()
+				require.True(t, ok)
+				require.Zero(t, f)
+			})
+		}
+	})
+
 	// The significand accumulates one digit at a time, and each step rounds
 	// the multiplication and the addition separately, the way MySQL's builds
 	// run the loop. Fusing the two into one rounding — which the Go compiler

--- a/go/mysql/json/parser_test.go
+++ b/go/mysql/json/parser_test.go
@@ -163,6 +163,46 @@ func TestParseNumberTooBigForDouble(t *testing.T) {
 	})
 }
 
+// TestParseNumberGrammar covers the shapes JSON's grammar allows a number to
+// take. A number opens with a minus or a digit, an integer part of more than
+// one digit does not open with a zero, and a decimal point has digits on both
+// sides of it. MySQL holds documents to the same grammar, and nan is not a
+// number to either of them.
+func TestParseNumberGrammar(t *testing.T) {
+	t.Run("accepted", func(t *testing.T) {
+		for _, doc := range []string{
+			"0", "-0", "0.5", "-0.5", "1", "-1", "1.2", "0e0", "-0e0",
+			"1e5", "1E5", "1e007", "1e+007", "1e-5", "0.0",
+			"[0,1,2]", `{"a":-0.5,"b":[1e5]}`,
+		} {
+			t.Run(doc, func(t *testing.T) {
+				var p Parser
+				_, err := p.Parse(doc)
+				require.NoError(t, err)
+			})
+		}
+	})
+
+	t.Run("rejected", func(t *testing.T) {
+		for _, doc := range []string{
+			// An integer part that opens with a zero.
+			"007", "-003", "01", "00", "00.5", "01.5", "[007]",
+			// A decimal point missing a digit on one side.
+			".2", "-.2", "12.", "-12.", "1.e5", `{"a": .2}`, "[12.]",
+			// A written plus.
+			"+1", "+1.5", "+0", "[+1]",
+			// Not a number at all.
+			"nan", "NaN", "NAN", "[nan]", `{"a": nan}`, "-nan", ".", "-",
+		} {
+			t.Run(doc, func(t *testing.T) {
+				var p Parser
+				_, err := p.Parse(doc)
+				require.Error(t, err)
+			})
+		}
+	})
+}
+
 func TestUnescapeStringBestEffort(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		testUnescapeStringBestEffort(t, ``, ``)

--- a/go/mysql/json/parser_test.go
+++ b/go/mysql/json/parser_test.go
@@ -177,6 +177,20 @@ func TestParseNumberTooBigForDouble(t *testing.T) {
 		}
 	})
 
+	// Nothing bounds how long a number may be written, and Parse copies the
+	// message it wraps, so naming the number in full would carry the document
+	// twice over into the error a client is handed. It is abbreviated instead,
+	// as the unparsed tail already is.
+	t.Run("the error abbreviates a long number", func(t *testing.T) {
+		doc := "1" + strings.Repeat("0", 100000)
+
+		var p Parser
+		_, err := p.Parse(doc)
+		require.ErrorContains(t, err, "number too big to be stored in double")
+		require.NotContains(t, err.Error(), strings.Repeat("0", 200),
+			"the error carries the number it is reporting on")
+	})
+
 	// A negative exponent is not bounded, only stopped before it overflows the
 	// int it accumulates into, and what sends a number through the conversion at
 	// all is being written to more digits than a double holds. These cross the

--- a/go/mysql/json/parser_test.go
+++ b/go/mysql/json/parser_test.go
@@ -90,7 +90,15 @@ func TestParseNumberTooBigForDouble(t *testing.T) {
 			// Underflow keeps the document valid and reads as zero.
 			"1e-400",
 			"1e-1000",
+			"1e-1024",
 			"0." + strings.Repeat("0", 400) + "1",
+			// A written sign and a padded exponent are spellings, not
+			// magnitudes, and none of these is anywhere near the limit.
+			"1e+0",
+			"1e-0",
+			"1e0000000000",
+			"1e-0000000000",
+			"1e+308",
 		} {
 			t.Run(startEndString(doc), func(t *testing.T) {
 				var p Parser
@@ -107,6 +115,7 @@ func TestParseNumberTooBigForDouble(t *testing.T) {
 			"-1e309",
 			"1e1025",
 			"1.7976931348623159e308",
+			"1e+309",
 			tooManyDigits,
 			// A number anywhere in the document invalidates all of it.
 			"[1, 1e309]",

--- a/go/mysql/json/parser_test.go
+++ b/go/mysql/json/parser_test.go
@@ -98,6 +98,12 @@ func TestParseNumberTooBigForDouble(t *testing.T) {
 			"1e-1000",
 			"1e-1024",
 			"0." + strings.Repeat("0", 400) + "1",
+			// Digits a double has room for, moved out of the way by a negative
+			// exponent.
+			"1" + strings.Repeat("0", 307) + "e-1",
+			"1" + strings.Repeat("0", 307) + "e-400",
+			"-1" + strings.Repeat("0", 307) + "e-400",
+			"0." + strings.Repeat("0", 400) + "1e-400",
 			// A written sign and a padded exponent are spellings, not
 			// magnitudes, and none of these is anywhere near the limit.
 			"1e+0",
@@ -149,6 +155,15 @@ func TestParseNumberTooBigForDouble(t *testing.T) {
 			// Within the written bound, but too big once converted.
 			"10e308",
 			"1" + strings.Repeat("0", 30) + "e279",
+			// More digits than a double has room for. The digits are read before
+			// the exponent is applied, so a negative exponent does not buy the
+			// room back however far it moves the decimal point afterwards.
+			"1" + strings.Repeat("0", 320) + "e-20",
+			"1" + strings.Repeat("0", 350) + "e-50",
+			"1" + strings.Repeat("0", 400) + "e-400",
+			"-1" + strings.Repeat("0", 400) + "e-400",
+			"1" + strings.Repeat("0", 400) + ".5e-400",
+			strings.Repeat("9", 400) + "e-100",
 			// A number anywhere in the document invalidates all of it.
 			"[1, 1e309]",
 			`{"a": 1e309}`,

--- a/go/mysql/json/parser_test.go
+++ b/go/mysql/json/parser_test.go
@@ -31,7 +31,7 @@ func TestParseRawNumber(t *testing.T) {
 		f := func(s, expectedRN, expectedTail string) {
 			t.Helper()
 
-			flen, _, _, ok := readFloat(s)
+			flen, _, ok := readFloat(s)
 			require.Truef(t, ok, "unexpected error when parsing '%s'", s)
 
 			rn, tail := s[:flen], s[flen:]
@@ -57,7 +57,7 @@ func TestParseRawNumber(t *testing.T) {
 		f := func(s, expectedTail string) {
 			t.Helper()
 
-			flen, _, _, ok := readFloat(s)
+			flen, _, ok := readFloat(s)
 			require.False(t, ok, "expecting non-nil error")
 			require.Equalf(t, expectedTail, s[flen:], "unexpected tail; got %q; want %q", s[flen:], expectedTail)
 		}
@@ -158,6 +158,42 @@ func TestParseNumberTooBigForDouble(t *testing.T) {
 				var p Parser
 				_, err := p.Parse(doc)
 				require.ErrorContains(t, err, "number too big to be stored in double")
+			})
+		}
+	})
+
+	// Right at the top of the range the answer turns on how a number was
+	// written rather than on what it is worth. The digits are split between a
+	// significand and a power of ten to scale it by, and where that split falls
+	// decides which way the last place rounds — so writing the same value to one
+	// more digit moves the split and can move the answer with it.
+	t.Run("spelling at the largest double", func(t *testing.T) {
+		for _, tc := range []struct {
+			doc  string
+			fits bool
+		}{
+			{"1.7976931348623157e308", true},
+			{"1.7976931348623158e308", false},
+			{"1.79769313486231580e308", true},
+			{"1.797693134862315800e308", true},
+			{"1.79769313486231581e308", true},
+			{"1.79769313486231585e308", true},
+			{"1.7976931348623159e308", false},
+			{"1.7976931348623157081e308", true},
+			{"17976931348623157e292", true},
+			{"17976931348623158e292", false},
+			{"179769313486231580e291", true},
+			{"1797693134862315800e290", false},
+			{"17976931348623158000000e286", false},
+		} {
+			t.Run(tc.doc, func(t *testing.T) {
+				var p Parser
+				_, err := p.Parse(tc.doc)
+				if tc.fits {
+					require.NoError(t, err)
+				} else {
+					require.ErrorContains(t, err, "number too big to be stored in double")
+				}
 			})
 		}
 	})

--- a/go/mysql/json/parser_test.go
+++ b/go/mysql/json/parser_test.go
@@ -49,9 +49,8 @@ func TestParseRawNumber(t *testing.T) {
 		f("-12.345E+67 tail", "-12.345E+67", " tail")
 		f("-12.345E-67,tail", "-12.345E-67", ",tail")
 		f("-1234567.8e+90tail", "-1234567.8e+90", "tail")
-		f("12.tail", "12.", "tail")
-		f(".2tail", ".2", "tail")
-		f("-.2tail", "-.2", "tail")
+		f("0.2tail", "0.2", "tail")
+		f("-0.2tail", "-0.2", "tail")
 	})
 
 	t.Run("error", func(t *testing.T) {
@@ -69,6 +68,13 @@ func TestParseRawNumber(t *testing.T) {
 		f(",", ",")
 		f("{", "{")
 		f("\"", "\"")
+
+		// A decimal point needs a digit on either side of it, and a number
+		// opens with a minus or a digit.
+		f("12.tail", "tail")
+		f(".2tail", ".2tail")
+		f("-.2tail", ".2tail")
+		f("+1tail", "+1tail")
 	})
 }
 

--- a/go/mysql/json/parser_test.go
+++ b/go/mysql/json/parser_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package json
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,7 +31,7 @@ func TestParseRawNumber(t *testing.T) {
 		f := func(s, expectedRN, expectedTail string) {
 			t.Helper()
 
-			flen, ok := readFloat(s)
+			flen, _, ok := readFloat(s)
 			require.Truef(t, ok, "unexpected error when parsing '%s'", s)
 
 			rn, tail := s[:flen], s[flen:]
@@ -57,7 +58,7 @@ func TestParseRawNumber(t *testing.T) {
 		f := func(s, expectedTail string) {
 			t.Helper()
 
-			flen, ok := readFloat(s)
+			flen, _, ok := readFloat(s)
 			require.False(t, ok, "expecting non-nil error")
 			require.Equalf(t, expectedTail, s[flen:], "unexpected tail; got %q; want %q", s[flen:], expectedTail)
 		}
@@ -68,6 +69,56 @@ func TestParseRawNumber(t *testing.T) {
 		f(",", ",")
 		f("{", "{")
 		f("\"", "\"")
+	})
+}
+
+// TestParseNumberTooBigForDouble covers the boundary MySQL puts on JSON
+// numbers: a number it cannot store as a double makes the whole document
+// invalid, rather than being kept at the precision it was written to.
+// Underflow is not rejected — it flushes to zero.
+func TestParseNumberTooBigForDouble(t *testing.T) {
+	tooManyDigits := "1" + strings.Repeat("0", 309)
+
+	t.Run("accepted", func(t *testing.T) {
+		for _, doc := range []string{
+			"1e308",
+			"-1e308",
+			"1.7976931348623157e308",
+			"-1.7976931348623157e308",
+			"99999999999999999999999999999999999999999",
+			"1" + strings.Repeat("0", 307),
+			// Underflow keeps the document valid and reads as zero.
+			"1e-400",
+			"1e-1000",
+			"0." + strings.Repeat("0", 400) + "1",
+		} {
+			t.Run(startEndString(doc), func(t *testing.T) {
+				var p Parser
+				v, err := p.Parse(doc)
+				require.NoError(t, err)
+				require.Equal(t, TypeNumber, v.Type())
+			})
+		}
+	})
+
+	t.Run("rejected", func(t *testing.T) {
+		for _, doc := range []string{
+			"1e309",
+			"-1e309",
+			"1e1025",
+			"1.7976931348623159e308",
+			tooManyDigits,
+			// A number anywhere in the document invalidates all of it.
+			"[1, 1e309]",
+			`{"a": 1e309}`,
+			"[[1e309]]",
+		} {
+			t.Run(startEndString(doc), func(t *testing.T) {
+				var p Parser
+				_, err := p.Parse(doc)
+				require.ErrorContains(t, err, "number too big to be stored in double")
+			})
+		}
 	})
 }
 

--- a/go/mysql/json/parser_test.go
+++ b/go/mysql/json/parser_test.go
@@ -31,7 +31,7 @@ func TestParseRawNumber(t *testing.T) {
 		f := func(s, expectedRN, expectedTail string) {
 			t.Helper()
 
-			flen, _, ok := readFloat(s)
+			flen, _, _, ok := readFloat(s)
 			require.Truef(t, ok, "unexpected error when parsing '%s'", s)
 
 			rn, tail := s[:flen], s[flen:]
@@ -58,7 +58,7 @@ func TestParseRawNumber(t *testing.T) {
 		f := func(s, expectedTail string) {
 			t.Helper()
 
-			flen, _, ok := readFloat(s)
+			flen, _, _, ok := readFloat(s)
 			require.False(t, ok, "expecting non-nil error")
 			require.Equalf(t, expectedTail, s[flen:], "unexpected tail; got %q; want %q", s[flen:], expectedTail)
 		}
@@ -99,6 +99,17 @@ func TestParseNumberTooBigForDouble(t *testing.T) {
 			"1e0000000000",
 			"1e-0000000000",
 			"1e+308",
+			"1e00000000000000000308",
+			// A written exponent is bounded by where it puts the decimal
+			// point, so digits after the point buy the same number of places
+			// back. Zero is subject to the bound like anything else.
+			"0e308",
+			"-0e308",
+			"0.0e309",
+			"0.00e310",
+			"0.1e309",
+			"0.01e310",
+			"0." + strings.Repeat("0", 400) + "1e700",
 		} {
 			t.Run(startEndString(doc), func(t *testing.T) {
 				var p Parser
@@ -117,6 +128,21 @@ func TestParseNumberTooBigForDouble(t *testing.T) {
 			"1.7976931348623159e308",
 			"1e+309",
 			tooManyDigits,
+			// One place past what the digits after the point buy back. These
+			// all convert to zero, so only the exponent as written rules them
+			// out.
+			"0e309",
+			"-0e309",
+			"0e+309",
+			"0e1000",
+			"0.0e310",
+			"0.00e311",
+			"0.1e310",
+			"0.01e311",
+			"0." + strings.Repeat("0", 400) + "1e710",
+			// Within the written bound, but too big once converted.
+			"10e308",
+			"1" + strings.Repeat("0", 30) + "e279",
 			// A number anywhere in the document invalidates all of it.
 			"[1, 1e309]",
 			`{"a": 1e309}`,

--- a/go/mysql/json/parser_test.go
+++ b/go/mysql/json/parser_test.go
@@ -162,6 +162,28 @@ func TestParseNumberTooBigForDouble(t *testing.T) {
 		}
 	})
 
+	// The significand accumulates one digit at a time, and each step rounds
+	// the multiplication and the addition separately, the way MySQL's builds
+	// run the loop. Fusing the two into one rounding — which the Go compiler
+	// may do on arm64 unless the conversion in mysqlNumberFits stops it —
+	// moves the accumulation an ULP for these documents, and that is enough
+	// to push them over the largest double. MySQL 8.0.45, 8.4.11 and 9.4.0
+	// accept all of them.
+	t.Run("each accumulation step rounds on its own", func(t *testing.T) {
+		for _, doc := range []string{
+			"17976931348623154547712857878e280",
+			"179769313486231559524062337652e279",
+			"179769313486231577704643761e282",
+			"1797693134862315724800793889e281",
+		} {
+			t.Run(startEndString(doc), func(t *testing.T) {
+				var p Parser
+				_, err := p.Parse(doc)
+				require.NoError(t, err)
+			})
+		}
+	})
+
 	// Right at the top of the range the answer turns on how a number was
 	// written rather than on what it is worth. The digits are split between a
 	// significand and a power of ten to scale it by, and where that split falls


### PR DESCRIPTION
## Description

MySQL and Vitess did not agree on which JSON documents exist. Vitess parsed numbers MySQL refuses, so the same expression could be answered in vtgate and rejected in MySQL, and the answer a query got depended on where it ran. This brings the parser to MySQL's rules, in four parts.

**A number too big for a double.** MySQL decides how a JSON number will be stored when it parses the document: an integer that fits stays exact, and everything else becomes a double. A number too large for a double has nowhere to live, so MySQL calls the whole document invalid rather than keeping it at the precision it was written to:

```
SELECT JSON_VALID('1e1025')            -> 0
SELECT JSON_VALID('1e308')             -> 1
SELECT JSON_TYPE('1e1025')             -> ERROR 3141: Invalid JSON text:
                                          "Number too big to be stored in double." at position 0
INSERT INTO t (doc) VALUES ('1e1025')  -> ERROR 3140: same, in value for column 't.doc'
```

Underflow is not rejected, also matching MySQL — `1e-1000` is a valid document that reads as zero.

The digits go into the significand before the exponent is applied, so what settles this is how a number was written and not what it is worth. A number written to more digits than a double has room for is refused even where a negative exponent would bring it back inside:

```
SELECT JSON_VALID(CONCAT('1', REPEAT('0', 400)))           -> 0
SELECT JSON_VALID(CONCAT('1', REPEAT('0', 400), 'e-400'))  -> 0   -- worth one
SELECT JSON_VALID(CONCAT(REPEAT('9', 400), 'e-100'))       -> 0
SELECT JSON_VALID(CONCAT('1', REPEAT('0', 307), 'e-400'))  -> 1   -- 308 digits, room to spare
```

**An exponent too big as written.** MySQL bounds the exponent before it converts anything. The decimal point may travel 308 places, plus one more for every digit the number already carries after it, so `0e309` is refused even though it is zero while `0.00e310` is fine — its two fraction digits buy the places back:

```
accepted: 0e308   0.0e309   0.00e310   0.1e309   0.01e310
rejected: 0e309   0.0e310   0.00e311   0.1e310   0.01e311
```

Neither rule subsumes the other. `0.00e311` converts to zero and is caught only as written; `10e308` is written inside the bound and overflows only once converted.

**Numbers written in shapes JSON does not have.** The number reader was a general-purpose one rather than a JSON one. It took a written plus, an integer part opening with a zero, and a decimal point with nothing on one side of it — none of which JSON allows and none of which MySQL accepts:

```
                     vitess (before)   mysql
{"a": .2}            0.2               ERROR 3141
[007]                [007]             ERROR 3141
12.                  12.0              ERROR 3141
+1                   1.0               ERROR 3141
```

This is the part already causing query failures in the field: whether a JSON expression is evaluated in vtgate or pushed down to MySQL decides whether it answers or errors.

**`nan`.** The parser carried a branch for it, inherited from the JSON reader this code grew out of. It is an extension to JSON rather than part of it, and `JSON_VALID('nan')` is 0.

**Attribution.** The magnitude check reproduces what RapidJSON's number reader decides, because that is the reader MySQL parses JSON with, and matching it is the whole point. No RapidJSON source is copied — the Go was written to land on the same answers — but reproducing one function's decisions step for step is close enough that its notice belongs in the tree either way, so this adds `go/mysql/json/LICENSE.rapidjson` and a copyright line to `parser.go`. That follows what the package already does for fastjson, which it is derived from.

## Related Issue(s)

Fixes #20724. Related to #20720.

#20724 closes here: `nan` was raised against the combined #20723/#20718 code, and the parser no longer reads it as a number.

#20720 stays open, because two of the things it asks for are not the parser's to give.

The first is that no comparison-invalid number reaches execution. This gets most of the way — a number too big for a double no longer parses at all — but a document can still be written inside the bound and carry a number `decimal.NewFromString` refuses. `0.` followed by 800 zeros and `1e1100` is one: its 800 fraction digits buy back its written exponent, so the bound accepts it, and its double is an ordinary `1e299`. MySQL compares it against `1e299` and says equal; Vitess answers `DECIMAL value is out of range` in the interpreter while the compiled path reads a fingerprint instead. So the divergence that prompted the issue is narrowed here rather than closed, and what closes it is #20718, which compares the double MySQL stored instead of the text the number was written as. Underflow is the same story from the other end: `1e-1025` parses, and MySQL reads it as zero, but comparing its written form errors the same way. @mattlord raised that one in review here.

The second is `sqltypes.NewJSON`, which validates with `encoding/json` and so still accepts these documents. That one cannot use the JSON parser: `go/mysql/json` already imports `go/sqltypes`, so the dependency would be a cycle. It is only reached from test helpers today, and a value built through it is parsed — and now rejected — as soon as it reaches the evalengine through `NewFromSQL`.

## Backport justification

These are wrong answers and spurious failures on released versions, not new behaviour.

The grammar divergence is already breaking queries in production: a JSON expression over a document containing something like `.2` or `007` succeeds when vtgate evaluates it and fails when the same query is pushed down to MySQL, so whether a query works depends on planning decisions the user has no control over.

The magnitude and `nan` divergences give two different answers for one expression. With a JSON column holding `1e1025`, `column0 IN (CAST('1e1025' AS JSON))` errors in the interpreter — the decimal conversion is out of range — and returns 1 in the compiled form, which reads the fingerprint instead. Which one runs is not a user-visible choice either.

The change is contained to the JSON number reader, and everything it now rejects is a document MySQL would never have accepted in the first place, so nothing that can be stored in a MySQL JSON column is affected.

## Verification against MySQL

Checked differentially against a live MySQL 8.0.46 through the `evalengine/integration` harness, comparing accept/reject on 874 documents: the magnitude boundary walked one step at a time across five fraction widths and both signs, long-fraction forms where the exponent and the fraction are both far out of range but the value lands back inside it, every grammar shape above, `nan` in four spellings and nested in arrays and objects, and 500 randomly spelled numbers between 1e290 and 1e340 free to emit leading zeros and written plusses. No mismatches.

That walk varies the exponent and the fraction width but keeps the digit string short, which leaves out the numbers written to more digits than a double holds. A second sweep of 5566 documents covers those: digit counts from 305 to 312, the same boundary walks, and 5000 randomly spelled numbers carrying up to 340 digits on either side of the decimal point with exponents out to ±700, so that long digit strings and compensating negative exponents are crossed with each other. No mismatches. That sweep was run against 8.0.46 only.

### What this does not cover

Whether a document exists and what its numbers are worth are two questions, and this answers the first one only.

@GrahamCampbell found the case that settled how the first had to be answered. At the top of the range MySQL's verdict turns on how a number is spelled rather than on what it is worth — the same value accepted or rejected according to a trailing zero:

```
                            mysql      vitess
1.7976931348623157e308      accepted   accepted
1.7976931348623158e308      rejected   rejected
1.79769313486231580e308     accepted   accepted
17976931348623158e292       rejected   rejected
179769313486231580e291      accepted   accepted
```

No comparison of a correctly converted value against the largest double can produce that, which is why `mysqlNumberFits` transcribes RapidJSON's conversion rather than doing its own: where the digits stop being a significand and start being a power of ten to scale it by is what decides these, so landing the split where RapidJSON lands it lands the verdict too. `TestParseNumberTooBigForDouble` pins all five, along with the spellings either side of them.

What is left over is the value. Vitess reads a number with `fastparse`, which is correctly rounded, while MySQL keeps whatever its approximate conversion arrived at — reading `1.7976931348623157081e308` back gives `1.7976931348623155e308`, two ULP low. That is not confined to the boundary:

```
input shape                                    differs from correctly-rounded
15 significant digits, exponent within ±20      0 / 150
15 significant digits, large exponent          31 / 150
25 significant digits, exponent within ±20     80 / 150
25 significant digits, large exponent          91 / 150
plain decimals, e.g. 291.276103743955106997454 16 / 150
```

So Vitess still reads a different double than MySQL stores for a large share of JSON numbers carrying more than 15 significant digits. Closing that means having the parser return the value its conversion arrived at and not only its verdict, which is what #20726 does, further up this stack.

## Performance

Reading JSON's grammar directly turns out to be less work than the loop that read around it — the leading-zero bookkeeping and the labelled switch both go away — and for a number that never reaches the magnitude check it more than pays for the two new ones. A number that does reach it pays about twice over. Against the merge base, twenty runs a side:

```
parse                    before      after
int/1024                 14.14µs     8.26µs    -41.6%  (p=0.000, n=20)
frac/1024                17.07µs     9.38µs    -45.1%  (p=0.000, n=20)
exp/1024                 19.66µs    11.98µs    -39.1%  (p=0.000, n=20)
mixed-object              140.5n     124.3n    -11.5%  (p=0.000, n=20)
checked/1024             21.72µs    41.13µs    +89.4%  (p=0.000, n=20)
checked-long-fraction     475.5n     949.9n    +99.8%  (p=0.000, n=20)
rejected                       -      1.66µs
```

`BenchmarkParse` in `parser_bench_test.go` produces these. The first four are arrays of a thousand numbers written three ways and a small mixed object; the last three are the shapes that reach the magnitude check.

That is what the check costs when a number reaches it, and until @GrahamCampbell's review the benchmark did not show it: an earlier version of these cases was written before the prefilter counted leading digits rather than the whole written string, and afterwards a number with one integer digit and a large exponent answered from its digits alone. All three accepted `checked` cases had stopped reaching the conversion, so they went on measuring the scan and reported a speed-up — the -11.7% and -33.8% an earlier revision of this section claimed for them. `reachesMagnitudeCheck` now holds every case to what its name says, so a document that stops short of the check fails the benchmark instead of quietly flattering it. All the rows above were re-measured together afterwards, so they differ slightly from that revision's throughout.

What keeps the check off the path an ordinary number takes is asking only what can put a number past the largest double: the digits in front of its decimal point, moved by its exponent. Measuring the whole written number instead counts its fraction, its `e` and its exponent's own digits as well, which is enough to send a `1.5e303` off to be converted to find out what its four digits already said. `readFloat` reports the exponent it scanned so that nothing has to look for it again, and the digits are counted only once the cheaper over-count says they might matter.

Reaching the check at all means being written to more digits than a double has room for — over 308 of them, less whatever a positive exponent takes away. `checked/1024` is twenty digits scaled by `e289` and `checked-long-fraction` a 309-digit integer with a 400-digit fraction; nothing shorter gets there, and the numbers a document usually carries are three orders of magnitude short of it.

Those two rows are a property of the documents rather than of the check, and measuring the same shapes either side of the prefilter says so — identical numbers, one spelling that reaches the conversion and one that answers from its digits alone:

```
number                doesn't reach   reaches   check costs
1.5e308                       9.9n     17.2n         +7.3n
twenty digits, e289          14.6n     41.7n          +27n
309-digit integer             109n      659n         +550n
```

A few nanoseconds fixed and about 1.5n per written digit, which is roughly what a dependent multiply-add chain costs, so there is no fat in it. That is also why `checked/1024` reads as +89%: it is a thousand numbers each written to twenty digits and each landing in `[1e308, 1e309)`. A number that plausibly reaches the check is short and pays 7n for it, against the 39-45% saved on every ordinary number sharing the document with it.

Two savings are left unclaimed, both no-ops rather than approximations: the integer loop goes on accumulating after the significand is already infinite, and the fraction loop goes on iterating after seventeen significant digits with its body switched off — 400 fraction digits are about 290n of `checked-long-fraction`'s 950n. Taking them would help the 300-to-700-digit shapes by roughly a fifth and the short ones not at all, in exchange for more branches inside the one function that has to land on RapidJSON's answer decision for decision. A divergence there is the bug this change exists to close, so they are not worth it at that size. Keeping more numbers off the conversion altogether would mean a sharper prefilter — comparing leading digits against 1.797 with a margin wide enough that the conversion's last-place wobble cannot reach it — which is worth doing if a workload ever asks for it and not before.

`rejected` has no before: that document parsed successfully until this change.

An earlier attempt classified the number eagerly instead, which was much worse — `parseNumberType` tries `ParseInt64` and `ParseUint64` before `ParseFloat64`, so a fractional number pays for two failures (`frac/1024` went from 11.5µs to 327µs).

## Tests

`TestParseNumberTooBigForDouble` covers both sides of the magnitude boundary and both sides of the written-exponent bound, underflow, numbers that are long but small, and rejection nested inside arrays and objects. It also covers the spellings called out on the issue — `1e+0`, `1e0000000000`, `1e-0000000000`, `1e-1024`, `1e00000000000000000308` — which stay valid: each carries an exponent and so goes through the checks, making them the cases most likely to be rejected by mistake.

It also pins that a negative exponent written to more places than an int holds stays valid and reads as zero, on a number long enough to reach the conversion in the first place: without the stop on the exponent accumulator, the overflow lands on a power of ten the table does not go up to. @GrahamCampbell asked for that one in review.

It also crosses long digit strings with negative exponents in both directions — rejected where the digits run past a double's room (`1` and 400 zeros with `e-400`, 400 nines with `e-100`), accepted where they do not (`1` and 307 zeros with `e-400`) — since a number can be written well out of range and still be worth very little.

`TestParseNumberGrammar` covers the four shapes JSON does not have, along with `nan`, each bare and inside a document.

These are unit tests rather than differential cases on purpose: `knownErrors` in the integration harness already whitelists MySQL's `Invalid JSON text in argument N to function W` message, so a differential case passes whether or not Vitess errors. That is also why the harness never caught Vitess accepting these documents, and why the verification above compares accept/reject directly instead.

`go/mysql/json`, `go/mysql/binlog`, `go/mysql/decimal`, `go/mysql/datetime`, `go/sqltypes`, `go/vt/vtgate/evalengine`, the MySQL differential suite, `go/vt/vtgate/engine` and `go/vt/vttablet/tabletmanager/vreplication` pass locally. Nothing in the suite depended on any of these documents parsing; the only tests that changed are the three assertions in `TestParseRawNumber` that pinned the old lax shapes.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI? (locally yes; CI pending)
-   [x] Documentation was added or is not required

## Deployment Notes

JSON documents carrying a number MySQL will not store are now rejected where they used to be accepted: a number too large for a double, a number written to more digits than a double holds even where a negative exponent brings its value back inside, an exponent past what its fraction digits allow, `nan`, and numbers written with a leading plus, a leading zero, or a decimal point missing digits on one side. Documents already stored are unaffected — none of these could be stored in a MySQL JSON column to begin with — and this is about what Vitess will parse. No migrations or configuration changes.

A release note still needs writing for this.

### AI Disclosure

Claude Code wrote this one, including the tests and benchmarks — I reviewed it and provided direction. It came out of reviewing #20691, and grew as @GrahamCampbell found more of the boundary in review.






