### PR TITLE
fix: close discarded candidate cluster to prevent VTAdmin dynamic cluster resource leak

### DIFF
--- a/go/vt/vtadmin/api.go
+++ b/go/vt/vtadmin/api.go
@@ -352,6 +352,14 @@ func (api *API) WithCluster(c *cluster.Cluster, id string) dynamic.API {
 			api.clusterCache.Set(id, c, cache.DefaultExpiration)
 		} else {
 			log.Info(fmt.Sprintf("API already has cluster with id %s, using that instead", id))
+			// Close the candidate cluster to avoid leaking its
+			// schema-cache worker, client proxies, and RPC pools.
+			// The discarded candidate is never stored or used;
+			// without this Close() each rejected candidate leaves
+			// a schema-cache worker running.
+			if err := c.Close(); err != nil {
+				log.Error(fmt.Sprintf("candidate cluster %s leaked resources on close: %v", id, err))
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #20866

## Problem
When `WithCluster` receives a candidate cluster that matches an existing cached cluster, the candidate is discarded but never closed. Each rejected candidate leaves a schema-cache worker running and retains its client proxies and RPC pools.

In deployments using `--enable-dynamic-clusters`, sending N identical requests creates N schema-cache workers; only 1 is stopped when the API closes.

## Root Cause
In `WithCluster`, when `shouldAddCluster` is false (candidate equals existing), the `else` branch only logs a message — the candidate `c` is never `Close()`d.

## Fix
Close the candidate cluster in the `else` branch to release its schema-cache worker, client proxies, and RPC pools. This mirrors the existing cleanup pattern used when replacing an existing cluster with a new one.

## Verification
- Without the fix: 5 identical dynamic-cluster requests create 5 schema-cache workers
- With the fix: each rejected candidate is properly closed, keeping only the cached cluster's worker
