### PR TITLE
evalengine: round to target scale in CAST to DECIMAL(M,D) #20750

### DIFF
--- a/go/vt/vtgate/evalengine/compiler_test.go
+++ b/go/vt/vtgate/evalengine/compiler_test.go
@@ -871,6 +871,18 @@ func TestCompilerSingle(t *testing.T) {
 			expression: `GREATEST(JSON_OBJECT(), JSON_ARRAY())`,
 			result:     `VARCHAR("{}")`,
 		},
+		{
+			expression: `CAST('0.5' AS DECIMAL(10,0))`,
+			result:     `DECIMAL(1)`,
+		},
+		{
+			expression: `CAST('0.4' AS DECIMAL(10,0)) + 0.3`,
+			result:     `DECIMAL(0.3)`,
+		},
+		{
+			expression: `CAST('1.44' AS DECIMAL(10,1)) + 0.01`,
+			result:     `DECIMAL(1.41)`,
+		},
 	}
 
 	tz, _ := time.LoadLocation("Europe/Madrid")

--- a/go/vt/vtgate/evalengine/eval_numeric.go
+++ b/go/vt/vtgate/evalengine/eval_numeric.go
@@ -89,6 +89,12 @@ func newEvalFloat(f float64) *evalFloat {
 }
 
 func newEvalDecimal(dec decimal.Decimal, m, d int32) *evalDecimal {
+	// When a target scale is specified (e.g. CAST(x AS DECIMAL(m,d))), MySQL rounds
+	// the value to d fractional digits before applying precision limits. The (0, 0)
+	// case is used for generic decimal conversion without an explicit scale.
+	if !(m == 0 && d == 0) {
+		dec = dec.Round(d)
+	}
 	switch {
 	case m == 0 && d == 0:
 		return newEvalDecimalWithPrec(dec, -dec.Exponent())


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
RCA: 
Queries like `SELECT CAST('0.5' AS DECIMAL(10,0));` are typically written as bare `SELECT` expressions (no real table), so `gen4SelectStmtPlanner` takes the `isOnlyDual` path: `handleDualSelects` builds an `engine.Projection` over `engine.SingleRow`, and the expressions are evaluated entirely at VTGate via the evalengine — they never reach a tablet.

`CAST(... AS DECIMAL(M,D))` in the evalengine did not round to scale `D` before applying precision limits. `newEvalDecimal` only called `decimal.Clamp`, which caps integral overflow but leaves fractional digits untouched when the integral part already fits.
That caused two classes of MySQL mismatches:
- **Hidden precision leaking into arithmetic** — e.g. `CAST('0.4' AS DECIMAL(10,0)) + 0.3` returned `0.7` instead of `0.3`
- **Incorrect scale-0 results** — e.g. `CAST('0.5' AS DECIMAL(10,0))` returned `0` instead of `1`

FIX:
Round to scale `D` in `newEvalDecimal` when an explicit target scale is specified (`!(m == 0 && d == 0)`), then apply the existing `Clamp` logic. Generic `CAST(x AS DECIMAL)` without explicit scale is unchanged.

## Related Issue(s)
Fixes #20750
<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
**User-visible behavior change** (VTGate evalengine). No schema migrations, config changes, or flags are touched. Fixes `CAST(... AS DECIMAL(M,D))` rounding to match MySQL for evalengine-evaluated expressions. 
### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
All the code is written by Claude Code. Directions were provided by me.