### PR TITLE
servenv: fix data race and goroutine leaks in pprof tests

### DIFF
--- a/go/vt/servenv/pprof_test.go
+++ b/go/vt/servenv/pprof_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2026 The Vitess Authors.
 
@@ -16,19 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Disabling race detector because it doesn't like TestPProfInitWithWaitSig and TestPProfInitWithoutWaitSig,
-// but the profileStarted variable is updated in response to signals invoked in the tests and works as intended.
-
 package servenv
 
 import (
 	"os/signal"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseProfileFlag(t *testing.T) {
@@ -74,50 +71,59 @@ func TestParseProfileFlag(t *testing.T) {
 	}
 }
 
+// toggleProfiling sends SIGUSR1 and waits for profileStarted to reach want.
+// The signal is re-sent on each poll because a SIGUSR1 that arrives between
+// the listener's signal.Reset and signal.Notify is dropped by the OS.
+func toggleProfiling(t *testing.T, want uint32) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		if atomic.LoadUint32(&profileStarted) == want {
+			return true
+		}
+		syscall.Kill(syscall.Getpid(), syscall.SIGUSR1)
+		return atomic.LoadUint32(&profileStarted) == want
+	}, 30*time.Second, 50*time.Millisecond)
+}
+
 // with waitSig, we should start with profiling off and toggle on-off-on-off
 func TestPProfInitWithWaitSig(t *testing.T) {
 	signal.Reset(syscall.SIGUSR1)
+
+	oldFlag := pprofFlag
+	t.Cleanup(func() { pprofFlag = oldFlag })
 	pprofFlag = strings.Split("cpu,waitSig", ",")
 
-	pprofInit()
-	time.Sleep(1 * time.Second)
-	assert.Equal(t, uint32(0), profileStarted)
+	stop := startPprof()
+	require.NotNil(t, stop)
+	t.Cleanup(stop)
 
-	syscall.Kill(syscall.Getpid(), syscall.SIGUSR1)
-	time.Sleep(1 * time.Second)
-	assert.Equal(t, uint32(1), profileStarted)
+	assert.Eventually(t, func() bool {
+		return atomic.LoadUint32(&profileStarted) == 0
+	}, 30*time.Second, 10*time.Millisecond)
 
-	syscall.Kill(syscall.Getpid(), syscall.SIGUSR1)
-	time.Sleep(1 * time.Second)
-	assert.Equal(t, uint32(0), profileStarted)
-
-	syscall.Kill(syscall.Getpid(), syscall.SIGUSR1)
-	time.Sleep(1 * time.Second)
-	assert.Equal(t, uint32(1), profileStarted)
-
-	syscall.Kill(syscall.Getpid(), syscall.SIGUSR1)
-	time.Sleep(1 * time.Second)
-	assert.Equal(t, uint32(0), profileStarted)
+	toggleProfiling(t, 1)
+	toggleProfiling(t, 0)
+	toggleProfiling(t, 1)
+	toggleProfiling(t, 0)
 }
 
 // without waitSig, we should start with profiling on and toggle off-on-off
 func TestPProfInitWithoutWaitSig(t *testing.T) {
 	signal.Reset(syscall.SIGUSR1)
+
+	oldFlag := pprofFlag
+	t.Cleanup(func() { pprofFlag = oldFlag })
 	pprofFlag = strings.Split("cpu", ",")
 
-	pprofInit()
-	time.Sleep(1 * time.Second)
-	assert.Equal(t, uint32(1), profileStarted)
+	stop := startPprof()
+	require.NotNil(t, stop)
+	t.Cleanup(stop)
 
-	syscall.Kill(syscall.Getpid(), syscall.SIGUSR1)
-	time.Sleep(1 * time.Second)
-	assert.Equal(t, uint32(0), profileStarted)
+	assert.Eventually(t, func() bool {
+		return atomic.LoadUint32(&profileStarted) == 1
+	}, 30*time.Second, 10*time.Millisecond)
 
-	syscall.Kill(syscall.Getpid(), syscall.SIGUSR1)
-	time.Sleep(1 * time.Second)
-	assert.Equal(t, uint32(1), profileStarted)
-
-	syscall.Kill(syscall.Getpid(), syscall.SIGUSR1)
-	time.Sleep(1 * time.Second)
-	assert.Equal(t, uint32(0), profileStarted)
+	toggleProfiling(t, 0)
+	toggleProfiling(t, 1)
+	toggleProfiling(t, 0)
 }

