### PR TITLE
endtoend: add `VTOrcExtraArgs` to the cluster framework

### DIFF
--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -125,6 +125,9 @@ type LocalProcessCluster struct {
 
 	VtctldExtraArgs []string
 
+	// Extra arguments for vtorc
+	VTOrcExtraArgs []string
+
 	// mutex added to handle the parallel teardowns
 	mx                *sync.Mutex
 	teardownCompleted bool
@@ -283,6 +286,7 @@ func (cluster *LocalProcessCluster) StartTopo() (err error) {
 func (cluster *LocalProcessCluster) StartVTOrc(cell, keyspace string) error {
 	// Start vtorc
 	vtorcProcess := cluster.NewVTOrcProcess(VTOrcConfiguration{}, cell)
+	vtorcProcess.ExtraArgs = append(vtorcProcess.ExtraArgs, cluster.VTOrcExtraArgs...)
 	err := vtorcProcess.Setup()
 	if err != nil {
 		log.Error(err.Error())


### PR DESCRIPTION
## Description

The endtoend cluster framework plumbs extra arguments to vtctld, vttablet, and vtgate (`VtctldExtraArgs`, `VtTabletExtraArgs`, `VtGateExtraArgs`), but not to vtorc: `StartVTOrc` builds the process with no way to receive per-test flags.

This adds a `VTOrcExtraArgs` field to `LocalProcessCluster`, mirroring `VtGateExtraArgs`, and appends it to the vtorc process arguments in `StartVTOrc`. This is useful for tests that need to pass extra flags to vtorc (e.g., topology credentials flags).

## Related Issue(s)

N/A

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on the CI
-   [x] Documentation was added or is not required

### AI Disclosure

Claude Code wrote this PR. A human gave direction and did the reviews.