### PR TITLE
vtgate: expand qualified stars without JOIN USING coalescing

### DIFF
--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -358,6 +358,28 @@
     }
   },
   {
+    "comment": "qualified star after join using keeps the join column",
+    "query": "select b.* from authoritative a join authoritative b using (user_id)",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select b.* from authoritative a join authoritative b using (user_id)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select b.user_id, b.col1, b.col2 from authoritative as a, authoritative as b where 1 != 1",
+        "Query": "select b.user_id, b.col1, b.col2 from authoritative as a, authoritative as b where a.user_id = b.user_id"
+      },
+      "TablesUsed": [
+        "user.authoritative"
+      ]
+    }
+  },
+  {
     "comment": "select * from authoritative table",
     "query": "select * from authoritative",
     "plan": {

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -1075,6 +1075,11 @@ func (r *earlyRewriter) expandTableColumns(
 		org:             org,
 		expandedColumns: map[sqlparser.TableName][]*sqlparser.ColName{},
 	}
+	if !starExpr.TableName.IsEmpty() {
+		// USING coalescing applies to an unqualified * only: a qualified star
+		// returns every column of its table, join columns included
+		state.joinUsing = nil
+	}
 
 	for _, tbl := range tables {
 		if !starExpr.TableName.IsEmpty() && !tbl.matches(starExpr.TableName) {

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -175,6 +175,20 @@ func TestExpandStar(t *testing.T) {
 		sql:    "select 1 from t1 join t5 using (b) where b = 12",
 		expSQL: "select 1 from t1 join t5 on t1.b = t5.b where t1.b = 12",
 	}, {
+		// USING coalescing applies to an unqualified * only: a qualified star
+		// returns every column of its table, join columns included
+		sql:    "select t2.* from t2 join t4 using (c1)",
+		expSQL: "select t2.c1, t2.c2 from t2 join t4 on t2.c1 = t4.c1",
+	}, {
+		sql:    "select t4.* from t2 join t4 using (c1)",
+		expSQL: "select t4.c1, t4.c4 from t2 join t4 on t2.c1 = t4.c1",
+	}, {
+		sql:    "select t2.*, t4.* from t2 join t4 using (c1)",
+		expSQL: "select t2.c1, t2.c2, t4.c1, t4.c4 from t2 join t4 on t2.c1 = t4.c1",
+	}, {
+		sql:    "select t1.*, t5.* from t1 join t5 using (b)",
+		expSQL: "select t1.a, t1.b, t1.c, t5.a, t5.b from t1 join t5 on t1.b = t5.b",
+	}, {
 		sql:    "select * from (select 12) as t",
 		expSQL: "select `12` from (select 12 from dual) as t",
 	}, {

--- a/go/vt/vtgate/semantics/early_rewriter_test.go
+++ b/go/vt/vtgate/semantics/early_rewriter_test.go
@@ -175,6 +175,17 @@ func TestExpandStar(t *testing.T) {
 		sql:    "select 1 from t1 join t5 using (b) where b = 12",
 		expSQL: "select 1 from t1 join t5 on t1.b = t5.b where t1.b = 12",
 	}, {
+		// USING coalescing applies to an unqualified * only: a qualified star
+		// returns every column of its table, join columns included
+		sql:    "select t4.* from t2 join t4 using (c1)",
+		expSQL: "select t4.c1, t4.c4 from t2 join t4 on t2.c1 = t4.c1",
+	}, {
+		sql:    "select t2.*, t4.* from t2 join t4 using (c1)",
+		expSQL: "select t2.c1, t2.c2, t4.c1, t4.c4 from t2 join t4 on t2.c1 = t4.c1",
+	}, {
+		sql:    "select t1.*, t5.* from t1 join t5 using (b)",
+		expSQL: "select t1.a, t1.b, t1.c, t5.a, t5.b from t1 join t5 on t1.b = t5.b",
+	}, {
 		sql:    "select * from (select 12) as t",
 		expSQL: "select `12` from (select 12 from dual) as t",
 	}, {


### PR DESCRIPTION
## Description

The early rewriter applies JOIN USING coalescing to qualified stars. MySQL coalesces the join columns for an unqualified `*` only: `tbl.*` returns every column of the named table, join columns included, so `select r.* from t l join t r using (col1)` returns three columns on MySQL but two on Vitess, silently dropping `r.col1` from the results. The right-hand side of the join loses its join columns; the left-hand side keeps them, so the wrong shape only shows on one side.

The fix clears the coalescing state when the star carries a qualifier, before the expander runs. Unqualified stars keep the existing coalesced expansion and ordering unchanged, pinned by the existing cases. Three new expansion cases cover both join sides, a mixed qualified pair, and a second table shape, and a planner golden pins the emitted SQL end to end; that file runs in the plan e2e suite, so CI compares the corrected expansion against MySQL directly.

This came out of reviewing #20633, whose declared-column-list validation turns the wrong expansion into a spurious VT03033 for `select a from (select r.* from t l join t r using (col1)) x(a, b, c)`. The validation change now stacks on this fix. Since the wrong column set is returned to clients on current releases, this is probably worth backporting.

## Related Issue(s)

Found while addressing review feedback on #20633.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Qualified stars in queries with JOIN USING now expand to every column of the named table, matching MySQL: previously the join columns were omitted from the right-hand table's `tbl.*` expansion, and results silently differed from MySQL. No migrations or configuration changes.

### AI Disclosure

This PR was written primarily by Fable.

---

```mermaid
graph LR
    subgraph json [JSON support]
        direction TB
        PR20625["#20625 (merged)<br>mysql/json: fix MarshalTo discarding accumulated output for nested blob and bit values"]
        PR20632["#20632<br>vtgate: preserve IN value lists in complex aggregate projections"]
        PRA["#20691<br>evalengine: disable the static IN hash table for JSON operands"]
        PR20682["#20682 (draft)<br>evalengine: support constant-folded JSON values as literals"]
        PR20683["#20683 (draft)<br>evalengine, sqlparser: MySQL comparison domains; nested BETWEEN parentheses"]
        PR20626["#20626 (draft)<br>vtgate: support cross-shard JSON_ARRAYAGG and JSON_OBJECTAGG"]
        PR20625 --> PR20682
        PRA --> PR20682
        PR20682 --> PR20683
        PR20632 --> PR20626
        PR20683 --> PR20626
    end

    subgraph union [Union routing]
        direction TB
        PR20628["#20628<br>vtgate: track per-source copies of pushed join predicates so merges skip them"]
        PR20629["#20629 (merged)<br>vtgate: fix None routing handling when merging unions"]
        PR20630["#20630 (draft)<br>vtgate: merge unions on join-predicate-free routings when all sources agree"]
        PR20755["#20755<br>vtgate: fix union merging through reference-table alternates"]
        PR20756["#20756 (draft)<br>vtgate: merge empty reference branches through rewritten copies"]
        PR20628 --> PR20630
        PR20629 --> PR20630
        PR20630 --> PR20756
        PR20755 --> PR20756
    end

    subgraph cte [Recursive CTEs]
        direction TB
        PR20759["#20759<br>vtgate: expand qualified stars without JOIN USING coalescing"]
        PR20633["#20633 (draft)<br>vtgate: validate the declared column list length of CTEs and derived tables"]
        PR20631["#20631 (draft)<br>vtgate: bind recursive CTE column filters as arguments in unmerged term queries"]
        PR20759 --> PR20633
        PR20633 --> PR20631
    end

    json ~~~ union ~~~ cte
```

