### PR TITLE
vttablet: perform an initial heartbeat read when opening the heartbeat reader

### DIFF
--- a/go/vt/vttablet/tabletserver/repltracker/reader.go
+++ b/go/vt/vttablet/tabletserver/repltracker/reader.go
@@ -106,6 +106,11 @@ func (r *heartbeatReader) Open() {
 
 	r.pool.Open(r.env.Config().DB.AppWithDB(), r.env.Config().DB.DbaWithDB(), r.env.Config().DB.AppDebugWithDB())
 	r.lastKnownTime = r.now()
+	// Read the current heartbeat synchronously so that a real lag measurement
+	// (or error) is available before the first tick fires. Otherwise Status()
+	// reports the zero-value lag until then, and a tablet restored from an old
+	// backup is briefly advertised as healthy despite hours of replication lag.
+	r.readHeartbeat()
 	r.ticks.Start(func() { r.readHeartbeat() })
 	r.isOpen = true
 }

--- a/go/vt/vttablet/tabletserver/repltracker/reader_test.go
+++ b/go/vt/vttablet/tabletserver/repltracker/reader_test.go
@@ -91,10 +91,10 @@ func TestReaderInitialHeartbeatReadOnOpen(t *testing.T) {
 	t.Cleanup(db.Close)
 
 	now := time.Now()
-	tr := newReader(db, &now)
+	tr := newReader(db, nil)
 	t.Cleanup(tr.Close)
 	// A generous read deadline so a paused CI runner cannot expire the
-	// frozen-clock-based context before Open performs the initial read.
+	// context before Open performs the initial read.
 	tr.interval = 30 * time.Second
 
 	db.AddQuery(fmt.Sprintf("SELECT ts FROM %s.heartbeat WHERE keyspaceShard='%s'", "_vt", tr.keyspaceShard), &sqltypes.Result{
@@ -110,7 +110,8 @@ func TestReaderInitialHeartbeatReadOnOpen(t *testing.T) {
 	lag, err := tr.Status()
 
 	require.NoError(t, err)
-	assert.Equal(t, 2*time.Hour, lag, "expected the real lag immediately after Open")
+	assert.GreaterOrEqual(t, lag, 2*time.Hour, "expected at least the seeded 2h lag immediately after Open")
+	assert.Less(t, lag, 2*time.Hour+5*time.Minute, "lag should be within a few minutes of the seeded 2h")
 }
 
 // TestReaderInitialHeartbeatReadFailsClosed tests that when the initial

--- a/go/vt/vttablet/tabletserver/repltracker/reader_test.go
+++ b/go/vt/vttablet/tabletserver/repltracker/reader_test.go
@@ -83,6 +83,51 @@ func TestReaderReadHeartbeat(t *testing.T) {
 	utils.MustMatch(t, expectedHisto, heartbeatLagNsHistogram.Counts(), "wrong counts in histogram")
 }
 
+// TestReaderInitialHeartbeatReadOnOpen tests that Open performs a synchronous
+// initial heartbeat read, so that Status reflects the true lag immediately
+// rather than reporting the zero-value lag until the first tick fires.
+func TestReaderInitialHeartbeatReadOnOpen(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+
+	now := time.Now()
+	tr := newReader(db, &now)
+	defer tr.Close()
+
+	db.AddQuery(fmt.Sprintf("SELECT ts FROM %s.heartbeat WHERE keyspaceShard='%s'", "_vt", tr.keyspaceShard), &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{Name: "ts", Type: sqltypes.Int64},
+		},
+		Rows: [][]sqltypes.Value{{
+			sqltypes.NewInt64(now.Add(-2 * time.Hour).UnixNano()),
+		}},
+	})
+
+	tr.Open()
+	lag, err := tr.Status()
+
+	require.NoError(t, err)
+	assert.Equal(t, 2*time.Hour, lag, "expected the real lag immediately after Open")
+}
+
+// TestReaderInitialHeartbeatReadFailsClosed tests that when the initial
+// heartbeat read on Open fails (e.g. the heartbeat table is empty or
+// unreadable), Status reports the error instead of a zero-value lag.
+func TestReaderInitialHeartbeatReadFailsClosed(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+
+	now := time.Now()
+	tr := newReader(db, &now)
+	defer tr.Close()
+
+	tr.Open()
+	lag, err := tr.Status()
+
+	require.Error(t, err)
+	assert.Equal(t, time.Duration(0), lag, "wrong lastKnownLag")
+}
+
 // TestReaderCloseSetsCurrentLagToZero tests that when closing the heartbeat reader, the current lag is
 // set to zero.
 func TestReaderCloseSetsCurrentLagToZero(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/repltracker/reader_test.go
+++ b/go/vt/vttablet/tabletserver/repltracker/reader_test.go
@@ -88,11 +88,14 @@ func TestReaderReadHeartbeat(t *testing.T) {
 // rather than reporting the zero-value lag until the first tick fires.
 func TestReaderInitialHeartbeatReadOnOpen(t *testing.T) {
 	db := fakesqldb.New(t)
-	defer db.Close()
+	t.Cleanup(db.Close)
 
 	now := time.Now()
 	tr := newReader(db, &now)
-	defer tr.Close()
+	t.Cleanup(tr.Close)
+	// A generous read deadline so a paused CI runner cannot expire the
+	// frozen-clock-based context before Open performs the initial read.
+	tr.interval = 30 * time.Second
 
 	db.AddQuery(fmt.Sprintf("SELECT ts FROM %s.heartbeat WHERE keyspaceShard='%s'", "_vt", tr.keyspaceShard), &sqltypes.Result{
 		Fields: []*querypb.Field{
@@ -115,11 +118,12 @@ func TestReaderInitialHeartbeatReadOnOpen(t *testing.T) {
 // unreadable), Status reports the error instead of a zero-value lag.
 func TestReaderInitialHeartbeatReadFailsClosed(t *testing.T) {
 	db := fakesqldb.New(t)
-	defer db.Close()
+	t.Cleanup(db.Close)
 
 	now := time.Now()
 	tr := newReader(db, &now)
-	defer tr.Close()
+	t.Cleanup(tr.Close)
+	tr.interval = 30 * time.Second
 
 	tr.Open()
 	lag, err := tr.Status()

--- a/go/vt/vttablet/tabletserver/repltracker/repltracker_test.go
+++ b/go/vt/vttablet/tabletserver/repltracker/repltracker_test.go
@@ -40,7 +40,10 @@ func TestReplTracker(t *testing.T) {
 
 	cfg := tabletenv.NewDefaultConfig()
 	cfg.ReplicationTracker.Mode = tabletenv.Heartbeat
-	cfg.ReplicationTracker.HeartbeatInterval = time.Second
+	// A long interval keeps the reader's async ticker from firing during the
+	// test: the initial read on open runs synchronously on this goroutine, so
+	// the direct lastKnownLag mutations below cannot race with a tick.
+	cfg.ReplicationTracker.HeartbeatInterval = 30 * time.Second
 	params := db.ConnParams()
 	cp := *params
 	cfg.DB = dbconfigs.NewTestDBConfigs(cp, cp, "")

--- a/go/vt/vttablet/tabletserver/repltracker/repltracker_test.go
+++ b/go/vt/vttablet/tabletserver/repltracker/repltracker_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/fakesqldb"
+	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	querypb "vitess.io/vitess/go/vt/proto/query"
@@ -50,6 +51,16 @@ func TestReplTracker(t *testing.T) {
 	}
 	target := &querypb.Target{}
 	mysqld := mysqlctl.NewFakeMysqlDaemon(nil)
+
+	// The heartbeat reader performs an initial read when it is opened.
+	db.AddQuery("SELECT ts FROM _vt.heartbeat WHERE keyspaceShard=':'", &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{Name: "ts", Type: sqltypes.Int64},
+		},
+		Rows: [][]sqltypes.Value{{
+			sqltypes.NewInt64(time.Now().UnixNano()),
+		}},
+	})
 
 	t.Run("always-on heartbeat", func(t *testing.T) {
 		rt := NewReplTracker(env, alias)


### PR DESCRIPTION
## Description

When the heartbeat reader is opened (i.e. the tablet transitions to a non-PRIMARY serving state), `Status()` reported the zero-value `lastKnownLag` until the first ticker-driven read fired one `heartbeat_interval` later — `timer.Timer` never fires immediately, and `Open()` setting `lastKnownTime = now()` arms the staleness guard so `Status()` happily returns `(0, nil)`.

Because the state manager evaluates and broadcasts replication health inline at the serving-state transition (`setState` → `refreshReplHealthLocked` → `hcticks.Trigger()`), a tablet restored from an old backup was briefly advertised as **healthy with zero lag** despite being hours behind. Healthcheck consumers act on that window: a rolling-restart orchestrator can conclude the restored replica is caught up and take down the next one — with semi-sync and two replicas, that takes the shard down.

This PR performs a synchronous heartbeat read in `heartbeatReader.Open()`, before the ticker starts, mirroring what polling mode already does via `poller.Status()` in `ReplTracker.MakeNonPrimary()`. From the very first health evaluation, `Status()` now reports a real measurement — or fails closed with an error if the read fails.

Intentional behavior change: on a brand-new shard whose heartbeat table is still empty (primary's first write not yet replicated), the replica now briefly reports *unhealthy* (error) instead of briefly reporting *healthy* (zero lag) — failing closed instead of open.

Tests: `TestReaderInitialHeartbeatReadOnOpen` and `TestReaderInitialHeartbeatReadFailsClosed` both fail without the fix and pass with it. `TestReplTracker`'s fake DB now provides the heartbeat fetch query, since `MakeNonPrimary` triggers the initial read.

## Related Issue(s)

- Fixes https://github.com/vitessio/vitess/issues/20867

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches — I don't have label permissions; requesting `Backport to: release-23.0` and `Backport to: release-24.0` from a maintainer
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

Backport justification: this is a small, self-contained correctness fix to health reporting; the false-healthy window has caused full-shard outages on v23 in production deployments.

## Deployment Notes

Opening the heartbeat reader now performs one synchronous heartbeat table read (bounded by one `heartbeat_interval`), slightly delaying the non-PRIMARY serving transition. Replicas on brand-new shards report unhealthy until the first heartbeat row replicates.
