### PR TITLE
fix(vttablet): scope 2PC redo rows by tablet database

### DIFF
--- a/doc/design-docs/AtomicDistributedTransaction.md
+++ b/doc/design-docs/AtomicDistributedTransaction.md
@@ -363,10 +363,11 @@ The redo_state table needs to support the following use cases:
 ```
 create table redo_state(
   dtid varbinary(512),
+  db_name varbinary(256) not null default '',
   state bigint, // state can be 0: Failed, 1: Prepared.
   time_created bigint,
   message text, // record any error message.
-  primary key(dtid)
+  primary key(dtid, db_name)
 )
 ```
 
@@ -376,9 +377,10 @@ It needs the ability to read the statements of a dtid in the correct order (by i
 ```
 create table redo_statement(
   dtid varbinary(512),
+  db_name varbinary(256) not null default '',
   id bigint,
   statement mediumblob,
-  primary key(dtid, id)
+  primary key(dtid, db_name, id)
 )
 ```
 

--- a/go/test/endtoend/transaction/twopc/main_test.go
+++ b/go/test/endtoend/transaction/twopc/main_test.go
@@ -193,14 +193,14 @@ var tables = map[string]extractInterestingValues{
 	},
 	"ks.redo_state": func(dtidMap map[string]string, vals []sqltypes.Value) (out []sqltypes.Value) {
 		dtid := getDTID(dtidMap, vals[0].ToString())
-		dtState := getDTState(vals[1])
+		dtState := getDTState(vals[2])
 		out = append(out, sqltypes.NewVarChar(dtid), sqltypes.NewVarChar(dtState.String()))
 		return
 	},
 	"ks.redo_statement": func(dtidMap map[string]string, vals []sqltypes.Value) (out []sqltypes.Value) {
 		dtid := getDTID(dtidMap, vals[0].ToString())
-		stmt := getStatement(vals[2].ToString())
-		out = append([]sqltypes.Value{sqltypes.NewVarChar(dtid)}, vals[1], sqltypes.TestValue(sqltypes.Blob, stmt))
+		stmt := getStatement(vals[3].ToString())
+		out = append([]sqltypes.Value{sqltypes.NewVarChar(dtid)}, vals[2], sqltypes.TestValue(sqltypes.Blob, stmt))
 		return
 	},
 	"ks.twopc_user": func(_ map[string]string, vals []sqltypes.Value) []sqltypes.Value { return vals },

--- a/go/vt/sidecardb/schema/twopc/redo_state.sql
+++ b/go/vt/sidecardb/schema/twopc/redo_state.sql
@@ -16,8 +16,9 @@ limitations under the License.
 
 CREATE TABLE IF NOT EXISTS redo_state(
   dtid varbinary(512) NOT NULL,
+  db_name varbinary(256) NOT NULL DEFAULT '',
   state bigint NOT NULL,
   time_created bigint NOT NULL,
   message text,
-  primary key(dtid)
+  primary key(dtid, db_name)
 ) ENGINE = InnoDB CHARSET = utf8mb4

--- a/go/vt/sidecardb/schema/twopc/redo_statement.sql
+++ b/go/vt/sidecardb/schema/twopc/redo_statement.sql
@@ -16,7 +16,8 @@ limitations under the License.
 
 CREATE TABLE IF NOT EXISTS redo_statement(
   dtid varbinary(512) NOT NULL,
+  db_name varbinary(256) NOT NULL DEFAULT '',
   id bigint NOT NULL,
   statement mediumblob NOT NULL,
-  primary key(dtid, id)
+  primary key(dtid, db_name, id)
 ) ENGINE = InnoDB CHARSET = utf8mb4

--- a/go/vt/vtexplain/testdata/twopc-output/deletesharded-output.txt
+++ b/go/vt/vtexplain/testdata/twopc-output/deletesharded-output.txt
@@ -25,13 +25,13 @@ delete from user where id=1
 4 ks_sharded/-40: insert into `_vt`.dt_participant(dtid, id, keyspace, shard) values ('ks_sharded:-40:1515392388787015722', 1, 'ks_sharded', '80-c0')
 4 ks_sharded/-40: commit
 5 ks_sharded/80-c0: begin
-5 ks_sharded/80-c0: insert into `_vt`.redo_state(dtid, state, time_created) values ('ks_sharded:-40:1515392388787015722', 1, 1515392388909259045)
-5 ks_sharded/80-c0: insert into `_vt`.redo_statement(dtid, id, statement) values ('ks_sharded:-40:1515392388787015722', 1, 'delete from name_user_map where (name = \'name_val_1\' and user_id = 1) /* vtgate:: keyspace_id:a6e89b54b129c33051b76db219595660 */')
+5 ks_sharded/80-c0: insert into `_vt`.redo_state(dtid, db_name, state, time_created) values ('ks_sharded:-40:1515392388787015722', '', 1, 1515392388909259045)
+5 ks_sharded/80-c0: insert into `_vt`.redo_statement(dtid, db_name, id, statement) values ('ks_sharded:-40:1515392388787015722', '', 1, 'delete from name_user_map where (name = \'name_val_1\' and user_id = 1) /* vtgate:: keyspace_id:a6e89b54b129c33051b76db219595660 */')
 5 ks_sharded/80-c0: commit
 6 ks_sharded/-40: update `_vt`.dt_state set state = 2 where dtid = 'ks_sharded:-40:1515392388787015722' and state = 1
 6 ks_sharded/-40: commit
-7 ks_sharded/80-c0: delete from `_vt`.redo_state where dtid = 'ks_sharded:-40:1515392388787015722'
-7 ks_sharded/80-c0: delete from `_vt`.redo_statement where dtid = 'ks_sharded:-40:1515392388787015722'
+7 ks_sharded/80-c0: delete from `_vt`.redo_state where dtid = 'ks_sharded:-40:1515392388787015722' and db_name = ''
+7 ks_sharded/80-c0: delete from `_vt`.redo_statement where dtid = 'ks_sharded:-40:1515392388787015722' and db_name = ''
 7 ks_sharded/80-c0: commit
 8 ks_sharded/-40: begin
 8 ks_sharded/-40: delete from `_vt`.dt_state where dtid = 'ks_sharded:-40:1515392388787015722'
@@ -54,20 +54,20 @@ delete from user where name='billy'
 5 ks_sharded/c0-: insert into `_vt`.dt_participant(dtid, id, keyspace, shard) values ('ks_sharded:c0-:1515392388798209886', 1, 'ks_sharded', '-40'), ('ks_sharded:c0-:1515392388798209886', 2, 'ks_sharded', '80-c0')
 5 ks_sharded/c0-: commit
 6 ks_sharded/-40: begin
-6 ks_sharded/-40: insert into `_vt`.redo_state(dtid, state, time_created) values ('ks_sharded:c0-:1515392388798209886', 1, 1515392389021902468)
-6 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, id, statement) values ('ks_sharded:c0-:1515392388798209886', 1, 'delete from user where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */')
+6 ks_sharded/-40: insert into `_vt`.redo_state(dtid, db_name, state, time_created) values ('ks_sharded:c0-:1515392388798209886', '', 1, 1515392389021902468)
+6 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, db_name, id, statement) values ('ks_sharded:c0-:1515392388798209886', '', 1, 'delete from user where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */')
 6 ks_sharded/-40: commit
 6 ks_sharded/80-c0: begin
-6 ks_sharded/80-c0: insert into `_vt`.redo_state(dtid, state, time_created) values ('ks_sharded:c0-:1515392388798209886', 1, 1515392389021902697)
-6 ks_sharded/80-c0: insert into `_vt`.redo_statement(dtid, id, statement) values ('ks_sharded:c0-:1515392388798209886', 1, 'delete from name_user_map where (name = \'name_val_1\' and user_id = 1) /* vtgate:: keyspace_id:a6e89b54b129c33051b76db219595660 */')
+6 ks_sharded/80-c0: insert into `_vt`.redo_state(dtid, db_name, state, time_created) values ('ks_sharded:c0-:1515392388798209886', '', 1, 1515392389021902697)
+6 ks_sharded/80-c0: insert into `_vt`.redo_statement(dtid, db_name, id, statement) values ('ks_sharded:c0-:1515392388798209886', '', 1, 'delete from name_user_map where (name = \'name_val_1\' and user_id = 1) /* vtgate:: keyspace_id:a6e89b54b129c33051b76db219595660 */')
 6 ks_sharded/80-c0: commit
 7 ks_sharded/c0-: update `_vt`.dt_state set state = 2 where dtid = 'ks_sharded:c0-:1515392388798209886' and state = 1
 7 ks_sharded/c0-: commit
-8 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:c0-:1515392388798209886'
-8 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:c0-:1515392388798209886'
+8 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:c0-:1515392388798209886' and db_name = ''
+8 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:c0-:1515392388798209886' and db_name = ''
 8 ks_sharded/-40: commit
