### PR TITLE
CI: pass GitHub context to run scripts via env vars instead of template expansion

### DIFF
--- a/.github/actions/setup-mysql/action.yml
+++ b/.github/actions/setup-mysql/action.yml
@@ -9,6 +9,8 @@ runs:
   steps:
     - name: Setup MySQL
       shell: bash -e {0}
+      env:
+        FLAVOR: ${{ inputs.flavor }}
       run: |
         export DEBIAN_FRONTEND="noninteractive"
 
@@ -52,8 +54,8 @@ runs:
           # Oracle's apt repo only publishes amd64 packages for Ubuntu, so on
           # arm64 we install MySQL from the Ubuntu archive instead, which only
           # ships MySQL 8.0.
-          if [[ "${{ inputs.flavor }}" != "mysql-8.0" ]]; then
-            echo "Unsupported MySQL flavor on arm64: ${{ inputs.flavor }}"
+          if [[ "$FLAVOR" != "mysql-8.0" ]]; then
+            echo "Unsupported MySQL flavor on arm64: $FLAVOR"
             exit 1
           fi
           sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
@@ -77,7 +79,7 @@ runs:
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A8D3785C
           wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.35-1_all.deb
 
-          if [[ "${{ inputs.flavor }}" == "mysql-5.7" ]]; then
+          if [[ "$FLAVOR" == "mysql-5.7" ]]; then
             # Bionic packages are still compatible for Jammy since there's no MySQL 5.7
             # packages for Jammy.
             echo mysql-apt-config mysql-apt-config/repo-codename select bionic | sudo debconf-set-selections
@@ -96,18 +98,18 @@ runs:
             sudo dpkg -i libtinfo5_6.3-2ubuntu0.2_amd64.deb
             rm libtinfo5_6.3-2ubuntu0.2_amd64.deb
             sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-client=5.7* mysql-community-server=5.7* mysql-server=5.7* libncurses6
-          elif [[ "${{ inputs.flavor }}" == "mysql-8.0" ]]; then
+          elif [[ "$FLAVOR" == "mysql-8.0" ]]; then
             echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections
             sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
             sudo apt-get update
             sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
-          elif [[ "${{ inputs.flavor }}" == "mysql-8.4" ]]; then
+          elif [[ "$FLAVOR" == "mysql-8.4" ]]; then
             echo mysql-apt-config mysql-apt-config/select-server select mysql-8.4-lts | sudo debconf-set-selections
             sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
             sudo apt-get update
             sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
           else
-            echo "Unsupported MySQL flavor: ${{ inputs.flavor }}"
+            echo "Unsupported MySQL flavor: $FLAVOR"
             exit 1
           fi
         fi

--- a/.github/workflows/auto_approve_pr.yml
+++ b/.github/workflows/auto_approve_pr.yml
@@ -28,10 +28,13 @@ jobs:
       - name: Auto Approve Pull Request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # here we are checking that the PR has been created by the vitess-bot[bot] account and that it is not a draft
           # if there is a merge conflict in the backport, the PR will always be created as a draft, meaning we can rely
           # on checking whether or not the PR is a draft
-          if [[ "${{github.event.pull_request.user.login}}" ==  "vitess-bot[bot]" ]] && [[ "${{github.event.pull_request.draft}}" == "false" ]]; then
-            gh pr review ${{ github.event.pull_request.number }} --approve
+          if [[ "$PR_AUTHOR" ==  "vitess-bot[bot]" ]] && [[ "$PR_DRAFT" == "false" ]]; then
+            gh pr review "$PR_NUMBER" --approve
           fi

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -215,13 +215,18 @@ jobs:
       - name: Run cluster endtoend test
         if: steps.changes.outputs.end_to_end == 'true'
         timeout-minutes: 45
+        env:
+          LIMIT_RESOURCES: ${{ contains(matrix.needs, 'limit-resources') }}
+          BINLOG_COMPRESSION: ${{ contains(matrix.needs, 'binlog-compression') }}
+          BUILD_TAG: ${{ matrix.buildTag }}
+          SHARD: ${{ matrix.shard }}
         run: |
           export VTDATAROOT="/tmp/"
           source build.env
           set -exo pipefail
 
           # Apply resource limits for heavy shards
