### PR TITLE
`golangci-lint`: add `prealloc` linter, part 5

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -164,10 +164,10 @@ linters:
         path: _test\.go$
       - linters:
           - prealloc
-        path: ^go/(test|tools)/
+        path: ^go/(test|tools|vt/vttablet/endtoend)/
       - linters:
           - prealloc
-        path: ^go/vt/(sqlparser|vtgate/planbuilder|vttablet)/
+        path: ^go/vt/(sqlparser|vttablet/tabletmanager)/
       - linters:
           - errcheck
         path: ^go/vt/proto/

--- a/go/vt/vtgate/planbuilder/operators/delete.go
+++ b/go/vt/vtgate/planbuilder/operators/delete.go
@@ -176,7 +176,7 @@ func createDeleteOpWithTarget(ctx *plancontext.PlanningContext, target semantics
 		panic(err)
 	}
 
-	var leftComp sqlparser.ValTuple
+	leftComp := make(sqlparser.ValTuple, 0, len(vTbl.PrimaryKey))
 	cols := make([]*sqlparser.ColName, 0, len(vTbl.PrimaryKey))
 	for _, col := range vTbl.PrimaryKey {
 		colName := sqlparser.NewColNameWithQualifier(col.String(), tblName)
@@ -341,7 +341,7 @@ func updateQueryGraphWithSource(ctx *plancontext.PlanningContext, input Operator
 }
 
 func createFkCascadeOpForDelete(ctx *plancontext.PlanningContext, parentOp Operator, delStmt *sqlparser.Delete, childFks []vindexes.ChildFKInfo, deletedTbl *vindexes.BaseTable) Operator {
-	var fkChildren []*FkChild
+	fkChildren := make([]*FkChild, 0, len(childFks))
 	var selectExprs []sqlparser.SelectExpr
 	tblName := delStmt.Targets[0]
 	for _, fk := range childFks {
@@ -375,7 +375,7 @@ func createFkChildForDelete(ctx *plancontext.PlanningContext, fk vindexes.ChildF
 	case sqlparser.Cascade:
 		// We now construct the delete query for the child table.
 		// The query looks something like this - `DELETE FROM <child_table> WHERE <child_columns_in_fk> IN (<bind variable for the output from SELECT>)`
-		var valTuple sqlparser.ValTuple
+		valTuple := make(sqlparser.ValTuple, 0, len(fk.ChildColumns))
 		for _, column := range fk.ChildColumns {
 			valTuple = append(valTuple, sqlparser.NewColName(column.String()))
 		}
@@ -388,8 +388,8 @@ func createFkChildForDelete(ctx *plancontext.PlanningContext, fk vindexes.ChildF
 	case sqlparser.SetNull:
 		// We now construct the update query for the child table.
 		// The query looks something like this - `UPDATE <child_table> SET <child_column_in_fk> = NULL [AND <another_child_column_in_fk> = NULL]... WHERE <child_columns_in_fk> IN (<bind variable for the output from SELECT>)`
-		var valTuple sqlparser.ValTuple
-		var updExprs sqlparser.UpdateExprs
+		valTuple := make(sqlparser.ValTuple, 0, len(fk.ChildColumns))
+		updExprs := make(sqlparser.UpdateExprs, 0, len(fk.ChildColumns))
 		for _, column := range fk.ChildColumns {
 			valTuple = append(valTuple, sqlparser.NewColName(column.String()))
 			updExprs = append(updExprs, &sqlparser.UpdateExpr{

--- a/go/vt/vtgate/planbuilder/operators/fk_cascade.go
+++ b/go/vt/vtgate/planbuilder/operators/fk_cascade.go
@@ -50,7 +50,7 @@ var _ Operator = (*FkCascade)(nil)
 
 // Inputs implements the Operator interface
 func (fkc *FkCascade) Inputs() []Operator {
-	var inputs []Operator
+	inputs := make([]Operator, 0, 2+len(fkc.Children))
 	inputs = append(inputs, fkc.Parent)
 	inputs = append(inputs, fkc.Selection)
 	for _, child := range fkc.Children {

--- a/go/vt/vtgate/planbuilder/operators/fk_verify.go
+++ b/go/vt/vtgate/planbuilder/operators/fk_verify.go
@@ -42,7 +42,8 @@ var _ Operator = (*FkVerify)(nil)
 
 // Inputs implements the Operator interface
 func (fkv *FkVerify) Inputs() []Operator {
-	inputs := []Operator{fkv.Input}
+	inputs := make([]Operator, 0, 1+len(fkv.Verify))
+	inputs = append(inputs, fkv.Input)
 	for _, v := range fkv.Verify {
 		inputs = append(inputs, v.Op)
 	}

--- a/go/vt/vtgate/planbuilder/operators/horizon_expanding.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon_expanding.go
@@ -355,7 +355,7 @@ func createProjectionWithoutAggr(ctx *plancontext.PlanningContext, qp *QueryProj
 }
 
 func newStarProjection(src Operator, qp *QueryProjection) *Projection {
-	var cols []sqlparser.SelectExpr
+	cols := make([]sqlparser.SelectExpr, 0, len(qp.SelectExprs))
 
 	for _, expr := range qp.SelectExprs {
 		_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {

--- a/go/vt/vtgate/planbuilder/operators/phases.go
+++ b/go/vt/vtgate/planbuilder/operators/phases.go
@@ -149,7 +149,7 @@ func createDMLWithInput(ctx *plancontext.PlanningContext, op, src Operator, in *
 		panic(vterrors.VT09015())
 	}
 	dm := &DMLWithInput{}
-	var leftComp sqlparser.ValTuple
+	leftComp := make(sqlparser.ValTuple, 0, len(in.Target.VTable.PrimaryKey))
 	proj := newAliasedProjection(src)
 	dm.cols = make([][]*sqlparser.ColName, 1)
 	for _, col := range in.Target.VTable.PrimaryKey {

--- a/go/vt/vtgate/planbuilder/operators/subquery_container.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_container.go
@@ -54,7 +54,8 @@ func (sqc *SubQueryContainer) GetOrdering(ctx *plancontext.PlanningContext) []Or
 
 // Inputs implements the Operator interface
 func (sqc *SubQueryContainer) Inputs() []Operator {
-	operators := []Operator{sqc.Outer}
+	operators := make([]Operator, 0, 1+len(sqc.Inner))
+	operators = append(operators, sqc.Outer)
 	for _, inner := range sqc.Inner {
 		operators = append(operators, inner)
 	}

--- a/go/vt/vtgate/planbuilder/operators/table.go
+++ b/go/vt/vtgate/planbuilder/operators/table.go
@@ -44,6 +44,9 @@ type (
 // Clone implements the Operator interface
 func (to *Table) Clone([]Operator) Operator {
 	var columns []*sqlparser.ColName
+	if len(to.Columns) > 0 {
+		columns = make([]*sqlparser.ColName, 0, len(to.Columns))
+	}
 	for _, name := range to.Columns {
 		columns = append(columns, sqlparser.Clone(name))
 	}

--- a/go/vt/vtgate/planbuilder/operators/update.go
+++ b/go/vt/vtgate/planbuilder/operators/update.go
@@ -255,6 +255,9 @@ func createUpdateOpWithTarget(ctx *plancontext.PlanningContext, updStmt *sqlpars
 	}
 
 	var leftComp sqlparser.ValTuple
+	if len(vTbl.PrimaryKey) > 0 {
+		leftComp = make(sqlparser.ValTuple, 0, len(vTbl.PrimaryKey))
+	}
 	cols := make([]*sqlparser.ColName, 0, len(vTbl.PrimaryKey))
 	for _, col := range vTbl.PrimaryKey {
 		colName := sqlparser.NewColNameWithQualifier(col.String(), tblName)
@@ -269,7 +272,7 @@ func createUpdateOpWithTarget(ctx *plancontext.PlanningContext, updStmt *sqlpars
 	}
 	compExpr := sqlparser.NewComparisonExpr(sqlparser.InOp, lhs, sqlparser.ListArg(engine.DmlVals), nil)
 
-	var updExprs sqlparser.UpdateExprs
+	updExprs := make(sqlparser.UpdateExprs, 0, len(uList))
 	for _, expr := range uList {
 		ue := &sqlparser.UpdateExpr{
 			Name: expr.updCol,
@@ -617,7 +620,7 @@ func getCastTypeForColumn(updatedTable *vindexes.BaseTable, updExpr *sqlparser.U
 // createFkChildForUpdate creates the update query operator for the child table based on the foreign key constraints.
 func createFkChildForUpdate(ctx *plancontext.PlanningContext, fk vindexes.ChildFKInfo, selectOffsets []int, nonLiteralUpdateInfo []engine.NonLiteralUpdateInfo, updatedTable *vindexes.BaseTable) *FkChild {
 	// Create a ValTuple of child column names
-	var valTuple sqlparser.ValTuple
+	valTuple := make(sqlparser.ValTuple, 0, len(fk.ChildColumns))
 	for _, column := range fk.ChildColumns {
 		valTuple = append(valTuple, sqlparser.NewColName(column.String()))
 	}
@@ -710,7 +713,7 @@ func buildChildUpdOpForSetNull(
 	updatedTable *vindexes.BaseTable,
 ) Operator {
 	// For the SET NULL type constraint, we need to set all the child columns to NULL.
-	var childUpdateExprs sqlparser.UpdateExprs
+	childUpdateExprs := make(sqlparser.UpdateExprs, 0, len(fk.ChildColumns))
 	for _, column := range fk.ChildColumns {
 		childUpdateExprs = append(childUpdateExprs, &sqlparser.UpdateExpr{
 			Name: sqlparser.NewColName(column.String()),

--- a/go/vt/vtgate/planbuilder/operators/upsert.go
+++ b/go/vt/vtgate/planbuilder/operators/upsert.go
@@ -55,6 +55,9 @@ func (u *Upsert) setInputs(inputs []Operator) {
 
 func (u *Upsert) Inputs() []Operator {
 	var inputs []Operator
+	if len(u.Sources) > 0 {
+		inputs = make([]Operator, 0, 2*len(u.Sources))
+	}
 	for _, source := range u.Sources {
 		inputs = append(inputs, source.Insert, source.Update)
 	}

--- a/go/vt/vtgate/planbuilder/show.go
+++ b/go/vt/vtgate/planbuilder/show.go
@@ -639,7 +639,7 @@ func buildWarnings() (engine.Primitive, error) {
 }
 
 func buildPluginsPlan() (engine.Primitive, error) {
-	var rows [][]sqltypes.Value
+	var rows [][]sqltypes.Value //nolint:prealloc
 	rows = append(rows, buildVarCharRow(
 		"InnoDB",
 		"ACTIVE",
@@ -652,7 +652,7 @@ func buildPluginsPlan() (engine.Primitive, error) {
 }
 
 func buildEnginesPlan() (engine.Primitive, error) {
-	var rows [][]sqltypes.Value
+	var rows [][]sqltypes.Value //nolint:prealloc
 	rows = append(rows, buildVarCharRow(
 		"InnoDB",
 		"DEFAULT",
@@ -668,8 +668,11 @@ func buildEnginesPlan() (engine.Primitive, error) {
 func buildVschemaKeyspacesPlan(vschema plancontext.VSchema) (engine.Primitive, error) {
 	vs := vschema.GetVSchema()
 	var rows [][]sqltypes.Value
+	if len(vs.Keyspaces) > 0 {
+		rows = make([][]sqltypes.Value, 0, len(vs.Keyspaces))
+	}
 	for ksName, ks := range vs.Keyspaces {
-		var row []sqltypes.Value
+		row := make([]sqltypes.Value, 0, 4)
 		row = append(row, sqltypes.NewVarChar(ksName))
 		row = append(row, sqltypes.NewVarChar(strconv.FormatBool(ks.Keyspace.Sharded)))
 		fkMode, _ := vschema.ForeignKeyMode(ksName)

--- a/go/vt/vtgate/planbuilder/single_sharded_shortcut.go
+++ b/go/vt/vtgate/planbuilder/single_sharded_shortcut.go
@@ -77,12 +77,15 @@ func getTableNames(semTable *semantics.SemTable) ([]sqlparser.TableName, error) 
 			}
 		}
 	}
-	var keys []string
+	if len(tableNameMap) == 0 {
+		return nil, nil
+	}
+	keys := make([]string, 0, len(tableNameMap))
 	for k := range tableNameMap {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	var tableNames []sqlparser.TableName
+	tableNames := make([]sqlparser.TableName, 0, len(keys))
 	for _, k := range keys {
 		tableNames = append(tableNames, tableNameMap[k])
 	}

--- a/go/vt/vttablet/tabletserver/planbuilder/permission.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/permission.go
@@ -123,6 +123,9 @@ func buildSubqueryPermissions(stmt sqlparser.Statement, role tableacl.Role, perm
 // gatherCTEs gathers the CTEs from the WITH clause.
 func gatherCTEs(with *sqlparser.With) []sqlparser.IdentifierCS {
 	var ctes []sqlparser.IdentifierCS
+	if len(with.CTEs) > 0 {
+		ctes = make([]sqlparser.IdentifierCS, 0, len(with.CTEs))
+	}
 	for _, cte := range with.CTEs {
 		ctes = append(ctes, cte.ID)
 	}

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -1846,6 +1846,9 @@ func (qre *QueryExecutor) getUDFs(callback func(schemaRes *querypb.GetSchemaResp
 
 	return qre.execStreamSQL(conn, false /* isTransaction */, query, func(result *sqltypes.Result) error {
 		var udfs []*querypb.UDFInfo
+		if len(result.Rows) > 0 {
+			udfs = make([]*querypb.UDFInfo, 0, len(result.Rows))
+		}
 		for _, row := range result.Rows {
 			aggr := strings.EqualFold(row[2].ToString(), "aggregate")
 			udf := &querypb.UDFInfo{

--- a/go/vt/vttablet/tabletserver/schema/engine.go
+++ b/go/vt/vttablet/tabletserver/schema/engine.go
@@ -1209,6 +1209,9 @@ func (se *Engine) Environment() *vtenv.Environment {
 
 func extractNamesFromTablesList(tables []*Table) []string {
 	var tableNames []string
+	if len(tables) > 0 {
+		tableNames = make([]string, 0, len(tables))
+	}
 	for _, table := range tables {
 		tableNames = append(tableNames, table.Name.String())
 	}

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -2330,7 +2330,7 @@ func queryAsString(sql string, bindVariables map[string]*querypb.BindVariable, s
 		if sanitize {
 			fmt.Fprintf(bvBuf, "[REDACTED]")
 		} else {
-			var keys []string
+			keys := make([]string, 0, len(bindVariables))
 			for key := range bindVariables {
 				keys = append(keys, key)
 			}

--- a/go/vt/vttablet/tabletserver/vstreamer/copy.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/copy.go
@@ -130,7 +130,7 @@ func (uvs *uvstreamer) sendFieldEvent(ctx context.Context, gtid string, fieldEve
 
 // send one RowEvent per row, followed by a LastPK (merged in VTGate with vgtid)
 func (uvs *uvstreamer) sendEventsForRows(ctx context.Context, tableName string, rows *binlogdatapb.VStreamRowsResponse, qr *querypb.QueryResult) error {
-	var evs []*binlogdatapb.VEvent
+	evs := make([]*binlogdatapb.VEvent, 0, len(rows.Rows)+2)
 	for _, row := range rows.Rows {
 		ev := &binlogdatapb.VEvent{
 			Type:     binlogdatapb.VEventType_ROW,


### PR DESCRIPTION
## Description

As a follow-up to https://github.com/vitessio/vitess/pull/20092, this continues the `prealloc` rollout to `go/vt/vtgate/planbuilder` and `go/vt/vttablet/tabletserver`

`go/vt/vtgate/planbuilder` was deferred from the last part because some call sites rely on the `nil` vs empty-slice distinction. This preserves that behaviour while enabling the linter there

Test code remains excluded; this also moves `go/vt/vttablet/endtoend` alongside the other test/tool paths we will continue to ignore after the `prealloc` rollout is completed by the next PR

## Related Issue(s)

Related: https://github.com/vitessio/vitess/pull/20092

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

### AI Disclosure

Codex assisted with the `prealloc` fixes and prepared this PR summary