### PR TITLE
vtexplain: handle sequence comments case-insensitively

### DIFF
--- a/go/vt/vtexplain/vtexplain_test.go
+++ b/go/vt/vtexplain/vtexplain_test.go
@@ -182,6 +182,59 @@ func TestExplain(t *testing.T) {
 	}
 }
 
+func TestExplainSequenceTableCommentCase(t *testing.T) {
+	const (
+		vSchema = `{
+  "commerce": {
+    "sharded": false,
+    "tables": {
+      "customer": {
+        "auto_increment": {
+          "column": "id",
+          "sequence": "commerce.customer_seq"
+        }
+      },
+      "customer_seq": {
+        "type": "sequence"
+      }
+    }
+  }
+}`
+		schema = `create table customer (
+  id bigint not null,
+  email varchar(128),
+  primary key(id)
+);
+create table customer_seq (
+  id bigint not null,
+  next_id bigint,
+  cache bigint,
+  primary key(id)
+) %s 'vitess_sequence';`
+		query = "insert into customer(email) values ('alice@example.com')"
+	)
+
+	for _, keyword := range []string{"comment", "COMMENT", "CoMmEnT"} {
+		t.Run(keyword, func(t *testing.T) {
+			ctx := utils.LeakCheckContext(t)
+			ts := memorytopo.NewServer(ctx, Cell)
+			opts := defaultTestOpts()
+			opts.ExecutionMode = ModeMulti
+			srvTopoCounts := stats.NewCountersWithSingleLabel("", "Resilient srvtopo server operations", "type")
+			vte, err := Init(ctx, vtenv.NewTestEnv(), ts, vSchema, fmt.Sprintf(schema, keyword), "", opts, srvTopoCounts)
+			require.NoError(t, err)
+			t.Cleanup(vte.Stop)
+
+			explains, err := vte.Run(query)
+			require.NoError(t, err)
+
+			explainText, err := vte.ExplainsAsText(explains)
+			require.NoError(t, err)
+			require.Contains(t, explainText, "select next_id, cache from customer_seq where id = 0 for update")
+		})
+	}
+}
+
 func TestErrors(t *testing.T) {
 	ctx := utils.LeakCheckContext(t)
 	ts := memorytopo.NewServer(ctx, Cell)

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -437,7 +437,7 @@ func newTabletEnvironment(ddls []sqlparser.DDLStatement, opts *Options, collatio
 		spec := ddl.GetTableSpec()
 		if spec != nil {
 			for _, option := range spec.Options {
-				if option.Name == "comment" && string(option.Value.Val) == "vitess_sequence" {
+				if strings.EqualFold(option.Name, "comment") && string(option.Value.Val) == "vitess_sequence" {
 					options = "vitess_sequence"
 				}
 			}


### PR DESCRIPTION
## Description

vtexplain now recognizes sequence tables when the DDL uses uppercase or mixed-case `COMMENT`. The parser preserves table-option keyword casing, so the previous case-sensitive comparison omitted the `vitess_sequence` metadata.

The option keyword comparison now uses `strings.EqualFold`, while the `vitess_sequence` sentinel remains exact. The regression test exercises lowercase, uppercase, and mixed-case forms through the user-visible vtexplain insert path.

## Related Issue(s)

Fixes #14941

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [ ] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

vtexplain now accepts case-insensitive SQL spelling of the `COMMENT` table option when identifying `vitess_sequence` tables. No migration or runtime deployment steps are required.

### AI Disclosure

This PR was developed with assistance from an LLM. I made all key decisions, determined the technical direction, and personally reviewed and validated the final changes.