-          if [[ "${{ contains(matrix.needs, 'limit-resources') }}" == "true" ]]; then
+          if [[ "$LIMIT_RESOURCES" == "true" ]]; then
             ulimit -n 65536
             cat <<-EOF>>./config/mycnf/mysql84.cnf
           innodb_buffer_pool_dump_at_shutdown=OFF
@@ -241,7 +246,7 @@ jobs:
           fi
 
           # Enable binlog compression for vreplication shards
-          if [[ "${{ contains(matrix.needs, 'binlog-compression') }}" == "true" ]]; then
+          if [[ "$BINLOG_COMPRESSION" == "true" ]]; then
             cat <<-EOF>>./config/mycnf/mysql84.cnf
           binlog-transaction-compression=ON
           binlog-row-value-options=PARTIAL_JSON
@@ -250,14 +255,14 @@ jobs:
 
           # Build test command with optional flags
           EXTRA_FLAGS=""
-          if [[ "${{ matrix.buildTag }}" != "" ]]; then
-            EXTRA_FLAGS="$EXTRA_FLAGS -build-tag=${{ matrix.buildTag }}"
+          if [[ "$BUILD_TAG" != "" ]]; then
+            EXTRA_FLAGS="$EXTRA_FLAGS -build-tag=$BUILD_TAG"
           fi
-          if [[ "${{ matrix.shard }}" == *"partial_keyspace"* ]]; then
+          if [[ "$SHARD" == *"partial_keyspace"* ]]; then
             EXTRA_FLAGS="$EXTRA_FLAGS -partial-keyspace=true"
           fi
 
-          go run test.go -docker=false -follow -shard "${{ matrix.shard }}" $EXTRA_FLAGS
+          go run test.go -docker=false -follow -shard "$SHARD" $EXTRA_FLAGS
 
       - name: Record test results in launchable
         if: |

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -142,16 +142,19 @@ jobs:
     - name: Run coverage tests
       if: steps.mode.outputs.is_full_run == 'true' || (steps.changes.outputs.changed_files == 'true' && steps.packages.outputs.packages != '')
       timeout-minutes: 60
+      env:
+        IS_FULL_RUN: ${{ steps.mode.outputs.is_full_run }}
+        COVERAGE_PACKAGES: ${{ steps.packages.outputs.packages }}
       run: |
         set -exo pipefail
         export VTDATAROOT="/tmp/"
         export NOVTADMINBUILD=1
         source build.env
 
-        if [ "${{ steps.mode.outputs.is_full_run }}" = "true" ]; then
+        if [ "$IS_FULL_RUN" = "true" ]; then
           make unit_test_cover
         else
-          make COVERAGE_PACKAGES="${{ steps.packages.outputs.packages }}" unit_test_cover
+          make COVERAGE_PACKAGES="$COVERAGE_PACKAGES" unit_test_cover
         fi
 
     - name: Upload coverage reports

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e.yml
@@ -41,8 +41,11 @@ jobs:
 
     - name: Set output with latest release branch
       id: output-previous-release-ref
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        REF: ${{ github.ref }}
       run: |
-        previous_release_ref=$(./tools/get_previous_release.sh ${{github.base_ref}} ${{github.ref}})
+        previous_release_ref=$(./tools/get_previous_release.sh "$BASE_REF" "$REF")
         echo $previous_release_ref
         echo "previous_release_ref=${previous_release_ref}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_e2e_next_release.yml
@@ -42,8 +42,11 @@ jobs:
 
     - name: Set output with latest release branch
       id: output-next-release-ref
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        REF: ${{ github.ref }}
       run: |
-        next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})
+        next_release_ref=$(./tools/get_next_release.sh "$BASE_REF" "$REF")
         echo $next_release_ref
         echo "next_release_ref=${next_release_ref}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/upgrade_downgrade_test_backups_manual.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual.yml
