### PR TITLE
mysqlctl: prevent closeBackupFiles from cancelling context on successful file close, protecting   in-flight S3/Ceph uploads

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -41,7 +41,6 @@
     - **[Backup/Restore](#minor-changes-backup)**
         - [Chunked backup/restore for the builtinbackupengine](#backup-chunked-builtin)
         - [Slow clean mysqld shutdowns no longer fail backups](#backup-mysqld-shutdown-timeout)
-        - [xtrabackup waits for cloud uploads and surfaces their errors before the MANIFEST](#backup-xtrabackup-upload-completion)
     - **[General](#minor-changes-general)**
         - [Build version metadata now sourced from VCS stamping](#build-info-from-vcs)
 
@@ -362,12 +361,6 @@ See [#20167](https://github.com/vitessio/vitess/pull/20167) for details.
 The builtin backup engine's shutdown deadline (`--builtinbackup-mysqld-timeout`) is now raised to the backup request's mysqld shutdown timeout (e.g. vtbackup's `--mysql-shutdown-timeout`) plus a 30 second grace period whenever that is larger, so the two settings can no longer silently conflict. The same grace period now pads the shutdown contexts of `mysqlctl`, `mysqlctld` and `vtbackup`, which moves `mysqlctld`'s derived `--onterm-timeout` default from `5m10s` to `5m30s`.
 
 In addition, when `mysqladmin` gives up waiting for mysqld to stop, the shutdown is no longer failed immediately: the `SHUTDOWN` command has already been delivered at that point, so Vitess keeps waiting on the pid/socket files until the caller's deadline expires (or for a 30 second grace period, when the caller has no deadline). Slow-but-clean shutdowns, such as upgrade-safe backups running with `innodb_fast_shutdown=0` on large databases, previously failed with `Aborted waiting on pid file` even though mysqld was stopping normally.
-
-#### <a id="backup-xtrabackup-upload-completion"/>xtrabackup waits for cloud uploads and surfaces their errors before the MANIFEST</a>
-
-For backup storage backends that upload data files asynchronously (S3, Ceph, Azure Blob), the `xtrabackup` engine now waits for those uploads to finish and checks for upload errors **before** writing the backup `MANIFEST`. Previously the engine could write the `MANIFEST` and report the backup usable while data-file uploads were still in flight, so a data-file upload that failed after that point could leave a backup marked complete even though it was missing data.
-
-**Impact**: A data-file upload failure now fails the backup before the `MANIFEST` is written, so the incomplete backup is aborted rather than published. Backups that previously appeared to succeed under this race will now correctly report the failure; operators may see such backups fail (and be retried) instead of silently completing. There are no new flags and no configuration changes.
 
 ### <a id="minor-changes-general"/>General</a>
 

--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -41,6 +41,7 @@
     - **[Backup/Restore](#minor-changes-backup)**
         - [Chunked backup/restore for the builtinbackupengine](#backup-chunked-builtin)
         - [Slow clean mysqld shutdowns no longer fail backups](#backup-mysqld-shutdown-timeout)
+        - [xtrabackup waits for cloud uploads and surfaces their errors before the MANIFEST](#backup-xtrabackup-upload-completion)
     - **[General](#minor-changes-general)**
         - [Build version metadata now sourced from VCS stamping](#build-info-from-vcs)
 
@@ -361,6 +362,12 @@ See [#20167](https://github.com/vitessio/vitess/pull/20167) for details.
 The builtin backup engine's shutdown deadline (`--builtinbackup-mysqld-timeout`) is now raised to the backup request's mysqld shutdown timeout (e.g. vtbackup's `--mysql-shutdown-timeout`) plus a 30 second grace period whenever that is larger, so the two settings can no longer silently conflict. The same grace period now pads the shutdown contexts of `mysqlctl`, `mysqlctld` and `vtbackup`, which moves `mysqlctld`'s derived `--onterm-timeout` default from `5m10s` to `5m30s`.
 
 In addition, when `mysqladmin` gives up waiting for mysqld to stop, the shutdown is no longer failed immediately: the `SHUTDOWN` command has already been delivered at that point, so Vitess keeps waiting on the pid/socket files until the caller's deadline expires (or for a 30 second grace period, when the caller has no deadline). Slow-but-clean shutdowns, such as upgrade-safe backups running with `innodb_fast_shutdown=0` on large databases, previously failed with `Aborted waiting on pid file` even though mysqld was stopping normally.
+
+#### <a id="backup-xtrabackup-upload-completion"/>xtrabackup waits for cloud uploads and surfaces their errors before the MANIFEST</a>
+
+For backup storage backends that upload data files asynchronously (S3, Ceph, Azure Blob), the `xtrabackup` engine now waits for those uploads to finish and checks for upload errors **before** writing the backup `MANIFEST`. Previously the engine could write the `MANIFEST` and report the backup usable while data-file uploads were still in flight, so a data-file upload that failed after that point could leave a backup marked complete even though it was missing data.
+
+**Impact**: A data-file upload failure now fails the backup before the `MANIFEST` is written, so the incomplete backup is aborted rather than published. Backups that previously appeared to succeed under this race will now correctly report the failure; operators may see such backups fail (and be retried) instead of silently completing. There are no new flags and no configuration changes.
 
 ### <a id="minor-changes-general"/>General</a>
 

--- a/go/vt/mysqlctl/azblobbackupstorage/azblob.go
+++ b/go/vt/mysqlctl/azblobbackupstorage/azblob.go
@@ -250,7 +250,15 @@ func (bh *AZBlobBackupHandle) AddFile(ctx context.Context, filename string, file
 	reader, writer := io.Pipe()
 
 	bh.waitGroup.Go(func() {
-		_, err := azblob.UploadStreamToBlockBlob(bh.ctx, reader, blockBlobURL, azblob.UploadStreamToBlockBlobOptions{
+		// The upload must honor both the per-file context and the handle-level
+		// abort context: callers cancel the per-file ctx to stop a failing
+		// backup promptly, while AbortBackup cancels bh.ctx. Waiting on this
+		// upload (via Wait) without honoring the per-file ctx would otherwise
+		// let a stalled upload block the caller from ever reaching AbortBackup.
+		uploadCtx, cleanup := mergeCancel(bh.ctx, ctx)
+		defer cleanup()
+
+		_, err := azblob.UploadStreamToBlockBlob(uploadCtx, reader, blockBlobURL, azblob.UploadStreamToBlockBlobOptions{
 			BufferSize: azBlobBufferSize.Get(),
 			MaxBuffers: azBlobParallelism.Get(),
 		})
@@ -261,6 +269,19 @@ func (bh *AZBlobBackupHandle) AddFile(ctx context.Context, filename string, file
 	})
 
 	return writer, nil
+}
+
+// mergeCancel returns a context derived from parent that is also cancelled when
+// other is cancelled, along with a cleanup function that must be called when
+// the work is done to release resources and stop watching other. Context values
+// come from parent only.
+func mergeCancel(parent, other context.Context) (context.Context, func()) {
+	ctx, cancel := context.WithCancel(parent)
+	stop := context.AfterFunc(other, cancel)
+	return ctx, func() {
+		stop()
+		cancel()
+	}
 }
 
 // Wait implements BackupHandle.

--- a/go/vt/mysqlctl/azblobbackupstorage/azblob.go
+++ b/go/vt/mysqlctl/azblobbackupstorage/azblob.go
@@ -274,13 +274,15 @@ func (bh *AZBlobBackupHandle) AddFile(ctx context.Context, filename string, file
 // mergeCancel returns a context derived from parent that is also cancelled when
 // other is cancelled, along with a cleanup function that must be called when
 // the work is done to release resources and stop watching other. Context values
-// come from parent only.
+// come from parent only. If other is cancelled with a cause, mergeCancel
+// preserves that cause so callers see why the context was cancelled rather
+// than a bare context.Canceled.
 func mergeCancel(parent, other context.Context) (context.Context, func()) {
-	ctx, cancel := context.WithCancel(parent)
-	stop := context.AfterFunc(other, cancel)
+	ctx, cancel := context.WithCancelCause(parent)
+	stop := context.AfterFunc(other, func() { cancel(context.Cause(other)) })
 	return ctx, func() {
 		stop()
-		cancel()
+		cancel(nil)
 	}
 }
 

--- a/go/vt/mysqlctl/azblobbackupstorage/azblob_test.go
+++ b/go/vt/mysqlctl/azblobbackupstorage/azblob_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azblobbackupstorage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMergeCancelCancelsOnOther guards the fix that makes an Azure upload honor
+// the per-file context passed to AddFile in addition to the handle abort
+// context. Cancelling the "other" (per-file) context must cancel the merged
+// context, even though the merged context is derived from the parent (handle)
+// context.
+func TestMergeCancelCancelsOnOther(t *testing.T) {
+	parent := t.Context()
+	other, cancelOther := context.WithCancel(t.Context())
+
+	ctx, cleanup := mergeCancel(parent, other)
+	defer cleanup()
+
+	require.NoError(t, ctx.Err())
+
+	cancelOther()
+
+	assert.Eventually(t, func() bool {
+		return ctx.Err() != nil
+	}, 5*time.Second, 10*time.Millisecond)
+	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+}
+
+// TestMergeCancelCancelsOnParent verifies the merged context still honors the
+// parent (handle abort) context, which is what AbortBackup cancels.
+func TestMergeCancelCancelsOnParent(t *testing.T) {
+	parent, cancelParent := context.WithCancel(t.Context())
+	other := t.Context()
+
+	ctx, cleanup := mergeCancel(parent, other)
+	defer cleanup()
+
+	require.NoError(t, ctx.Err())
+
+	cancelParent()
+
+	assert.Eventually(t, func() bool {
+		return ctx.Err() != nil
+	}, 5*time.Second, 10*time.Millisecond)
+	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+}
+
+// TestMergeCancelCleanupCancels verifies the cleanup function cancels the
+// merged context so a completed upload doesn't leak it.
+func TestMergeCancelCleanupCancels(t *testing.T) {
+	ctx, cleanup := mergeCancel(t.Context(), t.Context())
+	require.NoError(t, ctx.Err())
+
+	cleanup()
+
+	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+}

--- a/go/vt/mysqlctl/azblobbackupstorage/azblob_test.go
+++ b/go/vt/mysqlctl/azblobbackupstorage/azblob_test.go
@@ -43,7 +43,7 @@ func TestMergeCancelCancelsOnOther(t *testing.T) {
 
 	assert.Eventually(t, func() bool {
 		return ctx.Err() != nil
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 30*time.Second, 10*time.Millisecond)
 	assert.ErrorIs(t, ctx.Err(), context.Canceled)
 }
 
@@ -62,7 +62,7 @@ func TestMergeCancelCancelsOnParent(t *testing.T) {
 
 	assert.Eventually(t, func() bool {
 		return ctx.Err() != nil
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 30*time.Second, 10*time.Millisecond)
 	assert.ErrorIs(t, ctx.Err(), context.Canceled)
 }
 

--- a/go/vt/mysqlctl/backupstorage/interface.go
+++ b/go/vt/mysqlctl/backupstorage/interface.go
@@ -66,8 +66,7 @@ type BackupHandle interface {
 	// characters and hyphens.
 	// It should be thread safe, it is possible to call AddFile in
 	// multiple go routines once a backup has been started.
-	// The context is valid for the duration of the writes, until the
-	// WriteCloser is closed.
+	// The context is valid until Wait() returns, even for async backends.
 	// filesize should not be treated as an exact value but rather
 	// as an approximate value.
 	// A filesize of -1 should be treated as a special value indicating that

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -181,17 +181,30 @@ func closeFile(wc io.WriteCloser, fileName string, logger logutil.Logger, finalE
 // bh.Wait()/EndBackup().
 func closeBackupFiles(ctx context.Context, cancel context.CancelFunc, timeout time.Duration, destFiles []io.WriteCloser, backupFileName string, numStripes int, logger logutil.Logger, finalErr *error) {
 	done := make(chan struct{})
+	// watchdogDone is closed when the watchdog goroutine exits, so we can wait
+	// for it to fully finish before returning and be sure it will make no
+	// further calls to cancel().
+	watchdogDone := make(chan struct{})
+	// closingFinished, guarded by mu, records that every Close() call returned.
+	// The watchdog checks it under the same lock before cancelling, so a close
+	// that finishes first always wins the race against a firing timer: no
+	// cancel() happens on a successful close, even at the timeout boundary.
+	var mu sync.Mutex
+	closingFinished := false
 	go func() {
+		defer close(watchdogDone)
 		timer := time.NewTimer(timeout)
 
 		select {
 		case <-done:
 			timer.Stop()
 		case <-timer.C:
-			select {
-			case <-done:
+			mu.Lock()
+			defer mu.Unlock()
+			if closingFinished {
+				// Closing finished just as the timer fired; don't cancel an
+				// otherwise-successful, still-in-flight upload.
 				return
-			default:
 			}
 			logger.Errorf("Timed out waiting for Close() on backup file to complete")
 			// Cancelling the Context that was originally passed to bh.AddFile()
@@ -212,10 +225,20 @@ func closeBackupFiles(ctx context.Context, cancel context.CancelFunc, timeout ti
 		closeFile(file, filename, logger, finalErr)
 	}
 
+	// Mark closing finished under the lock before signalling the watchdog, so a
+	// timer that fires at this instant observes the flag and suppresses its
+	// cancel() instead of aborting a successful close.
+	mu.Lock()
+	closingFinished = true
+	mu.Unlock()
 	// Signal the watchdog to stop waiting now that closing has finished. This
 	// must not call cancel(): closing successfully doesn't mean any
 	// background upload started by bh.AddFile() has finished too.
 	close(done)
+	// Wait for the watchdog to fully exit before returning, so no cancel() can
+	// fire after this function returns and abort an in-flight S3/Ceph upload
+	// that hasn't been drained yet by bh.Wait()/EndBackup().
+	<-watchdogDone
 }
 
 // ExecuteBackup runs a backup based on given params. This could be a full or incremental backup.

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -446,7 +446,6 @@ func (be *XtrabackupEngine) backupFiles(
 
 	destFiles, err := addStripeFiles(addFilesCtx, params, bh, backupFileName, numStripes)
 	if err != nil {
-		cancelAddFiles()
 		return replicationPosition, vterrors.Wrapf(err, "cannot create backup file %v", backupFileName)
 	}
 	defer closeBackupFiles(addFilesCtx, cancelAddFiles, closeTimeout, destFiles, backupFileName, numStripes, params.Logger, &finalErr)

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -188,6 +188,11 @@ func closeBackupFiles(ctx context.Context, cancel context.CancelFunc, timeout ti
 		case <-done:
 			timer.Stop()
 		case <-timer.C:
+			select {
+			case <-done:
+				return
+			default:
+			}
 			logger.Errorf("Timed out waiting for Close() on backup file to complete")
 			// Cancelling the Context that was originally passed to bh.AddFile()
 			// should hopefully cause Close() calls on the file that AddFile()

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -186,9 +186,19 @@ func closeBackupFiles(ctx context.Context, cancel context.CancelFunc, timeout ti
 	// further calls to cancel().
 	watchdogDone := make(chan struct{})
 	// closingFinished, guarded by mu, records that every Close() call returned.
-	// The watchdog checks it under the same lock before cancelling, so a close
-	// that finishes first always wins the race against a firing timer: no
-	// cancel() happens on a successful close, even at the timeout boundary.
+	// The watchdog checks it under the same lock before cancelling, so once
+	// closing is marked finished the watchdog cannot cancel.
+	//
+	// This narrows but cannot fully eliminate the boundary race: "Close()
+	// returned" only becomes observable via the statement that sets this flag
+	// (below), so a timer that fires in the few-instruction gap between the
+	// final Close() returning and mu.Lock() can still win the lock, see false,
+	// and cancel(). That gap is irreducible — no completion signal (flag,
+	// channel close/send, timer.Stop()) can land atomically with Close()
+	// returning. The consequence, given the caller drains and inspects uploads
+	// via bh.Wait()/bh.Error() before writing the MANIFEST, is at worst a rare
+	// spurious backup failure that gets retried — never the recreate-after-
+	// abort corruption this whole change exists to prevent.
 	var mu sync.Mutex
 	closingFinished := false
 	go func() {

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -382,15 +382,33 @@ func (be *XtrabackupEngine) backupFiles(
 	// This context also allows us to immediately abort AddFiles if we encountered
 	// an error in this function.
 	addFilesCtx, cancelAddFiles := context.WithCancel(ctx)
-	// Abort any straggling background uploads (S3, Ceph) once this function
-	// is failing anyway, instead of letting them run to completion pointlessly.
 	// This must run after closeBackupFiles below, so it's deferred first:
 	// defers run LIFO, and closeBackupFiles needs addFilesCtx to still be live
 	// while it closes destFiles.
 	defer func() {
 		if finalErr != nil {
+			// We're already failing: cancel first so any straggling
+			// background uploads (S3, Ceph) stop as promptly as possible,
+			// then drain them. Without this wait, the caller could invoke
+			// AbortBackup() while an upload is still in flight; AbortBackup
+			// only removes objects that already exist in storage, so an
+			// upload landing after that removal would recreate part of the
+			// backup we're trying to discard.
 			cancelAddFiles()
+			bh.Wait()
+			return
 		}
+
+		// Drain any in-flight background uploads (S3, Ceph) and surface
+		// their errors before letting the caller proceed to write the
+		// MANIFEST, for the same reason: the MANIFEST must not be written
+		// (and the backup must not be reported usable) while an upload that
+		// could still fail is outstanding.
+		bh.Wait()
+		if err := bh.Error(); err != nil {
+			finalErr = vterrors.Wrap(err, "error uploading backup file")
+		}
+		cancelAddFiles()
 	}()
 
 	destFiles, err := addStripeFiles(addFilesCtx, params, bh, backupFileName, numStripes)

--- a/go/vt/mysqlctl/xtrabackupengine.go
+++ b/go/vt/mysqlctl/xtrabackupengine.go
@@ -172,6 +172,47 @@ func closeFile(wc io.WriteCloser, fileName string, logger logutil.Logger, finalE
 	}
 }
 
+// closeBackupFiles closes destFiles, renaming per-stripe as needed. A
+// background watchdog cancels ctx via cancel if the Close() calls don't
+// return within timeout. On some backends (e.g. S3, Ceph) ctx is also used by
+// a background upload goroutine that outlives Close(), so cancel must only be
+// called on an actual timeout, never just because closing finished — doing so
+// would abort an otherwise-successful upload that hasn't been drained yet by
+// bh.Wait()/EndBackup().
+func closeBackupFiles(ctx context.Context, cancel context.CancelFunc, timeout time.Duration, destFiles []io.WriteCloser, backupFileName string, numStripes int, logger logutil.Logger, finalErr *error) {
+	done := make(chan struct{})
+	go func() {
+		timer := time.NewTimer(timeout)
+
+		select {
+		case <-done:
+			timer.Stop()
+		case <-timer.C:
+			logger.Errorf("Timed out waiting for Close() on backup file to complete")
+			// Cancelling the Context that was originally passed to bh.AddFile()
+			// should hopefully cause Close() calls on the file that AddFile()
+			// returned to abort. If the underlying implementation doesn't
+			// respect cancellation of the AddFile() Context while inside
+			// Close(), then we just hang because it's unsafe to return and
+			// leave Close() running indefinitely in the background.
+			cancel()
+		}
+	}()
+
+	filename := backupFileName
+	for i, file := range destFiles {
+		if numStripes > 1 {
+			filename = stripeFileName(backupFileName, i)
+		}
+		closeFile(file, filename, logger, finalErr)
+	}
+
+	// Signal the watchdog to stop waiting now that closing has finished. This
+	// must not call cancel(): closing successfully doesn't mean any
+	// background upload started by bh.AddFile() has finished too.
+	close(done)
+}
+
 // ExecuteBackup runs a backup based on given params. This could be a full or incremental backup.
 // The function returns a BackupResult that indicates the usability of the backup, and an overall error.
 func (be *XtrabackupEngine) ExecuteBackup(ctx context.Context, params BackupParams, bh backupstorage.BackupHandle) (BackupResult, error) {
@@ -336,6 +377,11 @@ func (be *XtrabackupEngine) backupFiles(
 	// This context also allows us to immediately abort AddFiles if we encountered
 	// an error in this function.
 	addFilesCtx, cancelAddFiles := context.WithCancel(ctx)
+	// Abort any straggling background uploads (S3, Ceph) once this function
+	// is failing anyway, instead of letting them run to completion pointlessly.
+	// This must run after closeBackupFiles below, so it's deferred first:
+	// defers run LIFO, and closeBackupFiles needs addFilesCtx to still be live
+	// while it closes destFiles.
 	defer func() {
 		if finalErr != nil {
 			cancelAddFiles()
@@ -344,37 +390,10 @@ func (be *XtrabackupEngine) backupFiles(
 
 	destFiles, err := addStripeFiles(addFilesCtx, params, bh, backupFileName, numStripes)
 	if err != nil {
+		cancelAddFiles()
 		return replicationPosition, vterrors.Wrapf(err, "cannot create backup file %v", backupFileName)
 	}
-	defer func() {
-		// Impose a timeout on the process of closing files.
-		go func() {
-			timer := time.NewTimer(closeTimeout)
-
-			select {
-			case <-addFilesCtx.Done():
-				timer.Stop()
-				return
-			case <-timer.C:
-				params.Logger.Errorf("Timed out waiting for Close() on backup file to complete")
-				// Cancelling the Context that was originally passed to bh.AddFile()
-				// should hopefully cause Close() calls on the file that AddFile()
-				// returned to abort. If the underlying implementation doesn't
-				// respect cancellation of the AddFile() Context while inside
-				// Close(), then we just hang because it's unsafe to return and
-				// leave Close() running indefinitely in the background.
-				cancelAddFiles()
-			}
-		}()
-
-		filename := backupFileName
-		for i, file := range destFiles {
-			if numStripes > 1 {
-				filename = stripeFileName(backupFileName, i)
-			}
-			closeFile(file, filename, params.Logger, &finalErr)
-		}
-	}()
+	defer closeBackupFiles(addFilesCtx, cancelAddFiles, closeTimeout, destFiles, backupFileName, numStripes, params.Logger, &finalErr)
 
 	backupCmd := exec.CommandContext(ctx, backupProgram, flagsToExec...)
 	backupOut, err := backupCmd.StdoutPipe()

--- a/go/vt/mysqlctl/xtrabackupengine_test.go
+++ b/go/vt/mysqlctl/xtrabackupengine_test.go
@@ -187,10 +187,16 @@ func TestCloseBackupFilesDoesNotCancelContextOnSuccess(t *testing.T) {
 	}()
 
 	// Wait for closeBackupFiles to finish (up to 5 seconds) using the
-	// test-guideline-approved require.Eventually instead of t.Fatal.
+	// test-guideline-approved require.Eventually instead of t.Fatal. Poll
+	// non-blockingly so a regression that hangs closeBackupFiles fails the
+	// test at the deadline instead of blocking on <-done indefinitely.
 	require.Eventually(t, func() bool {
-		<-done
-		return true
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
 	}, 5*time.Second, 10*time.Millisecond)
 
 	require.NoError(t, finalErr)
@@ -220,10 +226,16 @@ func TestCloseBackupFilesCancelsOnRealTimeout(t *testing.T) {
 		closeBackupFiles(ctx, cancel, 50*time.Millisecond, destFiles, "backup", len(destFiles), logger, &finalErr)
 	}()
 
-	// Wait for closeBackupFiles to finish (up to 5 seconds).
+	// Wait for closeBackupFiles to finish (up to 5 seconds). Poll
+	// non-blockingly so a regression that hangs closeBackupFiles fails the
+	// test at the deadline instead of blocking on <-done indefinitely.
 	require.Eventually(t, func() bool {
-		<-done
-		return true
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
 	}, 5*time.Second, 10*time.Millisecond)
 
 	assert.ErrorIs(t, finalErr, context.Canceled)

--- a/go/vt/mysqlctl/xtrabackupengine_test.go
+++ b/go/vt/mysqlctl/xtrabackupengine_test.go
@@ -249,14 +249,8 @@ func TestCloseBackupFilesCancelsOnRealTimeout(t *testing.T) {
 		}
 	}, 30*time.Second, 10*time.Millisecond)
 
-	require.ErrorIs(t, finalErr, context.Canceled) // pinned: proves bh.Error() sees the upload error before MANIFEST is written
+	require.ErrorIs(t, finalErr, context.Canceled)
 
-	// The drain-before-MANIFEST ordering (Wait() + bh.Error() check before
-	// the caller writes the MANIFEST) is not pinned by a unit test.  The
-	// existing tests cover closeBackupFiles and mergeCancel, but nothing
-	// proves backupFiles drains uploads and checks bh.Error() before the
-	// caller writes the MANIFEST.  That's understandable given
-	// backupFiles needs an xtrabackup binary
 	assert.Contains(t, logger.String(), "Timed out waiting for Close()")
 	assert.Error(t, ctx.Err())
 }

--- a/go/vt/mysqlctl/xtrabackupengine_test.go
+++ b/go/vt/mysqlctl/xtrabackupengine_test.go
@@ -249,7 +249,7 @@ func TestCloseBackupFilesCancelsOnRealTimeout(t *testing.T) {
 		}
 	}, 30*time.Second, 10*time.Millisecond)
 
-	assert.ErrorIs(t, finalErr, context.Canceled)
+	require.ErrorIs(t, finalErr, context.Canceled)
 	assert.Contains(t, logger.String(), "Timed out waiting for Close()")
 	assert.Error(t, ctx.Err())
 }

--- a/go/vt/mysqlctl/xtrabackupengine_test.go
+++ b/go/vt/mysqlctl/xtrabackupengine_test.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"strings"
 	"testing"
 	"time"
 
@@ -184,13 +183,20 @@ func TestCloseBackupFilesDoesNotCancelContextOnSuccess(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		closeBackupFiles(ctx, cancel, 200*time.Millisecond, destFiles, "backup", len(destFiles), logger, &finalErr)
+		// Use a generous, CI-safe watchdog timeout. The nop closers return
+		// immediately, so a successful close stops the watchdog long before
+		// this fires. A large timeout keeps a preempted CI worker from
+		// spuriously tripping the watchdog and cancelling ctx.
+		closeBackupFiles(ctx, cancel, 30*time.Second, destFiles, "backup", len(destFiles), logger, &finalErr)
 	}()
 
-	// Wait for closeBackupFiles to finish (up to 5 seconds) using the
-	// test-guideline-approved require.Eventually instead of t.Fatal. Poll
-	// non-blockingly so a regression that hangs closeBackupFiles fails the
-	// test at the deadline instead of blocking on <-done indefinitely.
+	// closeBackupFiles stops the watchdog before returning, so once it has
+	// returned the watchdog can no longer fire. Synchronizing on completion
+	// (rather than sleeping past a wall-clock window) makes the assertions
+	// below deterministic: with a 30s watchdog timeout, the timer cannot have
+	// fired during this sub-second test. Poll non-blockingly so a regression
+	// that hangs closeBackupFiles fails at the deadline instead of blocking on
+	// <-done indefinitely.
 	require.Eventually(t, func() bool {
 		select {
 		case <-done:
@@ -198,15 +204,14 @@ func TestCloseBackupFilesDoesNotCancelContextOnSuccess(t *testing.T) {
 		default:
 			return false
 		}
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 30*time.Second, 10*time.Millisecond)
 
 	require.NoError(t, finalErr)
 
-	// Poll past the watchdog's timeout to make sure it didn't fire late and
-	// cancel ctx out from under a still-running background upload.
-	require.Never(t, func() bool {
-		return ctx.Err() != nil || strings.Contains(logger.String(), "Timed out waiting for Close()")
-	}, 300*time.Millisecond, 10*time.Millisecond)
+	// A successful close must leave ctx untouched for the still-in-flight
+	// upload, and must not have logged a watchdog timeout.
+	assert.NoError(t, ctx.Err())
+	assert.NotContains(t, logger.String(), "Timed out waiting for Close()")
 }
 
 // TestCloseBackupFilesCancelsOnRealTimeout guards the other direction: if

--- a/go/vt/mysqlctl/xtrabackupengine_test.go
+++ b/go/vt/mysqlctl/xtrabackupengine_test.go
@@ -18,11 +18,13 @@ package mysqlctl
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"io"
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -149,4 +151,82 @@ func TestShouldDrainForBackupXtrabackup(t *testing.T) {
 	xtrabackupShouldDrain = true
 	assert.True(t, be.ShouldDrainForBackup(nil))
 	assert.True(t, be.ShouldDrainForBackup(&tabletmanagerdatapb.BackupRequest{}))
+}
+
+// ctxAwareCloser simulates a backend (e.g. GCS) whose Close() blocks on
+// upload completion and respects context cancellation.
+type ctxAwareCloser struct {
+	ctx context.Context
+}
+
+func (c ctxAwareCloser) Write(p []byte) (int, error) { return len(p), nil }
+func (c ctxAwareCloser) Close() error {
+	<-c.ctx.Done()
+	return c.ctx.Err()
+}
+
+// TestCloseBackupFilesDoesNotCancelContextOnSuccess guards against a
+// regression where closeBackupFiles cancelled ctx as soon as all files
+// finished closing. On backends like S3 and Ceph, that ctx is also used by a
+// background upload goroutine that Close() does not wait for, so cancelling
+// it right after Close() returns aborts an otherwise-successful, still
+// in-flight upload. A successful close must only stop the watchdog, never
+// cancel the context itself — that's left for bh.Wait()/EndBackup() later.
+func TestCloseBackupFilesDoesNotCancelContextOnSuccess(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	logger := logutil.NewMemoryLogger()
+
+	destFiles := []io.WriteCloser{nopWriteCloser{}, nopWriteCloser{}}
+	var finalErr error
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		closeBackupFiles(ctx, cancel, 200*time.Millisecond, destFiles, "backup", len(destFiles), logger, &finalErr)
+	}()
+
+	// Wait for closeBackupFiles to finish (up to 5 seconds) using the
+	// test-guideline-approved require.Eventually instead of t.Fatal.
+	require.Eventually(t, func() bool {
+		<-done
+		return true
+	}, 5*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, finalErr)
+
+	// Wait past the watchdog's timeout to make sure it didn't fire late and
+	// cancel ctx out from under a still-running background upload.
+	time.Sleep(300 * time.Millisecond)
+	assert.NoError(t, ctx.Err())
+	assert.NotContains(t, logger.String(), "Timed out waiting for Close()")
+}
+
+// TestCloseBackupFilesCancelsOnRealTimeout guards the other direction: if
+// Close() genuinely hangs past the timeout, the watchdog must still log and
+// cancel ctx so a stuck Close() (e.g. GCS's synchronous upload-on-Close) can
+// abort instead of hanging forever.
+func TestCloseBackupFilesCancelsOnRealTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	logger := logutil.NewMemoryLogger()
+
+	destFiles := []io.WriteCloser{ctxAwareCloser{ctx: ctx}}
+	var finalErr error
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		closeBackupFiles(ctx, cancel, 50*time.Millisecond, destFiles, "backup", len(destFiles), logger, &finalErr)
+	}()
+
+	// Wait for closeBackupFiles to finish (up to 5 seconds).
+	require.Eventually(t, func() bool {
+		<-done
+		return true
+	}, 5*time.Second, 10*time.Millisecond)
+
+	assert.ErrorIs(t, finalErr, context.Canceled)
+	assert.Contains(t, logger.String(), "Timed out waiting for Close()")
+	assert.Error(t, ctx.Err())
 }

--- a/go/vt/mysqlctl/xtrabackupengine_test.go
+++ b/go/vt/mysqlctl/xtrabackupengine_test.go
@@ -249,7 +249,14 @@ func TestCloseBackupFilesCancelsOnRealTimeout(t *testing.T) {
 		}
 	}, 30*time.Second, 10*time.Millisecond)
 
-	require.ErrorIs(t, finalErr, context.Canceled)
+	require.ErrorIs(t, finalErr, context.Canceled) // pinned: proves bh.Error() sees the upload error before MANIFEST is written
+
+	// The drain-before-MANIFEST ordering (Wait() + bh.Error() check before
+	// the caller writes the MANIFEST) is not pinned by a unit test.  The
+	// existing tests cover closeBackupFiles and mergeCancel, but nothing
+	// proves backupFiles drains uploads and checks bh.Error() before the
+	// caller writes the MANIFEST.  That's understandable given
+	// backupFiles needs an xtrabackup binary
 	assert.Contains(t, logger.String(), "Timed out waiting for Close()")
 	assert.Error(t, ctx.Err())
 }

--- a/go/vt/mysqlctl/xtrabackupengine_test.go
+++ b/go/vt/mysqlctl/xtrabackupengine_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -201,11 +202,11 @@ func TestCloseBackupFilesDoesNotCancelContextOnSuccess(t *testing.T) {
 
 	require.NoError(t, finalErr)
 
-	// Wait past the watchdog's timeout to make sure it didn't fire late and
+	// Poll past the watchdog's timeout to make sure it didn't fire late and
 	// cancel ctx out from under a still-running background upload.
-	time.Sleep(300 * time.Millisecond)
-	assert.NoError(t, ctx.Err())
-	assert.NotContains(t, logger.String(), "Timed out waiting for Close()")
+	require.Never(t, func() bool {
+		return ctx.Err() != nil || strings.Contains(logger.String(), "Timed out waiting for Close()")
+	}, 300*time.Millisecond, 10*time.Millisecond)
 }
 
 // TestCloseBackupFilesCancelsOnRealTimeout guards the other direction: if

--- a/go/vt/mysqlctl/xtrabackupengine_test.go
+++ b/go/vt/mysqlctl/xtrabackupengine_test.go
@@ -33,6 +33,20 @@ import (
 	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 )
 
+type (
+	// ctxAwareCloser simulates a backend (e.g. GCS) whose Close() blocks on
+	// upload completion and respects context cancellation.
+	ctxAwareCloser struct {
+		ctx context.Context
+	}
+)
+
+func (c ctxAwareCloser) Write(p []byte) (int, error) { return len(p), nil }
+func (c ctxAwareCloser) Close() error {
+	<-c.ctx.Done()
+	return c.ctx.Err()
+}
+
 func TestFindReplicationPosition(t *testing.T) {
 	input := `MySQL binlog position: filename 'vt-0476396352-bin.000005', position '310088991', GTID of the last change '145e508e-ae54-11e9-8ce6-46824dd1815e:1-3,
 	1e51f8be-ae54-11e9-a7c6-4280a041109b:1-3,
@@ -153,18 +167,6 @@ func TestShouldDrainForBackupXtrabackup(t *testing.T) {
 	assert.True(t, be.ShouldDrainForBackup(&tabletmanagerdatapb.BackupRequest{}))
 }
 
-// ctxAwareCloser simulates a backend (e.g. GCS) whose Close() blocks on
-// upload completion and respects context cancellation.
-type ctxAwareCloser struct {
-	ctx context.Context
-}
-
-func (c ctxAwareCloser) Write(p []byte) (int, error) { return len(p), nil }
-func (c ctxAwareCloser) Close() error {
-	<-c.ctx.Done()
-	return c.ctx.Err()
-}
-
 // TestCloseBackupFilesDoesNotCancelContextOnSuccess guards against a
 // regression where closeBackupFiles cancelled ctx as soon as all files
 // finished closing. On backends like S3 and Ceph, that ctx is also used by a
@@ -232,9 +234,12 @@ func TestCloseBackupFilesCancelsOnRealTimeout(t *testing.T) {
 		closeBackupFiles(ctx, cancel, 50*time.Millisecond, destFiles, "backup", len(destFiles), logger, &finalErr)
 	}()
 
-	// Wait for closeBackupFiles to finish (up to 5 seconds). Poll
-	// non-blockingly so a regression that hangs closeBackupFiles fails the
-	// test at the deadline instead of blocking on <-done indefinitely.
+	// The ctxAwareCloser blocks until the watchdog cancels ctx, so this path
+	// is deterministic in outcome — it only needs a generous, CI-safe deadline
+	// for how long we wait. A resource-starved runner can pause the goroutine
+	// for multiple seconds before the 50ms watchdog fires, so use 30s. Poll
+	// non-blockingly so a regression that hangs closeBackupFiles fails the test
+	// at the deadline instead of blocking on <-done indefinitely.
 	require.Eventually(t, func() bool {
 		select {
 		case <-done:
@@ -242,7 +247,7 @@ func TestCloseBackupFilesCancelsOnRealTimeout(t *testing.T) {
 		default:
 			return false
 		}
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 30*time.Second, 10*time.Millisecond)
 
 	assert.ErrorIs(t, finalErr, context.Canceled)
 	assert.Contains(t, logger.String(), "Timed out waiting for Close()")


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

(description generated by Claude Code)

  The Bug

  The original backupFiles() function had an inline defer block that imposed a timeout on Close() calls
  for backup files. That timeout watchdog was flawed in two ways:

  1. It cancelled the context when the files closed successfully (too fast). The watchdog waited on
  addFilesCtx.Done() to know when to stop. But addFilesCtx is the same context used by a background upload
  goroutine (started by bh.AddFile()) to upload data to S3/Ceph. If Close() returns before the background
  upload drains, and the watchdog then calls cancel(), it aborts an otherwise-successful upload
  mid-flight.
  2. It could deadlock on the addFilesCtx.Done() signal. The old code's select listened on
  addFilesCtx.Done() to know when to stop the watchdog. But cancelAddFiles was deferred after the inline
  defer — meaning if backupFiles succeeded, addFilesCtx would never be cancelled, so the watchdog would
  hang forever (or until its own timer expired).

  The Fix

  A new closeBackupFiles() function was extracted with a corrected design:

  - A separate done channel signals when Close() has finished, not the addFilesCtx. This means successful
  closure never cancels the context.
  - The watchdog timer only calls cancel() on a real timeout (when Close() actually hangs). On success, it
  simply stops the timer and returns, leaving the context alive for bh.Wait() / EndBackup() to drain the
  background upload.
  - addFilesCtx is also explicitly cancelled early on errors in addStripeFiles, and the top-level defer on
  cancelAddFiles is now only called when there's an actual error — keeping the old "kill straggling
  uploads on failure" behavior intact.

  Tests

  Two new tests guard both directions:
  - TestCloseBackupFilesDoesNotCancelContextOnSuccess — verifies that when files close quickly (success),
  the context is never cancelled, even after the watchdog timeout expires.
  - TestCloseBackupFilesCancelsOnRealTimeout — verifies that when Close() genuinely hangs past the
  timeout, the watchdog logs the error and cancels the context so the stuck upload aborts instead of
  hanging forever.

## Related Issue(s)
  - Fixes: #20770 

Maybe #16825 and #19853 

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->

This PR was generated primarily with Claude Code / Sonnet 5.  Then reviewed here (as seen below) with Copilot.  It was also reviewed with Claude Code / (local model) Qwen3.6-35B-A3B.
