### PR TITLE
vtgate: merge empty reference branches through rewritten copies

### DIFF
--- a/go/test/endtoend/vtgate/plan_tests/plan_e2e_test.go
+++ b/go/test/endtoend/vtgate/plan_tests/plan_e2e_test.go
@@ -29,9 +29,12 @@ func TestE2ECases(t *testing.T) {
 	err := utils.WaitForAuthoritative(t, "main", "source_of_ref", clusterInstance.VtgateProcess.ReadVSchema)
 	require.NoError(t, err)
 
+	// union_cases must run before dml_cases: the dml cases empty user_extra,
+	// and several union cases need its rows to reach their join primitives.
 	e2eTestCaseFiles := []string{
 		"select_cases.json",
 		"filter_cases.json",
+		"union_cases.json",
 		"dml_cases.json",
 		"reference_cases.json",
 	}

--- a/go/test/endtoend/vtgate/queries/union/union_test.go
+++ b/go/test/endtoend/vtgate/queries/union/union_test.go
@@ -67,6 +67,8 @@ func TestUnionDistinct(t *testing.T) {
 			mcmp.AssertMatchesNoOrder("select id1, id2 from t1 union select 827, 452 union select id3,id4 from t2",
 				"[[INT64(4) INT64(4)] [INT64(1) INT64(1)] [INT64(2) INT64(2)] [INT64(3) INT64(3)] [INT64(827) INT64(452)] [INT64(2) INT64(3)] [INT64(3) INT64(4)] [INT64(5) INT64(5)]]")
 			mcmp.AssertMatches("select 1 from dual where 1 IN (select 1 as col union select 2)", "[[INT64(1)]]")
+			mcmp.AssertMatches("select 1 from dual union select id1 from t1 where id1 in (null)", "[[INT64(1)]]")
+			mcmp.AssertMatches("select id1 from t1 where id1 in (null) union select 1 from dual", "[[INT64(1)]]")
 			mcmp.AssertMatches(`SELECT 1 from t1 UNION SELECT 2 from t1`, `[[INT64(1)] [INT64(2)]]`)
 			mcmp.AssertMatches(`SELECT 5 from t1 UNION SELECT 6 from t1`, `[[INT64(5)] [INT64(6)]]`)
 			mcmp.AssertMatchesNoOrder(`SELECT id1 from t1 UNION SELECT id2 from t1`, `[[INT64(1)] [INT64(2)] [INT64(3)] [INT64(4)]]`)

--- a/go/vt/vtgate/planbuilder/operators/SQL_builder.go
+++ b/go/vt/vtgate/planbuilder/operators/SQL_builder.go
@@ -616,7 +616,7 @@ func buildProjection(op *Projection, qb *queryBuilder) {
 func buildApplyJoin(op *ApplyJoin, qb *queryBuilder) {
 	preds := slice.Map(op.JoinPredicates.columns, func(jc applyJoinColumn) sqlparser.Expr {
 		if jc.JoinPredicateID != nil {
-			qb.ctx.PredTracker.Skip(*jc.JoinPredicateID)
+			qb.ctx.PredTracker.SkipWithDescendants(*jc.JoinPredicateID)
 		}
 		return jc.Original
 	})

--- a/go/vt/vtgate/planbuilder/operators/cte_merging.go
+++ b/go/vt/vtgate/planbuilder/operators/cte_merging.go
@@ -22,6 +22,20 @@ import (
 )
 
 func tryMergeRecurse(ctx *plancontext.PlanningContext, in *RecurseCTE) (Operator, *ApplyResult) {
+	// A recursive predicate that was pushed into every source of a UNION inside
+	// the term leaves per-source copies behind. Those copies cannot be restored
+	// to column form (their column belongs to another scope) and cannot be
+	// skipped (they carry the recursion condition), so mergeCTE would emit them
+	// as arguments no primitive produces. Keep the RecurseCTE primitive instead.
+	for _, predicate := range in.Predicates {
+		if predicate.JoinPredicateID == nil {
+			continue
+		}
+		if len(ctx.PredTracker.DescendantIDs(*predicate.JoinPredicateID)) > 0 {
+			return in, NoRewrite
+		}
+	}
+
 	op := tryMergeCTE(ctx, in.Seed(), in.Term(), in)
 	if op == nil {
 		return in, NoRewrite

--- a/go/vt/vtgate/planbuilder/operators/cte_merging.go
+++ b/go/vt/vtgate/planbuilder/operators/cte_merging.go
@@ -84,7 +84,7 @@ func mergeCTE(ctx *plancontext.PlanningContext, seed, term *Route, r Routing, in
 	newTerm, _ := expandHorizon(ctx, hz)
 	for _, predicate := range in.Predicates {
 		if predicate.JoinPredicateID != nil {
-			ctx.PredTracker.Set(*predicate.JoinPredicateID, predicate.Original)
+			ctx.PredTracker.ResetToOriginal(*predicate.JoinPredicateID, predicate.Original)
 		}
 	}
 

--- a/go/vt/vtgate/planbuilder/operators/horizon.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon.go
@@ -211,6 +211,20 @@ func (h *Horizon) getQP(ctx *plancontext.PlanningContext) *QueryProjection {
 	return h.QP
 }
 
+// computesRowByRow reports whether the horizon yields the same rows whether it
+// runs once or once per shard, so it can be pushed under a route that fans out
+// to several shards.
+func (h *Horizon) computesRowByRow(ctx *plancontext.PlanningContext) bool {
+	sel, isSel := h.Query.(*sqlparser.Select)
+	qp := h.getQP(ctx)
+	return !(isSel && sel.Having != nil) &&
+		len(qp.OrderExprs) == 0 &&
+		!qp.NeedsAggregation() &&
+		!qp.HasWindow &&
+		!isDistinctAST(h.Query) &&
+		h.Query.GetLimit() == nil
+}
+
 func (h *Horizon) ShortDescription() string {
 	return fmt.Sprintf("Horizon (Alias: %s)", h.Alias)
 }

--- a/go/vt/vtgate/planbuilder/operators/misc_routing.go
+++ b/go/vt/vtgate/planbuilder/operators/misc_routing.go
@@ -29,6 +29,11 @@ type (
 	// Can be merged with any other route going to the same keyspace
 	NoneRouting struct {
 		keyspace *vindexes.Keyspace
+
+		// inferredKeyspace is set when the routing this replaced had no keyspace
+		// of its own (information_schema, dual): keyspace is then only a
+		// placeholder giving the engine route a target, not a genuine read.
+		inferredKeyspace bool
 	}
 
 	// TargetedRouting is used when the user has used syntax to target the

--- a/go/vt/vtgate/planbuilder/operators/predicates/predicate.go
+++ b/go/vt/vtgate/planbuilder/operators/predicates/predicate.go
@@ -59,10 +59,14 @@ func (j *JoinPredicate) Current() sqlparser.Expr {
 func (j *JoinPredicate) IsExpr() {}
 
 func (j *JoinPredicate) Format(buf *sqlparser.TrackedBuffer) {
-	j.Current().Format(buf)
+	if expr := j.Current(); expr != nil {
+		expr.Format(buf)
+	}
 }
 
 func (j *JoinPredicate) FormatFast(buf *sqlparser.TrackedBuffer) {
 	fmt.Fprintf(buf, "JP(%d):", j.ID)
-	j.Current().FormatFast(buf)
+	if expr := j.Current(); expr != nil {
+		expr.FormatFast(buf)
+	}
 }

--- a/go/vt/vtgate/planbuilder/operators/predicates/tracker.go
+++ b/go/vt/vtgate/planbuilder/operators/predicates/tracker.go
@@ -17,9 +17,10 @@ limitations under the License.
 package predicates
 
 import (
-	"vitess.io/vitess/go/vt/vterrors"
+	"maps"
 
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 type (
@@ -29,15 +30,27 @@ type (
 	Tracker struct {
 		lastID      ID
 		expressions map[ID]sqlparser.Expr
+
+		// children tracks per-source copies of a predicate, such as the copies
+		// created when a predicate is pushed into every source of a UNION.
+		// When the original predicate is restored or skipped, the copies must
+		// be skipped as well - they cannot be restored to column form inside
+		// their source, and after a merge no one produces their arguments.
+		children map[ID][]ID
 	}
 
 	// ID is a unique key that references the current expression a join predicate represents.
 	ID int
+
+	// Snapshot holds the previous expressions of a predicate and its copies,
+	// captured by ResetToOriginal so an abandoned rewrite can be rolled back.
+	Snapshot map[ID]sqlparser.Expr
 )
 
 func NewTracker() *Tracker {
 	return &Tracker{
 		expressions: make(map[ID]sqlparser.Expr),
+		children:    make(map[ID][]ID),
 	}
 }
 
@@ -48,6 +61,24 @@ func (t *Tracker) NewJoinPredicate(org sqlparser.Expr) *JoinPredicate {
 		ID:      nextID,
 		tracker: t,
 	}
+}
+
+// NewChildJoinPredicate creates a new JoinPredicate that is tracked as a copy of the
+// given parent predicate, so that Skip/restore operations on the parent cascade to it.
+func (t *Tracker) NewChildJoinPredicate(parent *JoinPredicate, org sqlparser.Expr) *JoinPredicate {
+	jp := t.NewJoinPredicate(org)
+	t.children[parent.ID] = append(t.children[parent.ID], jp.ID)
+	return jp
+}
+
+// DescendantIDs returns the IDs of all transitive copies of the given predicate.
+func (t *Tracker) DescendantIDs(id ID) []ID {
+	ids := make([]ID, 0, len(t.children[id]))
+	for _, child := range t.children[id] {
+		ids = append(ids, child)
+		ids = append(ids, t.DescendantIDs(child)...)
+	}
+	return ids
 }
 
 func (t *Tracker) nextID() ID {
@@ -70,4 +101,32 @@ func (t *Tracker) Get(id ID) (sqlparser.Expr, error) {
 
 func (t *Tracker) Skip(id ID) {
 	t.expressions[id] = nil
+}
+
+// SkipWithDescendants skips the given predicate and all its transitive copies.
+func (t *Tracker) SkipWithDescendants(id ID) {
+	t.Skip(id)
+	for _, child := range t.children[id] {
+		t.SkipWithDescendants(child)
+	}
+}
+
+// ResetToOriginal returns the predicate to its pre-push expression and skips
+// all of its transitive copies: they cannot be restored to column form inside
+// their source, and once the parent is restored nothing produces their
+// arguments. It returns a Snapshot of the previous state so callers that may
+// abandon the rewrite can undo it with Rollback.
+func (t *Tracker) ResetToOriginal(id ID, expr sqlparser.Expr) Snapshot {
+	snapshot := Snapshot{id: t.expressions[id]}
+	t.expressions[id] = expr
+	for _, child := range t.DescendantIDs(id) {
+		snapshot[child] = t.expressions[child]
+		t.Skip(child)
+	}
+	return snapshot
+}
+
+// Rollback puts back the expressions captured in a Snapshot.
+func (t *Tracker) Rollback(s Snapshot) {
+	maps.Copy(t.expressions, s)
 }

--- a/go/vt/vtgate/planbuilder/operators/predicates/tracker.go
+++ b/go/vt/vtgate/planbuilder/operators/predicates/tracker.go
@@ -17,9 +17,10 @@ limitations under the License.
 package predicates
 
 import (
-	"vitess.io/vitess/go/vt/vterrors"
+	"maps"
 
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vterrors"
 )
 
 type (
@@ -29,15 +30,27 @@ type (
 	Tracker struct {
 		lastID      ID
 		expressions map[ID]sqlparser.Expr
+
+		// children tracks per-source copies of a predicate, such as the copies
+		// created when a predicate is pushed into every source of a UNION.
+		// When the original predicate is restored or skipped, the copies must
+		// be skipped as well - they cannot be restored to column form inside
+		// their source, and after a merge no one produces their arguments.
+		children map[ID][]ID
 	}
 
 	// ID is a unique key that references the current expression a join predicate represents.
 	ID int
+
+	// Snapshot holds the previous expressions of a predicate and its copies,
+	// captured by ResetToOriginal so an abandoned rewrite can be rolled back.
+	Snapshot map[ID]sqlparser.Expr
 )
 
 func NewTracker() *Tracker {
 	return &Tracker{
 		expressions: make(map[ID]sqlparser.Expr),
+		children:    make(map[ID][]ID),
 	}
 }
 
@@ -48,6 +61,24 @@ func (t *Tracker) NewJoinPredicate(org sqlparser.Expr) *JoinPredicate {
 		ID:      nextID,
 		tracker: t,
 	}
+}
+
+// NewChildJoinPredicate creates a new JoinPredicate that is tracked as a copy of the
+// given parent predicate, so that Skip/restore operations on the parent cascade to it.
+func (t *Tracker) NewChildJoinPredicate(parent *JoinPredicate, org sqlparser.Expr) *JoinPredicate {
+	jp := t.NewJoinPredicate(org)
+	t.children[parent.ID] = append(t.children[parent.ID], jp.ID)
+	return jp
+}
+
+// DescendantIDs returns the IDs of all transitive copies of the given predicate.
+func (t *Tracker) DescendantIDs(id ID) []ID {
+	var ids []ID
+	for _, child := range t.children[id] {
+		ids = append(ids, child)
+		ids = append(ids, t.DescendantIDs(child)...)
+	}
+	return ids
 }
 
 func (t *Tracker) nextID() ID {
@@ -70,4 +101,32 @@ func (t *Tracker) Get(id ID) (sqlparser.Expr, error) {
 
 func (t *Tracker) Skip(id ID) {
 	t.expressions[id] = nil
+}
+
+// SkipWithDescendants skips the given predicate and all its transitive copies.
+func (t *Tracker) SkipWithDescendants(id ID) {
+	t.Skip(id)
+	for _, child := range t.children[id] {
+		t.SkipWithDescendants(child)
+	}
+}
+
+// ResetToOriginal returns the predicate to its pre-push expression and skips
+// all of its transitive copies: they cannot be restored to column form inside
+// their source, and once the parent is restored nothing produces their
+// arguments. It returns a Snapshot of the previous state so callers that may
+// abandon the rewrite can undo it with Rollback.
+func (t *Tracker) ResetToOriginal(id ID, expr sqlparser.Expr) Snapshot {
+	snapshot := Snapshot{id: t.expressions[id]}
+	t.expressions[id] = expr
+	for _, child := range t.DescendantIDs(id) {
+		snapshot[child] = t.expressions[child]
+		t.Skip(child)
+	}
+	return snapshot
+}
+
+// Rollback puts back the expressions captured in a Snapshot.
+func (t *Tracker) Rollback(s Snapshot) {
+	maps.Copy(t.expressions, s)
 }

--- a/go/vt/vtgate/planbuilder/operators/predicates/tracker_test.go
+++ b/go/vt/vtgate/planbuilder/operators/predicates/tracker_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+func TestSkipWithDescendantsCascadesToChildren(t *testing.T) {
+	tracker := NewTracker()
+	parent := tracker.NewJoinPredicate(sqlparser.NewIntLiteral("1"))
+	childA := tracker.NewChildJoinPredicate(parent, sqlparser.NewIntLiteral("2"))
+	childB := tracker.NewChildJoinPredicate(parent, sqlparser.NewIntLiteral("3"))
+
+	tracker.SkipWithDescendants(parent.ID)
+
+	require.Nil(t, parent.Current())
+	require.Nil(t, childA.Current())
+	require.Nil(t, childB.Current())
+}
+
+func TestSkipWithDescendantsCascadesTransitively(t *testing.T) {
+	tracker := NewTracker()
+	parent := tracker.NewJoinPredicate(sqlparser.NewIntLiteral("1"))
+	child := tracker.NewChildJoinPredicate(parent, sqlparser.NewIntLiteral("2"))
+	grandchild := tracker.NewChildJoinPredicate(child, sqlparser.NewIntLiteral("3"))
+
+	tracker.SkipWithDescendants(parent.ID)
+
+	require.Nil(t, parent.Current())
+	require.Nil(t, child.Current())
+	require.Nil(t, grandchild.Current())
+}
+
+func TestSkipWithDescendantsLeavesUnrelatedPredicates(t *testing.T) {
+	tracker := NewTracker()
+	parent := tracker.NewJoinPredicate(sqlparser.NewIntLiteral("1"))
+	child := tracker.NewChildJoinPredicate(parent, sqlparser.NewIntLiteral("2"))
+	other := tracker.NewJoinPredicate(sqlparser.NewIntLiteral("3"))
+
+	tracker.SkipWithDescendants(parent.ID)
+
+	require.Nil(t, parent.Current())
+	require.Nil(t, child.Current())
+	require.NotNil(t, other.Current())
+}
+
+func TestDescendantIDsReturnsTransitiveClosure(t *testing.T) {
+	tracker := NewTracker()
+	parent := tracker.NewJoinPredicate(sqlparser.NewIntLiteral("1"))
+	childA := tracker.NewChildJoinPredicate(parent, sqlparser.NewIntLiteral("2"))
+	childB := tracker.NewChildJoinPredicate(parent, sqlparser.NewIntLiteral("3"))
+	grandchild := tracker.NewChildJoinPredicate(childA, sqlparser.NewIntLiteral("4"))
+
+	require.ElementsMatch(t, []ID{childA.ID, childB.ID, grandchild.ID}, tracker.DescendantIDs(parent.ID))
+	require.Empty(t, tracker.DescendantIDs(childB.ID))
+}
+
+func TestResetToOriginalRestoresParentAndSkipsDescendants(t *testing.T) {
+	tracker := NewTracker()
+	parent := tracker.NewJoinPredicate(sqlparser.NewIntLiteral("1"))
+	child := tracker.NewChildJoinPredicate(parent, sqlparser.NewIntLiteral("2"))
+	grandchild := tracker.NewChildJoinPredicate(child, sqlparser.NewIntLiteral("3"))
+	original := sqlparser.NewIntLiteral("42")
+
+	snapshot := tracker.ResetToOriginal(parent.ID, original)
+
+	require.Same(t, original, parent.Current())
+	require.Nil(t, child.Current())
+	require.Nil(t, grandchild.Current())
+	require.Len(t, snapshot, 3)
+}
+
+func TestRollbackRestoresSnapshotState(t *testing.T) {
+	tracker := NewTracker()
+	parent := tracker.NewJoinPredicate(sqlparser.NewIntLiteral("1"))
+	child := tracker.NewChildJoinPredicate(parent, sqlparser.NewIntLiteral("2"))
+	pushed := parent.Current()
+	copied := child.Current()
+
+	snapshot := tracker.ResetToOriginal(parent.ID, sqlparser.NewIntLiteral("42"))
+	tracker.Rollback(snapshot)
+
+	require.Same(t, pushed, parent.Current())
+	require.Same(t, copied, child.Current())
+}

--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -19,6 +19,7 @@ package operators
 import (
 	"fmt"
 	"io"
+	"maps"
 	"strconv"
 
 	"vitess.io/vitess/go/slice"
@@ -151,26 +152,18 @@ func tryMergeApplyJoin(in *ApplyJoin, ctx *plancontext.PlanningContext) (_ Opera
 
 	//  - Rewrite join predicates already pushed down &&
 	//  - Save original join predicates if we have to bail out of the rewrite
-	original := map[predicates.ID]sqlparser.Expr{}
+	original := predicates.Snapshot{}
 	for _, col := range aj.JoinPredicates.columns {
 		if col.JoinPredicateID != nil {
 			// if we have pushed down a join predicate, we need to restore it to its original shape, without the argument from the LHS
-			id := *col.JoinPredicateID
-			oldExpr, err := ctx.PredTracker.Get(id)
-			if err != nil {
-				panic(err)
-			}
-			original[id] = oldExpr
-			ctx.PredTracker.Set(id, col.Original)
+			maps.Copy(original, ctx.PredTracker.ResetToOriginal(*col.JoinPredicateID, col.Original))
 		}
 	}
 
 	// Defer restoration of original predicates if no successful rewrite happens.
 	defer func() {
 		if res == NoRewrite {
-			for id, expr := range original {
-				ctx.PredTracker.Set(id, expr)
-			}
+			ctx.PredTracker.Rollback(original)
 		}
 	}()
 

--- a/go/vt/vtgate/planbuilder/operators/query_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/query_planning.go
@@ -281,13 +281,7 @@ func pushOrExpandHorizon(ctx *plancontext.PlanningContext, in *Horizon) (Operato
 	needsOrdering := len(qp.OrderExprs) > 0
 	hasHaving := isSel && sel.Having != nil
 
-	canPush := isRoute &&
-		!hasHaving &&
-		!needsOrdering &&
-		!qp.NeedsAggregation() &&
-		!qp.HasWindow &&
-		!isDistinctAST(in.selectStatement()) &&
-		in.selectStatement().GetLimit() == nil
+	canPush := isRoute && in.computesRowByRow(ctx)
 
 	if canPush {
 		return Swap(in, rb, "push horizon into route")

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -133,6 +133,11 @@ func UpdateRoutingLogic(ctx *plancontext.PlanningContext, in sqlparser.Expr, r R
 	pred, isJP := in.(*predicates.JoinPredicate)
 	if isJP {
 		expr = pred.Current()
+		if expr == nil {
+			// the predicate has been skipped - the join it belonged to has been
+			// merged away, so it no longer applies and must not influence routing
+			return r
+		}
 	}
 
 	if b := ctx.IsConstantBool(expr); b != nil && !*b {

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -52,6 +52,15 @@ type (
 		// this field will contain the conditions under which this route is valid
 		Conditions []engine.Condition
 
+		// MergeFallback is set when a UNION was merged into this route on a
+		// routing that ignores join predicates pushed down from an ApplyJoin
+		// above. It records the routing an argument-based merge would have
+		// installed instead, so later union merge attempts against sources
+		// routed elsewhere can still merge this route the way they would have
+		// before. It is never simultaneously this route's Routing, so
+		// predicates pushed into this route cannot mutate it.
+		MergeFallback *ShardedRouting
+
 		ResultColumns int
 	}
 
@@ -199,6 +208,9 @@ func (r *Route) Clone(inputs []Operator) Operator {
 	cloneRoute := *r
 	cloneRoute.Source = inputs[0]
 	cloneRoute.Routing = r.Routing.Clone()
+	if r.MergeFallback != nil {
+		cloneRoute.MergeFallback = r.MergeFallback.Clone().(*ShardedRouting)
+	}
 	return &cloneRoute
 }
 

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -124,6 +124,18 @@ func UpdateRoutingLogic(ctx *plancontext.PlanningContext, in sqlparser.Expr, r R
 		return nr
 	}
 
+	expr := in
+	// If we have a JoinPredicate, let's get the inner expression
+	pred, isJP := in.(*predicates.JoinPredicate)
+	if isJP {
+		expr = pred.Current()
+		if expr == nil {
+			// the predicate has been skipped - the join it belonged to has been
+			// merged away, so it no longer applies and must not influence routing
+			return r
+		}
+	}
+
 	ks := r.Keyspace()
 	inferred := false
 	if ks == nil {
@@ -135,13 +147,6 @@ func UpdateRoutingLogic(ctx *plancontext.PlanningContext, in sqlparser.Expr, r R
 		inferred = true
 	}
 	nr := &NoneRouting{keyspace: ks, inferredKeyspace: inferred}
-
-	expr := in
-	// If we have a JoinPredicate, let's get the inner expression
-	pred, isJP := in.(*predicates.JoinPredicate)
-	if isJP {
-		expr = pred.Current()
-	}
 
 	if b := ctx.IsConstantBool(expr); b != nil && !*b {
 		return nr

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -118,15 +118,23 @@ type (
 
 // UpdateRoutingLogic first checks if we are dealing with a predicate that
 func UpdateRoutingLogic(ctx *plancontext.PlanningContext, in sqlparser.Expr, r Routing) Routing {
+	if nr, ok := r.(*NoneRouting); ok {
+		// a none routing stays none no matter what further predicates say, and
+		// returning it as-is keeps its inferred-keyspace marker intact.
+		return nr
+	}
+
 	ks := r.Keyspace()
+	inferred := false
 	if ks == nil {
 		var err error
 		ks, err = ctx.VSchema.AnyKeyspace()
 		if err != nil {
 			panic(err)
 		}
+		inferred = true
 	}
-	nr := &NoneRouting{keyspace: ks}
+	nr := &NoneRouting{keyspace: ks, inferredKeyspace: inferred}
 
 	expr := in
 	// If we have a JoinPredicate, let's get the inner expression

--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -341,8 +341,8 @@ func checkCrossKeyspaceOp(ctx *plancontext.PlanningContext, lhs, rhs Operator, o
 	// Fast path: both sides are direct *Route — two type assertions + pointer comparison, no allocations.
 	if lRoute, ok := lhs.(*Route); ok {
 		if rRoute, ok := rhs.(*Route); ok {
-			lhsKs := lRoute.Routing.Keyspace()
-			rhsKs := rRoute.Routing.Keyspace()
+			lhsKs := crossKeyspaceAccountable(lRoute)
+			rhsKs := crossKeyspaceAccountable(rRoute)
 			if lhsKs == nil || rhsKs == nil || lhsKs == rhsKs {
 				return
 			}
@@ -397,9 +397,12 @@ func checkCrossKeyspacePair(ctx *plancontext.PlanningContext, lhs, rhs Operator,
 	}
 }
 
-// hasAlternateInKeyspace checks if op is a direct *Route with an AnyShardRouting alternate
-// in the given keyspace. Only checks direct routes because mergeJoinInputs (via operatorsToRoutes)
-// only uses alternates for direct *Route operators — wrapped routes won't be merged.
+// hasAlternateInKeyspace checks if op is a direct *Route whose tables also live
+// in the given keyspace: through an AnyShardRouting alternate, or — for a route
+// degraded to NoneRouting, where the alternates were discarded — by checking
+// every real table's reference-copy placements in the vschema. Only checks
+// direct routes because mergeJoinInputs (via operatorsToRoutes) only uses
+// alternates for direct *Route operators — wrapped routes won't be merged.
 func hasAlternateInKeyspace(ctx *plancontext.PlanningContext, op Operator, ks *vindexes.Keyspace) bool {
 	route, ok := op.(*Route)
 	if !ok {
@@ -408,11 +411,77 @@ func hasAlternateInKeyspace(ctx *plancontext.PlanningContext, op Operator, ks *v
 	if !ctx.SemTable.DMLTargets.IsEmpty() && TableID(route).IsOverlapping(ctx.SemTable.DMLTargets) {
 		return false
 	}
-	ref, ok := route.Routing.(*AnyShardRouting)
-	if !ok {
+	switch routing := route.Routing.(type) {
+	case *AnyShardRouting:
+		return routing.AlternateInKeyspace(ks) != nil
+	case *NoneRouting:
+		return allRealTablesHaveCopyIn(ctx, route.Source, ks)
+	}
+	return false
+}
+
+// allRealTablesHaveCopyIn reports whether the operator tree has at least one
+// real table and every one of them also lives in ks: as the table's own
+// keyspace, through a reference copy recorded in ReferencedBy, or as the
+// source of a reference table. This only makes a cross-keyspace exemption
+// safe; it does not make the query text runnable in ks, since physical table
+// names can differ between keyspaces.
+func allRealTablesHaveCopyIn(ctx *plancontext.PlanningContext, op Operator, ks *vindexes.Keyspace) bool {
+	if op == nil {
 		return false
 	}
-	return ref.AlternateInKeyspace(ks) != nil
+	found := false
+	covered := true
+	_ = Visit(op, func(this Operator) error {
+		tbl, isTable := this.(*Table)
+		if !isTable || tbl.VTable == nil {
+			return nil
+		}
+		if tbl.QTable != nil && tbl.QTable.IsInfSchema {
+			// information_schema is present on every shard
+			return nil
+		}
+		found = true
+		if tableHasCopyIn(ctx, tbl.VTable, ks) {
+			return nil
+		}
+		covered = false
+		return io.EOF
+	})
+	return found && covered
+}
+
+func tableHasCopyIn(ctx *plancontext.PlanningContext, vt *vindexes.BaseTable, ks *vindexes.Keyspace) bool {
+	if vt.Keyspace == ks {
+		return true
+	}
+	if _, referenced := vt.ReferencedBy[ks.Name]; referenced {
+		return true
+	}
+	if vt.Source == nil {
+		return false
+	}
+	if qualifier := vt.Source.TableName.Qualifier.String(); qualifier != "" {
+		return qualifier == ks.Name
+	}
+	// an unqualified source declaration resolves through the vschema
+	src, _, _, _, _, err := ctx.VSchema.FindTableOrVindex(vt.Source.TableName)
+	return err == nil && src != nil && src.Keyspace == ks
+}
+
+// crossKeyspaceAccountable returns the keyspace the route genuinely reads
+// from. A none routing with an inferred keyspace (information_schema, dual)
+// reads from no keyspace — unless a merge absorbed real tables under it, in
+// which case the placeholder keyspace is where those tables live.
+func crossKeyspaceAccountable(route *Route) *vindexes.Keyspace {
+	nr, ok := route.Routing.(*NoneRouting)
+	if !ok || !nr.inferredKeyspace {
+		return route.Routing.Keyspace()
+	}
+	if len(realTableKeyspaces(route.Source)) == 0 {
+		return nil
+	}
+	return nr.keyspace
 }
 
 // operatorKeyspaces collects all unique keyspaces from an operator tree by recursively
@@ -430,7 +499,7 @@ func collectOperatorKeyspaces(op Operator, result *[]*vindexes.Keyspace) {
 		return
 	}
 	if route, ok := op.(*Route); ok {
-		addOperatorKeyspace(result, route.Routing.Keyspace())
+		addOperatorKeyspace(result, crossKeyspaceAccountable(route))
 		return
 	}
 	for _, input := range op.Inputs() {
@@ -446,6 +515,45 @@ func addOperatorKeyspace(result *[]*vindexes.Keyspace, ks *vindexes.Keyspace) {
 		return
 	}
 	*result = append(*result, ks)
+}
+
+// realTableKeyspaces collects the distinct keyspaces of the real tables under
+// op. Virtual tables (dual, recursive CTE references) have no vschema table
+// behind them, and information_schema tables only get a synthetic VTable in an
+// arbitrary keyspace (createInfSchemaRoute), so neither contributes anything.
+// Unlike operatorKeyspaces, this reflects where the referenced tables actually
+// live rather than where a routing points.
+func realTableKeyspaces(op Operator) []*vindexes.Keyspace {
+	if op == nil {
+		return nil
+	}
+	var result []*vindexes.Keyspace
+	_ = Visit(op, func(this Operator) error {
+		tbl, ok := this.(*Table)
+		if !ok || tbl.VTable == nil {
+			return nil
+		}
+		if tbl.QTable != nil && tbl.QTable.IsInfSchema {
+			return nil
+		}
+		addOperatorKeyspace(&result, tbl.VTable.Keyspace)
+		return nil
+	})
+	return result
+}
+
+// hasInfoSchemaTables reports whether any table under op reads from
+// information_schema.
+func hasInfoSchemaTables(op Operator) bool {
+	var found bool
+	_ = Visit(op, func(this Operator) error {
+		if tbl, ok := this.(*Table); ok && tbl.QTable != nil && tbl.QTable.IsInfSchema {
+			found = true
+			return io.EOF
+		}
+		return nil
+	})
+	return found
 }
 
 func operatorsToRoutes(a, b Operator) (*Route, *Route) {

--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -452,21 +452,13 @@ func allRealTablesHaveCopyIn(ctx *plancontext.PlanningContext, op Operator, ks *
 }
 
 func tableHasCopyIn(ctx *plancontext.PlanningContext, vt *vindexes.BaseTable, ks *vindexes.Keyspace) bool {
-	if vt.Keyspace == ks {
-		return true
+	for _, name := range copyCandidates(vt, ks) {
+		src, _, _, _, _, err := ctx.VSchema.FindTableOrVindex(name)
+		if err == nil && src != nil && src.Keyspace == ks {
+			return true
+		}
 	}
-	if _, referenced := vt.ReferencedBy[ks.Name]; referenced {
-		return true
-	}
-	if vt.Source == nil {
-		return false
-	}
-	if qualifier := vt.Source.TableName.Qualifier.String(); qualifier != "" {
-		return qualifier == ks.Name
-	}
-	// an unqualified source declaration resolves through the vschema
-	src, _, _, _, _, err := ctx.VSchema.FindTableOrVindex(vt.Source.TableName)
-	return err == nil && src != nil && src.Keyspace == ks
+	return false
 }
 
 // crossKeyspaceAccountable returns the keyspace the route genuinely reads

--- a/go/vt/vtgate/planbuilder/operators/route_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning.go
@@ -453,21 +453,13 @@ func allRealTablesHaveCopyIn(ctx *plancontext.PlanningContext, op Operator, ks *
 }
 
 func tableHasCopyIn(ctx *plancontext.PlanningContext, vt *vindexes.BaseTable, ks *vindexes.Keyspace) bool {
-	if vt.Keyspace == ks {
-		return true
+	for _, name := range copyCandidates(vt, ks) {
+		src, _, _, _, _, err := ctx.VSchema.FindTableOrVindex(name)
+		if err == nil && src != nil && src.Keyspace == ks {
+			return true
+		}
 	}
-	if _, referenced := vt.ReferencedBy[ks.Name]; referenced {
-		return true
-	}
-	if vt.Source == nil {
-		return false
-	}
-	if qualifier := vt.Source.Qualifier.String(); qualifier != "" {
-		return qualifier == ks.Name
-	}
-	// an unqualified source declaration resolves through the vschema
-	src, _, _, _, _, err := ctx.VSchema.FindTableOrVindex(vt.Source.TableName)
-	return err == nil && src != nil && src.Keyspace == ks
+	return false
 }
 
 // crossKeyspaceAccountable returns the keyspace the route genuinely reads

--- a/go/vt/vtgate/planbuilder/operators/route_planning_test.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning_test.go
@@ -80,9 +80,11 @@ func TestCheckCrossKeyspaceJoin(t *testing.T) {
 		return &Table{
 			QTable: &QueryTable{Table: sqlparser.NewTableName("ref")},
 			VTable: &vindexes.BaseTable{
-				Name:         sqlparser.NewIdentifierCS("ref"),
-				Keyspace:     ks,
-				ReferencedBy: map[string]*vindexes.BaseTable{copyKs: {}},
+				Name:     sqlparser.NewIdentifierCS("ref"),
+				Keyspace: ks,
+				ReferencedBy: map[string]*vindexes.BaseTable{
+					copyKs: {Name: sqlparser.NewIdentifierCS("refcopy")},
+				},
 			},
 		}
 	}
@@ -287,6 +289,9 @@ func TestCheckCrossKeyspaceJoin(t *testing.T) {
 			rhs:  makeRoute(ks2),
 			vschema: &mockVSchema{
 				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+				tables: map[string]*vindexes.BaseTable{
+					"refcopy": {Name: sqlparser.NewIdentifierCS("refcopy"), Keyspace: ks2},
+				},
 			},
 		},
 		{
@@ -295,6 +300,9 @@ func TestCheckCrossKeyspaceJoin(t *testing.T) {
 			rhs:  noneRouteOver(ks2, sourcedTable(ks2, "ks1")),
 			vschema: &mockVSchema{
 				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+				tables: map[string]*vindexes.BaseTable{
+					"src": {Name: sqlparser.NewIdentifierCS("src"), Keyspace: ks1},
+				},
 			},
 		},
 		{
@@ -326,6 +334,9 @@ func TestCheckCrossKeyspaceJoin(t *testing.T) {
 			rhs: makeRoute(ks2),
 			vschema: &mockVSchema{
 				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+				tables: map[string]*vindexes.BaseTable{
+					"refcopy": {Name: sqlparser.NewIdentifierCS("refcopy"), Keyspace: ks2},
+				},
 			},
 			expectPanic: true,
 		},

--- a/go/vt/vtgate/planbuilder/operators/route_planning_test.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning_test.go
@@ -80,9 +80,11 @@ func TestCheckCrossKeyspaceJoin(t *testing.T) {
 		return &Table{
 			QTable: &QueryTable{Table: sqlparser.NewTableName("ref")},
 			VTable: &vindexes.BaseTable{
-				Name:         sqlparser.NewIdentifierCS("ref"),
-				Keyspace:     ks,
-				ReferencedBy: map[string]*vindexes.BaseTable{copyKs: {}},
+				Name:     sqlparser.NewIdentifierCS("ref"),
+				Keyspace: ks,
+				ReferencedBy: map[string]*vindexes.BaseTable{
+					copyKs: {Name: sqlparser.NewIdentifierCS("refcopy")},
+				},
 			},
 		}
 	}
@@ -289,6 +291,9 @@ func TestCheckCrossKeyspaceJoin(t *testing.T) {
 			rhs:  makeRoute(ks2),
 			vschema: &mockVSchema{
 				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+				tables: map[string]*vindexes.BaseTable{
+					"refcopy": {Name: sqlparser.NewIdentifierCS("refcopy"), Keyspace: ks2},
+				},
 			},
 		},
 		{
@@ -297,6 +302,9 @@ func TestCheckCrossKeyspaceJoin(t *testing.T) {
 			rhs:  noneRouteOver(ks2, sourcedTable(ks2, "ks1")),
 			vschema: &mockVSchema{
 				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+				tables: map[string]*vindexes.BaseTable{
+					"src": {Name: sqlparser.NewIdentifierCS("src"), Keyspace: ks1},
+				},
 			},
 		},
 		{
@@ -328,6 +336,9 @@ func TestCheckCrossKeyspaceJoin(t *testing.T) {
 			rhs: makeRoute(ks2),
 			vschema: &mockVSchema{
 				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+				tables: map[string]*vindexes.BaseTable{
+					"refcopy": {Name: sqlparser.NewIdentifierCS("refcopy"), Keyspace: ks2},
+				},
 			},
 			expectPanic: true,
 		},

--- a/go/vt/vtgate/planbuilder/operators/route_planning_test.go
+++ b/go/vt/vtgate/planbuilder/operators/route_planning_test.go
@@ -23,7 +23,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/vt/key"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtenv"
+	"vitess.io/vitess/go/vt/vterrors"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 	"vitess.io/vitess/go/vt/vtgate/semantics"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
@@ -32,6 +37,7 @@ import (
 type mockVSchema struct {
 	plancontext.VSchema
 	preventCrossKeyspaceReads map[string]bool
+	tables                    map[string]*vindexes.BaseTable
 }
 
 func (m *mockVSchema) AllowCrossKeyspaceReads(keyspace string) (bool, error) {
@@ -41,12 +47,62 @@ func (m *mockVSchema) AllowCrossKeyspaceReads(keyspace string) (bool, error) {
 	return !m.preventCrossKeyspaceReads[keyspace], nil
 }
 
+func (m *mockVSchema) FindTableOrVindex(tab sqlparser.TableName) (*vindexes.BaseTable, vindexes.Vindex, string, topodatapb.TabletType, key.ShardDestination, error) {
+	tbl, found := m.tables[tab.Name.String()]
+	if !found {
+		return nil, nil, "", topodatapb.TabletType_PRIMARY, nil, vterrors.VT05004(tab.Name.String())
+	}
+	return tbl, nil, tbl.Keyspace.Name, topodatapb.TabletType_PRIMARY, nil, nil
+}
+
+func (m *mockVSchema) Environment() *vtenv.Environment {
+	return vtenv.NewTestEnv()
+}
+
+func (m *mockVSchema) ConnCollation() collations.ID {
+	return collations.CollationUtf8mb4ID
+}
+
 func TestCheckCrossKeyspaceJoin(t *testing.T) {
 	ks1 := &vindexes.Keyspace{Name: "ks1"}
 	ks2 := &vindexes.Keyspace{Name: "ks2"}
 
 	makeRoute := func(ks *vindexes.Keyspace) *Route {
 		return &Route{Routing: &NoneRouting{keyspace: ks}}
+	}
+	plainTable := func(ks *vindexes.Keyspace) *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("t")},
+			VTable: &vindexes.BaseTable{Name: sqlparser.NewIdentifierCS("t"), Keyspace: ks},
+		}
+	}
+	refTable := func(ks *vindexes.Keyspace, copyKs string) *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("ref")},
+			VTable: &vindexes.BaseTable{
+				Name:         sqlparser.NewIdentifierCS("ref"),
+				Keyspace:     ks,
+				ReferencedBy: map[string]*vindexes.BaseTable{copyKs: {}},
+			},
+		}
+	}
+	sourcedTable := func(ks *vindexes.Keyspace, sourceKs string) *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("ref")},
+			VTable: &vindexes.BaseTable{
+				Name:     sqlparser.NewIdentifierCS("ref"),
+				Keyspace: ks,
+				Source: &vindexes.Source{
+					TableName: sqlparser.TableName{
+						Qualifier: sqlparser.NewIdentifierCS(sourceKs),
+						Name:      sqlparser.NewIdentifierCS("src"),
+					},
+				},
+			},
+		}
+	}
+	noneRouteOver := func(ks *vindexes.Keyspace, src Operator) *Route {
+		return &Route{unaryOperator: newUnaryOp(src), Routing: &NoneRouting{keyspace: ks}}
 	}
 
 	tests := []struct {
@@ -209,6 +265,84 @@ func TestCheckCrossKeyspaceJoin(t *testing.T) {
 				preventCrossKeyspaceReads: map[string]bool{"ks1": false, "ks2": false},
 			},
 		},
+		{
+			name: "inferred none keyspace does not create a cross-keyspace pair",
+			lhs:  &Route{Routing: &NoneRouting{keyspace: ks1, inferredKeyspace: true}},
+			rhs:  makeRoute(ks2),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+			},
+		},
+		{
+			name: "inferred none keyspace wrapped in a non-route is also skipped",
+			lhs: &Projection{
+				unaryOperator: newUnaryOp(&Route{Routing: &NoneRouting{keyspace: ks1, inferredKeyspace: true}}),
+			},
+			rhs: makeRoute(ks2),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+			},
+		},
+		{
+			name: "cross-keyspace denied but the lhs none branch's table has a reference copy on the rhs",
+			lhs:  noneRouteOver(ks1, refTable(ks1, "ks2")),
+			rhs:  makeRoute(ks2),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+			},
+		},
+		{
+			name: "cross-keyspace denied but the rhs none branch's table is sourced from the lhs keyspace",
+			lhs:  makeRoute(ks1),
+			rhs:  noneRouteOver(ks2, sourcedTable(ks2, "ks1")),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+			},
+		},
+		{
+			name: "cross-keyspace denied but the rhs none branch's table has an unqualified source resolving to the lhs keyspace",
+			lhs:  makeRoute(ks1),
+			rhs: noneRouteOver(ks2, &Table{
+				QTable: &QueryTable{Table: sqlparser.NewTableName("ref")},
+				VTable: &vindexes.BaseTable{
+					Name:     sqlparser.NewIdentifierCS("ref"),
+					Keyspace: ks2,
+					Source: &vindexes.Source{
+						TableName: sqlparser.TableName{Name: sqlparser.NewIdentifierCS("src")},
+					},
+				},
+			}),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+				tables: map[string]*vindexes.BaseTable{
+					"src": {Name: sqlparser.NewIdentifierCS("src"), Keyspace: ks1},
+				},
+			},
+		},
+		{
+			name: "a none branch that absorbed a table without a copy on the rhs stays denied",
+			lhs: noneRouteOver(ks1, &Join{binaryOperator: binaryOperator{
+				LHS: refTable(ks1, "ks2"),
+				RHS: plainTable(ks1),
+			}}),
+			rhs: makeRoute(ks2),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+			},
+			expectPanic: true,
+		},
+		{
+			name: "an inferred none keyspace over a real table stays accountable",
+			lhs: &Route{
+				unaryOperator: newUnaryOp(plainTable(ks1)),
+				Routing:       &NoneRouting{keyspace: ks1, inferredKeyspace: true},
+			},
+			rhs: makeRoute(ks2),
+			vschema: &mockVSchema{
+				preventCrossKeyspaceReads: map[string]bool{"ks1": true, "ks2": true},
+			},
+			expectPanic: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -289,6 +423,150 @@ func TestOperatorKeyspaces(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, operatorKeyspaces(tt.op))
+		})
+	}
+}
+
+func TestRealTableKeyspaces(t *testing.T) {
+	ks1 := &vindexes.Keyspace{Name: "ks1"}
+	ks2 := &vindexes.Keyspace{Name: "ks2"}
+
+	makeTable := func(ks *vindexes.Keyspace) *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("t")},
+			VTable: &vindexes.BaseTable{Name: sqlparser.NewIdentifierCS("t"), Keyspace: ks},
+		}
+	}
+	makeInfSchemaTable := func(ks *vindexes.Keyspace) *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("tables"), IsInfSchema: true},
+			VTable: &vindexes.BaseTable{Name: sqlparser.NewIdentifierCS("tables"), Keyspace: ks},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		op       Operator
+		expected []*vindexes.Keyspace
+	}{
+		{
+			name:     "real table",
+			op:       makeTable(ks1),
+			expected: []*vindexes.Keyspace{ks1},
+		},
+		{
+			name:     "virtual dual table has no keyspace",
+			op:       &Table{},
+			expected: nil,
+		},
+		{
+			name:     "table nested under a projection",
+			op:       &Projection{unaryOperator: newUnaryOp(makeTable(ks1))},
+			expected: []*vindexes.Keyspace{ks1},
+		},
+		{
+			name:     "same keyspace tables are deduplicated",
+			op:       &Join{binaryOperator: binaryOperator{LHS: makeTable(ks1), RHS: makeTable(ks1)}},
+			expected: []*vindexes.Keyspace{ks1},
+		},
+		{
+			name:     "tables from different keyspaces",
+			op:       &Join{binaryOperator: binaryOperator{LHS: makeTable(ks1), RHS: makeTable(ks2)}},
+			expected: []*vindexes.Keyspace{ks1, ks2},
+		},
+		{
+			name:     "real table joined with a virtual dual",
+			op:       &Join{binaryOperator: binaryOperator{LHS: makeTable(ks1), RHS: &Table{}}},
+			expected: []*vindexes.Keyspace{ks1},
+		},
+		{
+			name:     "information_schema table with a synthetic vtable contributes nothing",
+			op:       makeInfSchemaTable(ks1),
+			expected: nil,
+		},
+		{
+			name:     "information_schema table joined with a real table",
+			op:       &Join{binaryOperator: binaryOperator{LHS: makeInfSchemaTable(ks1), RHS: makeTable(ks2)}},
+			expected: []*vindexes.Keyspace{ks2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, realTableKeyspaces(tt.op))
+		})
+	}
+}
+
+func TestUpdateRoutingLogicKeepsNoneRouting(t *testing.T) {
+	ks := &vindexes.Keyspace{Name: "ks1"}
+	ctx := &plancontext.PlanningContext{
+		SemTable: &semantics.SemTable{},
+		VSchema:  &mockVSchema{},
+	}
+	orig := &NoneRouting{keyspace: ks, inferredKeyspace: true}
+	falseCmp := &sqlparser.ComparisonExpr{
+		Operator: sqlparser.EqualOp,
+		Left:     sqlparser.NewIntLiteral("1"),
+		Right:    sqlparser.NewIntLiteral("2"),
+	}
+
+	got := UpdateRoutingLogic(ctx, falseCmp, orig)
+
+	assert.Same(t, orig, got)
+}
+
+func TestHasInfoSchemaTables(t *testing.T) {
+	ks1 := &vindexes.Keyspace{Name: "ks1"}
+
+	makeTable := func() *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("t")},
+			VTable: &vindexes.BaseTable{Name: sqlparser.NewIdentifierCS("t"), Keyspace: ks1},
+		}
+	}
+	makeInfSchemaTable := func() *Table {
+		return &Table{
+			QTable: &QueryTable{Table: sqlparser.NewTableName("tables"), IsInfSchema: true},
+			VTable: &vindexes.BaseTable{Name: sqlparser.NewIdentifierCS("tables"), Keyspace: ks1},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		op       Operator
+		expected bool
+	}{
+		{
+			name:     "real table",
+			op:       makeTable(),
+			expected: false,
+		},
+		{
+			name:     "information_schema table",
+			op:       makeInfSchemaTable(),
+			expected: true,
+		},
+		{
+			name:     "virtual dual table",
+			op:       &Table{},
+			expected: false,
+		},
+		{
+			name:     "information_schema table nested under a projection",
+			op:       &Projection{unaryOperator: newUnaryOp(makeInfSchemaTable())},
+			expected: true,
+		},
+		{
+			name:     "information_schema table joined with a real table",
+			op:       &Join{binaryOperator: binaryOperator{LHS: makeTable(), RHS: makeInfSchemaTable()}},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, hasInfoSchemaTables(tt.op))
 		})
 	}
 }

--- a/go/vt/vtgate/planbuilder/operators/route_test.go
+++ b/go/vt/vtgate/planbuilder/operators/route_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operators
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+)
+
+func TestRouteCloneMergeFallback(t *testing.T) {
+	ks := &vindexes.Keyspace{Name: "ks", Sharded: true}
+	route := &Route{
+		unaryOperator: newUnaryOp(&Route{Routing: &NoneRouting{keyspace: ks}}),
+		Routing:       &ShardedRouting{keyspace: ks, RouteOpCode: engine.Scatter},
+		MergeFallback: &ShardedRouting{keyspace: ks, RouteOpCode: engine.EqualUnique},
+	}
+
+	clone := route.Clone(route.Inputs()).(*Route)
+	require.NotSame(t, route.MergeFallback, clone.MergeFallback)
+
+	// mutating the clone's fallback must not reach through to the original
+	clone.MergeFallback.RouteOpCode = engine.Scatter
+	assert.Equal(t, engine.EqualUnique, route.MergeFallback.RouteOpCode)
+}

--- a/go/vt/vtgate/planbuilder/operators/route_test.go
+++ b/go/vt/vtgate/planbuilder/operators/route_test.go
@@ -27,6 +27,7 @@ import (
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtenv"
+	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
@@ -48,4 +49,20 @@ func TestUpdateRoutingLogicSequenceRouting(t *testing.T) {
 	// a sequence routing must pass through predicate handling untouched
 	seq := &SequenceRouting{keyspace: &vindexes.Keyspace{Name: "main"}}
 	assert.Same(t, seq, UpdateRoutingLogic(ctx, sqlparser.NewIntLiteral("1"), seq))
+}
+
+func TestRouteCloneMergeFallback(t *testing.T) {
+	ks := &vindexes.Keyspace{Name: "ks", Sharded: true}
+	route := &Route{
+		unaryOperator: newUnaryOp(&Route{Routing: &NoneRouting{keyspace: ks}}),
+		Routing:       &ShardedRouting{keyspace: ks, RouteOpCode: engine.Scatter},
+		MergeFallback: &ShardedRouting{keyspace: ks, RouteOpCode: engine.EqualUnique},
+	}
+
+	clone := route.Clone(route.Inputs()).(*Route)
+	require.NotSame(t, route.MergeFallback, clone.MergeFallback)
+
+	// mutating the clone's fallback must not reach through to the original
+	clone.MergeFallback.RouteOpCode = engine.Scatter
+	assert.Equal(t, engine.EqualUnique, route.MergeFallback.RouteOpCode)
 }

--- a/go/vt/vtgate/planbuilder/operators/route_test.go
+++ b/go/vt/vtgate/planbuilder/operators/route_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operators
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/vschemawrapper"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtenv"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+)
+
+func TestUpdateRoutingLogicSequenceRouting(t *testing.T) {
+	env := vtenv.NewTestEnv()
+	vs := vindexes.BuildVSchema(&vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{"main": {}},
+	}, sqlparser.NewTestParser())
+	vw, err := vschemawrapper.NewVschemaWrapper(env, vs, nil)
+	require.NoError(t, err)
+
+	stmt, err := sqlparser.NewTestParser().Parse("select 1 from dual")
+	require.NoError(t, err)
+	reservedVars := sqlparser.NewReservedVars("vtg", make(sqlparser.BindVars))
+	ctx, err := plancontext.CreatePlanningContext(stmt, reservedVars, vw, querypb.ExecuteOptions_Gen4)
+	require.NoError(t, err)
+
+	// a sequence routing must pass through predicate handling untouched
+	seq := &SequenceRouting{keyspace: &vindexes.Keyspace{Name: "main"}}
+	assert.Same(t, seq, UpdateRoutingLogic(ctx, sqlparser.NewIntLiteral("1"), seq))
+}

--- a/go/vt/vtgate/planbuilder/operators/sharded_routing.go
+++ b/go/vt/vtgate/planbuilder/operators/sharded_routing.go
@@ -676,6 +676,49 @@ func (tr *ShardedRouting) extraInfo() string {
 	)
 }
 
+// hasJoinPredicates returns true if any of the seen predicates is a join predicate
+// that was pushed into this route from an ApplyJoin above it.
+func (tr *ShardedRouting) hasJoinPredicates() bool {
+	return slices.ContainsFunc(tr.SeenPredicates, func(expr sqlparser.Expr) bool {
+		_, ok := expr.(*predicates.JoinPredicate)
+		return ok
+	})
+}
+
+// withoutJoinPredicates re-derives this routing from its seen predicates, ignoring
+// join predicates pushed down from an ApplyJoin. When a predicate like `col = :arg`
+// is pushed into a route, the argument vindex option can replace a previously selected
+// option, such as a literal pin from the WHERE clause. The routing returned here
+// reflects only the predicates that hold for the route regardless of any join above
+// it. If no join predicates have been seen, the routing itself is returned unchanged.
+// Returns nil if the join-predicate-free routing did not select a vindex.
+func (tr *ShardedRouting) withoutJoinPredicates(ctx *plancontext.PlanningContext) *ShardedRouting {
+	if !tr.hasJoinPredicates() {
+		if tr.Selected == nil {
+			return nil
+		}
+		return tr
+	}
+	replay, ok := tr.Clone().(*ShardedRouting)
+	if !ok {
+		return nil
+	}
+	replay.SeenPredicates = slice.Filter(replay.SeenPredicates, func(expr sqlparser.Expr) bool {
+		_, isJP := expr.(*predicates.JoinPredicate)
+		return !isJP
+	})
+	seen := replay.SeenPredicates
+	routing, ok := replay.resetRoutingLogic(ctx).(*ShardedRouting)
+	if !ok || routing.Selected == nil {
+		return nil
+	}
+	// resetRoutingLogic replays through updateRoutingLogic, which appends every
+	// replayed predicate to SeenPredicates again. This routing outlives the merge
+	// decision, so restore the filtered list instead of keeping the duplicates.
+	routing.SeenPredicates = seen
+	return routing
+}
+
 func tryMergeShardedRouting(
 	ctx *plancontext.PlanningContext,
 	routeA, routeB *Route,

--- a/go/vt/vtgate/planbuilder/operators/union.go
+++ b/go/vt/vtgate/planbuilder/operators/union.go
@@ -122,8 +122,12 @@ func (u *Union) predicatePerSource(ctx *plancontext.PlanningContext, expr sqlpar
 		if jp, ok := predicate.(*predicates.JoinPredicate); ok {
 			// Create a new JoinPredicate for each source to keep tracking working
 			// We can't use `*JoinPredicate.Clone` here as that would update the tracker and overwrite
-			// the expression for the original predicate
-			predicate = ctx.PredTracker.NewJoinPredicate(jp.Current())
+			// the expression for the original predicate.
+			// The copy is registered as a child of the original so that skipping the
+			// original (when the join it belongs to is merged into a single route)
+			// cascades to the per-source copies, whose arguments would otherwise
+			// have no producer left in the plan.
+			predicate = ctx.PredTracker.NewChildJoinPredicate(jp, jp.Current())
 		}
 
 		predicate = sqlparser.CopyOnRewrite(predicate, nil, func(cursor *sqlparser.CopyOnWriteCursor) {

--- a/go/vt/vtgate/planbuilder/operators/union_merging.go
+++ b/go/vt/vtgate/planbuilder/operators/union_merging.go
@@ -17,6 +17,8 @@ limitations under the License.
 package operators
 
 import (
+	"slices"
+
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
@@ -114,6 +116,18 @@ func mergeUnionInputs(
 		return nil, nil
 	}
 
+	// a none routing resolves to no shards at execution time, so its side of the
+	// union contributes no rows. None pairings must be decided before the dual
+	// and anyShard cases below: those would retain the none routing and
+	// incorrectly discard the other side's rows.
+	if a == none || b == none {
+		if op, exprs, merged := tryMergeNoneUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingA, routingB, a, b); merged {
+			return op, exprs
+		}
+		checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
+		return nil, nil
+	}
+
 	switch {
 	// if either side is a dual query, we can always merge them together
 	// an unsharded/reference route can be merged with anything going to that keyspace
@@ -121,11 +135,6 @@ func mergeUnionInputs(
 		return createMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingA, nil)
 	case a == dual || (a == anyShard && sameKeyspace):
 		return createMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingB, nil)
-
-	case a == none:
-		return createMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingB, nil)
-	case b == none:
-		return createMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingA, nil)
 
 	case a == sharded && b == sharded && sameKeyspace:
 		res, exprs := tryMergeUnionShardedRouting(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct)
@@ -138,6 +147,75 @@ func mergeUnionInputs(
 	checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
 
 	return nil, nil
+}
+
+// tryMergeNoneUnion merges a union pairing in which at least one side has a
+// none routing. The none side contributes no rows, but its query text (and the
+// field query derived from it) still references its tables, so a merge may only
+// adopt a routing whose keyspace holds every real table of the none side.
+func tryMergeNoneUnion(
+	ctx *plancontext.PlanningContext,
+	lhsRoute, rhsRoute *Route,
+	lhsExprs, rhsExprs []sqlparser.SelectExpr,
+	distinct bool,
+	routingA, routingB Routing,
+	a, b routingType,
+) (Operator, []sqlparser.SelectExpr, bool) {
+	otherRouting, otherType := routingB, b
+	noneRoute, otherRoute := lhsRoute, rhsRoute
+	if a != none {
+		otherRouting, otherType = routingA, a
+		noneRoute, otherRoute = rhsRoute, lhsRoute
+	}
+	noneKeyspaces := realTableKeyspaces(noneRoute.Source)
+
+	var routing Routing
+	switch {
+	case otherType == none:
+		// both sides are empty. They can collapse into a single none route as
+		// long as their combined real tables live in one keyspace: the merged
+		// route's field query must be executable on a shard of that keyspace.
+		for _, ks := range realTableKeyspaces(otherRoute.Source) {
+			if !slices.Contains(noneKeyspaces, ks) {
+				noneKeyspaces = append(noneKeyspaces, ks)
+			}
+		}
+		switch len(noneKeyspaces) {
+		case 0:
+			routing = noneRoute.Routing
+		case 1:
+			routing = &NoneRouting{keyspace: noneKeyspaces[0]}
+		default:
+			return nil, nil, false
+		}
+	case hasInfoSchemaTables(noneRoute.Source):
+		// an information_schema comparison may have been rewritten to a
+		// planner-generated argument (e.g. :__vtschemaname) that only a DBA
+		// route binds. Adopting an executable routing would ship that argument
+		// to a shard with no binding for it, so this branch must stay separate.
+		return nil, nil, false
+	case len(noneKeyspaces) == 0:
+		// the none side references no real tables, so its keyspace is only a
+		// placeholder: adopt the other side's routing unconditionally.
+		routing = otherRouting
+	case otherType == dual:
+		// a dual side has no keyspace and no tables of its own, so any shard
+		// in the none side's single keyspace can produce its rows.
+		if len(noneKeyspaces) != 1 {
+			return nil, nil, false
+		}
+		routing = &AnyShardRouting{keyspace: noneKeyspaces[0]}
+	default:
+		// the other side's routing is retained, but only when it targets the
+		// keyspace holding the none side's tables: they exist nowhere else.
+		if len(noneKeyspaces) != 1 || noneKeyspaces[0] != otherRouting.Keyspace() {
+			return nil, nil, false
+		}
+		routing = otherRouting
+	}
+
+	op, exprs := createMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routing, nil)
+	return op, exprs, true
 }
 
 func tryMergeUnionShardedRouting(

--- a/go/vt/vtgate/planbuilder/operators/union_merging.go
+++ b/go/vt/vtgate/planbuilder/operators/union_merging.go
@@ -132,9 +132,9 @@ func mergeUnionInputs(
 	// if either side is a dual query, we can always merge them together
 	// an unsharded/reference route can be merged with anything going to that keyspace
 	case b == dual || (b == anyShard && sameKeyspace):
-		return createMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingA, nil)
+		return createTrivialMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingA, lhsRoute)
 	case a == dual || (a == anyShard && sameKeyspace):
-		return createMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingB, nil)
+		return createTrivialMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingB, rhsRoute)
 
 	case a == sharded && b == sharded && sameKeyspace:
 		res, exprs := tryMergeUnionShardedRouting(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct)
@@ -169,7 +169,11 @@ func tryMergeNoneUnion(
 	}
 	noneKeyspaces := realTableKeyspaces(noneRoute.Source)
 
+	// owner is the route whose MergeFallback must survive the merge, so that a
+	// later source routed elsewhere can still merge with the result through the
+	// argument-based routing recorded there.
 	var routing Routing
+	owner := otherRoute
 	switch {
 	case otherType == none:
 		// both sides are empty. They can collapse into a single none route as
@@ -205,6 +209,7 @@ func tryMergeNoneUnion(
 			return nil, nil, false
 		}
 		routing = &AnyShardRouting{keyspace: noneKeyspaces[0]}
+		owner = noneRoute
 	default:
 		// the other side's routing is retained, but only when it targets the
 		// keyspace holding the none side's tables: they exist nowhere else.
@@ -214,7 +219,7 @@ func tryMergeNoneUnion(
 		routing = otherRouting
 	}
 
-	op, exprs := createMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routing, nil)
+	op, exprs := createTrivialMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routing, owner)
 	return op, exprs, true
 }
 
@@ -238,6 +243,34 @@ func tryMergeUnionShardedRouting(
 		return createMergedUnion(ctx, routeA, routeB, exprsA, exprsB, distinct, tblB, nil)
 
 	case tblA.RouteOpCode == engine.EqualUnique && tblB.RouteOpCode == engine.EqualUnique:
+		// If both sides route to the same shard even without the join predicates
+		// pushed down from an ApplyJoin above, prefer that routing: it does not
+		// depend on join arguments, so the merged route can later be merged with
+		// the join producing those arguments. The routing an argument-based merge
+		// would have installed is kept as a fallback, so sources routed elsewhere
+		// can still merge with this route the way they otherwise would have.
+		if canReplayWithoutJoinPredicates(routeA, tblA) && canReplayWithoutJoinPredicates(routeB, tblB) {
+			freeA := tblA.withoutJoinPredicates(ctx)
+			freeB := tblB.withoutJoinPredicates(ctx)
+			if freeA != nil && freeB != nil &&
+				(tblA.hasJoinPredicates() || tblB.hasJoinPredicates()) &&
+				freeA.RouteOpCode == tblA.RouteOpCode &&
+				freeA.RouteOpCode == freeB.RouteOpCode &&
+				freeA.SelectedVindex() == freeB.SelectedVindex() {
+				equal, conditions := gen4ValuesEqual(ctx, freeA.VindexExpressions(), freeB.VindexExpressions())
+				if equal {
+					allCond := append(routeA.Conditions, routeB.Conditions...)
+					allCond = append(allCond, conditions...)
+					op, exprs := createMergedUnion(ctx, routeA, routeB, exprsA, exprsB, distinct, freeA, allCond)
+					if route, ok := op.(*Route); ok {
+						if fb := unionMergeFallback(ctx, routeA, routeB, tblA, tblB); fb != freeA {
+							route.MergeFallback = fb
+						}
+					}
+					return op, exprs
+				}
+			}
+		}
 		fallthrough
 	case tblA.RouteOpCode == engine.Equal && tblB.RouteOpCode == engine.Equal:
 		fallthrough
@@ -251,12 +284,108 @@ func tryMergeUnionShardedRouting(
 			if equal {
 				allCond := append(routeA.Conditions, routeB.Conditions...)
 				allCond = append(allCond, conditions...)
-				return createMergedUnion(ctx, routeA, routeB, exprsA, exprsB, distinct, tblA, allCond)
+				op, exprs := createMergedUnion(ctx, routeA, routeB, exprsA, exprsB, distinct, tblA, allCond)
+				if routeA.MergeFallback != nil || routeB.MergeFallback != nil {
+					if route, ok := op.(*Route); ok {
+						if fb := unionMergeFallback(ctx, routeA, routeB, tblA, tblB); fb != tblA {
+							route.MergeFallback = fb
+						}
+					}
+				}
+				return op, exprs
+			}
+		}
+
+		// One of the sides may have been merged onto a routing that ignores join
+		// predicates and carry the argument-based routing it displaced as a
+		// fallback. Comparing the fallbacks merges the routes exactly the way the
+		// displaced routings would have merged.
+		fbA := unionMergeRouting(routeA, tblA)
+		fbB := unionMergeRouting(routeB, tblB)
+		if (fbA != tblA || fbB != tblB) &&
+			fbA.RouteOpCode == fbB.RouteOpCode &&
+			fbA.SelectedVindex() == fbB.SelectedVindex() {
+			equal, conditions := gen4ValuesEqual(ctx, fbA.VindexExpressions(), fbB.VindexExpressions())
+			if equal {
+				allCond := append(routeA.Conditions, routeB.Conditions...)
+				allCond = append(allCond, conditions...)
+				return createMergedUnion(ctx, routeA, routeB, exprsA, exprsB, distinct, fbA, allCond)
 			}
 		}
 	}
 
 	return nil, nil
+}
+
+// unionMergeRouting returns the routing to use when comparing this route against
+// another union source: the argument-based routing recorded when a merge pinned
+// this route onto a join-predicate-free routing, or the given routing itself.
+func unionMergeRouting(route *Route, tbl *ShardedRouting) *ShardedRouting {
+	if route.MergeFallback != nil {
+		return route.MergeFallback
+	}
+	return tbl
+}
+
+// unionMergeFallback computes the MergeFallback for a pair of union sources
+// about to be merged onto a join-predicate-free routing: the routing an
+// argument-based merge would have installed instead. It is only returned when
+// both sides route identically under it, with no extra engine conditions, so
+// the recorded routing covers every source of the merged union; sides that
+// already carry a fallback contribute that fallback. Callers skip recording
+// when the result is the very routing they are installing, since a routing
+// without join predicates falls back to itself.
+func unionMergeFallback(ctx *plancontext.PlanningContext, routeA, routeB *Route, tblA, tblB *ShardedRouting) *ShardedRouting {
+	fbA := unionMergeRouting(routeA, tblA)
+	fbB := unionMergeRouting(routeB, tblB)
+	if fbA.RouteOpCode != fbB.RouteOpCode || fbA.SelectedVindex() != fbB.SelectedVindex() {
+		return nil
+	}
+	equal, conditions := gen4ValuesEqual(ctx, fbA.VindexExpressions(), fbB.VindexExpressions())
+	if !equal || len(conditions) != 0 {
+		return nil
+	}
+	return fbA
+}
+
+// canReplayWithoutJoinPredicates reports whether the route's routing can soundly be
+// re-derived from its seen predicates alone. Once a merged UNION sits under a route,
+// the routing keeps the seen predicates of just one of the union's sources (see
+// createMergedUnion), so replaying them could produce a routing that does not cover
+// the other sources - such as a shard pin that only one source satisfies. Merging
+// several sources on argument equality and then replaying without join predicates
+// would collapse differently pinned sources onto one shard and silently lose rows.
+// A routing without join predicates is always safe: withoutJoinPredicates returns
+// it unchanged, so no re-derivation takes place.
+func canReplayWithoutJoinPredicates(route *Route, tr *ShardedRouting) bool {
+	return !tr.hasJoinPredicates() || !containsUnion(route.Source)
+}
+
+func containsUnion(op Operator) bool {
+	if _, ok := op.(*Union); ok {
+		return true
+	}
+	return slices.ContainsFunc(op.Inputs(), containsUnion)
+}
+
+// createTrivialMergedUnion merges a union pair where one side trivially adopts
+// the owning side's routing: the dual, anyShard and none cases. The owning
+// route's MergeFallback must survive the merge, so that a later source routed
+// elsewhere can still merge with the result through the argument-based routing
+// recorded there.
+func createTrivialMergedUnion(
+	ctx *plancontext.PlanningContext,
+	lhsRoute, rhsRoute *Route,
+	lhsExprs, rhsExprs []sqlparser.SelectExpr,
+	distinct bool,
+	routing Routing,
+	owner *Route,
+) (Operator, []sqlparser.SelectExpr) {
+	op, exprs := createMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routing, nil)
+	if route, ok := op.(*Route); ok {
+		route.MergeFallback = owner.MergeFallback
+	}
+	return op, exprs
 }
 
 func createMergedUnion(

--- a/go/vt/vtgate/planbuilder/operators/union_merging.go
+++ b/go/vt/vtgate/planbuilder/operators/union_merging.go
@@ -232,16 +232,78 @@ func tryMergeNoneUnion(
 		routing = &AnyShardRouting{keyspace: noneKeyspaces[0]}
 		owner = noneRoute
 	default:
-		// the other side's routing is retained, but only when it targets the
-		// keyspace holding the none side's tables: they exist nowhere else.
+		// the other side's routing is retained when it targets the keyspace
+		// holding the none side's tables — or, failing that, when every real
+		// table of the none side has a reference copy there: the branch is
+		// then rewritten to read those copies, so the merged query text only
+		// names tables that exist in that keyspace.
 		if len(noneKeyspaces) != 1 || noneKeyspaces[0] != otherRouting.Keyspace() {
-			return nil, nil, false
+			rewrittenNone := rewriteNoneBranchToKeyspace(ctx, noneRoute, otherRouting.Keyspace())
+			if rewrittenNone == nil {
+				return nil, nil, false
+			}
+			if noneRoute == lhsRoute {
+				lhsRoute = rewrittenNone
+			} else {
+				rhsRoute = rewrittenNone
+			}
 		}
 		routing = otherRouting
 	}
 
 	op, exprs := createTrivialMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routing, owner)
 	return op, exprs, true
+}
+
+// rewriteNoneBranchToKeyspace points the none route's tables at the reference
+// copies living in ks, or returns nil if any table has none. A routing
+// degrades to none before alternates are attached, so each copy is resolved
+// from the vschema through the same lookup that builds alternate routes,
+// keeping routing rules in effect. Only leaf routes are moved, for the same
+// normalization reasons as tryAlternateUnionMerge.
+func rewriteNoneBranchToKeyspace(ctx *plancontext.PlanningContext, route *Route, ks *vindexes.Keyspace) *Route {
+	if ks == nil {
+		return nil
+	}
+	if !ctx.SemTable.DMLTargets.IsEmpty() && TableID(route).IsOverlapping(ctx.SemTable.DMLTargets) {
+		return nil
+	}
+
+	type tableSwap struct {
+		tbl       *Table
+		altQTable *QueryTable
+		altVTable *vindexes.BaseTable
+	}
+	var swaps []tableSwap
+	resolvable := true
+	_ = Visit(route.Source, func(op Operator) error {
+		if _, ok := op.(*Union); ok {
+			resolvable = false
+			return io.EOF
+		}
+		tbl, ok := op.(*Table)
+		if !ok || tbl.VTable == nil || tbl.QTable == nil {
+			return nil
+		}
+		alt := resolveTableCopyIn(ctx, tbl, ks)
+		if alt == nil {
+			resolvable = false
+			return io.EOF
+		}
+		swaps = append(swaps, tableSwap{tbl: tbl, altQTable: alt.QTable, altVTable: alt.VTable})
+		return nil
+	})
+	if !resolvable || len(swaps) == 0 {
+		return nil
+	}
+
+	for _, s := range swaps {
+		s.tbl.QTable, s.tbl.VTable = s.altQTable, s.altVTable
+	}
+
+	rewritten := *route
+	rewritten.Routing = &NoneRouting{keyspace: ks}
+	return &rewritten
 }
 
 // tryAlternateUnionMerge retries a declined cross-keyspace pairing by moving

--- a/go/vt/vtgate/planbuilder/operators/union_merging.go
+++ b/go/vt/vtgate/planbuilder/operators/union_merging.go
@@ -17,12 +17,14 @@ limitations under the License.
 package operators
 
 import (
+	"io"
 	"slices"
 
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
 // mergeUnionInputInAnyOrder merges sources the sources of the union in any order
@@ -110,22 +112,44 @@ func mergeUnionInputs(
 	lhsExprs, rhsExprs []sqlparser.SelectExpr,
 	distinct bool,
 ) (Operator, []sqlparser.SelectExpr) {
-	lhsRoute, rhsRoute, routingA, routingB, a, b, sameKeyspace := prepareInputRoutes(ctx, lhs, rhs)
-	if lhsRoute == nil {
+	lhsRoute, rhsRoute := operatorsToRoutes(lhs, rhs)
+	if lhsRoute == nil || rhsRoute == nil {
 		checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
 		return nil, nil
 	}
+
+	if op, exprs := mergeUnionRoutings(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct); op != nil {
+		return op, exprs
+	}
+	if op, exprs := tryAlternateUnionMerge(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct); op != nil {
+		return op, exprs
+	}
+
+	// Check cross-keyspace restrictions for UNIONs that cannot be merged.
+	checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
+
+	return nil, nil
+}
+
+// mergeUnionRoutings merges two union sources whose routes are usable as they
+// stand, or returns nil when their routings do not allow it.
+func mergeUnionRoutings(
+	ctx *plancontext.PlanningContext,
+	lhsRoute, rhsRoute *Route,
+	lhsExprs, rhsExprs []sqlparser.SelectExpr,
+	distinct bool,
+) (Operator, []sqlparser.SelectExpr) {
+	routingA, routingB := lhsRoute.Routing, rhsRoute.Routing
+	sameKeyspace := routingA.Keyspace() == routingB.Keyspace()
+	a, b := getRoutingType(routingA), getRoutingType(routingB)
 
 	// a none routing resolves to no shards at execution time, so its side of the
 	// union contributes no rows. None pairings must be decided before the dual
 	// and anyShard cases below: those would retain the none routing and
 	// incorrectly discard the other side's rows.
 	if a == none || b == none {
-		if op, exprs, merged := tryMergeNoneUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingA, routingB, a, b); merged {
-			return op, exprs
-		}
-		checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
-		return nil, nil
+		op, exprs, _ := tryMergeNoneUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingA, routingB, a, b)
+		return op, exprs
 	}
 
 	switch {
@@ -142,9 +166,6 @@ func mergeUnionInputs(
 			return res, exprs
 		}
 	}
-
-	// Check cross-keyspace restrictions for UNIONs that cannot be merged.
-	checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
 
 	return nil, nil
 }
@@ -221,6 +242,154 @@ func tryMergeNoneUnion(
 
 	op, exprs := createTrivialMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routing, owner)
 	return op, exprs, true
+}
+
+// tryAlternateUnionMerge retries a declined cross-keyspace pairing by moving
+// one side onto the reference copies of its tables in the other side's
+// keyspace. The move mutates the moved side's tables in place, so all
+// semantic bookkeeping keyed on its expressions stays valid; a retry that
+// still cannot merge undoes the move.
+func tryAlternateUnionMerge(
+	ctx *plancontext.PlanningContext,
+	lhsRoute, rhsRoute *Route,
+	lhsExprs, rhsExprs []sqlparser.SelectExpr,
+	distinct bool,
+) (Operator, []sqlparser.SelectExpr) {
+	lhsKs, rhsKs := lhsRoute.Routing.Keyspace(), rhsRoute.Routing.Keyspace()
+	if lhsKs == nil || rhsKs == nil || lhsKs == rhsKs {
+		return nil, nil
+	}
+
+	// a side already composed of a merged union carries shapes the remaining
+	// phases no longer normalize: moving it can hand offset planning a nested
+	// horizon it cannot push into, so only leaf routes are moved
+	canRewrite := func(route *Route) bool {
+		hasUnion := false
+		_ = Visit(route.Source, func(op Operator) error {
+			if _, ok := op.(*Union); ok {
+				hasUnion = true
+				return io.EOF
+			}
+			return nil
+		})
+		return !hasUnion
+	}
+
+	if canRewrite(lhsRoute) {
+		if rewritten, undo := rewriteRouteToAlternate(ctx, lhsRoute, rhsKs); rewritten != nil {
+			if op, exprs := mergeUnionRoutings(ctx, rewritten, rhsRoute, lhsExprs, rhsExprs, distinct); op != nil {
+				return op, exprs
+			}
+			undo()
+		}
+	}
+	if canRewrite(rhsRoute) {
+		if rewritten, undo := rewriteRouteToAlternate(ctx, rhsRoute, lhsKs); rewritten != nil {
+			if op, exprs := mergeUnionRoutings(ctx, lhsRoute, rewritten, lhsExprs, rhsExprs, distinct); op != nil {
+				return op, exprs
+			}
+			undo()
+		}
+	}
+	return nil, nil
+}
+
+// rewriteRouteToAlternate points route's tables at the reference copies living
+// in ks, or returns nil if the route cannot move there. Every real table under
+// the planned tree is resolved to its copy independently, so a route composed
+// by earlier merges moves when each of its tables has a copy. The planned
+// operators are kept and only the table nodes are swapped, so predicates and
+// projections pushed after route creation are preserved and the semantic
+// analysis of the tree stays authoritative. The returned undo puts the
+// original tables back.
+func rewriteRouteToAlternate(ctx *plancontext.PlanningContext, route *Route, ks *vindexes.Keyspace) (*Route, func()) {
+	if _, ok := route.Routing.(*AnyShardRouting); !ok {
+		return nil, nil
+	}
+	if !ctx.SemTable.DMLTargets.IsEmpty() && TableID(route).IsOverlapping(ctx.SemTable.DMLTargets) {
+		return nil, nil
+	}
+
+	type tableSwap struct {
+		tbl        *Table
+		altQTable  *QueryTable
+		altVTable  *vindexes.BaseTable
+		origQTable *QueryTable
+		origVTable *vindexes.BaseTable
+	}
+	var swaps []tableSwap
+	resolvable := true
+	_ = Visit(route.Source, func(op Operator) error {
+		tbl, ok := op.(*Table)
+		if !ok || tbl.VTable == nil || tbl.QTable == nil {
+			return nil
+		}
+		alt := resolveTableCopyIn(ctx, tbl, ks)
+		if alt == nil ||
+			// this route serves rows from a single shard of ks, which only a
+			// reference or unsharded copy can provide in full
+			(alt.VTable.Type != vindexes.TypeReference && alt.VTable.Keyspace.Sharded) {
+			resolvable = false
+			return io.EOF
+		}
+		swaps = append(swaps, tableSwap{tbl: tbl, altQTable: alt.QTable, altVTable: alt.VTable, origQTable: tbl.QTable, origVTable: tbl.VTable})
+		return nil
+	})
+	if !resolvable || len(swaps) == 0 {
+		return nil, nil
+	}
+
+	for _, s := range swaps {
+		s.tbl.QTable, s.tbl.VTable = s.altQTable, s.altVTable
+	}
+	undo := func() {
+		for _, s := range swaps {
+			s.tbl.QTable, s.tbl.VTable = s.origQTable, s.origVTable
+		}
+	}
+
+	rewritten := *route
+	rewritten.Routing = &AnyShardRouting{keyspace: ks}
+	return &rewritten, undo
+}
+
+// resolveTableCopyIn resolves the physical copy of tbl's table living in ks:
+// the table itself, a reference copy from ReferencedBy, or a reference
+// source, looked up through the VSchema so routing rules and unqualified
+// source declarations are honored. The returned table carries the physical
+// name with the original name preserved as an alias, or nil when ks holds no
+// copy.
+func resolveTableCopyIn(ctx *plancontext.PlanningContext, tbl *Table, ks *vindexes.Keyspace) *Table {
+	for _, name := range copyCandidates(tbl.VTable, ks) {
+		src, _, _, _, _, err := ctx.VSchema.FindTableOrVindex(name)
+		if err != nil || src == nil || src.Keyspace != ks {
+			continue
+		}
+		altRoute := findVSchemaTableAndCreateRoute(ctx, tbl.QTable, name, false /*planAlternates*/)
+		altTbl, ok := altRoute.Source.(*Table)
+		if !ok || altTbl.VTable == nil || altTbl.VTable.Keyspace != ks {
+			continue
+		}
+		return altTbl
+	}
+	return nil
+}
+
+// copyCandidates lists the declared names under which vt's data may also live
+// in ks. The source name is returned as declared — possibly unqualified — so
+// the VSchema lookup resolves it the same way the reference itself was.
+func copyCandidates(vt *vindexes.BaseTable, ks *vindexes.Keyspace) []sqlparser.TableName {
+	var candidates []sqlparser.TableName
+	if vt.Keyspace == ks {
+		candidates = append(candidates, sqlparser.TableName{Name: vt.Name, Qualifier: sqlparser.NewIdentifierCS(ks.Name)})
+	}
+	if ref, found := vt.ReferencedBy[ks.Name]; found {
+		candidates = append(candidates, sqlparser.TableName{Name: ref.Name, Qualifier: sqlparser.NewIdentifierCS(ks.Name)})
+	}
+	if vt.Source != nil {
+		candidates = append(candidates, vt.Source.TableName)
+	}
+	return candidates
 }
 
 func tryMergeUnionShardedRouting(

--- a/go/vt/vtgate/planbuilder/operators/union_merging.go
+++ b/go/vt/vtgate/planbuilder/operators/union_merging.go
@@ -17,12 +17,14 @@ limitations under the License.
 package operators
 
 import (
+	"io"
 	"slices"
 
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
 // mergeUnionInputInAnyOrder merges sources the sources of the union in any order
@@ -110,22 +112,44 @@ func mergeUnionInputs(
 	lhsExprs, rhsExprs []sqlparser.SelectExpr,
 	distinct bool,
 ) (Operator, []sqlparser.SelectExpr) {
-	lhsRoute, rhsRoute, routingA, routingB, a, b, sameKeyspace := prepareInputRoutes(ctx, lhs, rhs)
-	if lhsRoute == nil {
+	lhsRoute, rhsRoute := operatorsToRoutes(lhs, rhs)
+	if lhsRoute == nil || rhsRoute == nil {
 		checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
 		return nil, nil
 	}
+
+	if op, exprs := mergeUnionRoutings(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct); op != nil {
+		return op, exprs
+	}
+	if op, exprs := tryAlternateUnionMerge(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct); op != nil {
+		return op, exprs
+	}
+
+	// Check cross-keyspace restrictions for UNIONs that cannot be merged.
+	checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
+
+	return nil, nil
+}
+
+// mergeUnionRoutings merges two union sources whose routes are usable as they
+// stand, or returns nil when their routings do not allow it.
+func mergeUnionRoutings(
+	ctx *plancontext.PlanningContext,
+	lhsRoute, rhsRoute *Route,
+	lhsExprs, rhsExprs []sqlparser.SelectExpr,
+	distinct bool,
+) (Operator, []sqlparser.SelectExpr) {
+	routingA, routingB := lhsRoute.Routing, rhsRoute.Routing
+	sameKeyspace := routingA.Keyspace() == routingB.Keyspace()
+	a, b := getRoutingType(routingA), getRoutingType(routingB)
 
 	// a none routing resolves to no shards at execution time, so its side of the
 	// union contributes no rows. None pairings must be decided before the dual
 	// and anyShard cases below: those would retain the none routing and
 	// incorrectly discard the other side's rows.
 	if a == none || b == none {
-		if op, exprs, merged := tryMergeNoneUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingA, routingB, a, b); merged {
-			return op, exprs
-		}
-		checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
-		return nil, nil
+		op, exprs, _ := tryMergeNoneUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routingA, routingB, a, b)
+		return op, exprs
 	}
 
 	switch {
@@ -142,9 +166,6 @@ func mergeUnionInputs(
 			return res, exprs
 		}
 	}
-
-	// Check cross-keyspace restrictions for UNIONs that cannot be merged.
-	checkCrossKeyspaceOp(ctx, lhs, rhs, "UNION")
 
 	return nil, nil
 }
@@ -221,6 +242,180 @@ func tryMergeNoneUnion(
 
 	op, exprs := createTrivialMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routing, owner)
 	return op, exprs, true
+}
+
+// tryAlternateUnionMerge retries a declined cross-keyspace pairing by moving
+// one side onto the reference copies of its tables in the other side's
+// keyspace. The move mutates the moved side's tables in place, so all
+// semantic bookkeeping keyed on its expressions stays valid; a retry that
+// still cannot merge undoes the move.
+func tryAlternateUnionMerge(
+	ctx *plancontext.PlanningContext,
+	lhsRoute, rhsRoute *Route,
+	lhsExprs, rhsExprs []sqlparser.SelectExpr,
+	distinct bool,
+) (Operator, []sqlparser.SelectExpr) {
+	lhsKs, rhsKs := lhsRoute.Routing.Keyspace(), rhsRoute.Routing.Keyspace()
+	if lhsKs == nil || rhsKs == nil || lhsKs == rhsKs {
+		return nil, nil
+	}
+
+	// a side already composed of a merged union carries shapes the remaining
+	// phases no longer normalize: moving it can hand offset planning a nested
+	// horizon it cannot push into, so only leaf routes are moved
+	canRewrite := func(route *Route) bool {
+		hasUnion := false
+		_ = Visit(route.Source, func(op Operator) error {
+			if _, ok := op.(*Union); ok {
+				hasUnion = true
+				return io.EOF
+			}
+			return nil
+		})
+		return !hasUnion
+	}
+
+	if canRewrite(lhsRoute) {
+		if rewritten, undo := rewriteRouteToAlternate(ctx, lhsRoute, rhsKs); rewritten != nil {
+			if op, exprs := mergeUnionRoutings(ctx, rewritten, rhsRoute, lhsExprs, rhsExprs, distinct); op != nil {
+				return op, exprs
+			}
+			undo()
+		}
+	}
+	if canRewrite(rhsRoute) {
+		if rewritten, undo := rewriteRouteToAlternate(ctx, rhsRoute, lhsKs); rewritten != nil {
+			if op, exprs := mergeUnionRoutings(ctx, lhsRoute, rewritten, lhsExprs, rhsExprs, distinct); op != nil {
+				return op, exprs
+			}
+			undo()
+		}
+	}
+	return nil, nil
+}
+
+// rewriteRouteToAlternate points route's tables at the reference copies living
+// in ks, or returns nil if the route cannot move there. Every real table under
+// the planned tree is resolved to its copy independently, so a route composed
+// by earlier merges moves when each of its tables has a copy. The planned
+// operators are kept and only the table nodes are swapped, so predicates and
+// projections pushed after route creation are preserved and the semantic
+// analysis of the tree stays authoritative. The returned undo puts the
+// original tables back. Reference and unsharded copies are complete on any
+// shard; a single ordinary sharded source keeps its resolved routing.
+func rewriteRouteToAlternate(ctx *plancontext.PlanningContext, route *Route, ks *vindexes.Keyspace) (*Route, func()) {
+	if _, ok := route.Routing.(*AnyShardRouting); !ok {
+		return nil, nil
+	}
+	if !ctx.SemTable.DMLTargets.IsEmpty() && TableID(route).IsOverlapping(ctx.SemTable.DMLTargets) {
+		return nil, nil
+	}
+
+	type tableSwap struct {
+		tbl        *Table
+		altQTable  *QueryTable
+		altVTable  *vindexes.BaseTable
+		origQTable *QueryTable
+		origVTable *vindexes.BaseTable
+	}
+	var swaps []tableSwap
+	var shardedRouting *ShardedRouting
+	resolvable := true
+	_ = Visit(route.Source, func(op Operator) error {
+		tbl, ok := op.(*Table)
+		if !ok || tbl.VTable == nil || tbl.QTable == nil {
+			return nil
+		}
+		alt, altRouting := resolveTableCopyIn(ctx, tbl, ks)
+		if alt == nil {
+			resolvable = false
+			return io.EOF
+		}
+		if alt.VTable.Type != vindexes.TypeReference && alt.VTable.Keyspace.Sharded {
+			var ok bool
+			shardedRouting, ok = altRouting.(*ShardedRouting)
+			if !ok || shardedRouting.Keyspace() != ks {
+				resolvable = false
+				return io.EOF
+			}
+		}
+		swaps = append(swaps, tableSwap{tbl: tbl, altQTable: alt.QTable, altVTable: alt.VTable, origQTable: tbl.QTable, origVTable: tbl.VTable})
+		return nil
+	})
+	if !resolvable || len(swaps) == 0 ||
+		(shardedRouting != nil && (TableID(route).NumberOfTables() != 1 || len(swaps) != 1 || !computesRowByRow(ctx, route))) {
+		return nil, nil
+	}
+
+	for _, s := range swaps {
+		s.tbl.QTable, s.tbl.VTable = s.altQTable, s.altVTable
+	}
+	undo := func() {
+		for _, s := range swaps {
+			s.tbl.QTable, s.tbl.VTable = s.origQTable, s.origVTable
+		}
+	}
+
+	rewritten := *route
+	if shardedRouting != nil {
+		rewritten.Routing = shardedRouting
+	} else {
+		rewritten.Routing = &AnyShardRouting{keyspace: ks}
+	}
+	return &rewritten, undo
+}
+
+// computesRowByRow reports whether everything planned under route yields the
+// same rows once per shard as it does once against a full copy of its table.
+// A horizon pushed into the single-shard reference route may assume it runs
+// once.
+func computesRowByRow(ctx *plancontext.PlanningContext, route *Route) bool {
+	rowByRow := true
+	_ = Visit(route.Source, func(op Operator) error {
+		if horizon, ok := op.(*Horizon); ok && !horizon.computesRowByRow(ctx) {
+			rowByRow = false
+			return io.EOF
+		}
+		return nil
+	})
+	return rowByRow
+}
+
+// resolveTableCopyIn resolves the physical copy of tbl's table living in ks:
+// the table itself, a reference copy from ReferencedBy, or a declared reference
+// source. Candidates are looked up through the planning VSchema and accepted
+// only when they resolve in ks. The returned table carries the physical name
+// with the original name preserved as an alias, along with its routing.
+func resolveTableCopyIn(ctx *plancontext.PlanningContext, tbl *Table, ks *vindexes.Keyspace) (*Table, Routing) {
+	for _, name := range copyCandidates(tbl.VTable, ks) {
+		src, _, _, _, _, err := ctx.VSchema.FindTableOrVindex(name)
+		if err != nil || src == nil || src.Keyspace != ks {
+			continue
+		}
+		altRoute := findVSchemaTableAndCreateRoute(ctx, tbl.QTable, name, false /*planAlternates*/)
+		altTbl, ok := altRoute.Source.(*Table)
+		if !ok || altTbl.VTable == nil || altTbl.VTable.Keyspace != ks {
+			continue
+		}
+		return altTbl, altRoute.Routing
+	}
+	return nil, nil
+}
+
+// copyCandidates lists the declared names under which vt's data may also live
+// in ks. A reference source is returned exactly as declared.
+func copyCandidates(vt *vindexes.BaseTable, ks *vindexes.Keyspace) []sqlparser.TableName {
+	var candidates []sqlparser.TableName
+	if vt.Keyspace == ks {
+		candidates = append(candidates, sqlparser.TableName{Name: vt.Name, Qualifier: sqlparser.NewIdentifierCS(ks.Name)})
+	}
+	if ref, found := vt.ReferencedBy[ks.Name]; found {
+		candidates = append(candidates, sqlparser.TableName{Name: ref.Name, Qualifier: sqlparser.NewIdentifierCS(ks.Name)})
+	}
+	if vt.Source != nil {
+		candidates = append(candidates, vt.Source.TableName)
+	}
+	return candidates
 }
 
 func tryMergeUnionShardedRouting(

--- a/go/vt/vtgate/planbuilder/operators/union_merging.go
+++ b/go/vt/vtgate/planbuilder/operators/union_merging.go
@@ -232,16 +232,78 @@ func tryMergeNoneUnion(
 		routing = &AnyShardRouting{keyspace: noneKeyspaces[0]}
 		owner = noneRoute
 	default:
-		// the other side's routing is retained, but only when it targets the
-		// keyspace holding the none side's tables: they exist nowhere else.
+		// the other side's routing is retained when it targets the keyspace
+		// holding the none side's tables — or, failing that, when every real
+		// table of the none side has a reference copy there: the branch is
+		// then rewritten to read those copies, so the merged query text only
+		// names tables that exist in that keyspace.
 		if len(noneKeyspaces) != 1 || noneKeyspaces[0] != otherRouting.Keyspace() {
-			return nil, nil, false
+			rewrittenNone := rewriteNoneBranchToKeyspace(ctx, noneRoute, otherRouting.Keyspace())
+			if rewrittenNone == nil {
+				return nil, nil, false
+			}
+			if noneRoute == lhsRoute {
+				lhsRoute = rewrittenNone
+			} else {
+				rhsRoute = rewrittenNone
+			}
 		}
 		routing = otherRouting
 	}
 
 	op, exprs := createTrivialMergedUnion(ctx, lhsRoute, rhsRoute, lhsExprs, rhsExprs, distinct, routing, owner)
 	return op, exprs, true
+}
+
+// rewriteNoneBranchToKeyspace points the none route's tables at the reference
+// copies living in ks, or returns nil if any table has none. A routing
+// degrades to none before alternates are attached, so each copy is resolved
+// from the vschema through the same lookup that builds alternate routes,
+// keeping routing rules in effect. Only leaf routes are moved, for the same
+// normalization reasons as tryAlternateUnionMerge.
+func rewriteNoneBranchToKeyspace(ctx *plancontext.PlanningContext, route *Route, ks *vindexes.Keyspace) *Route {
+	if ks == nil {
+		return nil
+	}
+	if !ctx.SemTable.DMLTargets.IsEmpty() && TableID(route).IsOverlapping(ctx.SemTable.DMLTargets) {
+		return nil
+	}
+
+	type tableSwap struct {
+		tbl       *Table
+		altQTable *QueryTable
+		altVTable *vindexes.BaseTable
+	}
+	var swaps []tableSwap
+	resolvable := true
+	_ = Visit(route.Source, func(op Operator) error {
+		if _, ok := op.(*Union); ok {
+			resolvable = false
+			return io.EOF
+		}
+		tbl, ok := op.(*Table)
+		if !ok || tbl.VTable == nil || tbl.QTable == nil {
+			return nil
+		}
+		alt, _ := resolveTableCopyIn(ctx, tbl, ks)
+		if alt == nil {
+			resolvable = false
+			return io.EOF
+		}
+		swaps = append(swaps, tableSwap{tbl: tbl, altQTable: alt.QTable, altVTable: alt.VTable})
+		return nil
+	})
+	if !resolvable || len(swaps) == 0 {
+		return nil
+	}
+
+	for _, s := range swaps {
+		s.tbl.QTable, s.tbl.VTable = s.altQTable, s.altVTable
+	}
+
+	rewritten := *route
+	rewritten.Routing = &NoneRouting{keyspace: ks}
+	return &rewritten
 }
 
 // tryAlternateUnionMerge retries a declined cross-keyspace pairing by moving

--- a/go/vt/vtgate/planbuilder/testdata/cte_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/cte_cases.json
@@ -2510,5 +2510,64 @@
         "Query": "select a from (select 1 from dual union all select 2 from dual) as dt(a) where exists (with recursive qn as (select a * 0 as b from dual union all select b + 1 from qn where b = 0) select 1 from qn where b = a)"
       }
     }
