### PR TITLE
[release-24.0] test: gate TestReplicationStopped on vtctld version for upgrade/downgrade

### DIFF
--- a/go/test/endtoend/reparent/emergencyreparent/ers_test.go
+++ b/go/test/endtoend/reparent/emergencyreparent/ers_test.go
@@ -663,12 +663,12 @@ func TestReplicationStopped(t *testing.T) {
 		out, err := utils.Ers(clusterInstance, tablets[3], "60s", "30s")
 		require.NoError(t, err, out)
 		// Verify that the tablet has the inserted value
-		err = utils.CheckInsertedValues(context.Background(), t, tablets[3], insertedVal)
+		err = utils.CheckInsertedValues(t.Context(), t, tablets[3], insertedVal)
 		require.NoError(t, err)
 		// Confirm that replication is setup correctly from tablets[3] to tablets[0]
 		utils.ConfirmReplication(t, tablets[3], tablets[:1])
 		// Confirm that tablets[2] which had replication stopped initially still has its replication stopped
-		utils.CheckReplicationStatus(context.Background(), t, tablets[2], false, false)
+		utils.CheckReplicationStatus(t.Context(), t, tablets[2], false, false)
 		return
 	}
 

--- a/go/test/endtoend/reparent/emergencyreparent/ers_test.go
+++ b/go/test/endtoend/reparent/emergencyreparent/ers_test.go
@@ -30,6 +30,7 @@ import (
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/test/endtoend/reparent/utils"
+	endtoendutils "vitess.io/vitess/go/test/endtoend/utils"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/vtctl/reparentutil/policy"
 
@@ -638,14 +639,40 @@ func TestERSFailFast(t *testing.T) {
 	}
 }
 
