### PR TITLE
Allow single element IN to return rows rather than empty sets

### DIFF
--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -454,7 +454,8 @@ func (nz *normalizer) decideBindVarName(lit *Literal, col *ColName, bval *queryp
 	return bvname
 }
 
-// rewriteInComparisons converts IN and NOT IN expressions to use list bind variables.
+// rewriteInComparisons converts IN and NOT IN expressions to use list bind
+// variables, except single-element lists which get a scalar bind variable.
 func (nz *normalizer) rewriteInComparisons(node *ComparisonExpr) {
 	if !nz.shouldParameterize() {
 		return
@@ -462,6 +463,15 @@ func (nz *normalizer) rewriteInComparisons(node *ComparisonExpr) {
 	tupleVals, ok := node.Right.(ValTuple)
 	if !ok {
 		return
+	}
+
+	// a single-element IN list is parameterized with a scalar bind variable so
+	// the tuple size stays visible to the planner, which needs it for routing
+	if len(tupleVals) == 1 {
+		if newR := nz.normalizeComparisonWithBindVar(node.Left, tupleVals[0]); newR != nil {
+			node.Right = ValTuple{newR}
+			return
+		}
 	}
 
 	// Create a list bind variable for the tuple.

--- a/go/vt/sqlparser/normalizer_test.go
+++ b/go/vt/sqlparser/normalizer_test.go
@@ -309,6 +309,20 @@ func TestNormalize(t *testing.T) {
 			"bv1": sqltypes.Int64BindVariable(1),
 		},
 	}, {
+		// single-element IN clause is parameterized with a scalar bindvar
+		in:      "select * from t where v1 in (1)",
+		outstmt: "select * from t where v1 in (:v1 /* INT64 */)",
+		outbv: map[string]*querypb.BindVariable{
+			"v1": sqltypes.Int64BindVariable(1),
+		},
+	}, {
+		// single-element NOT IN clause
+		in:      "select * from t where v1 not in ('a')",
+		outstmt: "select * from t where v1 not in (:v1 /* VARCHAR */)",
+		outbv: map[string]*querypb.BindVariable{
+			"v1": sqltypes.StringBindVariable("a"),
+		},
+	}, {
 		// IN clause with vals
 		in:      "select * from t where v1 in (1, '2')",
 		outstmt: "select * from t where v1 in ::bv1",

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -133,13 +133,26 @@ func (isr *InfoSchemaRouting) Keyspace() *vindexes.Keyspace {
 
 func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlparser.Expr) (bool, string, sqlparser.Expr) {
 	cmp, ok := in.(*sqlparser.ComparisonExpr)
-	if !ok || cmp.Operator != sqlparser.EqualOp {
+	if !ok || (cmp.Operator != sqlparser.EqualOp && cmp.Operator != sqlparser.InOp) {
 		return false, "", nil
 	}
 
 	isSchemaName, col := isTableOrSchemaRoutable(cmp, ctx.VSchema.Environment().MySQLVersion())
+	if col == nil {
+		return false, "", nil
+	}
+
 	rhs := cmp.Right
-	if col == nil || !shouldRewrite(rhs) {
+	if cmp.Operator == sqlparser.InOp {
+		// a single-element IN is routable like an equality; multi-element
+		// lists could span keyspaces, so we leave them alone
+		tuple, ok := cmp.Right.(sqlparser.ValTuple)
+		if !ok || len(tuple) != 1 {
+			return false, "", nil
+		}
+		rhs = tuple[0]
+	}
+	if !shouldRewrite(rhs) {
 		return false, "", nil
 	}
 
@@ -162,7 +175,12 @@ func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlp
 	} else {
 		name = ctx.GetReservedArgumentFor(col)
 	}
-	cmp.Right = sqlparser.NewTypedArgument(name, sqltypes.VarChar)
+	arg := sqlparser.NewTypedArgument(name, sqltypes.VarChar)
+	if cmp.Operator == sqlparser.InOp {
+		cmp.Right = sqlparser.ValTuple{arg}
+	} else {
+		cmp.Right = arg
+	}
 	return isSchemaName, name, rhs
 }
 

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -1149,5 +1149,65 @@
         "Query": "select c.`column_name` from (select `table_name` from information_schema.`tables` where table_schema != 'information_schema' limit 1) as `tables`, information_schema.`columns` as c where `tables`.`table_name` = c.`table_name`"
       }
     }
+  },
+  {
+    "comment": "single-element IN on table_name is treated like an equality comparison",
+    "query": "select column_name from information_schema.statistics where index_name = 'PRIMARY' and table_schema = 'table_schema' and table_name in ('table_name') order by seq_in_index",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select column_name from information_schema.statistics where index_name = 'PRIMARY' and table_schema = 'table_schema' and table_name in ('table_name') order by seq_in_index",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `column_name` from information_schema.statistics where 1 != 1",
+        "Query": "select `column_name` from information_schema.statistics where index_name = 'PRIMARY' and table_schema = :__vtschemaname /* VARCHAR */ and `table_name` in (:table_name /* VARCHAR */) order by seq_in_index asc",
+        "SysTableTableName": "[table_name:'table_name']",
+        "SysTableTableSchema": "['table_schema']"
+      }
+    }
+  },
+  {
+    "comment": "single-element IN on table_schema is treated like an equality comparison",
+    "query": "select table_name from information_schema.`tables` where table_schema in ('ks')",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.`tables` where table_schema in ('ks')",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where table_schema in (:__vtschemaname /* VARCHAR */)",
+        "SysTableTableSchema": "['ks']"
+      }
+    }
+  },
+  {
+    "comment": "multi-element IN is not used for routing",
+    "query": "select table_name from information_schema.`tables` where table_schema in ('ks1', 'ks2')",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.`tables` where table_schema in ('ks1', 'ks2')",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where table_schema in ('ks1', 'ks2')"
+      }
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -1289,5 +1289,65 @@
         "SysTableTableSchema": "['ks']"
       }
     }
