### PR TITLE
VReplication: only build a bulk-delete plan for insertNormal table plans

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/replicator_plan_test.go
@@ -848,6 +848,62 @@ func TestBuildPlayerPlanExclude(t *testing.T) {
 	assert.Equal(t, string(wantPlan), string(gotPlan))
 }
 
+// TestBuildPlayerPlanMultiDelete confirms that a bulk-delete (MultiDelete)
+// plan is only built for insertNormal plans. Grouped plans -- as built for
+// lookup vindex backfills and aggregating materializations -- must stay on
+// the per-row path, where deletes are applied with the semantics chosen by
+// generateDeleteStatement: a count-decrementing UPDATE for insertOnDup and a
+// no-op for insertIgnore.
+func TestBuildPlayerPlanMultiDelete(t *testing.T) {
+	PrimaryKeyInfos := map[string][]*ColumnInfo{
+		"t1": {&ColumnInfo{Name: "c1", IsPK: true}},
+	}
+
+	vttablet.InitVReplicationConfigDefaults()
+	require.NotZero(t, vttablet.DefaultVReplicationConfig.ExperimentalFlags&vttablet.VReplicationExperimentalFlagVPlayerBatching,
+		"this test requires VPlayer batching to be enabled in the default config")
+
+	testcases := []struct {
+		name            string
+		filter          string
+		wantMultiDelete string
+	}{{
+		name:            "insertNormal builds a bulk delete",
+		filter:          "select c1, c2 from t1",
+		wantMultiDelete: "delete from t1 where c1 in ::bulk_pks",
+	}, {
+		name:   "insertOnDup (partial group by) must not build a bulk delete",
+		filter: "select c1, count(*) as c2 from t1 group by c1",
+	}, {
+		name:   "insertIgnore (full group by) must not build a bulk delete",
+		filter: "select c1, c2 from t1 group by c1, c2",
+	}}
+
+	for _, tcase := range testcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			input := &binlogdatapb.Filter{
+				Rules: []*binlogdatapb.Rule{{
+					Match:  "t1",
+					Filter: tcase.filter,
+				}},
+			}
+			vr := &vreplicator{
+				workflowConfig: vttablet.DefaultVReplicationConfig,
+			}
+			plan, err := vr.buildReplicatorPlan(getSource(input), PrimaryKeyInfos, nil, binlogplayer.NewStats(), collations.MySQL8(), sqlparser.NewTestParser())
+			require.NoError(t, err)
+			tplan := plan.TargetTables["t1"]
+			require.NotNil(t, tplan)
+			if tcase.wantMultiDelete == "" {
+				require.Nil(t, tplan.MultiDelete)
+			} else {
+				require.NotNil(t, tplan.MultiDelete)
+				require.Equal(t, tcase.wantMultiDelete, tplan.MultiDelete.Query)
+			}
+		})
+	}
+}
+
 func TestAppendFromRow(t *testing.T) {
 	testCases := []struct {
 		name    string

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -890,13 +890,10 @@ func (tpb *tablePlanBuilder) generateMultiDeleteStatement() *sqlparser.ParsedQue
 		(len(tpb.pkCols)+len(tpb.extraSourcePkCols)) != 1 {
 		return nil
 	}
-	// A bulk DELETE is only valid for insertNormal plans. Grouped plans must
-	// stay on the per-row path, which applies the semantics that
-	// generateDeleteStatement chose for them: a count-decrementing UPDATE for
-	// insertOnDup, and a deliberate no-op for insertIgnore (one target row can
-	// be backed by multiple source rows, so deleting it would be incorrect).
-	// Note that these plans also never populate tpb.pkIndices, so the bulk
-	// path could not derive a valid PK index for them anyway.
+	// Grouped plans must stay on the per-row path: their delete semantics
+	// are a count-decrementing UPDATE (insertOnDup) or a deliberate no-op
+	// (insertIgnore), never a plain DELETE, and they do not populate
+	// tpb.pkIndices.
 	if tpb.onInsert != insertNormal {
 		return nil
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/table_plan_builder.go
@@ -890,6 +890,16 @@ func (tpb *tablePlanBuilder) generateMultiDeleteStatement() *sqlparser.ParsedQue
 		(len(tpb.pkCols)+len(tpb.extraSourcePkCols)) != 1 {
 		return nil
 	}
+	// A bulk DELETE is only valid for insertNormal plans. Grouped plans must
+	// stay on the per-row path, which applies the semantics that
+	// generateDeleteStatement chose for them: a count-decrementing UPDATE for
+	// insertOnDup, and a deliberate no-op for insertIgnore (one target row can
+	// be backed by multiple source rows, so deleting it would be incorrect).
+	// Note that these plans also never populate tpb.pkIndices, so the bulk
+	// path could not derive a valid PK index for them anyway.
+	if tpb.onInsert != insertNormal {
+		return nil
+	}
 	return sqlparser.BuildParsedQuery(
 		"delete from %s where %s in %a",
 		sqlparser.String(tpb.name),

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -3949,6 +3949,9 @@ func TestPlayerBatchModeMixedRowEvent(t *testing.T) {
 func TestPlayerBatchModeGroupedPlans(t *testing.T) {
 	oldVreplicationExperimentalFlags := vttablet.DefaultVReplicationConfig.ExperimentalFlags
 	vttablet.DefaultVReplicationConfig.ExperimentalFlags = vttablet.VReplicationExperimentalFlagVPlayerBatching
+	// This test's teardown uses defer, not t.Cleanup: execStatements and the
+	// other framework helpers run on t.Context(), which is already canceled
+	// by the time t.Cleanup callbacks execute.
 	defer func() {
 		vttablet.DefaultVReplicationConfig.ExperimentalFlags = oldVreplicationExperimentalFlags
 	}()
@@ -3995,21 +3998,21 @@ func TestPlayerBatchModeGroupedPlans(t *testing.T) {
 	), recvTimeout)
 	expectData(t, "lkp1", [][]string{{"1", "a"}, {"2", "b"}, {"3", "c"}})
 
-	execStatements(t, []string{"insert into src2 values (1, 'x'), (2, 'x')"})
+	execStatements(t, []string{"insert into src2 values (1, 'x'), (2, 'x'), (3, 'x')"})
 	expectNontxQueries(t, qh.Expect(
-		"insert into lkp2(val,cnt) values (_binary'x',1), (_binary'x',1) on duplicate key update cnt=cnt+1",
+		"insert into lkp2(val,cnt) values (_binary'x',1), (_binary'x',1), (_binary'x',1) on duplicate key update cnt=cnt+1",
 	), recvTimeout)
-	expectData(t, "lkp2", [][]string{{"x", "2"}})
+	expectData(t, "lkp2", [][]string{{"x", "3"}})
 
-	// A multi-row delete produces a single row event with multiple
-	// delete-shaped row changes, which is what the bulk-delete path used to
-	// consume. For the insertIgnore plan the deletes must be a no-op: the
-	// bulk path would have deleted the lookup rows outright.
+	// Each multi-row delete produces one row event with multiple
+	// delete-shaped row changes, which is the shape the bulk-delete path
+	// consumes. insertIgnore deletes must be a no-op; insertOnDup deletes
+	// must decrement per row, leaving the row that still counts source
+	// row 3.
 	execStatements(t, []string{"delete from src1 where id in (1, 2)"})
-	// For the insertOnDup plan each delete must decrement the count: the
-	// bulk path would have deleted the row that still counts source row 2.
-	execStatements(t, []string{"delete from src2 where id = 1"})
+	execStatements(t, []string{"delete from src2 where id in (1, 2)"})
 	expectNontxQueries(t, qh.Expect(
+		"update lkp2 set cnt=cnt-1 where val=_binary'x'",
 		"update lkp2 set cnt=cnt-1 where val=_binary'x'",
 	), recvTimeout)
 	expectData(t, "lkp1", [][]string{{"1", "a"}, {"2", "b"}, {"3", "c"}})

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -3940,6 +3940,82 @@ func TestPlayerBatchModeMixedRowEvent(t *testing.T) {
 	expectData(t, "t1", [][]string{{"3", "b"}})
 }
 
+// TestPlayerBatchModeGroupedPlans confirms that batch mode keeps deletes for
+// grouped plans -- as built for lookup vindex backfills and aggregating
+// materializations -- on the per-row path. The bulk-delete path would apply a
+// plain multi-row DELETE, but the correct delete handling for these plans is
+// the one generateDeleteStatement chose: a no-op for insertIgnore plans and a
+// count-decrementing UPDATE for insertOnDup plans.
+func TestPlayerBatchModeGroupedPlans(t *testing.T) {
+	oldVreplicationExperimentalFlags := vttablet.DefaultVReplicationConfig.ExperimentalFlags
+	vttablet.DefaultVReplicationConfig.ExperimentalFlags = vttablet.VReplicationExperimentalFlagVPlayerBatching
+	defer func() {
+		vttablet.DefaultVReplicationConfig.ExperimentalFlags = oldVreplicationExperimentalFlags
+	}()
+
+	defer deleteTablet(addTablet(100))
+	execStatements(t, []string{
+		"create table src1(id bigint, val varbinary(128), primary key(id))",
+		// lkp1 mimics the backing table of a unique lookup vindex: every
+		// column is in the group by, so the plan is insertIgnore.
+		fmt.Sprintf("create table %s.lkp1(id bigint, val varbinary(128), primary key(id))", vrepldb),
+		"create table src2(id bigint, val varbinary(128), primary key(id))",
+		// lkp2 mimics the backing table of a non-unique lookup vindex: one
+		// target row counts multiple source rows, so the plan is insertOnDup.
+		fmt.Sprintf("create table %s.lkp2(val varbinary(128), cnt bigint, primary key(val))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table src1",
+		fmt.Sprintf("drop table %s.lkp1", vrepldb),
+		"drop table src2",
+		fmt.Sprintf("drop table %s.lkp2", vrepldb),
+	})
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match:  "lkp1",
+			Filter: "select id, val from src1 group by id, val",
+		}, {
+			Match:  "lkp2",
+			Filter: "select val, count(*) as cnt from src2 group by val",
+		}},
+	}
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
+	}
+	cancel, _ := startVReplication(t, bls, "")
+	defer cancel()
+
+	execStatements(t, []string{"insert into src1 values (1, 'a'), (2, 'b'), (3, 'c')"})
+	expectNontxQueries(t, qh.Expect(
+		"insert ignore into lkp1(id,val) values (1,_binary'a'), (2,_binary'b'), (3,_binary'c')",
+	), recvTimeout)
+	expectData(t, "lkp1", [][]string{{"1", "a"}, {"2", "b"}, {"3", "c"}})
+
+	execStatements(t, []string{"insert into src2 values (1, 'x'), (2, 'x')"})
+	expectNontxQueries(t, qh.Expect(
+		"insert into lkp2(val,cnt) values (_binary'x',1), (_binary'x',1) on duplicate key update cnt=cnt+1",
+	), recvTimeout)
+	expectData(t, "lkp2", [][]string{{"x", "2"}})
+
+	// A multi-row delete produces a single row event with multiple
+	// delete-shaped row changes, which is what the bulk-delete path used to
+	// consume. For the insertIgnore plan the deletes must be a no-op: the
+	// bulk path would have deleted the lookup rows outright.
+	execStatements(t, []string{"delete from src1 where id in (1, 2)"})
+	// For the insertOnDup plan each delete must decrement the count: the
+	// bulk path would have deleted the row that still counts source row 2.
+	execStatements(t, []string{"delete from src2 where id = 1"})
+	expectNontxQueries(t, qh.Expect(
+		"update lkp2 set cnt=cnt-1 where val=_binary'x'",
+	), recvTimeout)
+	expectData(t, "lkp1", [][]string{{"1", "a"}, {"2", "b"}, {"3", "c"}})
+	expectData(t, "lkp2", [][]string{{"x", "1"}})
+}
+
 // TestPlayerStalls confirms that the vplayer will detect a stall and generate
 // a meaningful error -- which is stored in the vreplication record and the
 // vreplication_log table as well as being logged -- when it does.


### PR DESCRIPTION
## Description

The VPlayer batching optimization (`VReplicationExperimentalFlagVPlayerBatching`, on by default) builds a `MultiDelete` plan — `delete from t where pk in (...)` — whenever batching is enabled and the target table has a single PK column. Unlike `generateDeleteStatement`, `generateMultiDeleteStatement` never looks at the plan's insert type, so it also builds the bulk plan for grouped table plans, where a plain `DELETE` is not the correct way to apply a source delete:

- **`insertOnDup` plans** (e.g. the backing table of a non-unique lookup vindex, or any aggregating materialization) handle a source delete with a count-decrementing `UPDATE`, because one target row can be backed by multiple source rows. Routing a multi-row delete through the bulk path hard-deletes target rows that are still referenced — silent data corruption of the target table.
- **`insertIgnore` plans** (e.g. the backing table of a unique lookup vindex, where every column is in the `GROUP BY`) deliberately skip source deletes. These plans also never populate `tpb.pkIndices` (the allocation sits below the `insertIgnore` early-return in `generateUpdateStatement`), so the bulk-delete apply path cannot derive a valid PK index. Since #20377 this fails the stream with `vreplication: bulk-delete plan for table ... has no valid primary key index (pkIndex=-1, ...)`; before #20377 it was one source of the vplayer panic tracked in #20360. Either way the workflow wedges deterministically: batching only activates once the copy phase completes, so a `LookupVindex` backfill runs clean for the whole copy and then fails on the first multi-row source `DELETE`.

The fix mirrors `generateDeleteStatement`'s insert-type awareness: `generateMultiDeleteStatement` returns `nil` for anything other than `insertNormal`, which keeps grouped plans on the per-row apply path (`applyRowEvent` already falls back to per-row application when `tplan.MultiDelete` is nil). Normal tables keep the bulk-delete optimization unchanged.

This PR implements the issue's first suggestion (the plan-builder gate) and deliberately leaves its second — boundary validation of each delete `RowChange`'s `Before` image against the field count — out of scope, so #20418 stays open. What remains is summarized in a comment on the issue; a follow-up PR for the validation is planned.

This should be backported to release-23.0 and release-24.0, like #20377 and #20565: it is a deterministic workflow-wedging bug for unique-lookup backfills and a silent-corruption risk for non-unique ones, and the change is a small, self-contained plan-builder gate.

## Related Issue(s)

- Related: #20418 (implements its first suggestion; the issue stays open for the row-image boundary validation)
- Related: #20360, #20377, #20565

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

With `VPlayerBatching` enabled (the default), multi-row source deletes applied to grouped table plans (`GROUP BY` filter rules: `LookupVindex` backfills, aggregating materializations) change behavior: `insertOnDup` plans previously bulk-deleted target rows that were still referenced and now decrement per row; `insertIgnore` plans previously failed the stream (`pkIndex=-1` internal error, or a vttablet panic before #20377) and are now a deliberate no-op, matching non-batched behavior. Per-workflow `vreplication-experimental-flags` overrides applied to work around this bug can be removed after upgrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