-8 ks_sharded/80-c0: delete from `_vt`.redo_state where dtid = 'ks_sharded:c0-:1515392388798209886'
-8 ks_sharded/80-c0: delete from `_vt`.redo_statement where dtid = 'ks_sharded:c0-:1515392388798209886'
+8 ks_sharded/80-c0: delete from `_vt`.redo_state where dtid = 'ks_sharded:c0-:1515392388798209886' and db_name = ''
+8 ks_sharded/80-c0: delete from `_vt`.redo_statement where dtid = 'ks_sharded:c0-:1515392388798209886' and db_name = ''
 8 ks_sharded/80-c0: commit
 9 ks_sharded/c0-: begin
 9 ks_sharded/c0-: delete from `_vt`.dt_state where dtid = 'ks_sharded:c0-:1515392388798209886'

--- a/go/vt/vtexplain/testdata/twopc-output/insertsharded-output.txt
+++ b/go/vt/vtexplain/testdata/twopc-output/insertsharded-output.txt
@@ -10,13 +10,13 @@ insert into user (id, name) values(1, 'alice')
 3 ks_sharded/40-80: insert into `_vt`.dt_participant(dtid, id, keyspace, shard) values ('ks_sharded:40-80:1515392387046738470', 1, 'ks_sharded', '-40')
 3 ks_sharded/40-80: commit
 4 ks_sharded/-40: begin
-4 ks_sharded/-40: insert into `_vt`.redo_state(dtid, state, time_created) values ('ks_sharded:40-80:1515392387046738470', 1, 1515392387101086738)
-4 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, id, statement) values ('ks_sharded:40-80:1515392387046738470', 1, 'insert into user(id, name) values (1, \'alice\') /* vtgate:: keyspace_id:166b40b44aba4bd6 */')
+4 ks_sharded/-40: insert into `_vt`.redo_state(dtid, db_name, state, time_created) values ('ks_sharded:40-80:1515392387046738470', '', 1, 1515392387101086738)
+4 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, db_name, id, statement) values ('ks_sharded:40-80:1515392387046738470', '', 1, 'insert into user(id, name) values (1, \'alice\') /* vtgate:: keyspace_id:166b40b44aba4bd6 */')
 4 ks_sharded/-40: commit
 5 ks_sharded/40-80: update `_vt`.dt_state set state = 2 where dtid = 'ks_sharded:40-80:1515392387046738470' and state = 1
 5 ks_sharded/40-80: commit
-6 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:40-80:1515392387046738470'
-6 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:40-80:1515392387046738470'
+6 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:40-80:1515392387046738470' and db_name = ''
+6 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:40-80:1515392387046738470' and db_name = ''
 6 ks_sharded/-40: commit
 7 ks_sharded/40-80: begin
 7 ks_sharded/40-80: delete from `_vt`.dt_state where dtid = 'ks_sharded:40-80:1515392387046738470'
@@ -35,13 +35,13 @@ insert into user (id, name) values(2, 'bob')
 3 ks_sharded/c0-: insert into `_vt`.dt_participant(dtid, id, keyspace, shard) values ('ks_sharded:c0-:1515392387053859424', 1, 'ks_sharded', '-40')
 3 ks_sharded/c0-: commit
 4 ks_sharded/-40: begin
-4 ks_sharded/-40: insert into `_vt`.redo_state(dtid, state, time_created) values ('ks_sharded:c0-:1515392387053859424', 1, 1515392387182475610)
-4 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, id, statement) values ('ks_sharded:c0-:1515392387053859424', 1, 'insert into user(id, name) values (2, \'bob\') /* vtgate:: keyspace_id:06e7ea22ce92708f */')
+4 ks_sharded/-40: insert into `_vt`.redo_state(dtid, db_name, state, time_created) values ('ks_sharded:c0-:1515392387053859424', '', 1, 1515392387182475610)
+4 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, db_name, id, statement) values ('ks_sharded:c0-:1515392387053859424', '', 1, 'insert into user(id, name) values (2, \'bob\') /* vtgate:: keyspace_id:06e7ea22ce92708f */')
 4 ks_sharded/-40: commit
 5 ks_sharded/c0-: update `_vt`.dt_state set state = 2 where dtid = 'ks_sharded:c0-:1515392387053859424' and state = 1
 5 ks_sharded/c0-: commit
-6 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:c0-:1515392387053859424'
-6 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:c0-:1515392387053859424'
+6 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:c0-:1515392387053859424' and db_name = ''
+6 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:c0-:1515392387053859424' and db_name = ''
 6 ks_sharded/-40: commit
 7 ks_sharded/c0-: begin
 7 ks_sharded/c0-: delete from `_vt`.dt_state where dtid = 'ks_sharded:c0-:1515392387053859424'
@@ -61,13 +61,13 @@ insert ignore into user (id, name) values(2, 'bob')
 4 ks_sharded/c0-: insert into `_vt`.dt_participant(dtid, id, keyspace, shard) values ('ks_sharded:c0-:1515392387053859427', 1, 'ks_sharded', '-40')
 4 ks_sharded/c0-: commit
 5 ks_sharded/-40: begin
-5 ks_sharded/-40: insert into `_vt`.redo_state(dtid, state, time_created) values ('ks_sharded:c0-:1515392387053859427', 1, 1515392387274980027)
-5 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, id, statement) values ('ks_sharded:c0-:1515392387053859427', 1, 'insert ignore into user(id, name) values (2, \'bob\') /* vtgate:: keyspace_id:06e7ea22ce92708f */')
+5 ks_sharded/-40: insert into `_vt`.redo_state(dtid, db_name, state, time_created) values ('ks_sharded:c0-:1515392387053859427', '', 1, 1515392387274980027)
+5 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, db_name, id, statement) values ('ks_sharded:c0-:1515392387053859427', '', 1, 'insert ignore into user(id, name) values (2, \'bob\') /* vtgate:: keyspace_id:06e7ea22ce92708f */')
 5 ks_sharded/-40: commit
 6 ks_sharded/c0-: update `_vt`.dt_state set state = 2 where dtid = 'ks_sharded:c0-:1515392387053859427' and state = 1
 6 ks_sharded/c0-: commit
-7 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:c0-:1515392387053859427'
-7 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:c0-:1515392387053859427'
+7 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:c0-:1515392387053859427' and db_name = ''
+7 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:c0-:1515392387053859427' and db_name = ''
 7 ks_sharded/-40: commit
 8 ks_sharded/c0-: begin
 8 ks_sharded/c0-: delete from `_vt`.dt_state where dtid = 'ks_sharded:c0-:1515392387053859427'
@@ -87,13 +87,13 @@ insert ignore into user (id, name, nickname) values(2, 'bob', 'bob')
 4 ks_sharded/c0-: insert into `_vt`.dt_participant(dtid, id, keyspace, shard) values ('ks_sharded:c0-:1515392387053859430', 1, 'ks_sharded', '-40')
 4 ks_sharded/c0-: commit
 5 ks_sharded/-40: begin
-5 ks_sharded/-40: insert into `_vt`.redo_state(dtid, state, time_created) values ('ks_sharded:c0-:1515392387053859430', 1, 1515392387372890757)
-5 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, id, statement) values ('ks_sharded:c0-:1515392387053859430', 1, 'insert ignore into user(id, name, nickname) values (2, \'bob\', \'bob\') /* vtgate:: keyspace_id:06e7ea22ce92708f */')
+5 ks_sharded/-40: insert into `_vt`.redo_state(dtid, db_name, state, time_created) values ('ks_sharded:c0-:1515392387053859430', '', 1, 1515392387372890757)
+5 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, db_name, id, statement) values ('ks_sharded:c0-:1515392387053859430', '', 1, 'insert ignore into user(id, name, nickname) values (2, \'bob\', \'bob\') /* vtgate:: keyspace_id:06e7ea22ce92708f */')
 5 ks_sharded/-40: commit
 6 ks_sharded/c0-: update `_vt`.dt_state set state = 2 where dtid = 'ks_sharded:c0-:1515392387053859430' and state = 1
 6 ks_sharded/c0-: commit
-7 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:c0-:1515392387053859430'
-7 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:c0-:1515392387053859430'
+7 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:c0-:1515392387053859430' and db_name = ''
+7 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:c0-:1515392387053859430' and db_name = ''
 7 ks_sharded/-40: commit
 8 ks_sharded/c0-: begin
 8 ks_sharded/c0-: delete from `_vt`.dt_state where dtid = 'ks_sharded:c0-:1515392387053859430'
@@ -113,13 +113,13 @@ insert into user (id, name, nickname) values(2, 'bob', 'bobby') on duplicate key
 4 ks_sharded/c0-: insert into `_vt`.dt_participant(dtid, id, keyspace, shard) values ('ks_sharded:c0-:1515392387053859433', 1, 'ks_sharded', '-40')
 4 ks_sharded/c0-: commit
 5 ks_sharded/-40: begin
