### PR TITLE
Fix the open high-severity CodeQL alerts

### DIFF
--- a/go/vt/mysqlctl/query.go
+++ b/go/vt/mysqlctl/query.go
@@ -149,7 +149,7 @@ func (mysqld *Mysqld) executeFetchContext(ctx context.Context, conn *dbconnpool.
 		// The context expired or was canceled.
 		// Try to kill the connection to effectively cancel the ExecuteFetch().
 		connID := conn.Conn.ID()
-		log.Info(fmt.Sprintf("Mysqld.executeFetchContext(): killing connID %v due to timeout of query: %v", connID, query))
+		log.Info(fmt.Sprintf("Mysqld.executeFetchContext(): killing connID %v due to timeout of query: %v", connID, redactPassword(query)))
 		if killErr := mysqld.killConnection(connID); killErr != nil {
 			// Log it, but go ahead and wait for the query anyway.
 			log.Warn(fmt.Sprintf("Mysqld.executeFetchContext(): failed to kill connID %v: %v", connID, killErr))

--- a/go/vt/mysqlctl/query_test.go
+++ b/go/vt/mysqlctl/query_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mysqlctl
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/fakesqldb"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/log"
+)
+
+// TestExecuteFetchContextTimeoutRedactsQuery verifies that when a query is
+// killed because its context expired, the query logged on the kill path has
+// its password redacted, like the exec log on the happy path.
+func TestExecuteFetchContextTimeoutRedactsQuery(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+
+	params := db.ConnParams()
+	cp := *params
+	dbc := dbconfigs.NewTestDBConfigs(cp, cp, "fakesqldb")
+	testMysqld := NewMysqld(dbc)
+	defer testMysqld.Close()
+
+	// Capture the structured log output.
+	var logBuf bytes.Buffer
+	oldLogger := log.SwapLogger(slog.New(slog.NewTextHandler(&logBuf, nil)))
+	defer log.SwapLogger(oldLogger)
+
+	query := `START xxx USER = 'vt_repl', PASSWORD = 'secret'`
+	db.AddQuery("SELECT 1", &sqltypes.Result{})
+	db.AddQuery(query, &sqltypes.Result{})
+	// Block the query until the timeout path kills the connection, so the
+	// kill branch is taken deterministically.
+	unblock := make(chan struct{})
+	db.SetBeforeFunc(query, func() {
+		<-unblock
+	})
+	db.AddQueryPatternWithCallback(`kill \d+`, &sqltypes.Result{}, func(string) {
+		close(unblock)
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	err := testMysqld.ExecuteSuperQueryList(ctx, []string{query})
+	// The fake returns the blocked query's result successfully once the kill
+	// releases it, so this lands in the "ExecuteFetch() may have succeeded
+	// before we tried to kill it" branch. The query can only complete after
+	// the kill callback fires, so reaching here proves the kill path ran.
+	require.NoError(t, err)
+
+	logs := logBuf.String()
+	assert.Contains(t, logs, "killing connID")
+	assert.Contains(t, logs, `PASSWORD = '****'`)
+	assert.NotContains(t, logs, "secret")
+}

--- a/go/vt/mysqlctl/tmutils/permissions.go
+++ b/go/vt/mysqlctl/tmutils/permissions.go
@@ -90,13 +90,13 @@ func UserPermissionPrimaryKey(up *tabletmanagerdatapb.UserPermission) string {
 
 // UserPermissionString pretty-prints a UserPermission
 func UserPermissionString(up *tabletmanagerdatapb.UserPermission) string {
-	var passwd string
+	var checksum string
 	if up.PasswordChecksum == 0 {
-		passwd = "NoPassword"
+		checksum = "NoPassword"
 	} else {
-		passwd = fmt.Sprintf("PasswordChecksum(%v)", up.PasswordChecksum)
+		checksum = fmt.Sprintf("PasswordChecksum(%v)", up.PasswordChecksum)
 	}
-	return "UserPermission " + passwd + printPrivileges(up.Privileges)
+	return "UserPermission " + checksum + printPrivileges(up.Privileges)
 }
 
 type userPermissionList []*tabletmanagerdatapb.UserPermission

--- a/go/vt/vtorc/inst/analysis.go
+++ b/go/vt/vtorc/inst/analysis.go
@@ -126,7 +126,7 @@ type DetectionAnalysis struct {
 	// i.e. the population eligible to vote in the shard-peer health quorum. It is the expected
 	// observer count fed to the quorum gate, derived independently of the primary's instance data
 	// so it is available even when VTOrc has never reached the primary (the cold-start case).
-	ShardEligibleObservers                    uint
+	ShardEligibleObservers                    int
 	CountValidReplicas                        uint
 	CountValidReplicatingReplicas             uint
 	CountValidSemiSyncReplicatingReplicas     uint

--- a/go/vt/vtorc/inst/analysis_dao.go
+++ b/go/vt/vtorc/inst/analysis_dao.go
@@ -403,7 +403,7 @@ func GetDetectionAnalysis(keyspace string, shard string, hints *DetectionAnalysi
 		a.LastCheckPartialSuccess = m.GetBool("last_check_partial_success")
 		a.PrimaryHealthUnhealthy = IsPrimaryHealthCheckUnhealthy(a.AnalyzedInstanceAlias)
 		a.CountReplicas = m.GetUint("count_replicas")
-		a.ShardEligibleObservers = m.GetUint("shard_eligible_observers")
+		a.ShardEligibleObservers = m.GetInt("shard_eligible_observers")
 		a.CountValidReplicas = m.GetUint("count_valid_replicas")
 		a.CountValidReplicatingReplicas = m.GetUint("count_valid_replicating_replicas")
 		a.ReplicationStopped = m.GetBool("replication_stopped")
@@ -738,7 +738,7 @@ func postProcessAnalyses(result []*DetectionAnalysis, clusters map[string]*clust
 		// form a 1/1 quorum in a larger shard. ShardEligibleObservers is the shard's REPLICA/RDONLY
 		// count straight from topo, so it is the true expected observer population regardless of
 		// whether VTOrc ever reached the primary.
-		quorum := evaluateAndLogPrimaryQuorum(analysis.AnalyzedInstanceAlias, analysis.AnalyzedKeyspace, analysis.AnalyzedShard, int(analysis.ShardEligibleObservers), time.Now())
+		quorum := evaluateAndLogPrimaryQuorum(analysis.AnalyzedInstanceAlias, analysis.AnalyzedKeyspace, analysis.AnalyzedShard, analysis.ShardEligibleObservers, time.Now())
 		if !quorum.Down {
 			continue
 		}

--- a/go/vt/vtorc/inst/analysis_dao_test.go
+++ b/go/vt/vtorc/inst/analysis_dao_test.go
@@ -1302,7 +1302,7 @@ func TestGetDetectionAnalysisShardEligibleObservers(t *testing.T) {
 
 	// primaryEligibleObservers runs the real analysis query and returns the ks/0 primary row's
 	// ShardEligibleObservers count.
-	primaryEligibleObservers := func(t *testing.T) uint {
+	primaryEligibleObservers := func(t *testing.T) int {
 		t.Helper()
 		got, err := GetDetectionAnalysis("", "", &DetectionAnalysisHints{})
 		require.NoError(t, err)
@@ -1320,14 +1320,14 @@ func TestGetDetectionAnalysisShardEligibleObservers(t *testing.T) {
 	// Even with quorum ERS disabled (the default), the count is computed: the flag is dynamic and
 	// its consumers re-read it later in the analysis cycle, so the denominator must never be a
 	// baked-in 0 just because the flag was off when the query was built.
-	assert.Equal(t, uint(3), primaryEligibleObservers(t),
+	assert.Equal(t, 3, primaryEligibleObservers(t),
 		"shard_eligible_observers must be computed regardless of the quorum-ERS flag")
 
 	// With quorum ERS enabled, only the shard's 2 REPLICA + 1 RDONLY tablets are eligible observers;
 	// the SPARE and PRIMARY must be excluded.
 	config.SetERSOnTabletUnreachable(true)
 	t.Cleanup(func() { config.SetERSOnTabletUnreachable(false) })
-	assert.Equal(t, uint(3), primaryEligibleObservers(t),
+	assert.Equal(t, 3, primaryEligibleObservers(t),
 		"only the shard's 2 REPLICA + 1 RDONLY tablets are eligible observers; the SPARE and PRIMARY must be excluded")
 
 	// ShardEligibleObserverCount — the standalone helper the /api/shard-tablet-health-quorum endpoint uses to source
@@ -1444,7 +1444,7 @@ func TestPostProcessAnalyses(t *testing.T) {
 	// real InvalidPrimary it is joined through the primary's database_instance row, which VTOrc never
 	// created); ShardEligibleObservers carries the shard's REPLICA/RDONLY count from the analysis
 	// query, which is the expected observer population the quorum gate must use.
-	invalidPrimaryAnalysis := func(shardEligibleObservers uint) *DetectionAnalysis {
+	invalidPrimaryAnalysis := func(shardEligibleObservers int) *DetectionAnalysis {
 		return &DetectionAnalysis{
 			Analysis:               InvalidPrimary,
 			Description:            "VTOrc hasn't been able to reach the primary even once since restart/shutdown",
@@ -1457,7 +1457,7 @@ func TestPostProcessAnalyses(t *testing.T) {
 	}
 	// shutdownInvalidPrimaryAnalysis is an InvalidPrimary whose vttablet was gracefully shut down
 	// (TabletShutdownTime stamped), so the quorum path must fail closed and leave it InvalidPrimary.
-	shutdownInvalidPrimaryAnalysis := func(shardEligibleObservers uint) *DetectionAnalysis {
+	shutdownInvalidPrimaryAnalysis := func(shardEligibleObservers int) *DetectionAnalysis {
 		a := invalidPrimaryAnalysis(shardEligibleObservers)
 		a.IsTabletShutdown = true
 		return a

--- a/go/vt/vtorc/inst/analysis_problem.go
+++ b/go/vt/vtorc/inst/analysis_problem.go
@@ -516,7 +516,7 @@ func matchPrimaryTabletUnreachableByQuorum(a *DetectionAnalysis, now time.Time) 
 	// ShardEligibleObservers (REPLICA/RDONLY count from topo) is the expected observer population
 	// that matches the quorum voters. CountReplicas is derived from the database_instance
 	// replication join and can include non-voting tablet types, so it is not used here.
-	result := evaluateAndLogPrimaryQuorum(a.AnalyzedInstanceAlias, a.AnalyzedKeyspace, a.AnalyzedShard, int(a.ShardEligibleObservers), now)
+	result := evaluateAndLogPrimaryQuorum(a.AnalyzedInstanceAlias, a.AnalyzedKeyspace, a.AnalyzedShard, a.ShardEligibleObservers, now)
 	if result.Down {
 		a.QuorumDetail = &result
 	}


### PR DESCRIPTION
## Description

This fixes all of the open high-severity CodeQL code scanning alerts:

- **[Alerts 4434–4439](https://github.com/vitessio/vitess/security/code-scanning?query=is%3Aopen+rule%3Ago%2Fclear-text-logging) (`go/clear-text-logging`)**: two taint sources reached the `go/vt/log` sinks.
  - The real one: `executeSuperQueryListConn` logs queries through `redactPassword()`, but the kill-after-timeout branch in `executeFetchContext` logged the raw query — so a timed-out `CHANGE REPLICATION SOURCE ... SOURCE_PASSWORD='...'` logged the actual replication password. It now uses the same redaction, with a regression test that hangs a query via fakesqldb until the kill path fires and asserts the logged query is redacted (it fails without the fix, showing the password in the log line).
  - The false-positive trigger: the local variable named `passwd` in `UserPermissionString` holds a `"PasswordChecksum(<crc64>)"` display string, not a password, but the name matches CodeQL's sensitive-variable heuristic. Renamed to `checksum`. (Alert 2992 was previously dismissed as a false positive for this same value.)
- **[Alert 4472](https://github.com/vitessio/vitess/security/code-scanning/4472) (`go/incorrect-integer-conversion`)**: `ShardEligibleObservers` was parsed as `uint` via `ParseUint` and then converted to `int` at both consumers. It's a REPLICA/RDONLY tablet count consumed as an `int`, so it's now parsed as one — no conversions left.

## Related Issue(s)

CodeQL code scanning alerts 4434–4439 and 4472.

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

---
_Most of this was written by Claude Code — I just provided direction._

🤖 Generated with [Claude Code](https://claude.com/claude-code)