--- a/go/vt/servenv/pprof_unix.go
+++ b/go/vt/servenv/pprof_unix.go
@@ -89,11 +89,14 @@ func startPprof() (stop func()) {
 	}()
 
 	return sync.OnceFunc(func() {
-		signal.Stop(startSignal)
-		signal.Stop(stopSignal)
 		close(stopCh)
 		<-startDoneCh
 		<-stopDoneCh
+		// Unregister the channels only after both listeners have exited;
+		// a listener handling a signal could otherwise re-register a
+		// channel via signal.Notify after it was stopped here.
+		signal.Stop(startSignal)
+		signal.Stop(stopSignal)
 		stopProf()
 	})
 }

--- a/go/vt/servenv/pprof_unix.go
+++ b/go/vt/servenv/pprof_unix.go
@@ -22,47 +22,78 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 
 	"vitess.io/vitess/go/vt/log"
 )
 
 func pprofInit() {
+	if stop := startPprof(); stop != nil {
+		OnTerm(stop)
+	}
+}
+
+func startPprof() (stop func()) {
 	prof, err := parseProfileFlag(pprofFlag)
 	if err != nil {
 		log.Error(fmt.Sprint(err))
 		os.Exit(1)
 	}
-	if prof != nil {
-		start, stop := prof.init()
-		startSignal := make(chan os.Signal, 1)
-		stopSignal := make(chan os.Signal, 1)
 
-		if prof.waitSig {
-			signal.Notify(startSignal, syscall.SIGUSR1)
-		} else {
-			start()
-			signal.Notify(stopSignal, syscall.SIGUSR1)
-		}
+	if prof == nil {
+		return nil
+	}
 
-		go func() {
-			for {
-				<-startSignal
+	start, stopProf := prof.init()
+	startSignal := make(chan os.Signal, 1)
+	stopSignal := make(chan os.Signal, 1)
+
+	startDoneCh := make(chan struct{})
+	stopDoneCh := make(chan struct{})
+	stopCh := make(chan struct{})
+
+	if prof.waitSig {
+		signal.Notify(startSignal, syscall.SIGUSR1)
+	} else {
+		start()
+		signal.Notify(stopSignal, syscall.SIGUSR1)
+	}
+
+	go func() {
+		defer close(startDoneCh)
+		for {
+			select {
+			case <-startSignal:
 				start()
 				signal.Reset(syscall.SIGUSR1)
 				signal.Notify(stopSignal, syscall.SIGUSR1)
+			case <-stopCh:
+				return
 			}
-		}()
+		}
+	}()
 
-		go func() {
-			for {
-				<-stopSignal
-				stop()
+	go func() {
+		defer close(stopDoneCh)
+		for {
+			select {
+			case <-stopSignal:
+				stopProf()
 				signal.Reset(syscall.SIGUSR1)
 				signal.Notify(startSignal, syscall.SIGUSR1)
+			case <-stopCh:
+				return
 			}
-		}()
+		}
+	}()
 
-		OnTerm(stop)
-	}
+	return sync.OnceFunc(func() {
+		signal.Stop(startSignal)
+		signal.Stop(stopSignal)
+		close(stopCh)
+		<-startDoneCh
+		<-stopDoneCh
+		stopProf()
+	})
 }


### PR DESCRIPTION
## Description

The pprof tests in `go/vt/servenv` were hidden from the race detector with a `//go:build !race` tag, and each test run leaked the signal-listener goroutines spawned by `pprofInit()`. This PR removes the build tag and fixes the underlying issues instead:

- Tests now read `profileStarted` with `atomic.LoadUint32` instead of a plain read, which is what the race detector was (correctly) complaining about.
- The signal-listener goroutines in `pprof_unix.go` are now stoppable: the logic moved into a `startPprof()` helper that returns a cleanup function which unregisters the signal handlers, shuts down both goroutines, and stops any in-flight profile. `pprofInit()` keeps the same production behavior by registering that cleanup with `OnTerm`.
- Fixed `time.Sleep` calls in the tests were replaced with polling (`assert.Eventually` / `require.Eventually`). Because a `SIGUSR1` that arrives in the small window between the listener's `signal.Reset` and `signal.Notify` is dropped by the OS, the toggle helper re-sends the signal on each poll until the expected state is observed, which keeps the tests deterministic.

With this change the tests run (and pass) under `go test -race`, and no goroutines or `OnTerm` hooks accumulate across tests.

## Related Issue(s)

Fixes #20478

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

None. The production behavior of `pprofInit()` is unchanged; the refactor only makes the signal listeners stoppable for tests.

### AI Disclosure

The PR description and some tweaks in the tests were written using Cursor; the rest I hand-wrote myself.