### PR TITLE
sqlparser: remove ORDER BY in existsRewrite to prevent dangling alias references

### DIFF
--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -860,6 +860,7 @@ func (nz *normalizer) existsRewrite(cursor *Cursor, node *ExistsExpr) {
 		Exprs: []SelectExpr{&AliasedExpr{Expr: NewIntLiteral("1")}},
 	}
 	sel.GroupBy = nil
+	sel.OrderBy = nil
 }
 
 // rewriteDistinctableAggr removes DISTINCT from certain aggregations to simplify the plan.

--- a/go/vt/sqlparser/normalizer_test.go
+++ b/go/vt/sqlparser/normalizer_test.go
@@ -820,6 +820,12 @@ func TestRewrites(in *testing.T) {
 		in:       "SELECT * FROM tbl WHERE exists(select col1, col2 from other_table where foo > bar)",
 		expected: "SELECT * FROM tbl WHERE exists(select 1 from other_table where foo > bar)",
 	}, {
+		in:       "SELECT * FROM tbl WHERE exists(select col1 as alias1 from other_table order by alias1)",
+		expected: "SELECT * FROM tbl WHERE exists(select 1 from other_table)",
+	}, {
+		in:       "SELECT * FROM tbl WHERE exists(select col1 as alias1, count(*) from other_table group by col1 order by alias1)",
+		expected: "SELECT * FROM tbl WHERE exists(select 1 from other_table)",
+	}, {
 		in:       "SELECT * FROM tbl WHERE exists(select col1, col2 from other_table where foo > bar limit 100 offset 34)",
 		expected: "SELECT * FROM tbl WHERE exists(select 1 from other_table where foo > bar limit 100 offset 34)",
 	}, {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
`existsRewrite` in `go/vt/sqlparser/normalizer.go` simplifies `EXISTS` subqueries by replacing the select list with the constant `1` and clearing `GROUP BY`, but it leaves `ORDER BY` untouched. When the original `ORDER BY` references a select-list alias, that alias no longer exists after the rewrite, producing SQL that MySQL rejects.

## The fix

`ORDER BY` has no semantic effect inside `EXISTS` only row existence is observable, and ordering cannot affect that. This PR removes it alongside `GROUP BY`:

```go
sel.SelectExprs = &SelectExprs{
    Exprs: []SelectExpr{&AliasedExpr{Expr: NewIntLiteral("1")}},
}
sel.GroupBy = nil
sel.OrderBy = nil
```

Added testcases for ORDER BY alias in TestRewrites in `go/vt/sqlparser/normalizer_test.go` 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes #20895 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
### AI Disclosure
<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->