### PR TITLE
vttestserver: fail, don't panic, on a vschema missing a table or vindex

### DIFF
--- a/go/cmd/vttestserver/cli/main_test.go
+++ b/go/cmd/vttestserver/cli/main_test.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"math/rand/v2"
 	"os/exec"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -457,12 +459,21 @@ func assertColumnVindex(t *testing.T, cluster vttest.LocalCluster, expected colu
 
 	err := vtctlclient.RunCommandAndWait(ctx, server, args, func(e *logutilpb.Event) {
 		var keyspace vschemapb.Keyspace
-		if err := protojson.Unmarshal([]byte(e.Value), &keyspace); err != nil {
-			assert.NoError(t, err)
-		}
+		require.NoError(t, protojson.Unmarshal([]byte(e.Value), &keyspace))
 
-		columnVindex := keyspace.Tables[expected.table].ColumnVindexes[0]
-		actualVindex := keyspace.Vindexes[expected.vindex]
+		// Look the table and vindex up before dereferencing them, so that a
+		// vschema missing either fails with a message naming what was missing
+		// instead of panicking on a nil map entry and taking down the whole
+		// test binary.
+		table, ok := keyspace.Tables[expected.table]
+		require.Truef(t, ok, "keyspace %s has no table %s in its vschema, found tables %v", expected.keyspace, expected.table, slices.Sorted(maps.Keys(keyspace.Tables)))
+		require.NotEmptyf(t, table.ColumnVindexes, "table %s.%s has no column vindexes", expected.keyspace, expected.table)
+		columnVindex := table.ColumnVindexes[0]
+		require.NotEmptyf(t, columnVindex.Columns, "column vindex %s on %s.%s has no columns", columnVindex.Name, expected.keyspace, expected.table)
+
+		actualVindex, ok := keyspace.Vindexes[expected.vindex]
+		require.Truef(t, ok, "keyspace %s has no vindex %s in its vschema, found vindexes %v", expected.keyspace, expected.vindex, slices.Sorted(maps.Keys(keyspace.Vindexes)))
+
 		assertEqual(t, actualVindex.Type, expected.vindexType, "Actual vindex type different from expected")
 		assertEqual(t, columnVindex.Name, expected.vindex, "Actual vindex name different from expected")
 		assertEqual(t, columnVindex.Columns[0], expected.column, "Actual vindex column different from expected")


### PR DESCRIPTION
## Description

`assertColumnVindex` in the vttestserver tests indexed straight into the vschema's table and vindex maps:

```go
columnVindex := keyspace.Tables[expected.table].ColumnVindexes[0]
actualVindex := keyspace.Vindexes[expected.vindex]
```

A missing entry gives back a nil proto pointer, and dereferencing it segfaults, so instead of one failed assertion the whole test binary goes down:

```
panic: runtime error: invalid memory address or nil pointer dereference
  cli.assertColumnVindex.func1  main_test.go:464
  cli.TestPersistentMode        main_test.go:124
```

The blast radius is what makes this worth fixing on its own. Because it's a panic and not a failure, gotestsum refuses to retry — `rerun aborted because previous run had a suspected panic` — so a single `TestPersistentMode` flake fails the entire unit test shard, all 28k tests of it. See [this Unit Test (Race) failure on main](https://github.com/vitessio/vitess/actions/runs/30308969874/job/90119884786).

This looks the table and vindex up before dereferencing them, and checks the column vindex and column slices are non-empty before indexing. A vschema missing any of them now fails with a message naming what was missing and listing what the keyspace actually had, which also makes the underlying flake easier to diagnose. The unmarshal error path gets a `require` so it stops there rather than falling through to the same dereference with a zero-value keyspace.

This does not fix the flake itself — it makes it a retryable failure instead of a shard-wide abort, and reports what was actually in the vschema when it happens. The flake is being fixed separately in #19994.

## Backport

This affects `release-23.0` and `release-24.0` identically, which is why it's labelled for both.

Both branches carry the same unguarded dereference in `assertColumnVindex` — `keyspace.Tables[expected.table].ColumnVindexes[0]` at `main_test.go:428` on release-23.0 and `main_test.go:443` on release-24.0 — reached from the same `TestPersistentMode` assertions, including the post-reboot `persistence_test` lookup that produced the panic on `main`.

The conditions that make it fire are also present. Neither branch has the vschema persistence fixes: `persistNewSrvVSchema` still uses a plain `os.WriteFile` (release-24.0 `vschema_watcher.go:114`), so a torn write or a change lost at shutdown can still leave a keyspace file that comes back missing a table.

And the consequence is the same on both, which is the real reason to backport a test-only change: `tools/unit_test_runner.sh` runs gotestsum with `--rerun-fails=3` on both branches, and gotestsum will not retry a run it suspects panicked. So one flake takes down the whole unit test shard rather than costing a retry.

Note for whoever runs the backport: the cherry-pick conflicts on both branches. The release branches use `t.Error(err)` on the unmarshal path where `main` had `assert.NoError(t, err)`; that hunk becomes the `require.NoError` line. The rest applies as-is.

## Related Issue(s)

Split out of #19994, where this was one of three independent changes. None of the rest of that PR is needed for this.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description — see [Backport](#backport) above
-   [x] Tests were added or are not required — this only changes how an existing test assertion reports failure
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — test-only change.

### AI Disclosure

This was written by Claude Code; I provided the direction and reviewed the result.
