### PR TITLE
charset: distinguish unmappable from malformed multibyte sequences

### DIFF
--- a/go/mysql/collations/charset/charset_test.go
+++ b/go/mysql/collations/charset/charset_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/collations/charset/types"
 )
 
 func TestIsMultibyteByName(t *testing.T) {
@@ -153,10 +155,10 @@ func TestDecodeRuneWidthContract(t *testing.T) {
 
 	for _, cs := range charsets {
 		t.Run(cs.Name(), func(t *testing.T) {
-			r, width, ok := cs.DecodeRune(nil)
+			r, width, d := cs.DecodeRune(nil)
 			require.Equal(t, RuneError, r)
 			require.Zero(t, width)
-			require.False(t, ok)
+			require.Equal(t, types.DecodeInvalid, d)
 
 			for _, in := range inputs {
 				_, width, _ := cs.DecodeRune(in)
@@ -184,8 +186,8 @@ func TestGB18030PUAMapping(t *testing.T) {
 		{[]byte{0xA2, 0xE3}, 0x20AC},
 	}
 	for _, tc := range testCases {
-		r, width, ok := cs.DecodeRune(tc.bytes)
-		require.True(t, ok, "DecodeRune(%X)", tc.bytes)
+		r, width, d := cs.DecodeRune(tc.bytes)
+		require.Equal(t, types.DecodeOK, d, "DecodeRune(%X)", tc.bytes)
 		require.Equal(t, tc.r, r, "DecodeRune(%X)", tc.bytes)
 		require.Equal(t, len(tc.bytes), width, "DecodeRune(%X)", tc.bytes)
 
@@ -200,8 +202,8 @@ func TestGB18030PUAMapping(t *testing.T) {
 			if trail == 0x7F {
 				continue
 			}
-			r, width, ok := cs.DecodeRune([]byte{byte(lead), byte(trail)})
-			require.True(t, ok, "DecodeRune(%X %X) = %U", lead, trail, r)
+			r, width, d := cs.DecodeRune([]byte{byte(lead), byte(trail)})
+			require.Equal(t, types.DecodeOK, d, "DecodeRune(%X %X) = %U", lead, trail, r)
 			require.Equal(t, 2, width)
 		}
 	}
@@ -209,66 +211,66 @@ func TestGB18030PUAMapping(t *testing.T) {
 
 func TestDecodeRuneValidity(t *testing.T) {
 	testCases := []struct {
-		name      string
-		cs        Charset
-		input     []byte
-		wantRune  rune
-		wantWidth int
-		wantOK    bool
+		name         string
+		cs           Charset
+		input        []byte
+		wantRune     rune
+		wantWidth    int
+		wantDecoding types.Decoding
 	}{
-		{"utf8mb3 valid RuneError", Charset_utf8mb3{}, []byte{0xEF, 0xBF, 0xBD}, RuneError, 3, true},
-		{"utf8mb3 invalid", Charset_utf8mb3{}, []byte{0xFF}, RuneError, 1, false},
-		{"utf8mb4 valid RuneError", Charset_utf8mb4{}, []byte{0xEF, 0xBF, 0xBD}, RuneError, 3, true},
-		{"utf8mb4 invalid", Charset_utf8mb4{}, []byte{0xFF}, RuneError, 1, false},
-		{"utf16 valid RuneError", Charset_utf16{}, []byte{0xFF, 0xFD}, RuneError, 2, true},
-		{"utf16 unpaired surrogate", Charset_utf16{}, []byte{0xD8, 0x00}, RuneError, 2, false},
-		{"utf16 broken surrogate pair", Charset_utf16{}, []byte{0xD8, 0x00, 0x00, 0x31}, RuneError, 2, false},
-		{"utf16le valid RuneError", Charset_utf16le{}, []byte{0xFD, 0xFF}, RuneError, 2, true},
-		{"utf16le unpaired surrogate", Charset_utf16le{}, []byte{0x00, 0xD8}, RuneError, 2, false},
-		{"ucs2 valid RuneError", Charset_ucs2{}, []byte{0xFF, 0xFD}, RuneError, 2, true},
-		{"ucs2 invalid", Charset_ucs2{}, []byte{0x00}, RuneError, 1, false},
-		{"ucs2 high surrogate", Charset_ucs2{}, []byte{0xD8, 0x00}, RuneError, 2, false},
-		{"ucs2 low surrogate", Charset_ucs2{}, []byte{0xDC, 0x00}, RuneError, 2, false},
-		{"utf32 valid RuneError", Charset_utf32{}, []byte{0x00, 0x00, 0xFF, 0xFD}, RuneError, 4, true},
-		{"utf32 invalid", Charset_utf32{}, []byte{0x00}, RuneError, 1, false},
-		{"utf32 surrogate", Charset_utf32{}, []byte{0x00, 0x00, 0xD8, 0x00}, RuneError, 4, false},
-		{"utf32 beyond max rune", Charset_utf32{}, []byte{0x00, 0x11, 0x00, 0x00}, RuneError, 4, false},
-		{"utf32 negative rune", Charset_utf32{}, []byte{0xFF, 0xFF, 0xFF, 0xFF}, RuneError, 4, false},
-		{"gb18030 invalid", Charset_gb18030{}, []byte{0xFF}, RuneError, 1, false},
-		{"gb18030 invalid lead 0x80", Charset_gb18030{}, []byte{0x80, 0x41}, RuneError, 1, false},
-		{"gb18030 second byte beyond digits", Charset_gb18030{}, []byte{0x81, 0x3A, 0x81, 0x30}, RuneError, 1, false},
-		{"gb18030 third byte beyond 0xFE", Charset_gb18030{}, []byte{0x81, 0x30, 0xFF, 0x30}, RuneError, 1, false},
-		{"gb18030 reserved pointer", Charset_gb18030{}, []byte{0x84, 0x31, 0xA5, 0x30}, RuneError, 4, false},
-		{"gb18030 four byte minimum", Charset_gb18030{}, []byte{0x81, 0x30, 0x81, 0x30}, 0x80, 4, true},
-		{"gb18030 four byte maximum", Charset_gb18030{}, []byte{0xE3, 0x32, 0x9A, 0x35}, 0x10FFFF, 4, true},
-		{"gb2312 invalid", Charset_gb2312{}, []byte{0xFF}, RuneError, 1, false},
-		{"gb2312 aliasing trail", Charset_gb2312{}, []byte{0xA1, 0x21}, RuneError, 1, false},
-		{"gb2312 invalid trail", Charset_gb2312{}, []byte{0xA1, 0x20}, RuneError, 1, false},
-		{"gb2312 invalid lead", Charset_gb2312{}, []byte{0xF8, 0xA1}, RuneError, 1, false},
-		{"ujis invalid", Charset_ujis{}, []byte{0xFF}, RuneError, 1, false},
-		{"ujis kana invalid trail", Charset_ujis{}, []byte{0x8E, 0xE5}, RuneError, 1, false},
-		{"ujis plane2 invalid trail", Charset_ujis{}, []byte{0x8F, 0xA1, 0x20}, RuneError, 1, false},
-		{"ujis plane2 truncated", Charset_ujis{}, []byte{0x8F, 0xA1}, RuneError, 1, false},
-		{"ujis unassigned pair", Charset_ujis{}, []byte{0xA2, 0xF1}, RuneError, 2, false},
-		{"sjis invalid", Charset_sjis{}, []byte{0x81}, RuneError, 1, false},
-		{"sjis invalid lead", Charset_sjis{}, []byte{0x80, 0x41}, RuneError, 1, false},
-		{"sjis invalid trail", Charset_sjis{}, []byte{0x81, 0x20}, RuneError, 1, false},
-		{"sjis unassigned pair", Charset_sjis{}, []byte{0x81, 0xAD}, RuneError, 2, false},
-		{"cp932 invalid", Charset_cp932{}, []byte{0x81}, RuneError, 1, false},
-		{"cp932 invalid trail", Charset_cp932{}, []byte{0x81, 0x20}, RuneError, 1, false},
-		{"eucjpms invalid", Charset_eucjpms{}, []byte{0xFF}, RuneError, 1, false},
-		{"euckr invalid", Charset_euckr{}, []byte{0xFF}, RuneError, 1, false},
-		{"euckr invalid trail", Charset_euckr{}, []byte{0xB0, 0xFF}, RuneError, 1, false},
-		{"euckr gap trail", Charset_euckr{}, []byte{0xB0, 0x5B}, RuneError, 1, false},
-		{"euckr unassigned pair", Charset_euckr{}, []byte{0xC9, 0x41}, RuneError, 2, false},
+		{"utf8mb3 valid RuneError", Charset_utf8mb3{}, []byte{0xEF, 0xBF, 0xBD}, RuneError, 3, types.DecodeOK},
+		{"utf8mb3 invalid", Charset_utf8mb3{}, []byte{0xFF}, RuneError, 1, types.DecodeInvalid},
+		{"utf8mb4 valid RuneError", Charset_utf8mb4{}, []byte{0xEF, 0xBF, 0xBD}, RuneError, 3, types.DecodeOK},
+		{"utf8mb4 invalid", Charset_utf8mb4{}, []byte{0xFF}, RuneError, 1, types.DecodeInvalid},
+		{"utf16 valid RuneError", Charset_utf16{}, []byte{0xFF, 0xFD}, RuneError, 2, types.DecodeOK},
+		{"utf16 unpaired surrogate", Charset_utf16{}, []byte{0xD8, 0x00}, RuneError, 2, types.DecodeInvalid},
+		{"utf16 broken surrogate pair", Charset_utf16{}, []byte{0xD8, 0x00, 0x00, 0x31}, RuneError, 2, types.DecodeInvalid},
+		{"utf16le valid RuneError", Charset_utf16le{}, []byte{0xFD, 0xFF}, RuneError, 2, types.DecodeOK},
+		{"utf16le unpaired surrogate", Charset_utf16le{}, []byte{0x00, 0xD8}, RuneError, 2, types.DecodeInvalid},
+		{"ucs2 valid RuneError", Charset_ucs2{}, []byte{0xFF, 0xFD}, RuneError, 2, types.DecodeOK},
+		{"ucs2 invalid", Charset_ucs2{}, []byte{0x00}, RuneError, 1, types.DecodeInvalid},
+		{"ucs2 high surrogate", Charset_ucs2{}, []byte{0xD8, 0x00}, RuneError, 2, types.DecodeInvalid},
+		{"ucs2 low surrogate", Charset_ucs2{}, []byte{0xDC, 0x00}, RuneError, 2, types.DecodeInvalid},
+		{"utf32 valid RuneError", Charset_utf32{}, []byte{0x00, 0x00, 0xFF, 0xFD}, RuneError, 4, types.DecodeOK},
+		{"utf32 invalid", Charset_utf32{}, []byte{0x00}, RuneError, 1, types.DecodeInvalid},
+		{"utf32 surrogate", Charset_utf32{}, []byte{0x00, 0x00, 0xD8, 0x00}, RuneError, 4, types.DecodeInvalid},
+		{"utf32 beyond max rune", Charset_utf32{}, []byte{0x00, 0x11, 0x00, 0x00}, RuneError, 4, types.DecodeInvalid},
+		{"utf32 negative rune", Charset_utf32{}, []byte{0xFF, 0xFF, 0xFF, 0xFF}, RuneError, 4, types.DecodeInvalid},
+		{"gb18030 invalid", Charset_gb18030{}, []byte{0xFF}, RuneError, 1, types.DecodeInvalid},
+		{"gb18030 invalid lead 0x80", Charset_gb18030{}, []byte{0x80, 0x41}, RuneError, 1, types.DecodeInvalid},
+		{"gb18030 second byte beyond digits", Charset_gb18030{}, []byte{0x81, 0x3A, 0x81, 0x30}, RuneError, 1, types.DecodeInvalid},
+		{"gb18030 third byte beyond 0xFE", Charset_gb18030{}, []byte{0x81, 0x30, 0xFF, 0x30}, RuneError, 1, types.DecodeInvalid},
+		{"gb18030 reserved pointer", Charset_gb18030{}, []byte{0x84, 0x31, 0xA5, 0x30}, RuneError, 4, types.DecodeUnmappable},
+		{"gb18030 four byte minimum", Charset_gb18030{}, []byte{0x81, 0x30, 0x81, 0x30}, 0x80, 4, types.DecodeOK},
+		{"gb18030 four byte maximum", Charset_gb18030{}, []byte{0xE3, 0x32, 0x9A, 0x35}, 0x10FFFF, 4, types.DecodeOK},
+		{"gb2312 invalid", Charset_gb2312{}, []byte{0xFF}, RuneError, 1, types.DecodeInvalid},
+		{"gb2312 aliasing trail", Charset_gb2312{}, []byte{0xA1, 0x21}, RuneError, 1, types.DecodeInvalid},
+		{"gb2312 invalid trail", Charset_gb2312{}, []byte{0xA1, 0x20}, RuneError, 1, types.DecodeInvalid},
+		{"gb2312 invalid lead", Charset_gb2312{}, []byte{0xF8, 0xA1}, RuneError, 1, types.DecodeInvalid},
+		{"ujis invalid", Charset_ujis{}, []byte{0xFF}, RuneError, 1, types.DecodeInvalid},
+		{"ujis kana invalid trail", Charset_ujis{}, []byte{0x8E, 0xE5}, RuneError, 1, types.DecodeInvalid},
+		{"ujis plane2 invalid trail", Charset_ujis{}, []byte{0x8F, 0xA1, 0x20}, RuneError, 1, types.DecodeInvalid},
+		{"ujis plane2 truncated", Charset_ujis{}, []byte{0x8F, 0xA1}, RuneError, 1, types.DecodeInvalid},
+		{"ujis unassigned pair", Charset_ujis{}, []byte{0xA2, 0xF1}, RuneError, 2, types.DecodeUnmappable},
+		{"sjis invalid", Charset_sjis{}, []byte{0x81}, RuneError, 1, types.DecodeInvalid},
+		{"sjis invalid lead", Charset_sjis{}, []byte{0x80, 0x41}, RuneError, 1, types.DecodeInvalid},
+		{"sjis invalid trail", Charset_sjis{}, []byte{0x81, 0x20}, RuneError, 1, types.DecodeInvalid},
+		{"sjis unassigned pair", Charset_sjis{}, []byte{0x81, 0xAD}, RuneError, 2, types.DecodeUnmappable},
+		{"cp932 invalid", Charset_cp932{}, []byte{0x81}, RuneError, 1, types.DecodeInvalid},
+		{"cp932 invalid trail", Charset_cp932{}, []byte{0x81, 0x20}, RuneError, 1, types.DecodeInvalid},
+		{"eucjpms invalid", Charset_eucjpms{}, []byte{0xFF}, RuneError, 1, types.DecodeInvalid},
+		{"euckr invalid", Charset_euckr{}, []byte{0xFF}, RuneError, 1, types.DecodeInvalid},
+		{"euckr invalid trail", Charset_euckr{}, []byte{0xB0, 0xFF}, RuneError, 1, types.DecodeInvalid},
+		{"euckr gap trail", Charset_euckr{}, []byte{0xB0, 0x5B}, RuneError, 1, types.DecodeInvalid},
+		{"euckr unassigned pair", Charset_euckr{}, []byte{0xC9, 0x41}, RuneError, 2, types.DecodeUnmappable},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotRune, gotWidth, gotOK := tc.cs.DecodeRune(tc.input)
+			gotRune, gotWidth, gotDecoding := tc.cs.DecodeRune(tc.input)
 			require.Equal(t, tc.wantRune, gotRune)
 			require.Equal(t, tc.wantWidth, gotWidth)
-			require.Equal(t, tc.wantOK, gotOK)
+			require.Equal(t, tc.wantDecoding, gotDecoding)
 		})
 	}
 }

--- a/go/mysql/collations/charset/convert.go
+++ b/go/mysql/collations/charset/convert.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"vitess.io/vitess/go/hack"
+	"vitess.io/vitess/go/mysql/collations/charset/types"
 )
 
 func failedConversionError(from, to Charset, input []byte) error {
@@ -70,9 +71,11 @@ func convertSlow(dst []byte, dstCharset Charset, src []byte, srcCharset Charset)
 	}
 
 	for len(src) > 0 {
-		cp, width, ok := srcCharset.DecodeRune(src)
-		if !ok {
-			failed++
+		cp, width, d := srcCharset.DecodeRune(src)
+		if d != types.DecodeOK {
+			if d == types.DecodeInvalid {
+				failed++
+			}
 			cp = '?'
 		}
 		src = src[width:]

--- a/go/mysql/collations/charset/convert.go
+++ b/go/mysql/collations/charset/convert.go
@@ -156,7 +156,10 @@ func Expand(dst []rune, src []byte, srcCharset Charset) []rune {
 			dst = make([]rune, 0, len(src))
 		}
 		for len(src) > 0 {
-			cp, width, _ := srcCharset.DecodeRune(src)
+			cp, width, d := srcCharset.DecodeRune(src)
+			if d == types.DecodeUnmappable {
+				cp = '?'
+			}
 			src = src[width:]
 			dst = append(dst, cp)
 		}

--- a/go/mysql/collations/charset/convert_test.go
+++ b/go/mysql/collations/charset/convert_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/collations/charset/types"
 )
 
 type testCharset1 struct{}
@@ -45,11 +47,11 @@ func (c *testCharset1) EncodeRune([]byte, rune) int {
 	return 0
 }
 
-func (c *testCharset1) DecodeRune(bytes []byte) (rune, int, bool) {
+func (c *testCharset1) DecodeRune(bytes []byte) (rune, int, types.Decoding) {
 	if len(bytes) < 1 {
-		return RuneError, 0, false
+		return RuneError, 0, types.DecodeInvalid
 	}
-	return 1, 1, true
+	return 1, 1, types.DecodeOK
 }
 
 type testCharset2 struct{}
@@ -74,11 +76,11 @@ func (c *testCharset2) EncodeRune([]byte, rune) int {
 	return 0
 }
 
-func (c *testCharset2) DecodeRune(bytes []byte) (rune, int, bool) {
+func (c *testCharset2) DecodeRune(bytes []byte) (rune, int, types.Decoding) {
 	if len(bytes) < 1 {
-		return RuneError, 0, false
+		return RuneError, 0, types.DecodeInvalid
 	}
-	return rune(bytes[0]), 1, true
+	return rune(bytes[0]), 1, types.DecodeOK
 }
 
 func (c *testCharset2) Convert(_, src []byte, from Charset) ([]byte, error) {
@@ -211,7 +213,6 @@ func TestConvert(t *testing.T) {
 			dst:        nil,
 			dstCharset: Charset_utf8mb4{},
 			want:       []byte("A?B"),
-			err:        "Cannot convert string",
 		},
 		{
 			src:        []byte{0xFF, 0xFF, 0xFF, 0xFF},
@@ -235,7 +236,6 @@ func TestConvert(t *testing.T) {
 			dst:        nil,
 			dstCharset: Charset_utf8mb4{},
 			want:       []byte("A?B"),
-			err:        "Cannot convert string",
 		},
 		{
 			src:        []byte{0x80, 0x41},
@@ -467,5 +467,30 @@ func TestConvertFromBinary(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, got)
 		}
+	}
+}
+
+func TestUnmappableSequences(t *testing.T) {
+	cases := []struct {
+		name string
+		cs   Charset
+		in   []byte
+	}{
+		{"gb18030 reserved", Charset_gb18030{}, []byte{0xE3, 0x32, 0x9A, 0x36}},
+		{"sjis unassigned", Charset_sjis{}, []byte{0x81, 0xAD}},
+		{"euckr unassigned", Charset_euckr{}, []byte{0xC9, 0x41}},
+		{"ujis unassigned", Charset_ujis{}, []byte{0xA2, 0xF1}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.True(t, Validate(tc.cs, tc.in))
+			require.Equal(t, 1, Length(tc.cs, tc.in))
+
+			framed := append(append([]byte{0x41}, tc.in...), 0x42)
+			out, err := Convert(nil, Charset_utf8mb4{}, framed, tc.cs)
+			require.NoError(t, err)
+			require.Equal(t, []byte("A?B"), out)
+		})
 	}
 }

--- a/go/mysql/collations/charset/eightbit/8bit.go
+++ b/go/mysql/collations/charset/eightbit/8bit.go
@@ -50,15 +50,15 @@ func (e *Charset_8bit) SupportsSupplementaryChars() bool {
 	return false
 }
 
-func (e *Charset_8bit) DecodeRune(bytes []byte) (rune, int, bool) {
+func (e *Charset_8bit) DecodeRune(bytes []byte) (rune, int, types.Decoding) {
 	if len(bytes) < 1 {
-		return utf8.RuneError, 0, false
+		return utf8.RuneError, 0, types.DecodeInvalid
 	}
 	cp := e.ToUnicode[bytes[0]]
 	if cp == 0 && bytes[0] != 0 {
-		return utf8.RuneError, 1, false
+		return utf8.RuneError, 1, types.DecodeInvalid
 	}
-	return rune(cp), 1, true
+	return rune(cp), 1, types.DecodeOK
 }
 
 func (e *Charset_8bit) EncodeRune(dst []byte, r rune) int {

--- a/go/mysql/collations/charset/eightbit/binary.go
+++ b/go/mysql/collations/charset/eightbit/binary.go
@@ -44,11 +44,11 @@ func (c Charset_binary) EncodeRune(dst []byte, r rune) int {
 	return 1
 }
 
-func (c Charset_binary) DecodeRune(bytes []byte) (rune, int, bool) {
+func (c Charset_binary) DecodeRune(bytes []byte) (rune, int, types.Decoding) {
 	if len(bytes) < 1 {
-		return utf8.RuneError, 0, false
+		return utf8.RuneError, 0, types.DecodeInvalid
 	}
-	return rune(bytes[0]), 1, true
+	return rune(bytes[0]), 1, types.DecodeOK
 }
 
 func (c Charset_binary) Convert(_, in []byte, _ types.Charset) ([]byte, error) {

--- a/go/mysql/collations/charset/eightbit/latin1.go
+++ b/go/mysql/collations/charset/eightbit/latin1.go
@@ -216,11 +216,11 @@ func (Charset_latin1) EncodeRune(dst []byte, r rune) int {
 	return -1
 }
 
-func (Charset_latin1) DecodeRune(src []byte) (rune, int, bool) {
+func (Charset_latin1) DecodeRune(src []byte) (rune, int, types.Decoding) {
 	if len(src) < 1 {
-		return utf8.RuneError, 0, false
+		return utf8.RuneError, 0, types.DecodeInvalid
 	}
-	return rune(tounicode_latin1[src[0]]), 1, true
+	return rune(tounicode_latin1[src[0]]), 1, types.DecodeOK
 }
 
 func (Charset_latin1) Length(src []byte) int {

--- a/go/mysql/collations/charset/helpers.go
+++ b/go/mysql/collations/charset/helpers.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package charset
 
+import (
+	"vitess.io/vitess/go/mysql/collations/charset/types"
+)
+
 func Slice(charset Charset, input []byte, from, to int) []byte {
 	if charset, ok := charset.(interface{ Slice([]byte, int, int) []byte }); ok {
 		return charset.Slice(input, from, to)
@@ -23,8 +27,8 @@ func Slice(charset Charset, input []byte, from, to int) []byte {
 	iter := input
 	start := 0
 	for i := range to {
-		_, size, ok := charset.DecodeRune(iter)
-		if !ok {
+		_, size, d := charset.DecodeRune(iter)
+		if d == types.DecodeInvalid {
 			break
 		}
 		if i < from {
@@ -40,8 +44,8 @@ func Validate(charset Charset, input []byte) bool {
 		return charset.Validate(input)
 	}
 	for len(input) > 0 {
-		_, size, ok := charset.DecodeRune(input)
-		if !ok {
+		_, size, d := charset.DecodeRune(input)
+		if d == types.DecodeInvalid {
 			return false
 		}
 		input = input[size:]

--- a/go/mysql/collations/charset/japanese/sjis.go
+++ b/go/mysql/collations/charset/japanese/sjis.go
@@ -79,35 +79,35 @@ func (Charset_sjis) EncodeRune(dst []byte, r rune) int {
 	return encodeSJIS(dst, r, &table_sjisEncode)
 }
 
-func decodeSJIS(src []byte, table *[65536]uint16) (rune, int, bool) {
+func decodeSJIS(src []byte, table *[65536]uint16) (rune, int, types.Decoding) {
 	if len(src) < 1 {
-		return utf8.RuneError, 0, false
+		return utf8.RuneError, 0, types.DecodeInvalid
 	}
 	c0 := src[0]
 	if c0 < utf8.RuneSelf {
-		return rune(c0), 1, true
+		return rune(c0), 1, types.DecodeOK
 	}
 	if c0 >= 0xA1 && c0 <= 0xDF {
-		return rune(table[c0]), 1, true
+		return rune(table[c0]), 1, types.DecodeOK
 	}
 	if c0 < 0x81 || (0x9F < c0 && c0 < 0xE0) || 0xFC < c0 {
-		return utf8.RuneError, 1, false
+		return utf8.RuneError, 1, types.DecodeInvalid
 	}
 	if len(src) < 2 {
-		return utf8.RuneError, 1, false
+		return utf8.RuneError, 1, types.DecodeInvalid
 	}
 	c1 := src[1]
 	if c1 < 0x40 || c1 == 0x7F || 0xFC < c1 {
-		return utf8.RuneError, 1, false
+		return utf8.RuneError, 1, types.DecodeInvalid
 	}
 	sj := uint16(c0)<<8 | uint16(c1)
 	if cp := table[sj]; cp != 0 {
-		return rune(cp), 2, true
+		return rune(cp), 2, types.DecodeOK
 	}
-	return utf8.RuneError, 2, false
+	return utf8.RuneError, 2, types.DecodeUnmappable
 }
 
-func (Charset_sjis) DecodeRune(src []byte) (rune, int, bool) {
+func (Charset_sjis) DecodeRune(src []byte) (rune, int, types.Decoding) {
 	return decodeSJIS(src, &table_sjisDecode)
 }
 
@@ -138,7 +138,7 @@ func (Charset_cp932) EncodeRune(dst []byte, r rune) int {
 	return encodeSJIS(dst, r, &table_cp932Encode)
 }
 
-func (Charset_cp932) DecodeRune(src []byte) (rune, int, bool) {
+func (Charset_cp932) DecodeRune(src []byte) (rune, int, types.Decoding) {
 	return decodeSJIS(src, &table_cp932Decode)
 }
 

--- a/go/mysql/collations/charset/japanese/ujis.go
+++ b/go/mysql/collations/charset/japanese/ujis.go
@@ -55,58 +55,58 @@ func ujisEncodeRune(dst []byte, r rune, table208, table212 *[65536]uint16) int {
 	return -1
 }
 
-func ujisDecodeRune(src []byte, table208, table212 *[65536]uint16) (rune, int, bool) {
+func ujisDecodeRune(src []byte, table208, table212 *[65536]uint16) (rune, int, types.Decoding) {
 	if len(src) < 1 {
-		return utf8.RuneError, 0, false
+		return utf8.RuneError, 0, types.DecodeInvalid
 	}
 
 	switch c0 := src[0]; {
 	case c0 < utf8.RuneSelf:
-		return rune(c0), 1, true
+		return rune(c0), 1, types.DecodeOK
 
 	case c0 == 0x8e:
 		if len(src) < 2 {
-			return utf8.RuneError, 1, false
+			return utf8.RuneError, 1, types.DecodeInvalid
 		}
 		c1 := src[1]
 		if c1 < 0xa1 || 0xdf < c1 {
-			return utf8.RuneError, 1, false
+			return utf8.RuneError, 1, types.DecodeInvalid
 		}
-		return rune(c1) + (0xff61 - 0xa1), 2, true
+		return rune(c1) + (0xff61 - 0xa1), 2, types.DecodeOK
 	case c0 == 0x8f:
 		if len(src) < 3 {
-			return utf8.RuneError, 1, false
+			return utf8.RuneError, 1, types.DecodeInvalid
 		}
 		c1 := src[1]
 		if c1 < 0xa1 || 0xfe < c1 {
-			return utf8.RuneError, 1, false
+			return utf8.RuneError, 1, types.DecodeInvalid
 		}
 		c2 := src[2]
 		if c2 < 0xa1 || 0xfe < c2 {
-			return utf8.RuneError, 1, false
+			return utf8.RuneError, 1, types.DecodeInvalid
 		}
 		r := rune(table212[uint16(c1)<<8|uint16(c2)])
 		if r == 0 {
-			return utf8.RuneError, 3, false
+			return utf8.RuneError, 3, types.DecodeUnmappable
 		}
-		return r, 3, true
+		return r, 3, types.DecodeOK
 
 	case 0xa1 <= c0 && c0 <= 0xfe:
 		if len(src) < 2 {
-			return utf8.RuneError, 1, false
+			return utf8.RuneError, 1, types.DecodeInvalid
 		}
 		c1 := src[1]
 		if c1 < 0xa1 || 0xfe < c1 {
-			return utf8.RuneError, 1, false
+			return utf8.RuneError, 1, types.DecodeInvalid
 		}
 		r := rune(table208[uint16(c0)<<8|uint16(c1)])
 		if r == 0 {
-			return utf8.RuneError, 2, false
+			return utf8.RuneError, 2, types.DecodeUnmappable
 		}
-		return r, 2, true
+		return r, 2, types.DecodeOK
 
 	default:
-		return utf8.RuneError, 1, false
+		return utf8.RuneError, 1, types.DecodeInvalid
 	}
 }
 
@@ -133,7 +133,7 @@ func (Charset_ujis) EncodeRune(dst []byte, r rune) int {
 	return ujisEncodeRune(dst, r, &table_jis208Encode, &table_jis212Encode)
 }
 
-func (Charset_ujis) DecodeRune(src []byte) (rune, int, bool) {
+func (Charset_ujis) DecodeRune(src []byte) (rune, int, types.Decoding) {
 	return ujisDecodeRune(src, &table_jis208Decode, &table_jis212Decode)
 }
 
@@ -169,7 +169,7 @@ func (Charset_eucjpms) EncodeRune(dst []byte, r rune) int {
 // intentional difference from MySQL. The MySQL eucjpms converter removes the
 // incomplete character and shows no warning. The MySQL sjis and ujis
 // converters show warning 1300 for the same input.
-func (Charset_eucjpms) DecodeRune(src []byte) (rune, int, bool) {
+func (Charset_eucjpms) DecodeRune(src []byte) (rune, int, types.Decoding) {
 	return ujisDecodeRune(src, &table_jis208_eucjpmsDecode, &table_jis212_eucjpmsDecode)
 }
 

--- a/go/mysql/collations/charset/korean/euckr.go
+++ b/go/mysql/collations/charset/korean/euckr.go
@@ -85,22 +85,22 @@ write2:
 	return 2
 }
 
-func (Charset_euckr) DecodeRune(src []byte) (rune, int, bool) {
+func (Charset_euckr) DecodeRune(src []byte) (rune, int, types.Decoding) {
 	if len(src) < 1 {
-		return utf8.RuneError, 0, false
+		return utf8.RuneError, 0, types.DecodeInvalid
 	}
 
 	switch c0 := src[0]; {
 	case c0 < utf8.RuneSelf:
-		return rune(c0), 1, true
+		return rune(c0), 1, types.DecodeOK
 
 	case 0x81 <= c0 && c0 < 0xff:
 		if len(src) < 2 {
-			return utf8.RuneError, 1, false
+			return utf8.RuneError, 1, types.DecodeInvalid
 		}
 		c1 := src[1]
 		if c1 < 0x41 || (0x5a < c1 && c1 < 0x61) || (0x7a < c1 && c1 < 0x81) || 0xfe < c1 {
-			return utf8.RuneError, 1, false
+			return utf8.RuneError, 1, types.DecodeInvalid
 		}
 		var r rune
 		if c0 < 0xc7 {
@@ -116,17 +116,17 @@ func (Charset_euckr) DecodeRune(src []byte) (rune, int, bool) {
 		} else if 0xa1 <= c1 {
 			r = 178*(0xc7-0x81) + rune(c0-0xc7)*94 + rune(c1-0xa1)
 		} else {
-			return utf8.RuneError, 2, false
+			return utf8.RuneError, 2, types.DecodeUnmappable
 		}
 		if int(r) < len(decode) {
 			if r = rune(decode[r]); r != 0 {
-				return r, 2, true
+				return r, 2, types.DecodeOK
 			}
 		}
-		return utf8.RuneError, 2, false
+		return utf8.RuneError, 2, types.DecodeUnmappable
 
 	default:
-		return utf8.RuneError, 1, false
+		return utf8.RuneError, 1, types.DecodeInvalid
 	}
 }
 

--- a/go/mysql/collations/charset/simplifiedchinese/gb18030.go
+++ b/go/mysql/collations/charset/simplifiedchinese/gb18030.go
@@ -230,18 +230,18 @@ write4:
 	return 4
 }
 
-func (Charset_gb18030) DecodeRune(src []byte) (rune, int, bool) {
+func (Charset_gb18030) DecodeRune(src []byte) (rune, int, types.Decoding) {
 	if len(src) < 1 {
-		return utf8.RuneError, 0, false
+		return utf8.RuneError, 0, types.DecodeInvalid
 	}
 
 	switch c0 := src[0]; {
 	case c0 < utf8.RuneSelf:
-		return rune(c0), 1, true
+		return rune(c0), 1, types.DecodeOK
 
 	case 0x81 <= c0 && c0 < 0xff:
 		if len(src) < 2 {
-			return utf8.RuneError, 1, false
+			return utf8.RuneError, 1, types.DecodeInvalid
 		}
 
 		c1 := src[1]
@@ -254,15 +254,15 @@ func (Charset_gb18030) DecodeRune(src []byte) (rune, int, bool) {
 			if len(src) < 4 {
 				// The second byte here is always ASCII, so we can set size
 				// to 1 in all cases.
-				return utf8.RuneError, 1, false
+				return utf8.RuneError, 1, types.DecodeInvalid
 			}
 			c2 := src[2]
 			if c2 < 0x81 || 0xfe < c2 {
-				return utf8.RuneError, 1, false
+				return utf8.RuneError, 1, types.DecodeInvalid
 			}
 			c3 := src[3]
 			if c3 < 0x30 || 0x3a <= c3 {
-				return utf8.RuneError, 1, false
+				return utf8.RuneError, 1, types.DecodeInvalid
 			}
 			r := ((rune(c0-0x81)*10+rune(c1-0x30))*126+rune(c2-0x81))*10 + rune(c3-0x30)
 			if r < 39420 {
@@ -282,27 +282,27 @@ func (Charset_gb18030) DecodeRune(src []byte) (rune, int, bool) {
 					// U+1E3F moved to the two-byte position A8BC.
 					r = 0xE7C7
 				}
-				return r, 4, true
+				return r, 4, types.DecodeOK
 			}
 			r -= 189000
 			if 0 <= r && r < 0x100000 {
 				r += 0x10000
 			} else {
-				return utf8.RuneError, 4, false
+				return utf8.RuneError, 4, types.DecodeUnmappable
 			}
-			return r, 4, true
+			return r, 4, types.DecodeOK
 		default:
-			return utf8.RuneError, 1, false
+			return utf8.RuneError, 1, types.DecodeInvalid
 		}
 		if i := int(c0-0x81)*190 + int(c1); i < len(gb18030Decode) {
 			if r := rune(gb18030Decode[i]); r != 0 {
-				return r, 2, true
+				return r, 2, types.DecodeOK
 			}
 		}
-		return utf8.RuneError, 2, false
+		return utf8.RuneError, 2, types.DecodeUnmappable
 
 	default:
-		return utf8.RuneError, 1, false
+		return utf8.RuneError, 1, types.DecodeInvalid
 	}
 }
 

--- a/go/mysql/collations/charset/simplifiedchinese/gb2312.go
+++ b/go/mysql/collations/charset/simplifiedchinese/gb2312.go
@@ -96,23 +96,23 @@ writeGB:
 	return 2
 }
 
-func (Charset_gb2312) DecodeRune(src []byte) (rune, int, bool) {
+func (Charset_gb2312) DecodeRune(src []byte) (rune, int, types.Decoding) {
 	if len(src) < 1 {
-		return utf8.RuneError, 0, false
+		return utf8.RuneError, 0, types.DecodeInvalid
 	}
 
 	c0 := src[0]
 	if c0 < utf8.RuneSelf {
-		return rune(c0), 1, true
+		return rune(c0), 1, types.DecodeOK
 	}
 
 	if len(src) < 2 {
-		return utf8.RuneError, 1, false
+		return utf8.RuneError, 1, types.DecodeInvalid
 	}
 
 	c1 := src[1]
 	if c0 < 0xa1 || 0xf7 < c0 || c1 < 0xa1 || 0xfe < c1 {
-		return utf8.RuneError, 1, false
+		return utf8.RuneError, 1, types.DecodeInvalid
 	}
 
 	r := (uint16(c0)<<8 | uint16(c1)) & 0x7f7f
@@ -127,9 +127,9 @@ func (Charset_gb2312) DecodeRune(src []byte) (rune, int, bool) {
 		r = 0
 	}
 	if r == 0 {
-		return utf8.RuneError, 2, false
+		return utf8.RuneError, 2, types.DecodeUnmappable
 	}
-	return rune(r), 2, true
+	return rune(r), 2, types.DecodeOK
 }
 
 func (Charset_gb2312) MaxWidth() int {

--- a/go/mysql/collations/charset/types/charset.go
+++ b/go/mysql/collations/charset/types/charset.go
@@ -16,13 +16,23 @@ limitations under the License.
 
 package types
 
+// Decoding is the result of decoding a rune. It mirrors the two predicates
+// MySQL keeps separate for multibyte data: whether a byte sequence is a
+// well-formed character (ismbchar, used for walking and counting) and whether
+// it maps to Unicode (mb_wc, used for conversion).
 type Decoding uint8
 
 const (
+	// DecodeOK means the input is well-formed and maps to Unicode. The rune is
+	// the decoded codepoint and the width is the width of the character.
 	DecodeOK Decoding = iota
 
+	// DecodeUnmappable means the input is a well-formed character with no
+	// Unicode mapping. The rune is RuneError and the width is the width of the character.
 	DecodeUnmappable
 
+	// DecodeInvalid means the input is malformed. The rune is RuneError and the
+	// width is the number of bytes to skip to reach the next rune.
 	DecodeInvalid
 )
 
@@ -38,8 +48,10 @@ type Charset interface {
 
 	EncodeRune([]byte, rune) int
 	// DecodeRune decodes the first rune in the input and returns it along with
-	// its width in bytes and the decoding result. On malformed
-	// input it returns RuneError, the number of bytes to skip to reach the
-	// next rune (zero for empty input), and false.
+	// its width in bytes and the decoding result. The rune is only meaningful
+	// when the result is DecodeOK. Unless the result is DecodeInvalid, the
+	// first width bytes are exactly one character and can be copied through
+	// verbatim; on DecodeInvalid the width is the number of bytes to skip to
+	// reach the next rune, which is zero only for empty input.
 	DecodeRune([]byte) (rune, int, Decoding)
 }

--- a/go/mysql/collations/charset/types/charset.go
+++ b/go/mysql/collations/charset/types/charset.go
@@ -16,6 +16,20 @@ limitations under the License.
 
 package types
 
+type Decoding uint8
+
+const (
+	DecodeOK Decoding = iota
+
+	DecodeUnmappable
+
+	DecodeInvalid
+)
+
+func (d Decoding) IsChar() bool { return d != DecodeInvalid }
+
+func (d Decoding) IsMapped() bool { return d == DecodeOK }
+
 type Charset interface {
 	Name() string
 	SupportsSupplementaryChars() bool
@@ -24,8 +38,8 @@ type Charset interface {
 
 	EncodeRune([]byte, rune) int
 	// DecodeRune decodes the first rune in the input and returns it along with
-	// its width in bytes and whether the input was well-formed. On malformed
+	// its width in bytes and the decoding result. On malformed
 	// input it returns RuneError, the number of bytes to skip to reach the
 	// next rune (zero for empty input), and false.
-	DecodeRune([]byte) (rune, int, bool)
+	DecodeRune([]byte) (rune, int, Decoding)
 }

--- a/go/mysql/collations/charset/unicode/utf16.go
+++ b/go/mysql/collations/charset/unicode/utf16.go
@@ -65,26 +65,26 @@ func (Charset_utf16be) EncodeRune(dst []byte, r rune) int {
 	}
 }
 
-func (Charset_utf16be) DecodeRune(b []byte) (rune, int, bool) {
+func (Charset_utf16be) DecodeRune(b []byte) (rune, int, types.Decoding) {
 	if len(b) < 2 {
-		return utf8.RuneError, len(b), false
+		return utf8.RuneError, len(b), types.DecodeInvalid
 	}
 
 	r1 := uint16(b[1]) | uint16(b[0])<<8
 	if r1 < surr1 || surr3 <= r1 {
-		return rune(r1), 2, true
+		return rune(r1), 2, types.DecodeOK
 	}
 
 	if len(b) < 4 {
-		return utf8.RuneError, 2, false
+		return utf8.RuneError, 2, types.DecodeInvalid
 	}
 
 	r2 := uint16(b[3]) | uint16(b[2])<<8
 	if surr1 <= r1 && r1 < surr2 && surr2 <= r2 && r2 < surr3 {
-		return (rune(r1)-surr1)<<10 | (rune(r2) - surr2) + surrSelf, 4, true
+		return (rune(r1)-surr1)<<10 | (rune(r2) - surr2) + surrSelf, 4, types.DecodeOK
 	}
 
-	return utf8.RuneError, 2, false
+	return utf8.RuneError, 2, types.DecodeInvalid
 }
 
 func (Charset_utf16be) SupportsSupplementaryChars() bool {
@@ -127,26 +127,26 @@ func (Charset_utf16le) EncodeRune(dst []byte, r rune) int {
 	}
 }
 
-func (Charset_utf16le) DecodeRune(b []byte) (rune, int, bool) {
+func (Charset_utf16le) DecodeRune(b []byte) (rune, int, types.Decoding) {
 	if len(b) < 2 {
-		return utf8.RuneError, len(b), false
+		return utf8.RuneError, len(b), types.DecodeInvalid
 	}
 
 	r1 := uint16(b[0]) | uint16(b[1])<<8
 	if r1 < surr1 || surr3 <= r1 {
-		return rune(r1), 2, true
+		return rune(r1), 2, types.DecodeOK
 	}
 
 	if len(b) < 4 {
-		return utf8.RuneError, 2, false
+		return utf8.RuneError, 2, types.DecodeInvalid
 	}
 
 	r2 := uint16(b[2]) | uint16(b[3])<<8
 	if surr1 <= r1 && r1 < surr2 && surr2 <= r2 && r2 < surr3 {
-		return (rune(r1)-surr1)<<10 | (rune(r2) - surr2) + surrSelf, 4, true
+		return (rune(r1)-surr1)<<10 | (rune(r2) - surr2) + surrSelf, 4, types.DecodeOK
 	}
 
-	return utf8.RuneError, 2, false
+	return utf8.RuneError, 2, types.DecodeInvalid
 }
 
 func (Charset_utf16le) SupportsSupplementaryChars() bool {
@@ -183,9 +183,9 @@ func (Charset_ucs2) EncodeRune(dst []byte, r rune) int {
 	return -1
 }
 
-func (Charset_ucs2) DecodeRune(p []byte) (rune, int, bool) {
+func (Charset_ucs2) DecodeRune(p []byte) (rune, int, types.Decoding) {
 	if len(p) < 2 {
-		return utf8.RuneError, len(p), false
+		return utf8.RuneError, len(p), types.DecodeInvalid
 	}
 	r := rune(p[0])<<8 | rune(p[1])
 	if surr1 <= r && r < surr3 {
@@ -195,9 +195,9 @@ func (Charset_ucs2) DecodeRune(p []byte) (rune, int, bool) {
 		// fails. The utf16 and utf32 decoders reject lone surrogates in
 		// MySQL and in Vitess. This check makes sure that a conversion
 		// cannot write U+FFFD and show no error.
-		return utf8.RuneError, 2, false
+		return utf8.RuneError, 2, types.DecodeInvalid
 	}
-	return r, 2, true
+	return r, 2, types.DecodeOK
 }
 
 func (Charset_ucs2) SupportsSupplementaryChars() bool {

--- a/go/mysql/collations/charset/unicode/utf32.go
+++ b/go/mysql/collations/charset/unicode/utf32.go
@@ -47,15 +47,15 @@ func (Charset_utf32) EncodeRune(dst []byte, r rune) int {
 	return 4
 }
 
-func (Charset_utf32) DecodeRune(p []byte) (rune, int, bool) {
+func (Charset_utf32) DecodeRune(p []byte) (rune, int, types.Decoding) {
 	if len(p) < 4 {
-		return utf8.RuneError, len(p), false
+		return utf8.RuneError, len(p), types.DecodeInvalid
 	}
 	r := uint32(p[0])<<24 | uint32(p[1])<<16 | uint32(p[2])<<8 | uint32(p[3])
 	if r > uint32(utf8.MaxRune) || (surr1 <= r && r < surr3) {
-		return utf8.RuneError, 4, false
+		return utf8.RuneError, 4, types.DecodeInvalid
 	}
-	return rune(r), 4, true
+	return rune(r), 4, types.DecodeOK
 }
 
 func (Charset_utf32) SupportsSupplementaryChars() bool {

--- a/go/mysql/collations/charset/unicode/utf8.go
+++ b/go/mysql/collations/charset/unicode/utf8.go
@@ -137,39 +137,39 @@ func (Charset_utf8mb3) EncodeRune(p []byte, r rune) int {
 	}
 }
 
-func (Charset_utf8mb3) DecodeRune(p []byte) (rune, int, bool) {
+func (Charset_utf8mb3) DecodeRune(p []byte) (rune, int, types.Decoding) {
 	n := len(p)
 	if n < 1 {
-		return utf8.RuneError, 0, false
+		return utf8.RuneError, 0, types.DecodeInvalid
 	}
 	p0 := p[0]
 	x := first[p0]
 	if x >= as {
 		if x == xx {
-			return utf8.RuneError, 1, false
+			return utf8.RuneError, 1, types.DecodeInvalid
 		}
-		return rune(p[0]), 1, true
+		return rune(p[0]), 1, types.DecodeOK
 	}
 	sz := int(x & 7)
 	accept := acceptRanges[x>>4]
 	if n < sz {
-		return utf8.RuneError, 1, false
+		return utf8.RuneError, 1, types.DecodeInvalid
 	}
 	b1 := p[1]
 	if b1 < accept.lo || accept.hi < b1 {
-		return utf8.RuneError, 1, false
+		return utf8.RuneError, 1, types.DecodeInvalid
 	}
 	if sz <= 2 { // <= instead of == to help the compiler eliminate some bounds checks
-		return rune(p0&mask2)<<6 | rune(b1&maskx), 2, true
+		return rune(p0&mask2)<<6 | rune(b1&maskx), 2, types.DecodeOK
 	}
 	b2 := p[2]
 	if b2 < locb || hicb < b2 {
-		return utf8.RuneError, 1, false
+		return utf8.RuneError, 1, types.DecodeInvalid
 	}
 	if sz <= 3 {
-		return rune(p0&mask3)<<12 | rune(b1&maskx)<<6 | rune(b2&maskx), 3, true
+		return rune(p0&mask3)<<12 | rune(b1&maskx)<<6 | rune(b2&maskx), 3, types.DecodeOK
 	}
-	return utf8.RuneError, 1, false
+	return utf8.RuneError, 1, types.DecodeInvalid
 }
 
 func (Charset_utf8mb3) SupportsSupplementaryChars() bool {
@@ -203,12 +203,12 @@ func (Charset_utf8mb4) EncodeRune(p []byte, r rune) int {
 	return utf8.EncodeRune(p, r)
 }
 
-func (Charset_utf8mb4) DecodeRune(p []byte) (rune, int, bool) {
+func (Charset_utf8mb4) DecodeRune(p []byte) (rune, int, types.Decoding) {
 	r, width := utf8.DecodeRune(p)
 	if r == utf8.RuneError && width <= 1 {
-		return r, width, false
+		return r, width, types.DecodeInvalid
 	}
-	return r, width, true
+	return r, width, types.DecodeOK
 }
 
 func (Charset_utf8mb4) SupportsSupplementaryChars() bool {

--- a/go/mysql/collations/colldata/fuzz_test.go
+++ b/go/mysql/collations/colldata/fuzz_test.go
@@ -22,6 +22,7 @@ import (
 	"unicode/utf8"
 
 	"vitess.io/vitess/go/mysql/collations/charset"
+	"vitess.io/vitess/go/mysql/collations/charset/types"
 	"vitess.io/vitess/go/vt/vthash"
 )
 
@@ -73,28 +74,34 @@ func fuzzCharsets() []charset.Charset {
 func decodeWalk(t *testing.T, cs charset.Charset, input []byte) (runes int, valid bool) {
 	valid = true
 	for in := input; len(in) > 0; {
-		r, width, ok := cs.DecodeRune(in)
+		r, width, d := cs.DecodeRune(in)
 		if width < 1 || width > len(in) || width > cs.MaxWidth() {
 			t.Fatalf("%s.DecodeRune(%#v) = %d, %d, %v: width out of range 1..min(%d, %d)",
-				cs.Name(), in, r, width, ok, len(in), cs.MaxWidth())
+				cs.Name(), in, r, width, d, len(in), cs.MaxWidth())
 		}
-		if !ok {
+		switch d {
+		case types.DecodeInvalid:
 			valid = false
 			if r != charset.RuneError {
 				t.Fatalf("%s.DecodeRune(%#v) = %d, %d, %v: rune is not RuneError for malformed input",
-					cs.Name(), in, r, width, ok)
+					cs.Name(), in, r, width, d)
 			}
-		} else {
+		case types.DecodeUnmappable:
+			if r != charset.RuneError {
+				t.Fatalf("%s.DecodeRune(%#v) = %d, %d, %v: rune is not RuneError for unmappable input",
+					cs.Name(), in, r, width, d)
+			}
+		default:
 			var enc [8]byte
 			encWidth := cs.EncodeRune(enc[:], r)
 			if encWidth < 1 {
 				t.Fatalf("%s.EncodeRune(%U) = %d: decoded rune does not encode",
 					cs.Name(), r, encWidth)
 			}
-			r2, width2, ok2 := cs.DecodeRune(enc[:encWidth])
-			if r2 != r || width2 != encWidth || !ok2 {
+			r2, width2, d2 := cs.DecodeRune(enc[:encWidth])
+			if r2 != r || width2 != encWidth || d2 != types.DecodeOK {
 				t.Fatalf("%s: decode(encode(%U)) = %U, %d, %v: want %U, %d, true",
-					cs.Name(), r, r2, width2, ok2, r, encWidth)
+					cs.Name(), r, r2, width2, d2, r, encWidth)
 			}
 		}
 		in = in[width:]

--- a/go/mysql/collations/colldata/uca_test.go
+++ b/go/mysql/collations/colldata/uca_test.go
@@ -1220,3 +1220,11 @@ func BenchmarkUCA900Collation(b *testing.B) {
 		}
 	}
 }
+
+func TestGB18030UnmappableWeights(t *testing.T) {
+	coll := testcollation(t, "gb18030_unicode_520_ci")
+
+	ws := coll.WeightString(nil, []byte{0xE3, 0x32, 0x9A, 0x36}, 0)
+	require.Equal(t, []byte{0x02, 0x73}, ws)
+	require.Equal(t, coll.WeightString(nil, []byte{0x3F}, 0), ws)
+}

--- a/go/mysql/collations/colldata/uca_test.go
+++ b/go/mysql/collations/colldata/uca_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations/charset"
+	"vitess.io/vitess/go/mysql/collations/charset/types"
 	"vitess.io/vitess/go/vt/vthash"
 )
 
@@ -183,14 +184,14 @@ func TestMalformedInput(t *testing.T) {
 	}
 
 	ascii := testcollation(t, "ascii_general_ci").Charset()
-	r, width, ok := ascii.DecodeRune([]byte{0x80})
+	r, width, d := ascii.DecodeRune([]byte{0x80})
 	require.Equal(t, charset.RuneError, r)
 	require.Equal(t, 1, width)
-	require.False(t, ok)
-	r, width, ok = ascii.DecodeRune([]byte{0x00})
+	require.NotEqual(t, types.DecodeOK, d)
+	r, width, d = ascii.DecodeRune([]byte{0x00})
 	require.Equal(t, rune(0), r)
 	require.Equal(t, 1, width)
-	require.True(t, ok)
+	require.Equal(t, types.DecodeOK, d)
 
 	out, err := charset.Convert(nil, charset.Charset_utf8mb4{}, []byte{0x41, 0x80, 0x42}, ascii)
 	require.ErrorContains(t, err, "Cannot convert string")

--- a/go/mysql/collations/colldata/unicode.go
+++ b/go/mysql/collations/colldata/unicode.go
@@ -23,6 +23,7 @@ import (
 
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/mysql/collations/charset"
+	"vitess.io/vitess/go/mysql/collations/charset/types"
 	"vitess.io/vitess/go/vt/vthash"
 )
 
@@ -57,7 +58,7 @@ func (c *Collation_unicode_general_ci) Collate(left, right []byte, isPrefix bool
 		l, lWidth, lOK := cs.DecodeRune(left)
 		r, rWidth, rOK := cs.DecodeRune(right)
 
-		if !lOK || !rOK {
+		if lOK != types.DecodeOK || rOK != types.DecodeOK {
 			return bytes.Compare(left, right)
 		}
 
@@ -85,8 +86,8 @@ func (c *Collation_unicode_general_ci) WeightString(dst, src []byte, numCodepoin
 
 	if numCodepoints == 0 || numCodepoints == PadToMax {
 		for {
-			r, width, ok := cs.DecodeRune(src)
-			if !ok {
+			r, width, d := cs.DecodeRune(src)
+			if d != types.DecodeOK {
 				break
 			}
 
@@ -105,8 +106,8 @@ func (c *Collation_unicode_general_ci) WeightString(dst, src []byte, numCodepoin
 		}
 	} else {
 		for numCodepoints > 0 {
-			r, width, ok := cs.DecodeRune(src)
-			if !ok {
+			r, width, d := cs.DecodeRune(src)
+			if d != types.DecodeOK {
 				break
 			}
 
@@ -135,8 +136,8 @@ func (c *Collation_unicode_general_ci) Hash(hasher *vthash.Hasher, src []byte, n
 	}
 
 	for left > 0 {
-		r, width, ok := cs.DecodeRune(src)
-		if !ok {
+		r, width, d := cs.DecodeRune(src)
+		if d != types.DecodeOK {
 			break
 		}
 		src = src[width:]
@@ -201,8 +202,8 @@ func (c *Collation_unicode_bin) weightStringBMP(dst, src []byte, numCodepoints i
 	cs := c.charset
 	if numCodepoints == 0 || numCodepoints == PadToMax {
 		for {
-			r, width, ok := cs.DecodeRune(src)
-			if !ok {
+			r, width, d := cs.DecodeRune(src)
+			if d != types.DecodeOK {
 				break
 			}
 			src = src[width:]
@@ -219,8 +220,8 @@ func (c *Collation_unicode_bin) weightStringBMP(dst, src []byte, numCodepoints i
 		}
 	} else {
 		for numCodepoints > 0 {
-			r, width, ok := cs.DecodeRune(src)
-			if !ok {
+			r, width, d := cs.DecodeRune(src)
+			if d != types.DecodeOK {
 				break
 			}
 			src = src[width:]
@@ -240,8 +241,8 @@ func (c *Collation_unicode_bin) weightStringUnicode(dst, src []byte, numCodepoin
 	cs := c.charset
 	if numCodepoints == 0 || numCodepoints == PadToMax {
 		for {
-			r, width, ok := cs.DecodeRune(src)
-			if !ok {
+			r, width, d := cs.DecodeRune(src)
+			if d != types.DecodeOK {
 				break
 			}
 
@@ -265,8 +266,8 @@ func (c *Collation_unicode_bin) weightStringUnicode(dst, src []byte, numCodepoin
 		}
 	} else {
 		for numCodepoints > 0 {
-			r, width, ok := cs.DecodeRune(src)
-			if !ok {
+			r, width, d := cs.DecodeRune(src)
+			if d != types.DecodeOK {
 				break
 			}
 
@@ -300,8 +301,8 @@ func (c *Collation_unicode_bin) hashUnicode(hasher *vthash.Hasher, src []byte, n
 		left = math.MaxInt32
 	}
 	for left > 0 {
-		r, width, ok := cs.DecodeRune(src)
-		if !ok {
+		r, width, d := cs.DecodeRune(src)
+		if d != types.DecodeOK {
 			break
 		}
 		src = src[width:]
@@ -325,8 +326,8 @@ func (c *Collation_unicode_bin) hashBMP(hasher *vthash.Hasher, src []byte, numCo
 		left = math.MaxInt32
 	}
 	for left > 0 {
-		r, width, ok := cs.DecodeRune(src)
-		if !ok {
+		r, width, d := cs.DecodeRune(src)
+		if d != types.DecodeOK {
 			break
 		}
 		src = src[width:]

--- a/go/mysql/collations/colldata/wildcard.go
+++ b/go/mysql/collations/colldata/wildcard.go
@@ -45,6 +45,7 @@ import (
 	"unicode/utf8"
 
 	"vitess.io/vitess/go/mysql/collations/charset"
+	"vitess.io/vitess/go/mysql/collations/charset/types"
 )
 
 type match byte
@@ -145,8 +146,8 @@ func newUnicodeWildcardMatcher(
 	chOneWidth, chManyWidth, chEscWidth := metaWidth(chOne), metaWidth(chMany), metaWidth(chEsc)
 
 	for len(pat) > 0 {
-		cp, width, ok := cs.DecodeRune(pat)
-		if !ok {
+		cp, width, d := cs.DecodeRune(pat)
+		if d != types.DecodeOK {
 			return nopMatcher{}
 		}
 		pat = pat[width:]
@@ -226,8 +227,8 @@ retry:
 
 		switch p0 {
 		case patternMatchOne:
-			_, width, ok := cs.DecodeRune(s)
-			if !ok {
+			_, width, d := cs.DecodeRune(s)
+			if d != types.DecodeOK {
 				return false
 			}
 			s = s[width:]
@@ -240,8 +241,8 @@ retry:
 			}
 			goto retry
 		default:
-			c0, width, ok := cs.DecodeRune(s)
-			if !ok {
+			c0, width, d := cs.DecodeRune(s)
+			if d != types.DecodeOK {
 				return false
 			}
 			if !wc.equals(c0, p0) {
@@ -258,8 +259,8 @@ starCheck:
 		return false
 	}
 	if len(str) > 0 {
-		_, width, ok := cs.DecodeRune(str)
-		if !ok {
+		_, width, d := cs.DecodeRune(str)
+		if d != types.DecodeOK {
 			return false
 		}
 		str = str[width:]
@@ -289,8 +290,8 @@ many:
 	case patternMatchMany:
 		goto many
 	case patternMatchOne:
-		_, width, ok := cs.DecodeRune(in)
-		if !ok {
+		_, width, d := cs.DecodeRune(in)
+		if d != types.DecodeOK {
 			return matchFail
 		}
 		in = in[width:]
@@ -305,9 +306,9 @@ retry:
 	var width int
 	for len(in) > 0 {
 		var cpIn rune
-		var ok bool
-		cpIn, width, ok = cs.DecodeRune(in)
-		if !ok {
+		var d types.Decoding
+		cpIn, width, d = cs.DecodeRune(in)
+		if d != types.DecodeOK {
 			return matchFail
 		}
 		if wc.equals(cpIn, p0) {
@@ -339,8 +340,8 @@ func (wc *unicodeWildcard) matchRecursive(in []byte, pat []rune, depth int) matc
 			return wc.matchMany(in, pat[1:], depth)
 		}
 
-		cpIn, width, ok := cs.DecodeRune(in)
-		if !ok {
+		cpIn, width, d := cs.DecodeRune(in)
+		if d != types.DecodeOK {
 			return matchFail
 		}
 
@@ -641,8 +642,8 @@ func newMultibyteWildcardMatcher(
 	var elements int
 	lastMany := false
 	for p := pat; len(p) > 0; {
-		cp, width, ok := cs.DecodeRune(p)
-		if !ok {
+		cp, width, d := cs.DecodeRune(p)
+		if d != types.DecodeOK {
 			return nopMatcher{}
 		}
 		p = p[width:]
@@ -780,8 +781,8 @@ many:
 	case patternMatchMany:
 		goto many
 	case patternMatchOne:
-		_, width, ok := cs.DecodeRune(in)
-		if !ok {
+		_, width, d := cs.DecodeRune(in)
+		if d != types.DecodeOK {
 			return matchFail
 		}
 		in = in[width:]
@@ -795,9 +796,9 @@ many:
 retry:
 	var width int
 	for len(in) > 0 {
-		var ok bool
-		_, width, ok = cs.DecodeRune(in)
-		if !ok {
+		var d types.Decoding
+		_, width, d = cs.DecodeRune(in)
+		if d != types.DecodeOK {
 			return matchFail
 		}
 		if wc.equals(&p0, in[:width]) {
@@ -829,8 +830,8 @@ func (wc *multibyteWildcard) matchRecursive(in []byte, pat []multibytePatternCha
 			return wc.matchMany(in, pat[1:], depth)
 		}
 
-		_, width, ok := cs.DecodeRune(in)
-		if !ok {
+		_, width, d := cs.DecodeRune(in)
+		if d != types.DecodeOK {
 			return matchFail
 		}
 
@@ -868,8 +869,8 @@ retry:
 
 		switch p0.match {
 		case patternMatchOne:
-			_, width, ok := cs.DecodeRune(s)
-			if !ok {
+			_, width, d := cs.DecodeRune(s)
+			if d != types.DecodeOK {
 				return false
 			}
 			s = s[width:]
@@ -882,8 +883,8 @@ retry:
 			}
 			goto retry
 		default:
-			_, width, ok := cs.DecodeRune(s)
-			if !ok {
+			_, width, d := cs.DecodeRune(s)
+			if d != types.DecodeOK {
 				return false
 			}
 			if len(p) == 0 || !wc.equals(&p0, s[:width]) {
@@ -900,8 +901,8 @@ starCheck:
 		return false
 	}
 	if len(str) > 0 {
-		_, width, ok := cs.DecodeRune(str)
-		if !ok {
+		_, width, d := cs.DecodeRune(str)
+		if d != types.DecodeOK {
 			return false
 		}
 		str = str[width:]

--- a/go/mysql/collations/colldata/wildcard.go
+++ b/go/mysql/collations/colldata/wildcard.go
@@ -147,7 +147,7 @@ func newUnicodeWildcardMatcher(
 
 	for len(pat) > 0 {
 		cp, width, d := cs.DecodeRune(pat)
-		if d != types.DecodeOK {
+		if d == types.DecodeInvalid {
 			return nopMatcher{}
 		}
 		pat = pat[width:]
@@ -228,7 +228,7 @@ retry:
 		switch p0 {
 		case patternMatchOne:
 			_, width, d := cs.DecodeRune(s)
-			if d != types.DecodeOK {
+			if d == types.DecodeInvalid {
 				return false
 			}
 			s = s[width:]
@@ -242,7 +242,7 @@ retry:
 			goto retry
 		default:
 			c0, width, d := cs.DecodeRune(s)
-			if d != types.DecodeOK {
+			if d == types.DecodeInvalid {
 				return false
 			}
 			if !wc.equals(c0, p0) {
@@ -260,7 +260,7 @@ starCheck:
 	}
 	if len(str) > 0 {
 		_, width, d := cs.DecodeRune(str)
-		if d != types.DecodeOK {
+		if d == types.DecodeInvalid {
 			return false
 		}
 		str = str[width:]
@@ -291,7 +291,7 @@ many:
 		goto many
 	case patternMatchOne:
 		_, width, d := cs.DecodeRune(in)
-		if d != types.DecodeOK {
+		if d == types.DecodeInvalid {
 			return matchFail
 		}
 		in = in[width:]
@@ -308,7 +308,7 @@ retry:
 		var cpIn rune
 		var d types.Decoding
 		cpIn, width, d = cs.DecodeRune(in)
-		if d != types.DecodeOK {
+		if d == types.DecodeInvalid {
 			return matchFail
 		}
 		if wc.equals(cpIn, p0) {
@@ -341,7 +341,7 @@ func (wc *unicodeWildcard) matchRecursive(in []byte, pat []rune, depth int) matc
 		}
 
 		cpIn, width, d := cs.DecodeRune(in)
-		if d != types.DecodeOK {
+		if d == types.DecodeInvalid {
 			return matchFail
 		}
 
@@ -643,7 +643,7 @@ func newMultibyteWildcardMatcher(
 	lastMany := false
 	for p := pat; len(p) > 0; {
 		cp, width, d := cs.DecodeRune(p)
-		if d != types.DecodeOK {
+		if d == types.DecodeInvalid {
 			return nopMatcher{}
 		}
 		p = p[width:]
@@ -782,7 +782,7 @@ many:
 		goto many
 	case patternMatchOne:
 		_, width, d := cs.DecodeRune(in)
-		if d != types.DecodeOK {
+		if d == types.DecodeInvalid {
 			return matchFail
 		}
 		in = in[width:]
@@ -798,7 +798,7 @@ retry:
 	for len(in) > 0 {
 		var d types.Decoding
 		_, width, d = cs.DecodeRune(in)
-		if d != types.DecodeOK {
+		if d == types.DecodeInvalid {
 			return matchFail
 		}
 		if wc.equals(&p0, in[:width]) {
@@ -831,7 +831,7 @@ func (wc *multibyteWildcard) matchRecursive(in []byte, pat []multibytePatternCha
 		}
 
 		_, width, d := cs.DecodeRune(in)
-		if d != types.DecodeOK {
+		if d == types.DecodeInvalid {
 			return matchFail
 		}
 
@@ -870,7 +870,7 @@ retry:
 		switch p0.match {
 		case patternMatchOne:
 			_, width, d := cs.DecodeRune(s)
-			if d != types.DecodeOK {
+			if d == types.DecodeInvalid {
 				return false
 			}
 			s = s[width:]
@@ -884,7 +884,7 @@ retry:
 			goto retry
 		default:
 			_, width, d := cs.DecodeRune(s)
-			if d != types.DecodeOK {
+			if d == types.DecodeInvalid {
 				return false
 			}
 			if len(p) == 0 || !wc.equals(&p0, s[:width]) {
@@ -902,7 +902,7 @@ starCheck:
 	}
 	if len(str) > 0 {
 		_, width, d := cs.DecodeRune(str)
-		if d != types.DecodeOK {
+		if d == types.DecodeInvalid {
 			return false
 		}
 		str = str[width:]

--- a/go/mysql/collations/colldata/wildcard.go
+++ b/go/mysql/collations/colldata/wildcard.go
@@ -101,9 +101,26 @@ func (cm *fastMatcher) Match(in []byte) bool {
 // unicodeWildcard is an implementation of WildcardPattern for multibyte charsets;
 // it is used for all UCA collations, multibyte collations and all Unicode-based collations
 type unicodeWildcard struct {
-	equals  func(a, b rune) bool
+	eq      func(a, b rune) bool
 	charset charset.Charset
-	pattern []rune
+	pattern []unicodePatternChar
+}
+
+// unicodePatternChar is one parsed pattern element: a wildcard when match is
+// patternMatchOne or patternMatchMany, otherwise one literal character. A
+// character with no Unicode mapping has no usable rune, so its encoded bytes
+// are kept instead and compared against the input bytes; MySQL compares such
+// characters by their encoding, and two different unmapped sequences are not
+// equal to each other.
+type unicodePatternChar struct {
+	ch    [4]byte
+	cp    rune
+	match int16
+	width uint8
+}
+
+func (p *unicodePatternChar) literal() []byte {
+	return p.ch[:p.width]
 }
 
 func newUnicodeWildcardMatcher(
@@ -114,7 +131,7 @@ func newUnicodeWildcardMatcher(
 ) WildcardPattern {
 	var escape bool
 	var chOneCount, chManyCount, chEscCount int
-	parsedPattern := make([]rune, 0, len(pat))
+	parsedPattern := make([]unicodePatternChar, 0, len(pat))
 	patOriginal := pat
 
 	if chOne == 0 {
@@ -145,38 +162,49 @@ func newUnicodeWildcardMatcher(
 	}
 	chOneWidth, chManyWidth, chEscWidth := metaWidth(chOne), metaWidth(chMany), metaWidth(chEsc)
 
+	appendLiteral := func(cp rune, ch []byte, d types.Decoding) {
+		var token unicodePatternChar
+		if d == types.DecodeUnmappable {
+			token.width = uint8(copy(token.ch[:], ch))
+		} else {
+			token.cp = cp
+		}
+		parsedPattern = append(parsedPattern, token)
+	}
+
 	for len(pat) > 0 {
 		cp, width, d := cs.DecodeRune(pat)
 		if d == types.DecodeInvalid {
 			return nopMatcher{}
 		}
+		ch := pat[:width]
 		pat = pat[width:]
 
 		if escape {
-			parsedPattern = append(parsedPattern, cp)
+			appendLiteral(cp, ch, d)
 			escape = false
 			continue
 		}
 
 		switch {
-		case cp == chOne && width == chOneWidth:
+		case d == types.DecodeOK && cp == chOne && width == chOneWidth:
 			chOneCount++
-			parsedPattern = append(parsedPattern, patternMatchOne)
-		case cp == chMany && width == chManyWidth:
+			parsedPattern = append(parsedPattern, unicodePatternChar{match: patternMatchOne})
+		case d == types.DecodeOK && cp == chMany && width == chManyWidth:
 			chManyCount++
-			if len(parsedPattern) > 0 && parsedPattern[len(parsedPattern)-1] == patternMatchMany {
+			if len(parsedPattern) > 0 && parsedPattern[len(parsedPattern)-1].match == patternMatchMany {
 				continue
 			}
-			parsedPattern = append(parsedPattern, patternMatchMany)
-		case cp == chEsc && width == chEscWidth:
+			parsedPattern = append(parsedPattern, unicodePatternChar{match: patternMatchMany})
+		case d == types.DecodeOK && cp == chEsc && width == chEscWidth:
 			chEscCount++
 			escape = true
 		default:
-			parsedPattern = append(parsedPattern, cp)
+			appendLiteral(cp, ch, d)
 		}
 	}
 	if escape {
-		parsedPattern = append(parsedPattern, chEsc)
+		parsedPattern = append(parsedPattern, unicodePatternChar{cp: chEsc})
 	}
 
 	// if we have a collation callback, we can detect some common cases for patterns
@@ -193,7 +221,8 @@ func newUnicodeWildcardMatcher(
 					isPrefix: false,
 				}
 			}
-			if chManyCount == 1 && chMany < utf8.RuneSelf && parsedPattern[len(parsedPattern)-1] == chMany {
+			if chManyCount == 1 && chMany < utf8.RuneSelf &&
+				parsedPattern[len(parsedPattern)-1].match == patternMatchMany {
 				return &fastMatcher{
 					collate:  collate,
 					pattern:  patOriginal[:len(patOriginal)-1],
@@ -204,15 +233,22 @@ func newUnicodeWildcardMatcher(
 	}
 
 	return &unicodeWildcard{
-		equals:  equals,
+		eq:      equals,
 		charset: cs,
 		pattern: parsedPattern,
 	}
 }
 
-func (wc *unicodeWildcard) matchIter(str []byte, pat []rune) bool {
+func (wc *unicodeWildcard) equals(p *unicodePatternChar, cpIn rune, in []byte, d types.Decoding) bool {
+	if p.width > 0 || d == types.DecodeUnmappable {
+		return p.width > 0 && d == types.DecodeUnmappable && bytes.Equal(p.literal(), in)
+	}
+	return wc.eq(p.cp, cpIn)
+}
+
+func (wc *unicodeWildcard) matchIter(str []byte, pat []unicodePatternChar) bool {
 	var s []byte
-	var p []rune
+	var p []unicodePatternChar
 	star := false
 	cs := wc.charset
 
@@ -220,12 +256,12 @@ retry:
 	s = str
 	p = pat
 	for len(s) > 0 {
-		var p0 rune
+		var p0 unicodePatternChar
 		if len(p) > 0 {
 			p0 = p[0]
 		}
 
-		switch p0 {
+		switch p0.match {
 		case patternMatchOne:
 			_, width, d := cs.DecodeRune(s)
 			if d == types.DecodeInvalid {
@@ -245,14 +281,14 @@ retry:
 			if d == types.DecodeInvalid {
 				return false
 			}
-			if !wc.equals(c0, p0) {
+			if len(p) == 0 || !wc.equals(&p0, c0, s[:width], d) {
 				goto starCheck
 			}
 			s = s[width:]
 		}
 		p = p[1:]
 	}
-	return len(p) == 0 || (len(p) == 1 && p[0] == patternMatchMany)
+	return len(p) == 0 || (len(p) == 1 && p[0].match == patternMatchMany)
 
 starCheck:
 	if !star {
@@ -275,9 +311,9 @@ func (wc *unicodeWildcard) Match(in []byte) bool {
 	return wc.matchRecursive(in, wc.pattern, 0) == matchOK
 }
 
-func (wc *unicodeWildcard) matchMany(in []byte, pat []rune, depth int) match {
+func (wc *unicodeWildcard) matchMany(in []byte, pat []unicodePatternChar, depth int) match {
 	cs := wc.charset
-	var p0 rune
+	var p0 unicodePatternChar
 
 many:
 	if len(pat) == 0 {
@@ -286,7 +322,7 @@ many:
 	p0 = pat[0]
 	pat = pat[1:]
 
-	switch p0 {
+	switch p0.match {
 	case patternMatchMany:
 		goto many
 	case patternMatchOne:
@@ -311,7 +347,7 @@ retry:
 		if d == types.DecodeInvalid {
 			return matchFail
 		}
-		if wc.equals(cpIn, p0) {
+		if wc.equals(&p0, cpIn, in[:width], d) {
 			break
 		}
 		in = in[width:]
@@ -329,14 +365,14 @@ retry:
 	return m
 }
 
-func (wc *unicodeWildcard) matchRecursive(in []byte, pat []rune, depth int) match {
+func (wc *unicodeWildcard) matchRecursive(in []byte, pat []unicodePatternChar, depth int) match {
 	if depth >= wildcardRecursionDepth {
 		return matchFail
 	}
 
 	cs := wc.charset
 	for len(pat) > 0 {
-		if pat[0] == patternMatchMany {
+		if pat[0].match == patternMatchMany {
 			return wc.matchMany(in, pat[1:], depth)
 		}
 
@@ -346,8 +382,8 @@ func (wc *unicodeWildcard) matchRecursive(in []byte, pat []rune, depth int) matc
 		}
 
 		switch {
-		case pat[0] == patternMatchOne:
-		case wc.equals(pat[0], cpIn):
+		case pat[0].match == patternMatchOne:
+		case wc.equals(&pat[0], cpIn, in[:width], d):
 		default:
 			return matchFail
 		}

--- a/go/mysql/collations/colldata/wildcard_test.go
+++ b/go/mysql/collations/colldata/wildcard_test.go
@@ -397,3 +397,16 @@ func BenchmarkWildcardMatching(b *testing.B) {
 		}
 	})
 }
+
+func TestUnmappableWildcard(t *testing.T) {
+	const u = "\xE3\x32\x9A\x36"
+	const v = "\xE3\x32\x9A\x37"
+
+	testWildcardMatches(t, "gb18030_unicode_520_ci", 0, 0, 0, []wildcardtest{
+		{u, "%", true},
+		{u, "_", true},
+		{u, "?", false},
+		{u, u, true},
+		{u, v, false},
+	})
+}

--- a/go/mysql/collations/internal/uca/iter_legacy.go
+++ b/go/mysql/collations/internal/uca/iter_legacy.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package uca
 
+import (
+	"vitess.io/vitess/go/mysql/collations/charset/types"
+)
+
 type WeightIteratorLegacy struct {
 	// Constant
 	*CollationLegacy
@@ -64,7 +68,7 @@ func (it *WeightIteratorLegacy) reset(input []byte) {
 	it.codepoint.weights = nil
 }
 
-func (it *WeightIteratorLegacy) DebugCodepoint() (rune, int, bool) {
+func (it *WeightIteratorLegacy) DebugCodepoint() (rune, int, types.Decoding) {
 	return it.charset.DecodeRune(it.input)
 }
 
@@ -74,8 +78,8 @@ func (it *WeightIteratorLegacy) Next() (uint16, bool) {
 			return w, true
 		}
 
-		cp, width, ok := it.charset.DecodeRune(it.input)
-		if !ok {
+		cp, width, d := it.charset.DecodeRune(it.input)
+		if d != types.DecodeOK {
 			return 0, false
 		}
 		it.input = it.input[width:]

--- a/go/mysql/collations/internal/uca/iter_legacy.go
+++ b/go/mysql/collations/internal/uca/iter_legacy.go
@@ -79,15 +79,19 @@ func (it *WeightIteratorLegacy) Next() (uint16, bool) {
 		}
 
 		cp, width, d := it.charset.DecodeRune(it.input)
-		if d != types.DecodeOK {
+		if d == types.DecodeInvalid {
 			return 0, false
 		}
 		it.input = it.input[width:]
 		it.length++
 
+		if d == types.DecodeUnmappable {
+			cp = '?'
+		}
 		if cp > it.maxCodepoint {
 			return 0xFFFD, true
 		}
+
 		if it.contract != nil {
 			if weights, remainder, skip := it.contract.Find(it.charset, cp, it.input); weights != nil {
 				it.codepoint.initContraction(weights)

--- a/go/mysql/collations/remote/charset.go
+++ b/go/mysql/collations/remote/charset.go
@@ -25,6 +25,7 @@ import (
 	"vitess.io/vitess/go/bytes2"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/mysql/collations/charset"
+	"vitess.io/vitess/go/mysql/collations/charset/types"
 )
 
 type Charset struct {
@@ -68,7 +69,7 @@ func (c *Charset) EncodeRune(dst []byte, r rune) int {
 	panic("unsupported: EncodeRune in remote.Charset (use Charset.Convert directly)")
 }
 
-func (c *Charset) DecodeRune(bytes []byte) (rune, int, bool) {
+func (c *Charset) DecodeRune(bytes []byte) (rune, int, types.Decoding) {
 	panic("unsupported: DecodeRune in remote.Charset (use Charset.Convert directly)")
 }
 


### PR DESCRIPTION
## Description

`Charset.DecodeRune` returned a single `ok bool`, collapsing the two predicates MySQL keeps separate for multibyte data: whether a byte sequence is a well-formed character (`ismbchar`) and whether it maps to Unicode (`mb_wc`). Sequences that are structurally valid but unmapped, such as the reserved four-byte space in gb18030 and the unassigned pairs in the EUC and SJIS families, could only be reported as failures, so `Validate` rejected them and `Convert` errored where MySQL is silent.

This replaces the bool with a `Decoding` value: `DecodeOK`, `DecodeUnmappable` (well-formed, no mapping; rune is `RuneError`, width is the full character width), and `DecodeInvalid` (malformed; width is bytes to skip). `Validate` and `Slice` now reject only `DecodeInvalid`, `Convert` writes `?` without an error, and the gb18030 UCA iterator weighs unmappable characters as `?`.

Verified against MySQL 8.0.46. Every sequence is one character with no warning:

| charset | sequence | `CHAR_LENGTH` | warnings |
|---|---|---|---|
| sjis | `81AD` | 1 | none |
| cp932 | `81AD` | 1 | none |
| ujis | `A2F1` | 1 | none |
| eucjpms | `A2F1` | 1 | none |
| euckr | `C941` | 1 | none |
| gb2312 | `A2A1` | 1 | none |
| gb18030 | `E3329A36` | 1 | none |

The converted output bytes were already correct. The reference case produced `41 3F 41` and then errored anyway, so the diff on those `TestConvert` rows is only the removal of the error expectation.

`WEIGHT_STRING` under `gb18030_unicode_520_ci` gives `0273` for `E3329A36`, which is `?`'s weight and not `U+FFFD`'s (`110F`), so the iterator substitutes `?` rather than passing the decoder's `RuneError` through. It previously terminated on the decode failure and produced an empty weight string.

Two scope decisions:

- The positional weight from the issue (`FF12E248`) belongs to `gb18030_chinese_ci`, which is unsupported in Vitess. `LookupByName` returns 0, because the `makecolldata` generator has a case only for `gb18030_unicode_520_ci`. Implementing it means a new collation family with variable-width weights.
- LIKE, measured on 8.0.46 with `@u = X'E3329A36'`, `@v = X'E3329A37'`: `LIKE '%'` gives 1, `'_'` gives 1, `'?'` gives 0, `@u` gives 1, `@v` gives 0. Unmappable characters count as one character but compare by bytes, so the wildcard matchers do no `?` substitution. `multibyteWildcard` matches this exactly. `unicodeWildcard` stores its pattern as `[]rune`, so distinct unmappable sequences still compare equal there, which is noted in a comment on the type.

`Expand` does substitute `?`, since its only consumers are the REGEXP functions and MySQL's regexp pipeline converts the subject first.

## Related Issue(s)

Fixes #20775

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

User-visible behaviour change: converting a structurally valid but unmapped multibyte sequence out of its charset previously failed with `Cannot convert string ...` and now silently yields `?`, matching MySQL. `Validate` accepts these sequences where it previously rejected them. No schema or migration impact.

### AI Disclosure

AI used to assist with code generation and tests under my supervision. MySQL behaviour was verified manually.