+  },
+  {
+    "comment": "recursive cte joined against a derived union whose sources merge on the recursive predicate: the CTE merge must be declined, keeping the RecurseCTE primitive that produces the per-source :cte_id arguments. The column-form cte.depth in the term WHERE is a pre-existing bug on main, byte-identical there and unrelated to the merge decline: filters over pure CTE columns are never rewritten to their bind-variable form when the term does not merge",
+    "query": "with recursive cte as (select id, 0 as depth from user where id = 5 union all select refs.user_id, cte.depth + 1 from cte join (select user_id from music where user_id = 5 union all select user_id from user_extra where user_id = 5) as refs on refs.user_id = cte.id where cte.depth < 1) select id, depth from cte order by depth, id",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "with recursive cte as (select id, 0 as depth from user where id = 5 union all select refs.user_id, cte.depth + 1 from cte join (select user_id from music where user_id = 5 union all select user_id from user_extra where user_id = 5) as refs on refs.user_id = cte.id where cte.depth < 1) select id, depth from cte order by depth, id",
+      "Instructions": {
+        "OperatorType": "Sort",
+        "Variant": "Memory",
+        "OrderBy": "(1|2) ASC, (0|3) ASC",
+        "ResultColumns": 2,
+        "Inputs": [
+          {
+            "OperatorType": "RecurseCTE",
+            "JoinVars": {
+              "cte_depth": 1,
+              "cte_id": 0
+            },
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "EqualUnique",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, dt.c1 as depth, weight_string(dt.c1), weight_string(dt.c0) from (select id, 0 as depth from `user` where 1 != 1) as dt(c0, c1) where 1 != 1",
+                "Query": "select dt.c0 as id, dt.c1 as depth, weight_string(dt.c1), weight_string(dt.c0) from (select id, 0 as depth from `user` where id = 5) as dt(c0, c1)",
+                "Values": [
+                  "5"
+                ],
+                "Vindex": "user_index"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "EqualUnique",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select refs.user_id, :cte_depth + 1 as `cte.depth + 1`, weight_string(:cte_depth + 1), weight_string(refs.user_id) from (select user_id from music where 1 != 1 union all select user_id from user_extra where 1 != 1) as refs where 1 != 1",
+                "Query": "select refs.user_id, :cte_depth + 1 as `cte.depth + 1`, weight_string(:cte_depth + 1), weight_string(refs.user_id) from (select user_id from music where user_id = 5 and user_id = :cte_id union all select user_id from user_extra where user_id = 5 and user_id = :cte_id) as refs where cte.depth < 1",
+                "Values": [
+                  "5"
+                ],
+                "Vindex": "user_index"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user",
+        "user.user_extra"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/reference_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/reference_cases.json
@@ -915,5 +915,333 @@
         "user.ref"
       ]
     }
+  },
+  {
+    "comment": "union of a reference table with a sharded table merges through the reference copy",
+    "query": "select id from ambiguous_ref_with_source union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from ambiguous_ref_with_source union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ambiguous_ref_with_source where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ambiguous_ref_with_source union select id, weight_string(id) from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ambiguous_ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "union order does not matter when merging through the reference copy",
+    "query": "select id from user union select id from ambiguous_ref_with_source",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user union select id from ambiguous_ref_with_source",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from ambiguous_ref_with_source where 1 != 1",
+            "Query": "select id, weight_string(id) from `user` union select id, weight_string(id) from ambiguous_ref_with_source"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ambiguous_ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "union through a reference copy with a different physical name rewrites the table",
+    "query": "select id from source_of_ref union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from source_of_ref union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ref_with_source as source_of_ref where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ref_with_source as source_of_ref union select id, weight_string(id) from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "predicates on the reference branch survive the rewrite to the reference copy",
+    "query": "select id from source_of_ref where id = 3 union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from source_of_ref where id = 3 union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ref_with_source as source_of_ref where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ref_with_source as source_of_ref where id = 3 union select id, weight_string(id) from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "union all through a reference copy keeps merging",
+    "query": "select id from source_of_ref union all select id from user",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select id from source_of_ref union all select id from user",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from ref_with_source as source_of_ref where 1 != 1 union all select id from `user` where 1 != 1",
+        "Query": "select id from ref_with_source as source_of_ref union all select id from `user`"
+      },
+      "TablesUsed": [
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a union composed of two reference-backed tables before the sharded side stays split",
+    "query": "select id from main.source_of_ref union select id from main.rerouted_ref union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from main.source_of_ref union select id from main.rerouted_ref union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref where 1 != 1 union select id from rerouted_ref where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref union select id from rerouted_ref) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.rerouted_ref",
+        "main.source_of_ref",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a composite reference union also stays split under union all",
+    "query": "select id from main.source_of_ref union all select id from main.rerouted_ref union all select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from main.source_of_ref union all select id from main.rerouted_ref union all select id from user",
+      "Instructions": {
+        "OperatorType": "Concatenate",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "main",
+              "Sharded": false
+            },
+            "FieldQuery": "select id from source_of_ref where 1 != 1 union all select id from rerouted_ref where 1 != 1",
+            "Query": "select id from source_of_ref union all select id from rerouted_ref"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id from `user` where 1 != 1",
+            "Query": "select id from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.rerouted_ref",
+        "main.source_of_ref",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a distinct reference union merges table by table when the sharded side merges first",
+    "query": "select id from user union select id from main.source_of_ref union select id from main.rerouted_ref",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user union select id from main.source_of_ref union select id from main.rerouted_ref",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from ref_with_source as source_of_ref where 1 != 1 union select id, weight_string(id) from ref as rerouted_ref where 1 != 1",
+            "Query": "select id, weight_string(id) from `user` union select id, weight_string(id) from ref_with_source as source_of_ref union select id, weight_string(id) from ref as rerouted_ref"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ref",
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a composite union with a table that has no copy in the target keyspace stays split",
+    "query": "select id from main.source_of_ref union select col from unsharded union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from main.source_of_ref union select col from unsharded union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref where 1 != 1 union select col from unsharded where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref union select col from unsharded) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.source_of_ref",
+        "main.unsharded",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/reference_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/reference_cases.json
@@ -915,5 +915,404 @@
         "user.ref"
       ]
     }