@@ -73,8 +73,11 @@ jobs:
     - name: Set output with latest release branch
       if: steps.changes.outputs.end_to_end == 'true'
       id: output-previous-release-ref
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        REF: ${{ github.ref }}
       run: |
-        previous_release_ref=$(./tools/get_previous_release.sh ${{github.base_ref}} ${{github.ref}})
+        previous_release_ref=$(./tools/get_previous_release.sh "$BASE_REF" "$REF")
         echo $previous_release_ref
         echo "previous_release_ref=${previous_release_ref}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_backups_manual_next_release.yml
@@ -73,8 +73,11 @@ jobs:
     - name: Set output with latest release branch
       id: output-next-release-ref
       if: steps.changes.outputs.end_to_end == 'true'
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        REF: ${{ github.ref }}
       run: |
-        next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})
+        next_release_ref=$(./tools/get_next_release.sh "$BASE_REF" "$REF")
         echo $next_release_ref
         echo "next_release_ref=${next_release_ref}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
+++ b/.github/workflows/upgrade_downgrade_test_onlineddl_flow.yml
@@ -72,16 +72,22 @@ jobs:
     - name: Set output with latest release branch
       if: steps.changes.outputs.end_to_end == 'true'
       id: output-previous-release-ref
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        REF: ${{ github.ref }}
       run: |
-        previous_release_ref=$(./tools/get_previous_release.sh ${{github.base_ref}} ${{github.ref}})
+        previous_release_ref=$(./tools/get_previous_release.sh "$BASE_REF" "$REF")
         echo $previous_release_ref
         echo "previous_release_ref=${previous_release_ref}" >> $GITHUB_OUTPUT
 
     - name: Set output with next release branch
       if: steps.changes.outputs.end_to_end == 'true'
       id: output-next-release-ref
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        REF: ${{ github.ref }}
       run: |
-        next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})
+        next_release_ref=$(./tools/get_next_release.sh "$BASE_REF" "$REF")
         echo $next_release_ref
         echo "next_release_ref=${next_release_ref}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries.yml
@@ -45,8 +45,11 @@ jobs:
 
     - name: Set output with latest release branch
       id: output-previous-release-ref
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        REF: ${{ github.ref }}
       run: |
-        previous_release_ref=$(./tools/get_previous_release.sh ${{github.base_ref}} ${{github.ref}})
+        previous_release_ref=$(./tools/get_previous_release.sh "$BASE_REF" "$REF")
         echo $previous_release_ref
         echo "previous_release_ref=${previous_release_ref}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2.yml
@@ -71,8 +71,11 @@ jobs:
     - name: Set output with latest release branch
       if: steps.changes.outputs.end_to_end == 'true'
       id: output-previous-release-ref
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        REF: ${{ github.ref }}
       run: |
-        previous_release_ref=$(./tools/get_previous_release.sh ${{github.base_ref}} ${{github.ref}})
+        previous_release_ref=$(./tools/get_previous_release.sh "$BASE_REF" "$REF")
         echo $previous_release_ref
         echo "previous_release_ref=${previous_release_ref}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_2_next_release.yml
@@ -45,8 +45,11 @@ jobs:
 
     - name: Set output with latest release branch
       id: output-next-release-ref
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        REF: ${{ github.ref }}
       run: |
-        next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})
+        next_release_ref=$(./tools/get_next_release.sh "$BASE_REF" "$REF")
         echo $next_release_ref
         echo "next_release_ref=${next_release_ref}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_queries_next_release.yml
@@ -45,8 +45,11 @@ jobs:
 
     - name: Set output with latest release branch
       id: output-next-release-ref
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        REF: ${{ github.ref }}
       run: |
-        next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})
+        next_release_ref=$(./tools/get_next_release.sh "$BASE_REF" "$REF")
         echo $next_release_ref
         echo "next_release_ref=${next_release_ref}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema.yml
@@ -45,8 +45,11 @@ jobs:
 
     - name: Set output with latest release branch
       id: output-previous-release-ref
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        REF: ${{ github.ref }}
       run: |
