### PR TITLE
sqlparser: fix parser panics on trailing-dot and escaped-backtick variable names

### DIFF
--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -1005,7 +1005,7 @@ func NewVariableExpression(str string, at AtCount) *Variable {
 
 func createIdentifierCI(str string) IdentifierCI {
 	size := len(str)
-	if str[0] == '`' && str[size-1] == '`' {
+	if size > 1 && str[0] == '`' && str[size-1] == '`' {
 		str = str[1 : size-1]
 	}
 	return NewIdentifierCI(str)

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -4431,6 +4431,39 @@ func TestInvalid(t *testing.T) {
 		}, {
 			input: "select _binary foo",
 			err:   "syntax error at position 19 near 'foo'",
+		}, {
+			input: "select @@session. from t",
+			err:   "syntax error at position 18 near 'session.'",
+		}, {
+			input: "select @@session.% from t",
+			err:   "syntax error at position 18 near 'session.'",
+		}, {
+			input: "select @@global.% from t",
+			err:   "syntax error at position 17 near 'global.'",
+		}, {
+			input: "select @@global.+ from t",
+			err:   "syntax error at position 17 near 'global.'",
+		}, {
+			input: "select @@local.% from t",
+			err:   "syntax error at position 16 near 'local.'",
+		}, {
+			input: "select @@vitess_metadata.% from t",
+			err:   "syntax error at position 26 near 'vitess_metadata.'",
+		}, {
+			input: "select 1 from t where a = @@global.%",
+			err:   "syntax error at position 36 near 'global.'",
+		}, {
+			input: "set @@session.% = 1",
+			err:   "syntax error at position 15 near 'session.'",
+		}, {
+			input: "set @@global. = 1",
+			err:   "syntax error at position 14 near 'global.'",
+		}, {
+			input: "select @@a. from t",
+			err:   "syntax error at position 12 near 'a.'",
+		}, {
+			input: "select @@`session.` from t",
+			err:   "syntax error at position 20 near 'session.'",
 		},
 	}
 
@@ -4440,6 +4473,57 @@ func TestInvalid(t *testing.T) {
 			_, err := parser.Parse(tcase.input)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tcase.err)
+		})
+	}
+}
+
+// TestSystemVariableNameMustNotEndInDot exists as a standalone test because a
+// table entry that expects an error would also be satisfied by a panic being
+// recovered somewhere upstream; this pins down that Parse returns instead of
+// panicking.
+func TestSystemVariableNameMustNotEndInDot(t *testing.T) {
+	parser := NewTestParser()
+	for _, sql := range []string{
+		"select @@session. from t",
+		"select @@session.% from t",
+		"select @@global.% from t",
+		"select @@global.+ from t",
+		"select @@local.% from t",
+		"select @@vitess_metadata.% from t",
+		"select 1 from t where a = @@global.%",
+		"set @@session.% = 1",
+		"set @@global. = 1",
+		"select @@a. from t",
+		"select @@`session.` from t",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				_, err := parser.Parse(sql)
+				assert.Error(t, err)
+			})
+		})
+	}
+}
+
+// TestSystemVariableNamesStillParse guards the lexer's trailing-dot check
+// against over-rejecting well-formed variable references.
+func TestSystemVariableNamesStillParse(t *testing.T) {
+	parser := NewTestParser()
+	for _, sql := range []string{
+		"select @@autocommit from t",
+		"select @@global.autocommit from t",
+		"select @@session.autocommit from t",
+		"select @@local.x from t",
+		"select @@vitess_metadata.x from t",
+		"select @@`weird var` from t",
+		"select @@foo.bar from t",
+		"set @@global.autocommit = 1",
+		"set @@vitess_metadata.app_v1 = '1'",
+		"select @a.b from t",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			_, err := parser.Parse(sql)
+			require.NoError(t, err)
 		})
 	}
 }

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -4528,6 +4528,43 @@ func TestSystemVariableNamesStillParse(t *testing.T) {
 	}
 }
 