+  },
+  {
+    "comment": "single-element IN on table_name is treated like an equality comparison",
+    "query": "select column_name from information_schema.statistics where index_name = 'PRIMARY' and table_schema = 'table_schema' and table_name in ('table_name') order by seq_in_index",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select column_name from information_schema.statistics where index_name = 'PRIMARY' and table_schema = 'table_schema' and table_name in ('table_name') order by seq_in_index",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `column_name` from information_schema.statistics where 1 != 1",
+        "Query": "select `column_name` from information_schema.statistics where index_name = 'PRIMARY' and table_schema = :__vtschemaname /* VARCHAR */ and `table_name` in (:table_name /* VARCHAR */) order by seq_in_index asc",
+        "SysTableTableName": "[table_name:'table_name']",
+        "SysTableTableSchema": "['table_schema']"
+      }
+    }
+  },
+  {
+    "comment": "single-element IN on table_schema is treated like an equality comparison",
+    "query": "select table_name from information_schema.`tables` where table_schema in ('ks')",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.`tables` where table_schema in ('ks')",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where table_schema in (:__vtschemaname /* VARCHAR */)",
+        "SysTableTableSchema": "['ks']"
+      }
+    }
+  },
+  {
+    "comment": "multi-element IN is not used for routing",
+    "query": "select table_name from information_schema.`tables` where table_schema in ('ks1', 'ks2')",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.`tables` where table_schema in ('ks1', 'ks2')",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where table_schema in ('ks1', 'ks2')"
+      }
+    }
   }
 ]


### PR DESCRIPTION
## Description

We run Rails main in production and since rails/rails#58421 all six of Rails' schema readers (indexes, columns, primary keys, collations, FKs, check constraints) query information_schema with `IN` instead of `=`, even for a single table. On Vitess these silently return an empty set — `extractInfoSchemaRoutingPredicate` only matches EqualOp, so the predicate is never extracted and the schema name never gets the `__vtschemaname` rewrite. Full details in the linked issue.

This treats a single-element IN as the equality it is, in two parts:

- **planner** (`info_schema_planning.go`): `extractInfoSchemaRoutingPredicate` now also accepts an InOp whose RHS is a one-element ValTuple — extracts the sole value for routing and swaps in the typed argument inside the tuple, so the query keeps its IN shape (`in (:__vtschemaname)`). This mirrors what `ShardedRouting.planInOp` already does for vindex routing (sharded_routing.go#L319).
- **normalizer** (`normalizer.go`): one-element IN lists are parameterized with a scalar bindvar (`in (:col)`) instead of a list bindvar (`in ::bv1`). Without this the planner half never fires for text-protocol queries, the list bindvar hides the tuple size, and one cached plan has to serve every list length. Length-1 always normalizes to the same shape so plan-cache consistency holds.

Multi-element IN is deliberately untouched (that's #12693 — the tables could live in different keyspaces), and there's a plan test pinning that it stays unrewritten.

Worth calling out: the normalizer change affects every single-element IN, not just information_schema — query fingerprints shift from `in ::bv1` to `in (:col)`, so plan caches see transient misses on upgrade. Semantically identical, and no tablet-side changes needed (the `__vtschemaname` substitution is a bindvar-value overwrite, so it works inside a tuple as-is). If the repo-wide normalizer change feels too broad I'm happy to discuss scoping it down.

Verified end-to-end on the `examples/local` cluster: before, `SELECT table_name FROM information_schema.tables WHERE table_schema IN ('commerce')` returns an empty set; after, it returns the keyspace's tables, and VEXPLAIN shows `in (:__vtschemaname)` with `SysTableTableSchema` populated.

I think this is worth backporting, every Rails 8.2 app on Vitess hits this on current releases.

## Related Issue(s)

Fixes #20878 

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [ ] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

No tablet-side changes; wire-compatible in both directions (old tablets already handle scalar bindvars in tuples). Single-element IN query fingerprints change, so vtgate plan caches see transient misses on upgrade.

### AI Disclosure

Used Claude Code to write the code as I am not to familiar with go, manually tested the changes locally and also issue was verified in production.