### PR TITLE
test: capture log output via atomic SwapLogger instead of racy global…

### DIFF
--- a/go/vt/log/log.go
+++ b/go/vt/log/log.go
@@ -65,6 +65,30 @@ func SwapLogger(newLogger *slog.Logger) *slog.Logger {
 	return logger.Swap(newLogger)
 }
 
+// WrapLogger atomically replaces the structured logger with the result of calling
+// wrap on the currently installed one, and returns the logger that was replaced
+// along with the one that is now installed. No log record can slip through between
+// reading the current logger and installing the wrapper.
+//
+// wrap must be free of side effects: it is called again if another goroutine
+// installs a logger concurrently. Its argument is nil if no logger is installed.
+func WrapLogger(wrap func(current *slog.Logger) *slog.Logger) (previous, installed *slog.Logger) {
+	for {
+		previous = logger.Load()
+		installed = wrap(previous)
+		if logger.CompareAndSwap(previous, installed) {
+			return previous, installed
+		}
+	}
+}
+
+// CompareAndSwapLogger installs newLogger only if oldLogger is the one currently
+// installed, and reports whether it did. It lets a caller give up its own logger
+// without clobbering one that another caller installed on top of it.
+func CompareAndSwapLogger(oldLogger, newLogger *slog.Logger) bool {
+	return logger.CompareAndSwap(oldLogger, newLogger)
+}
+
 // log is a helper that logs with glog or slog depending on the configured flags.
 func log(level slog.Level, depth int, msg string, attrs ...slog.Attr) {
 	if !structured.Load() {

--- a/go/vt/log/log_test.go
+++ b/go/vt/log/log_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingHandler counts the records it handles and forwards them.
+type countingHandler struct {
+	count   *atomic.Int64
+	wrapped slog.Handler
+}
+
+func (h *countingHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return true
+}
+
+func (h *countingHandler) Handle(ctx context.Context, r slog.Record) error {
+	h.count.Add(1)
+	if !h.wrapped.Enabled(ctx, r.Level) {
+		return nil
+	}
+
+	return h.wrapped.Handle(ctx, r)
+}
+
+func (h *countingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &countingHandler{count: h.count, wrapped: h.wrapped.WithAttrs(attrs)}
+}
+
+func (h *countingHandler) WithGroup(name string) slog.Handler {
+	return &countingHandler{count: h.count, wrapped: h.wrapped.WithGroup(name)}
+}
+
+// restoreLogger reinstalls the logger that was installed when the test started.
+func restoreLogger(t *testing.T) *slog.Logger {
+	original := logger.Load()
+	t.Cleanup(func() {
+		logger.Store(original)
+	})
+
+	return original
+}
+
+func TestWrapLogger(t *testing.T) {
+	original := restoreLogger(t)
+
+	var count atomic.Int64
+	previous, installed := WrapLogger(func(current *slog.Logger) *slog.Logger {
+		require.Equal(t, original, current)
+		return slog.New(&countingHandler{count: &count, wrapped: current.Handler()})
+	})
+
+	assert.Equal(t, original, previous)
+	assert.Equal(t, installed, logger.Load())
+
+	Info("logged")
+	assert.Equal(t, int64(1), count.Load())
+}
+
+func TestWrapLoggerWithNoLoggerInstalled(t *testing.T) {
+	restoreLogger(t)
+	logger.Store(nil)
+
+	var gotCurrent *slog.Logger
+	var called bool
+	previous, installed := WrapLogger(func(current *slog.Logger) *slog.Logger {
+		gotCurrent, called = current, true
+		return slog.New(slog.DiscardHandler)
+	})
+
+	assert.True(t, called)
+	assert.Nil(t, gotCurrent)
+	assert.Nil(t, previous)
+	assert.Equal(t, installed, logger.Load())
+}
+
+func TestWrapLoggerKeepsEveryConcurrentWrapper(t *testing.T) {
+	restoreLogger(t)
+
+	// Every wrapper must end up in the chain: a lost update would silently drop
+	// one caller's capture.
+	const wrappers = 16
+	counts := make([]atomic.Int64, wrappers)
+	var wg sync.WaitGroup
+	wg.Add(wrappers)
+	for i := range wrappers {
+		go func() {
+			defer wg.Done()
+			WrapLogger(func(current *slog.Logger) *slog.Logger {
+				return slog.New(&countingHandler{count: &counts[i], wrapped: current.Handler()})
+			})
+		}()
+	}
+	wg.Wait()
+
+	Info("logged")
+
+	for i := range wrappers {
+		assert.Equal(t, int64(1), counts[i].Load(), "wrapper %d did not see the record", i)
+	}
+}
+
+func TestCompareAndSwapLogger(t *testing.T) {
+	original := restoreLogger(t)
+	other := slog.New(slog.DiscardHandler)
+
+	assert.False(t, CompareAndSwapLogger(other, other))
+	assert.Equal(t, original, logger.Load())
+
+	assert.True(t, CompareAndSwapLogger(original, other))
+	assert.Equal(t, other, logger.Load())
+}

--- a/go/vt/log/logtest/logtest.go
+++ b/go/vt/log/logtest/logtest.go
@@ -14,17 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package logtest lets tests capture log output through [log.SwapLogger], which is
-// atomic. Assigning to the log package's function variables instead (log.Warn = ...)
-// races with every concurrent log call in the process.
+// Package logtest lets tests capture log output through [log.WrapLogger], which
+// installs the capture atomically. Assigning to the log package's function
+// variables instead (log.Warn = ...) races with every concurrent log call in the
+// process.
 package logtest
 
 import (
 	"context"
-	"io"
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"vitess.io/vitess/go/vt/log"
@@ -41,6 +42,13 @@ type (
 		// a nil levels map captures every level.
 		levels map[slog.Level]bool
 
+		// previous and installed are written by Capture before the recorder is
+		// handed out, and are only read by Stop.
+		previous  *slog.Logger
+		installed *slog.Logger
+
+		active atomic.Bool
+
 		mu      sync.Mutex
 		records []Record
 	}
@@ -53,6 +61,9 @@ type (
 
 // Capture records everything logged at the given levels, all levels if none are
 // given, until the test ends. Records are still forwarded to the previous logger.
+//
+// Captures may overlap: installing and giving up a capture never drops a record
+// and never disables a capture belonging to another test.
 func Capture(t testing.TB, levels ...slog.Level) *Recorder {
 	r := &Recorder{}
 	if len(levels) > 0 {
@@ -61,21 +72,31 @@ func Capture(t testing.TB, levels ...slog.Level) *Recorder {
 			r.levels[level] = true
 		}
 	}
+	r.active.Store(true)
 
-	// the log package has no accessor for the current logger, so swap in a
-	// placeholder to get hold of the handler to wrap.
-	var wrapped slog.Handler = slog.NewTextHandler(io.Discard, nil)
-	previous := log.SwapLogger(slog.New(wrapped))
-	if previous != nil {
-		wrapped = previous.Handler()
-	}
-	log.SwapLogger(slog.New(&handler{recorder: r, wrapped: wrapped}))
-
-	t.Cleanup(func() {
-		log.SwapLogger(previous)
+	r.previous, r.installed = log.WrapLogger(func(current *slog.Logger) *slog.Logger {
+		wrapped := slog.DiscardHandler
+		if current != nil {
+			wrapped = current.Handler()
+		}
+		return slog.New(&handler{recorder: r, wrapped: wrapped})
 	})
 
+	t.Cleanup(r.Stop)
+
 	return r
+}
+
+// Stop ends the capture. The previous logger is restored if this capture is still
+// the installed one; otherwise the handler stays in the chain as a pass-through,
+// so that a capture installed on top of this one keeps working. Capture calls Stop
+// when the test ends, so calling it early is only needed to end a capture sooner.
+func (r *Recorder) Stop() {
+	if !r.active.Swap(false) {
+		return
+	}
+
+	log.CompareAndSwapLogger(r.installed, r.previous)
 }
 
 func (r *Recorder) Records() []Record {
@@ -105,8 +126,8 @@ func (r *Recorder) Clear() {
 	r.records = nil
 }
 
-func (r *Recorder) capturing(level slog.Level) bool {
-	return r.levels == nil || r.levels[level]
+func (r *Recorder) recording(level slog.Level) bool {
+	return r.active.Load() && (r.levels == nil || r.levels[level])
 }
 
 func (r *Recorder) record(rec Record) {
@@ -117,11 +138,11 @@ func (r *Recorder) record(rec Record) {
 }
 
 func (h *handler) Enabled(ctx context.Context, level slog.Level) bool {
-	return h.recorder.capturing(level) || h.wrapped.Enabled(ctx, level)
+	return h.recorder.recording(level) || h.wrapped.Enabled(ctx, level)
 }
 
 func (h *handler) Handle(ctx context.Context, r slog.Record) error {
-	if h.recorder.capturing(r.Level) {
+	if h.recorder.recording(r.Level) {
 		rec := Record{
 			Level:   r.Level,
 			Message: r.Message,

--- a/go/vt/log/logtest/logtest.go
+++ b/go/vt/log/logtest/logtest.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package logtest lets tests capture log output through [log.SwapLogger], which is
+// atomic. Assigning to the log package's function variables instead (log.Warn = ...)
+// races with every concurrent log call in the process.
+package logtest
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"vitess.io/vitess/go/vt/log"
+)
+
+type (
+	Record struct {
+		Level   slog.Level
+		Message string
+		Attrs   []slog.Attr
+	}
+
+	Recorder struct {
+		// a nil levels map captures every level.
+		levels map[slog.Level]bool
+
+		mu      sync.Mutex
+		records []Record
+	}
+
+	handler struct {
+		recorder *Recorder
+		wrapped  slog.Handler
+	}
+)
+
+// Capture records everything logged at the given levels, all levels if none are
+// given, until the test ends. Records are still forwarded to the previous logger.
+func Capture(t testing.TB, levels ...slog.Level) *Recorder {
+	r := &Recorder{}
+	if len(levels) > 0 {
+		r.levels = make(map[slog.Level]bool, len(levels))
+		for _, level := range levels {
+			r.levels[level] = true
+		}
+	}
+
+	// the log package has no accessor for the current logger, so swap in a
+	// placeholder to get hold of the handler to wrap.
+	var wrapped slog.Handler = slog.NewTextHandler(io.Discard, nil)
+	previous := log.SwapLogger(slog.New(wrapped))
+	if previous != nil {
+		wrapped = previous.Handler()
+	}
+	log.SwapLogger(slog.New(&handler{recorder: r, wrapped: wrapped}))
+
+	t.Cleanup(func() {
+		log.SwapLogger(previous)
+	})
+
+	return r
+}
+
+func (r *Recorder) Records() []Record {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]Record(nil), r.records...)
+}
+
+// String returns the captured messages, one per line.
+func (r *Recorder) String() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	messages := make([]string, 0, len(r.records))
+	for _, record := range r.records {
+		messages = append(messages, record.Message)
+	}
+
+	return strings.Join(messages, "\n")
+}
+
+func (r *Recorder) Clear() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.records = nil
+}
+
+func (r *Recorder) capturing(level slog.Level) bool {
+	return r.levels == nil || r.levels[level]
+}
+
+func (r *Recorder) record(rec Record) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.records = append(r.records, rec)
+}
+
+func (h *handler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.recorder.capturing(level) || h.wrapped.Enabled(ctx, level)
+}
+
+func (h *handler) Handle(ctx context.Context, r slog.Record) error {
+	if h.recorder.capturing(r.Level) {
+		rec := Record{
+			Level:   r.Level,
+			Message: r.Message,
+			Attrs:   make([]slog.Attr, 0, r.NumAttrs()),
+		}
+		r.Attrs(func(attr slog.Attr) bool {
+			rec.Attrs = append(rec.Attrs, attr)
+			return true
+		})
+		h.recorder.record(rec)
+	}
+
+	if !h.wrapped.Enabled(ctx, r.Level) {
+		return nil
+	}
+
+	return h.wrapped.Handle(ctx, r)
+}
+
+func (h *handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &handler{recorder: h.recorder, wrapped: h.wrapped.WithAttrs(attrs)}
+}
+
+func (h *handler) WithGroup(name string) slog.Handler {
+	return &handler{recorder: h.recorder, wrapped: h.wrapped.WithGroup(name)}
+}

--- a/go/vt/log/logtest/logtest_test.go
+++ b/go/vt/log/logtest/logtest_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package logtest
 
 import (
+	"context"
+	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +29,34 @@ import (
 
 	"vitess.io/vitess/go/vt/log"
 )
+
+// sink is a handler that counts every record reaching the bottom of the chain,
+// so that a test can tell whether installing a capture dropped anything.
+type sink struct {
+	count atomic.Int64
+}
+
+func (s *sink) Enabled(ctx context.Context, level slog.Level) bool { return true }
+
+func (s *sink) Handle(ctx context.Context, r slog.Record) error {
+	s.count.Add(1)
+	return nil
+}
+
+func (s *sink) WithAttrs(attrs []slog.Attr) slog.Handler { return s }
+
+func (s *sink) WithGroup(name string) slog.Handler { return s }
+
+// installSink makes s the bottom of the logger chain for the test.
+func installSink(t *testing.T, s *sink) *slog.Logger {
+	installed := slog.New(s)
+	previous := log.SwapLogger(installed)
+	t.Cleanup(func() {
+		log.SwapLogger(previous)
+	})
+
+	return installed
+}
 
 func TestCaptureRecordsMessagesAndAttrs(t *testing.T) {
 	recorder := Capture(t, slog.LevelWarn)
@@ -69,6 +100,16 @@ func TestCaptureRecordsDisabledLevels(t *testing.T) {
 	assert.Equal(t, "a debug message", recorder.String())
 }
 
+func TestCaptureForwardsToThePreviousLogger(t *testing.T) {
+	var s sink
+	installSink(t, &s)
+
+	Capture(t, slog.LevelWarn)
+	log.Warn("a warning")
+
+	assert.Equal(t, int64(1), s.count.Load())
+}
+
 func TestClear(t *testing.T) {
 	recorder := Capture(t, slog.LevelWarn)
 
@@ -80,6 +121,8 @@ func TestClear(t *testing.T) {
 }
 
 func TestCaptureRestoresPreviousLogger(t *testing.T) {
+	var s sink
+	installed := installSink(t, &s)
 	outer := Capture(t, slog.LevelWarn)
 
 	t.Run("inner", func(t *testing.T) {
@@ -93,29 +136,105 @@ func TestCaptureRestoresPreviousLogger(t *testing.T) {
 	log.Warn("logged after the inner test")
 
 	assert.Equal(t, "logged while nested\nlogged after the inner test", outer.String())
+
+	outer.Stop()
+	assert.Equal(t, installed, log.SwapLogger(installed), "captures unwound in order must restore the original logger")
 }
 
-func TestCaptureIsConcurrencySafe(t *testing.T) {
-	// under -race: goroutines log while the test reads and clears the recorder.
+func TestStopIsIdempotent(t *testing.T) {
+	var s sink
+	installed := installSink(t, &s)
 	recorder := Capture(t, slog.LevelWarn)
 
-	const goroutines = 8
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
-	for i := range goroutines {
+	recorder.Stop()
+	recorder.Stop()
+
+	assert.Equal(t, installed, log.SwapLogger(installed))
+
+	log.Warn("logged after stopping")
+	assert.Empty(t, recorder.String())
+	assert.Equal(t, int64(1), s.count.Load(), "the record must still reach the previous logger")
+}
+
+func TestOverlappingCapturesStoppedOutOfOrder(t *testing.T) {
+	var s sink
+	installSink(t, &s)
+
+	first := Capture(t, slog.LevelWarn)
+	second := Capture(t, slog.LevelWarn)
+
+	// stopping the capture underneath must not disable the one on top of it.
+	first.Stop()
+	log.Warn("logged after the first stopped")
+
+	assert.Empty(t, first.String())
+	assert.Equal(t, "logged after the first stopped", second.String())
+
+	second.Stop()
+	log.Warn("logged after both stopped")
+
+	assert.Empty(t, first.String())
+	assert.Equal(t, "logged after the first stopped", second.String())
+	assert.Equal(t, int64(2), s.count.Load(), "no record may be lost while captures are stopped")
+}
+
+func TestOverlappingCapturesRecordIndependently(t *testing.T) {
+	warnings := Capture(t, slog.LevelWarn)
+	errors := Capture(t, slog.LevelError)
+
+	log.Warn("a warning")
+	log.Error("an error")
+
+	assert.Equal(t, "a warning", warnings.String())
+	assert.Equal(t, "an error", errors.String())
+}
+
+func TestConcurrentCapturesDoNotDropOrLoseRecords(t *testing.T) {
+	// under -race: captures are installed and stopped while another goroutine
+	// logs continuously. every record must reach the sink at the bottom of the
+	// chain, and every capture must see what it logged while it was active.
+	var s sink
+	installSink(t, &s)
+
+	const (
+		capturers = 8
+		records   = 100
+	)
+
+	done := make(chan struct{})
+	var logged atomic.Int64
+	var logging sync.WaitGroup
+	logging.Go(func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				log.Warn("background")
+				logged.Add(1)
+			}
+		}
+	})
+
+	var capturing sync.WaitGroup
+	capturing.Add(capturers)
+	for i := range capturers {
 		go func() {
-			defer wg.Done()
-			for range 100 {
-				log.Warn("concurrent", slog.Int("goroutine", i))
+			defer capturing.Done()
+			message := fmt.Sprintf("capture %d", i)
+			for range records {
+				recorder := Capture(t, slog.LevelWarn)
+				log.Warn(message)
+				logged.Add(1)
+				assert.Contains(t, recorder.String(), message)
+				recorder.Stop()
 			}
 		}()
 	}
+	capturing.Wait()
 
-	for range 100 {
-		_ = recorder.String()
-		_ = recorder.Records()
-		recorder.Clear()
-	}
+	close(done)
+	logging.Wait()
 
-	wg.Wait()
+	assert.Equal(t, logged.Load(), s.count.Load(), "records were dropped while captures were installed")
 }

--- a/go/vt/log/logtest/logtest_test.go
+++ b/go/vt/log/logtest/logtest_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logtest
+
+import (
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/log"
+)
+
+func TestCaptureRecordsMessagesAndAttrs(t *testing.T) {
+	recorder := Capture(t, slog.LevelWarn)
+
+	log.Warn("a warning", slog.String("name", "value"))
+
+	records := recorder.Records()
+	require.Len(t, records, 1)
+	assert.Equal(t, slog.LevelWarn, records[0].Level)
+	assert.Equal(t, "a warning", records[0].Message)
+	require.Len(t, records[0].Attrs, 1)
+	assert.Equal(t, "name", records[0].Attrs[0].Key)
+	assert.Equal(t, "value", records[0].Attrs[0].Value.String())
+}
+
+func TestCaptureFiltersLevels(t *testing.T) {
+	recorder := Capture(t, slog.LevelError)
+
+	log.Info("an info")
+	log.Warn("a warning")
+	log.Error("an error")
+
+	assert.Equal(t, "an error", recorder.String())
+}
+
+func TestCaptureWithoutLevelsRecordsEverything(t *testing.T) {
+	recorder := Capture(t)
+
+	log.Info("an info")
+	log.Error("an error")
+
+	assert.Equal(t, "an info\nan error", recorder.String())
+}
+
+func TestCaptureRecordsDisabledLevels(t *testing.T) {
+	// the default logger is at info level, so it drops debug records.
+	recorder := Capture(t, slog.LevelDebug)
+
+	log.Debug("a debug message")
+
+	assert.Equal(t, "a debug message", recorder.String())
+}
+
+func TestClear(t *testing.T) {
+	recorder := Capture(t, slog.LevelWarn)
+
+	log.Warn("first")
+	recorder.Clear()
+	log.Warn("second")
+
+	assert.Equal(t, "second", recorder.String())
+}
+
+func TestCaptureRestoresPreviousLogger(t *testing.T) {
+	outer := Capture(t, slog.LevelWarn)
+
+	t.Run("inner", func(t *testing.T) {
+		inner := Capture(t, slog.LevelWarn)
+
+		log.Warn("logged while nested")
+
+		assert.Equal(t, "logged while nested", inner.String())
+	})
+
+	log.Warn("logged after the inner test")
+
+	assert.Equal(t, "logged while nested\nlogged after the inner test", outer.String())
+}
+
+func TestCaptureIsConcurrencySafe(t *testing.T) {
+	// under -race: goroutines log while the test reads and clears the recorder.
+	recorder := Capture(t, slog.LevelWarn)
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				log.Warn("concurrent", slog.Int("goroutine", i))
+			}
+		}()
+	}
+
+	for range 100 {
+		_ = recorder.String()
+		_ = recorder.Records()
+		recorder.Clear()
+	}
+
+	wg.Wait()
+}

--- a/go/vt/vtgate/executor_set_test.go
+++ b/go/vt/vtgate/executor_set_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/mysql/sqlerror"
-	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/log/logtest"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	econtext "vitess.io/vitess/go/vt/vtgate/executorcontext"
 
@@ -308,17 +308,7 @@ func TestExecutorInitVConfigUsesSetVarFlag(t *testing.T) {
 }
 
 func TestBuildDeniedSystemVariablesWarnsForUnknownNames(t *testing.T) {
-	oldWarn := log.Warn
-	t.Cleanup(func() {
-		log.Warn = oldWarn
-	})
-
-	var gotMessage string
-	var gotAttrs []slog.Attr
-	log.Warn = func(msg string, attrs ...slog.Attr) {
-		gotMessage = msg
-		gotAttrs = append([]slog.Attr(nil), attrs...)
-	}
+	logger := logtest.Capture(t, slog.LevelWarn)
 
 	denied := buildDeniedSystemVariables([]string{"unique_checks", "not_a_real_sysvar", " "})
 
@@ -326,10 +316,12 @@ func TestBuildDeniedSystemVariablesWarnsForUnknownNames(t *testing.T) {
 		"unique_checks":     {},
 		"not_a_real_sysvar": {},
 	}, denied)
-	assert.Equal(t, "unknown system variable in --denied-system-variables", gotMessage)
-	require.Len(t, gotAttrs, 1)
-	assert.Equal(t, "name", gotAttrs[0].Key)
-	assert.Equal(t, "not_a_real_sysvar", gotAttrs[0].Value.String())
+	records := logger.Records()
+	require.Len(t, records, 1)
+	assert.Equal(t, "unknown system variable in --denied-system-variables", records[0].Message)
+	require.Len(t, records[0].Attrs, 1)
+	assert.Equal(t, "name", records[0].Attrs[0].Key)
+	assert.Equal(t, "not_a_real_sysvar", records[0].Attrs[0].Value.String())
 }
 
 func TestExecutorSetOp(t *testing.T) {

--- a/go/vt/vtgate/scatter_conn_test.go
+++ b/go/vt/vtgate/scatter_conn_test.go
@@ -29,7 +29,7 @@ import (
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/discovery"
 	"vitess.io/vitess/go/vt/key"
-	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/log/logtest"
 	querypb "vitess.io/vitess/go/vt/proto/query"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
@@ -332,20 +332,12 @@ func TestExecutePanic(t *testing.T) {
 		Autocommit: false,
 	}
 
-	original := log.Error
-	defer func() {
-		log.Error = original
-	}()
-
-	var logMessage string
-	log.Error = func(msg string, _ ...slog.Attr) {
-		logMessage = msg
-	}
+	logger := logtest.Capture(t, slog.LevelError)
 
 	assert.Panics(t, func() {
 		_, _ = sc.ExecuteMultiShard(ctx, nil, rss, queries, econtext.NewSafeSession(session), true /*autocommit*/, false, nullResultsObserver{}, false)
 	})
-	require.Contains(t, logMessage, "(*ScatterConn).multiGoTransaction")
+	require.Contains(t, logger.String(), "(*ScatterConn).multiGoTransaction")
 }
 
 func TestReservedOnMultiReplica(t *testing.T) {

--- a/go/vt/vtgate/vstream_manager_test.go
+++ b/go/vt/vtgate/vstream_manager_test.go
@@ -36,8 +36,7 @@ import (
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/discovery"
-	"vitess.io/vitess/go/vt/log"
-	"vitess.io/vitess/go/vt/logutil"
+	"vitess.io/vitess/go/vt/log/logtest"
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/topoproto"
@@ -2482,10 +2481,7 @@ func TestVStreamManagerHealthCheckResponseHandling(t *testing.T) {
 	// Capture the vstream warning log. Otherwise we need to re-implement the vstream error
 	// handling in SandboxConn's implementation and then we're not actually testing the
 	// production code.
-	logger := logutil.NewMemoryLogger()
-	log.Warn = func(msg string, _ ...slog.Attr) {
-		logger.Warningf("%s", msg)
-	}
+	logger := logtest.Capture(t, slog.LevelWarn)
 
 	cell := "aa"
 	ks := "TestVStream"

--- a/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/controller_test.go
@@ -30,8 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"vitess.io/vitess/go/vt/log"
-	"vitess.io/vitess/go/vt/logutil"
+	"vitess.io/vitess/go/vt/log/logtest"
 	vttablet "vitess.io/vitess/go/vt/vttablet/common"
 
 	"vitess.io/vitess/go/sqltypes"
@@ -783,19 +782,8 @@ func TestControllerErrorLogMessages(t *testing.T) {
 		100: vterrors.New(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.GTIDSetMismatch+" test"),
 	}
 
-	infoLogger := logutil.NewMemoryLogger()
-	oldLogInfo := log.Info
-	log.Info = func(msg string, _ ...slog.Attr) {
-		infoLogger.Infof("%s", msg)
-	}
-	defer func() { log.Info = oldLogInfo }()
-
-	errorLogger := logutil.NewMemoryLogger()
-	oldLogError := log.Error
-	log.Error = func(msg string, _ ...slog.Attr) {
-		errorLogger.Errorf("%s", msg)
-	}
-	defer func() { log.Error = oldLogError }()
+	infoLogger := logtest.Capture(t, slog.LevelInfo)
+	errorLogger := logtest.Capture(t, slog.LevelError)
 
 	dbClient := binlogplayer.NewMockDBClient(t)
 	dbClient.AddInvariant("update _vt.vreplication set message=", testDMLResponse)

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -38,7 +38,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/log"
-	"vitess.io/vitess/go/vt/logutil"
+	"vitess.io/vitess/go/vt/log/logtest"
 	vttablet "vitess.io/vitess/go/vt/vttablet/common"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/testenv"
 
@@ -604,14 +604,7 @@ func TestPlayerStatementModeWithFilterAndErrorHandling(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 
 	// We want to check for the expected log message.
-	ole := log.Error
-	logger := logutil.NewMemoryLogger()
-	log.Error = func(msg string, _ ...slog.Attr) {
-		logger.Errorf("%s", msg)
-	}
-	defer func() {
-		log.Error = ole
-	}()
+	logger := logtest.Capture(t, slog.LevelError)
 
 	execStatements(t, []string{
 		"create table src1(id int, val varbinary(128), primary key(id))",
@@ -3948,18 +3941,13 @@ func TestPlayerStalls(t *testing.T) {
 	defer deleteTablet(addTablet(100))
 
 	// We want to check for the expected log messages.
-	ole := log.Error
-	logger := logutil.NewMemoryLogger()
-	log.Error = func(msg string, _ ...slog.Attr) {
-		logger.Errorf("%s", msg)
-	}
+	logger := logtest.Capture(t, slog.LevelError)
 
 	oldMinimumHeartbeatUpdateInterval := vreplicationMinimumHeartbeatUpdateInterval
 	oldProgressDeadline := vplayerProgressDeadline
 	oldRelayLogMaxItems := vttablet.DefaultVReplicationConfig.RelayLogMaxItems
 	oldRetryDelay := vttablet.DefaultVReplicationConfig.RetryDelay
 	defer func() {
-		log.Error = ole
 		vreplicationMinimumHeartbeatUpdateInterval = oldMinimumHeartbeatUpdateInterval
 		vplayerProgressDeadline = oldProgressDeadline
 		vttablet.DefaultVReplicationConfig.RelayLogMaxItems = oldRelayLogMaxItems


### PR DESCRIPTION
## Description

Several unit tests captured log output by directly reassigning the `go/vt/log` package-level function variables (`log.Warn = func(...) {...}`). Those writes are unsynchronized, so they race with any concurrently running goroutine that logs - the tests in question run real machinery (vtgate executors, VStream, vreplication players/controllers) that spawns logging goroutines. One site (`TestVStreamManagerHealthCheckResponseHandling`) also never restored the swap, so every later test in the vtgate package logged warnings into the dead test's memory logger.

This PR adds a small `go/vt/log/logtest` package with a `Capture(t, levels...)` helper built on the existing atomic `log.SwapLogger` (from #19844). It records matching log records behind a mutex, forwards everything to the previous logger, and restores it via `t.Cleanup` so a swap can never outlive its test. All six racy sites are converted:

- `go/vt/vtgate/vstream_manager_test.go` (also fixes the missing restore)
- `go/vt/vtgate/executor_set_test.go`
- `go/vt/vtgate/scatter_conn_test.go`
- `go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go` (two sites)
- `go/vt/vttablet/tabletmanager/vreplication/controller_test.go` (two sites)

A few other packages (`syslogger`, `grpcclient`, `logutil`, `trace`, `querythrottler`, vttablet endtoend) still swap the globals directly  left for a follow-up, now that there's a supported capture helper to migrate them to.
Note: `Capture(t, slog.LevelWarn)` matches the exact level, not "level and above".

All three affected packages pass locally under `go test -race`.

## Related Issue(s)

Fixes #20479

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Test-only change; no deployment impact.

### AI Disclosure

This PR was written primarily by Claude Code - I provided direction and review.
