### PR TITLE
mysql/json: read character data's numbers as the double MySQL stores

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -27,6 +27,7 @@
         - [PREPARE statements no longer report the prepared statement's tables](#vtgate-prepare-tables-used)
         - [Preparing a statement no longer starts an implicit transaction](#vtgate-prepare-no-implicit-tx)
         - [Stricter validation of SQL-level PREPARE statements](#vtgate-prepare-stricter-validation)
+        - [JSON numbers cast from strings read as the double MySQL stores](#vtgate-json-number-doubles)
     - **[Reparent](#minor-changes-reparent)**
         - [`EmergencyReparentShard` no longer waits on replicas that cannot win the election](#ers-lagging-relay-log-wait)
     - **[VTTablet](#minor-changes-vttablet)**
@@ -248,6 +249,12 @@ SQL-level `PREPARE` and binary-protocol `COM_STMT_PREPARE` now reject statement 
 Additionally, `PREPARE ... FROM ?` is now a syntax error, matching MySQL: the grammar accidentally accepted a positional parameter as the statement text, but no value could ever reach it and the statement always failed. This also affects programs that parse SQL using the `go/vt/sqlparser` package directly.
 
 See [#20562](https://github.com/vitessio/vitess/pull/20562) for details.
+
+#### <a id="vtgate-json-number-doubles"/>JSON numbers cast from strings read as the double MySQL stores</a>
+
+When VTGate converts character data to JSON — `CAST(... AS JSON)`, a string argument to a JSON function, or a JSON-typed bind variable — numbers that only a double can hold now convert to the same double MySQL stores when it parses the same text. MySQL reads JSON numbers at normal precision rather than by correct rounding, so for numbers with 16 or more significant digits, or with large exponents, its double can sit an ULP or two away from the nearest one; VTGate previously landed on the nearest, so the same expression could produce a different value at VTGate than pushed down to MySQL. Comparisons, hashing, weight strings and the printed form of such values follow the converted double.
+
+Numbers with up to 15 significant digits and moderate exponents are unaffected, as are JSON values read from columns, whose text spells the stored double exactly. Bind variables count as character data because a parameter reaches MySQL as text for its document parser to read.
 
 ### <a id="minor-changes-reparent"/>Reparent</a>
 

--- a/go/mysql/json/parser.go
+++ b/go/mysql/json/parser.go
@@ -63,15 +63,48 @@ func startEndString(s string) string {
 	return start + "..." + end
 }
 
-// Parse parses s containing JSON.
+// Parse parses s containing JSON, where s is a printed JSON value: each of
+// its numbers is the exact spelling of the value that was printed, and reads
+// back as the nearest double, which reconstructs that value without loss.
 //
 // The returned value is valid until the next call to Parse*.
 //
 // Use Scanner if a stream of JSON values must be parsed.
 func (p *Parser) Parse(s string) (*Value, error) {
+	return p.parse(s, false)
+}
+
+// ParseBytes parses b containing JSON.
+//
+// The returned Value is valid until the next call to Parse*.
+//
+// Use Scanner if a stream of JSON values must be parsed.
+func (p *Parser) ParseBytes(b []byte) (*Value, error) {
+	return p.parse(hack.String(b), false)
+}
+
+// ParseCast parses s the way MySQL casts character data to JSON. Numbers that
+// only a double can hold read back as the double MySQL's parser stores for
+// the same text, which sits an ULP or two from the nearest one for long
+// significands and large exponents.
+//
+// The returned value is valid until the next call to Parse*.
+func (p *Parser) ParseCast(s string) (*Value, error) {
+	return p.parse(s, true)
+}
+
+// ParseCastBytes parses b the way MySQL casts character data to JSON.
+//
+// The returned Value is valid until the next call to Parse*.
+func (p *Parser) ParseCastBytes(b []byte) (*Value, error) {
+	return p.parse(hack.String(b), true)
+}
+
+func (p *Parser) parse(s string, cast bool) (*Value, error) {
 	s = skipWS(s)
 	p.b = append(p.b[:0], s...)
 	p.c.reset()
+	p.c.cast = cast
 
 	v, tail, err := parseValue(hack.String(p.b), &p.c, 0)
 	if err != nil {
@@ -84,17 +117,13 @@ func (p *Parser) Parse(s string) (*Value, error) {
 	return v, nil
 }
 
-// ParseBytes parses b containing JSON.
-//
-// The returned Value is valid until the next call to Parse*.
-//
-// Use Scanner if a stream of JSON values must be parsed.
-func (p *Parser) ParseBytes(b []byte) (*Value, error) {
-	return p.Parse(hack.String(b))
-}
-
 type cache struct {
 	vs []Value
+
+	// cast is whether this parse reads numbers the way a MySQL cast from
+	// character data does. It is set at every entry, so a pooled parser
+	// cannot carry one caller's choice into the next parse.
+	cast bool
 }
 
 func (c *cache) reset() {
@@ -205,8 +234,13 @@ func parseValue(s string, c *cache, depth int) (*Value, string, error) {
 	// An integer that fits is nowhere near the range of a double, so only the
 	// kind that did not fit one can be too big for the other.
 	v.n = numberKind(v.s, fractional)
-	if v.n == NumberTypeFloat && mayExceedFloat64(v.s, exponent) && !mysqlNumberFits(v.s) {
-		return nil, s, fmt.Errorf("number too big to be stored in double: %q", v.s)
+	if v.n == NumberTypeFloat {
+		if mayExceedFloat64(v.s, exponent) && !mysqlNumberFits(v.s) {
+			return nil, s, fmt.Errorf("number too big to be stored in double: %q", v.s)
+		}
+		if c.cast {
+			v.n = numberTypeCastFloat
+		}
 	}
 	return v, s[flen:], nil
 }
@@ -240,30 +274,39 @@ func init() {
 
 // mysqlNumberFits reports whether MySQL can store num, which has to already be
 // a grammatically valid JSON number.
+func mysqlNumberFits(num string) bool {
+	_, ok := mysqlDouble(num)
+	return ok
+}
+
+// mysqlDouble converts num, which has to already be a grammatically valid JSON
+// number, to the double MySQL stores for it, and reports whether MySQL can
+// store it at all.
 //
-// MySQL parses JSON with RapidJSON, which decides this in two places. While
-// reading the exponent, a written exponent may not move the decimal point more
-// than maxFloat64Digits places past the digits already behind it. After
-// converting, the result may not be larger than the largest double. Neither
-// place catches what the other does: an exponent that lands on zero is refused
-// only as written, and a number written within the bound can still overflow
-// once converted.
+// MySQL parses JSON with RapidJSON, which refuses a number in two places.
+// While reading the exponent, a written exponent may not move the decimal
+// point more than maxFloat64Digits places past the digits already behind it.
+// After converting, the result may not be larger than the largest double.
+// Neither place catches what the other does: an exponent that lands on zero is
+// refused only as written, and a number written within the bound can still
+// overflow once converted.
 //
 // The conversion below is the one RapidJSON does rather than a correct one. It
 // accumulates the significand into a double and scales that by a power of ten,
-// which lands an ULP or two from the true value, and the boundary sits wherever
-// that lands. A number a hair under the largest double therefore comes down to
-// how it was spelled: 1.7976931348623158e308 does not fit, while writing the
-// same value as 1.79769313486231580e308 does, because the extra digit moves
-// where the significand ends and the scaling begins. Converting the same way is
-// what makes a document valid here exactly when it is valid in MySQL.
+// which lands an ULP or two from the true value, and both the value and the
+// boundary sit wherever that lands. A number a hair under the largest double
+// therefore comes down to how it was spelled: 1.7976931348623158e308 does not
+// fit, while writing the same value as 1.79769313486231580e308 does, because
+// the extra digit moves where the significand ends and the scaling begins.
+// Converting the same way is what makes a document valid here exactly when it
+// is valid in MySQL, and worth the same double here as there.
 //
 // The float64 conversions in the digit loops keep the multiply and the add as
 // two roundings. Without them the compiler is free to fuse both into one FMA
 // on arm64, which rounds once and can land the accumulation one ULP away from
 // where MySQL's builds put it — enough to flip which side of the largest
 // double a number falls on.
-func mysqlNumberFits(num string) bool {
+func mysqlDouble(num string) (float64, bool) {
 	i := 0
 	minus := num[i] == '-'
 	if minus {
@@ -399,17 +442,33 @@ func mysqlNumberFits(num string) bool {
 				exp = exp*10 + int(num[i]-'0')
 				i++
 				if exp > maxExp {
-					return false
+					return 0, false
 				}
 			}
 		}
 	}
 
-	// A number that never needed a double is an integer MySQL keeps exact.
+	// A number that never needed a double is an integer MySQL keeps exact. As
+	// a double it is worth the integer, rounded once by the conversion.
 	if !useDouble {
-		return true
+		if use64 {
+			d = float64(u64)
+		} else {
+			d = float64(u32)
+		}
+		if minus {
+			return -d, true
+		}
+		return d, true
 	}
-	return scaleByPow10(d, exp+expFrac) <= math.MaxFloat64
+	d = scaleByPow10(d, exp+expFrac)
+	if d > math.MaxFloat64 {
+		return 0, false
+	}
+	if minus {
+		return -d, true
+	}
+	return d, true
 }
 
 // scaleByPow10 moves d by p decimal places the way RapidJSON does, in one
@@ -1217,6 +1276,10 @@ const (
 	NumberTypeUnsigned
 	NumberTypeDecimal
 	NumberTypeFloat
+	// numberTypeCastFloat is a float parsed from character data the way MySQL
+	// casts it to JSON. It reads as NumberTypeFloat, but converts to the
+	// double MySQL stores for its text rather than to the nearest one.
+	numberTypeCastFloat
 )
 
 // String returns string representation of t.
@@ -1327,6 +1390,9 @@ func (v *Value) NumberType() NumberType {
 	if v.t != TypeNumber {
 		return NumberTypeUnknown
 	}
+	if v.n == numberTypeCastFloat {
+		return NumberTypeFloat
+	}
 	return v.n
 }
 
@@ -1363,6 +1429,11 @@ func (v *Value) Uint64() (uint64, bool) {
 }
 
 func (v *Value) Float64() (float64, bool) {
+	if v.n == numberTypeCastFloat {
+		if f, ok := mysqlDouble(v.s); ok {
+			return f, true
+		}
+	}
 	val, err := fastparse.ParseFloat64(v.s)
 	if err != nil {
 		return val, false
@@ -1370,7 +1441,19 @@ func (v *Value) Float64() (float64, bool) {
 	return val, true
 }
 
+// Decimal returns the value as a decimal. A float becomes the decimal spelled
+// by the shortest text that reads back as the same double, which is how MySQL
+// turns a double into a decimal: double2decimal prints it through my_gcvt and
+// reads the digits back. Every other number keeps each digit it was written
+// with.
 func (v *Value) Decimal() (decimal.Decimal, bool) {
+	if v.NumberType() == NumberTypeFloat {
+		f, ok := v.Float64()
+		if !ok || math.IsInf(f, 0) || math.IsNaN(f) {
+			return decimal.Zero, false
+		}
+		return decimal.NewFromFloat(f), true
+	}
 	dec, err := decimal.NewFromString(v.s)
 	if err != nil {
 		return decimal.Zero, false

--- a/go/mysql/json/parser_test.go
+++ b/go/mysql/json/parser_test.go
@@ -18,6 +18,8 @@ limitations under the License.
 package json
 
 import (
+	"math"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -25,6 +27,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/hack"
+	"vitess.io/vitess/go/mysql/decimal"
+	"vitess.io/vitess/go/mysql/format"
 	"vitess.io/vitess/go/vt/vthash"
 )
 
@@ -167,7 +171,7 @@ func TestParseNumberTooBigForDouble(t *testing.T) {
 	// The significand accumulates one digit at a time, and each step rounds
 	// the multiplication and the addition separately, the way MySQL's builds
 	// run the loop. Fusing the two into one rounding — which the Go compiler
-	// may do on arm64 unless the conversion in mysqlNumberFits stops it —
+	// may do on arm64 unless the conversion in mysqlDouble stops it —
 	// moves the accumulation an ULP for these documents, and that is enough
 	// to push them over the largest double. MySQL 8.0.45, 8.4.11 and 9.4.0
 	// accept all of them.
@@ -221,6 +225,141 @@ func TestParseNumberTooBigForDouble(t *testing.T) {
 			})
 		}
 	})
+}
+
+// TestParseCastDoubles pins the double a number is worth to the double MySQL
+// stores for the same text. MySQL parses JSON at normal precision — the
+// significand accumulates into a double and one multiplication scales it —
+// so for long significands and large exponents its double sits an ULP or two
+// from the nearest one, and an expression evaluated here has to land on
+// MySQL's. The expected bits below are what MySQL 8.0.45, 8.4.11 and 9.4.0
+// store, confirmed by comparing JSON_EXTRACT of each document against a
+// correctly-rounded CAST of the expected value inside the server.
+func TestParseCastDoubles(t *testing.T) {
+	docs := []struct {
+		doc  string
+		want uint64 // IEEE 754 bits of MySQL's double
+	}{
+		{"99999999999999999999999999999999999999999", 0x48725dfa371a19e6},  // 9.999999999999998e40, nearest is 1e41
+		{"-99999999999999999999999999999999999999999", 0xc8725dfa371a19e6}, // sign rides on the same conversion
+		{"100000000000000000000000000000000000000000", 0x48725dfa371a19e6}, // meets the nines at the same double
+		{"1e41", 0x48725dfa371a19e7},                                       // one table lookup, lands on the nearest double
+		{"10e40", 0x48725dfa371a19e7},
+		{"1.7976931348623157081e308", 0x7feffffffffffffe}, // one below the largest double; nearest is the largest
+		{"1.79769313486231580e308", 0x7fefffffffffffff},
+		{"17976931348623157e292", 0x7fefffffffffffff},
+		{"291.276103743955106997454", 0x4072346aebc26973},
+		{"41.451230056623148274", 0x4044b9c1e8101597},
+		{"2.2250738585072014e-308", 0x0010000000000000}, // smallest normal double
+		{"1e-320", 0x00000000000007e8},                  // subnormal, scaled in two steps
+		{"1e-400", 0x0000000000000000},                  // flushes to zero rather than the smallest subnormal
+		{"123456789012345678901234567890", 0x45f8ee90ff6c373d},
+		{"3.14159265358979323846264338327950288", 0x400921fb54442d18},
+		{"18446744073709551616", 0x43f0000000000000},      // one past the largest integer, forced onto the double path
+		{"0.99999999999999999999999", 0x3ff0000000000001}, // one above 1.0; the nearest double is 1.0
+		{"1234567890.12345678901234567890", 0x41d26580b487e6b8},
+		{"0.30000000000000000000000000001", 0x3fd3333333333333},
+		{"0.5", 0x3fe0000000000000},
+	}
+
+	t.Run("character data reads as MySQL's double", func(t *testing.T) {
+		for _, tc := range docs {
+			t.Run(tc.doc, func(t *testing.T) {
+				var p Parser
+				v, err := p.ParseCast(tc.doc)
+				require.NoError(t, err)
+				require.Equal(t, NumberTypeFloat, v.NumberType())
+				f, ok := v.Float64()
+				require.True(t, ok)
+				require.Equal(t, tc.want, math.Float64bits(f),
+					"got %v (%016x), want %v (%016x)",
+					f, math.Float64bits(f), math.Float64frombits(tc.want), tc.want)
+			})
+		}
+	})
+
+	// A printed JSON value spells each double exactly — whoever printed it
+	// chose text that reads back as the double it held — so reading it as the
+	// nearest double reconstructs that double, and MySQL's conversion must
+	// stay out of it.
+	t.Run("printed JSON reads as the nearest double", func(t *testing.T) {
+		for _, tc := range docs {
+			t.Run(tc.doc, func(t *testing.T) {
+				var p Parser
+				v, err := p.Parse(tc.doc)
+				require.NoError(t, err)
+				f, ok := v.Float64()
+				require.True(t, ok)
+				nearest, err := strconv.ParseFloat(tc.doc, 64)
+				require.NoError(t, err)
+				require.Equal(t, math.Float64bits(nearest), math.Float64bits(f))
+			})
+		}
+	})
+
+	// A number built around an existing double — a float column, a binary log
+	// entry — carries that double's exact spelling and has to keep holding the
+	// same double, even where MySQL's document conversion would read the very
+	// same text into a different one.
+	t.Run("numbers built from a double keep that double", func(t *testing.T) {
+		f := math.Float64frombits(0xd64d4ae72831c4f2) // -5.3746011104623175e107
+		text := string(format.FormatFloat(f))
+
+		v := NewNumber(text, NumberTypeFloat)
+		got, ok := v.Float64()
+		require.True(t, ok)
+		require.Equal(t, math.Float64bits(f), math.Float64bits(got))
+
+		var p Parser
+		doc, err := p.ParseCast(text)
+		require.NoError(t, err)
+		converted, ok := doc.Float64()
+		require.True(t, ok)
+		require.Equal(t, uint64(0xd64d4ae72831c4f3), math.Float64bits(converted),
+			"MySQL reads this spelling into the double one ULP over")
+	})
+
+	// Two spellings that MySQL stores as the same double are the same value
+	// everywhere a value reaches: they convert, weigh and therefore hash
+	// alike, while a spelling stored as a different double weighs apart.
+	t.Run("spellings weigh by their double", func(t *testing.T) {
+		var p Parser
+		nines, err := p.ParseCast("99999999999999999999999999999999999999999")
+		require.NoError(t, err)
+		ninesWeight := nines.WeightString(nil)
+
+		var q Parser
+		ten41, err := q.ParseCast("100000000000000000000000000000000000000000")
+		require.NoError(t, err)
+		require.Equal(t, ninesWeight, ten41.WeightString(nil))
+
+		var r Parser
+		e41, err := r.ParseCast("1e41")
+		require.NoError(t, err)
+		require.NotEqual(t, ninesWeight, e41.WeightString(nil))
+	})
+}
+
+// TestDecimalOfFloat pins how a float becomes a decimal: through the shortest
+// text of its double, which is what MySQL's double2decimal prints and reads
+// back. The digits the document spelled beyond the double's precision are
+// gone by then, while a number that is a decimal to begin with keeps all of
+// them.
+func TestDecimalOfFloat(t *testing.T) {
+	text := "0.30000000000000000000000000001"
+
+	var p Parser
+	v, err := p.ParseCast(text)
+	require.NoError(t, err)
+	dec, ok := v.Decimal()
+	require.True(t, ok)
+	require.True(t, dec.Equal(decimal.NewFromFloat(0.3)), "got %s", dec.String())
+
+	exact, err := decimal.NewFromString(text)
+	require.NoError(t, err)
+	kept, ok := NewNumber(text, NumberTypeDecimal).Decimal()
+	require.True(t, ok)
+	require.True(t, kept.Equal(exact), "got %s", kept.String())
 }
 
 // TestParseNumberGrammar covers the shapes JSON's grammar allows a number to

--- a/go/vt/vtgate/evalengine/compiler_asm.go
+++ b/go/vt/vtgate/evalengine/compiler_asm.go
@@ -3631,7 +3631,7 @@ func (asm *assembler) Parse_j(offset int) {
 	asm.emit(func(env *ExpressionEnv) int {
 		var p json.Parser
 		arg := env.vm.stack[env.vm.sp-offset].(*evalBytes)
-		env.vm.stack[env.vm.sp-offset], env.vm.err = p.ParseBytes(arg.bytes)
+		env.vm.stack[env.vm.sp-offset], env.vm.err = p.ParseCastBytes(arg.bytes)
 		return 1
 	}, "PARSE_JSON VARCHAR(SP-%d)", offset)
 }

--- a/go/vt/vtgate/evalengine/compiler_asm_push.go
+++ b/go/vt/vtgate/evalengine/compiler_asm_push.go
@@ -313,9 +313,13 @@ func (asm *assembler) PushBVar_hexval(key string) {
 	}, "PUSH HEXVAL(:%q)", key)
 }
 
-func push_json(env *ExpressionEnv, raw []byte) int {
+func push_json(env *ExpressionEnv, raw []byte, cast bool) int {
 	var parser json.Parser
-	env.vm.stack[env.vm.sp], env.vm.err = parser.ParseBytes(raw)
+	if cast {
+		env.vm.stack[env.vm.sp], env.vm.err = parser.ParseCastBytes(raw)
+	} else {
+		env.vm.stack[env.vm.sp], env.vm.err = parser.ParseBytes(raw)
+	}
 	env.vm.sp++
 	return 1
 }
@@ -328,7 +332,7 @@ func (asm *assembler) PushColumn_json(offset int) {
 		if col.IsNull() {
 			return push_null(env)
 		}
-		return push_json(env, col.Raw())
+		return push_json(env, col.Raw(), false)
 	}, "PUSH JSON(:%d)", offset)
 }
 
@@ -341,7 +345,9 @@ func (asm *assembler) PushBVar_json(key string) {
 		if env.vm.err != nil {
 			return 0
 		}
-		return push_json(env, bvar.Value)
+		// A bind variable holds character data, so its numbers convert the
+		// way MySQL's document parser converts them; see valueToEvalBindVar.
+		return push_json(env, bvar.Value, true)
 	}, "PUSH JSON(:%q)", key)
 }
 

--- a/go/vt/vtgate/evalengine/eval.go
+++ b/go/vt/vtgate/evalengine/eval.go
@@ -369,6 +369,25 @@ func valueToEvalCast(v sqltypes.Value, typ sqltypes.Type, collation collations.I
 	return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "coercion should not try to coerce this value: %v", v)
 }
 
+// valueToEvalBindVar converts a bind variable's value, and differs from
+// valueToEval in one place. A JSON bind variable holds character data, not a
+// printed JSON value: wherever it travels, it reaches mysqld as text for its
+// document parser to read — a parameter cannot carry a double any other way —
+// so its numbers convert the way MySQL converts them. A JSON column's text,
+// by contrast, spells the double the tablet's mysqld already holds, and
+// converts back to exactly that double.
+func valueToEvalBindVar(value sqltypes.Value, collation collations.TypedCollation, values *EnumSetValues) (eval, error) {
+	if value.Type() == sqltypes.TypeJSON {
+		var p json.Parser
+		j, err := p.ParseCastBytes(value.Raw())
+		if err != nil {
+			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%v", err)
+		}
+		return j, nil
+	}
+	return valueToEval(value, collation, values)
+}
+
 func valueToEval(value sqltypes.Value, collation collations.TypedCollation, values *EnumSetValues) (eval, error) {
 	wrap := func(err error) error {
 		if err == nil {

--- a/go/vt/vtgate/evalengine/eval_json.go
+++ b/go/vt/vtgate/evalengine/eval_json.go
@@ -51,7 +51,7 @@ func intoJSON(fn string, e eval) (*evalJSON, error) {
 		return e, nil
 	case *evalBytes:
 		var p json.Parser
-		return p.ParseBytes(e.bytes)
+		return p.ParseCastBytes(e.bytes)
 	default:
 		return nil, errJSONType(fn)
 	}
@@ -106,7 +106,7 @@ func evalConvert_cj(e *evalBytes) (*evalJSON, error) {
 		return nil, err
 	}
 	var p json.Parser
-	return p.ParseBytes(jsonText)
+	return p.ParseCastBytes(jsonText)
 }
 
 func evalConvertArg_cj(e *evalBytes) (*evalJSON, error) {

--- a/go/vt/vtgate/evalengine/eval_tuple.go
+++ b/go/vt/vtgate/evalengine/eval_tuple.go
@@ -34,7 +34,9 @@ func newEvalTuple(values []*querypb.Value, collation collations.ID) (*evalTuple,
 	for _, value := range values {
 		val := sqltypes.ProtoToValue(value)
 
-		e, err := valueToEval(val, typedCoercionCollation(val.Type(), collations.CollationForType(val.Type(), collation)), nil)
+		// Tuples only reach the evalengine as bind variables, so each element
+		// converts as one.
+		e, err := valueToEvalBindVar(val, typedCoercionCollation(val.Type(), collations.CollationForType(val.Type(), collation)), nil)
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/vtgate/evalengine/expr_bvar.go
+++ b/go/vt/vtgate/evalengine/expr_bvar.go
@@ -72,7 +72,7 @@ func (bv *BindVariable) eval(env *ExpressionEnv) (eval, error) {
 
 		tuple := make([]eval, 0, len(bvar.Values))
 		for _, value := range bvar.Values {
-			e, err := valueToEval(sqltypes.MakeTrusted(value.Type, value.Value), typedCoercionCollation(value.Type, collations.CollationForType(value.Type, bv.Collation)), nil)
+			e, err := valueToEvalBindVar(sqltypes.MakeTrusted(value.Type, value.Value), typedCoercionCollation(value.Type, collations.CollationForType(value.Type, bv.Collation)), nil)
 			if err != nil {
 				return nil, err
 			}
@@ -85,7 +85,7 @@ func (bv *BindVariable) eval(env *ExpressionEnv) (eval, error) {
 			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "query argument '%s' cannot be a tuple", bv.Key)
 		}
 		typ := bvar.Type
-		return valueToEval(sqltypes.MakeTrusted(typ, bvar.Value), typedCoercionCollation(typ, collations.CollationForType(typ, bv.Collation)), nil)
+		return valueToEvalBindVar(sqltypes.MakeTrusted(typ, bvar.Value), typedCoercionCollation(typ, collations.CollationForType(typ, bv.Collation)), nil)
 	}
 }
 

--- a/go/vt/vtgate/evalengine/expr_tuple_bvar.go
+++ b/go/vt/vtgate/evalengine/expr_tuple_bvar.go
@@ -72,7 +72,7 @@ func (bv *TupleBindVariable) eval(env *ExpressionEnv) (eval, error) {
 				return
 			}
 			found = true
-			e, err := valueToEval(val, typedCoercionCollation(val.Type(), collations.CollationForType(val.Type(), bv.Collation)), nil)
+			e, err := valueToEvalBindVar(val, typedCoercionCollation(val.Type(), collations.CollationForType(val.Type(), bv.Collation)), nil)
 			if err != nil {
 				evalErr = err
 				return

--- a/go/vt/vtgate/evalengine/json_doubles_test.go
+++ b/go/vt/vtgate/evalengine/json_doubles_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package evalengine
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtenv"
+)
+
+// TestJSONDoublesByOrigin pins which double a JSON number is worth, by where
+// the JSON came from. A bind variable holds character data: wherever it
+// travels it reaches mysqld as text for its document parser to read, so its
+// numbers convert the way MySQL converts them — an ULP or two from the
+// nearest double for long significands. A column's text spells the double the
+// tablet's mysqld already holds, so it converts back to exactly that double.
+// The two expected doubles below differ by one ULP; the MySQL one is what
+// 8.0.45, 8.4.11 and 9.4.0 store for this document.
+func TestJSONDoublesByOrigin(t *testing.T) {
+	venv := vtenv.NewTestEnv()
+	coll := collations.MySQL8().DefaultConnectionCharset()
+
+	const doc = `{"x": 99999999999999999999999999999999999999999}`
+	mysqlDouble := math.Float64frombits(0x48725dfa371a19e6)   // 9.999999999999998e40
+	nearestDouble := math.Float64frombits(0x48725dfa371a19e7) // 1.0000000000000002e41
+
+	evalBits := func(t *testing.T, env *ExpressionEnv, expr Expr, compiled bool) uint64 {
+		t.Helper()
+		var res EvalResult
+		if compiled {
+			res = evaluateCompiled(t, env, expr)
+		} else {
+			var err error
+			res, err = env.EvaluateAST(expr)
+			require.NoError(t, err)
+		}
+		f, err := res.Value(coll).ToFloat64()
+		require.NoError(t, err)
+		return math.Float64bits(f)
+	}
+
+	t.Run("bind variable", func(t *testing.T) {
+		astExpr, err := venv.Parser().ParseExpr(`cast(json_extract(:j, '$.x') as double)`)
+		require.NoError(t, err)
+		astExpr = sqlparser.Rewrite(astExpr, nil, func(c *sqlparser.Cursor) bool {
+			if arg, ok := c.Node().(*sqlparser.Argument); ok {
+				arg.Type = sqltypes.TypeJSON
+			}
+			return true
+		}).(sqlparser.Expr)
+
+		translated, err := Translate(astExpr, &Config{
+			Collation:   coll,
+			Environment: venv,
+		})
+		require.NoError(t, err)
+
+		newEnv := func() *ExpressionEnv {
+			return NewExpressionEnv(t.Context(), map[string]*querypb.BindVariable{
+				"j": {Type: sqltypes.TypeJSON, Value: []byte(doc)},
+			}, NewEmptyVCursor(venv, time.UTC))
+		}
+
+		t.Run("compiled", func(t *testing.T) {
+			require.Equal(t, math.Float64bits(mysqlDouble), evalBits(t, newEnv(), translated, true))
+		})
+		t.Run("interpreted", func(t *testing.T) {
+			require.Equal(t, math.Float64bits(mysqlDouble), evalBits(t, newEnv(), translated, false))
+		})
+	})
+
+	t.Run("column", func(t *testing.T) {
+		fields := FieldResolver([]*querypb.Field{
+			{Name: "j", Type: sqltypes.TypeJSON, Charset: collations.CollationBinaryID},
+		})
+		astExpr, err := venv.Parser().ParseExpr(`cast(json_extract(j, '$.x') as double)`)
+		require.NoError(t, err)
+		translated, err := Translate(astExpr, &Config{
+			ResolveColumn: fields.Column,
+			ResolveType:   fields.Type,
+			Collation:     coll,
+			Environment:   venv,
+		})
+		require.NoError(t, err)
+
+		newEnv := func() *ExpressionEnv {
+			env := NewExpressionEnv(t.Context(), nil, NewEmptyVCursor(venv, time.UTC))
+			env.Row = []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.TypeJSON, []byte(doc))}
+			return env
+		}
+
+		t.Run("compiled", func(t *testing.T) {
+			require.Equal(t, math.Float64bits(nearestDouble), evalBits(t, newEnv(), translated, true))
+		})
+		t.Run("interpreted", func(t *testing.T) {
+			require.Equal(t, math.Float64bits(nearestDouble), evalBits(t, newEnv(), translated, false))
+		})
+	})
+}


### PR DESCRIPTION
## Description

Stacked on #20722 and #20723 — only the last commit is new here; the base retargets down the stack as those merge.

#20722 made Vitess agree with MySQL on which JSON documents *exist*. This one makes it agree on what their numbers are *worth*. MySQL parses JSON numbers at normal precision (significand accumulated into a double, one multiplication to scale it), so for long significands and large exponents its stored double sits an ULP or two away from the correctly-rounded one Vitess produced — for 17+ significant digits that's a majority of numbers, so the same expression could produce a different value evaluated in vtgate than pushed down.

The parser gains `ParseCast`/`ParseCastBytes`, which read numbers with the same conversion the validity check already transcribes, now returning the value. A float's kind settles at parse time, in keeping with #20723 — reading a value never writes back, and the mode is per-call, so a pooled parser cannot carry one caller's choice into the next parse. Where the cast reading applies is decided by one question: what would mysqld do with the same bytes?

- **Character data** — `CAST(... AS JSON)`, string arguments to JSON functions, and JSON-typed bind variables — gets MySQL's conversion, because mysqld would parse that text with its document parser (a parameter can't reach mysqld any other way).
- **JSON columns** keep the exact reading: their wire text spells the double the tablet's mysqld already holds, and correct rounding reconstructs it losslessly. Re-reading printed text MySQL's way would move roughly a third of doubles by an ULP, which is why this isn't applied wholesale.

`Decimal()` on a float now derives from the double's shortest round-trip text, which is what MySQL's `double2decimal` does (it prints through `my_gcvt` and reads the digits back) — with that, JSON comparisons, hashing and weight strings all follow the stored double with no changes of their own.

Verified over 4,649 documents against real MySQL 8.0.45, 8.4.11 and 9.4.0 on arm64 plus 8.4.11 on x86_64: zero validity or value mismatches, and bit-exact agreement with MySQL's vendored RapidJSON compiled the way MySQL builds it. The expected bits in the tests were confirmed inside the servers with `JSON_EXTRACT(...) = CAST(... AS DOUBLE)` probes.

Backport justification: on a supported release, the same expression answers differently depending on whether it runs in vtgate or is pushed down to MySQL — the divergence this PR removes is itself the bug, and it bites hardest when one query mixes both, like a scatter query with vtgate-side post-processing over documents MySQL parsed. Values move only for numbers with 16+ significant digits or extreme exponents, the same class whose validity #20722 already changes on those branches.

## Related Issue(s)

Same class as #20720/#20724, in the value rather than in whether the document is valid. Stacked on #20722 and #20723.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

User-visible: numbers with 16+ significant digits or large exponents in JSON built from character data convert, compare, hash and print by MySQL's double instead of the nearest one. Numbers with up to 15 significant digits and moderate exponents don't move, and JSON column values are unaffected. Release note included in `changelog/25.0/25.0.0/summary.md`.

### AI Disclosure

This PR was written primarily by Claude Code — investigation, implementation and tests — with direction and review from me.

