### PR TITLE
sqlparser: Fix EXISTS rewrite ignoring LIMIT in aggregate subqueries

### DIFF
--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -849,6 +849,9 @@ func (nz *normalizer) existsRewrite(cursor *Cursor, node *ExistsExpr) {
 	}
 
 	if sel.GroupBy == nil && sel.SelectExprs.AllAggregation() {
+		if sel.Limit != nil {
+			return
+		}
 		// Replace EXISTS with a boolean true if guaranteed to be non-empty.
 		cursor.Replace(BoolVal(true))
 		return

--- a/go/vt/sqlparser/normalizer_test.go
+++ b/go/vt/sqlparser/normalizer_test.go
@@ -832,6 +832,15 @@ func TestRewrites(in *testing.T) {
 		in:       "SELECT * FROM tbl WHERE exists(select count(*) from other_table where foo > bar)",
 		expected: "SELECT * FROM tbl WHERE true",
 	}, {
+		in:       "SELECT * FROM tbl WHERE exists(select count(*) from other_table where foo > bar limit 0)",
+		expected: "SELECT * FROM tbl WHERE exists(select count(*) from other_table where foo > bar limit 0)",
+	}, {
+		in:       "SELECT * FROM tbl WHERE exists(select count(*) from other_table where foo > bar limit 1 offset 1)",
+		expected: "SELECT * FROM tbl WHERE exists(select count(*) from other_table where foo > bar limit 1 offset 1)",
+	}, {
+		in:       "SELECT * FROM tbl WHERE exists(select count(*) from other_table where foo > bar limit 5)",
+		expected: "SELECT * FROM tbl WHERE exists(select count(*) from other_table where foo > bar limit 5)",
+	}, {
 		in:       "SELECT * FROM tbl WHERE exists(select col1, col2, count(*) from other_table where foo > bar group by col1, col2 having count(*) > 3)",
 		expected: "SELECT * FROM tbl WHERE exists(select col1, col2, count(*) from other_table where foo > bar group by col1, col2 having count(*) > 3)",
 	}, {


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Fixes a wrong-result rewrite for `EXISTS` subqueries that contain an ungrouped aggregate and a `LIMIT`. 

The normalizer now leaves these subqueries unchanged when `LIMIT` is present. This avoids both folding them to `true` and rewriting them to `SELECT 1`, either of which can change MySQL semantics.

The issue proposed preventing the `true` fold by adding `sel.Limit == nil` to its condition:

  ```go
  if sel.Limit == nil && sel.GroupBy == nil &&
  sel.SelectExprs.AllAggregation() {
      cursor.Replace(BoolVal(true))
      return
  }
```
That alone is not sufficient: a limited aggregate subquery like `EXISTS(SELECT COUNT(*) FROM t LIMIT ...)` would fall through to the generic rewrite below and become `EXISTS(SELECT 1 FROM t LIMIT ...)`. 

Instead, when an ungrouped all-aggregate subquery has a LIMIT, the normalizer returns without applying either rewrite:
```go
if sel.GroupBy == nil && sel.SelectExprs.AllAggregation() {
    if sel.Limit != nil {
        return
    }
    cursor.Replace(BoolVal(true))
    return
}
```
This preserves MySQL semantics for `LIMIT 0`, `LIMIT ... OFFSET ...`, and nonzero limits.

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes #20894 

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes
<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
After upgrading, `EXISTS` queries containing an ungrouped aggregate and a `LIMIT` clause may return different results. Vitess now preserves MySQL-compatible semantics instead of incorrectly rewriting these queries to a constant result or a non-aggregate subquery.

This affects cases such as `EXISTS(SELECT COUNT(*) FROM t LIMIT 0)` and `EXISTS(SELECT COUNT(*) FROM t LIMIT 1 OFFSET 1)`, which now correctly return `0`. No operator action is required.

### AI Disclosure
<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->