### PR TITLE
`golangci-lint`: add `prealloc` linter, final phase

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -155,19 +155,14 @@ linters:
       - legacy
       - std-error-handling
     rules:
-      # prealloc is being enabled incrementally, package-by-package.
-      # These exclusions will be removed as packages are fixed.
-      # Unfortunately golangci-lint's regex is quite limited, so
-      # we must construct this big regex match for now.
+      # prealloc is enabled for all non-test code.
+      # Test code and test-only paths are permanently excluded.
       - linters:
           - prealloc
         path: _test\.go$
       - linters:
           - prealloc
         path: ^go/(test|tools|vt/vttablet/endtoend)/
-      - linters:
-          - prealloc
-        path: ^go/vt/(sqlparser|vttablet/tabletmanager)/
       - linters:
           - errcheck
         path: ^go/vt/proto/

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -1487,7 +1487,7 @@ func (node *DropProcedure) GetTableSpec() *TableSpec {
 
 // GetFromTables implements the DDLStatement interface
 func (node *RenameTable) GetFromTables() TableNames {
-	var fromTables TableNames
+	fromTables := make(TableNames, 0, len(node.TablePairs))
 	for _, pair := range node.TablePairs {
 		fromTables = append(fromTables, pair.FromTable)
 	}
@@ -1777,7 +1777,7 @@ func (node *DropProcedure) GetParsedComments() *ParsedComments {
 
 // GetToTables implements the DDLStatement interface
 func (node *RenameTable) GetToTables() TableNames {
-	var toTables TableNames
+	toTables := make(TableNames, 0, len(node.TablePairs))
 	for _, pair := range node.TablePairs {
 		toTables = append(toTables, pair.ToTable)
 	}
@@ -3926,6 +3926,7 @@ func (variance *Variance) SetArgs(exprs []Expr) error {
 }
 func (av *AnyValue) SetArgs(exprs []Expr) error      { return setFuncArgs(av, exprs, "ANY_VALUE") }
 func (jaa *JSONArrayAgg) SetArgs(exprs []Expr) error { return setFuncArgs(jaa, exprs, "JSON_ARRAYARG") }
+
 func (joa *JSONObjectAgg) SetArgs(exprs []Expr) error {
 	if len(exprs) != 2 {
 		return vterrors.VT13001("JSONObjectAgg takes in 2 expressions")

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -2640,7 +2640,7 @@ func AndExpressions(exprs ...Expr) Expr {
 	case 1:
 		return exprs[0]
 	default:
-		result := (Expr)(nil)
+		result := Expr(nil)
 	outer:
 		// we'll loop and remove any duplicates
 		for i, expr := range exprs {
@@ -2914,6 +2914,9 @@ func (cols Columns) Indexes(subSetCols Columns) (bool, []int) {
 // This function is meant to be used in testing code.
 func MakeColumns(colNames ...string) Columns {
 	var cols Columns
+	if len(colNames) > 0 {
+		cols = make(Columns, 0, len(colNames))
+	}
 	for _, name := range colNames {
 		cols = append(cols, NewIdentifierCI(name))
 	}
@@ -3191,8 +3194,8 @@ func (node *ValuesStatement) GetColumnCount() int {
 }
 
 func (node *ValuesStatement) GetColumns() []SelectExpr {
-	var sel []SelectExpr
 	columnCount := node.GetColumnCount()
+	sel := make([]SelectExpr, 0, columnCount)
 	for i := range columnCount {
 		sel = append(sel, &AliasedExpr{Expr: NewColName(fmt.Sprintf("column_%d", i))})
 	}

--- a/go/vt/sqlparser/random_expr.go
+++ b/go/vt/sqlparser/random_expr.go
@@ -428,7 +428,7 @@ func (g *Generator) caseExpr(genConfig ExprGeneratorConfig) Expr {
 	}
 
 	size := rand.IntN(2) + 1
-	var whens []*When
+	whens := make([]*When, 0, size)
 	for range size {
 		var cond Expr
 		if exp == nil {

--- a/go/vt/vttablet/tabletmanager/vdiff/utils.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/utils.go
@@ -62,7 +62,7 @@ func encodeString(in string) string {
 }
 
 func pkColsToGroupByParams(pkCols []int, collationEnv *collations.Environment) []*engine.GroupByParams {
-	var res []*engine.GroupByParams
+	res := make([]*engine.GroupByParams, 0, len(pkCols))
 	for _, col := range pkCols {
 		res = append(res, &engine.GroupByParams{KeyCol: col, WeightStringCol: -1, CollationEnv: collationEnv})
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan.go
@@ -149,6 +149,9 @@ func (rp *ReplicatorPlan) buildFromFields(tableName string, lastpk *sqltypes.Res
 // MarshalJSON performs a custom JSON Marshalling.
 func (rp *ReplicatorPlan) MarshalJSON() ([]byte, error) {
 	var targets []string
+	if len(rp.TargetTables) > 0 {
+		targets = make([]string, 0, len(rp.TargetTables))
+	}
 	for k := range rp.TargetTables {
 		targets = append(targets, k)
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -890,7 +890,8 @@ func (tpb *tablePlanBuilder) generateMultiDeleteStatement() *sqlparser.ParsedQue
 		(len(tpb.pkCols)+len(tpb.extraSourcePkCols)) != 1 {
 		return nil
 	}
-	return sqlparser.BuildParsedQuery("delete from %s where %s in %a",
+	return sqlparser.BuildParsedQuery(
+		"delete from %s where %s in %a",
 		sqlparser.String(tpb.name),
 		sqlparser.String(tpb.pkCols[0].colName),
 		"::bulk_pks",
@@ -943,7 +944,7 @@ func (tpb *tablePlanBuilder) generatePKConstraint(buf *sqlparser.TrackedBuffer, 
 		charSet   string
 		collation string
 	}
-	var charSetCollations []*charSetCollation
+	charSetCollations := make([]*charSetCollation, 0, len(tpb.lastpk.Fields))
 	separator := "("
 	for _, pkname := range tpb.lastpk.Fields {
 		charSet, collation := tpb.getCharsetAndCollation(pkname.Name)


### PR DESCRIPTION
## Description

As a final follow-up (🎉) to https://github.com/vitessio/vitess/pull/20829, this completes the `prealloc` rollout by enabling the linter for `go/vt/sqlparser` and `go/vt/vttablet/tabletmanager`, the last remaining packages

Call sites that rely on the `nil` vs empty-slice distinction (`MakeColumns`, `ReplicatorPlan.MarshalJSON`) preserve that behaviour, as in the last part

With the rollout complete, the `.golangci.yml` comment is updated to note that test code and test-only paths remain permanently excluded

This completes the 6-part rollout of `prealloc`, which was done in phases to reduce risk and PR size 🎉 

## Related Issue(s)

Related: https://github.com/vitessio/vitess/pull/20092

## Checklist

-   [x] &#34;Backport to:&#34; labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

### AI Disclosure

Claude Code assisted with the `prealloc` fixes and prepared this PR summary