### PR TITLE
`reparentutil`: order reparent candidates by GTID dominance for a consistent sort

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -29,6 +29,7 @@
         - [Stricter validation of SQL-level PREPARE statements](#vtgate-prepare-stricter-validation)
     - **[Reparent](#minor-changes-reparent)**
         - [`EmergencyReparentShard` no longer waits on replicas that cannot win the election](#ers-lagging-relay-log-wait)
+        - [Reparent candidate ordering now respects partially ordered GTID histories](#reparent-gtid-candidate-ordering)
     - **[VTTablet](#minor-changes-vttablet)**
         - [Consolidator Reject on Waiter Cap](#vttablet-consolidator-reject-on-cap)
         - [Query timeout for state-changing statements on the streaming path](#vttablet-stream-query-timeout)
@@ -262,6 +263,14 @@ This mirrors a tradeoff `orchestrator` made before Vitess: it never gated dead-p
 **Impact**: emergency failovers now succeed in shard states where they previously timed out. A reparent can succeed while some replicas are still catching up; they are repointed and continue replicating under the new primary. No flags were added or changed.
 
 See [#18529](https://github.com/vitessio/vitess/issues/18529).
+
+#### <a id="reparent-gtid-candidate-ordering"/>Reparent candidate ordering now respects partially ordered GTID histories</a>
+
+GTID containment is pairwise, so a candidate set can mix comparable and divergent histories: candidate A at `p:1-100,a:1-10` is strictly ahead of B at `p:1-100,a:1-5`, while C at `p:1-100,c:1-3` is incomparable with both. The reparent sorter that both `EmergencyReparentShard` and `PlannedReparentShard` use compared such candidates non-transitively, so ordering could depend on map iteration or RPC completion order, and `PlannedReparentShard` could select B even though A was known to be more advanced.
+
+Candidates are now ordered by GTID dominance before the existing promotion-rule, buffer-pool, and tablet-alias tiebreakers, so a dominated candidate can never rank ahead of its dominator regardless of input order. `EmergencyReparentShard` still rejects incomparable candidates as split brain, and `PlannedReparentShard` still chooses among incomparable maximal candidates.
+
+See [#20579](https://github.com/vitessio/vitess/issues/20579).
 
 ### <a id="minor-changes-vttablet"/>VTTablet</a>
 

--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -268,7 +268,7 @@ See [#18529](https://github.com/vitessio/vitess/issues/18529).
 
 GTID containment is pairwise, so a candidate set can mix comparable and divergent histories: candidate A at `p:1-100,a:1-10` is strictly ahead of B at `p:1-100,a:1-5`, while C at `p:1-100,c:1-3` is incomparable with both. The reparent sorter that both `EmergencyReparentShard` and `PlannedReparentShard` use compared such candidates non-transitively, so ordering could depend on map iteration or RPC completion order, and `PlannedReparentShard` could select B even though A was known to be more advanced.
 
-Candidates are now ordered by GTID dominance before the existing promotion-rule, buffer-pool, and tablet-alias tiebreakers, so a dominated candidate can never rank ahead of its dominator regardless of input order. `EmergencyReparentShard` still rejects incomparable candidates as split brain, and `PlannedReparentShard` still chooses among incomparable maximal candidates.
+Candidates are now ordered by GTID dominance before the existing promotion-rule, buffer-pool, and tablet-alias tiebreakers, so a dominated candidate can never rank ahead of its dominator regardless of input order. `EmergencyReparentShard` still rejects incomparable candidates as split brain, and `PlannedReparentShard` still chooses among incomparable maximal candidates. Positions that contain each other without being equal (possible with MariaDB GTIDs, where containment ignores the origin server) are now also rejected by `EmergencyReparentShard` as split brain, wherever the pair sits among the candidates; previously a leading pair failed with an internal sorting error, while a pair behind a more advanced candidate was not detected at all.
 
 See [#20579](https://github.com/vitessio/vitess/issues/20579).
 

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -789,7 +789,10 @@ func (erp *EmergencyReparenter) findMostAdvanced(
 	// We have already removed the tablets with errant GTIDs before calling this function. At this point our winning position must be a
 	// superset of all the other valid positions. If any position is incomparable with it, then we have a split brain scenario, and we
 	// should cancel the ERS. Split brain is about divergent received history, so we only compare the Combined positions; the Executed
-	// positions can be transiently incomparable at an equal Combined position (multi-threaded apply gaps) without any divergence
+	// positions can be transiently incomparable at an equal Combined position (multi-threaded apply gaps) without any divergence.
+	// Reciprocally contained but unequal positions are divergent too, containment just can't order them (MariaDB GTID containment
+	// ignores the origin server), so they must also fail closed. The divergent pair can sit behind a candidate that dominates both
+	// of them, so reciprocal containment is checked between every pair of candidates, not just against the winning position
 	for i, position := range tabletPositions {
 		if haveIncomparablePositions(winningPosition.Combined, position.Combined) {
 			return nil, nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "split brain detected between servers - %s and %s", topoproto.TabletAliasString(winningPrimaryTablet.Alias), topoproto.TabletAliasString(validTablets[i].Alias))
@@ -797,6 +800,11 @@ func (erp *EmergencyReparenter) findMostAdvanced(
 		// Keep the sort's maximum-at-index-zero guarantee as a defense-in-depth invariant.
 		if hasDominantReparentPosition(position, winningPosition) {
 			return nil, nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "candidate sorting error: %s has a more advanced position than the chosen candidate %s", topoproto.TabletAliasString(validTablets[i].Alias), topoproto.TabletAliasString(winningPrimaryTablet.Alias))
+		}
+		for j := i + 1; j < len(tabletPositions); j++ {
+			if haveReciprocallyContainedPositions(position.Combined, tabletPositions[j].Combined) {
+				return nil, nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "split brain detected between servers - %s and %s", topoproto.TabletAliasString(validTablets[i].Alias), topoproto.TabletAliasString(validTablets[j].Alias))
+			}
 		}
 	}
 

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -794,9 +794,8 @@ func (erp *EmergencyReparenter) findMostAdvanced(
 		if haveIncomparablePositions(winningPosition.Combined, position.Combined) {
 			return nil, nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "split brain detected between servers - %s and %s", topoproto.TabletAliasString(winningPrimaryTablet.Alias), topoproto.TabletAliasString(validTablets[i].Alias))
 		}
-		// The sort can't guarantee a maximum at index 0 when some positions are incomparable, so also reject a winner that
-		// another candidate dominates. This is an invariant check that should never fire, not an expected path
-		if hasDominantPosition(position.Combined, winningPosition.Combined) {
+		// Keep the sort's maximum-at-index-zero guarantee as a defense-in-depth invariant.
+		if hasDominantReparentPosition(position, winningPosition) {
 			return nil, nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "candidate sorting error: %s has a more advanced position than the chosen candidate %s", topoproto.TabletAliasString(validTablets[i].Alias), topoproto.TabletAliasString(winningPrimaryTablet.Alias))
 		}
 	}

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -6289,6 +6289,21 @@ func TestEmergencyReparenter_findMostAdvanced(t *testing.T) {
 		Executed: replication.Position{GTIDSet: replication.Mysql56GTIDSet{}},
 	}
 
+	// MariaDB GTID containment ignores the origin server, so these two positions contain
+	// each other while holding a different write for sequence 10
+	positionMariadbServer1 := &RelayLogPositions{
+		Combined: replication.MustParsePosition(replication.MariadbFlavorID, "0-1-10"),
+		Executed: replication.MustParsePosition(replication.MariadbFlavorID, "0-1-10"),
+	}
+	positionMariadbServer2 := &RelayLogPositions{
+		Combined: replication.MustParsePosition(replication.MariadbFlavorID, "0-2-10"),
+		Executed: replication.MustParsePosition(replication.MariadbFlavorID, "0-2-10"),
+	}
+	positionMariadbServer1Seq11 := &RelayLogPositions{
+		Combined: replication.MustParsePosition(replication.MariadbFlavorID, "0-1-11"),
+		Executed: replication.MustParsePosition(replication.MariadbFlavorID, "0-1-11"),
+	}
+
 	tests := []struct {
 		name                 string
 		validCandidates      map[string]*RelayLogPositions
@@ -6559,6 +6574,72 @@ func TestEmergencyReparenter_findMostAdvanced(t *testing.T) {
 							Uid:  404,
 						},
 						Hostname: "ignored tablet",
+					},
+				},
+			},
+			err: "split brain detected between servers",
+		}, {
+			// reciprocally contained but unequal positions (MariaDB GTIDs with the same
+			// domain and sequence from different origin servers) are divergent histories
+			// that containment can't order, so ERS must fail closed instead of picking
+			// a side of the divergence by tiebreak
+			name: "split brain detection on reciprocal but unequal mariadb positions",
+			validCandidates: map[string]*RelayLogPositions{
+				"zone1-0000000100": positionMariadbServer1,
+				"zone1-0000000101": positionMariadbServer2,
+			},
+			tabletMap: map[string]*topo.TabletInfo{
+				"zone1-0000000100": {
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  100,
+						},
+					},
+				},
+				"zone1-0000000101": {
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  101,
+						},
+					},
+				},
+			},
+			err: "split brain detected between servers",
+		}, {
+			// the divergent pair can sit behind a candidate that dominates both of them,
+			// so reciprocal containment must be checked between every pair of candidates,
+			// not just against the winning position
+			name: "split brain detection on reciprocal mariadb positions behind the winner",
+			validCandidates: map[string]*RelayLogPositions{
+				"zone1-0000000100": positionMariadbServer1Seq11,
+				"zone1-0000000101": positionMariadbServer1,
+				"zone1-0000000102": positionMariadbServer2,
+			},
+			tabletMap: map[string]*topo.TabletInfo{
+				"zone1-0000000100": {
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  100,
+						},
+					},
+				},
+				"zone1-0000000101": {
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  101,
+						},
+					},
+				},
+				"zone1-0000000102": {
+					Tablet: &topodatapb.Tablet{
+						Alias: &topodatapb.TabletAlias{
+							Cell: "zone1",
+							Uid:  102,
+						},
 					},
 				},
 			},