+// TestVariableNamesWithBackticks pins the parser's handling of backtick-quoted
+// variable names that are empty or consist only of an escaped backtick: empty
+// names are syntax errors, while a name holding a single literal backtick
+// parses and prints back unchanged. Parse must return in both cases instead of
+// panicking.
+func TestVariableNamesWithBackticks(t *testing.T) {
+	parser := NewTestParser()
+	t.Run("empty names are syntax errors", func(t *testing.T) {
+		for _, sql := range []string{
+			"select @`` from t",
+			"select @@`` from t",
+			"set @@`` = 1",
+		} {
+			t.Run(sql, func(t *testing.T) {
+				require.NotPanics(t, func() {
+					_, err := parser.Parse(sql)
+					assert.Error(t, err)
+				})
+			})
+		}
+	})
+	t.Run("a name that is a single escaped backtick parses", func(t *testing.T) {
+		for _, sql := range []string{
+			"select @```` from t",
+			"select @@```` from t",
+		} {
+			t.Run(sql, func(t *testing.T) {
+				require.NotPanics(t, func() {
+					stmt, err := parser.Parse(sql)
+					require.NoError(t, err)
+					require.Equal(t, sql, String(stmt))
+				})
+			})
+		}
+	})
+}
+
 func TestIntroducers(t *testing.T) {
 	validSQL := []struct {
 		input  string

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -188,6 +188,13 @@ func (tkn *Tokenizer) Scan() (int, string) {
 			if tID == LEX_ERROR {
 				return tID, ""
 			}
+			// A system variable name may not end in a dot; MySQL rejects such
+			// references as syntax errors. Here they would otherwise reach
+			// NewVariableExpression, which strips a scope prefix off the front
+			// and can be left holding nothing at all.
+			if tokenID == AT_AT_ID && strings.HasSuffix(tBytes, ".") {
+				return LEX_ERROR, tBytes
+			}
 			return tokenID, tBytes
 		case isLetter(ch):
 			if ch == 'X' || ch == 'x' {


### PR DESCRIPTION
## Description

`Parser.Parse` panics with `index out of range [0] with length 0` when a system variable reference has a scope prefix and nothing after the dot:

```sql
SELECT @@session.%
SELECT @@global.+
SET @@global. = 1
```

The tokenizer returns the whole reference as a single `AT_AT_ID` token (`session.`), `NewVariableExpression` strips the known scope prefix off the front, and `createIdentifierCI` then indexes the first byte of the empty remainder. Because this runs inside a grammar action, the panic escapes `Parse`.

The fix has two parts:

- The lexer now rejects a system variable name that ends in a dot. MySQL does the same — all of the inputs above fail with `ERROR 1064` (syntax error) on MySQL 8.0.43. Rejecting in the lexer also keeps unprintable variables (empty name, which would format back as `select @@`) out of the AST.
- `createIdentifierCI` now bounds its index, so it cannot panic on short input regardless of caller. This is not just defense in depth — it fixes a second reachable panic, described below.

No grammar change, so `sql.go` is untouched.

One behavior change beyond the panics: `SELECT @@a.` (trailing dot, no recognized scope prefix) used to parse as a variable literally named `a.`; it is now a syntax error. MySQL also rejects it with `ERROR 1064`. Valid dotted names like `@@a.b` and quoted names like ``@@`weird var` `` parse exactly as before.

The backtick-quoted form ``SELECT @@`session.` `` also panicked and is now a syntax error too. This one differs from MySQL in error kind: MySQL treats a backtick-quoted name literally (no scope resolution inside quotes), so it parses and fails at resolution with `ERROR 1193` unknown system variable. Vitess's tokenizer discards the backticks before the scope prefix is stripped, so treating the quoted name literally would need a larger tokenizer change; a syntax error seemed like the right trade-off next to the current panic.

The second panic has a different trigger: a backtick-quoted variable name consisting of a single escaped backtick, ````` select @@```` `````, reaches `createIdentifierCI` as the one-byte string `` ` ``, both byte comparisons hit the same backtick, and the `str[1:0]` slice panics. With the bound this now parses, matching MySQL (verified on 8.0.46): ````` select @```` ````` is a valid user variable (NULL) and ````` select @@```` ````` parses and fails at resolution with `ERROR 1193` unknown system variable `` '`' ``. Empty quoted names like ``` select @`` ``` never panicked — the lexer already rejects an empty quoted identifier — and a test pins that behavior too. (MySQL accepts empty quoted names at parse time and fails at resolution instead; that pre-existing divergence is untouched here.)

## Related Issue(s)

Fixes #20806

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Queries with a system variable name ending in a dot (e.g. `SELECT @@a.`) now return a syntax error instead of parsing (or, for scope-prefixed forms like `@@session.`, crashing the parser). MySQL rejects all of these forms. Backtick-quoted variable names consisting of a single escaped backtick now parse, matching MySQL, instead of crashing the parser.

### AI Disclosure

This PR was written by Claude Code following a reviewed plan.


