### PR TITLE
CI: move zizmor ignore comments off action version-pin lines

### DIFF
--- a/.github/workflows/check_make_vtadmin_web_proto.yml
+++ b/.github/workflows/check_make_vtadmin_web_proto.yml
@@ -62,7 +62,8 @@ jobs:
 
     - name: Setup Node
       if: steps.changes.outputs.proto_changes == 'true'
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0  # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
       with:
         # node-version should match package.json
         node-version: '22.13.1'

--- a/.github/workflows/check_make_vtadmin_web_proto.yml
+++ b/.github/workflows/check_make_vtadmin_web_proto.yml
@@ -62,8 +62,8 @@ jobs:
 
     - name: Setup Node
       if: steps.changes.outputs.proto_changes == 'true'
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         # node-version should match package.json
         node-version: '22.13.1'

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -192,7 +192,8 @@ jobs:
       # There is no separate 'zookeeper' need, so 'consul' is the correct proxy for "this shard needs ZooKeeper".
       - name: Cache ZooKeeper
         if: steps.changes.outputs.end_to_end == 'true' && contains(matrix.needs, 'consul')
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0  # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
         with:
           path: dist/vt-zookeeper-*
           key: zookeeper-${{ hashFiles('build.env', 'bootstrap.sh') }}

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -192,8 +192,8 @@ jobs:
       # There is no separate 'zookeeper' need, so 'consul' is the correct proxy for "this shard needs ZooKeeper".
       - name: Cache ZooKeeper
         if: steps.changes.outputs.end_to_end == 'true' && contains(matrix.needs, 'consul')
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: dist/vt-zookeeper-*
           key: zookeeper-${{ hashFiles('build.env', 'bootstrap.sh') }}

--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -239,7 +239,8 @@ jobs:
 
       - name: Setup Node
         if: steps.changes.outputs.proto_changes == 'true'
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0  # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
         with:
           # make proto requires newer node than the pre-installed one
           node-version: '22.13.1'

--- a/.github/workflows/static_checks_etc.yml
+++ b/.github/workflows/static_checks_etc.yml
@@ -239,8 +239,8 @@ jobs:
 
       - name: Setup Node
         if: steps.changes.outputs.proto_changes == 'true'
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # make proto requires newer node than the pre-installed one
           node-version: '22.13.1'

--- a/.github/workflows/vtadmin_web_build.yml
+++ b/.github/workflows/vtadmin_web_build.yml
@@ -43,8 +43,9 @@ jobs:
         timeout-minutes: 5
         uses: ./.github/actions/tune-os
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: Setup Node
         # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # node-version should match package.json
           node-version: '22.13.1'

--- a/.github/workflows/vtadmin_web_build.yml
+++ b/.github/workflows/vtadmin_web_build.yml
@@ -43,7 +43,8 @@ jobs:
         timeout-minutes: 5
         uses: ./.github/actions/tune-os
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0  # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
         with:
           # node-version should match package.json
           node-version: '22.13.1'

--- a/.github/workflows/vtadmin_web_lint.yml
+++ b/.github/workflows/vtadmin_web_lint.yml
@@ -43,8 +43,9 @@ jobs:
         timeout-minutes: 5
         uses: ./.github/actions/tune-os
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: Setup Node
         # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # node-version should match package.json
           node-version: '22.13.1'

--- a/.github/workflows/vtadmin_web_lint.yml
+++ b/.github/workflows/vtadmin_web_lint.yml
@@ -43,7 +43,8 @@ jobs:
         timeout-minutes: 5
         uses: ./.github/actions/tune-os
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0  # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
         with:
           # node-version should match package.json
           node-version: '22.13.1'

--- a/.github/workflows/vtadmin_web_unit_tests.yml
+++ b/.github/workflows/vtadmin_web_unit_tests.yml
@@ -38,8 +38,9 @@ jobs:
         timeout-minutes: 5
         uses: ./.github/actions/tune-os
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: Setup Node
         # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # node-version should match package.json
           node-version: '22.13.1'

--- a/.github/workflows/vtadmin_web_unit_tests.yml
+++ b/.github/workflows/vtadmin_web_unit_tests.yml
@@ -38,7 +38,8 @@ jobs:
         timeout-minutes: 5
         uses: ./.github/actions/tune-os
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0  # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
         with:
           # node-version should match package.json
           node-version: '22.13.1'


### PR DESCRIPTION
## Description

A few of our `# zizmor: ignore[cache-poisoning]` comments sit on the same line as the action's version-pin comment, like this:

```yaml
uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0  # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
```

In YAML that's all one comment, so the `# v7.0.0` ends up buried inside the ignore comment and zizmor's `ref-version-mismatch` audit silently stops validating the pin. Easy to check with zizmor 1.29.0 (the version our zizmor-action pins) and `GH_TOKEN` set (it's an online audit):

- Change `# v7.0.0` to a wrong value like `# v3.1.4` with the trailing ignore in place → **no findings**.
- Same change with the ignore comment moved off the line → `warning[ref-version-mismatch]: action's hash pin has mismatched or missing version comment ... is pointed to by tag v7.0.0`.

This matters because Dependabot bumps these SHAs weekly (`package-ecosystem: github-actions` in `.github/dependabot.yml`), so a version comment that drifts out of sync with its SHA would never get caught on these lines.

This PR moves each ignore onto its own line directly before the `uses:` line:

```yaml
- name: Setup Node
  # zizmor: ignore[cache-poisoning] this workflow publishes no artifacts
  uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
```

One wrinkle: for zizmor to associate the ignore with the step, the comment has to sit *inside* the step. Three of the six steps were bare `- uses:` steps (no `name:`), where any preceding line falls outside the step and the `cache-poisoning` findings come back as errors. Those three steps (setup-node in the vtadmin web workflows) now get a `name: Setup Node`, so the comment can sit between `name:` and `uses:` like in the already-named steps. Tested placements against a bare `- uses:` step with zizmor 1.29.0:

| Placement | Suppressed? |
|---|---|
| On the dash line (`- # zizmor: ignore[...]`), `uses:` below | ❌ |
| On the line before a bare `- uses:` step | ❌ |
| Inside the step, before or after `uses:` | ✅ |

Verified after the change:

- `zizmor .github/` exits 0 with no findings — all `cache-poisoning` ignores still apply.
- Temporarily corrupting a fixed pin's version comment (one originally-named step, one newly-named step) now makes `ref-version-mismatch` fire on both.
- `actionlint` on the changed files reports no issues.

An alternative would be moving these into a `zizmor.yml` config with per-path rule ignores, which sidesteps comment placement entirely — but inline comments keep the justification next to the code, so this keeps them inline.

Beyond the three added step names, no SHAs, versions, actions or steps were changed.

## Related Issue(s)

n/a

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

None — CI comment placement only.

---
_Most of this was written by Claude Code - I just provided direction._