-        previous_release_ref=$(./tools/get_previous_release.sh ${{github.base_ref}} ${{github.ref}})
+        previous_release_ref=$(./tools/get_previous_release.sh "$BASE_REF" "$REF")
         echo $previous_release_ref
         echo "previous_release_ref=${previous_release_ref}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
+++ b/.github/workflows/upgrade_downgrade_test_query_serving_schema_next_release.yml
@@ -45,8 +45,11 @@ jobs:
 
     - name: Set output with latest release branch
       id: output-next-release-ref
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        REF: ${{ github.ref }}
       run: |
-        next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})
+        next_release_ref=$(./tools/get_next_release.sh "$BASE_REF" "$REF")
         echo $next_release_ref
         echo "next_release_ref=${next_release_ref}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vtctl.yml
@@ -45,8 +45,11 @@ jobs:
 
     - name: Set output with latest release branch
       id: output-next-release-ref
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        REF: ${{ github.ref }}
       run: |
-        next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})
+        next_release_ref=$(./tools/get_next_release.sh "$BASE_REF" "$REF")
         echo $next_release_ref
         echo "next_release_ref=${next_release_ref}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_new_vttablet.yml
@@ -45,8 +45,11 @@ jobs:
 
     - name: Set output with latest release branch
       id: output-next-release-ref
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        REF: ${{ github.ref }}
       run: |
-        next_release_ref=$(./tools/get_next_release.sh ${{github.base_ref}} ${{github.ref}})
+        next_release_ref=$(./tools/get_next_release.sh "$BASE_REF" "$REF")
         echo $next_release_ref
         echo "next_release_ref=${next_release_ref}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vtctl.yml
@@ -45,8 +45,11 @@ jobs:
 
     - name: Set output with latest release branch
       id: output-previous-release-ref
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        REF: ${{ github.ref }}
       run: |
-        previous_release_ref=$(./tools/get_previous_release.sh ${{github.base_ref}} ${{github.ref}})
+        previous_release_ref=$(./tools/get_previous_release.sh "$BASE_REF" "$REF")
         echo $previous_release_ref
         echo "previous_release_ref=${previous_release_ref}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
+++ b/.github/workflows/upgrade_downgrade_test_reparent_old_vttablet.yml
@@ -45,8 +45,11 @@ jobs:
 
     - name: Set output with latest release branch
       id: output-previous-release-ref
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        REF: ${{ github.ref }}
       run: |
-        previous_release_ref=$(./tools/get_previous_release.sh ${{github.base_ref}} ${{github.ref}})
+        previous_release_ref=$(./tools/get_previous_release.sh "$BASE_REF" "$REF")
         echo $previous_release_ref
         echo "previous_release_ref=${previous_release_ref}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Description

Running [zizmor](https://docs.zizmor.sh/) against our workflows (see #19149) reports a bunch of `template-injection` findings: expressions like `${{ github.base_ref }}` or `${{ inputs.flavor }}` interpolated directly into `run:` scripts get expanded *before* the shell runs, so anyone who can influence those values could inject shell code.

This fixes all high- and medium-severity template-injection findings by routing the values through step-level `env:` vars instead — the shell then reads them as plain data. Same pattern we already use in `backport.yml` and the error-code-docs workflows. No behavior change:

- the 15 `upgrade_downgrade_test_*.yml` files pass `github.base_ref`/`github.ref` to `tools/get_previous_release.sh` / `get_next_release.sh`. Quoting the (empty-on-push) `base_ref` is safe — both scripts already fall back from `$1` to `$2` when the first arg is empty.
- `cluster_endtoend.yml`'s `contains(...)` results still compare as the strings `"true"`/`"false"`.
- `setup-mysql`, `auto_approve_pr.yml`, and `codecov.yml` are straight substitutions.

This is the first of a few PRs fixing zizmor findings so the check from #19149 can eventually land green. Two follow-ups (permissions/credentials hygiene, `GITHUB_ENV` token handling) are coming separately.

## Related Issue(s)

- #19149

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — CI-only change.

### AI Disclosure

This PR was written by Claude Code — I provided direction and reviewed the changes.
