### PR TITLE
vtgate: fix union merging through reference-table alternates

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/horizon.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon.go
@@ -211,6 +211,20 @@ func (h *Horizon) getQP(ctx *plancontext.PlanningContext) *QueryProjection {
 	return h.QP
 }
 
+// computesRowByRow reports whether the horizon yields the same rows whether it
+// runs once or once per shard, so it can be pushed under a route that fans out
+// to several shards.
+func (h *Horizon) computesRowByRow(ctx *plancontext.PlanningContext) bool {
+	sel, isSel := h.Query.(*sqlparser.Select)
+	qp := h.getQP(ctx)
+	return !(isSel && sel.Having != nil) &&
+		len(qp.OrderExprs) == 0 &&
+		!qp.NeedsAggregation() &&
+		!qp.HasWindow &&
+		!isDistinctAST(h.Query) &&
+		h.Query.GetLimit() == nil
+}
+
 func (h *Horizon) ShortDescription() string {
 	return fmt.Sprintf("Horizon (Alias: %s)", h.Alias)
 }

--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -288,13 +288,7 @@ func pushOrExpandHorizon(ctx *plancontext.PlanningContext, in *Horizon) (Operato
 	needsOrdering := len(qp.OrderExprs) > 0
 	hasHaving := isSel && sel.Having != nil
 
-	canPush := isRoute &&
-		!hasHaving &&
-		!needsOrdering &&
-		!qp.NeedsAggregation() &&
-		!qp.HasWindow &&
-		!isDistinctAST(in.selectStatement()) &&
-		in.selectStatement().GetLimit() == nil
+	canPush := isRoute && in.computesRowByRow(ctx)
 
 	if canPush {
 		return Swap(in, rb, "push horizon into route")

--- a/go/vt/vtgate/planbuilder/operators/union_merging.go
+++ b/go/vt/vtgate/planbuilder/operators/union_merging.go
@@ -17,10 +17,13 @@ limitations under the License.
 package operators
 
 import (
+	"io"
+
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
 // mergeUnionInputInAnyOrder merges sources the sources of the union in any order
@@ -108,11 +111,36 @@ func mergeUnionInputs(
 	lhsExprs, rhsExprs []sqlparser.SelectExpr,
 	distinct bool,
 ) (Operator, []sqlparser.SelectExpr) {
-	lhsRoute, rhsRoute, routingA, routingB, a, b, sameKeyspace := prepareInputRoutes(ctx, lhs, rhs)
-	if lhsRoute == nil {
+	lhsRoute, rhsRoute := operatorsToRoutes(lhs, rhs)
+	if lhsRoute == nil || rhsRoute == nil {
 		checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
 		return nil, nil
 	}
+
+	if op, exprs := mergeUnionRoutings(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct); op != nil {
+		return op, exprs
+	}
+	if op, exprs := tryAlternateUnionMerge(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct); op != nil {
+		return op, exprs
+	}
+
+	// Check cross-keyspace restrictions for UNIONs that cannot be merged.
+	checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
+
+	return nil, nil
+}
+
+// mergeUnionRoutings merges two union sources whose routes are usable as they
+// stand, or returns nil when their routings do not allow it.
+func mergeUnionRoutings(
+	ctx *plancontext.PlanningContext,
+	lhsRoute, rhsRoute *Route,
+	lhsExprs, rhsExprs []sqlparser.SelectExpr,
+	distinct bool,
+) (Operator, []sqlparser.SelectExpr) {
+	routingA, routingB := lhsRoute.Routing, rhsRoute.Routing
+	sameKeyspace := routingA.Keyspace() == routingB.Keyspace()
+	a, b := getRoutingType(routingA), getRoutingType(routingB)
 
 	switch {
 	// if either side is a dual query, we can always merge them together
@@ -134,10 +162,155 @@ func mergeUnionInputs(
 		}
 	}
 
-	// Check cross-keyspace restrictions for UNIONs that cannot be merged.
-	checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
-
 	return nil, nil
+}
+
+// tryAlternateUnionMerge retries a declined cross-keyspace pairing by moving
+// one side onto the reference copies of its tables in the other side's
+// keyspace. The move mutates the moved side's tables in place, so all
+// semantic bookkeeping keyed on its expressions stays valid; a retry that
+// still cannot merge undoes the move.
+func tryAlternateUnionMerge(
+	ctx *plancontext.PlanningContext,
+	lhsRoute, rhsRoute *Route,
+	lhsExprs, rhsExprs []sqlparser.SelectExpr,
+	distinct bool,
+) (Operator, []sqlparser.SelectExpr) {
+	lhsKs, rhsKs := lhsRoute.Routing.Keyspace(), rhsRoute.Routing.Keyspace()
+	if lhsKs == nil || rhsKs == nil || lhsKs == rhsKs {
+		return nil, nil
+	}
+
+	// a side already composed of a merged union carries shapes the remaining
+	// phases no longer normalize: moving it can hand offset planning a nested
+	// horizon it cannot push into, so only leaf routes are moved
+	canRewrite := func(route *Route) bool {
+		hasUnion := false
+		_ = Visit(route.Source, func(op Operator) error {
+			if _, ok := op.(*Union); ok {
+				hasUnion = true
+				return io.EOF
+			}
+			return nil
+		})
+		return !hasUnion
+	}
+
+	if canRewrite(lhsRoute) {
+		if rewritten, undo := rewriteRouteToAlternate(ctx, lhsRoute, rhsKs); rewritten != nil {
+			if op, exprs := mergeUnionRoutings(ctx, rewritten, rhsRoute, lhsExprs, rhsExprs, distinct); op != nil {
+				return op, exprs
+			}
+			undo()
+		}
+	}
+	if canRewrite(rhsRoute) {
+		if rewritten, undo := rewriteRouteToAlternate(ctx, rhsRoute, lhsKs); rewritten != nil {
+			if op, exprs := mergeUnionRoutings(ctx, lhsRoute, rewritten, lhsExprs, rhsExprs, distinct); op != nil {
+				return op, exprs
+			}
+			undo()
+		}
+	}
+	return nil, nil
+}
+
+// rewriteRouteToAlternate points route's tables at the reference copies living
+// in ks, or returns nil if the route cannot move there. Every real table under
+// the planned tree is resolved to its copy independently, so a route composed
+// by earlier merges moves when each of its tables has a copy. The planned
+// operators are kept and only the table nodes are swapped, so predicates and
+// projections pushed after route creation are preserved and the semantic
+// analysis of the tree stays authoritative. The returned undo puts the
+// original tables back.
+func rewriteRouteToAlternate(ctx *plancontext.PlanningContext, route *Route, ks *vindexes.Keyspace) (*Route, func()) {
+	if _, ok := route.Routing.(*AnyShardRouting); !ok {
+		return nil, nil
+	}
+	if !ctx.SemTable.DMLTargets.IsEmpty() && TableID(route).IsOverlapping(ctx.SemTable.DMLTargets) {
+		return nil, nil
+	}
+
+	type tableSwap struct {
+		tbl        *Table
+		altQTable  *QueryTable
+		altVTable  *vindexes.BaseTable
+		origQTable *QueryTable
+		origVTable *vindexes.BaseTable
+	}
+	var swaps []tableSwap
+	resolvable := true
+	_ = Visit(route.Source, func(op Operator) error {
+		tbl, ok := op.(*Table)
+		if !ok || tbl.VTable == nil || tbl.QTable == nil {
+			return nil
+		}
+		alt := resolveTableCopyIn(ctx, tbl, ks)
+		if alt == nil ||
+			// this route serves rows from a single shard of ks, which only a
+			// reference or unsharded copy can provide in full
+			(alt.VTable.Type != vindexes.TypeReference && alt.VTable.Keyspace.Sharded) {
+			resolvable = false
+			return io.EOF
+		}
+		swaps = append(swaps, tableSwap{tbl: tbl, altQTable: alt.QTable, altVTable: alt.VTable, origQTable: tbl.QTable, origVTable: tbl.VTable})
+		return nil
+	})
+	if !resolvable || len(swaps) == 0 {
+		return nil, nil
+	}
+
+	for _, s := range swaps {
+		s.tbl.QTable, s.tbl.VTable = s.altQTable, s.altVTable
+	}
+	undo := func() {
+		for _, s := range swaps {
+			s.tbl.QTable, s.tbl.VTable = s.origQTable, s.origVTable
+		}
+	}
+
+	rewritten := *route
+	rewritten.Routing = &AnyShardRouting{keyspace: ks}
+	return &rewritten, undo
+}
+
+// resolveTableCopyIn resolves the physical copy of tbl's table living in ks:
+// the table itself, a reference copy from ReferencedBy, or a reference
+// source, looked up through the VSchema so routing rules and unqualified
+// source declarations are honored. The returned table carries the physical
+// name with the original name preserved as an alias, or nil when ks holds no
+// copy.
+func resolveTableCopyIn(ctx *plancontext.PlanningContext, tbl *Table, ks *vindexes.Keyspace) *Table {
+	for _, name := range copyCandidates(tbl.VTable, ks) {
+		src, _, _, _, _, err := ctx.VSchema.FindTableOrVindex(name)
+		if err != nil || src == nil || src.Keyspace != ks {
+			continue
+		}
+		altRoute := findVSchemaTableAndCreateRoute(ctx, tbl.QTable, name, false /*planAlternates*/)
+		altTbl, ok := altRoute.Source.(*Table)
+		if !ok || altTbl.VTable == nil || altTbl.VTable.Keyspace != ks {
+			continue
+		}
+		return altTbl
+	}
+	return nil
+}
+
+// copyCandidates lists the declared names under which vt's data may also live
+// in ks. The source name is returned as declared — possibly unqualified — so
+// the VSchema lookup resolves it the same way the reference itself was.
+func copyCandidates(vt *vindexes.BaseTable, ks *vindexes.Keyspace) []sqlparser.TableName {
+	var candidates []sqlparser.TableName
+	if vt.Keyspace == ks {
+		candidates = append(candidates, sqlparser.TableName{Name: vt.Name, Qualifier: sqlparser.NewIdentifierCS(ks.Name)})
+	}
+	if ref, found := vt.ReferencedBy[ks.Name]; found {
+		candidates = append(candidates, sqlparser.TableName{Name: ref.Name, Qualifier: sqlparser.NewIdentifierCS(ks.Name)})
+	}
+	if vt.Source != nil {
+		candidates = append(candidates, vt.Source.TableName)
+	}
+	return candidates
 }
 
 func tryMergeUnionShardedRouting(

--- a/go/vt/vtgate/planbuilder/operators/union_merging.go
+++ b/go/vt/vtgate/planbuilder/operators/union_merging.go
@@ -17,12 +17,14 @@ limitations under the License.
 package operators
 
 import (
+	"io"
 	"slices"
 
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
 // mergeUnionInputInAnyOrder merges sources the sources of the union in any order
@@ -110,22 +112,44 @@ func mergeUnionInputs(
 	lhsExprs, rhsExprs []sqlparser.SelectExpr,
 	distinct bool,
 ) (Operator, []sqlparser.SelectExpr) {
-	lhsRoute, rhsRoute, routingA, routingB, a, b, sameKeyspace := prepareInputRoutes(ctx, lhs, rhs)
-	if lhsRoute == nil {
+	lhsRoute, rhsRoute := operatorsToRoutes(lhs, rhs)
+	if lhsRoute == nil || rhsRoute == nil {
 		checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
 		return nil, nil
 	}
+
+	if op, exprs := mergeUnionRoutings(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct); op != nil {
+		return op, exprs
+	}
+	if op, exprs := tryAlternateUnionMerge(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct); op != nil {
+		return op, exprs
+	}
+
+	// Check cross-keyspace restrictions for UNIONs that cannot be merged.
+	checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
+
+	return nil, nil
+}
+
+// mergeUnionRoutings merges two union sources whose routes are usable as they
+// stand, or returns nil when their routings do not allow it.
+func mergeUnionRoutings(
+	ctx *plancontext.PlanningContext,
+	lhsRoute, rhsRoute *Route,
+	lhsExprs, rhsExprs []sqlparser.SelectExpr,
+	distinct bool,
+) (Operator, []sqlparser.SelectExpr) {
+	routingA, routingB := lhsRoute.Routing, rhsRoute.Routing
+	sameKeyspace := routingA.Keyspace() == routingB.Keyspace()
+	a, b := getRoutingType(routingA), getRoutingType(routingB)
 
 	// a none routing resolves to no shards at execution time, so its side of the
 	// union contributes no rows. None pairings must be decided before the dual
 	// and anyShard cases below: those would retain the none routing and
 	// incorrectly discard the other side's rows.
 	if a == none || b == none {
-		if op, exprs, merged := tryMergeNoneUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingA, routingB, a, b); merged {
-			return op, exprs
-		}
-		checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
-		return nil, nil
+		op, exprs, _ := tryMergeNoneUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingA, routingB, a, b)
+		return op, exprs
 	}
 
 	switch {
@@ -142,9 +166,6 @@ func mergeUnionInputs(
 			return res, exprs
 		}
 	}
-
-	// Check cross-keyspace restrictions for UNIONs that cannot be merged.
-	checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
 
 	return nil, nil
 }
@@ -216,6 +237,180 @@ func tryMergeNoneUnion(
 
 	op, exprs := createMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routing, nil)
 	return op, exprs, true
+}
+
+// tryAlternateUnionMerge retries a declined cross-keyspace pairing by moving
+// one side onto the reference copies of its tables in the other side's
+// keyspace. The move mutates the moved side's tables in place, so all
+// semantic bookkeeping keyed on its expressions stays valid; a retry that
+// still cannot merge undoes the move.
+func tryAlternateUnionMerge(
+	ctx *plancontext.PlanningContext,
+	lhsRoute, rhsRoute *Route,
+	lhsExprs, rhsExprs []sqlparser.SelectExpr,
+	distinct bool,
+) (Operator, []sqlparser.SelectExpr) {
+	lhsKs, rhsKs := lhsRoute.Routing.Keyspace(), rhsRoute.Routing.Keyspace()
+	if lhsKs == nil || rhsKs == nil || lhsKs == rhsKs {
+		return nil, nil
+	}
+
+	// a side already composed of a merged union carries shapes the remaining
+	// phases no longer normalize: moving it can hand offset planning a nested
+	// horizon it cannot push into, so only leaf routes are moved
+	canRewrite := func(route *Route) bool {
+		hasUnion := false
+		_ = Visit(route.Source, func(op Operator) error {
+			if _, ok := op.(*Union); ok {
+				hasUnion = true
+				return io.EOF
+			}
+			return nil
+		})
+		return !hasUnion
+	}
+
+	if canRewrite(lhsRoute) {
+		if rewritten, undo := rewriteRouteToAlternate(ctx, lhsRoute, rhsKs); rewritten != nil {
+			if op, exprs := mergeUnionRoutings(ctx, rewritten, rhsRoute, lhsExprs, rhsExprs, distinct); op != nil {
+				return op, exprs
+			}
+			undo()
+		}
+	}
+	if canRewrite(rhsRoute) {
+		if rewritten, undo := rewriteRouteToAlternate(ctx, rhsRoute, lhsKs); rewritten != nil {
+			if op, exprs := mergeUnionRoutings(ctx, lhsRoute, rewritten, lhsExprs, rhsExprs, distinct); op != nil {
+				return op, exprs
+			}
+			undo()
+		}
+	}
+	return nil, nil
+}
+
+// rewriteRouteToAlternate points route's tables at the reference copies living
+// in ks, or returns nil if the route cannot move there. Every real table under
+// the planned tree is resolved to its copy independently, so a route composed
+// by earlier merges moves when each of its tables has a copy. The planned
+// operators are kept and only the table nodes are swapped, so predicates and
+// projections pushed after route creation are preserved and the semantic
+// analysis of the tree stays authoritative. The returned undo puts the
+// original tables back. Reference and unsharded copies are complete on any
+// shard; a single ordinary sharded source keeps its resolved routing.
+func rewriteRouteToAlternate(ctx *plancontext.PlanningContext, route *Route, ks *vindexes.Keyspace) (*Route, func()) {
+	if _, ok := route.Routing.(*AnyShardRouting); !ok {
+		return nil, nil
+	}
+	if !ctx.SemTable.DMLTargets.IsEmpty() && TableID(route).IsOverlapping(ctx.SemTable.DMLTargets) {
+		return nil, nil
+	}
+
+	type tableSwap struct {
+		tbl        *Table
+		altQTable  *QueryTable
+		altVTable  *vindexes.BaseTable
+		origQTable *QueryTable
+		origVTable *vindexes.BaseTable
+	}
+	var swaps []tableSwap
+	var shardedRouting *ShardedRouting
+	resolvable := true
+	_ = Visit(route.Source, func(op Operator) error {
+		tbl, ok := op.(*Table)
+		if !ok || tbl.VTable == nil || tbl.QTable == nil {
+			return nil
+		}
+		alt, altRouting := resolveTableCopyIn(ctx, tbl, ks)
+		if alt == nil {
+			resolvable = false
+			return io.EOF
+		}
+		if alt.VTable.Type != vindexes.TypeReference && alt.VTable.Keyspace.Sharded {
+			var ok bool
+			shardedRouting, ok = altRouting.(*ShardedRouting)
+			if !ok || shardedRouting.Keyspace() != ks {
+				resolvable = false
+				return io.EOF
+			}
+		}
+		swaps = append(swaps, tableSwap{tbl: tbl, altQTable: alt.QTable, altVTable: alt.VTable, origQTable: tbl.QTable, origVTable: tbl.VTable})
+		return nil
+	})
+	if !resolvable || len(swaps) == 0 ||
+		(shardedRouting != nil && (TableID(route).NumberOfTables() != 1 || len(swaps) != 1 || !computesRowByRow(ctx, route))) {
+		return nil, nil
+	}
+
+	for _, s := range swaps {
+		s.tbl.QTable, s.tbl.VTable = s.altQTable, s.altVTable
+	}
+	undo := func() {
+		for _, s := range swaps {
+			s.tbl.QTable, s.tbl.VTable = s.origQTable, s.origVTable
+		}
+	}
+
+	rewritten := *route
+	if shardedRouting != nil {
+		rewritten.Routing = shardedRouting
+	} else {
+		rewritten.Routing = &AnyShardRouting{keyspace: ks}
+	}
+	return &rewritten, undo
+}
+
+// computesRowByRow reports whether everything planned under route yields the
+// same rows once per shard as it does once against a full copy of its table.
+// A horizon pushed into the single-shard reference route may assume it runs
+// once.
+func computesRowByRow(ctx *plancontext.PlanningContext, route *Route) bool {
+	rowByRow := true
+	_ = Visit(route.Source, func(op Operator) error {
+		if horizon, ok := op.(*Horizon); ok && !horizon.computesRowByRow(ctx) {
+			rowByRow = false
+			return io.EOF
+		}
+		return nil
+	})
+	return rowByRow
+}
+
+// resolveTableCopyIn resolves the physical copy of tbl's table living in ks:
+// the table itself, a reference copy from ReferencedBy, or a declared reference
+// source. Candidates are looked up through the planning VSchema and accepted
+// only when they resolve in ks. The returned table carries the physical name
+// with the original name preserved as an alias, along with its routing.
+func resolveTableCopyIn(ctx *plancontext.PlanningContext, tbl *Table, ks *vindexes.Keyspace) (*Table, Routing) {
+	for _, name := range copyCandidates(tbl.VTable, ks) {
+		src, _, _, _, _, err := ctx.VSchema.FindTableOrVindex(name)
+		if err != nil || src == nil || src.Keyspace != ks {
+			continue
+		}
+		altRoute := findVSchemaTableAndCreateRoute(ctx, tbl.QTable, name, false /*planAlternates*/)
+		altTbl, ok := altRoute.Source.(*Table)
+		if !ok || altTbl.VTable == nil || altTbl.VTable.Keyspace != ks {
+			continue
+		}
+		return altTbl, altRoute.Routing
+	}
+	return nil, nil
+}
+
+// copyCandidates lists the declared names under which vt's data may also live
+// in ks. A reference source is returned exactly as declared.
+func copyCandidates(vt *vindexes.BaseTable, ks *vindexes.Keyspace) []sqlparser.TableName {
+	var candidates []sqlparser.TableName
+	if vt.Keyspace == ks {
+		candidates = append(candidates, sqlparser.TableName{Name: vt.Name, Qualifier: sqlparser.NewIdentifierCS(ks.Name)})
+	}
+	if ref, found := vt.ReferencedBy[ks.Name]; found {
+		candidates = append(candidates, sqlparser.TableName{Name: ref.Name, Qualifier: sqlparser.NewIdentifierCS(ks.Name)})
+	}
+	if vt.Source != nil {
+		candidates = append(candidates, vt.Source.TableName)
+	}
+	return candidates
 }
 
 func tryMergeUnionShardedRouting(

--- a/go/vt/vtgate/planbuilder/testdata/reference_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/reference_cases.json
@@ -915,5 +915,333 @@
         "user.ref"
       ]
     }
+  },
+  {
+    "comment": "union of a reference table with a sharded table merges through the reference copy",
+    "query": "select id from ambiguous_ref_with_source union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from ambiguous_ref_with_source union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ambiguous_ref_with_source where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ambiguous_ref_with_source union select id, weight_string(id) from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ambiguous_ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "union order does not matter when merging through the reference copy",
+    "query": "select id from user union select id from ambiguous_ref_with_source",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user union select id from ambiguous_ref_with_source",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from ambiguous_ref_with_source where 1 != 1",
+            "Query": "select id, weight_string(id) from `user` union select id, weight_string(id) from ambiguous_ref_with_source"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ambiguous_ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "union through a reference copy with a different physical name rewrites the table",
+    "query": "select id from source_of_ref union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from source_of_ref union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ref_with_source as source_of_ref where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ref_with_source as source_of_ref union select id, weight_string(id) from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "predicates on the reference branch survive the rewrite to the reference copy",
+    "query": "select id from source_of_ref where id = 3 union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from source_of_ref where id = 3 union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ref_with_source as source_of_ref where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ref_with_source as source_of_ref where id = 3 union select id, weight_string(id) from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "union all through a reference copy keeps merging",
+    "query": "select id from source_of_ref union all select id from user",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select id from source_of_ref union all select id from user",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from ref_with_source as source_of_ref where 1 != 1 union all select id from `user` where 1 != 1",
+        "Query": "select id from ref_with_source as source_of_ref union all select id from `user`"
+      },
+      "TablesUsed": [
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a union composed of two reference-backed tables before the sharded side stays split",
+    "query": "select id from main.source_of_ref union select id from main.rerouted_ref union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from main.source_of_ref union select id from main.rerouted_ref union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref where 1 != 1 union select id from rerouted_ref where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref union select id from rerouted_ref) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.rerouted_ref",
+        "main.source_of_ref",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a composite reference union also stays split under union all",
+    "query": "select id from main.source_of_ref union all select id from main.rerouted_ref union all select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from main.source_of_ref union all select id from main.rerouted_ref union all select id from user",
+      "Instructions": {
+        "OperatorType": "Concatenate",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "main",
+              "Sharded": false
+            },
+            "FieldQuery": "select id from source_of_ref where 1 != 1 union all select id from rerouted_ref where 1 != 1",
+            "Query": "select id from source_of_ref union all select id from rerouted_ref"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id from `user` where 1 != 1",
+            "Query": "select id from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.rerouted_ref",
+        "main.source_of_ref",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a distinct reference union merges table by table when the sharded side merges first",
+    "query": "select id from user union select id from main.source_of_ref union select id from main.rerouted_ref",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user union select id from main.source_of_ref union select id from main.rerouted_ref",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from ref_with_source as source_of_ref where 1 != 1 union select id, weight_string(id) from ref as rerouted_ref where 1 != 1",
+            "Query": "select id, weight_string(id) from `user` union select id, weight_string(id) from ref_with_source as source_of_ref union select id, weight_string(id) from ref as rerouted_ref"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ref",
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a composite union with a table that has no copy in the target keyspace stays split",
+    "query": "select id from main.source_of_ref union select col from unsharded union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from main.source_of_ref union select col from unsharded union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref where 1 != 1 union select col from unsharded where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref union select col from unsharded) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.source_of_ref",
+        "main.unsharded",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/reference_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/reference_cases.json
@@ -915,5 +915,404 @@
         "user.ref"
       ]
     }
+  },
+  {
+    "comment": "union of a reference table with a sharded table merges through the reference copy",
+    "query": "select id from ambiguous_ref_with_source union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from ambiguous_ref_with_source union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ambiguous_ref_with_source where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ambiguous_ref_with_source union select id, weight_string(id) from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ambiguous_ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "union order does not matter when merging through the reference copy",
+    "query": "select id from user union select id from ambiguous_ref_with_source",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user union select id from ambiguous_ref_with_source",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from ambiguous_ref_with_source where 1 != 1",
+            "Query": "select id, weight_string(id) from `user` union select id, weight_string(id) from ambiguous_ref_with_source"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ambiguous_ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "union through a reference copy with a different physical name rewrites the table",
+    "query": "select id from source_of_ref union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from source_of_ref union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ref_with_source as source_of_ref where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ref_with_source as source_of_ref union select id, weight_string(id) from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "predicates on the reference branch survive the rewrite to the reference copy",
+    "query": "select id from source_of_ref where id = 3 union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from source_of_ref where id = 3 union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ref_with_source as source_of_ref where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ref_with_source as source_of_ref where id = 3 union select id, weight_string(id) from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "union all through a reference copy keeps merging",
+    "query": "select id from source_of_ref union all select id from user",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select id from source_of_ref union all select id from user",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from ref_with_source as source_of_ref where 1 != 1 union all select id from `user` where 1 != 1",
+        "Query": "select id from ref_with_source as source_of_ref union all select id from `user`"
+      },
+      "TablesUsed": [
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a union composed of two reference-backed tables before the sharded side stays split",
+    "query": "select id from main.source_of_ref union select id from main.rerouted_ref union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from main.source_of_ref union select id from main.rerouted_ref union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref where 1 != 1 union select id from rerouted_ref where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref union select id from rerouted_ref) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.rerouted_ref",
+        "main.source_of_ref",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a distinct union through a sharded reference source merges onto the source's scatter routing",
+    "query": "select col1 from main_2.sharded_sales_ref union select cola from user.sales_extra",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select col1 from main_2.sharded_sales_ref union select cola from user.sales_extra",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0: latin1_swedish_ci"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select col1 from sales as sharded_sales_ref where 1 != 1 union select cola from sales_extra where 1 != 1",
+            "Query": "select col1 from sales as sharded_sales_ref union select cola from sales_extra"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.sales",
+        "user.sales_extra"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "an aggregate pushed into a reference branch stays split from its sharded source",
+    "query": "select count(*) from main_2.sharded_sales_ref union all select 0 from user.sales_extra",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select count(*) from main_2.sharded_sales_ref union all select 0 from user.sales_extra",
+      "Instructions": {
+        "OperatorType": "Concatenate",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "main_2",
+              "Sharded": false
+            },
+            "FieldQuery": "select count(*) from sharded_sales_ref where 1 != 1",
+            "Query": "select count(*) from sharded_sales_ref"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 0 from sales_extra where 1 != 1",
+            "Query": "select 0 from sales_extra"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main_2.sharded_sales_ref",
+        "user.sales_extra"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a composite reference union also stays split under union all",
+    "query": "select id from main.source_of_ref union all select id from main.rerouted_ref union all select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from main.source_of_ref union all select id from main.rerouted_ref union all select id from user",
+      "Instructions": {
+        "OperatorType": "Concatenate",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "main",
+              "Sharded": false
+            },
+            "FieldQuery": "select id from source_of_ref where 1 != 1 union all select id from rerouted_ref where 1 != 1",
+            "Query": "select id from source_of_ref union all select id from rerouted_ref"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id from `user` where 1 != 1",
+            "Query": "select id from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.rerouted_ref",
+        "main.source_of_ref",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a distinct reference union merges table by table when the sharded side merges first",
+    "query": "select id from user union select id from main.source_of_ref union select id from main.rerouted_ref",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user union select id from main.source_of_ref union select id from main.rerouted_ref",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from ref_with_source as source_of_ref where 1 != 1 union select id, weight_string(id) from ref as rerouted_ref where 1 != 1",
+            "Query": "select id, weight_string(id) from `user` union select id, weight_string(id) from ref_with_source as source_of_ref union select id, weight_string(id) from ref as rerouted_ref"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ref",
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a composite union with a table that has no copy in the target keyspace stays split",
+    "query": "select id from main.source_of_ref union select col from unsharded union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from main.source_of_ref union select col from unsharded union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref where 1 != 1 union select col from unsharded where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref union select col from unsharded) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.source_of_ref",
+        "main.unsharded",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/vschemas/schema.json
+++ b/go/vt/vtgate/planbuilder/testdata/vschemas/schema.json
@@ -736,6 +736,10 @@
     },
     "main_2": {
       "tables": {
+        "sharded_sales_ref": {
+          "type": "reference",
+          "source": "user.sales"
+        },
         "unsharded_tab": {
           "columns": [
             {


### PR DESCRIPTION
## Description

A UNION DISTINCT between a reference table and a table in the keyspace holding one of its copies panics with `VT13001: [BUG] did not expect this method to be called`. When the two sides' keyspaces differ, the planner makes them mergeable by swapping in the alternate route prebuilt at route-creation time, but unions merge later, during horizon planning, and the prebuilt route still holds the unplanned bare table it was created with. As soon as the union pushes its result columns into that source — the weight-string columns DISTINCT needs — the bare table operator panics in `Table.AddColumn`. UNION ALL survives because it pushes nothing.

The fix stops using the prebuilt alternate as the merge payload. A declined cross-keyspace pairing is retried by resolving every real table under the moved side to its copy in the other side's keyspace through the VSchema — the table itself, a ReferencedBy copy, or a reference source, so routing rules stay in effect — and pointing the planned operators at those copies in place, undoing the move when the retry still cannot merge. Predicates and projections pushed after route creation are preserved because the operators are kept, physical renames keep the original name as an alias so column references still resolve, and later column pushes land on operators the planner has analyzed. A side already composed of a merged union is not moved: the remaining phases no longer normalize the shape that produces, so composite pairings stay split for now. Join and subquery merging keep the prebuilt-route mechanism: they merge during physical planning, when every route source is still a bare table, and that path is covered and correct.

Ten planner cases in reference_cases.json cover both merge orders, the differing-physical-name rewrite, predicate preservation through the rewrite, the sharded-source routing preservation, the composite pairings that stay split, a no-copy control, and pin the already-working UNION ALL path; the four single-table DISTINCT cases fail on main with the panic. The reference-copy cases are skip_e2e like the rest of that file's, since the e2e fixture does not define the copy tables. Recursive CTE merging shares the swap through prepareInputRoutes and likely has the same latent panic, left for a follow-up. This is part one of the fix for #20754, and since the panic exists in released versions it is probably worth backporting.

## Related Issue(s)

Part one of https://github.com/vitessio/vitess/issues/20754.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

UNION DISTINCT queries pairing a reference table with a table in a keyspace holding one of its copies previously failed to plan with an internal error; they now plan as a single merged route. No migrations or configuration changes.

### AI Disclosure

This PR was written primarily by Fable.

---

```mermaid
graph LR
    subgraph json [JSON support]
        direction TB
        PR20625["#20625 (merged)<br>mysql/json: fix MarshalTo discarding accumulated output for nested blob and bit values"]
        PR20632["#20632<br>vtgate: preserve IN value lists in complex aggregate projections"]
        PRA["#20691<br>evalengine: disable the static IN hash table for JSON operands"]
        PR20682["#20682 (draft)<br>evalengine: support constant-folded JSON values as literals"]
        PR20683["#20683 (draft)<br>evalengine, sqlparser: MySQL comparison domains; nested BETWEEN parentheses"]
        PR20626["#20626 (draft)<br>vtgate: support cross-shard JSON_ARRAYAGG and JSON_OBJECTAGG"]
        PR20625 --> PR20682
        PRA --> PR20682
        PR20682 --> PR20683
        PR20632 --> PR20626
        PR20683 --> PR20626
    end

    subgraph union [Union routing]
        direction TB
        PR20628["#20628<br>vtgate: track per-source copies of pushed join predicates so merges skip them"]
        PR20629["#20629 (merged)<br>vtgate: fix None routing handling when merging unions"]
        PR20630["#20630 (draft)<br>vtgate: merge unions on join-predicate-free routings when all sources agree"]
        PR20755["#20755<br>vtgate: fix union merging through reference-table alternates"]
        PR20756["#20756 (draft)<br>vtgate: merge empty reference branches through rewritten copies"]
        PR20628 --> PR20630
        PR20629 --> PR20630
        PR20630 --> PR20756
        PR20755 --> PR20756
    end

    subgraph cte [Recursive CTEs]
        direction TB
        PR20759["#20759<br>vtgate: expand qualified stars without JOIN USING coalescing"]
        PR20633["#20633 (draft)<br>vtgate: validate the declared column list length of CTEs and derived tables"]
        PR20631["#20631 (draft)<br>vtgate: bind recursive CTE column filters as arguments in unmerged term queries"]
        PR20759 --> PR20633
        PR20633 --> PR20631
    end

    json ~~~ union ~~~ cte
```

