### PR TITLE
CI: tighten GITHUB_TOKEN permissions in three workflows

### DIFF
--- a/.github/workflows/ci-rerun.yml
+++ b/.github/workflows/ci-rerun.yml
@@ -23,14 +23,15 @@ concurrency:
   group: ci-rerun
   cancel-in-progress: true
 
-permissions:
-  actions: write
-  pull-requests: read
+permissions: read-all
 
 jobs:
   rerun-failed:
     name: Rerun Failed CI Jobs
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: read
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1

--- a/.github/workflows/update_golang_dependencies.yml
+++ b/.github/workflows/update_golang_dependencies.yml
@@ -11,8 +11,7 @@ jobs:
   update_golang_deps:
     if: github.repository == 'vitessio/vitess'
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     name: Update Golang Dependencies
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/update_golang_version.yml
+++ b/.github/workflows/update_golang_version.yml
@@ -10,8 +10,8 @@ jobs:
   update_golang_version:
     if: github.repository == 'vitessio/vitess'
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      pull-requests: read
     strategy:
       matrix:
         branch: [ main, release-24.0, release-23.0 ]


### PR DESCRIPTION
## Description

This fixes the open high-severity Scorecard `Token-Permissions` code scanning alerts (4466, 4470, 4431) by reducing each workflow's `GITHUB_TOKEN` to what it actually uses:

- **ci-rerun.yml**: `actions: write` was declared at the workflow level; it now lives on the single job that reruns failed CI jobs, with the top level at `read-all`.
- **update_golang_version.yml / update_golang_dependencies.yml**: every write these workflows perform goes through the generated GitHub App token — `peter-evans/create-pull-request` receives `steps.app-token.outputs.token` for both the branch push and the PR creation, and checkout runs with `persist-credentials: 'false'`. `GITHUB_TOKEN` is only used for the checkout fetch and a `gh pr list`, so its job-level permissions drop to read.

The create_release.yml alert (4430) was dismissed instead: it uploads the release assets with `GITHUB_TOKEN`, so its job-level `contents: write` is required and already minimal.

## Related Issue(s)

Scorecard code scanning alerts 4466, 4470, and 4431.

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] Tests were added or are not required (workflow permissions change only; zizmor reports no findings)
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

---
_Most of this was written by Claude Code — I just provided direction._

🤖 Generated with [Claude Code](https://claude.com/claude-code)