### PR TITLE
CI: tighten workflow token permissions and checkout credentials

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -36,6 +36,11 @@ jobs:
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # contents to push the port branches, pull-requests to create the
+          # port PRs and request reviews, issues to apply labels and comment.
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: Get GitHub App User ID
         id: get-user-id

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -13,7 +13,8 @@ concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Cluster End-to-End Tests')
   cancel-in-progress: true
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   LAUNCHABLE_ORGANIZATION: "vitess"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -73,7 +73,7 @@ jobs:
         ./tools/make-release-packages.sh
 
     - name: Upload Files
-      uses: csexton/release-asset-action@3567794e918fa3068116688122a76cdeb57b5f09 # v3.0.0
+      uses: csexton/release-asset-action@3567794e918fa3068116688122a76cdeb57b5f09 # v3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         pattern: "releases/*.{tar.gz,rpm,deb}"

--- a/.github/workflows/docker_build_images.yml
+++ b/.github/workflows/docker_build_images.yml
@@ -11,7 +11,8 @@ concurrency:
   group: format('{0}-{1}', ${{ github.ref }}, 'Build Docker Images')
   cancel-in-progress: true
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   build_and_push_vttestserver:
@@ -246,6 +247,8 @@ jobs:
   slack_notification:
     name: Slack Notification if failed
     runs-on: ubuntu-24.04
+    permissions:
+      actions: read
     needs:
       - build_and_push_vttestserver
       - build_and_push_lite

--- a/.github/workflows/docker_lite_build_check.yml
+++ b/.github/workflows/docker_lite_build_check.yml
@@ -8,7 +8,8 @@ on:
       - "main"
       - "release-[0-9]+.[0-9]"
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   generate-matrix:

--- a/.github/workflows/error_code_docs_generate.yml
+++ b/.github/workflows/error_code_docs_generate.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Checkout vitess
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: 'false'
 
       - name: Set up Go
         uses: ./.github/actions/setup-go

--- a/.github/workflows/pr_opened_tasks.yml
+++ b/.github/workflows/pr_opened_tasks.yml
@@ -3,7 +3,8 @@
 # - Adds initial labels (NeedsWebsiteDocsUpdate, NeedsDescriptionUpdate, NeedsIssue, NeedsBackportReason)
 name: PR opened tasks
 
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   pull_request_target:

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ matrix.branch }}
+          persist-credentials: 'false'
 
       - name: Set up Go
         # The shared setup-go action is resolved from the matrix.branch


### PR DESCRIPTION
## Description

Second batch of fixes for the [zizmor](https://docs.zizmor.sh/) findings from #19149 (first batch: #20784). This one is permissions and credentials hygiene:

- **`backport.yml`**: the GitHub App token was minted with the app's full installation permissions. It's now scoped to what the workflow actually uses — `contents: write` (pushing port branches), `pull-requests: write` (creating PRs, requesting reviews), and `issues: write` (labels and PR comments go through the issues API).
- **`cluster_endtoend.yml`, `docker_build_images.yml`, `docker_lite_build_check.yml`, `pr_opened_tasks.yml`**: workflow-level `permissions: read-all` becomes `contents: read`. Jobs that write already use app tokens or their own job-level permission blocks. The Slack-notification job in the docker build workflow gets an explicit `actions: read`, which the status-reporting action relies on.
- **`error_code_docs_generate.yml`, `update_golang_version.yml`**: `persist-credentials: 'false'` on checkouts, matching every other workflow. Neither pushes with the persisted credential — the golang-version workflow delegates pushing entirely to `create-pull-request` with its own app token.
- **`create_release.yml`**: the version comment on the `release-asset-action` pin said `v3.0.0`, but no such tag exists — the pinned SHA is tag `v3`. Comment corrected, SHA unchanged.

This resolves zizmor's `github-app`, `excessive-permissions`, `artipacked`, and `ref-version-mismatch` findings. One more PR (token handling via `GITHUB_ENV` + a codecov flags fix) coming separately.

## Related Issue(s)

- #19149

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — CI-only change.

### AI Disclosure

This PR was written by Claude Code — I provided direction and reviewed the changes.
