### PR TITLE
Properly handle vstream filter predicates with multi-col PKs

### DIFF
--- a/go/test/endtoend/vreplication/multi_tenant_test.go
+++ b/go/test/endtoend/vreplication/multi_tenant_test.go
@@ -259,10 +259,11 @@ func TestMultiTenantSimple(t *testing.T) {
 		require.Equal(t, "completed", previous.State)
 		previousCompletedAt, err := time.Parse(vdiff2.TimestampFormat, previous.CompletedAt)
 		require.NoError(t, err)
+		completedAtMin := previousCompletedAt.Add(-time.Nanosecond)
 		lastIndex = insertRows(lastIndex, sourceKeyspace)
 		_, _, err = performVDiff2Action(t, ksWorkflow, defaultCellName, "resume", uuid, false)
 		require.NoError(t, err)
-		info := waitForVDiff2ToComplete(t, ksWorkflow, defaultCellName, uuid, previousCompletedAt)
+		info := waitForVDiff2ToComplete(t, ksWorkflow, defaultCellName, uuid, completedAtMin)
 		require.NotNil(t, info)
 		require.False(t, info.HasMismatch)
 

--- a/go/test/endtoend/vreplication/multi_tenant_test.go
+++ b/go/test/endtoend/vreplication/multi_tenant_test.go
@@ -598,6 +598,11 @@ func (mtm *multiTenantMigration) switchTraffic(tenantId int64) {
 	require.NoError(t, waitForWorkflowState(vc, ksWorkflow, binlogdatapb.VReplicationWorkflowState_Running.String()))
 	vdiff(t, mt.targetKeyspace, mt.workflowName, defaultCellName, nil)
 	mtm.insertSomeData(t, tenantId, sourceKeyspaceName, numAdditionalRowsPerTenant)
+	// Resuming the VDiff restarts it from the LastPK, which is what combines the
+	// tenant filter with the keyset pagination predicate against the target's
+	// composite primary key. Any other tenant's rows leaking into the comparison
+	// shows up as a mismatch.
+	require.NoError(t, resumeLastVDiff(t, mt.targetKeyspace, mt.workflowName, defaultCellName))
 	mt.SwitchReadsAndWrites()
 	mtm.insertSomeData(t, tenantId, sourceKeyspaceName, numAdditionalRowsPerTenant)
 }

--- a/go/test/endtoend/vreplication/multi_tenant_test.go
+++ b/go/test/endtoend/vreplication/multi_tenant_test.go
@@ -45,6 +45,7 @@ import (
 
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/proto/vtctldata"
+	vdiff2 "vitess.io/vitess/go/vt/vttablet/tabletmanager/vdiff"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
@@ -254,12 +255,14 @@ func TestMultiTenantSimple(t *testing.T) {
 		ksWorkflow := fmt.Sprintf("%s.%s", targetKeyspace, defaultWorkflowName)
 		uuid, output, err := performVDiff2Action(t, ksWorkflow, defaultCellName, "show", "last", false)
 		require.NoError(t, err)
-		require.Equal(t, "completed", getVDiffInfo(output).State)
-		ogTime := time.Now() // The resumed run's completed_at should be later than this.
+		previous := getVDiffInfo(output)
+		require.Equal(t, "completed", previous.State)
+		previousCompletedAt, err := time.Parse(vdiff2.TimestampFormat, previous.CompletedAt)
+		require.NoError(t, err)
 		lastIndex = insertRows(lastIndex, sourceKeyspace)
 		_, _, err = performVDiff2Action(t, ksWorkflow, defaultCellName, "resume", uuid, false)
 		require.NoError(t, err)
-		info := waitForVDiff2ToComplete(t, ksWorkflow, defaultCellName, uuid, ogTime)
+		info := waitForVDiff2ToComplete(t, ksWorkflow, defaultCellName, uuid, previousCompletedAt)
 		require.NotNil(t, info)
 		require.False(t, info.HasMismatch)
 

--- a/go/test/endtoend/vreplication/multi_tenant_test.go
+++ b/go/test/endtoend/vreplication/multi_tenant_test.go
@@ -598,11 +598,6 @@ func (mtm *multiTenantMigration) switchTraffic(tenantId int64) {
 	require.NoError(t, waitForWorkflowState(vc, ksWorkflow, binlogdatapb.VReplicationWorkflowState_Running.String()))
 	vdiff(t, mt.targetKeyspace, mt.workflowName, defaultCellName, nil)
 	mtm.insertSomeData(t, tenantId, sourceKeyspaceName, numAdditionalRowsPerTenant)
-	// Resuming the VDiff restarts it from the LastPK, which is what combines the
-	// tenant filter with the keyset pagination predicate against the target's
-	// composite primary key. Any other tenant's rows leaking into the comparison
-	// shows up as a mismatch.
-	require.NoError(t, resumeLastVDiff(t, mt.targetKeyspace, mt.workflowName, defaultCellName))
 	mt.SwitchReadsAndWrites()
 	mtm.insertSomeData(t, tenantId, sourceKeyspaceName, numAdditionalRowsPerTenant)
 }

--- a/go/test/endtoend/vreplication/multi_tenant_test.go
+++ b/go/test/endtoend/vreplication/multi_tenant_test.go
@@ -31,6 +31,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand/v2"
+	"os"
+	"path"
+	"regexp"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -96,7 +99,7 @@ const (
 	// PK requires a full table rebuild. So as a practical matter in production the
 	// source schema will likely have the tenant_id column, but NOT have it be part of
 	// the PK.
-	mtSchema = "create table t1(id int, tenant_id int, primary key(id)) Engine=InnoDB"
+	mtSchema = "create table t1(id int, tenant_id int, primary key(id, tenant_id)) Engine=InnoDB"
 	// The target/st schema must have the tenant_id column in the PK and the primary
 	// vindex.
 	stSchema  = "create table t1(id int, tenant_id int, primary key(id, tenant_id)) Engine=InnoDB"
@@ -237,6 +240,42 @@ func TestMultiTenantSimple(t *testing.T) {
 	createFunc()
 
 	vdiff(t, targetKeyspace, defaultWorkflowName, defaultCellName, nil)
+
+	// Confirm that a resumed VDiff ANDs the workflow's tenant filter with the
+	// entire lastpk clause built from the target's composite primary key. All
+	// we need to verify is the query shape passed down to MySQL: rows matched
+	// by an unparenthesized lastpk disjunction are dropped in memory by the
+	// vstreamer's own filters, so the bug cannot surface as a mismatch and
+	// the cost is wasted work at the MySQL layer. We wait for the resumed
+	// VDiff to complete only so that we know the row streamer queries have
+	// been issued and logged before we read the tablet logs.
+	// See https://github.com/vitessio/vitess/issues/20857.
+	t.Run("resume vdiff from lastpk", func(t *testing.T) {
+		ksWorkflow := fmt.Sprintf("%s.%s", targetKeyspace, defaultWorkflowName)
+		uuid, output, err := performVDiff2Action(t, ksWorkflow, defaultCellName, "show", "last", false)
+		require.NoError(t, err)
+		require.Equal(t, "completed", getVDiffInfo(output).State)
+		ogTime := time.Now() // The resumed run's completed_at should be later than this.
+		lastIndex = insertRows(lastIndex, sourceKeyspace)
+		_, _, err = performVDiff2Action(t, ksWorkflow, defaultCellName, "resume", uuid, false)
+		require.NoError(t, err)
+		info := waitForVDiff2ToComplete(t, ksWorkflow, defaultCellName, uuid, ogTime)
+		require.NotNil(t, info)
+		require.False(t, info.HasMismatch)
+
+		resumedQuery := regexp.MustCompile(`Streaming rows for query: select .* from t1 where \(tenant_id = 1\) and \(\(id = \d+ and tenant_id > \d+\) or \(id > \d+\)\) order by id, tenant_id`)
+		found := false
+		for _, tablet := range vc.Cells["zone1"].Keyspaces[targetKeyspace].Shards["0"].Tablets {
+			logBytes, err := os.ReadFile(path.Join(tablet.Vttablet.LogDir, tablet.Vttablet.TabletPath+"-vttablet-stderr.txt"))
+			require.NoError(t, err)
+			if resumedQuery.Match(logBytes) {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "did not find a resumed row streamer query that ANDs the tenant filter with the parenthesized lastpk clause in the target tablet logs")
+	})
+
 	mt.SwitchReads()
 	confirmOnlyReadsSwitched(t)
 

--- a/go/test/endtoend/vreplication/multi_tenant_test.go
+++ b/go/test/endtoend/vreplication/multi_tenant_test.go
@@ -95,14 +95,12 @@ type multiTenantMigration struct {
 }
 
 const (
-	// The source/mt schema does not have the tenant_id column in the PK as adding a
-	// column to a table can be done as an INSTANT operation whereas modifying a table's
-	// PK requires a full table rebuild. So as a practical matter in production the
-	// source schema will likely have the tenant_id column, but NOT have it be part of
-	// the PK.
-	mtSchema = "create table t1(id int, tenant_id int, primary key(id, tenant_id)) Engine=InnoDB"
-	// The target/st schema must have the tenant_id column in the PK and the primary
-	// vindex.
+	mtSchema = "create table t1(id int, tenant_id int, primary key(id)) Engine=InnoDB"
+	// The source PK deliberately differs from the target PK and includes the
+	// tenant_id column. This exercises the VDiff path that stores a separate
+	// source lastpk when the two differ, and it gives the source-side resumed
+	// row streamer query the composite-PK disjunction that the resume subtest
+	// in TestMultiTenantSimple asserts on.
 	stSchema  = "create table t1(id int, tenant_id int, primary key(id, tenant_id)) Engine=InnoDB"
 	mtVSchema = `
 {
@@ -243,14 +241,15 @@ func TestMultiTenantSimple(t *testing.T) {
 	vdiff(t, targetKeyspace, defaultWorkflowName, defaultCellName, nil)
 
 	// Confirm that a resumed VDiff ANDs the workflow's tenant filter with the
-	// entire lastpk clause built from the target's composite primary key. All
-	// we need to verify is the query shape passed down to MySQL: rows matched
-	// by an unparenthesized lastpk disjunction are dropped in memory by the
-	// vstreamer's own filters, so the bug cannot surface as a mismatch and
-	// the cost is wasted work at the MySQL layer. We wait for the resumed
-	// VDiff to complete only so that we know the row streamer queries have
-	// been issued and logged before we read the tablet logs.
-	// See https://github.com/vitessio/vitess/issues/20857.
+	// entire lastpk clause built from the source's composite primary key.
+	// Because the source and target PKs differ, the resume uses the separately
+	// stored source lastpk. All we need to verify is the query shape passed
+	// down to MySQL: rows matched by an unparenthesized lastpk disjunction are
+	// dropped in memory by the vstreamer's own filters, so the bug cannot
+	// surface as a mismatch and the cost is wasted work at the MySQL layer. We
+	// wait for the resumed VDiff to complete only so that we know the row
+	// streamer queries have been issued and logged before we read the source
+	// tablet logs. See https://github.com/vitessio/vitess/issues/20857.
 	t.Run("resume vdiff from lastpk", func(t *testing.T) {
 		ksWorkflow := fmt.Sprintf("%s.%s", targetKeyspace, defaultWorkflowName)
 		uuid, output, err := performVDiff2Action(t, ksWorkflow, defaultCellName, "show", "last", false)
@@ -269,7 +268,7 @@ func TestMultiTenantSimple(t *testing.T) {
 
 		resumedQuery := regexp.MustCompile(`Streaming rows for query: select .* from t1 where \(tenant_id = 1\) and \(\(id = \d+ and tenant_id > \d+\) or \(id > \d+\)\) order by id, tenant_id`)
 		found := false
-		for _, tablet := range vc.Cells["zone1"].Keyspaces[targetKeyspace].Shards["0"].Tablets {
+		for _, tablet := range vc.Cells["zone1"].Keyspaces[sourceKeyspace].Shards["0"].Tablets {
 			logBytes, err := os.ReadFile(path.Join(tablet.Vttablet.LogDir, tablet.Vttablet.TabletPath+"-vttablet-stderr.txt"))
 			require.NoError(t, err)
 			if resumedQuery.Match(logBytes) {
@@ -277,7 +276,7 @@ func TestMultiTenantSimple(t *testing.T) {
 				break
 			}
 		}
-		require.True(t, found, "did not find a resumed row streamer query that ANDs the tenant filter with the parenthesized lastpk clause in the target tablet logs")
+		require.True(t, found, "did not find a resumed row streamer query that ANDs the tenant filter with the parenthesized lastpk clause in the source tablet logs")
 	})
 
 	mt.SwitchReads()

--- a/go/test/endtoend/vreplication/vdiff_helper_test.go
+++ b/go/test/endtoend/vreplication/vdiff_helper_test.go
@@ -49,6 +49,41 @@ func vdiff(t *testing.T, keyspace, workflow, cells string, wantV2Result *expecte
 	doVtctldclientVDiff(t, keyspace, workflow, cells, wantV2Result)
 }
 
+// resumeLastVDiff resumes the workflow's most recent VDiff and waits for it to
+// complete, returning an error rather than asserting so that it is safe to call
+// from a goroutine (go-require).
+//
+// Resuming restarts the diff from the LastPK recorded by the previous run, so
+// this is the only path that combines a workflow's row filter (for example the
+// tenant predicate added for a multi-tenant MoveTables) with the keyset
+// pagination predicate built from the LastPK. Those have to be ANDed as
+// separate units; otherwise the filter governs only one branch of the
+// pagination OR and unrelated rows leak into the comparison, which surfaces
+// here as a mismatch. See https://github.com/vitessio/vitess/issues/20857.
+func resumeLastVDiff(t *testing.T, keyspace, workflow, cells string) error {
+	ksWorkflow := fmt.Sprintf("%s.%s", keyspace, workflow)
+	uuid, output, err := performVDiff2Action(t, ksWorkflow, cells, "show", "last", false)
+	if err != nil {
+		return err
+	}
+	if state := getVDiffInfo(output).State; state != "completed" {
+		return fmt.Errorf("expected the last VDiff for %s to be completed before resuming it, but it was %s", ksWorkflow, state)
+	}
+	// The resumed run's completed_at must be later than this.
+	ogTime := time.Now()
+	if _, _, err := performVDiff2Action(t, ksWorkflow, cells, "resume", uuid, false); err != nil {
+		return err
+	}
+	info := waitForVDiff2ToComplete(t, ksWorkflow, cells, uuid, ogTime)
+	if info == nil {
+		return fmt.Errorf("failed to get info for the resumed VDiff %s on %s", uuid, ksWorkflow)
+	}
+	if info.HasMismatch {
+		return fmt.Errorf("resumed VDiff %s on %s reported a mismatch: %+v", uuid, ksWorkflow, info)
+	}
+	return nil
+}
+
 func doVDiff(t *testing.T, ksWorkflow, cells string) {
 	arr := strings.Split(ksWorkflow, ".")
 	keyspace := arr[0]

--- a/go/test/endtoend/vreplication/vdiff_helper_test.go
+++ b/go/test/endtoend/vreplication/vdiff_helper_test.go
@@ -49,51 +49,6 @@ func vdiff(t *testing.T, keyspace, workflow, cells string, wantV2Result *expecte
 	doVtctldclientVDiff(t, keyspace, workflow, cells, wantV2Result)
 }
 
-// resumeLastVDiff resumes the workflow's most recent VDiff and waits for it to
-// complete, returning an error rather than asserting so that it is safe to call
-// from a goroutine (go-require).
-//
-// Resuming restarts the diff from the LastPK recorded by the previous run, so
-// this is the only path that combines a workflow's row filter (for example the
-// tenant predicate added for a multi-tenant MoveTables) with the keyset
-// pagination predicate built from the LastPK. Those have to be ANDed as
-// separate units; otherwise the filter governs only one branch of the
-// pagination OR and unrelated rows leak into the comparison, which surfaces
-// here as a mismatch. See https://github.com/vitessio/vitess/issues/20857.
-func resumeLastVDiff(t *testing.T, keyspace, workflow, cells string) error {
-	ksWorkflow := fmt.Sprintf("%s.%s", keyspace, workflow)
-	uuid, output, err := performVDiff2Action(t, ksWorkflow, cells, "show", "last", false)
-	if err != nil {
-		return err
-	}
-	previous := getVDiffInfo(output)
-	if previous.State != "completed" {
-		return fmt.Errorf("expected the last VDiff for %s to be completed before resuming it, but it was %s", ksWorkflow, previous.State)
-	}
-	// Anchor the "has it finished again?" threshold to the previous run's own
-	// completed_at rather than to time.Now(). completed_at is stored with second
-	// precision, so a wall clock threshold carrying sub-second precision could
-	// never be beaten by a resumed run that finishes within the same second,
-	// and rounding that threshold down instead risks accepting the previous
-	// run's completion before the resume has taken effect.
-	previousCompletedAt, err := time.Parse(vdiff2.TimestampFormat, previous.CompletedAt)
-	if err != nil {
-		return fmt.Errorf("failed to parse the completed_at value %q for VDiff %s on %s: %v",
-			previous.CompletedAt, uuid, ksWorkflow, err)
-	}
-	if _, _, err := performVDiff2Action(t, ksWorkflow, cells, "resume", uuid, false); err != nil {
-		return err
-	}
-	info := waitForVDiff2ToComplete(t, ksWorkflow, cells, uuid, previousCompletedAt)
-	if info == nil {
-		return fmt.Errorf("failed to get info for the resumed VDiff %s on %s", uuid, ksWorkflow)
-	}
-	if info.HasMismatch {
-		return fmt.Errorf("resumed VDiff %s on %s reported a mismatch: %+v", uuid, ksWorkflow, info)
-	}
-	return nil
-}
-
 func doVDiff(t *testing.T, ksWorkflow, cells string) {
 	arr := strings.Split(ksWorkflow, ".")
 	keyspace := arr[0]

--- a/go/test/endtoend/vreplication/vdiff_helper_test.go
+++ b/go/test/endtoend/vreplication/vdiff_helper_test.go
@@ -66,15 +66,25 @@ func resumeLastVDiff(t *testing.T, keyspace, workflow, cells string) error {
 	if err != nil {
 		return err
 	}
-	if state := getVDiffInfo(output).State; state != "completed" {
-		return fmt.Errorf("expected the last VDiff for %s to be completed before resuming it, but it was %s", ksWorkflow, state)
+	previous := getVDiffInfo(output)
+	if previous.State != "completed" {
+		return fmt.Errorf("expected the last VDiff for %s to be completed before resuming it, but it was %s", ksWorkflow, previous.State)
 	}
-	// The resumed run's completed_at must be later than this.
-	ogTime := time.Now()
+	// Anchor the "has it finished again?" threshold to the previous run's own
+	// completed_at rather than to time.Now(). completed_at is stored with second
+	// precision, so a wall clock threshold carrying sub-second precision could
+	// never be beaten by a resumed run that finishes within the same second,
+	// and rounding that threshold down instead risks accepting the previous
+	// run's completion before the resume has taken effect.
+	previousCompletedAt, err := time.Parse(vdiff2.TimestampFormat, previous.CompletedAt)
+	if err != nil {
+		return fmt.Errorf("failed to parse the completed_at value %q for VDiff %s on %s: %v",
+			previous.CompletedAt, uuid, ksWorkflow, err)
+	}
 	if _, _, err := performVDiff2Action(t, ksWorkflow, cells, "resume", uuid, false); err != nil {
 		return err
 	}
-	info := waitForVDiff2ToComplete(t, ksWorkflow, cells, uuid, ogTime)
+	info := waitForVDiff2ToComplete(t, ksWorkflow, cells, uuid, previousCompletedAt)
 	if info == nil {
 		return fmt.Errorf("failed to get info for the resumed VDiff %s on %s", uuid, ksWorkflow)
 	}

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -295,10 +295,17 @@ func (rs *rowStreamer) buildSelect(st *binlogdatapb.MinimalTable) (string, error
 		}
 		buf.WriteString(" where ")
 		// First we add any predicates that should be pushed down.
-		if len(rs.plan.whereExprsToPushDown) > 0 {
+		pushingDownExprs := len(rs.plan.whereExprsToPushDown) > 0
+		if pushingDownExprs {
 			addPushdownExpressions()
 			// Only AND expressions are supported.
 			buf.Myprintf(" and ")
+			// The lastpk clause built below is a disjunction, so it has to be
+			// parenthesized as a single unit before being ANDed with the
+			// pushed down predicates. Without this, AND binding more tightly
+			// than OR would let the trailing OR terms match rows that the
+			// pushed down predicates are meant to exclude.
+			buf.Myprintf("(")
 		}
 		prefix := ""
 		// This loop handles the case for composite PKs. For example,
@@ -316,6 +323,9 @@ func (rs *rowStreamer) buildSelect(st *binlogdatapb.MinimalTable) (string, error
 			}
 			buf.Myprintf("%v > ", sqlparser.NewIdentifierCI(rs.plan.Table.Fields[pkCol].Name))
 			rs.lastpk[lastcol].EncodeSQL(buf)
+			buf.Myprintf(")")
+		}
+		if pushingDownExprs {
 			buf.Myprintf(")")
 		}
 	} else if len(rs.plan.whereExprsToPushDown) > 0 { // We're in the first copy phase cycle

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -290,43 +290,45 @@ func (rs *rowStreamer) buildSelect(st *binlogdatapb.MinimalTable) (string, error
 	buf.Myprintf(" from %v%s", sqlparser.NewIdentifierCS(rs.plan.Table.Name), indexHint)
 	if len(rs.lastpk) != 0 { // We're in the Nth copy phase cycle and need to resume
 		if len(rs.lastpk) != len(rs.pkColumns) {
-			return "", fmt.Errorf("cannot build a row streamer plan for the %s table as a lastpk value was provided and the number of primary key values within it (%v) does not match the number of primary key columns in the table (%d)",
-				st.Name, rs.lastpk, rs.pkColumns)
+			return "", fmt.Errorf("cannot build a row streamer plan for the %s table as a lastpk value was provided (%v) and the number of primary key values within it (%d) does not match the number of primary key columns in the table (%d)",
+				st.Name, rs.lastpk, len(rs.lastpk), len(rs.pkColumns))
 		}
 		buf.WriteString(" where ")
-		// First we add any predicates that should be pushed down.
-		pushingDownExprs := len(rs.plan.whereExprsToPushDown) > 0
-		if pushingDownExprs {
-			addPushdownExpressions()
-			// Only AND expressions are supported.
-			buf.Myprintf(" and ")
-			// The lastpk clause built below is a disjunction, so it has to be
-			// parenthesized as a single unit before being ANDed with the
-			// pushed down predicates. Without this, AND binding more tightly
-			// than OR would let the trailing OR terms match rows that the
-			// pushed down predicates are meant to exclude.
-			buf.Myprintf("(")
-		}
-		prefix := ""
-		// This loop handles the case for composite PKs. For example,
+		// This closure handles the case for composite PKs. For example,
 		// if lastpk was (1,2), the where clause would be:
 		// (col1 = 1 and col2 > 2) or (col1 > 1).
 		// A tuple inequality like (col1,col2) > (1,2) ends up
 		// being a full table scan for MySQL.
-		for lastcol, pkCol := range slices.Backward(rs.pkColumns) {
-			buf.Myprintf("%s(", prefix)
-			prefix = " or "
-			for i, pk := range rs.pkColumns[:lastcol] {
-				buf.Myprintf("%v = ", sqlparser.NewIdentifierCI(rs.plan.Table.Fields[pk].Name))
-				rs.lastpk[i].EncodeSQL(buf)
-				buf.Myprintf(" and ")
+		addLastPKExpressions := func() {
+			prefix := ""
+			for lastcol, pkCol := range slices.Backward(rs.pkColumns) {
+				buf.Myprintf("%s(", prefix)
+				prefix = " or "
+				for i, pk := range rs.pkColumns[:lastcol] {
+					buf.Myprintf("%v = ", sqlparser.NewIdentifierCI(rs.plan.Table.Fields[pk].Name))
+					rs.lastpk[i].EncodeSQL(buf)
+					buf.Myprintf(" and ")
+				}
+				buf.Myprintf("%v > ", sqlparser.NewIdentifierCI(rs.plan.Table.Fields[pkCol].Name))
+				rs.lastpk[lastcol].EncodeSQL(buf)
+				buf.Myprintf(")")
 			}
-			buf.Myprintf("%v > ", sqlparser.NewIdentifierCI(rs.plan.Table.Fields[pkCol].Name))
-			rs.lastpk[lastcol].EncodeSQL(buf)
-			buf.Myprintf(")")
 		}
-		if pushingDownExprs {
+		if len(rs.plan.whereExprsToPushDown) > 0 {
+			// First we add any predicates that should be pushed down.
+			addPushdownExpressions()
+			// The lastpk clause is a disjunction, so it has to be parenthesized
+			// as a single unit before being ANDed with the pushed down
+			// predicates; otherwise AND binds more tightly than OR and the
+			// trailing OR terms match rows that the pushed down predicates are
+			// meant to exclude. Those rows would later be dropped in memory by
+			// the plan's filters, but only after being needlessly scanned and
+			// streamed by mysqld.
+			buf.Myprintf(" and (")
+			addLastPKExpressions()
 			buf.Myprintf(")")
+		} else {
+			addLastPKExpressions()
 		}
 	} else if len(rs.plan.whereExprsToPushDown) > 0 { // We're in the first copy phase cycle
 		buf.Myprintf(" where ")

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
@@ -449,6 +449,39 @@ func TestStreamRowsFilterIn(t *testing.T) {
 	require.NotZero(t, engine.vstreamerPacketSize.Get())
 }
 
+// TestStreamRowsFilterWithLastPK confirms that pushed down predicates are
+// ANDed with the *entire* lastpk clause when a copy phase cycle resumes.
+// The lastpk clause for a composite PK is a disjunction, so it has to be
+// parenthesized as a unit; otherwise AND binds more tightly than OR and the
+// trailing OR terms match rows that the pushed down predicates exclude.
+func TestStreamRowsFilterWithLastPK(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	require.NoError(t, env.SetVSchema(shardedVSchema))
+	defer env.SetVSchema("{}")
+
+	execStatements(t, []string{
+		"create table t1(id1 int, id2 int, val varbinary(128), primary key(id1, id2))",
+		// (2,1) is the row that leaks when the lastpk disjunction is not
+		// parenthesized: it fails the filter but satisfies `id1 > 1`.
+		"insert into t1 values (1, 1, 'include'), (1, 2, 'include'), (1, 3, 'exclude'), (2, 1, 'exclude'), (2, 2, 'include')",
+	})
+
+	defer execStatements(t, []string{
+		"drop table t1",
+	})
+
+	wantStream := []string{
+		`fields:{name:"id1" type:INT32 table:"t1" org_table:"t1" database:"vttest" org_name:"id1" column_length:11 charset:63 column_type:"int(11)"} fields:{name:"id2" type:INT32 table:"t1" org_table:"t1" database:"vttest" org_name:"id2" column_length:11 charset:63 column_type:"int(11)"} fields:{name:"val" type:VARBINARY table:"t1" org_table:"t1" database:"vttest" org_name:"val" column_length:128 charset:63 column_type:"varbinary(128)"} pkfields:{name:"id1" type:INT32 charset:63} pkfields:{name:"id2" type:INT32 charset:63}`,
+		`rows:{lengths:1 lengths:1 lengths:7 values:"12include"} rows:{lengths:1 lengths:1 lengths:7 values:"22include"} lastpk:{lengths:1 lengths:1 values:"22"}`,
+	}
+	wantQuery := "select /*+ MAX_EXECUTION_TIME(3600000) */ id1, id2, val from t1 where (val = 'include') and ((id1 = 1 and id2 > 1) or (id1 > 1)) order by id1, id2"
+	checkStream(t, "select id1, id2, val from t1 where (val = 'include')",
+		[]sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(1)}, wantQuery, wantStream, nil)
+}
+
 func TestStreamRowsFilterVarBinary(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
@@ -454,6 +454,10 @@ func TestStreamRowsFilterIn(t *testing.T) {
 // The lastpk clause for a composite PK is a disjunction, so it has to be
 // parenthesized as a unit; otherwise AND binds more tightly than OR and the
 // trailing OR terms match rows that the pushed down predicates exclude.
+// Such rows are dropped in memory by the plan's filters before being
+// streamed, so the row output is identical either way and the generated
+// query assertion below is what guards the fix: the cost of the bug is
+// mysqld needlessly scanning and returning the excluded rows.
 func TestStreamRowsFilterWithLastPK(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
@@ -464,8 +468,9 @@ func TestStreamRowsFilterWithLastPK(t *testing.T) {
 
 	execStatements(t, []string{
 		"create table t1(id1 int, id2 int, val varbinary(128), primary key(id1, id2))",
-		// (2,1) is the row that leaks when the lastpk disjunction is not
-		// parenthesized: it fails the filter but satisfies `id1 > 1`.
+		// (2,1) is the row that the unparenthesized lastpk disjunction lets
+		// escape the filter in the generated query: it fails the filter but
+		// satisfies `id1 > 1`.
 		"insert into t1 values (1, 1, 'include'), (1, 2, 'include'), (1, 3, 'exclude'), (2, 1, 'exclude'), (2, 2, 'include')",
 	})
 


### PR DESCRIPTION
## Description

Since #17677 we push VStream filter predicates down into the MySQL query. When a
copy phase cycle (or a VDiff) resumes from a LastPK, the resume clause for a
multi-column PK is a disjunction — `(id = 1 and col > 2) or (id > 1)` — and it
was appended to the pushed down predicates without being parenthesized. Since
`AND` binds tighter than `OR`, the filter only governed the first branch:

```sql
where (tenant_id = 2) and (id = 115113614 and col1 > 82708304) or (id > 115113614)
```

Everything past the resume point matched via the second branch regardless of the
filter. The vstreamer re-applies its filters in memory before sending rows, so
the streamed results were still correct, but mysqld needlessly scanned and
returned every filtered-out row past the resume point on each cycle — e.g. a
resumed VDiff for one tenant of a multi-tenant table reading all tenants' rows.

`buildSelect` in the row streamer now wraps the LastPK clause so it is ANDed with
the pushed down predicates as a single unit:

```sql
where (tenant_id = 2) and ((id = 115113614 and col1 > 82708304) or (id > 115113614))
```

This affects both the source and target side of a diff, and any filtered
workflow — not only multi-tenant ones. Queries without a filter or without a
LastPK are unchanged.

This should be backported to all supported releases that contain #17677.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/20857

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

I worked with Claude and Fable 5 on the work and with Codex and GPT-5.6 Sol on reviews.