+  },
+  {
+    "comment": "union of a reference table with a sharded table merges through the reference copy",
+    "query": "select id from ambiguous_ref_with_source union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from ambiguous_ref_with_source union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ambiguous_ref_with_source where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ambiguous_ref_with_source union select id, weight_string(id) from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ambiguous_ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "union order does not matter when merging through the reference copy",
+    "query": "select id from user union select id from ambiguous_ref_with_source",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user union select id from ambiguous_ref_with_source",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from ambiguous_ref_with_source where 1 != 1",
+            "Query": "select id, weight_string(id) from `user` union select id, weight_string(id) from ambiguous_ref_with_source"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ambiguous_ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "union through a reference copy with a different physical name rewrites the table",
+    "query": "select id from source_of_ref union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from source_of_ref union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ref_with_source as source_of_ref where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ref_with_source as source_of_ref union select id, weight_string(id) from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "predicates on the reference branch survive the rewrite to the reference copy",
+    "query": "select id from source_of_ref where id = 3 union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from source_of_ref where id = 3 union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ref_with_source as source_of_ref where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ref_with_source as source_of_ref where id = 3 union select id, weight_string(id) from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "union all through a reference copy keeps merging",
+    "query": "select id from source_of_ref union all select id from user",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select id from source_of_ref union all select id from user",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from ref_with_source as source_of_ref where 1 != 1 union all select id from `user` where 1 != 1",
+        "Query": "select id from ref_with_source as source_of_ref union all select id from `user`"
+      },
+      "TablesUsed": [
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a union composed of two reference-backed tables before the sharded side stays split",
+    "query": "select id from main.source_of_ref union select id from main.rerouted_ref union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from main.source_of_ref union select id from main.rerouted_ref union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref where 1 != 1 union select id from rerouted_ref where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref union select id from rerouted_ref) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.rerouted_ref",
+        "main.source_of_ref",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a distinct union through a sharded reference source merges onto the source's scatter routing",
+    "query": "select col1 from main_2.sharded_sales_ref union select cola from user.sales_extra",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select col1 from main_2.sharded_sales_ref union select cola from user.sales_extra",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0: latin1_swedish_ci"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select col1 from sales as sharded_sales_ref where 1 != 1 union select cola from sales_extra where 1 != 1",
+            "Query": "select col1 from sales as sharded_sales_ref union select cola from sales_extra"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.sales",
+        "user.sales_extra"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "an aggregate pushed into a reference branch stays split from its sharded source",
+    "query": "select count(*) from main_2.sharded_sales_ref union all select 0 from user.sales_extra",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select count(*) from main_2.sharded_sales_ref union all select 0 from user.sales_extra",
+      "Instructions": {
+        "OperatorType": "Concatenate",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "main_2",
+              "Sharded": false
+            },
+            "FieldQuery": "select count(*) from sharded_sales_ref where 1 != 1",
+            "Query": "select count(*) from sharded_sales_ref"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 0 from sales_extra where 1 != 1",
+            "Query": "select 0 from sales_extra"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main_2.sharded_sales_ref",
+        "user.sales_extra"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a composite reference union also stays split under union all",
+    "query": "select id from main.source_of_ref union all select id from main.rerouted_ref union all select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from main.source_of_ref union all select id from main.rerouted_ref union all select id from user",
+      "Instructions": {
+        "OperatorType": "Concatenate",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "main",
+              "Sharded": false
+            },
+            "FieldQuery": "select id from source_of_ref where 1 != 1 union all select id from rerouted_ref where 1 != 1",
+            "Query": "select id from source_of_ref union all select id from rerouted_ref"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id from `user` where 1 != 1",
+            "Query": "select id from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.rerouted_ref",
+        "main.source_of_ref",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a distinct reference union merges table by table when the sharded side merges first",
+    "query": "select id from user union select id from main.source_of_ref union select id from main.rerouted_ref",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user union select id from main.source_of_ref union select id from main.rerouted_ref",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from ref_with_source as source_of_ref where 1 != 1 union select id, weight_string(id) from ref as rerouted_ref where 1 != 1",
+            "Query": "select id, weight_string(id) from `user` union select id, weight_string(id) from ref_with_source as source_of_ref union select id, weight_string(id) from ref as rerouted_ref"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ref",
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a composite union with a table that has no copy in the target keyspace stays split",
+    "query": "select id from main.source_of_ref union select col from unsharded union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from main.source_of_ref union select col from unsharded union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref where 1 != 1 union select col from unsharded where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref union select col from unsharded) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.source_of_ref",
+        "main.unsharded",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/sampledata/user.sql
+++ b/go/vt/vtgate/planbuilder/testdata/sampledata/user.sql
@@ -21,3 +21,24 @@ VALUES (200, 'foo', 2);
 
 INSERT INTO rerouted_ref (id, ref_col, name)
 VALUES (200, 'bar', 'baz');
+
+INSERT INTO user (id, col, intcol, name, costly, col1, textcol1, foo)
+VALUES (5, 5, 5, '5', 'c5', 'a5', 't5', 'f5');
+
+INSERT INTO user (id, col, intcol, name, costly, col1, textcol1, foo)
+VALUES (6, 6, 6, '6', 'c6', 'a6', 't6', 'f6');
+
+INSERT INTO music (id, user_id, col)
+VALUES (101, 5, 'foo5');
+
+INSERT INTO music (id, user_id, col)
+VALUES (102, 6, 'foo6');
+
+INSERT INTO user_extra (id, user_id, extra_id, col)
+VALUES (1, 5, 1, 5);
+
+INSERT INTO user_extra (id, user_id, extra_id, col)
+VALUES (2, 6, 2, 6);
+
+INSERT INTO unsharded (id, col, col1, col2, name, baz)
+VALUES (300, 'x1', 'ua1', 'ub1', 'un1', 0);

--- a/go/vt/vtgate/planbuilder/testdata/sampledata/user.sql
+++ b/go/vt/vtgate/planbuilder/testdata/sampledata/user.sql
@@ -21,3 +21,22 @@ VALUES (200, 'foo', 2);
 
 INSERT INTO rerouted_ref (id, ref_col, name)
 VALUES (200, 'bar', 'baz');
+
+INSERT INTO user (id, col, intcol, name, costly, col1, textcol1, foo)
+VALUES (5, 5, 5, '5', 'c5', 'a5', 't5', 'f5');
+
+
+INSERT INTO music (id, user_id, col)
+VALUES (101, 5, 'foo5');
+
+INSERT INTO music (id, user_id, col)
+VALUES (102, 6, 'foo6');
+
+INSERT INTO user_extra (id, user_id, extra_id, col)
+VALUES (1, 5, 1, 5);
+
+INSERT INTO user_extra (id, user_id, extra_id, col)
+VALUES (2, 6, 2, 6);
+
+INSERT INTO unsharded (id, col, col1, col2, name, baz)
+VALUES (300, 'x1', 'ua1', 'ub1', 'un1', 0);

--- a/go/vt/vtgate/planbuilder/testdata/schemas/user.sql
+++ b/go/vt/vtgate/planbuilder/testdata/schemas/user.sql
@@ -158,7 +158,7 @@ CREATE TABLE name_user_map
 CREATE TABLE costly_map
 (
     costly      VARCHAR(255),
-    keyspace_id VARCHAR(255)
+    keyspace_id VARBINARY(10)
 );
 
 CREATE TABLE unq_binary_idx

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -240,7 +240,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union operations in subqueries (FROM)",
@@ -263,7 +264,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union operations in derived table, without star expression (FROM)\u00a1",
@@ -286,7 +288,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union all between two scatter selects, with order by",
@@ -415,12 +418,14 @@
       "TablesUsed": [
         "main.unsharded"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union of information_schema with normal table",
     "query": "select * from unsharded union select * from information_schema.CHARACTER_SETS",
-    "plan": "VT09015: schema tracking required"
+    "plan": "VT09015: schema tracking required",
+    "skip_e2e": true
   },
   {
     "comment": "multi-shard union",
@@ -1166,6 +1171,53 @@
     "skip_e2e": true
   },
   {
+    "comment": "join predicates pushed into the legs of a union bind the vindex value as an argument",
+    "query": "select d.id, refs.user_id from (select 5 as id from dual) d left join (select user_id from music union all select user_id from user_extra) refs on refs.user_id = d.id",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select d.id, refs.user_id from (select 5 as id from dual) d left join (select user_id from music union all select user_id from user_extra) refs on refs.user_id = d.id",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "LeftJoin",
+        "JoinColumnIndexes": "L:0,R:0",
+        "JoinVars": {
+          "d_id": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Reference",
+            "Keyspace": {
+              "Name": "main",
+              "Sharded": false
+            },
+            "FieldQuery": "select d.id from (select 5 as id from dual where 1 != 1) as d where 1 != 1",
+            "Query": "select d.id from (select 5 as id from dual) as d"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.user_id from (select user_id from music where 1 != 1 union all select user_id from user_extra where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.user_id from (select user_id from music where user_id = :d_id /* INT64 */ union all select user_id from user_extra where user_id = :d_id /* INT64 */) as refs",
+            "Values": [
+              ":d_id"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
     "comment": "union with the same target shard because of vindex",
     "query": "select * from music where user_id = 1 union select * from user where id = 1",
     "plan": {
@@ -1190,12 +1242,14 @@
         "user.music",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union with the different target shard because of vindex (music -> lookup vindex, user -> hash vindex)",
     "query": "select * from music where id = 1 union select * from user where id = 1",
-    "plan": "VT09015: schema tracking required"
+    "plan": "VT09015: schema tracking required",
+    "skip_e2e": true
   },
   {
     "comment": "union with different target shards",
@@ -1357,7 +1411,8 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union distinct between a scatter query and a join (other side)",
@@ -1422,7 +1477,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union distinct between a scatter query and a join (other side)",
@@ -1487,7 +1543,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "unmergable because we are using aggregation",
@@ -1727,7 +1784,8 @@
           }
         ]
       }
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "UNION that needs to be reordered to be merged more aggressively. Gen4 is able to get it down to 2 routes",
@@ -1855,22 +1913,26 @@
   {
     "comment": "ambiguous LIMIT",
     "query": "select id from user limit 1 union all select id from music limit 1",
-    "plan": "syntax error at position 34 near 'union'"
+    "plan": "syntax error at position 34 near 'union'",
+    "skip_e2e": true
   },
   {
     "comment": "ambiguous ORDER BY",
     "query": "select id from user order by id union all select id from music order by id desc",
-    "plan": "syntax error at position 38 near 'union'"
+    "plan": "syntax error at position 38 near 'union'",
+    "skip_e2e": true
   },
   {
     "comment": "different number of columns",
     "query": "select id, 42 from user where id = 1 union all select id from user where id = 5",
-    "plan": "The used SELECT statements have a different number of columns: 2, 1"
+    "plan": "The used SELECT statements have a different number of columns: 2, 1",
+    "skip_e2e": true
   },
   {
     "comment": "union with invalid order by clause with table qualifier",
     "query": "select id from user union select 3 order by user.id",
-    "plan": "Table `user` from one of the SELECTs cannot be used in global ORDER clause"
+    "plan": "Table `user` from one of the SELECTs cannot be used in global ORDER clause",
+    "skip_e2e": true
   },
   {
     "comment": "union with invalid order by clause with table qualifier",
@@ -1950,7 +2012,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "select 1 from (select id+42 as foo from user union select 1+id as foo from unsharded) as t",
@@ -2050,7 +2113,8 @@
           }
         ]
       }
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "pushes predicate on both sides of UNION",
@@ -2134,7 +2198,8 @@
           }
         ]
       }
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "unknown columns are OK as long as the whole query is unsharded",
@@ -2156,7 +2221,8 @@
       "TablesUsed": [
         "main.unsharded"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union of unsharded route with sharded join with involvement of weight string",
@@ -2223,7 +2289,8 @@
         "user.authoritative",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "UNION ALL with repeating column on the LHS",
@@ -2246,7 +2313,8 @@
         "user.music",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "UNION ALL with repeating column on the RHS",
@@ -2269,7 +2337,8 @@
         "user.music",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "UNION with repeating column on the RHS",
@@ -2303,7 +2372,8 @@
         "user.music",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "UNION with repeating column on the LHS",
@@ -2337,7 +2407,8 @@
         "user.music",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "join between two derived tables containing UNION",
@@ -2395,6 +2466,1085 @@
       "TablesUsed": [
         "user.music",
         "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "join to a derived table containing a UNION where every source is pinned to the same shard",
+    "query": "select refs.seg, u.id, u.col from user_extra as ue join user as u on u.id = ue.user_id join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5 group by refs.seg, u.id, u.col",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg, u.id, u.col from user_extra as ue join user as u on u.id = ue.user_id join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5 group by refs.seg, u.id, u.col",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select refs.seg, u.id, u.col from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as refs, user_extra as ue, `user` as u where 1 != 1 group by refs.seg, u.id, u.col",
+        "Query": "select refs.seg, u.id, u.col from (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs, user_extra as ue, `user` as u where ue.user_id = 5 and u.id = ue.user_id and refs.user_id = ue.user_id group by refs.seg, u.id, u.col",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join to a derived table containing a UNION ALL where every source is pinned to the same shard",
+    "query": "select refs.seg, u.id, u.col from user_extra as ue join user as u on u.id = ue.user_id join (select music.user_id, music.id as seg from music where music.user_id = 5 union all select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5 group by refs.seg, u.id, u.col",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg, u.id, u.col from user_extra as ue join user as u on u.id = ue.user_id join (select music.user_id, music.id as seg from music where music.user_id = 5 union all select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5 group by refs.seg, u.id, u.col",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select refs.seg, u.id, u.col from (select music.user_id, music.id as seg from music where 1 != 1 union all select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as refs, user_extra as ue, `user` as u where 1 != 1 group by refs.seg, u.id, u.col",
+        "Query": "select refs.seg, u.id, u.col from (select music.user_id, music.id as seg from music where music.user_id = 5 union all select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs, user_extra as ue, `user` as u where ue.user_id = 5 and u.id = ue.user_id and refs.user_id = ue.user_id group by refs.seg, u.id, u.col",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join to a derived table containing a UNION where every source is pinned to the same bind variable",
+    "query": "select refs.seg, u.id, u.col from user_extra as ue join user as u on u.id = ue.user_id join (select music.user_id, music.id as seg from music where music.user_id = :v union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = :v) as refs on refs.user_id = ue.user_id where ue.user_id = :v group by refs.seg, u.id, u.col",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg, u.id, u.col from user_extra as ue join user as u on u.id = ue.user_id join (select music.user_id, music.id as seg from music where music.user_id = :v union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = :v) as refs on refs.user_id = ue.user_id where ue.user_id = :v group by refs.seg, u.id, u.col",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select refs.seg, u.id, u.col from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as refs, user_extra as ue, `user` as u where 1 != 1 group by refs.seg, u.id, u.col",
+        "Query": "select refs.seg, u.id, u.col from (select music.user_id, music.id as seg from music where music.user_id = :v union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = :v) as refs, user_extra as ue, `user` as u where ue.user_id = :v and u.id = ue.user_id and refs.user_id = ue.user_id group by refs.seg, u.id, u.col",
+        "Values": [
+          ":v"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user",
+        "user.user_extra"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "left join to a derived table containing a UNION where every source is pinned to the same shard",
+    "query": "select refs.seg, u.id, u.col from user_extra as ue join user as u on u.id = ue.user_id left join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5 group by refs.seg, u.id, u.col",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg, u.id, u.col from user_extra as ue join user as u on u.id = ue.user_id left join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5 group by refs.seg, u.id, u.col",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select refs.seg, u.id, u.col from (user_extra as ue, `user` as u) left join (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as refs on refs.user_id = ue.user_id where 1 != 1 group by refs.seg, u.id, u.col",
+        "Query": "select refs.seg, u.id, u.col from (user_extra as ue, `user` as u) left join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5 and u.id = ue.user_id group by refs.seg, u.id, u.col",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a UNION where every source is pinned to the same shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as refs, user_extra as ue where 1 != 1",
+        "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs, user_extra as ue where ue.user_id = 5 and refs.user_id = ue.col",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join to a derived table containing a three-source UNION where every source is pinned to the same shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union select m2.user_id, m2.id from music as m2 where 1 != 1) as refs, user_extra as ue where 1 != 1",
+        "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs, user_extra as ue where ue.user_id = 5 and refs.user_id = ue.user_id",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join to a derived table containing a nested UNION and UNION ALL where every source is pinned to the same shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union all select m2.user_id, m2.id from music as m2 where 1 != 1) as refs, user_extra as ue where 1 != 1",
+        "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs, user_extra as ue where ue.user_id = 5 and refs.user_id = ue.user_id",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a UNION where every source is pinned to the same shard and the outer table is not pinned",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.col",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.col",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join to a derived table containing a UNION with sources pinned to the same shard where only one source exposes the vindex column",
+    "query": "select refs.user_id from user_extra as ue join (select music.user_id from music where music.user_id = 5 union select ue2.col from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select refs.user_id from user_extra as ue join (select music.user_id from music where music.user_id = 5 union select ue2.col from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select refs.user_id from (select music.user_id from music where 1 != 1 union select ue2.col from user_extra as ue2 where 1 != 1) as refs, user_extra as ue where 1 != 1",
+        "Query": "select refs.user_id from (select music.user_id from music where music.user_id = 5 union select ue2.col from user_extra as ue2 where ue2.user_id = 5) as refs, user_extra as ue where ue.user_id = 5 and refs.user_id = ue.col",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a UNION with sources pinned to different shards must not be merged",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on the pinned column to a derived table containing a UNION with sources pinned to different shards must not be merged",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6) as refs on refs.user_id = ue.user_id where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6) as refs on refs.user_id = ue.user_id where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_user_id": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.user_id from user_extra as ue where 1 != 1",
+            "Query": "select ue.user_id from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_user_id union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 and user_id = :ue_user_id) as refs",
+            "Values": [
+              ":ue_user_id"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a three-source UNION with sources pinned to different shards must not collapse onto one shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 union select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 union select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union select m2.user_id, m2.id from music as m2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 and user_id = :ue_col /* INT16 */ union select m2.user_id, m2.id from music as m2 where m2.user_id = 5 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a three-source UNION ALL with sources pinned to different shards must not collapse onto one shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union all select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union all select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union all select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union all select m2.user_id, m2.id from music as m2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union all select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 and user_id = :ue_col /* INT16 */ union all select m2.user_id, m2.id from music as m2 where m2.user_id = 5 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a nested UNION and UNION ALL with sources pinned to different shards must not collapse onto one shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union all select m2.user_id, m2.id from music as m2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 and user_id = :ue_col /* INT16 */ union all select m2.user_id, m2.id from music as m2 where m2.user_id = 5 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a three-source UNION with two sources pinned to the same shard and one pinned to a different shard must not collapse onto one shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union select m2.user_id, m2.id from music as m2 where m2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union select m2.user_id, m2.id from music as m2 where m2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union select m2.user_id, m2.id from music as m2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 and user_id = :ue_col /* INT16 */ union select m2.user_id, m2.id from music as m2 where m2.user_id = 6 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a three-source UNION ALL with two sources pinned to the same shard and one pinned to a different shard must not collapse onto one shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union all select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union all select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union all select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union all select m2.user_id, m2.id from music as m2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union all select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 and user_id = :ue_col /* INT16 */ union all select m2.user_id, m2.id from music as m2 where m2.user_id = 6 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a four-source UNION with source pairs pinned to two different shards must not collapse onto one shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union select m2.user_id, m2.id from music as m2 where m2.user_id = 6 union select ue3.user_id, ue3.id from user_extra as ue3 where ue3.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union select m2.user_id, m2.id from music as m2 where m2.user_id = 6 union select ue3.user_id, ue3.id from user_extra as ue3 where ue3.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union select m2.user_id, m2.id from music as m2 where 1 != 1 union select ue3.user_id, ue3.id from user_extra as ue3 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 and user_id = :ue_col /* INT16 */ union select m2.user_id, m2.id from music as m2 where m2.user_id = 6 and user_id = :ue_col /* INT16 */ union select ue3.user_id, ue3.id from user_extra as ue3 where ue3.user_id = 6 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a nested UNION pinned to one shard and a UNION ALL source pinned to a different shard must not collapse onto one shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union all select m2.user_id, m2.id from music as m2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 and user_id = :ue_col /* INT16 */ union all select m2.user_id, m2.id from music as m2 where m2.user_id = 6 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a UNION ALL of two derived tables pinned to the same shard and a source pinned to a different shard must not collapse onto one shard",
+    "query": "select refs.seg from user_extra as ue join (select t1.user_id, t1.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as t1 union all select t2.user_id, t2.seg from (select m2.user_id, m2.id as seg from music as m2 where m2.user_id = 5 union select ue3.user_id, ue3.id from user_extra as ue3 where ue3.user_id = 5) as t2 union all select m3.user_id, m3.id from music as m3 where m3.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select t1.user_id, t1.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as t1 union all select t2.user_id, t2.seg from (select m2.user_id, m2.id as seg from music as m2 where m2.user_id = 5 union select ue3.user_id, ue3.id from user_extra as ue3 where ue3.user_id = 5) as t2 union all select m3.user_id, m3.id from music as m3 where m3.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select t1.user_id, t1.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as t1 where 1 != 1 union all select t2.user_id, t2.seg from (select m2.user_id, m2.id as seg from music as m2 where 1 != 1 union select ue3.user_id, ue3.id from user_extra as ue3 where 1 != 1) as t2 where 1 != 1 union all select m3.user_id, m3.id from music as m3 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select t1.user_id, t1.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 and user_id = :ue_col /* INT16 */) as t1 union all select t2.user_id, t2.seg from (select m2.user_id, m2.id as seg from music as m2 where m2.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue3.user_id, ue3.id from user_extra as ue3 where ue3.user_id = 5 and user_id = :ue_col /* INT16 */) as t2 union all select m3.user_id, m3.id from music as m3 where m3.user_id = 6 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a UNION ALL of two derived tables pinned to two different shards",
+    "query": "select refs.seg from user_extra as ue join (select t1.user_id, t1.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as t1 union all select t2.user_id, t2.seg from (select m2.user_id, m2.id as seg from music as m2 where m2.user_id = 6 union select ue3.user_id, ue3.id from user_extra as ue3 where ue3.user_id = 6) as t2) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select t1.user_id, t1.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as t1 union all select t2.user_id, t2.seg from (select m2.user_id, m2.id as seg from music as m2 where m2.user_id = 6 union select ue3.user_id, ue3.id from user_extra as ue3 where ue3.user_id = 6) as t2) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select t1.user_id, t1.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as t1 where 1 != 1 union all select t2.user_id, t2.seg from (select m2.user_id, m2.id as seg from music as m2 where 1 != 1 union select ue3.user_id, ue3.id from user_extra as ue3 where 1 != 1) as t2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select t1.user_id, t1.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 and user_id = :ue_col /* INT16 */) as t1 union all select t2.user_id, t2.seg from (select m2.user_id, m2.id as seg from music as m2 where m2.user_id = 6 and user_id = :ue_col /* INT16 */ union select ue3.user_id, ue3.id from user_extra as ue3 where ue3.user_id = 6 and user_id = :ue_col /* INT16 */) as t2) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a four-source UNION with a dual source interposed between a same-shard pair and a differently pinned source: the recorded fallback must survive the dual merge",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union select 5, 42 from dual union select m2.user_id, m2.id from music as m2 where m2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union select 5, 42 from dual union select m2.user_id, m2.id from music as m2 where m2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union select 5, 42 from dual where 1 != 1 union select m2.user_id, m2.id from music as m2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 and user_id = :ue_col /* INT16 */ union select 5, 42 from dual where 5 = :ue_col /* INT16 */ union select m2.user_id, m2.id from music as m2 where m2.user_id = 6 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "union of two single-shard joins pinned to the same shard",
+    "query": "select music.id as seg, u.id, u.col from music join user as u on u.id = music.user_id where music.user_id = 5 union select ue2.id, u2.id, u2.col from user_extra as ue2 join user as u2 on u2.id = ue2.user_id where ue2.user_id = 5",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select music.id as seg, u.id, u.col from music join user as u on u.id = music.user_id where music.user_id = 5 union select ue2.id, u2.id, u2.col from user_extra as ue2 join user as u2 on u2.id = ue2.user_id where ue2.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select music.id as seg, u.id, u.col from music, `user` as u where 1 != 1 union select ue2.id, u2.id, u2.col from user_extra as ue2, `user` as u2 where 1 != 1",
+        "Query": "select music.id as seg, u.id, u.col from music, `user` as u where music.user_id = 5 and u.id = music.user_id union select ue2.id, u2.id, u2.col from user_extra as ue2, `user` as u2 where ue2.user_id = 5 and u2.id = ue2.user_id",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "union all of two single-shard selects pinned to the same shard",
+    "query": "select id from music where user_id = 5 union all select id from user_extra where user_id = 5",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select id from music where user_id = 5 union all select id from user_extra where user_id = 5",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from music where 1 != 1 union all select id from user_extra where 1 != 1",
+        "Query": "select id from music where user_id = 5 union all select id from user_extra where user_id = 5",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a UNION with sources pinned to the same non-unique vindex value",
+    "query": "select refs.x from user_extra as ue join (select u1.name as x, u1.id from user as u1 where u1.name = 'a' union select u2.name, u2.id from user as u2 where u2.name = 'a') as refs on refs.x = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.x from user_extra as ue join (select u1.name as x, u1.id from user as u1 where u1.name = 'a' union select u2.name, u2.id from user as u2 where u2.name = 'a') as refs on refs.x = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Distinct",
+            "Collations": [
+              "(0:2)",
+              "(1:3)"
+            ],
+            "Inputs": [
+              {
+                "OperatorType": "VindexLookup",
+                "Variant": "Equal",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "Values": [
+                  ":ue_col"
+                ],
+                "Vindex": "name_user_map",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "IN",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
+                    "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
+                    "Values": [
+                      "::name"
+                    ],
+                    "Vindex": "user_index"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "ByDestination",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select u1.`name` as x, u1.id, weight_string(u1.`name`), weight_string(u1.id) from `user` as u1 where 1 != 1 union select u2.`name`, u2.id, weight_string(u2.`name`), weight_string(u2.id) from `user` as u2 where 1 != 1",
+                    "Query": "select u1.`name` as x, u1.id, weight_string(u1.`name`), weight_string(u1.id) from `user` as u1 where u1.`name` = 'a' and `name` = :ue_col /* INT16 */ union select u2.`name`, u2.id, weight_string(u2.`name`), weight_string(u2.id) from `user` as u2 where u2.`name` = 'a' and `name` = :ue_col /* INT16 */"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a UNION with sources pinned to the same IN list",
+    "query": "select refs.col from user_extra as ue join (select m1.col from music as m1 where m1.user_id in (1, 2) union select m2.col from music as m2 where m2.user_id in (1, 2)) as refs on refs.col = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.col from user_extra as ue join (select m1.col from music as m1 where m1.user_id in (1, 2) union select m2.col from music as m2 where m2.user_id in (1, 2)) as refs on refs.col = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Distinct",
+            "Collations": [
+              "(0:1)"
+            ],
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "IN",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select m1.col, weight_string(m1.col) from music as m1 where 1 != 1 union select m2.col, weight_string(m2.col) from music as m2 where 1 != 1",
+                "Query": "select m1.col, weight_string(m1.col) from music as m1 where m1.user_id in ::__vals and col = :ue_col /* INT16 */ union select m2.col, weight_string(m2.col) from music as m2 where m2.user_id in (1, 2) and col = :ue_col /* INT16 */",
+                "Values": [
+                  "(1, 2)"
+                ],
+                "Vindex": "user_index"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
       ]
     }
   },
