### PR TITLE
vtorc e2e: disable semi-sync before instance cleanup to avoid a deadlock

### DIFF
--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -491,6 +491,29 @@ func (vttablet *VttabletProcess) SemiSyncExtensionLoaded() (mysql.SemiSyncType, 
 	return conn.SemiSyncExtensionLoaded()
 }
 
+// DisableSemiSyncCommand returns the command to disable semi-sync on both the
+// source and replica side, or an empty string when no semi-sync extension is
+// loaded.
+func (vttablet *VttabletProcess) DisableSemiSyncCommand() (string, error) {
+	conn, err := vttablet.TabletConn("", false)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	semiSyncType, err := conn.SemiSyncExtensionLoaded()
+	if err != nil {
+		return "", err
+	}
+	switch semiSyncType {
+	case mysql.SemiSyncTypeSource:
+		return "SET GLOBAL rpl_semi_sync_source_enabled = false, GLOBAL rpl_semi_sync_replica_enabled = false", nil
+	case mysql.SemiSyncTypeMaster:
+		return "SET GLOBAL rpl_semi_sync_master_enabled = false, GLOBAL rpl_semi_sync_slave_enabled = false", nil
+	default:
+		return "", nil
+	}
+}
+
 // ResetBinaryLogsCommand returns the commands to reset binary logs
 func (vttablet *VttabletProcess) ResetBinaryLogsCommand() (string, error) {
 	conn, err := vttablet.TabletConn("", false)

--- a/go/test/endtoend/vtorc/general/vtorc_test.go
+++ b/go/test/endtoend/vtorc/general/vtorc_test.go
@@ -1050,6 +1050,73 @@ func TestRecoveryDeadlocks(t *testing.T) {
 	})
 }
 
+// TestSetupWithOrphanedSemiSyncSource verifies that cluster setup completes
+// when a previous test left a mysqld as a semi-sync source with no ackers.
+// Vitess's my.cnf configures semi-sync waits to never time out
+// (rpl_semi_sync_source_timeout) and to keep waiting even with no replica
+// connected (rpl_semi_sync_source_wait_no_replica), so the binlogged
+// statements that instance cleanup issues (DROP DATABASE, ...) block forever
+// unless cleanup disables semi-sync first.
+// See https://github.com/vitessio/vitess/issues/20799.
+func TestSetupWithOrphanedSemiSyncSource(t *testing.T) {
+	defer utils.PrintVTOrcLogsOnFailure(t, clusterInfo.ClusterInstance)
+	utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 0, nil, cluster.VTOrcConfiguration{
+		PreventCrossCellFailover: true,
+	}, cluster.DefaultVtorcsByCell, policy.DurabilitySemiSync)
+	keyspace := &clusterInfo.ClusterInstance.Keyspaces[0]
+	shard0 := &keyspace.Shards[0]
+
+	primary := utils.ShardPrimaryTablet(t, clusterInfo, keyspace, shard0)
+	require.NotNil(t, primary, "should have elected a primary")
+	require.Eventually(t, func() bool {
+		return utils.IsPrimarySemiSyncSetupCorrectly(t, primary, "ON")
+	}, 30*time.Second, time.Second, "expected VTOrc to enable semi-sync on the primary")
+
+	// If the test fails before the second setup finishes, the primary must not
+	// stay a blocked semi-sync source for the rest of the package.
+	t.Cleanup(func() {
+		semiSyncType, err := utils.SemiSyncExtensionLoaded(t, primary)
+		require.NoError(t, err)
+		switch semiSyncType {
+		case mysql.SemiSyncTypeSource:
+			_, _ = utils.RunSQL(t, "SET GLOBAL rpl_semi_sync_source_enabled = false", primary, "")
+		case mysql.SemiSyncTypeMaster:
+			_, _ = utils.RunSQL(t, "SET GLOBAL rpl_semi_sync_master_enabled = false", primary, "")
+		}
+	})
+
+	// Stop VTOrc first so it cannot repair replication, then orphan the
+	// semi-sync source: stop replication on every other tablet so no acker
+	// remains connected to the primary.
+	utils.StopVTOrcs(t, clusterInfo)
+	for _, tablet := range shard0.Vttablets {
+		if tablet.Alias == primary.Alias {
+			continue
+		}
+		_, err := utils.RunSQL(t, "STOP REPLICA", tablet, "")
+		require.NoError(t, err)
+	}
+
+	// The setup call never returns when instance cleanup blocks on the
+	// semi-sync wait, so it runs in a goroutine and the test fails at a bound
+	// instead of the package timeout. SetupVttabletsAndVTOrcs asserts
+	// internally with require, so a genuine setup error calls FailNow from
+	// this goroutine; that is only reached when setup itself fails, which is
+	// how every test in this package already behaves.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		utils.SetupVttabletsAndVTOrcs(t, clusterInfo, 2, 0, nil, cluster.VTOrcConfiguration{
+			PreventCrossCellFailover: true,
+		}, cluster.DefaultVtorcsByCell, "")
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Minute):
+		require.Fail(t, "cluster setup did not complete, instance cleanup is blocked on an orphaned semi-sync source")
+	}
+}
+
 // disableSemiSyncOnAllTablets clears `rpl_semi_sync_source_enabled` and
 // `rpl_semi_sync_replica_enabled` on every tablet's mysqld in the shared
 // cluster. Required before SetupVttabletsAndVTOrcs when the previous test

