### PR TITLE
Fix planner panic when pushing predicates into a `UNION` of literals

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/horizon.go
+++ b/go/vt/vtgate/planbuilder/operators/horizon.go
@@ -82,25 +82,50 @@ func (h *Horizon) IsMergeable(ctx *plancontext.PlanningContext) bool {
 }
 
 func (h *Horizon) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) Operator {
-	if _, isUNion := h.Source.(*Union); isUNion {
+	if union, isUnion := h.Source.(*Union); isUnion {
+		if !union.canPushPredicate(ctx, expr) {
+			return newFilter(h, expr)
+		}
 		// If we have a derived table on top of a UNION, we can let the UNION do the expression rewriting
-		h.Source = h.Source.AddPredicate(ctx, expr)
+		h.Source = union.AddPredicate(ctx, expr)
 		return h
 	}
+
+	newExpr, ok := h.rewriteForSource(ctx, expr)
+	if !ok {
+		return newFilter(h, expr)
+	}
+	h.Source = h.Source.AddPredicate(ctx, newExpr)
+	return h
+}
+
+// canAbsorbPredicate reports whether AddPredicate pushes the predicate into the source
+// instead of wrapping the horizon in a Filter.
+func (h *Horizon) canAbsorbPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) bool {
+	if union, isUnion := h.Source.(*Union); isUnion {
+		return union.canPushPredicate(ctx, expr)
+	}
+
+	_, ok := h.rewriteForSource(ctx, expr)
+	return ok
+}
+
+// rewriteForSource rewrites the predicate into the scope of the source,
+// returning false if it can't be pushed there.
+func (h *Horizon) rewriteForSource(ctx *plancontext.PlanningContext, expr sqlparser.Expr) (sqlparser.Expr, bool) {
 	tableInfo, err := ctx.SemTable.TableInfoForExpr(expr)
 	if err != nil {
 		if errors.Is(err, semantics.ErrNotSingleTable) {
-			return newFilter(h, expr)
+			return nil, false
 		}
 		panic(err)
 	}
 
 	newExpr := semantics.RewriteDerivedTableExpression(expr, tableInfo)
 	if ctx.ContainsAggr(newExpr) {
-		return newFilter(h, expr)
+		return nil, false
 	}
-	h.Source = h.Source.AddPredicate(ctx, newExpr)
-	return h
+	return newExpr, true
 }
 
 func (h *Horizon) AddColumn(ctx *plancontext.PlanningContext, reuse bool, _ bool, expr *sqlparser.AliasedExpr) int {

--- a/go/vt/vtgate/planbuilder/operators/union.go
+++ b/go/vt/vtgate/planbuilder/operators/union.go
@@ -95,8 +95,47 @@ The first SELECT of the union dictates the column names, and the second is whate
 can be found on the same offset. The names of the RHS are discarded.
 */
 func (u *Union) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) Operator {
-	offsets := make(map[string]int)
+	offsets := u.columnOffsets()
+
+	exprPerSource := u.predicatePerSource(ctx, expr, offsets)
+	for i, src := range u.Sources {
+		u.Sources[i] = src.AddPredicate(ctx, exprPerSource[i])
+	}
+
+	return u
+}
+
+// canPushPredicate reports whether AddPredicate can push the predicate into every source.
+// A source that can't take it gets wrapped in a Filter, which breaks the invariant that all
+// sources of a UNION are horizons.
+func (u *Union) canPushPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Expr) bool {
+	horizons := make([]*Horizon, 0, len(u.Sources))
+	for i := range u.Sources {
+		horizon, ok := u.horizonFor(i)
+		if !ok {
+			return false
+		}
+		horizons = append(horizons, horizon)
+	}
+
+	if jp, ok := expr.(*predicates.JoinPredicate); ok {
+		// rewriting the JoinPredicate itself would overwrite the expression the tracker keeps for it
+		expr = jp.Current()
+	}
+
+	offsets := u.columnOffsets()
+	for i, horizon := range horizons {
+		if !horizon.canAbsorbPredicate(ctx, u.predicateForSource(i, expr, offsets)) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (u *Union) columnOffsets() map[string]int {
 	sel := u.GetSelectFor(0)
+	offsets := make(map[string]int, len(sel.GetColumns()))
 	for i, selectExpr := range sel.GetColumns() {
 		ae, ok := selectExpr.(*sqlparser.AliasedExpr)
 		if !ok {
@@ -105,12 +144,7 @@ func (u *Union) AddPredicate(ctx *plancontext.PlanningContext, expr sqlparser.Ex
 		offsets[strings.ToLower(ae.ColumnName())] = i
 	}
 
-	exprPerSource := u.predicatePerSource(ctx, expr, offsets)
-	for i, src := range u.Sources {
-		u.Sources[i] = src.AddPredicate(ctx, exprPerSource[i])
-	}
-
-	return u
+	return offsets
 }
 
 func (u *Union) predicatePerSource(ctx *plancontext.PlanningContext, expr sqlparser.Expr, offsets map[string]int) []sqlparser.Expr {
@@ -126,42 +160,53 @@ func (u *Union) predicatePerSource(ctx *plancontext.PlanningContext, expr sqlpar
 			predicate = ctx.PredTracker.NewJoinPredicate(jp.Current())
 		}
 
-		predicate = sqlparser.CopyOnRewrite(predicate, nil, func(cursor *sqlparser.CopyOnWriteCursor) {
-			col, ok := cursor.Node().(*sqlparser.ColName)
-			if !ok {
-				return
-			}
-
-			idx, ok := offsets[col.Name.Lowered()]
-			if !ok {
-				panic(vterrors.VT13001(fmt.Sprintf("could not find the column '%s' on the UNION", sqlparser.String(col))))
-			}
-
-			sel := u.GetSelectFor(i)
-			ae, ok := sel.GetColumns()[idx].(*sqlparser.AliasedExpr)
-			if !ok {
-				panic(vterrors.VT09015())
-			}
-
-			cursor.Replace(ae.Expr)
-		}, nil).(sqlparser.Expr)
-
-		exprPerSource[i] = predicate
+		exprPerSource[i] = u.predicateForSource(i, predicate, offsets)
 	}
 
 	return exprPerSource
 }
 
+func (u *Union) predicateForSource(source int, expr sqlparser.Expr, offsets map[string]int) sqlparser.Expr {
+	return sqlparser.CopyOnRewrite(expr, nil, func(cursor *sqlparser.CopyOnWriteCursor) {
+		col, ok := cursor.Node().(*sqlparser.ColName)
+		if !ok {
+			return
+		}
+
+		idx, ok := offsets[col.Name.Lowered()]
+		if !ok {
+			panic(vterrors.VT13001(fmt.Sprintf("could not find the column '%s' on the UNION", sqlparser.String(col))))
+		}
+
+		sel := u.GetSelectFor(source)
+		ae, ok := sel.GetColumns()[idx].(*sqlparser.AliasedExpr)
+		if !ok {
+			panic(vterrors.VT09015())
+		}
+
+		cursor.Replace(ae.Expr)
+	}, nil).(sqlparser.Expr)
+}
+
 func (u *Union) GetSelectFor(source int) *sqlparser.Select {
+	horizon, ok := u.horizonFor(source)
+	if !ok {
+		panic(vterrors.VT13001("expected all sources of the UNION to be horizons"))
+	}
+
+	return getFirstSelect(horizon.Query)
+}
+
+func (u *Union) horizonFor(source int) (*Horizon, bool) {
 	src := u.Sources[source]
 	for {
 		switch op := src.(type) {
 		case *Horizon:
-			return getFirstSelect(op.Query)
+			return op, true
 		case *Route:
 			src = op.Source
 		default:
-			panic(vterrors.VT13001("expected all sources of the UNION to be horizons"))
+			return nil, false
 		}
 	}
 }

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -2121,5 +2121,49 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "join with derived table containing a UNION of literal only SELECTs, predicate on the derived table",
+    "query": "select u.id, r.ordinal from user as u join (select 0 as ordinal, 1 as pid union all select 1, 2) as r on u.id = r.pid where r.ordinal <= 30000",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select u.id, r.ordinal from user as u join (select 0 as ordinal, 1 as pid union all select 1, 2) as r on u.id = r.pid where r.ordinal <= 30000",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select u.id, r.ordinal from `user` as u, (select 0 as ordinal, 1 as pid from dual where 1 != 1 union all select 1, 2 from dual where 1 != 1) as r where 1 != 1",
+        "Query": "select u.id, r.ordinal from `user` as u, (select 0 as ordinal, 1 as pid from dual union all select 1, 2 from dual) as r where r.ordinal <= 30000 and u.id = r.pid"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "derived table containing a UNION of literal only SELECTs joined with a table, predicate on the derived table",
+    "query": "select u.id, r.ordinal from (select 0 as ordinal, 1 as pid union all select 1, 2) as r join user as u on u.id = r.pid where r.ordinal <= 30000",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select u.id, r.ordinal from (select 0 as ordinal, 1 as pid union all select 1, 2) as r join user as u on u.id = r.pid where r.ordinal <= 30000",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select u.id, r.ordinal from `user` as u, (select 0 as ordinal, 1 as pid from dual where 1 != 1 union all select 1, 2 from dual where 1 != 1) as r where 1 != 1",
+        "Query": "select u.id, r.ordinal from `user` as u, (select 0 as ordinal, 1 as pid from dual union all select 1, 2 from dual) as r where r.ordinal <= 30000 and u.id = r.pid"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Description

Joining a table to a derived table built from literal only SELECTs kills the planner:

```sql
select c.customer_id, r.ordinal
from customer as c
join (select 0 as ordinal, 1 as customer_id union all select 1, 2) as r on c.customer_id = r.customer_id
where r.ordinal <= 30000;
```

```
ERROR 1815 (HY000): VT13001: [BUG] expected all sources of the UNION to be horizons
```

`Union.AddPredicate` rewrites a predicate once per source, swapping every column for the expression at the same offset in that branch. On a literal only branch, `r.ordinal <= 30000` becomes `0 <= 30000`, which has no table dependency left, so `Horizon.AddPredicate` has nowhere to push it and wraps the branch in a `Filter`. `Union.GetSelectFor` needs every source to be a horizon, so the next predicate pushed at the same union panics. A join sends two predicates at it, the join condition and the WHERE, so this shape fails every time.

The union now checks that every source can take its rewritten predicate before pushing any of them. If one can't, nothing is pushed and the predicate stays in a `Filter` on top of the horizon. That's where the two bail-outs already in `Horizon.AddPredicate` put their filters, and it's the only placement that works: putting it between the horizon and the union panics later in the SQL builder, since a `Filter` inside a union derived table has no WHERE clause to be written into.

The check is "would this source stop being a horizon" rather than "does the rewritten predicate have no dependencies", so it also catches the two other shapes that panic identically today, a branch predicate that resolves across several tables and one that resolves to an aggregate.

The query above now plans as a single scatter, with the predicate pushed into the same route it would have reached anyway:

```sql
select u.id, r.ordinal from `user` as u, (select 0 as ordinal, 1 as pid from dual union all select 1, 2 from dual) as r where r.ordinal <= 30000 and u.id = r.pid
```

## Related Issue(s)

Fixes #20610

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

Two cases added to `union_cases.json`. Verified the first fails without the fix, with the exact `VT13001` from the issue. No existing plan expectation in any testdata file changed.

## Deployment Notes

Queries that failed with `VT13001: [BUG] expected all sources of the UNION to be horizons` now plan and run. Predicate placement changes for derived tables whose UNION branches select only literals: the predicate is applied above the derived table rather than inside each branch. Results are unchanged.

### AI Disclosure

I used Claude Code to understand the package and to add the tests, and implemented the fix myself.
