### PR TITLE
`reparentutil`: keep nil-alias tablets out of candidate ordering

### DIFF
--- a/go/vt/vtctl/reparentutil/reparent_sorter.go
+++ b/go/vt/vtctl/reparentutil/reparent_sorter.go
@@ -75,10 +75,10 @@ func (rs *reparentSorter) Less(i, j int) bool {
 
 	// Should not happen
 	// fail-safe code
-	if rs.tablets[i] == nil {
+	if rs.tablets[i] == nil || rs.tablets[i].Alias == nil {
 		return false
 	}
-	if rs.tablets[j] == nil {
+	if rs.tablets[j] == nil || rs.tablets[j].Alias == nil {
 		return true
 	}
 
@@ -134,11 +134,11 @@ func (rs *reparentSorter) Less(i, j int) bool {
 func dominatedCountsForSort(tablets []*topodatapb.Tablet, positions []*RelayLogPositions, dominates func(*RelayLogPositions, *RelayLogPositions) bool) []int {
 	dominatedCounts := make([]int, len(positions))
 	for i := range positions {
-		if tablets[i] == nil {
+		if tablets[i] == nil || tablets[i].Alias == nil {
 			continue
 		}
 		for j := range positions {
-			if i == j || tablets[j] == nil {
+			if i == j || tablets[j] == nil || tablets[j].Alias == nil {
 				continue
 			}
 			if dominates(positions[j], positions[i]) {

--- a/go/vt/vtctl/reparentutil/reparent_sorter_test.go
+++ b/go/vt/vtctl/reparentutil/reparent_sorter_test.go
@@ -68,6 +68,9 @@ func TestReparentSorter(t *testing.T) {
 		},
 		Type: topodatapb.TabletType_RDONLY,
 	}
+	tabletWithoutAlias := &topodatapb.Tablet{
+		Type: topodatapb.TabletType_REPLICA,
+	}
 
 	mysqlGTID1 := replication.Mysql56GTID{
 		Server:   sid1,
@@ -193,6 +196,16 @@ func TestReparentSorter(t *testing.T) {
 			tablets:       []*topodatapb.Tablet{tabletReplica1_101, tabletRdonly1_102},
 			positions:     []*RelayLogPositions{positionMostAdvanced, positionMostAdvanced},
 			sortedTablets: []*topodatapb.Tablet{tabletReplica1_101, tabletRdonly1_102},
+		}, {
+			name:          "nil alias sorts last",
+			tablets:       []*topodatapb.Tablet{tabletWithoutAlias, tabletRdonly1_102},
+			positions:     []*RelayLogPositions{positionMostAdvanced, positionMostAdvanced},
+			sortedTablets: []*topodatapb.Tablet{tabletRdonly1_102, tabletWithoutAlias},
+		}, {
+			name:          "nil alias does not affect dominance counts",
+			tablets:       []*topodatapb.Tablet{tabletReplica1_100, tabletReplica2_100, tabletWithoutAlias},
+			positions:     []*RelayLogPositions{positionIntermediate1, positionDisjoint1, positionIntermediate2},
+			sortedTablets: []*topodatapb.Tablet{tabletReplica1_100, tabletReplica2_100, tabletWithoutAlias},
 		}, {
 			name:          "mixed",
 			tablets:       []*topodatapb.Tablet{tabletReplica1_101, tabletReplica2_100, tabletReplica1_100, tabletRdonly1_102, tabletReplica3_103},


### PR DESCRIPTION
## Description

The reparent sorter’s stable alias tiebreaker dereferences `Tablet.Alias`, even though the promotion policy deliberately handles a missing alias as `MustNot`. A malformed candidate can therefore panic when it ties with another `MustNot` candidate.

This treats nil aliases like nil tablets: they sort last and are excluded from dominance counts, so they cannot affect valid candidate ordering.

The issue also exists in `release-24.0` and was exposed by Codex on 1 of 2 backports: #20757. The 4 x LLMs I used to review #20757 plus 2 x human reviewers all missed this somehow 🤔. I’d like to backport this to release-24.0 and release-23.0.

## Related Issue(s)

Found in the Codex review of #20757: https://github.com/vitessio/vitess/pull/20757#discussion_r3678383004 - a backport of https://github.com/vitessio/vitess/pull/20728. Reviewers (seemingly the same ones) never detected this on the original PR or the other backport to v23 😕 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

Codex reviewed the report and wrote the fix and regression tests with my direction.