-// TestReplicationStopped checks that ERS ignores the tablets that have sql thread stopped.
-// If there are more than 1, we also fail.
+// TestReplicationStopped checks how ERS treats replicas with replication stopped.
+//
+// The behaviour changed in v25 (vitessio/vitess#20578): a replica that cannot win the
+// election no longer holds up or fails the reparent. The upgrade/downgrade jobs run this
+// release-24.0 test against a newer vtctld, so the expected outcome is gated on the
+// version of the vtctld actually driving ERS.
 func TestReplicationStopped(t *testing.T) {
 	clusterInstance := utils.SetupReparentCluster(t, policy.DurabilitySemiSync)
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
 	utils.ConfirmReplication(t, tablets[0], []*cluster.Vttablet{tablets[1], tablets[2], tablets[3]})
 
+	if endtoendutils.BinaryIsAtLeastAtVersion(25, "vtctld") {
+		// v25+ vtctld only waits on candidates that can win the election, so a
+		// fully-stopped replica neither delays nor fails the failover.
+		err := clusterInstance.VtctldClientProcess.ExecuteCommand("ExecuteFetchAsDBA", tablets[2].Alias, `STOP REPLICA;`)
+		require.NoError(t, err)
+		// This write will not reach tablets[2].
+		insertedVal := utils.ConfirmReplication(t, tablets[0], nil)
+		// Failover to tablets[3]; it succeeds despite tablets[2] being stopped.
+		out, err := utils.Ers(clusterInstance, tablets[3], "60s", "30s")
+		require.NoError(t, err, out)
+		// Verify that the tablet has the inserted value
+		err = utils.CheckInsertedValues(context.Background(), t, tablets[3], insertedVal)
+		require.NoError(t, err)
+		// Confirm that replication is setup correctly from tablets[3] to tablets[0]
+		utils.ConfirmReplication(t, tablets[3], tablets[:1])
+		// Confirm that tablets[2] which had replication stopped initially still has its replication stopped
+		utils.CheckReplicationStatus(context.Background(), t, tablets[2], false, false)
+		return
+	}
+
+	// Pre-v25 vtctld waits on every candidate's relay logs and fails when more than one
+	// replica has replication stopped.
 	err := clusterInstance.VtctldClientProcess.ExecuteCommand("ExecuteFetchAsDBA", tablets[1].Alias, `STOP REPLICA SQL_THREAD;`)
 	require.NoError(t, err)
 	err = clusterInstance.VtctldClientProcess.ExecuteCommand("ExecuteFetchAsDBA", tablets[2].Alias, `STOP REPLICA;`)

--- a/go/test/endtoend/reparent/emergencyreparent/ers_test.go
+++ b/go/test/endtoend/reparent/emergencyreparent/ers_test.go
@@ -642,7 +642,8 @@ func TestERSFailFast(t *testing.T) {
 // TestReplicationStopped checks how ERS treats replicas with replication stopped.
 //
 // The behaviour changed in v25 (vitessio/vitess#20578): a replica that cannot win the
-// election no longer holds up or fails the reparent. The upgrade/downgrade jobs run this
+// election no longer holds up or fails the reparent, whereas pre-v25 ERS fails when more
+// than one replica has replication stopped. The upgrade/downgrade jobs run this
 // release-24.0 test against a newer vtctld, so the expected outcome is gated on the
 // version of the vtctld actually driving ERS.
 func TestReplicationStopped(t *testing.T) {

--- a/go/test/endtoend/reparent/emergencyreparent/ers_test.go
+++ b/go/test/endtoend/reparent/emergencyreparent/ers_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -639,62 +640,113 @@ func TestERSFailFast(t *testing.T) {
 	}
 }
 
-// TestReplicationStopped checks how ERS treats replicas with replication stopped.
+// replicaStatusField returns the named field from `show replica status`, or an empty
+// string if the row or field is missing. It must not assert: it is called from polling
+// callbacks that run on a non-test goroutine, where a require failure would kill the
+// polling instead of retrying.
+func replicaStatusField(ctx context.Context, tablet *cluster.Vttablet, field string) (string, error) {
+	conn, err := utils.GetMySQLConn(ctx, tablet)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	res, err := conn.ExecuteFetch(`show replica status`, 1, true)
+	if err != nil {
+		return "", err
+	}
+	if len(res.Rows) != 1 {
+		return "", nil
+	}
+	for i, f := range res.Fields {
+		if f.Name == field {
+			return res.Rows[0][i].ToString(), nil
+		}
+	}
+	return "", nil
+}
+
+// waitForReceivedPosition waits until the tablet has received (not necessarily applied)
+// everything in the given GTID set.
+func waitForReceivedPosition(t *testing.T, tablet *cluster.Vttablet, position string) {
+	ctx := t.Context()
+	require.Eventually(t, func() bool {
+		retrievedField, err := replicaStatusField(ctx, tablet, "Retrieved_Gtid_Set")
+		if err != nil {
+			t.Logf("failed to fetch Retrieved_Gtid_Set from %s: %v", tablet.Alias, err)
+			return false
+		}
+		retrieved := strings.ReplaceAll(retrievedField, "\n", "")
+		if retrieved == "" {
+			return false
+		}
+		conn, err := utils.GetMySQLConn(ctx, tablet)
+		if err != nil {
+			t.Logf("failed to connect to %s: %v", tablet.Alias, err)
+			return false
+		}
+		defer conn.Close()
+		res, err := conn.ExecuteFetch(fmt.Sprintf(`select gtid_subset('%s', concat(@@global.gtid_executed, ',', '%s'))`, position, retrieved), 1, true)
+		if err != nil {
+			t.Logf("failed to check gtid_subset on %s: %v", tablet.Alias, err)
+			return false
+		}
+		return len(res.Rows) == 1 && res.Rows[0][0].ToString() == "1"
+	}, 30*time.Second, time.Second)
+}
+
+// TestReplicationStopped checks how ERS treats replicas with replication stopped:
+// tablets[1] has its SQL thread stopped after receiving a write it cannot apply, and
+// tablets[2] has replication fully stopped.
 //
 // The behaviour changed in v25 (vitessio/vitess#20578): a replica that cannot win the
-// election no longer holds up or fails the reparent, whereas pre-v25 ERS fails when more
-// than one replica has replication stopped. The upgrade/downgrade jobs run this
-// release-24.0 test against a newer vtctld, so the expected outcome is gated on the
-// version of the vtctld actually driving ERS.
+// election no longer holds up or fails the reparent, whereas pre-v25 ERS waits on every
+// candidate's relay logs and fails on tablets[1]'s received-but-unapplied backlog. The
+// upgrade/downgrade jobs run this release-24.0 test against a newer vtctld, so the
+// expected ERS outcome is gated on the version of the vtctld actually driving ERS.
 func TestReplicationStopped(t *testing.T) {
 	clusterInstance := utils.SetupReparentCluster(t, policy.DurabilitySemiSync)
 	defer utils.TeardownCluster(clusterInstance)
 	tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
 	utils.ConfirmReplication(t, tablets[0], []*cluster.Vttablet{tablets[1], tablets[2], tablets[3]})
 
-	if endtoendutils.BinaryIsAtLeastAtVersion(25, "vtctld") {
-		// v25+ vtctld only waits on candidates that can win the election, so a
-		// fully-stopped replica neither delays nor fails the failover.
-		err := clusterInstance.VtctldClientProcess.ExecuteCommand("ExecuteFetchAsDBA", tablets[2].Alias, `STOP REPLICA;`)
-		require.NoError(t, err)
-		// This write will not reach tablets[2].
-		insertedVal := utils.ConfirmReplication(t, tablets[0], nil)
-		// Failover to tablets[3]; it succeeds despite tablets[2] being stopped.
-		out, err := utils.Ers(clusterInstance, tablets[3], "60s", "30s")
-		require.NoError(t, err, out)
-		// Verify that the tablet has the inserted value
-		err = utils.CheckInsertedValues(t.Context(), t, tablets[3], insertedVal)
-		require.NoError(t, err)
-		// Confirm that replication is setup correctly from tablets[3] to tablets[0]
-		utils.ConfirmReplication(t, tablets[3], tablets[:1])
-		// Confirm that tablets[2] which had replication stopped initially still has its replication stopped
-		utils.CheckReplicationStatus(t.Context(), t, tablets[2], false, false)
-		return
-	}
-
-	// Pre-v25 vtctld waits on every candidate's relay logs and fails when more than one
-	// replica has replication stopped.
+	// Stop the SQL thread on tablets[1] so it keeps receiving changes without applying
+	// them, and stop replication fully on tablets[2].
 	err := clusterInstance.VtctldClientProcess.ExecuteCommand("ExecuteFetchAsDBA", tablets[1].Alias, `STOP REPLICA SQL_THREAD;`)
 	require.NoError(t, err)
 	err = clusterInstance.VtctldClientProcess.ExecuteCommand("ExecuteFetchAsDBA", tablets[2].Alias, `STOP REPLICA;`)
 	require.NoError(t, err)
-	// Run an additional command in the current primary which will only be acked by tablets[3] and be in its relay log.
-	insertedVal := utils.ConfirmReplication(t, tablets[0], nil)
-	// Failover to tablets[3]
-	_, err = utils.Ers(clusterInstance, tablets[3], "60s", "30s")
-	require.Error(t, err, "ERS should fail with 2 replicas having replication stopped")
+	// Run an additional command in the current primary which will be applied by
+	// tablets[3] and land in tablets[1]'s relay log without being applied.
+	insertedVal := utils.ConfirmReplication(t, tablets[0], []*cluster.Vttablet{tablets[3]})
+	// Wait until tablets[1] has actually received the write: semi-sync only needs one
+	// acker, so the write confirming on tablets[3] says nothing about tablets[1]'s relay
+	// log.
+	primaryPosition := strings.ReplaceAll(utils.RunSQL(t.Context(), t, `select @@global.gtid_executed`, tablets[0]).Rows[0][0].ToString(), "\n", "")
+	waitForReceivedPosition(t, tablets[1], primaryPosition)
 
-	// Start replication back on tablet[1]
-	err = clusterInstance.VtctldClientProcess.ExecuteCommand("ExecuteFetchAsDBA", tablets[1].Alias, `START REPLICA;`)
-	require.NoError(t, err)
-	// Failover to tablets[3] again. This time it should succeed
-	out, err := utils.Ers(clusterInstance, tablets[3], "60s", "30s")
-	require.NoError(t, err, out)
+	if endtoendutils.BinaryIsAtLeastAtVersion(25, "vtctld") {
+		// v25+ vtctld only waits on relay log apply of candidates that can win the
+		// election, so neither stopped replica delays nor fails the failover to tablets[3].
+		out, err := utils.Ers(clusterInstance, tablets[3], "60s", "30s")
+		require.NoError(t, err, out)
+	} else {
+		// Pre-v25 vtctld fails the failover on tablets[1]'s unapplied relay log.
+		_, err = utils.Ers(clusterInstance, tablets[3], "60s", "30s")
+		require.Error(t, err, "ERS should fail while tablets[1] has received relay logs it cannot apply")
+
+		// Start replication back on tablet[1]
+		err = clusterInstance.VtctldClientProcess.ExecuteCommand("ExecuteFetchAsDBA", tablets[1].Alias, `START REPLICA;`)
+		require.NoError(t, err)
+		// Failover to tablets[3] again. This time it should succeed
+		out, err := utils.Ers(clusterInstance, tablets[3], "60s", "30s")
+		require.NoError(t, err, out)
+	}
+
 	// Verify that the tablet has the inserted value
-	err = utils.CheckInsertedValues(context.Background(), t, tablets[3], insertedVal)
+	err = utils.CheckInsertedValues(t.Context(), t, tablets[3], insertedVal)
 	require.NoError(t, err)
 	// Confirm that replication is setup correctly from tablets[3] to tablets[0]
 	utils.ConfirmReplication(t, tablets[3], tablets[:1])
 	// Confirm that tablets[2] which had replication stopped initially still has its replication stopped
-	utils.CheckReplicationStatus(context.Background(), t, tablets[2], false, false)
+	utils.CheckReplicationStatus(t.Context(), t, tablets[2], false, false)
 }

--- a/go/test/endtoend/reparent/utils/utils.go
+++ b/go/test/endtoend/reparent/utils/utils.go
@@ -319,6 +319,14 @@ func getMysqlConnParam(tablet *cluster.Vttablet) mysql.ConnParams {
 	return connParams
 }
 
+// GetMySQLConn returns an open connection to the MySQL instance of a vttablet, for
+// callers that need to hold session state (locks, transactions) across other steps.
+// The caller must Close it.
+func GetMySQLConn(ctx context.Context, tablet *cluster.Vttablet) (*mysql.Conn, error) {
+	tabletParams := getMysqlConnParam(tablet)
+	return mysql.Connect(ctx, &tabletParams)
+}
+
 // RunSQLs is used to run SQL commands directly on the MySQL instance of a vttablet. All commands are
 // run in a single connection.
 func RunSQLs(ctx context.Context, t *testing.T, sqls []string, tablet *cluster.Vttablet) (results []*sqltypes.Result) {


### PR DESCRIPTION
## Description

The `Reparent New Vtctl - Upgrade Downgrade Testing` job builds `vtctld` from the next release _(main)_ and runs it against `release-24.0` `vttablet`s and `release-24.0` e2e test code. https://github.com/vitessio/vitess/pull/20578 changed `EmergencyReparentShard` in v25 so a replica that can't win the election no longer holds up or fails the reparent, so `TestReplicationStopped`, which still asserts the pre-v25 "ERS must fail" contract, now sees a successful failover and fails

Because the job triggers on any `go/` change, this breaks basically every `release-24.0` PR, including ones that have nothing to do with reparents :sweat_smile:

This gates the expected outcome on the version of the `vtctld` actually driving ERS via `endtoendutils.BinaryIsAtLeastAtVersion(25, "vtctld")`: v25+ takes the new success path, pre-v25 keeps the original assertions. It's test-only, so nothing a v24 operator runs changes. `main` already carries the rewritten test from #20578, so this only needs to land on `release-24.0`

## Related Issue(s)

Follow-up to https://github.com/vitessio/vitess/pull/20578 for the `release-24.0` upgrade/downgrade jobs

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

### AI Disclosure

This PR was assisted by Claude Code, which also drafted this summary; I gave the direction and reviewed it