-5 ks_sharded/-40: insert into `_vt`.redo_state(dtid, state, time_created) values ('ks_sharded:c0-:1515392387053859433', 1, 1515392387467658995)
-5 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, id, statement) values ('ks_sharded:c0-:1515392387053859433', 1, 'insert into user(id, name, nickname) values (2, \'bob\', \'bobby\') on duplicate key update nickname = \'bobby\' /* vtgate:: keyspace_id:06e7ea22ce92708f */')
+5 ks_sharded/-40: insert into `_vt`.redo_state(dtid, db_name, state, time_created) values ('ks_sharded:c0-:1515392387053859433', '', 1, 1515392387467658995)
+5 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, db_name, id, statement) values ('ks_sharded:c0-:1515392387053859433', '', 1, 'insert into user(id, name, nickname) values (2, \'bob\', \'bobby\') on duplicate key update nickname = \'bobby\' /* vtgate:: keyspace_id:06e7ea22ce92708f */')
 5 ks_sharded/-40: commit
 6 ks_sharded/c0-: update `_vt`.dt_state set state = 2 where dtid = 'ks_sharded:c0-:1515392387053859433' and state = 1
 6 ks_sharded/c0-: commit
-7 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:c0-:1515392387053859433'
-7 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:c0-:1515392387053859433'
+7 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:c0-:1515392387053859433' and db_name = ''
+7 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:c0-:1515392387053859433' and db_name = ''
 7 ks_sharded/-40: commit
 8 ks_sharded/c0-: begin
 8 ks_sharded/c0-: delete from `_vt`.dt_state where dtid = 'ks_sharded:c0-:1515392387053859433'
@@ -134,22 +134,22 @@ insert into user (id, name, nickname, address) values(2, 'bob', 'bobby', '123 ma
 2 ks_sharded/c0-: select name from name_user_map where name = 'bob' and user_id = 2 limit 10001
 3 ks_sharded/-40: begin
 3 ks_sharded/-40: insert into user(id, name, nickname, address) values (2, 'bob', 'bobby', '123 main st') on duplicate key update nickname = values(nickname), address = values(address) /* vtgate:: keyspace_id:06e7ea22ce92708f */
-3 ks_sharded/-40: select count(*) from `_vt`.redo_state where time_created < 1515392382546684649
+3 ks_sharded/-40: select count(*) from `_vt`.redo_state where time_created < 1515392382546684649 and db_name = ''
 3 ks_sharded/-40: select dtid, time_created from `_vt`.dt_state where time_created < 1515392386546990720
 4 ks_sharded/c0-: begin
 4 ks_sharded/c0-: insert into `_vt`.dt_state(dtid, state, time_created) values ('ks_sharded:c0-:1515392387053859436', 1, 1515392387549507151)
 4 ks_sharded/c0-: insert into `_vt`.dt_participant(dtid, id, keyspace, shard) values ('ks_sharded:c0-:1515392387053859436', 1, 'ks_sharded', '-40')
 4 ks_sharded/c0-: commit
-4 ks_sharded/c0-: select count(*) from `_vt`.redo_state where time_created < 1515392382555938983
+4 ks_sharded/c0-: select count(*) from `_vt`.redo_state where time_created < 1515392382555938983 and db_name = ''
 4 ks_sharded/c0-: select dtid, time_created from `_vt`.dt_state where time_created < 1515392386556481105
 5 ks_sharded/-40: begin
-5 ks_sharded/-40: insert into `_vt`.redo_state(dtid, state, time_created) values ('ks_sharded:c0-:1515392387053859436', 1, 1515392387561241013)
-5 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, id, statement) values ('ks_sharded:c0-:1515392387053859436', 1, 'insert into user(id, name, nickname, address) values (2, \'bob\', \'bobby\', \'123 main st\') on duplicate key update nickname = values(nickname), address = values(address) /* vtgate:: keyspace_id:06e7ea22ce92708f */')
+5 ks_sharded/-40: insert into `_vt`.redo_state(dtid, db_name, state, time_created) values ('ks_sharded:c0-:1515392387053859436', '', 1, 1515392387561241013)
+5 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, db_name, id, statement) values ('ks_sharded:c0-:1515392387053859436', '', 1, 'insert into user(id, name, nickname, address) values (2, \'bob\', \'bobby\', \'123 main st\') on duplicate key update nickname = values(nickname), address = values(address) /* vtgate:: keyspace_id:06e7ea22ce92708f */')
 5 ks_sharded/-40: commit
 6 ks_sharded/c0-: update `_vt`.dt_state set state = 2 where dtid = 'ks_sharded:c0-:1515392387053859436' and state = 1
 6 ks_sharded/c0-: commit
-7 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:c0-:1515392387053859436'
-7 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:c0-:1515392387053859436'
+7 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:c0-:1515392387053859436' and db_name = ''
+7 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:c0-:1515392387053859436' and db_name = ''
 7 ks_sharded/-40: commit
 8 ks_sharded/c0-: begin
 8 ks_sharded/c0-: delete from `_vt`.dt_state where dtid = 'ks_sharded:c0-:1515392387053859436'

--- a/go/vt/vtexplain/testdata/twopc-output/options-output.txt
+++ b/go/vt/vtexplain/testdata/twopc-output/options-output.txt
@@ -25,13 +25,13 @@ insert into user (id, name) values(2, 'bob')
 3 ks_sharded/c0-: insert into `_vt`.dt_participant(dtid, id, keyspace, shard) values ('ks_sharded:c0-:1515392389222930664', 1, 'ks_sharded', '-40')
 3 ks_sharded/c0-: commit
 4 ks_sharded/-40: begin
-4 ks_sharded/-40: insert into `_vt`.redo_state(dtid, state, time_created) values ('ks_sharded:c0-:1515392389222930664', 1, 1515392389297064830)
-4 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, id, statement) values ('ks_sharded:c0-:1515392389222930664', 1, 'insert into user(id, name) values (2, \'bob\') /* _stream user (id ) (2 ); */ /* vtgate:: keyspace_id:06e7ea22ce92708f */')
+4 ks_sharded/-40: insert into `_vt`.redo_state(dtid, db_name, state, time_created) values ('ks_sharded:c0-:1515392389222930664', '', 1, 1515392389297064830)
+4 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, db_name, id, statement) values ('ks_sharded:c0-:1515392389222930664', '', 1, 'insert into user(id, name) values (2, \'bob\') /* _stream user (id ) (2 ); */ /* vtgate:: keyspace_id:06e7ea22ce92708f */')
 4 ks_sharded/-40: commit
 5 ks_sharded/c0-: update `_vt`.dt_state set state = 2 where dtid = 'ks_sharded:c0-:1515392389222930664' and state = 1
 5 ks_sharded/c0-: commit
-6 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:c0-:1515392389222930664'
-6 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:c0-:1515392389222930664'
+6 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:c0-:1515392389222930664' and db_name = ''
+6 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:c0-:1515392389222930664' and db_name = ''
 6 ks_sharded/-40: commit
 7 ks_sharded/c0-: begin
 7 ks_sharded/c0-: delete from `_vt`.dt_state where dtid = 'ks_sharded:c0-:1515392389222930664'

--- a/go/vt/vtexplain/testdata/twopc-output/updatesharded-output.txt
+++ b/go/vt/vtexplain/testdata/twopc-output/updatesharded-output.txt
@@ -18,13 +18,13 @@ update user set nickname='alice' where name='alice'
 3 ks_sharded/40-80: insert into `_vt`.dt_participant(dtid, id, keyspace, shard) values ('ks_sharded:40-80:1515392388086929116', 1, 'ks_sharded', '-40')
 3 ks_sharded/40-80: commit
 4 ks_sharded/-40: begin
-4 ks_sharded/-40: insert into `_vt`.redo_state(dtid, state, time_created) values ('ks_sharded:40-80:1515392388086929116', 1, 1515392388159901825)
-4 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, id, statement) values ('ks_sharded:40-80:1515392388086929116', 1, 'update user set nickname = \'alice\' where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */')
+4 ks_sharded/-40: insert into `_vt`.redo_state(dtid, db_name, state, time_created) values ('ks_sharded:40-80:1515392388086929116', '', 1, 1515392388159901825)
+4 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, db_name, id, statement) values ('ks_sharded:40-80:1515392388086929116', '', 1, 'update user set nickname = \'alice\' where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */')
 4 ks_sharded/-40: commit
 5 ks_sharded/40-80: update `_vt`.dt_state set state = 2 where dtid = 'ks_sharded:40-80:1515392388086929116' and state = 1
 5 ks_sharded/40-80: commit