@@ -2516,7 +3666,8 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Select now() from table union Select literals from table",
@@ -2546,7 +3697,8 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Select now() from table union Select column from table",
@@ -2576,7 +3728,8 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Literals in UNION can be problematic",
@@ -2762,7 +3915,8 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "join with derived table containing UNION with aliased columns across different keyspaces",

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -217,7 +217,8 @@
         "user.music",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Union all",
@@ -240,7 +241,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union operations in subqueries (FROM)",
@@ -263,7 +265,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union operations in derived table, without star expression (FROM)¡",
@@ -286,7 +289,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union all between two scatter selects, with order by",
@@ -347,7 +351,8 @@
         "user.music",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union all on scatter and single route",
@@ -415,12 +420,14 @@
       "TablesUsed": [
         "main.unsharded"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union of information_schema with normal table",
     "query": "select * from unsharded union select * from information_schema.CHARACTER_SETS",
-    "plan": "VT09015: schema tracking required"
+    "plan": "VT09015: schema tracking required",
+    "skip_e2e": true
   },
   {
     "comment": "multi-shard union",
@@ -757,7 +764,8 @@
         "main.unsharded",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "a dual-derived none routing that absorbed a real table merges with a branch in that table's keyspace",
@@ -870,7 +878,8 @@
           }
         ]
       }
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "the information_schema guard also applies when the other side lands on the inferred keyspace",
@@ -916,7 +925,8 @@
       "TablesUsed": [
         "main.unsharded"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "a degraded information_schema branch stays separate from a sharded side",
@@ -962,7 +972,8 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "a degraded information_schema branch stays separate from a live DBA route",
@@ -1052,7 +1063,8 @@
         "main.ambiguous_ref_with_source",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "differing physical reference names must not merge: the none side's table does not exist in the other keyspace",
@@ -1135,6 +1147,53 @@
     "skip_e2e": true
   },
   {
+    "comment": "join predicates pushed into the legs of a union bind the vindex value as an argument",
+    "query": "select d.id, refs.user_id from (select 5 as id from dual) d left join (select user_id from music union all select user_id from user_extra) refs on refs.user_id = d.id",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select d.id, refs.user_id from (select 5 as id from dual) d left join (select user_id from music union all select user_id from user_extra) refs on refs.user_id = d.id",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "LeftJoin",
+        "JoinColumnIndexes": "L:0,R:0",
+        "JoinVars": {
+          "d_id": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Reference",
+            "Keyspace": {
+              "Name": "main",
+              "Sharded": false
+            },
+            "FieldQuery": "select d.id from (select 5 as id from dual where 1 != 1) as d where 1 != 1",
+            "Query": "select d.id from (select 5 as id from dual) as d"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.user_id from (select user_id from music where 1 != 1 union all select user_id from user_extra where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.user_id from (select user_id from music where user_id = :d_id /* INT64 */ union all select user_id from user_extra where user_id = :d_id /* INT64 */) as refs",
+            "Values": [
+              ":d_id"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
     "comment": "union with the same target shard because of vindex",
     "query": "select * from music where user_id = 1 union select * from user where id = 1",
     "plan": {
@@ -1159,12 +1218,14 @@
         "user.music",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union with the different target shard because of vindex (music -> lookup vindex, user -> hash vindex)",
     "query": "select * from music where id = 1 union select * from user where id = 1",
-    "plan": "VT09015: schema tracking required"
+    "plan": "VT09015: schema tracking required",
+    "skip_e2e": true
   },
   {
     "comment": "union with different target shards",
@@ -1326,7 +1387,8 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union distinct between a scatter query and a join (other side)",
@@ -1391,7 +1453,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union distinct between a scatter query and a join (other side)",
@@ -1456,7 +1519,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "unmergable because we are using aggregation",
@@ -1696,7 +1760,8 @@
           }
         ]
       }
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "UNION that needs to be reordered to be merged more aggressively. Gen4 is able to get it down to 2 routes",
@@ -1824,22 +1889,26 @@
   {
     "comment": "ambiguous LIMIT",
     "query": "select id from user limit 1 union all select id from music limit 1",
-    "plan": "syntax error at position 34 near 'union'"
+    "plan": "syntax error at position 34 near 'union'",
+    "skip_e2e": true
   },
   {
     "comment": "ambiguous ORDER BY",
     "query": "select id from user order by id union all select id from music order by id desc",
-    "plan": "syntax error at position 38 near 'union'"
+    "plan": "syntax error at position 38 near 'union'",
+    "skip_e2e": true
   },
   {
     "comment": "different number of columns",
     "query": "select id, 42 from user where id = 1 union all select id from user where id = 5",
-    "plan": "The used SELECT statements have a different number of columns: 2, 1"
+    "plan": "The used SELECT statements have a different number of columns: 2, 1",
+    "skip_e2e": true
   },
   {
     "comment": "union with invalid order by clause with table qualifier",
     "query": "select id from user union select 3 order by user.id",
-    "plan": "Table `user` from one of the SELECTs cannot be used in global ORDER clause"
+    "plan": "Table `user` from one of the SELECTs cannot be used in global ORDER clause",
+    "skip_e2e": true
   },
   {
     "comment": "union with invalid order by clause with table qualifier",
@@ -1919,7 +1988,8 @@
         "user.user",
         "user.user_extra"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "select 1 from (select id+42 as foo from user union select 1+id as foo from unsharded) as t",
@@ -2019,7 +2089,8 @@
           }
         ]
       }
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "pushes predicate on both sides of UNION",
@@ -2103,7 +2174,8 @@
           }
         ]
       }
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "unknown columns are OK as long as the whole query is unsharded",
@@ -2125,7 +2197,8 @@
       "TablesUsed": [
         "main.unsharded"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union of unsharded route with sharded join with involvement of weight string",
@@ -2192,7 +2265,8 @@
         "user.authoritative",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "UNION ALL with repeating column on the LHS",
@@ -2215,7 +2289,8 @@
         "user.music",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "UNION ALL with repeating column on the RHS",
@@ -2238,7 +2313,8 @@
         "user.music",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "UNION with repeating column on the RHS",
@@ -2272,7 +2348,8 @@
         "user.music",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "UNION with repeating column on the LHS",
@@ -2306,7 +2383,8 @@
         "user.music",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "join between two derived tables containing UNION",
@@ -2364,6 +2442,1085 @@
       "TablesUsed": [
         "user.music",
         "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "join to a derived table containing a UNION where every source is pinned to the same shard",
+    "query": "select refs.seg, u.id, u.col from user_extra as ue join user as u on u.id = ue.user_id join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5 group by refs.seg, u.id, u.col",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg, u.id, u.col from user_extra as ue join user as u on u.id = ue.user_id join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5 group by refs.seg, u.id, u.col",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select refs.seg, u.id, u.col from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as refs, user_extra as ue, `user` as u where 1 != 1 group by refs.seg, u.id, u.col",
+        "Query": "select refs.seg, u.id, u.col from (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs, user_extra as ue, `user` as u where ue.user_id = 5 and u.id = ue.user_id and refs.user_id = ue.user_id group by refs.seg, u.id, u.col",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join to a derived table containing a UNION ALL where every source is pinned to the same shard",
+    "query": "select refs.seg, u.id, u.col from user_extra as ue join user as u on u.id = ue.user_id join (select music.user_id, music.id as seg from music where music.user_id = 5 union all select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5 group by refs.seg, u.id, u.col",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg, u.id, u.col from user_extra as ue join user as u on u.id = ue.user_id join (select music.user_id, music.id as seg from music where music.user_id = 5 union all select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5 group by refs.seg, u.id, u.col",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select refs.seg, u.id, u.col from (select music.user_id, music.id as seg from music where 1 != 1 union all select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as refs, user_extra as ue, `user` as u where 1 != 1 group by refs.seg, u.id, u.col",
+        "Query": "select refs.seg, u.id, u.col from (select music.user_id, music.id as seg from music where music.user_id = 5 union all select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs, user_extra as ue, `user` as u where ue.user_id = 5 and u.id = ue.user_id and refs.user_id = ue.user_id group by refs.seg, u.id, u.col",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join to a derived table containing a UNION where every source is pinned to the same bind variable",
+    "query": "select refs.seg, u.id, u.col from user_extra as ue join user as u on u.id = ue.user_id join (select music.user_id, music.id as seg from music where music.user_id = :v union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = :v) as refs on refs.user_id = ue.user_id where ue.user_id = :v group by refs.seg, u.id, u.col",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg, u.id, u.col from user_extra as ue join user as u on u.id = ue.user_id join (select music.user_id, music.id as seg from music where music.user_id = :v union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = :v) as refs on refs.user_id = ue.user_id where ue.user_id = :v group by refs.seg, u.id, u.col",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select refs.seg, u.id, u.col from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as refs, user_extra as ue, `user` as u where 1 != 1 group by refs.seg, u.id, u.col",
+        "Query": "select refs.seg, u.id, u.col from (select music.user_id, music.id as seg from music where music.user_id = :v union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = :v) as refs, user_extra as ue, `user` as u where ue.user_id = :v and u.id = ue.user_id and refs.user_id = ue.user_id group by refs.seg, u.id, u.col",
+        "Values": [
+          ":v"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user",
+        "user.user_extra"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "left join to a derived table containing a UNION where every source is pinned to the same shard",
+    "query": "select refs.seg, u.id, u.col from user_extra as ue join user as u on u.id = ue.user_id left join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5 group by refs.seg, u.id, u.col",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg, u.id, u.col from user_extra as ue join user as u on u.id = ue.user_id left join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5 group by refs.seg, u.id, u.col",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select refs.seg, u.id, u.col from (user_extra as ue, `user` as u) left join (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as refs on refs.user_id = ue.user_id where 1 != 1 group by refs.seg, u.id, u.col",
+        "Query": "select refs.seg, u.id, u.col from (user_extra as ue, `user` as u) left join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5 and u.id = ue.user_id group by refs.seg, u.id, u.col",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a UNION where every source is pinned to the same shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as refs, user_extra as ue where 1 != 1",
+        "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs, user_extra as ue where ue.user_id = 5 and refs.user_id = ue.col",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join to a derived table containing a three-source UNION where every source is pinned to the same shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union select m2.user_id, m2.id from music as m2 where 1 != 1) as refs, user_extra as ue where 1 != 1",
+        "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs, user_extra as ue where ue.user_id = 5 and refs.user_id = ue.user_id",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join to a derived table containing a nested UNION and UNION ALL where every source is pinned to the same shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.user_id where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union all select m2.user_id, m2.id from music as m2 where 1 != 1) as refs, user_extra as ue where 1 != 1",
+        "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs, user_extra as ue where ue.user_id = 5 and refs.user_id = ue.user_id",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a UNION where every source is pinned to the same shard and the outer table is not pinned",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.col",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.col",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join to a derived table containing a UNION with sources pinned to the same shard where only one source exposes the vindex column",
+    "query": "select refs.user_id from user_extra as ue join (select music.user_id from music where music.user_id = 5 union select ue2.col from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select refs.user_id from user_extra as ue join (select music.user_id from music where music.user_id = 5 union select ue2.col from user_extra as ue2 where ue2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select refs.user_id from (select music.user_id from music where 1 != 1 union select ue2.col from user_extra as ue2 where 1 != 1) as refs, user_extra as ue where 1 != 1",
+        "Query": "select refs.user_id from (select music.user_id from music where music.user_id = 5 union select ue2.col from user_extra as ue2 where ue2.user_id = 5) as refs, user_extra as ue where ue.user_id = 5 and refs.user_id = ue.col",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a UNION with sources pinned to different shards must not be merged",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on the pinned column to a derived table containing a UNION with sources pinned to different shards must not be merged",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6) as refs on refs.user_id = ue.user_id where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6) as refs on refs.user_id = ue.user_id where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_user_id": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.user_id from user_extra as ue where 1 != 1",
+            "Query": "select ue.user_id from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_user_id union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 and user_id = :ue_user_id) as refs",
+            "Values": [
+              ":ue_user_id"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a three-source UNION with sources pinned to different shards must not collapse onto one shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 union select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 union select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union select m2.user_id, m2.id from music as m2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 and user_id = :ue_col /* INT16 */ union select m2.user_id, m2.id from music as m2 where m2.user_id = 5 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a three-source UNION ALL with sources pinned to different shards must not collapse onto one shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union all select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union all select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union all select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union all select m2.user_id, m2.id from music as m2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union all select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 and user_id = :ue_col /* INT16 */ union all select m2.user_id, m2.id from music as m2 where m2.user_id = 5 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a nested UNION and UNION ALL with sources pinned to different shards must not collapse onto one shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 5) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union all select m2.user_id, m2.id from music as m2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 6 and user_id = :ue_col /* INT16 */ union all select m2.user_id, m2.id from music as m2 where m2.user_id = 5 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a three-source UNION with two sources pinned to the same shard and one pinned to a different shard must not collapse onto one shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union select m2.user_id, m2.id from music as m2 where m2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union select m2.user_id, m2.id from music as m2 where m2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union select m2.user_id, m2.id from music as m2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 and user_id = :ue_col /* INT16 */ union select m2.user_id, m2.id from music as m2 where m2.user_id = 6 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a three-source UNION ALL with two sources pinned to the same shard and one pinned to a different shard must not collapse onto one shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union all select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union all select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union all select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union all select m2.user_id, m2.id from music as m2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union all select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 and user_id = :ue_col /* INT16 */ union all select m2.user_id, m2.id from music as m2 where m2.user_id = 6 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a four-source UNION with source pairs pinned to two different shards must not collapse onto one shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union select m2.user_id, m2.id from music as m2 where m2.user_id = 6 union select ue3.user_id, ue3.id from user_extra as ue3 where ue3.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union select m2.user_id, m2.id from music as m2 where m2.user_id = 6 union select ue3.user_id, ue3.id from user_extra as ue3 where ue3.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union select m2.user_id, m2.id from music as m2 where 1 != 1 union select ue3.user_id, ue3.id from user_extra as ue3 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 and user_id = :ue_col /* INT16 */ union select m2.user_id, m2.id from music as m2 where m2.user_id = 6 and user_id = :ue_col /* INT16 */ union select ue3.user_id, ue3.id from user_extra as ue3 where ue3.user_id = 6 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a nested UNION pinned to one shard and a UNION ALL source pinned to a different shard must not collapse onto one shard",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union all select m2.user_id, m2.id from music as m2 where m2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union all select m2.user_id, m2.id from music as m2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 and user_id = :ue_col /* INT16 */ union all select m2.user_id, m2.id from music as m2 where m2.user_id = 6 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a UNION ALL of two derived tables pinned to the same shard and a source pinned to a different shard must not collapse onto one shard",
+    "query": "select refs.seg from user_extra as ue join (select t1.user_id, t1.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as t1 union all select t2.user_id, t2.seg from (select m2.user_id, m2.id as seg from music as m2 where m2.user_id = 5 union select ue3.user_id, ue3.id from user_extra as ue3 where ue3.user_id = 5) as t2 union all select m3.user_id, m3.id from music as m3 where m3.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select t1.user_id, t1.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as t1 union all select t2.user_id, t2.seg from (select m2.user_id, m2.id as seg from music as m2 where m2.user_id = 5 union select ue3.user_id, ue3.id from user_extra as ue3 where ue3.user_id = 5) as t2 union all select m3.user_id, m3.id from music as m3 where m3.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select t1.user_id, t1.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as t1 where 1 != 1 union all select t2.user_id, t2.seg from (select m2.user_id, m2.id as seg from music as m2 where 1 != 1 union select ue3.user_id, ue3.id from user_extra as ue3 where 1 != 1) as t2 where 1 != 1 union all select m3.user_id, m3.id from music as m3 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select t1.user_id, t1.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 and user_id = :ue_col /* INT16 */) as t1 union all select t2.user_id, t2.seg from (select m2.user_id, m2.id as seg from music as m2 where m2.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue3.user_id, ue3.id from user_extra as ue3 where ue3.user_id = 5 and user_id = :ue_col /* INT16 */) as t2 union all select m3.user_id, m3.id from music as m3 where m3.user_id = 6 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a UNION ALL of two derived tables pinned to two different shards",
+    "query": "select refs.seg from user_extra as ue join (select t1.user_id, t1.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as t1 union all select t2.user_id, t2.seg from (select m2.user_id, m2.id as seg from music as m2 where m2.user_id = 6 union select ue3.user_id, ue3.id from user_extra as ue3 where ue3.user_id = 6) as t2) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select t1.user_id, t1.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5) as t1 union all select t2.user_id, t2.seg from (select m2.user_id, m2.id as seg from music as m2 where m2.user_id = 6 union select ue3.user_id, ue3.id from user_extra as ue3 where ue3.user_id = 6) as t2) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select t1.user_id, t1.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1) as t1 where 1 != 1 union all select t2.user_id, t2.seg from (select m2.user_id, m2.id as seg from music as m2 where 1 != 1 union select ue3.user_id, ue3.id from user_extra as ue3 where 1 != 1) as t2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select t1.user_id, t1.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 and user_id = :ue_col /* INT16 */) as t1 union all select t2.user_id, t2.seg from (select m2.user_id, m2.id as seg from music as m2 where m2.user_id = 6 and user_id = :ue_col /* INT16 */ union select ue3.user_id, ue3.id from user_extra as ue3 where ue3.user_id = 6 and user_id = :ue_col /* INT16 */) as t2) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a four-source UNION with a dual source interposed between a same-shard pair and a differently pinned source: the recorded fallback must survive the dual merge",
+    "query": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union select 5, 42 from dual union select m2.user_id, m2.id from music as m2 where m2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.seg from user_extra as ue join (select music.user_id, music.id as seg from music where music.user_id = 5 union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 union select 5, 42 from dual union select m2.user_id, m2.id from music as m2 where m2.user_id = 6) as refs on refs.user_id = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select refs.seg from (select music.user_id, music.id as seg from music where 1 != 1 union select ue2.user_id, ue2.id from user_extra as ue2 where 1 != 1 union select 5, 42 from dual where 1 != 1 union select m2.user_id, m2.id from music as m2 where 1 != 1) as refs where 1 != 1",
+            "Query": "select refs.seg from (select music.user_id, music.id as seg from music where music.user_id = 5 and user_id = :ue_col /* INT16 */ union select ue2.user_id, ue2.id from user_extra as ue2 where ue2.user_id = 5 and user_id = :ue_col /* INT16 */ union select 5, 42 from dual where 5 = :ue_col /* INT16 */ union select m2.user_id, m2.id from music as m2 where m2.user_id = 6 and user_id = :ue_col /* INT16 */) as refs",
+            "Values": [
+              ":ue_col"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "union of two single-shard joins pinned to the same shard",
+    "query": "select music.id as seg, u.id, u.col from music join user as u on u.id = music.user_id where music.user_id = 5 union select ue2.id, u2.id, u2.col from user_extra as ue2 join user as u2 on u2.id = ue2.user_id where ue2.user_id = 5",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select music.id as seg, u.id, u.col from music join user as u on u.id = music.user_id where music.user_id = 5 union select ue2.id, u2.id, u2.col from user_extra as ue2 join user as u2 on u2.id = ue2.user_id where ue2.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select music.id as seg, u.id, u.col from music, `user` as u where 1 != 1 union select ue2.id, u2.id, u2.col from user_extra as ue2, `user` as u2 where 1 != 1",
+        "Query": "select music.id as seg, u.id, u.col from music, `user` as u where music.user_id = 5 and u.id = music.user_id union select ue2.id, u2.id, u2.col from user_extra as ue2, `user` as u2 where ue2.user_id = 5 and u2.id = ue2.user_id",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "union all of two single-shard selects pinned to the same shard",
+    "query": "select id from music where user_id = 5 union all select id from user_extra where user_id = 5",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select id from music where user_id = 5 union all select id from user_extra where user_id = 5",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "EqualUnique",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from music where 1 != 1 union all select id from user_extra where 1 != 1",
+        "Query": "select id from music where user_id = 5 union all select id from user_extra where user_id = 5",
+        "Values": [
+          "5"
+        ],
+        "Vindex": "user_index"
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a UNION with sources pinned to the same non-unique vindex value",
+    "query": "select refs.x from user_extra as ue join (select u1.name as x, u1.id from user as u1 where u1.name = 'a' union select u2.name, u2.id from user as u2 where u2.name = 'a') as refs on refs.x = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.x from user_extra as ue join (select u1.name as x, u1.id from user as u1 where u1.name = 'a' union select u2.name, u2.id from user as u2 where u2.name = 'a') as refs on refs.x = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Distinct",
+            "Collations": [
+              "(0:2)",
+              "(1:3)"
+            ],
+            "Inputs": [
+              {
+                "OperatorType": "VindexLookup",
+                "Variant": "Equal",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "Values": [
+                  ":ue_col"
+                ],
+                "Vindex": "name_user_map",
+                "Inputs": [
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "IN",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select `name`, keyspace_id from name_user_vdx where 1 != 1",
+                    "Query": "select `name`, keyspace_id from name_user_vdx where `name` in ::__vals",
+                    "Values": [
+                      "::name"
+                    ],
+                    "Vindex": "user_index"
+                  },
+                  {
+                    "OperatorType": "Route",
+                    "Variant": "ByDestination",
+                    "Keyspace": {
+                      "Name": "user",
+                      "Sharded": true
+                    },
+                    "FieldQuery": "select u1.`name` as x, u1.id, weight_string(u1.`name`), weight_string(u1.id) from `user` as u1 where 1 != 1 union select u2.`name`, u2.id, weight_string(u2.`name`), weight_string(u2.id) from `user` as u2 where 1 != 1",
+                    "Query": "select u1.`name` as x, u1.id, weight_string(u1.`name`), weight_string(u1.id) from `user` as u1 where u1.`name` = 'a' and `name` = :ue_col /* INT16 */ union select u2.`name`, u2.id, weight_string(u2.`name`), weight_string(u2.id) from `user` as u2 where u2.`name` = 'a' and `name` = :ue_col /* INT16 */"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "join on an unpinned column to a derived table containing a UNION with sources pinned to the same IN list",
+    "query": "select refs.col from user_extra as ue join (select m1.col from music as m1 where m1.user_id in (1, 2) union select m2.col from music as m2 where m2.user_id in (1, 2)) as refs on refs.col = ue.col where ue.user_id = 5",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select refs.col from user_extra as ue join (select m1.col from music as m1 where m1.user_id in (1, 2) union select m2.col from music as m2 where m2.user_id in (1, 2)) as refs on refs.col = ue.col where ue.user_id = 5",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "R:0",
+        "JoinVars": {
+          "ue_col": 0
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select ue.col from user_extra as ue where 1 != 1",
+            "Query": "select ue.col from user_extra as ue where ue.user_id = 5",
+            "Values": [
+              "5"
+            ],
+            "Vindex": "user_index"
+          },
+          {
+            "OperatorType": "Distinct",
+            "Collations": [
+              "(0:1)"
+            ],
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "IN",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select m1.col, weight_string(m1.col) from music as m1 where 1 != 1 union select m2.col, weight_string(m2.col) from music as m2 where 1 != 1",
+                "Query": "select m1.col, weight_string(m1.col) from music as m1 where m1.user_id in ::__vals and col = :ue_col /* INT16 */ union select m2.col, weight_string(m2.col) from music as m2 where m2.user_id in (1, 2) and col = :ue_col /* INT16 */",
+                "Values": [
+                  "(1, 2)"
+                ],
+                "Vindex": "user_index"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.music",
+        "user.user_extra"
       ]
     }
   },
@@ -2485,7 +3642,8 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Select now() from table union Select literals from table",
@@ -2515,7 +3673,8 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Select now() from table union Select column from table",
@@ -2545,7 +3704,8 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "Literals in UNION can be problematic",
@@ -2731,7 +3891,8 @@
       "TablesUsed": [
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
     "comment": "join with derived table containing UNION with aliased columns across different keyspaces",

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -1044,7 +1044,7 @@
     }
   },
   {
-    "comment": "a reference-degraded none routing keeps its canonical keyspace and declines a cross-keyspace merge",
+    "comment": "a reference-degraded none routing merges into the keyspace holding a copy of its table",
     "query": "select id from ambiguous_ref_with_source where id in (null) union select id from user",
     "plan": {
       "Type": "Complex",
@@ -1058,40 +1058,26 @@
         "ResultColumns": 1,
         "Inputs": [
           {
-            "OperatorType": "Concatenate",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "None",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from ambiguous_ref_with_source where 1 != 1) as dt(c0) where 1 != 1",
-                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from ambiguous_ref_with_source where id in (null)) as dt(c0)"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
-                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
-              }
-            ]
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ambiguous_ref_with_source where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ambiguous_ref_with_source where id in (null) union select id, weight_string(id) from `user`"
           }
         ]
       },
       "TablesUsed": [
-        "main.ambiguous_ref_with_source",
+        "user.ambiguous_ref_with_source",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
   },
   {
-    "comment": "differing physical reference names must not merge: the none side's table does not exist in the other keyspace",
+    "comment": "a reference-degraded none branch is rewritten to the copy's physical name in the target keyspace",
     "query": "select id from source_of_ref where id in (null) union select id from user",
     "plan": {
       "Type": "Complex",
@@ -1105,37 +1091,56 @@
         "ResultColumns": 1,
         "Inputs": [
           {
-            "OperatorType": "Concatenate",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "None",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref where 1 != 1) as dt(c0) where 1 != 1",
-                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from source_of_ref where id in (null)) as dt(c0)"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
-                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
-              }
-            ]
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ref_with_source as source_of_ref where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ref_with_source as source_of_ref where id in (null) union select id, weight_string(id) from `user`"
           }
         ]
       },
       "TablesUsed": [
-        "main.source_of_ref",
+        "user.ref_with_source",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "the rewrite also applies when the empty reference branch is on the right",
+    "query": "select id from user union select id from source_of_ref where id in (null)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user union select id from source_of_ref where id in (null)",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from ref_with_source as source_of_ref where 1 != 1",
+            "Query": "select id, weight_string(id) from `user` union select id, weight_string(id) from ref_with_source as source_of_ref where id in (null)"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
   },
   {
     "comment": "a reference-degraded none routing whose keyspace matches the other side still merges",

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -266,7 +266,7 @@
     }
   },
   {
-    "comment": "union operations in derived table, without star expression (FROM)¡",
+    "comment": "union operations in derived table, without star expression (FROM)\u00a1",
     "query": "select col1,col2 from (select col1, col2 from user union all select col1, col2 from user_extra) as t",
     "plan": {
       "Type": "Scatter",
@@ -452,6 +452,718 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "none routing merged with dual: any shard in the none side's keyspace serves the dual rows",
+    "query": "select id from user where id in (null) union select 1 from dual",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select id from user where id in (null) union select 1 from dual",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from `user` where 1 != 1 union select 1 from dual where 1 != 1",
+        "Query": "select id from `user` where id in (null) union select 1 from dual"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "dual merged with a none routing on the right: any shard in the none side's keyspace serves the dual rows",
+    "query": "select 1 from dual union select id from user where id in (null)",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select 1 from dual union select id from user where id in (null)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select 1 from dual where 1 != 1 union select id from `user` where 1 != 1",
+        "Query": "select 1 from dual union select id from `user` where id in (null)"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "none routings from different keyspaces stay unmerged; the dual leg merges into one none side's keyspace",
+    "query": "select oid from ordering.order_event where oid in (null) union select id from user where id in (null) union select 1 from dual",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select oid from ordering.order_event where oid in (null) union select id from user where id in (null) union select 1 from dual",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "Reference",
+                "Keyspace": {
+                  "Name": "ordering",
+                  "Sharded": true
+                },
+                "FieldQuery": "select oid, weight_string(oid) from order_event where 1 != 1 union select 1, weight_string(1) from dual where 1 != 1",
+                "Query": "select oid, weight_string(oid) from order_event where oid in (null) union select 1, weight_string(1) from dual"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user` where id in (null)) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "ordering.order_event",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a none routing only merges with a sharded routing in its own keyspace",
+    "query": "select oid from ordering.order_event where oid in (null) union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select oid from ordering.order_event where oid in (null) union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "ordering",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as oid, weight_string(dt.c0) from (select oid from order_event where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as oid, weight_string(dt.c0) from (select distinct oid from order_event where oid in (null)) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "ordering.order_event",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a none routing only merges with an unsharded routing in its own keyspace",
+    "query": "select oid from ordering.order_event where oid in (null) union select col from unsharded",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select oid from ordering.order_event where oid in (null) union select col from unsharded",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "ordering",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as oid, weight_string(dt.c0) from (select oid from order_event where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as oid, weight_string(dt.c0) from (select distinct oid from order_event where oid in (null)) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as col, weight_string(dt.c0) from (select col from unsharded where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as col, weight_string(dt.c0) from (select distinct col from unsharded) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded",
+        "ordering.order_event"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a none routing merges with a sharded routing in the same keyspace",
+    "query": "select id from user where id in (null) union select id from user_extra",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user where id in (null) union select id from user_extra",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from user_extra where 1 != 1",
+            "Query": "select id, weight_string(id) from `user` where id in (null) union select id, weight_string(id) from user_extra"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "union all keeps cross-keyspace none legs unmerged while the dual leg merges in order",
+    "query": "select oid from ordering.order_event where oid in (null) union all select id from user where id in (null) union all select 1 from dual",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select oid from ordering.order_event where oid in (null) union all select id from user where id in (null) union all select 1 from dual",
+      "Instructions": {
+        "OperatorType": "Concatenate",
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "None",
+            "Keyspace": {
+              "Name": "ordering",
+              "Sharded": true
+            },
+            "FieldQuery": "select oid from order_event where 1 != 1",
+            "Query": "select oid from order_event where oid in (null)"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "Reference",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id from `user` where 1 != 1 union all select 1 from dual where 1 != 1",
+            "Query": "select id from `user` where id in (null) union all select 1 from dual"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "ordering.order_event",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a dual-derived none routing that absorbed a real table only merges into that table's keyspace",
+    "query": "select u.col from unsharded as u, (select 1 from dual where 1 in (null)) as x union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select u.col from unsharded as u, (select 1 from dual where 1 in (null)) as x union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as col, weight_string(dt.c0) from (select u.col from unsharded as u, (select 1 from dual where 1 != 1) as x where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as col, weight_string(dt.c0) from (select distinct u.col from unsharded as u, (select 1 from dual where 1 in (null)) as x) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "a dual-derived none routing that absorbed a real table merges with a branch in that table's keyspace",
+    "query": "select u.col from unsharded as u, (select 1 from dual where 1 in (null)) as x union select col2 from unsharded_auto",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select u.col from unsharded as u, (select 1 from dual where 1 in (null)) as x union select col2 from unsharded_auto",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Unsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select u.col from unsharded as u, (select 1 from dual where 1 != 1) as x where 1 != 1 union select col2 from unsharded_auto where 1 != 1",
+        "Query": "select u.col from unsharded as u, (select 1 from dual where 1 in (null)) as x union select col2 from unsharded_auto"
+      },
+      "TablesUsed": [
+        "main.unsharded",
+        "main.unsharded_auto"
+      ]
+    }
+  },
+  {
+    "comment": "none routings in the same keyspace collapse into a single none route",
+    "query": "select id from user where id in (null) union select id from user_extra where user_id in (null)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user where id in (null) union select id from user_extra where user_id in (null)",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "None",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from user_extra where 1 != 1",
+            "Query": "select id, weight_string(id) from `user` where id in (null) union select id, weight_string(id) from user_extra where user_id in (null)"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
+    "comment": "none routings from different keyspaces stay unmerged: no single keyspace could resolve the merged field query",
+    "query": "select id from user where id in (null) union select oid from ordering.order_event where oid in (null)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user where id in (null) union select oid from ordering.order_event where oid in (null)",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user` where id in (null)) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "ordering",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as oid, weight_string(dt.c0) from (select oid from order_event where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as oid, weight_string(dt.c0) from (select distinct oid from order_event where oid in (null)) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "ordering.order_event",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "a none routing over a rewritten information_schema branch must not adopt the dual side: only a DBA route binds :__vtschemaname",
+    "query": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select 1 from dual",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select 1 from dual",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0: utf8mb3_general_ci"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+                "Query": "select distinct `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and 0"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Reference",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select 1 from dual where 1 != 1",
+                "Query": "select distinct 1 from dual"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "comment": "the information_schema guard also applies when the other side lands on the inferred keyspace",
+    "query": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select col from unsharded",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select col from unsharded",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as `table_name`, weight_string(dt.c0) from (select `table_name` from information_schema.`tables` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as `table_name`, weight_string(dt.c0) from (select distinct `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and 0) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Unsharded",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as col, weight_string(dt.c0) from (select col from unsharded where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as col, weight_string(dt.c0) from (select distinct col from unsharded) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded"
+      ]
+    }
+  },
+  {
+    "comment": "a degraded information_schema branch stays separate from a sharded side",
+    "query": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as `table_name`, weight_string(dt.c0) from (select `table_name` from information_schema.`tables` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as `table_name`, weight_string(dt.c0) from (select distinct `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and 0) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "a degraded information_schema branch stays separate from a live DBA route",
+    "query": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select table_name from information_schema.columns",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema = 'user' and 1 = 2 union select table_name from information_schema.columns",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0: utf8mb3_general_ci"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+                "Query": "select distinct `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */ and 0"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "DBA",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select `table_name` from information_schema.`columns` where 1 != 1",
+                "Query": "select distinct `table_name` from information_schema.`columns`"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "comment": "a reference-degraded none routing keeps its canonical keyspace and declines a cross-keyspace merge",
+    "query": "select id from ambiguous_ref_with_source where id in (null) union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from ambiguous_ref_with_source where id in (null) union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from ambiguous_ref_with_source where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from ambiguous_ref_with_source where id in (null)) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.ambiguous_ref_with_source",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "differing physical reference names must not merge: the none side's table does not exist in the other keyspace",
+    "query": "select id from source_of_ref where id in (null) union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from source_of_ref where id in (null) union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Concatenate",
+            "Inputs": [
+              {
+                "OperatorType": "Route",
+                "Variant": "None",
+                "Keyspace": {
+                  "Name": "main",
+                  "Sharded": false
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from source_of_ref where id in (null)) as dt(c0)"
+              },
+              {
+                "OperatorType": "Route",
+                "Variant": "Scatter",
+                "Keyspace": {
+                  "Name": "user",
+                  "Sharded": true
+                },
+                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
+                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
+              }
+            ]
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.source_of_ref",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "a reference-degraded none routing whose keyspace matches the other side still merges",
+    "query": "select id from ref_with_source where id in (null) union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from ref_with_source where id in (null) union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ref_with_source where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ref_with_source where id in (null) union select id, weight_string(id) from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
   },
   {
     "comment": "union with the same target shard because of vindex",
@@ -2118,6 +2830,66 @@
       },
       "TablesUsed": [
         "main.unsharded",
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "statically false dual branch merges into the other side's keyspace",
+    "query": "select 42 from dual where false union select id from user",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select 42 from dual where false union select id from user",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 42 from dual where 1 != 1 union select id from `user` where 1 != 1",
+            "Query": "select 42 from dual where 0 union select id from `user`"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "statically false dual branch on the right merges into the other side's keyspace",
+    "query": "select id from user union select 42 from dual where false",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user union select 42 from dual where false",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "0"
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id from `user` where 1 != 1 union select 42 from dual where 1 != 1",
+            "Query": "select id from `user` union select 42 from dual where 0"
+          }
+        ]
+      },
+      "TablesUsed": [
         "user.user"
       ]
     }

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -1019,7 +1019,7 @@
     "skip_e2e": true
   },
   {
-    "comment": "a reference-degraded none routing keeps its canonical keyspace and declines a cross-keyspace merge",
+    "comment": "a reference-degraded none routing merges into the keyspace holding a copy of its table",
     "query": "select id from ambiguous_ref_with_source where id in (null) union select id from user",
     "plan": {
       "Type": "Complex",
@@ -1033,41 +1033,26 @@
         "ResultColumns": 1,
         "Inputs": [
           {
-            "OperatorType": "Concatenate",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "None",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from ambiguous_ref_with_source where 1 != 1) as dt(c0) where 1 != 1",
-                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from ambiguous_ref_with_source where id in (null)) as dt(c0)"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
-                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
-              }
-            ]
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ambiguous_ref_with_source where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ambiguous_ref_with_source where id in (null) union select id, weight_string(id) from `user`"
           }
         ]
       },
       "TablesUsed": [
-        "main.ambiguous_ref_with_source",
+        "user.ambiguous_ref_with_source",
         "user.user"
       ]
     },
     "skip_e2e": true
   },
   {
-    "comment": "differing physical reference names must not merge: the none side's table does not exist in the other keyspace",
+    "comment": "a reference-degraded none branch is rewritten to the copy's physical name in the target keyspace",
     "query": "select id from source_of_ref where id in (null) union select id from user",
     "plan": {
       "Type": "Complex",
@@ -1081,37 +1066,56 @@
         "ResultColumns": 1,
         "Inputs": [
           {
-            "OperatorType": "Concatenate",
-            "Inputs": [
-              {
-                "OperatorType": "Route",
-                "Variant": "None",
-                "Keyspace": {
-                  "Name": "main",
-                  "Sharded": false
-                },
-                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from source_of_ref where 1 != 1) as dt(c0) where 1 != 1",
-                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from source_of_ref where id in (null)) as dt(c0)"
-              },
-              {
-                "OperatorType": "Route",
-                "Variant": "Scatter",
-                "Keyspace": {
-                  "Name": "user",
-                  "Sharded": true
-                },
-                "FieldQuery": "select dt.c0 as id, weight_string(dt.c0) from (select id from `user` where 1 != 1) as dt(c0) where 1 != 1",
-                "Query": "select dt.c0 as id, weight_string(dt.c0) from (select distinct id from `user`) as dt(c0)"
-              }
-            ]
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from ref_with_source as source_of_ref where 1 != 1 union select id, weight_string(id) from `user` where 1 != 1",
+            "Query": "select id, weight_string(id) from ref_with_source as source_of_ref where id in (null) union select id, weight_string(id) from `user`"
           }
         ]
       },
       "TablesUsed": [
-        "main.source_of_ref",
+        "user.ref_with_source",
         "user.user"
       ]
