### PR TITLE
CI: let the backport app token update workflow files

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -37,10 +37,13 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           # contents to push the port branches, pull-requests to create the
-          # port PRs and request reviews, issues to apply labels and comment.
+          # port PRs and request reviews, issues to apply labels and comment,
+          # workflows because GitHub rejects a push from an app that touches
+          # .github/workflows without it.
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
+          permission-workflows: write
 
       - name: Get GitHub App User ID
         id: get-user-id


### PR DESCRIPTION
## Description

Regression from #20785 — my fault, sorry.

That PR scoped the backport workflow's GitHub App token to `contents`, `issues` and `pull-requests`. Before it, the token was minted with no `permission-*` inputs at all, so it inherited every permission the app installation has — including `workflows`. GitHub refuses a push from an app that creates or updates anything under `.github/workflows/` unless the token carries that permission, so backporting any CI change has been broken since #20785 merged.

It fails late and quietly: the cherry-pick succeeds, the branch is committed, and only the push is rejected, so the job reports success and no pull request is ever opened. I hit this trying to backport #20785 and #20786 themselves:

```
! [remote rejected] backport-20785-to-release-23.0 -> backport-20785-to-release-23.0
  (refusing to allow a GitHub App to create or update workflow `.github/workflows/cluster_endtoend.yml` without `workflows` permission)
```

Adding `permission-workflows: write` restores what the token had before, and no more. Backports of non-workflow changes were unaffected.

## Related Issue(s)

- #20785

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — CI-only change.

### AI Disclosure

This PR was written by Claude Code — I provided direction and reviewed the changes.