-6 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:40-80:1515392388086929116'
-6 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:40-80:1515392388086929116'
+6 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:40-80:1515392388086929116' and db_name = ''
+6 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:40-80:1515392388086929116' and db_name = ''
 6 ks_sharded/-40: commit
 7 ks_sharded/40-80: begin
 7 ks_sharded/40-80: delete from `_vt`.dt_state where dtid = 'ks_sharded:40-80:1515392388086929116'
@@ -53,20 +53,20 @@ update user set name='alicia' where id=1
 5 ks_sharded/-40: insert into `_vt`.dt_participant(dtid, id, keyspace, shard) values ('ks_sharded:-40:1515392388084762368', 1, 'ks_sharded', '80-c0'), ('ks_sharded:-40:1515392388084762368', 2, 'ks_sharded', 'c0-')
 5 ks_sharded/-40: commit
 6 ks_sharded/80-c0: begin
-6 ks_sharded/80-c0: insert into `_vt`.redo_state(dtid, state, time_created) values ('ks_sharded:-40:1515392388084762368', 1, 1515392388298778400)
-6 ks_sharded/80-c0: insert into `_vt`.redo_statement(dtid, id, statement) values ('ks_sharded:-40:1515392388084762368', 1, 'delete from name_user_map where (name = \'name_val_1\' and user_id = 1) /* vtgate:: keyspace_id:a6e89b54b129c33051b76db219595660 */')
+6 ks_sharded/80-c0: insert into `_vt`.redo_state(dtid, db_name, state, time_created) values ('ks_sharded:-40:1515392388084762368', '', 1, 1515392388298778400)
+6 ks_sharded/80-c0: insert into `_vt`.redo_statement(dtid, db_name, id, statement) values ('ks_sharded:-40:1515392388084762368', '', 1, 'delete from name_user_map where (name = \'name_val_1\' and user_id = 1) /* vtgate:: keyspace_id:a6e89b54b129c33051b76db219595660 */')
 6 ks_sharded/80-c0: commit
 6 ks_sharded/c0-: begin
-6 ks_sharded/c0-: insert into `_vt`.redo_state(dtid, state, time_created) values ('ks_sharded:-40:1515392388084762368', 1, 1515392388298735516)
-6 ks_sharded/c0-: insert into `_vt`.redo_statement(dtid, id, statement) values ('ks_sharded:-40:1515392388084762368', 1, 'insert into name_user_map(name, user_id) values (\'alicia\', 1) /* vtgate:: keyspace_id:e2821261367fbee90bb5cf72955146c6 */')
+6 ks_sharded/c0-: insert into `_vt`.redo_state(dtid, db_name, state, time_created) values ('ks_sharded:-40:1515392388084762368', '', 1, 1515392388298735516)
+6 ks_sharded/c0-: insert into `_vt`.redo_statement(dtid, db_name, id, statement) values ('ks_sharded:-40:1515392388084762368', '', 1, 'insert into name_user_map(name, user_id) values (\'alicia\', 1) /* vtgate:: keyspace_id:e2821261367fbee90bb5cf72955146c6 */')
 6 ks_sharded/c0-: commit
 7 ks_sharded/-40: update `_vt`.dt_state set state = 2 where dtid = 'ks_sharded:-40:1515392388084762368' and state = 1
 7 ks_sharded/-40: commit
-8 ks_sharded/80-c0: delete from `_vt`.redo_state where dtid = 'ks_sharded:-40:1515392388084762368'
-8 ks_sharded/80-c0: delete from `_vt`.redo_statement where dtid = 'ks_sharded:-40:1515392388084762368'
+8 ks_sharded/80-c0: delete from `_vt`.redo_state where dtid = 'ks_sharded:-40:1515392388084762368' and db_name = ''
+8 ks_sharded/80-c0: delete from `_vt`.redo_statement where dtid = 'ks_sharded:-40:1515392388084762368' and db_name = ''
 8 ks_sharded/80-c0: commit
-8 ks_sharded/c0-: delete from `_vt`.redo_state where dtid = 'ks_sharded:-40:1515392388084762368'
-8 ks_sharded/c0-: delete from `_vt`.redo_statement where dtid = 'ks_sharded:-40:1515392388084762368'
+8 ks_sharded/c0-: delete from `_vt`.redo_state where dtid = 'ks_sharded:-40:1515392388084762368' and db_name = ''
+8 ks_sharded/c0-: delete from `_vt`.redo_statement where dtid = 'ks_sharded:-40:1515392388084762368' and db_name = ''
 8 ks_sharded/c0-: commit
 9 ks_sharded/-40: begin
 9 ks_sharded/-40: delete from `_vt`.dt_state where dtid = 'ks_sharded:-40:1515392388084762368'
@@ -91,27 +91,27 @@ update user set name='alicia' where name='alice'
 6 ks_sharded/40-80: insert into `_vt`.dt_participant(dtid, id, keyspace, shard) values ('ks_sharded:40-80:1515392388086929119', 1, 'ks_sharded', '-40'), ('ks_sharded:40-80:1515392388086929119', 2, 'ks_sharded', '80-c0'), ('ks_sharded:40-80:1515392388086929119', 3, 'ks_sharded', 'c0-')
 6 ks_sharded/40-80: commit
 7 ks_sharded/-40: begin
-7 ks_sharded/-40: insert into `_vt`.redo_state(dtid, state, time_created) values ('ks_sharded:40-80:1515392388086929119', 1, 1515392388418784416)
-7 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, id, statement) values ('ks_sharded:40-80:1515392388086929119', 1, 'update user set name = \'alicia\' where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */')
+7 ks_sharded/-40: insert into `_vt`.redo_state(dtid, db_name, state, time_created) values ('ks_sharded:40-80:1515392388086929119', '', 1, 1515392388418784416)
+7 ks_sharded/-40: insert into `_vt`.redo_statement(dtid, db_name, id, statement) values ('ks_sharded:40-80:1515392388086929119', '', 1, 'update user set name = \'alicia\' where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */')
 7 ks_sharded/-40: commit
 7 ks_sharded/80-c0: begin
-7 ks_sharded/80-c0: insert into `_vt`.redo_state(dtid, state, time_created) values ('ks_sharded:40-80:1515392388086929119', 1, 1515392388418767663)
-7 ks_sharded/80-c0: insert into `_vt`.redo_statement(dtid, id, statement) values ('ks_sharded:40-80:1515392388086929119', 1, 'delete from name_user_map where (name = \'name_val_1\' and user_id = 1) /* vtgate:: keyspace_id:a6e89b54b129c33051b76db219595660 */')
+7 ks_sharded/80-c0: insert into `_vt`.redo_state(dtid, db_name, state, time_created) values ('ks_sharded:40-80:1515392388086929119', '', 1, 1515392388418767663)
+7 ks_sharded/80-c0: insert into `_vt`.redo_statement(dtid, db_name, id, statement) values ('ks_sharded:40-80:1515392388086929119', '', 1, 'delete from name_user_map where (name = \'name_val_1\' and user_id = 1) /* vtgate:: keyspace_id:a6e89b54b129c33051b76db219595660 */')
 7 ks_sharded/80-c0: commit
 7 ks_sharded/c0-: begin
-7 ks_sharded/c0-: insert into `_vt`.redo_state(dtid, state, time_created) values ('ks_sharded:40-80:1515392388086929119', 1, 1515392388418767689)
-7 ks_sharded/c0-: insert into `_vt`.redo_statement(dtid, id, statement) values ('ks_sharded:40-80:1515392388086929119', 1, 'insert into name_user_map(name, user_id) values (\'alicia\', 1) /* vtgate:: keyspace_id:e2821261367fbee90bb5cf72955146c6 */')
+7 ks_sharded/c0-: insert into `_vt`.redo_state(dtid, db_name, state, time_created) values ('ks_sharded:40-80:1515392388086929119', '', 1, 1515392388418767689)
+7 ks_sharded/c0-: insert into `_vt`.redo_statement(dtid, db_name, id, statement) values ('ks_sharded:40-80:1515392388086929119', '', 1, 'insert into name_user_map(name, user_id) values (\'alicia\', 1) /* vtgate:: keyspace_id:e2821261367fbee90bb5cf72955146c6 */')
 7 ks_sharded/c0-: commit
 8 ks_sharded/40-80: update `_vt`.dt_state set state = 2 where dtid = 'ks_sharded:40-80:1515392388086929119' and state = 1
 8 ks_sharded/40-80: commit
-9 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:40-80:1515392388086929119'
-9 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:40-80:1515392388086929119'
+9 ks_sharded/-40: delete from `_vt`.redo_state where dtid = 'ks_sharded:40-80:1515392388086929119' and db_name = ''
+9 ks_sharded/-40: delete from `_vt`.redo_statement where dtid = 'ks_sharded:40-80:1515392388086929119' and db_name = ''
 9 ks_sharded/-40: commit