--- a/go/test/endtoend/vtorc/utils/utils.go
+++ b/go/test/endtoend/vtorc/utils/utils.go
@@ -332,8 +332,18 @@ func SetupVttabletsAndVTOrcs(t *testing.T, clusterInfo *VTOrcClusterInfo, numRep
 // cleanAndStartVttablet cleans the MySQL instance underneath for running a new test. It also starts the vttablet.
 func cleanAndStartVttablet(t *testing.T, clusterInfo *VTOrcClusterInfo, vttablet *cluster.Vttablet) {
 	t.Helper()
+	// A previous test may have left this mysqld as a semi-sync source. Vitess's
+	// my.cnf configures semi-sync waits to never time out, even with no replica
+	// connected, so the binlogged statements below would block forever unless
+	// semi-sync is disabled first.
+	disableSemiSyncCmd, err := vttablet.VttabletProcess.DisableSemiSyncCommand()
+	require.NoError(t, err)
+	if disableSemiSyncCmd != "" {
+		_, err = RunSQL(t, disableSemiSyncCmd, vttablet, "")
+		require.NoError(t, err)
+	}
 	// set super_read_only to false
-	_, err := RunSQL(t, "SET GLOBAL super_read_only = OFF", vttablet, "")
+	_, err = RunSQL(t, "SET GLOBAL super_read_only = OFF", vttablet, "")
 	require.NoError(t, err)
 	// remove the databases if they exist
 	_, err = RunSQL(t, "DROP DATABASE IF EXISTS vt_ks", vttablet, "")


### PR DESCRIPTION
## Description

The vtorc e2e suites reuse mysqld instances across tests, but the per-test cleanup (`cleanAndStartVttablet`) only resets databases and binlogs — not replication configuration. If the previous test left a mysqld as an active semi-sync source, the cleanup's binlogged statements (`DROP DATABASE IF EXISTS vt_ks`, ...) can block forever in the semi-sync ACK wait, because our own my.cnf makes those waits unbounded. The whole package then dies with `panic: test timed out after 10m0s`, and since it's a panic the CI runner doesn't retry the shard. Whether it triggers depends on which tablet the previous test elected primary relative to the fixed cleanup order, which is why it shows up as an intermittent hard failure. Full mechanism and a captured goroutine dump are in #20799.

The fix mirrors what `resetReplicationCommands` (`go/mysql/flavor_mysql.go`) already does in production code: disable semi-sync (flavor-aware, both source and replica side) as the first step of instance cleanup, before any binlogged statement. A nice property we confirmed empirically: disabling `rpl_semi_sync_source_enabled` also releases a commit that's already blocked in the ACK wait, so the cleanup self-heals even if the poisoned state already exists.

The regression test creates the poisoned state deliberately (semi_sync durability, wait for VTOrc to enable source semi-sync on the primary, stop VTOrc, stop replication on all other tablets) and then requires that a second `SetupVttabletsAndVTOrcs` call completes within a bound. Without the fix it fails at its 3-minute bound; with the fix it passes in one setup cycle.

Note: `TestRecoveryDeadlocks` carries a local workaround for this exact hang (`disableSemiSyncOnAllTablets`, added in #20015). This PR makes it redundant, but I've left removing it out of scope for now.

Backport justification: the same test adjacency (`TestSemiSyncRecoveryOrdering` followed by `TestReplicationStoppedWithSemiSyncBlocked`) exists on release-23.0 and release-24.0, so those branches carry the same CI deadlock.

## Related Issue(s)

Fixes #20799

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None — test-only change.

### AI Disclosure

This PR was written by Claude Code — I provided direction and reviewed the changes.
