### PR TITLE
CI: scope app tokens to steps instead of exporting via GITHUB_ENV

### DIFF
--- a/.github/actions/setup-percona-repo/action.yml
+++ b/.github/actions/setup-percona-repo/action.yml
@@ -4,15 +4,16 @@ runs:
   using: "composite"
   steps:
     - name: Build weekly cache key
+      id: cache-key
       shell: bash -e {0}
-      run: echo "PERCONA_RELEASE_CACHE_WEEK=$(date +%G-%V)" >> "$GITHUB_ENV"
+      run: echo "week=$(date +%G-%V)" >> "$GITHUB_OUTPUT"
 
     - name: Cache percona-release package
       id: cache-percona-release
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: percona-release_latest.deb
-        key: percona-release_latest.deb.${{ env.PERCONA_RELEASE_CACHE_WEEK }}
+        key: percona-release_latest.deb.${{ steps.cache-key.outputs.week }}
 
     - name: Get Percona Apt Repo package (on cache miss)
       if: steps.cache-percona-release.outputs.cache-hit != 'true'

--- a/.github/workflows/arewefastyet_comment.yml
+++ b/.github/workflows/arewefastyet_comment.yml
@@ -29,11 +29,10 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-pull-requests: write
 
-      - name: Set token in environment
-        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
-
       - name: Check if comment already exists
         id: check_comment
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           # Get all comments on the PR
           COMMENTS=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq '.[].body')
@@ -48,6 +47,8 @@ jobs:
 
       - name: Add arewefastyet comment
         if: steps.check_comment.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh pr comment ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -161,6 +161,6 @@ jobs:
         files: coverage.out
         fail_ci_if_error: true
         verbose: true
-        flags: ${{ steps.mode.outputs.is_full_run == 'true' && '' || 'partial' }}
+        flags: ${{ steps.mode.outputs.is_full_run != 'true' && 'partial' || '' }}
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/error_code_docs_update.yml
+++ b/.github/workflows/error_code_docs_update.yml
@@ -55,16 +55,11 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      - name: Set token in environment
-        if: steps.metadata.outputs.skip != 'true'
-        env:
-          TOKEN: ${{ steps.app-token.outputs.token }}
-        run: echo "GH_TOKEN=$TOKEN" >> "$GITHUB_ENV"
-
       - name: Determine docs version
         if: steps.metadata.outputs.skip != 'true'
         id: docs_version
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BASE_REF: ${{ steps.metadata.outputs.base_ref }}
           REPO_OWNER: ${{ github.repository_owner }}
         run: |
@@ -130,6 +125,7 @@ jobs:
         if: steps.metadata.outputs.skip != 'true' && steps.docs_version.outputs.skip != 'true' && steps.update_docs.outputs.skip != 'true'
         id: get-user-id
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
@@ -146,6 +142,7 @@ jobs:
       - name: Create or update PR on website
         if: steps.metadata.outputs.skip != 'true' && steps.docs_version.outputs.skip != 'true' && steps.update_docs.outputs.skip != 'true'
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
           DOC_PATH: ${{ steps.update_docs.outputs.doc_path }}
           REPO_OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/pr_opened_tasks.yml
+++ b/.github/workflows/pr_opened_tasks.yml
@@ -64,9 +64,6 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-pull-requests: write
 
-      - name: Set token in environment
-        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
-
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -74,6 +71,8 @@ jobs:
           persist-credentials: 'false'
 
       - name: Add Review Checklist Comment
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh pr comment ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
@@ -94,10 +93,9 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-pull-requests: write
 
-      - name: Set token in environment
-        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
-
       - name: Add Initial Labels
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \


### PR DESCRIPTION
## Description

Third batch of fixes for the [zizmor](https://docs.zizmor.sh/) findings from #19149 (previous batches: #20784, #20785). This one is about token scoping via `GITHUB_ENV`:

- **`pr_opened_tasks.yml`, `arewefastyet_comment.yml`, `error_code_docs_update.yml`**: these wrote the GitHub App token into `$GITHUB_ENV`, exposing it to every subsequent step in the job. The export steps are gone; `GH_TOKEN` is now attached directly to the `env:` of each step that actually calls `gh` (or uses the token in a push URL).
- **`setup-percona-repo`**: the weekly cache key becomes a step output instead of a job-wide env var. The resulting cache key string is identical, so existing caches stay valid.
- **`codecov.yml`**: drive-by bug fix that zizmor's `unsound-ternary` audit caught — in `flags: ${{ is_full_run == 'true' && '' || 'partial' }}` the true-arm `''` is falsy, so the expression *always* evaluated to `'partial'`. Inverted to `${{ is_full_run != 'true' && 'partial' || '' }}`, which is sound. Behavior change: the scheduled full coverage runs now upload to Codecov unflagged, as originally intended, instead of being tagged `partial`.

This resolves zizmor's `github-env` and `unsound-ternary` findings. What remains after the three PRs is the judged-ignore baseline (`zizmor.yml` for the intentional `pull_request_target`/`workflow_run` triggers and the cache-poisoning heuristic misfires) and the rework of #19149 itself.

## Related Issue(s)

- #19149

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — CI-only change. Codecov uploads from scheduled full runs will no longer carry the `partial` flag.

### AI Disclosure

This PR was written by Claude Code — I provided direction and reviewed the changes.