-9 ks_sharded/80-c0: delete from `_vt`.redo_state where dtid = 'ks_sharded:40-80:1515392388086929119'
-9 ks_sharded/80-c0: delete from `_vt`.redo_statement where dtid = 'ks_sharded:40-80:1515392388086929119'
+9 ks_sharded/80-c0: delete from `_vt`.redo_state where dtid = 'ks_sharded:40-80:1515392388086929119' and db_name = ''
+9 ks_sharded/80-c0: delete from `_vt`.redo_statement where dtid = 'ks_sharded:40-80:1515392388086929119' and db_name = ''
 9 ks_sharded/80-c0: commit
-9 ks_sharded/c0-: delete from `_vt`.redo_state where dtid = 'ks_sharded:40-80:1515392388086929119'
-9 ks_sharded/c0-: delete from `_vt`.redo_statement where dtid = 'ks_sharded:40-80:1515392388086929119'
+9 ks_sharded/c0-: delete from `_vt`.redo_state where dtid = 'ks_sharded:40-80:1515392388086929119' and db_name = ''
+9 ks_sharded/c0-: delete from `_vt`.redo_statement where dtid = 'ks_sharded:40-80:1515392388086929119' and db_name = ''
 9 ks_sharded/c0-: commit
 10 ks_sharded/40-80: begin
 10 ks_sharded/40-80: delete from `_vt`.dt_state where dtid = 'ks_sharded:40-80:1515392388086929119'

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -386,14 +386,14 @@ func newTabletEnvironment(ddls []sqlparser.DDLStatement, opts *Options, collatio
 			}},
 			Rows: [][]sqltypes.Value{},
 		},