--- a/go/vt/vtctl/reparentutil/reparent_sorter.go
+++ b/go/vt/vtctl/reparentutil/reparent_sorter.go
@@ -29,17 +29,26 @@ import (
 // reparentSorter sorts tablets by GTID positions and Promotion rules aimed at finding the best
 // candidate for intermediate promotion in emergency reparent shard, and the new primary in planned reparent shard
 type reparentSorter struct {
-	tablets          []*topodatapb.Tablet
-	positions        []*RelayLogPositions
-	innodbBufferPool []int
-	durability       policy.Durabler
+	tablets                []*topodatapb.Tablet
+	positions              []*RelayLogPositions
+	combinedDominatedCount []int
+	executedDominatedCount []int
+	innodbBufferPool       []int
+	durability             policy.Durabler
 }
 
 // newReparentSorter creates a new reparentSorter
 func newReparentSorter(tablets []*topodatapb.Tablet, positions []*RelayLogPositions, innodbBufferPool []int, durability policy.Durabler) *reparentSorter {
 	return &reparentSorter{
-		tablets:          tablets,
-		positions:        positions,
+		tablets:   tablets,
+		positions: positions,
+		combinedDominatedCount: dominatedCountsForSort(tablets, positions, func(moreAdvanced, lessAdvanced *RelayLogPositions) bool {
+			return hasDominantPosition(moreAdvanced.Combined, lessAdvanced.Combined)
+		}),
+		executedDominatedCount: dominatedCountsForSort(tablets, positions, func(moreAdvanced, lessAdvanced *RelayLogPositions) bool {
+			return moreAdvanced.Combined.Equal(lessAdvanced.Combined) &&
+				hasDominantPosition(moreAdvanced.Executed, lessAdvanced.Executed)
+		}),
 		durability:       durability,
 		innodbBufferPool: innodbBufferPool,
 	}
@@ -52,6 +61,8 @@ func (rs *reparentSorter) Len() int { return len(rs.tablets) }
 func (rs *reparentSorter) Swap(i, j int) {
 	rs.tablets[i], rs.tablets[j] = rs.tablets[j], rs.tablets[i]
 	rs.positions[i], rs.positions[j] = rs.positions[j], rs.positions[i]
+	rs.combinedDominatedCount[i], rs.combinedDominatedCount[j] = rs.combinedDominatedCount[j], rs.combinedDominatedCount[i]
+	rs.executedDominatedCount[i], rs.executedDominatedCount[j] = rs.executedDominatedCount[j], rs.executedDominatedCount[i]
 	if len(rs.innodbBufferPool) != 0 {
 		rs.innodbBufferPool[i], rs.innodbBufferPool[j] = rs.innodbBufferPool[j], rs.innodbBufferPool[i]
 	}
@@ -71,33 +82,14 @@ func (rs *reparentSorter) Less(i, j int) bool {
 		return true
 	}
 
-	jPositions := rs.positions[j]
-	iPositions := rs.positions[i]
-
-	// sort by dominance of the combined positions first. GTID positions are partially
-	// ordered, so a pair can also be incomparable (disjoint UUIDs); those fall through to
-	// the tiebreakers below to keep the sort deterministic. this can't make the sort a
-	// total order, so findMostAdvanced re-checks the winner after sorting.
-	if hasDominantPosition(iPositions.Combined, jPositions.Combined) {
-		return true
-	}
-	if hasDominantPosition(jPositions.Combined, iPositions.Combined) {
-		return false
+	if rs.combinedDominatedCount[i] != rs.combinedDominatedCount[j] {
+		return rs.combinedDominatedCount[i] < rs.combinedDominatedCount[j]
 	}
 
-	// if the combined positions are equal, sort by the executed GTID positions. this
-	// prefers tablets with less SQL delay, which would otherwise slow down the reparent.
-	if iPositions.Combined.Equal(jPositions.Combined) {
-		if hasDominantPosition(iPositions.Executed, jPositions.Executed) {
-			return true
-		}
-		if hasDominantPosition(jPositions.Executed, iPositions.Executed) {
-			return false
-		}
+	if rs.executedDominatedCount[i] != rs.executedDominatedCount[j] {
+		return rs.executedDominatedCount[i] < rs.executedDominatedCount[j]
 	}
 
-	// at this point, neither tablet is ahead of the other
-	// so we check their promotion rules
 	jPromotionRule := policy.PromotionRule(rs.durability, rs.tablets[j])
 	iPromotionRule := policy.PromotionRule(rs.durability, rs.tablets[i])
 
@@ -121,6 +113,52 @@ func (rs *reparentSorter) Less(i, j int) bool {
 		return rs.tablets[i].Alias.Cell < rs.tablets[j].Alias.Cell
 	}
 	return rs.tablets[i].Alias.Uid < rs.tablets[j].Alias.Uid
+}
+
+// dominatedCountsForSort returns, for each candidate, how many other candidates
+// strictly dominate it under the dominates predicate. The result is only meaningful
+// as a sort key: a lower count means more advanced, and the maximal candidates that
+// nothing dominates all have count 0.
+//
+// This count is what lets Less sort safely. dominates is only a partial order, so
+// comparing two candidates head-to-head is not transitive — with an incomparable
+// third candidate in play, sort.Sort can otherwise seat a dominated candidate above
+// the one that dominates it. Counting dominators sidesteps that, because dominates
+// itself is transitive: whatever dominates a candidate also dominates everything below
+// it, so a dominated candidate always has a strictly higher count than its dominator.
+// Ordering by ascending count therefore never places a candidate ahead of one that
+// dominates it.
+//
+// Counts are not unique. Incomparable candidates (e.g. divergent GTID histories) can
+// share a count; the caller breaks those ties with its remaining preferences.
+func dominatedCountsForSort(tablets []*topodatapb.Tablet, positions []*RelayLogPositions, dominates func(*RelayLogPositions, *RelayLogPositions) bool) []int {
+	dominatedCounts := make([]int, len(positions))
+	for i := range positions {
+		if tablets[i] == nil {
+			continue
+		}
+		for j := range positions {
+			if i == j || tablets[j] == nil {
+				continue
+			}
+			if dominates(positions[j], positions[i]) {
+				dominatedCounts[i]++ // one more candidate strictly dominates i
+			}
+		}
+	}
+	return dominatedCounts
+}
+
+// hasDominantReparentPosition reports whether moreAdvanced is strictly ahead of
+// lessAdvanced under the same two-level order the sorter uses: a strictly greater
+// received (Combined) history, or an equal received history with strictly more of it
+// applied (Executed). findMostAdvanced uses it as a defense-in-depth check that the
+// sort really did place the maximum at index 0 — it should never find a candidate that
+// dominates the chosen winner.
+func hasDominantReparentPosition(moreAdvanced, lessAdvanced *RelayLogPositions) bool {
+	return hasDominantPosition(moreAdvanced.Combined, lessAdvanced.Combined) ||
+		(moreAdvanced.Combined.Equal(lessAdvanced.Combined) &&
+			hasDominantPosition(moreAdvanced.Executed, lessAdvanced.Executed))
 }
 
 // sortTabletsForReparent sorts the tablets, given their positions for emergency reparent shard and planned reparent shard.

--- a/go/vt/vtctl/reparentutil/reparent_sorter_test.go
+++ b/go/vt/vtctl/reparentutil/reparent_sorter_test.go
@@ -19,6 +19,7 @@ package reparentutil
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/replication"
@@ -99,6 +100,17 @@ func TestReparentSorter(t *testing.T) {
 	positionAlmostMostAdvanced.Combined.GTIDSet = positionAlmostMostAdvanced.Combined.GTIDSet.AddGTID(mysqlGTID2)
 	positionAlmostMostAdvanced.Combined.GTIDSet = positionAlmostMostAdvanced.Combined.GTIDSet.AddGTID(mysqlGTID3)
 	positionAlmostMostAdvanced.Executed.GTIDSet = positionAlmostMostAdvanced.Executed.GTIDSet.AddGTID(mysqlGTID1)
+
+	positionExecutedGap := &RelayLogPositions{
+		Combined: positionMostAdvanced.Combined,
+		Executed: replication.Position{GTIDSet: replication.Mysql56GTIDSet{}},
+	}
+	positionExecutedGap.Executed.GTIDSet = positionExecutedGap.Executed.GTIDSet.AddGTID(mysqlGTID3)
+
+	positionNothingExecuted := &RelayLogPositions{
+		Combined: positionMostAdvanced.Combined,
+		Executed: replication.Position{GTIDSet: replication.Mysql56GTIDSet{}},
+	}
 
 	positionEmpty := &RelayLogPositions{
 		Combined: replication.Position{GTIDSet: replication.Mysql56GTIDSet{}},
@@ -204,7 +216,7 @@ func TestReparentSorter(t *testing.T) {
 			name:          "dominated tablet sorts below an incomparable maximum",
 			tablets:       []*topodatapb.Tablet{tabletReplica1_101, tabletReplica2_100, tabletReplica1_100},
 			positions:     []*RelayLogPositions{positionIntermediate1, positionDisjoint1, positionIntermediate2},
-			sortedTablets: []*topodatapb.Tablet{tabletReplica1_100, tabletReplica1_101, tabletReplica2_100},
+			sortedTablets: []*topodatapb.Tablet{tabletReplica1_100, tabletReplica2_100, tabletReplica1_101},
 		}, {
 			name:          "incomparable positions fall through to deterministic tiebreak",
 			tablets:       []*topodatapb.Tablet{tabletReplica2_100, tabletReplica1_101},
@@ -226,4 +238,115 @@ func TestReparentSorter(t *testing.T) {
 			}
 		})
 	}
+
+	mariaDBPosition10Server1 := &RelayLogPositions{
+		Executed: replication.MustParsePosition(replication.MariadbFlavorID, "0-1-10"),
+	}
+	mariaDBPosition5Server1 := &RelayLogPositions{
+		Executed: replication.MustParsePosition(replication.MariadbFlavorID, "0-1-5"),
+	}
+	mariaDBPosition10Server2 := &RelayLogPositions{
+		Executed: replication.MustParsePosition(replication.MariadbFlavorID, "0-2-10"),
+	}
+	mariaDBPosition1Server1 := &RelayLogPositions{
+		Executed: replication.MustParsePosition(replication.MariadbFlavorID, "0-1-1"),
+	}
+
+	layerTests := []struct {
+		name               string
+		candidatePositions []*RelayLogPositions
+		expectedPositions  []*RelayLogPositions
+	}{
+		{
+			name: "combined position dominance layers are input order independent",
+			candidatePositions: []*RelayLogPositions{
+				positionIntermediate2,
+				positionIntermediate1,
+				positionDisjoint1,
+				positionEmpty,
+			},
+			expectedPositions: []*RelayLogPositions{
+				positionDisjoint1,
+				positionIntermediate2,
+				positionIntermediate1,
+				positionEmpty,
+			},
+		},
+		{
+			name: "executed position dominance layers are input order independent",
+			candidatePositions: []*RelayLogPositions{
+				positionMostAdvanced,
+				positionAlmostMostAdvanced,
+				positionExecutedGap,
+				positionNothingExecuted,
+			},
+			expectedPositions: []*RelayLogPositions{
+				positionExecutedGap,
+				positionMostAdvanced,
+				positionAlmostMostAdvanced,
+				positionNothingExecuted,
+			},
+		},
+		{
+			name: "reciprocal MariaDB containment preserves executed position dominance layers",
+			candidatePositions: []*RelayLogPositions{
+				mariaDBPosition10Server1,
+				mariaDBPosition5Server1,
+				mariaDBPosition10Server2,
+				mariaDBPosition1Server1,
+			},
+			expectedPositions: []*RelayLogPositions{
+				mariaDBPosition10Server2,
+				mariaDBPosition10Server1,
+				mariaDBPosition5Server1,
+				mariaDBPosition1Server1,
+			},
+		},
+	}
+	candidateTablets := []*topodatapb.Tablet{
+		tabletReplica2_100,
+		tabletReplica1_100,
+		tabletReplica1_101,
+		tabletReplica3_103,
+	}
+	expectedTablets := []*topodatapb.Tablet{
+		tabletReplica1_101,
+		tabletReplica2_100,
+		tabletReplica1_100,
+		tabletReplica3_103,
+	}
+
+	for _, testcase := range layerTests {
+		t.Run(testcase.name, func(t *testing.T) {
+			forEachReparentSorterPermutation([]int{0, 1, 2, 3}, func(permutation []int) {
+				tablets := make([]*topodatapb.Tablet, 0, len(permutation))
+				positions := make([]*RelayLogPositions, 0, len(permutation))
+				for _, index := range permutation {
+					tablets = append(tablets, candidateTablets[index])
+					positions = append(positions, testcase.candidatePositions[index])
+				}
+
+				err := sortTabletsForReparent(tablets, positions, nil, durability)
+				require.NoError(t, err)
+				assert.Equalf(t, expectedTablets, tablets, "input permutation: %v", permutation)
+				assert.Equalf(t, testcase.expectedPositions, positions, "input permutation: %v", permutation)
+			})
+		})
+	}
+}
+
+func forEachReparentSorterPermutation(values []int, test func([]int)) {
+	var permute func(int)
+	permute = func(i int) {
+		if i == len(values) {
+			test(values)
+			return
+		}
+		for j := i; j < len(values); j++ {
+			values[i], values[j] = values[j], values[i]
+			permute(i + 1)
+			values[i], values[j] = values[j], values[i]
+		}
+	}
+	permute(0)
 }

--- a/go/vt/vtctl/reparentutil/replication.go
+++ b/go/vt/vtctl/reparentutil/replication.go
@@ -99,6 +99,14 @@ func haveIncomparablePositions(a, b replication.Position) bool {
 	return !a.AtLeast(b) && !b.AtLeast(a)
 }
 
+// haveReciprocallyContainedPositions returns true if two unequal positions contain each
+// other. Containment can't order these: MariaDB GTID containment ignores the origin
+// server, so positions like 0-1-10 and 0-2-10 "contain" each other while holding
+// different histories (a split brain).
+func haveReciprocallyContainedPositions(a, b replication.Position) bool {
+	return a.AtLeast(b) && b.AtLeast(a) && !a.Equal(b)
+}
+
 // hasUniformCombinedPosition returns true when every candidate has the same Combined position. On the
 // output of filterToMostAdvancedCombined a false result means the leading candidates have
 // incomparable positions, as the filter already removed anything dominated.

--- a/go/vt/vtctl/reparentutil/replication.go
+++ b/go/vt/vtctl/reparentutil/replication.go
@@ -89,7 +89,7 @@ func (rlp *RelayLogPositions) IsZero() bool {
 // hasDominantPosition returns true if position a is strictly ahead of position b, meaning
 // a contains everything b has, plus more.
 func hasDominantPosition(a, b replication.Position) bool {
-	return a.AtLeast(b) && !a.Equal(b)
+	return a.AtLeast(b) && !b.AtLeast(a)
 }
 
 // haveIncomparablePositions returns true if neither position contains the other. Replication


### PR DESCRIPTION
## Description

This PR fixes the shared reparent sorter used by `EmergencyReparentShard` and `PlannedReparentShard`, which orders candidates inconsistently whenever their GTID positions are only partially ordered. It was a deferred review suggestion from https://github.com/vitessio/vitess/pull/20578, though the problem itself is long-standing; the same pairwise comparison has been in the sorter since it was first added for ERS back in 2021, so it affects all supported releases

GTID containment is pairwise, so a candidate set can mix comparable and incomparable histories. Usually histories are comparable, but in edge cases _(split brains and errant GTIDs)_ this is a real risk. For example, candidate A at `p:1-100,a:1-10` is ahead of B at `p:1-100,a:1-5`, while C at `p:1-100,c:1-3` is incomparable with both _(an errant GTID, or a split-brain with shortened UUIDs, can create this shape)_. `reparentSorter.Less` compared candidates two at a time, which falls apart once an incomparable candidate is in the mix: it ranks C as tied with both A and B, even though A clearly beats B. Go's `sort.Sort` needs a self-consistent ordering and quietly misbehaves without one, so the result could depend on map iteration or RPC completion order, and `PlannedReparentShard` could pick B even though A was known to be more advanced

The fix precomputes, per candidate, a count of how many other candidates strictly dominate it _(combined position first, then executed position at an equal combined position)_ and sorts on that integer. A dominated candidate always has a strictly higher count than its dominator, so it can never rank above it regardless of input order. `EmergencyReparentShard` still rejects incomparable candidates as split brain, and `PlannedReparentShard` still chooses among incomparable maximal candidates

This also fixes `hasDominantPosition` to use `a.AtLeast(b) && !b.AtLeast(a)` instead of `!a.Equal(b)`, so MariaDB positions that reciprocally contain each other _(same domain, different server)_ aren't reported as dominant in both directions. That helper is new in v25, so this part only applies here; the backports just need the sort-ordering fix

### Backport

I'd like to backport the ordering fix to the supported release branches _(`release-24.0` and `release-23.0`)_, since `PlannedReparentShard` electing a less-advanced primary on divergent histories is a correctness issue in shipped releases

## Related Issue(s)

Resolves https://github.com/vitessio/vitess/issues/20579

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

### AI Disclosure

Claude Code assisted with development and testing, and prepared this summary
