### PR TITLE
stream_migrator: skip OnlineDDL stopped streams during SwitchWrites

### DIFF
--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -671,6 +671,17 @@ func testPartialSwitches(t *testing.T) {
 	tstWorkflowSwitchReads(t, "", "")
 	checkStates(t, wrangler.WorkflowStateNotSwitched, wrangler.WorkflowStateReadsSwitched)
 
+	// Inject a fake stopped OnlineDDL VReplication stream on the source shard to
+	// verify that SwitchWrites correctly filters terminal OnlineDDL streams rather
+	// than failing with "cannot migrate until all streams are running".
+	// This must be done before the first SwitchWrites, which creates a resharding
+	// journal; subsequent SwitchWrites calls find the journal and skip
+	// BuildStreamMigrator entirely, so the filter would never be exercised.
+	if currentWorkflowType == binlogdatapb.VReplicationWorkflowType_Reshard {
+		cleanupOnlineDDL := injectTerminalOnlineDDLStream(t, sourceTab)
+		defer cleanupOnlineDDL()
+	}
+
 	tstWorkflowSwitchWrites(t)
 	currentState = nextState
 	nextState = wrangler.WorkflowStateAllSwitched
@@ -719,14 +730,6 @@ func testRestOfWorkflow(t *testing.T) {
 	checkStates(t, wrangler.WorkflowStateNotSwitched, wrangler.WorkflowStateReadsSwitched)
 	validateReadsRouteToTarget(t, "replica,rdonly")
 	validateWritesRouteToSource(t)
-
-	// Inject a fake stopped OnlineDDL VReplication stream on the source shard to
-	// verify that SwitchWrites correctly filters terminal OnlineDDL streams rather
-	// than failing with "cannot migrate until all streams are running".
-	if currentWorkflowType == binlogdatapb.VReplicationWorkflowType_Reshard {
-		cleanupOnlineDDL := injectTerminalOnlineDDLStream(t, sourceTab)
-		defer cleanupOnlineDDL()
-	}
 
 	tstWorkflowSwitchWrites(t)
 	checkStates(t, wrangler.WorkflowStateReadsSwitched, wrangler.WorkflowStateAllSwitched)

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -720,6 +720,13 @@ func testRestOfWorkflow(t *testing.T) {
 	validateReadsRouteToTarget(t, "replica,rdonly")
 	validateWritesRouteToSource(t)
 
+	// Inject a fake stopped OnlineDDL VReplication stream on the source shard to
+	// verify that SwitchWrites correctly filters terminal OnlineDDL streams rather
+	// than failing with "cannot migrate until all streams are running".
+	if currentWorkflowType == binlogdatapb.VReplicationWorkflowType_Reshard {
+		injectTerminalOnlineDDLStream(t, sourceTab)
+	}
+
 	tstWorkflowSwitchWrites(t)
 	checkStates(t, wrangler.WorkflowStateReadsSwitched, wrangler.WorkflowStateAllSwitched)
 	validateReadsRouteToTarget(t, "replica,rdonly")
@@ -1000,6 +1007,34 @@ func tstApplySchemaOnlineDDL(t *testing.T, sql string, keyspace string) {
 	err := vc.VtctldClient.ExecuteCommand("ApplySchema", "--ddl-strategy"+"=online",
 		"--sql", sql, keyspace)
 	require.NoError(t, err, "ApplySchema Error: %s", err)
+}
+
+// injectTerminalOnlineDDLStream inserts a fake stopped OnlineDDL VReplication
+// stream and a corresponding terminal schema_migrations row on the given tablet.
+// This simulates a completed OnlineDDL migration whose VReplication stream has
+// not yet been garbage collected.
+func injectTerminalOnlineDDLStream(t *testing.T, tablet *cluster.VttabletProcess) {
+	fakeUUID := "00000000_0000_0000_0000_000000000099"
+	dbName := "vt_" + defaultTargetKs
+
+	insertVRepl := fmt.Sprintf(
+		"insert into %s.vreplication (workflow, source, pos, max_tps, max_replication_lag, time_updated, transaction_timestamp, state, db_name, workflow_type, options) "+
+			"values ('%s', '', '', 0, 0, 0, 0, 'Stopped', '%s', %d, '{}')",
+		sidecarDBIdentifier, fakeUUID, dbName, binlogdatapb.VReplicationWorkflowType_OnlineDDL)
+	_, err := tablet.QueryTablet(insertVRepl, "", false)
+	require.NoError(t, err, "failed to insert fake VReplication stream: %v", err)
+
+	insertMigration := fmt.Sprintf(
+		"insert into %s.schema_migrations (migration_uuid, keyspace, shard, mysql_schema, mysql_table, migration_statement, strategy, options, migration_status, log_path, artifacts, message) "+
+			"values ('%s', '%s', '-80', '%s', 'fake_table', 'ALTER TABLE fake_table ADD COLUMN c1 INT', 'online', '', 'complete', '', '', '')",
+		sidecarDBIdentifier, fakeUUID, defaultTargetKs, dbName)
+	_, err = tablet.QueryTablet(insertMigration, "", false)
+	require.NoError(t, err, "failed to insert fake schema_migrations row: %v", err)
+
+	t.Cleanup(func() {
+		tablet.QueryTablet(fmt.Sprintf("delete from %s.vreplication where workflow = '%s'", sidecarDBIdentifier, fakeUUID), "", false)
+		tablet.QueryTablet(fmt.Sprintf("delete from %s.schema_migrations where migration_uuid = '%s'", sidecarDBIdentifier, fakeUUID), "", false)
+	})
 }
 
 func validateTableRoutingRule(t *testing.T, table, tabletType, fromKeyspace, toKeyspace string) {

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -724,7 +724,8 @@ func testRestOfWorkflow(t *testing.T) {
 	// verify that SwitchWrites correctly filters terminal OnlineDDL streams rather
 	// than failing with "cannot migrate until all streams are running".
 	if currentWorkflowType == binlogdatapb.VReplicationWorkflowType_Reshard {
-		injectTerminalOnlineDDLStream(t, sourceTab)
+		cleanupOnlineDDL := injectTerminalOnlineDDLStream(t, sourceTab)
+		defer cleanupOnlineDDL()
 	}
 
 	tstWorkflowSwitchWrites(t)
@@ -1012,8 +1013,9 @@ func tstApplySchemaOnlineDDL(t *testing.T, sql string, keyspace string) {
 // injectTerminalOnlineDDLStream inserts a fake stopped OnlineDDL VReplication
 // stream and a corresponding terminal schema_migrations row on the given tablet.
 // This simulates a completed OnlineDDL migration whose VReplication stream has
-// not yet been garbage collected.
-func injectTerminalOnlineDDLStream(t *testing.T, tablet *cluster.VttabletProcess) {
+// not yet been garbage collected. Returns a cleanup function that removes the
+// injected rows.
+func injectTerminalOnlineDDLStream(t *testing.T, tablet *cluster.VttabletProcess) func() {
 	fakeUUID := "00000000_0000_0000_0000_000000000099"
 	dbName := "vt_" + defaultTargetKs
 
@@ -1031,10 +1033,12 @@ func injectTerminalOnlineDDLStream(t *testing.T, tablet *cluster.VttabletProcess
 	_, err = tablet.QueryTablet(insertMigration, "", false)
 	require.NoError(t, err, "failed to insert fake schema_migrations row: %v", err)
 
-	t.Cleanup(func() {
-		tablet.QueryTablet(fmt.Sprintf("delete from %s.vreplication where workflow = '%s'", sidecarDBIdentifier, fakeUUID), "", false)
-		tablet.QueryTablet(fmt.Sprintf("delete from %s.schema_migrations where migration_uuid = '%s'", sidecarDBIdentifier, fakeUUID), "", false)
-	})
+	return func() {
+		_, err := tablet.QueryTablet(fmt.Sprintf("delete from %s.vreplication where workflow = '%s'", sidecarDBIdentifier, fakeUUID), "", false)
+		require.NoError(t, err, "failed to clean up fake VReplication stream: %v", err)
+		_, err = tablet.QueryTablet(fmt.Sprintf("delete from %s.schema_migrations where migration_uuid = '%s'", sidecarDBIdentifier, fakeUUID), "", false)
+		require.NoError(t, err, "failed to clean up fake schema_migrations row: %v", err)
+	}
 }
 
 func validateTableRoutingRule(t *testing.T, table, tabletType, fromKeyspace, toKeyspace string) {

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -1024,8 +1024,8 @@ func injectTerminalOnlineDDLStream(t *testing.T, tablet *cluster.VttabletProcess
 
 	insertVRepl := fmt.Sprintf(
 		"insert into %s.vreplication (workflow, source, pos, max_tps, max_replication_lag, time_updated, transaction_timestamp, state, db_name, workflow_type, options) "+
-			"values ('%s', '', '', 0, 0, 0, 0, 'Stopped', '%s', %d, '{}')",
-		sidecarDBIdentifier, fakeUUID, dbName, binlogdatapb.VReplicationWorkflowType_OnlineDDL)
+			"values ('%s', 'keyspace:\"%s\" shard:\"-80\" filter:{rules:{match:\"customer\"}}', '', 0, 0, 0, 0, 'Stopped', '%s', %d, '{}')",
+		sidecarDBIdentifier, fakeUUID, defaultTargetKs, dbName, binlogdatapb.VReplicationWorkflowType_OnlineDDL)
 	_, err := tablet.QueryTablet(insertVRepl, "", false)
 	require.NoError(t, err, "failed to insert fake VReplication stream: %v", err)
 

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -1030,8 +1030,10 @@ func injectTerminalOnlineDDLStream(t *testing.T, tablet *cluster.VttabletProcess
 	require.NoError(t, err, "failed to insert fake VReplication stream: %v", err)
 
 	insertMigration := fmt.Sprintf(
-		"insert into %s.schema_migrations (migration_uuid, keyspace, shard, mysql_schema, mysql_table, migration_statement, strategy, options, migration_status, log_path, artifacts, message) "+
-			"values ('%s', '%s', '-80', '%s', 'fake_table', 'ALTER TABLE fake_table ADD COLUMN c1 INT', 'online', '', 'complete', '', '', '')",
+		"insert into %s.schema_migrations (migration_uuid, keyspace, shard, mysql_schema, mysql_table, migration_statement, strategy, options, migration_status, log_path, artifacts, message, "+
+			"removed_unique_key_names, dropped_no_default_column_names, expanded_column_names, revertible_notes, special_plan, component_throttled, reason_throttled, stage, removed_foreign_key_names) "+
+			"values ('%s', '%s', '-80', '%s', 'fake_table', 'ALTER TABLE fake_table ADD COLUMN c1 INT', 'online', '', 'complete', '', '', '', "+
+			"'', '', '', '', '', '', '', '', '')",
 		sidecarDBIdentifier, fakeUUID, defaultTargetKs, dbName)
 	_, err = tablet.QueryTablet(insertMigration, "", false)
 	require.NoError(t, err, "failed to insert fake schema_migrations row: %v", err)

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -1023,8 +1023,8 @@ func injectTerminalOnlineDDLStream(t *testing.T, tablet *cluster.VttabletProcess
 	dbName := "vt_" + defaultTargetKs
 
 	insertVRepl := fmt.Sprintf(
-		"insert into %s.vreplication (workflow, source, pos, max_tps, max_replication_lag, time_updated, transaction_timestamp, state, db_name, workflow_type, options) "+
-			"values ('%s', 'keyspace:\"%s\" shard:\"-80\" filter:{rules:{match:\"customer\"}}', '', 0, 0, 0, 0, 'Stopped', '%s', %d, '{}')",
+		"insert into %s.vreplication (workflow, source, pos, max_tps, max_replication_lag, time_updated, transaction_timestamp, state, message, db_name, workflow_type, options) "+
+			"values ('%s', 'keyspace:\"%s\" shard:\"-80\" filter:{rules:{match:\"customer\"}}', '', 0, 0, 0, 0, 'Stopped', '', '%s', %d, '{}')",
 		sidecarDBIdentifier, fakeUUID, defaultTargetKs, dbName, binlogdatapb.VReplicationWorkflowType_OnlineDDL)
 	_, err := tablet.QueryTablet(insertVRepl, "", false)
 	require.NoError(t, err, "failed to insert fake VReplication stream: %v", err)

--- a/go/vt/vtctl/workflow/stream_migrator.go
+++ b/go/vt/vtctl/workflow/stream_migrator.go
@@ -476,7 +476,10 @@ func (sm *StreamMigrator) getTerminalOnlineDDLMigrations(ctx context.Context, ta
 		encodeString(string(schema.OnlineDDLStatusCancelled)),
 	)
 
-	p3qr, err := sm.ts.TabletManagerClient().VReplicationExec(ctx, tablet, query)
+	p3qr, err := sm.ts.TabletManagerClient().ExecuteFetchAsDba(ctx, tablet, true, &tabletmanagerdatapb.ExecuteFetchAsDbaRequest{
+		Query:   []byte(query),
+		MaxRows: uint64(len(uuids)),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtctl/workflow/stream_migrator.go
+++ b/go/vt/vtctl/workflow/stream_migrator.go
@@ -427,6 +427,70 @@ func (sm *StreamMigrator) readTabletStreams(ctx context.Context, ti *topo.Tablet
 	return tabletStreams, nil
 }
 
+// filterTerminalOnlineDDL removes VReplication streams belonging to OnlineDDL
+// migrations that have reached a terminal state (complete, failed, or cancelled)
+// in _vt.schema_migrations. These are dead streams waiting for GC and should
+// neither block SwitchWrites nor be migrated to target shards.
+func (sm *StreamMigrator) filterTerminalOnlineDDL(ctx context.Context, tablet *topodatapb.Tablet, streams []*VReplicationStream) ([]*VReplicationStream, error) {
+	var onlineDDLWorkflows []string
+	for _, s := range streams {
+		if s.WorkflowType == binlogdatapb.VReplicationWorkflowType_OnlineDDL {
+			onlineDDLWorkflows = append(onlineDDLWorkflows, s.Workflow)
+		}
+	}
+	if len(onlineDDLWorkflows) == 0 {
+		return streams, nil
+	}
+
+	terminalUUIDs, err := sm.getTerminalOnlineDDLMigrations(ctx, tablet, onlineDDLWorkflows)
+	if err != nil {
+		return nil, err
+	}
+	if len(terminalUUIDs) == 0 {
+		return streams, nil
+	}
+
+	filtered := make([]*VReplicationStream, 0, len(streams))
+	for _, s := range streams {
+		if s.WorkflowType == binlogdatapb.VReplicationWorkflowType_OnlineDDL && terminalUUIDs[s.Workflow] {
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+	return filtered, nil
+}
+
+// getTerminalOnlineDDLMigrations queries _vt.schema_migrations to find which of
+// the given migration UUIDs have reached a terminal state. This uses the same
+// criteria as gcArtifacts() to determine when a migration is done.
+func (sm *StreamMigrator) getTerminalOnlineDDLMigrations(ctx context.Context, tablet *topodatapb.Tablet, uuids []string) (map[string]bool, error) {
+	quotedUUIDs := make([]string, 0, len(uuids))
+	for _, uuid := range uuids {
+		quotedUUIDs = append(quotedUUIDs, encodeString(uuid))
+	}
+	query := fmt.Sprintf(
+		"select migration_uuid from _vt.schema_migrations where migration_uuid in (%s) and migration_status in (%s, %s, %s)",
+		strings.Join(quotedUUIDs, ", "),
+		encodeString(string(schema.OnlineDDLStatusComplete)),
+		encodeString(string(schema.OnlineDDLStatusFailed)),
+		encodeString(string(schema.OnlineDDLStatusCancelled)),
+	)
+
+	p3qr, err := sm.ts.TabletManagerClient().VReplicationExec(ctx, tablet, query)
+	if err != nil {
+		return nil, err
+	}
+
+	qr := sqltypes.Proto3ToResult(p3qr)
+	result := make(map[string]bool, len(qr.Rows))
+	for _, row := range qr.Rows {
+		if len(row) > 0 {
+			result[row[0].ToString()] = true
+		}
+	}
+	return result, nil
+}
+
 /* source streams */
 
 // legacyReadSourceStreams reads all of the VReplication workflow source streams using
@@ -456,12 +520,22 @@ func (sm *StreamMigrator) legacyReadSourceStreams(ctx context.Context, cancelMig
 				return err
 			}
 
+			stoppedStreams, err = sm.filterTerminalOnlineDDL(ctx, source.GetPrimary().Tablet, stoppedStreams)
+			if err != nil {
+				return err
+			}
+
 			if len(stoppedStreams) != 0 {
 				return fmt.Errorf("cannot migrate until all streams are running: %s: %d", source.GetShard().ShardName(), source.GetPrimary().Alias.Uid)
 			}
 		}
 
 		tabletStreams, err := sm.legacyReadTabletStreams(ctx, source.GetPrimary(), "")
+		if err != nil {
+			return err
+		}
+
+		tabletStreams, err = sm.filterTerminalOnlineDDL(ctx, source.GetPrimary().Tablet, tabletStreams)
 		if err != nil {
 			return err
 		}
@@ -561,12 +635,22 @@ func (sm *StreamMigrator) readSourceStreams(ctx context.Context, cancelMigrate b
 				return err
 			}
 
+			stoppedStreams, err = sm.filterTerminalOnlineDDL(ctx, source.GetPrimary().Tablet, stoppedStreams)
+			if err != nil {
+				return err
+			}
+
 			if len(stoppedStreams) != 0 {
 				return fmt.Errorf("cannot migrate until all streams are running: %s: %d", source.GetShard().ShardName(), source.GetPrimary().Alias.Uid)
 			}
 		}
 
 		tabletStreams, err := sm.readTabletStreams(ctx, source.GetPrimary(), nil, nil, false)
+		if err != nil {
+			return err
+		}
+
+		tabletStreams, err = sm.filterTerminalOnlineDDL(ctx, source.GetPrimary().Tablet, tabletStreams)
 		if err != nil {
 			return err
 		}

--- a/go/vt/vtctl/workflow/stream_migrator.go
+++ b/go/vt/vtctl/workflow/stream_migrator.go
@@ -427,11 +427,14 @@ func (sm *StreamMigrator) readTabletStreams(ctx context.Context, ti *topo.Tablet
 	return tabletStreams, nil
 }
 
-// filterTerminalOnlineDDL removes VReplication streams belonging to OnlineDDL
-// migrations that have reached a terminal state (complete, failed, or cancelled)
-// in _vt.schema_migrations. These are dead streams waiting for GC and should
-// neither block SwitchWrites nor be migrated to target shards.
-func (sm *StreamMigrator) filterTerminalOnlineDDL(ctx context.Context, tablet *topodatapb.Tablet, streams []*VReplicationStream) ([]*VReplicationStream, error) {
+// filterTerminalOnlineDDL queries _vt.schema_migrations and removes VReplication
+// streams belonging to OnlineDDL migrations that have reached a terminal state
+// (complete, failed, or cancelled). These are dead streams waiting for GC and
+// should neither block SwitchWrites nor be migrated to target shards.
+// It returns the filtered streams and the set of terminal UUIDs, which can be
+// passed to filterStreamsByTerminalUUIDs to filter additional stream lists
+// without a redundant DB query.
+func (sm *StreamMigrator) filterTerminalOnlineDDL(ctx context.Context, tablet *topodatapb.Tablet, streams []*VReplicationStream) ([]*VReplicationStream, map[string]bool, error) {
 	var onlineDDLWorkflows []string
 	for _, s := range streams {
 		if s.WorkflowType == binlogdatapb.VReplicationWorkflowType_OnlineDDL {
@@ -439,17 +442,24 @@ func (sm *StreamMigrator) filterTerminalOnlineDDL(ctx context.Context, tablet *t
 		}
 	}
 	if len(onlineDDLWorkflows) == 0 {
-		return streams, nil
+		return streams, nil, nil
 	}
 
 	terminalUUIDs, err := sm.getTerminalOnlineDDLMigrations(ctx, tablet, onlineDDLWorkflows)
 	if err != nil {
-		return nil, err
-	}
-	if len(terminalUUIDs) == 0 {
-		return streams, nil
+		return nil, nil, err
 	}
 
+	return filterStreamsByTerminalUUIDs(streams, terminalUUIDs), terminalUUIDs, nil
+}
+
+// filterStreamsByTerminalUUIDs removes VReplication streams whose workflow
+// matches a terminal OnlineDDL migration UUID. Use this with the terminalUUIDs
+// returned by filterTerminalOnlineDDL to avoid a redundant DB query.
+func filterStreamsByTerminalUUIDs(streams []*VReplicationStream, terminalUUIDs map[string]bool) []*VReplicationStream {
+	if len(terminalUUIDs) == 0 {
+		return streams
+	}
 	filtered := make([]*VReplicationStream, 0, len(streams))
 	for _, s := range streams {
 		if s.WorkflowType == binlogdatapb.VReplicationWorkflowType_OnlineDDL && terminalUUIDs[s.Workflow] {
@@ -457,7 +467,7 @@ func (sm *StreamMigrator) filterTerminalOnlineDDL(ctx context.Context, tablet *t
 		}
 		filtered = append(filtered, s)
 	}
-	return filtered, nil
+	return filtered
 }
 
 // getTerminalOnlineDDLMigrations queries _vt.schema_migrations to find which of
@@ -481,7 +491,7 @@ func (sm *StreamMigrator) getTerminalOnlineDDLMigrations(ctx context.Context, ta
 		MaxRows: uint64(len(uuids)),
 	})
 	if err != nil {
-		return nil, err
+		return nil, vterrors.Wrapf(err, "failed to query schema_migrations on tablet %s", topoproto.TabletAliasString(tablet.Alias))
 	}
 
 	qr := sqltypes.Proto3ToResult(p3qr)
@@ -506,6 +516,7 @@ func (sm *StreamMigrator) legacyReadSourceStreams(ctx context.Context, cancelMig
 	)
 
 	err := sm.ts.ForAllSources(func(source *MigrationSource) error {
+		var terminalUUIDs map[string]bool
 		if !cancelMigrate {
 			// This flow protects us from the following scenario: When we create streams,
 			// we always do it in two phases. We start them off as Stopped, and then
@@ -523,7 +534,7 @@ func (sm *StreamMigrator) legacyReadSourceStreams(ctx context.Context, cancelMig
 				return err
 			}
 
-			stoppedStreams, err = sm.filterTerminalOnlineDDL(ctx, source.GetPrimary().Tablet, stoppedStreams)
+			stoppedStreams, terminalUUIDs, err = sm.filterTerminalOnlineDDL(ctx, source.GetPrimary().Tablet, stoppedStreams)
 			if err != nil {
 				return err
 			}
@@ -538,10 +549,7 @@ func (sm *StreamMigrator) legacyReadSourceStreams(ctx context.Context, cancelMig
 			return err
 		}
 
-		tabletStreams, err = sm.filterTerminalOnlineDDL(ctx, source.GetPrimary().Tablet, tabletStreams)
-		if err != nil {
-			return err
-		}
+		tabletStreams = filterStreamsByTerminalUUIDs(tabletStreams, terminalUUIDs)
 
 		if len(tabletStreams) == 0 {
 			// No VReplication is running. So, we have no work to do.
@@ -620,6 +628,7 @@ func (sm *StreamMigrator) readSourceStreams(ctx context.Context, cancelMigrate b
 	)
 
 	err := sm.ts.ForAllSources(func(source *MigrationSource) error {
+		var terminalUUIDs map[string]bool
 		if !cancelMigrate {
 			// This flow protects us from the following scenario: When we create streams,
 			// we always do it in two phases. We start them off as Stopped, and then
@@ -638,7 +647,7 @@ func (sm *StreamMigrator) readSourceStreams(ctx context.Context, cancelMigrate b
 				return err
 			}
 
-			stoppedStreams, err = sm.filterTerminalOnlineDDL(ctx, source.GetPrimary().Tablet, stoppedStreams)
+			stoppedStreams, terminalUUIDs, err = sm.filterTerminalOnlineDDL(ctx, source.GetPrimary().Tablet, stoppedStreams)
 			if err != nil {
 				return err
 			}
@@ -653,10 +662,7 @@ func (sm *StreamMigrator) readSourceStreams(ctx context.Context, cancelMigrate b
 			return err
 		}
 
-		tabletStreams, err = sm.filterTerminalOnlineDDL(ctx, source.GetPrimary().Tablet, tabletStreams)
-		if err != nil {
-			return err
-		}
+		tabletStreams = filterStreamsByTerminalUUIDs(tabletStreams, terminalUUIDs)
 
 		if len(tabletStreams) == 0 {
 			// No VReplication is running. So, we have no work to do.

--- a/go/vt/vtctl/workflow/stream_migrator.go
+++ b/go/vt/vtctl/workflow/stream_migrator.go
@@ -29,7 +29,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/encoding/prototext"
 
-	"vitess.io/vitess/go/constants/sidecar"
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
@@ -475,13 +474,19 @@ func filterStreamsByTerminalUUIDs(streams []*VReplicationStream, terminalUUIDs m
 // the given migration UUIDs have reached a terminal state. This uses the same
 // criteria as gcArtifacts() to determine when a migration is done.
 func (sm *StreamMigrator) getTerminalOnlineDDLMigrations(ctx context.Context, tablet *topodatapb.Tablet, uuids []string) (map[string]bool, error) {
+	sidecarDBName, err := sm.ts.TopoServer().GetSidecarDBName(ctx, tablet.Keyspace)
+	if err != nil {
+		return nil, vterrors.Wrapf(err, "failed to get sidecar database name for keyspace %s", tablet.Keyspace)
+	}
+	sidecarDBIdentifier := sqlparser.String(sqlparser.NewIdentifierCS(sidecarDBName))
+
 	quotedUUIDs := make([]string, 0, len(uuids))
 	for _, uuid := range uuids {
 		quotedUUIDs = append(quotedUUIDs, encodeString(uuid))
 	}
 	query := fmt.Sprintf(
 		"select migration_uuid from %s.schema_migrations where migration_uuid in (%s) and migration_status in (%s, %s, %s)",
-		sidecar.GetIdentifier(),
+		sidecarDBIdentifier,
 		strings.Join(quotedUUIDs, ", "),
 		encodeString(string(schema.OnlineDDLStatusComplete)),
 		encodeString(string(schema.OnlineDDLStatusFailed)),

--- a/go/vt/vtctl/workflow/stream_migrator.go
+++ b/go/vt/vtctl/workflow/stream_migrator.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/encoding/prototext"
 
+	"vitess.io/vitess/go/constants/sidecar"
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
@@ -479,7 +480,8 @@ func (sm *StreamMigrator) getTerminalOnlineDDLMigrations(ctx context.Context, ta
 		quotedUUIDs = append(quotedUUIDs, encodeString(uuid))
 	}
 	query := fmt.Sprintf(
-		"select migration_uuid from _vt.schema_migrations where migration_uuid in (%s) and migration_status in (%s, %s, %s)",
+		"select migration_uuid from %s.schema_migrations where migration_uuid in (%s) and migration_status in (%s, %s, %s)",
+		sidecar.GetIdentifier(),
 		strings.Join(quotedUUIDs, ", "),
 		encodeString(string(schema.OnlineDDLStatusComplete)),
 		encodeString(string(schema.OnlineDDLStatusFailed)),


### PR DESCRIPTION
## Description

During Reshard `SwitchWrites`, `stream_migrator` reads all VReplication streams on source shards. OnlineDDL migrations that have already completed (or failed/cancelled) leave behind Stopped VReplication streams that linger until `gcArtifacts()` cleans them up (~24h later). These dead streams cause a spurious "cannot migrate until all streams are running" error, blocking `SwitchWrites`.

This PR cross-references `_vt.schema_migrations.migration_status` for any `WorkflowType=OnlineDDL` stream. If the migration has reached a terminal state (`complete`, `failed`, or `cancelled`), the stream is filtered out — matching the same criteria used by `gcArtifacts()` in the OnlineDDL executor.

Both the legacy (VReplicationExec/SQL) and gRPC (ReadVReplicationWorkflows) code paths are covered.

## Related Issue(s)

Fixes a production issue where Reshard SwitchWrites is blocked by dead OnlineDDL VReplication streams.

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [ ] Tests were added or are not required
- [ ] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

No migrations or configuration changes needed. The filtering is transparent — terminal OnlineDDL streams that were previously blocking SwitchWrites will now be silently skipped.

### AI Disclosure

This PR was written primarily by Claude Code with direction and review from the author.