-    }
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "the rewrite also applies when the empty reference branch is on the right",
+    "query": "select id from user union select id from source_of_ref where id in (null)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select id from user union select id from source_of_ref where id in (null)",
+      "Instructions": {
+        "OperatorType": "Distinct",
+        "Collations": [
+          "(0:1)"
+        ],
+        "ResultColumns": 1,
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id, weight_string(id) from `user` where 1 != 1 union select id, weight_string(id) from ref_with_source as source_of_ref where 1 != 1",
+            "Query": "select id, weight_string(id) from `user` union select id, weight_string(id) from ref_with_source as source_of_ref where id in (null)"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.ref_with_source",
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
   },
   {
     "comment": "a reference-degraded none routing whose keyspace matches the other side still merges",

--- a/go/vt/vtgate/planbuilder/testdata/vschemas/schema.json
+++ b/go/vt/vtgate/planbuilder/testdata/vschemas/schema.json
@@ -516,7 +516,7 @@
         "costly_map": {
           "column_vindexes": [
             {
-              "column": "name",
+              "column": "costly",
               "name": "user_md5_index"
             }
           ]

--- a/go/vt/vtgate/planbuilder/testdata/vschemas/schema.json
+++ b/go/vt/vtgate/planbuilder/testdata/vschemas/schema.json
@@ -736,6 +736,10 @@
     },
     "main_2": {
       "tables": {
+        "sharded_sales_ref": {
+          "type": "reference",
+          "source": "user.sales"
+        },
         "unsharded_tab": {
           "columns": [
             {


### PR DESCRIPTION
## Description

Statically empty reference branches used to merge blindly on main: `select id from source_of_ref where id in (null) union select id from user` planned SQL that named `source_of_ref` on user shards, where the table is physically `ref_with_source`, and failed at runtime with an unknown-table error. #20629 made those pairings decline instead, which is correct but plans a Concatenate where a single route used to suffice.

This change restores the merge, correctly. When the none side's keyspace does not match the other side's, every real table under the empty branch is resolved to its reference copy in the target keyspace — the table itself, a `ReferencedBy` copy, or a reference source — through the same lookup that builds alternate routes, so routing rules stay in effect and a copy that a rule sends elsewhere does not count. The branch's planned operators are then pointed at those copies in place with the original names kept as aliases, and the union merges into the other side's routing. The rewrite mechanism comes from #20755, which fixes the panic in the live-branch equivalent of this merge.

Three planner cases pin the restored merges: the same-name copy, the differing physical name (now rewritten where main used to emit the broken name), and the reversed order. Branches whose tables have no copy in the target keyspace keep planning as separate routes, pinned by the existing cross-keyspace cases, and the information_schema guard from #20629 still precedes the rewrite.

## Related Issue(s)

Closes https://github.com/vitessio/vitess/issues/20754 together with #20755. Builds on #20628, #20630, and #20755, and on #20629, which has now merged.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Unions with a statically empty reference-table branch and a branch in a keyspace holding a copy of its tables now plan as a single merged route using the copy's physical name. No migrations or configuration changes.

### AI Disclosure

This PR was written primarily by Fable.

---

```mermaid
graph LR
    subgraph json [JSON support]
        direction TB
        PR20625["#20625 (merged)<br>mysql/json: fix MarshalTo discarding accumulated output for nested blob and bit values"]
        PR20632["#20632<br>vtgate: preserve IN value lists in complex aggregate projections"]
        PRA["#20691<br>evalengine: disable the static IN hash table for JSON operands"]
        PR20682["#20682 (draft)<br>evalengine: support constant-folded JSON values as literals"]
        PR20683["#20683 (draft)<br>evalengine, sqlparser: MySQL comparison domains; nested BETWEEN parentheses"]
        PR20626["#20626 (draft)<br>vtgate: support cross-shard JSON_ARRAYAGG and JSON_OBJECTAGG"]
        PR20625 --> PR20682
        PRA --> PR20682
        PR20682 --> PR20683
        PR20632 --> PR20626
        PR20683 --> PR20626
    end

    subgraph union [Union routing]
        direction TB
        PR20628["#20628<br>vtgate: track per-source copies of pushed join predicates so merges skip them"]
        PR20629["#20629 (merged)<br>vtgate: fix None routing handling when merging unions"]
        PR20630["#20630 (draft)<br>vtgate: merge unions on join-predicate-free routings when all sources agree"]
        PR20755["#20755<br>vtgate: fix union merging through reference-table alternates"]
        PR20756["#20756 (draft)<br>vtgate: merge empty reference branches through rewritten copies"]
        PR20628 --> PR20630
        PR20629 --> PR20630
        PR20630 --> PR20756
        PR20755 --> PR20756
    end

    subgraph cte [Recursive CTEs]
        direction TB
        PR20759["#20759<br>vtgate: expand qualified stars without JOIN USING coalescing"]
        PR20633["#20633 (draft)<br>vtgate: validate the declared column list length of CTEs and derived tables"]
        PR20631["#20631 (draft)<br>vtgate: bind recursive CTE column filters as arguments in unmerged term queries"]
        PR20759 --> PR20633
        PR20633 --> PR20631
    end

    json ~~~ union ~~~ cte
```