-		"create table if not exists `_vt`.redo_state(\n  dtid varbinary(512),\n  state bigint,\n  time_created bigint,\n  primary key(dtid)\n\t) engine=InnoDB": {
+		"create table if not exists `_vt`.redo_state(\n  dtid varbinary(512),\n  db_name varbinary(256) default '',\n  state bigint,\n  time_created bigint,\n  primary key(dtid, db_name)\n\t) engine=InnoDB": {
 			Fields: []*querypb.Field{{
 				Type:    sqltypes.Uint64,
 				Charset: collations.CollationBinaryID,
 			}},
 			Rows: [][]sqltypes.Value{},
 		},
-		"create table if not exists `_vt`.redo_statement(\n  dtid varbinary(512),\n  id bigint,\n  statement mediumblob,\n  primary key(dtid, id)\n\t) engine=InnoDB": {
+		"create table if not exists `_vt`.redo_statement(\n  dtid varbinary(512),\n  db_name varbinary(256) default '',\n  id bigint,\n  statement mediumblob,\n  primary key(dtid, db_name, id)\n\t) engine=InnoDB": {
 			Fields: []*querypb.Field{{
 				Type:    sqltypes.Uint64,
 				Charset: collations.CollationBinaryID,

--- a/go/vt/vttablet/endtoend/twopc/prepare_test.go
+++ b/go/vt/vttablet/endtoend/twopc/prepare_test.go
@@ -47,7 +47,7 @@ func TestCommitPreparedFailNonRetryable(t *testing.T) {
 	require.NoError(t, err)
 
 	client2 := framework.NewClient()
-	_, err = client2.BeginExecute(`select * from _vt.redo_state where dtid = 'bb' for update`, nil, nil)
+	_, err = client2.BeginExecute(`select * from _vt.redo_state where dtid = 'bb' and db_name = database() for update`, nil, nil)
 	require.NoError(t, err)
 
 	errCh := make(chan error, 1)
@@ -61,7 +61,7 @@ func TestCommitPreparedFailNonRetryable(t *testing.T) {
 
 	qr, err := client2.Execute("select dtid, state, message from _vt.redo_state where dtid = 'bb'", nil)
 	require.NoError(t, err)
-	require.Equal(t, `[[VARBINARY("bb") INT64(0) TEXT("Lock wait timeout exceeded; try restarting transaction (errno 1205) (sqlstate HY000) during query: delete from _vt.redo_state where dtid = _binary'bb'")]]`, fmt.Sprintf("%v", qr.Rows))
+	require.Equal(t, `[[VARBINARY("bb") INT64(0) TEXT("Lock wait timeout exceeded; try restarting transaction (errno 1205) (sqlstate HY000) during query: delete from _vt.redo_state where dtid = _binary'bb' and db_name = 'vttest'")]]`, fmt.Sprintf("%v", qr.Rows))
 }
 
 // TestCommitPreparedFailRetryable tests the case where the commit_prepared fails when the query is killed.
@@ -78,7 +78,7 @@ func TestCommitPreparedFailRetryable(t *testing.T) {
 	require.NoError(t, err)
 
 	client2 := framework.NewClient()
-	_, err = client2.BeginExecute(`select * from _vt.redo_state where dtid = _binary'aa' for update`, nil, nil)
+	_, err = client2.BeginExecute(`select * from _vt.redo_state where dtid = _binary'aa' and db_name = database() for update`, nil, nil)
 	require.NoError(t, err)
 
 	errCh := make(chan error, 1)
@@ -100,5 +100,5 @@ func TestCommitPreparedFailRetryable(t *testing.T) {
 
 	qr, err := client2.Execute("select dtid, state, message from _vt.redo_state where dtid = _binary'aa'", nil)
 	require.NoError(t, err)
-	require.Equal(t, `[[VARBINARY("aa") INT64(1) TEXT("Query execution was interrupted (errno 1317) (sqlstate 70100) during query: delete from _vt.redo_state where dtid = _binary'aa'")]]`, fmt.Sprintf("%v", qr.Rows))
+	require.Equal(t, `[[VARBINARY("aa") INT64(1) TEXT("Query execution was interrupted (errno 1317) (sqlstate 70100) during query: delete from _vt.redo_state where dtid = _binary'aa' and db_name = 'vttest'")]]`, fmt.Sprintf("%v", qr.Rows))
 }

--- a/go/vt/vttablet/tabletserver/dt_executor_test.go
+++ b/go/vt/vttablet/tabletserver/dt_executor_test.go
@@ -253,8 +253,9 @@ func TestTxExecutorCommitRedoFail(t *testing.T) {
 	require.NoError(t, err)
 
 	// fail commit prepare as the delete redo query is in rejected query.
-	db.AddRejectedQuery("delete from _vt.redo_state where dtid = _binary'bb'", errors.New("delete redo log fail"))
-	db.AddQuery("update _vt.redo_state set state = 0 where dtid = _binary'bb'", sqltypes.MakeTestResult(nil))
+	db.AddRejectedQuery("delete from _vt.redo_state where dtid = _binary'bb' and db_name = 'fakesqldb'", errors.New("delete redo log fail"))
+	db.AddQuery("select t.db_name from _vt.redo_state t where t.dtid = _binary'bb' and (t.db_name = 'fakesqldb' or (t.db_name = '' and not exists (select 1 from _vt.redo_state cur where cur.dtid = t.dtid and cur.db_name = 'fakesqldb')))", sqltypes.MakeTestResult(sqltypes.MakeTestFields("db_name", "varbinary"), "fakesqldb"))
+	db.AddQuery("update _vt.redo_state set state = 0, message = '' where dtid = _binary'bb' and db_name = 'fakesqldb'", &sqltypes.Result{RowsAffected: 1})
 	err = txe.CommitPrepared("bb")
 	require.ErrorContains(t, err, "delete redo log fail")
 
@@ -684,10 +685,10 @@ func newTestTxExecutor(t *testing.T, ctx context.Context) (txe *DTExecutor, tsv 
 	env := tabletenv.NewEnv(vtenv.NewTestEnv(), cfg, "TabletServerTest")
 	se := schema.NewEngine(env)
 	qe := NewQueryEngine(env, se)
-	db.AddQueryPattern("insert into _vt\\.redo_state\\(dtid, state, time_created\\) values \\(_binary'aa', 1,.*", &sqltypes.Result{})
+	db.AddQueryPattern("insert into _vt\\.redo_state\\(dtid, db_name, state, time_created\\) values \\(_binary'aa', 'fakesqldb', 1,.*", &sqltypes.Result{})
 	db.AddQueryPattern("insert into _vt\\.redo_statement.*", &sqltypes.Result{})
-	db.AddQuery("delete from _vt.redo_state where dtid = _binary'aa'", &sqltypes.Result{})
-	db.AddQuery("delete from _vt.redo_statement where dtid = _binary'aa'", &sqltypes.Result{})
+	db.AddQuery("delete from _vt.redo_state where dtid = _binary'aa' and db_name = 'fakesqldb'", &sqltypes.Result{RowsAffected: 1})
+	db.AddQuery("delete from _vt.redo_statement where dtid = _binary'aa' and db_name = 'fakesqldb'", &sqltypes.Result{})
 	db.AddQuery("update test_table set `name` = 2 where pk = 1 limit 10001", &sqltypes.Result{})
 	db.AddRejectedQuery("bogus", sqlerror.NewSQLError(sqlerror.ERUnknownError, sqlerror.SSUnknownSQLState, "bogus query"))
 	return &DTExecutor{
@@ -706,10 +707,10 @@ func newShortAgeExecutor(t *testing.T, ctx context.Context) (txe *DTExecutor, ts
 	db = setUpQueryExecutorTest(t)
 	logStats := tabletenv.NewLogStats(ctx, "TestTxExecutor", streamlog.NewQueryLogConfigForTest())
 	tsv = newTestTabletServer(ctx, smallTxPool|shortTwopcAge, db)
-	db.AddQueryPattern("insert into _vt\\.redo_state\\(dtid, state, time_created\\) values \\(_binary'aa', 1,.*", &sqltypes.Result{})
+	db.AddQueryPattern("insert into _vt\\.redo_state\\(dtid, db_name, state, time_created\\) values \\(_binary'aa', 'fakesqldb', 1,.*", &sqltypes.Result{})
 	db.AddQueryPattern("insert into _vt\\.redo_statement.*", &sqltypes.Result{})
-	db.AddQuery("delete from _vt.redo_state where dtid = _binary'aa'", &sqltypes.Result{})
-	db.AddQuery("delete from _vt.redo_statement where dtid = _binary'aa'", &sqltypes.Result{})
+	db.AddQuery("delete from _vt.redo_state where dtid = _binary'aa' and db_name = 'fakesqldb'", &sqltypes.Result{RowsAffected: 1})
+	db.AddQuery("delete from _vt.redo_statement where dtid = _binary'aa' and db_name = 'fakesqldb'", &sqltypes.Result{})
 	db.AddQuery("update test_table set `name` = 2 where pk = 1 limit 10001", &sqltypes.Result{})
 	return &DTExecutor{
 		ctx:      ctx,

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -2316,10 +2316,10 @@ func addQueryExecutorSupportedQueries(db *fakesqldb.DB) {
 				mysql.ShowPrimaryRow("msg", "id"),
 			},
 		},
-		"begin":                                {},
-		"commit":                               {},
-		"rollback":                             {},
-		fmt.Sprintf(readAllRedo, "_vt", "_vt"): {},
+		"begin":    {},
+		"commit":   {},
+		"rollback": {},
+		fmt.Sprintf(readAllRedo, "_vt", "_vt", sqltypes.EncodeStringSQL("fakesqldb"), "_vt", sqltypes.EncodeStringSQL("fakesqldb")): {},
 	}
 
 	sidecardb.AddSchemaInitQueries(db, true, sqlparser.NewTestParser())

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2900,10 +2900,10 @@ func addTabletServerSupportedQueries(db *fakesqldb.DB) {
 				Type: sqltypes.Int64,
 			}},
 		},
-		"begin":                                {},
-		"commit":                               {},
-		"rollback":                             {},
-		fmt.Sprintf(readAllRedo, "_vt", "_vt"): {},
+		"begin":    {},
+		"commit":   {},
+		"rollback": {},
+		fmt.Sprintf(readAllRedo, "_vt", "_vt", sqltypes.EncodeStringSQL("fakesqldb"), "_vt", sqltypes.EncodeStringSQL("fakesqldb")): {},
 	}
 	parser := sqlparser.NewTestParser()
 	sidecardb.AddSchemaInitQueries(db, true, parser)

--- a/go/vt/vttablet/tabletserver/twopc.go
+++ b/go/vt/vttablet/tabletserver/twopc.go
@@ -50,7 +50,8 @@ const (
 
 	readAllRedo = `select t.dtid, t.state, t.time_created, s.statement, t.message
 	from %s.redo_state t
-    join %s.redo_statement s on t.dtid = s.dtid
+    join %s.redo_statement s on t.dtid = s.dtid and t.db_name = s.db_name
+    where t.db_name = %s or (t.db_name = '' and not exists (select 1 from %s.redo_state cur where cur.dtid = t.dtid and cur.db_name = %s))
 	order by t.dtid, s.id`
 
 	readAllTransactions = `select t.dtid, t.state, t.time_created, p.keyspace, p.shard
@@ -74,8 +75,10 @@ const (
 // TwoPC performs 2PC metadata management (MM) functions.
 type TwoPC struct {
 	readPool *connpool.Pool
+	dbName   string
 
 	insertRedoTx        *sqlparser.ParsedQuery
+	readRedoDBName      *sqlparser.ParsedQuery
 	readRedoTx          *sqlparser.ParsedQuery
 	insertRedoStmt      *sqlparser.ParsedQuery
 	readRedoStmts       *sqlparser.ParsedQuery
@@ -106,30 +109,34 @@ func NewTwoPC(readPool *connpool.Pool) *TwoPC {
 func (tpc *TwoPC) initializeQueries() {
 	dbname := sidecar.GetIdentifier()
 	tpc.insertRedoTx = sqlparser.BuildParsedQuery(
-		"insert into %s.redo_state(dtid, state, time_created) values (%a, %a, %a)",
-		dbname, ":dtid", ":state", ":time_created")
+		"insert into %s.redo_state(dtid, db_name, state, time_created) values (%a, %a, %a, %a)",
+		dbname, ":dtid", ":db_name", ":state", ":time_created")
+	tpc.readRedoDBName = sqlparser.BuildParsedQuery(
+		"select t.db_name from %s.redo_state t where t.dtid = %a and (t.db_name = %a or (t.db_name = '' and not exists (select 1 from %s.redo_state cur where cur.dtid = t.dtid and cur.db_name = %a)))",
+		dbname, ":dtid", ":db_name", dbname, ":db_name")
 	tpc.readRedoTx = sqlparser.BuildParsedQuery(
-		"select state, time_created, message from %s.redo_state where dtid = %a",
-		dbname, ":dtid")
+		"select state, time_created, message from %s.redo_state t where t.dtid = %a and (t.db_name = %a or (t.db_name = '' and not exists (select 1 from %s.redo_state cur where cur.dtid = t.dtid and cur.db_name = %a)))",
+		dbname, ":dtid", ":db_name", dbname, ":db_name")
 	tpc.insertRedoStmt = sqlparser.BuildParsedQuery(
-		"insert into %s.redo_statement(dtid, id, statement) values %a",
+		"insert into %s.redo_statement(dtid, db_name, id, statement) values %a",
 		dbname, ":vals")
 	tpc.readRedoStmts = sqlparser.BuildParsedQuery(
-		"select statement from %s.redo_statement where dtid = %a order by id",
-		dbname, ":dtid")
+		"select statement from %s.redo_statement s where s.dtid = %a and (s.db_name = %a or (s.db_name = '' and not exists (select 1 from %s.redo_state cur where cur.dtid = s.dtid and cur.db_name = %a))) order by s.id",
+		dbname, ":dtid", ":db_name", dbname, ":db_name")
 	tpc.updateRedoTx = sqlparser.BuildParsedQuery(
-		"update %s.redo_state set state = %a, message = %a where dtid = %a",
-		dbname, ":state", ":message", ":dtid")
+		"update %s.redo_state set state = %a, message = %a where dtid = %a and db_name = %a",
+		dbname, ":state", ":message", ":dtid", ":db_name")
 	tpc.deleteRedoTx = sqlparser.BuildParsedQuery(
-		"delete from %s.redo_state where dtid = %a",
-		dbname, ":dtid")
+		"delete from %s.redo_state where dtid = %a and db_name = %a",
+		dbname, ":dtid", ":db_name")
 	tpc.deleteRedoStmt = sqlparser.BuildParsedQuery(
-		"delete from %s.redo_statement where dtid = %a",
-		dbname, ":dtid")
-	tpc.readAllRedo = fmt.Sprintf(readAllRedo, dbname, dbname)
+		"delete from %s.redo_statement where dtid = %a and db_name = %a",
+		dbname, ":dtid", ":db_name")
+	encodedDBName := sqltypes.EncodeStringSQL(tpc.dbName)
+	tpc.readAllRedo = fmt.Sprintf(readAllRedo, dbname, dbname, encodedDBName, dbname, encodedDBName)
 	tpc.countUnresolvedRedo = sqlparser.BuildParsedQuery(
-		"select count(*) from %s.redo_state where time_created < %a",
-		dbname, ":time_created")
+		"select count(*) from %s.redo_state t where t.time_created < %a and (t.db_name = %a or (t.db_name = '' and not exists (select 1 from %s.redo_state cur where cur.dtid = t.dtid and cur.db_name = %a)))",
+		dbname, ":time_created", ":db_name", dbname, ":db_name")
 
 	tpc.insertTransaction = sqlparser.BuildParsedQuery(
 		"insert into %s.dt_state(dtid, state, time_created) values (%a, %a, %a)",
@@ -179,8 +186,9 @@ func (tpc *TwoPC) Open(dbconfigs *dbconfigs.DBConfigs) error {
 	}
 	defer conn.Close()
 	tpc.readPool.Open(dbconfigs.AppWithDB(), dbconfigs.DbaWithDB(), dbconfigs.DbaWithDB())
+	tpc.dbName = dbconfigs.DBName
 	tpc.initializeQueries()
-	log.Info("TwoPC: Engine open succeeded")
+	log.Info(fmt.Sprintf("TwoPC: Engine open succeeded (dbName=%s)", tpc.dbName))
 	return nil
 }
 
@@ -193,6 +201,7 @@ func (tpc *TwoPC) Close() {
 func (tpc *TwoPC) SaveRedo(ctx context.Context, conn *StatefulConnection, dtid string, queries []tx.Query) error {
 	bindVars := map[string]*querypb.BindVariable{
 		"dtid":         sqltypes.BytesBindVariable([]byte(dtid)),
+		"db_name":      sqltypes.StringBindVariable(tpc.dbName),
 		"state":        sqltypes.Int64BindVariable(RedoStatePrepared),
 		"time_created": sqltypes.Int64BindVariable(time.Now().UnixNano()),
 	}
@@ -205,6 +214,7 @@ func (tpc *TwoPC) SaveRedo(ctx context.Context, conn *StatefulConnection, dtid s
 	for i, query := range queries {
 		rows[i] = []sqltypes.Value{
 			sqltypes.NewVarBinary(dtid),
+			sqltypes.NewVarBinary(tpc.dbName),
 			sqltypes.NewInt64(int64(i + 1)),
 			sqltypes.NewVarBinary(query.Sql),
 		}
@@ -224,24 +234,49 @@ func (tpc *TwoPC) SaveRedo(ctx context.Context, conn *StatefulConnection, dtid s
 func (tpc *TwoPC) UpdateRedo(ctx context.Context, conn *StatefulConnection, dtid string, state int, message string) error {
 	bindVars := map[string]*querypb.BindVariable{
 		"dtid":    sqltypes.BytesBindVariable([]byte(dtid)),
+		"db_name": sqltypes.StringBindVariable(tpc.dbName),
 		"state":   sqltypes.Int64BindVariable(int64(state)),
 		"message": sqltypes.StringBindVariable(message),
 	}
-	_, err := tpc.exec(ctx, conn, tpc.updateRedoTx, bindVars)
+	dbName, ok, err := tpc.resolveRedoDBName(ctx, conn, bindVars)
+	if err != nil || !ok {
+		return err
+	}
+	bindVars["db_name"] = sqltypes.StringBindVariable(dbName)
+	_, err = tpc.exec(ctx, conn, tpc.updateRedoTx, bindVars)
 	return err
 }
 
 // DeleteRedo deletes the redo log for the dtid.
 func (tpc *TwoPC) DeleteRedo(ctx context.Context, conn *StatefulConnection, dtid string) error {
 	bindVars := map[string]*querypb.BindVariable{
-		"dtid": sqltypes.BytesBindVariable([]byte(dtid)),
+		"dtid":    sqltypes.BytesBindVariable([]byte(dtid)),
+		"db_name": sqltypes.StringBindVariable(tpc.dbName),
 	}
-	_, err := tpc.exec(ctx, conn, tpc.deleteRedoTx, bindVars)
+	qr, err := tpc.exec(ctx, conn, tpc.deleteRedoTx, bindVars)
 	if err != nil {
 		return err
 	}
+	if qr.RowsAffected == 0 && tpc.dbName != "" {
+		bindVars["db_name"] = sqltypes.StringBindVariable("")
+		_, err = tpc.exec(ctx, conn, tpc.deleteRedoTx, bindVars)
+		if err != nil {
+			return err
+		}
+	}
 	_, err = tpc.exec(ctx, conn, tpc.deleteRedoStmt, bindVars)
 	return err
+}
+
+func (tpc *TwoPC) resolveRedoDBName(ctx context.Context, conn *StatefulConnection, bindVars map[string]*querypb.BindVariable) (string, bool, error) {
+	qr, err := tpc.exec(ctx, conn, tpc.readRedoDBName, bindVars)
+	if err != nil {
+		return "", false, err
+	}
+	if len(qr.Rows) == 0 {
+		return "", false, nil
+	}
+	return qr.Rows[0][0].ToString(), true, nil
 }
 
 // ReadAllRedo returns all the prepared transactions from the redo logs.
@@ -299,6 +334,7 @@ func (tpc *TwoPC) CountUnresolvedRedo(ctx context.Context, unresolvedTime time.T
 
 	bindVars := map[string]*querypb.BindVariable{
 		"time_created": sqltypes.Int64BindVariable(unresolvedTime.UnixNano()),
+		"db_name":      sqltypes.StringBindVariable(tpc.dbName),
 	}
 	qr, err := tpc.read(ctx, conn.Conn, tpc.countUnresolvedRedo, bindVars)
 	if err != nil {
@@ -431,7 +467,8 @@ func (tpc *TwoPC) GetTransactionInfo(ctx context.Context, dtid string) (*tabletm
 
 	result := &tabletmanagerdatapb.GetTransactionInfoResponse{}
 	bindVars := map[string]*querypb.BindVariable{
-		"dtid": sqltypes.BytesBindVariable([]byte(dtid)),
+		"dtid":    sqltypes.BytesBindVariable([]byte(dtid)),
+		"db_name": sqltypes.StringBindVariable(tpc.dbName),
 	}
 	qr, err := tpc.read(ctx, conn.Conn, tpc.readRedoTx, bindVars)
 	if err != nil {

--- a/go/vt/vttablet/tabletserver/twopc_test.go
+++ b/go/vt/vttablet/tabletserver/twopc_test.go
@@ -31,6 +31,67 @@ import (
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/tx"
 )
 
+func TestRedoQueriesDiscriminateTabletDBName(t *testing.T) {
+	newRedoStateInsert := func(dbName string) string {
+		tpc := NewTwoPC(nil)
+		tpc.dbName = dbName
+		tpc.initializeQueries()
+
+		q, err := tpc.insertRedoTx.GenerateQuery(map[string]*querypb.BindVariable{
+			"dtid":         sqltypes.BytesBindVariable([]byte("ks:-80:123")),
+			"db_name":      sqltypes.StringBindVariable(tpc.dbName),
+			"state":        sqltypes.Int64BindVariable(RedoStatePrepared),
+			"time_created": sqltypes.Int64BindVariable(1),
+		}, nil)
+		require.NoError(t, err)
+		return q
+	}
+
+	assert.Equal(t,
+		"insert into _vt.redo_state(dtid, db_name, state, time_created) values (_binary'ks:-80:123', 'vt_ks_-80', 1, 1)",
+		newRedoStateInsert("vt_ks_-80"),
+	)
+	assert.Equal(t,
+		"insert into _vt.redo_state(dtid, db_name, state, time_created) values (_binary'ks:-80:123', 'vt_ks_80-', 1, 1)",
+		newRedoStateInsert("vt_ks_80-"),
+	)
+}
+
+func TestRedoQueriesPreferTabletDBNameOverLegacyRows(t *testing.T) {
+	tpc := NewTwoPC(nil)
+	tpc.dbName = "vt_ks_-80"
+	tpc.initializeQueries()
+
+	assert.Equal(t, `select t.dtid, t.state, t.time_created, s.statement, t.message
+	from _vt.redo_state t
+    join _vt.redo_statement s on t.dtid = s.dtid and t.db_name = s.db_name
+    where t.db_name = 'vt_ks_-80' or (t.db_name = '' and not exists (select 1 from _vt.redo_state cur where cur.dtid = t.dtid and cur.db_name = 'vt_ks_-80'))
+	order by t.dtid, s.id`, tpc.readAllRedo)
+
+	bindVars := map[string]*querypb.BindVariable{
+		"dtid":    sqltypes.BytesBindVariable([]byte("ks:-80:123")),
+		"db_name": sqltypes.StringBindVariable(tpc.dbName),
+	}
+	readRedoTx, err := tpc.readRedoTx.GenerateQuery(bindVars, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "select state, time_created, message from _vt.redo_state t where t.dtid = _binary'ks:-80:123' and (t.db_name = 'vt_ks_-80' or (t.db_name = '' and not exists (select 1 from _vt.redo_state cur where cur.dtid = t.dtid and cur.db_name = 'vt_ks_-80')))", readRedoTx)
+
+	readRedoDBName, err := tpc.readRedoDBName.GenerateQuery(bindVars, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "select t.db_name from _vt.redo_state t where t.dtid = _binary'ks:-80:123' and (t.db_name = 'vt_ks_-80' or (t.db_name = '' and not exists (select 1 from _vt.redo_state cur where cur.dtid = t.dtid and cur.db_name = 'vt_ks_-80')))", readRedoDBName)
+
+	readRedoStmts, err := tpc.readRedoStmts.GenerateQuery(bindVars, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "select statement from _vt.redo_statement s where s.dtid = _binary'ks:-80:123' and (s.db_name = 'vt_ks_-80' or (s.db_name = '' and not exists (select 1 from _vt.redo_state cur where cur.dtid = s.dtid and cur.db_name = 'vt_ks_-80'))) order by s.id", readRedoStmts)
+
+	countUnresolvedRedo, err := tpc.countUnresolvedRedo.GenerateQuery(map[string]*querypb.BindVariable{
+		"time_created": sqltypes.Int64BindVariable(1),
+		"db_name":      sqltypes.StringBindVariable(tpc.dbName),
+	}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "select count(*) from _vt.redo_state t where t.time_created < 1 and (t.db_name = 'vt_ks_-80' or (t.db_name = '' and not exists (select 1 from _vt.redo_state cur where cur.dtid = t.dtid and cur.db_name = 'vt_ks_-80')))", countUnresolvedRedo)
+}
+
 func TestReadAllRedo(t *testing.T) {
 	ctx := t.Context()
 	// Reuse code from tx_executor_test.

--- a/go/vt/vttablet/tabletserver/tx_engine_test.go
+++ b/go/vt/vttablet/tabletserver/tx_engine_test.go
@@ -778,49 +778,50 @@ func TestCheckReceivedError(t *testing.T) {
 	}{{
 		receivedErr: vterrors.New(vtrpcpb.Code_DEADLINE_EXCEEDED, "deadline exceeded"),
 		retryable:   true,
-		expQuery:    `update _vt.redo_state set state = 1, message = 'deadline exceeded' where dtid = _binary'aa'`,
+		expQuery:    `update _vt.redo_state set state = 1, message = 'deadline exceeded' where dtid = _binary'aa' and db_name = 'fakesqldb'`,
 	}, {
 		receivedErr: vterrors.New(vtrpcpb.Code_INVALID_ARGUMENT, "invalid argument"),
 		retryable:   false,
-		expQuery:    `update _vt.redo_state set state = 0, message = 'invalid argument' where dtid = _binary'aa'`,
+		expQuery:    `update _vt.redo_state set state = 0, message = 'invalid argument' where dtid = _binary'aa' and db_name = 'fakesqldb'`,
 	}, {
 		receivedErr: sqlerror.NewSQLError(sqlerror.ERLockDeadlock, sqlerror.SSLockDeadlock, "Deadlock found when trying to get lock; try restarting transaction"),
 		retryable:   false,
-		expQuery:    `update _vt.redo_state set state = 0, message = 'Deadlock found when trying to get lock; try restarting transaction (errno 1213) (sqlstate 40001)' where dtid = _binary'aa'`,
+		expQuery:    `update _vt.redo_state set state = 0, message = 'Deadlock found when trying to get lock; try restarting transaction (errno 1213) (sqlstate 40001)' where dtid = _binary'aa' and db_name = 'fakesqldb'`,
 	}, {
 		receivedErr: context.DeadlineExceeded,
 		retryable:   true,
-		expQuery:    `update _vt.redo_state set state = 1, message = 'context deadline exceeded' where dtid = _binary'aa'`,
+		expQuery:    `update _vt.redo_state set state = 1, message = 'context deadline exceeded' where dtid = _binary'aa' and db_name = 'fakesqldb'`,
 	}, {
 		receivedErr: context.Canceled,
 		retryable:   true,
-		expQuery:    `update _vt.redo_state set state = 1, message = 'context canceled' where dtid = _binary'aa'`,
+		expQuery:    `update _vt.redo_state set state = 1, message = 'context canceled' where dtid = _binary'aa' and db_name = 'fakesqldb'`,
 	}, {
 		receivedErr: sqlerror.NewSQLError(sqlerror.CRServerLost, sqlerror.SSUnknownSQLState, "Lost connection to MySQL server during query"),
 		retryable:   true,
-		expQuery:    `update _vt.redo_state set state = 1, message = 'Lost connection to MySQL server during query (errno 2013) (sqlstate HY000)' where dtid = _binary'aa'`,
+		expQuery:    `update _vt.redo_state set state = 1, message = 'Lost connection to MySQL server during query (errno 2013) (sqlstate HY000)' where dtid = _binary'aa' and db_name = 'fakesqldb'`,
 	}, {
 		receivedErr: sqlerror.NewSQLError(sqlerror.CRMalformedPacket, sqlerror.SSUnknownSQLState, "Malformed packet"),
 		retryable:   false,
-		expQuery:    `update _vt.redo_state set state = 0, message = 'Malformed packet (errno 2027) (sqlstate HY000)' where dtid = _binary'aa'`,
+		expQuery:    `update _vt.redo_state set state = 0, message = 'Malformed packet (errno 2027) (sqlstate HY000)' where dtid = _binary'aa' and db_name = 'fakesqldb'`,
 	}, {
 		receivedErr: sqlerror.NewSQLError(sqlerror.CRServerGone, sqlerror.SSUnknownSQLState, "Server has gone away"),
 		retryable:   true,
-		expQuery:    `update _vt.redo_state set state = 1, message = 'Server has gone away (errno 2006) (sqlstate HY000)' where dtid = _binary'aa'`,
+		expQuery:    `update _vt.redo_state set state = 1, message = 'Server has gone away (errno 2006) (sqlstate HY000)' where dtid = _binary'aa' and db_name = 'fakesqldb'`,
 	}, {
 		receivedErr: vterrors.New(vtrpcpb.Code_ABORTED, "Row count exceeded"),
 		retryable:   false,
-		expQuery:    `update _vt.redo_state set state = 0, message = 'Row count exceeded' where dtid = _binary'aa'`,
+		expQuery:    `update _vt.redo_state set state = 0, message = 'Row count exceeded' where dtid = _binary'aa' and db_name = 'fakesqldb'`,
 	}, {
 		receivedErr: errors.New("(errno 2013) (sqlstate HY000) lost connection"),
 		retryable:   true,
-		expQuery:    `update _vt.redo_state set state = 1, message = '(errno 2013) (sqlstate HY000) lost connection' where dtid = _binary'aa'`,
+		expQuery:    `update _vt.redo_state set state = 1, message = '(errno 2013) (sqlstate HY000) lost connection' where dtid = _binary'aa' and db_name = 'fakesqldb'`,
 	}}
 
 	for _, tc := range tcases {
 		t.Run(tc.receivedErr.Error(), func(t *testing.T) {
 			if tc.expQuery != "" {
-				db.AddQuery(tc.expQuery, &sqltypes.Result{})
+				db.AddQuery("select t.db_name from _vt.redo_state t where t.dtid = _binary'aa' and (t.db_name = 'fakesqldb' or (t.db_name = '' and not exists (select 1 from _vt.redo_state cur where cur.dtid = t.dtid and cur.db_name = 'fakesqldb')))", sqltypes.MakeTestResult(sqltypes.MakeTestFields("db_name", "varbinary"), "fakesqldb"))
+				db.AddQuery(tc.expQuery, &sqltypes.Result{RowsAffected: 1})
 			}
 			nonRetryable := te.checkErrorAndMarkFailed(t.Context(), "aa", tc.receivedErr, "")
 			require.NotEqual(t, tc.retryable, nonRetryable)


### PR DESCRIPTION
## Description
Add `db_name` to the 2PC redo sidecar tables and include it in the primary keys so multiple vttablets sharing a mysqld instance do not collide when preparing the same distributed transaction DTID.

Record the tablet DB name when saving redo state/statements, and scope redo reads, updates, deletes, and unresolved counts by that DB name. Keep fallback visibility for rows with an empty db_name so pre-upgrade prepared redo records can still be recovered or cleaned up.

Update tabletserver, end-to-end, vtexplain, and binlog test expectations for the new redo table shape.

Issue was confirmed fixed locally when running vttestserver and executing 2PCs.

Fixes vitessio/vitess#19493

## Related Issue(s)
https://github.com/vitessio/vitess/issues/19493

## Checklist
-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes
2PC redo sidecar tables now include the tablet database name in their primary key. Existing prepared redo rows from before this change use an empty `db_name` and remain visible for recovery and cleanup during upgrade. New redo rows are scoped by tablet database name, preventing DTID collisions when multiple vttablets share the same mysqld instance.

Legacy redo rows without `db_name` remain recoverable for the existing isolated-sidecar deployment model. In shared-sidecar environments, legacy rows were already ambiguous because they did not record the owning tablet DB; this change fixes newly written redo rows but cannot safely infer ownership for pre-existing shared-sidecar redo.

### AI Disclosure
AI Assistance: This PR was written primarily by Codex. I used Codex to help root cause the initial issue while using vttestserver, then used Codex to determine and implement an appropriate fix.
