### PR TITLE
VReplication: Interrupt post-copy action on workflow stop/delete

### DIFF
--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier.go
@@ -395,6 +395,13 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 		return fmt.Errorf("plan not found for table: %s, current plans are: %#v", tableName, plan.TargetTables)
 	}
 
+	// Save the controller-level context before applying the copy phase
+	// duration timeout to it. Its cancellation means that the controller
+	// is stopping -- because the workflow is being stopped or deleted, or
+	// the engine is closing -- and any in-flight post copy action must
+	// then be interrupted, whereas an elapsed copy phase duration must
+	// not interrupt it.
+	stopCtx := ctx
 	ctx, cancel := context.WithTimeout(ctx, vc.vr.workflowConfig.CopyPhaseDuration)
 	defer cancel()
 
@@ -679,7 +686,7 @@ func (vc *vcopier) copyTable(ctx context.Context, tableName string, copyState ma
 	}
 
 	// Perform any post copy actions
-	if err := vc.vr.execPostCopyActions(ctx, tableName); err != nil {
+	if err := vc.vr.execPostCopyActions(ctx, stopCtx, tableName); err != nil {
 		return vterrors.Wrapf(err, "failed to execute post copy actions for table %q", tableName)
 	}
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vcopier_atomic.go
@@ -78,6 +78,13 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 		return err
 	}
 
+	// Save the controller-level context before applying the copy phase
+	// duration timeout to it. Its cancellation means that the controller
+	// is stopping -- because the workflow is being stopped or deleted, or
+	// the engine is closing -- and any in-flight post copy action must
+	// then be interrupted, whereas an elapsed copy phase duration must
+	// not interrupt it.
+	stopCtx := ctx
 	ctx, cancel := context.WithTimeout(ctx, vc.vr.workflowConfig.CopyPhaseDuration)
 	defer cancel()
 
@@ -141,7 +148,7 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 			copyWorkQueue = vc.newCopyWorkQueue(parallelism, copyWorkerFactory)
 			if state.currentTableName != "" {
 				log.Info(fmt.Sprintf("copy of table %s is done at lastpk %+v", state.currentTableName, lastpkbv))
-				if err := vc.runPostCopyActionsAndDeleteCopyState(ctx, state.currentTableName); err != nil {
+				if err := vc.runPostCopyActionsAndDeleteCopyState(ctx, stopCtx, state.currentTableName); err != nil {
 					return err
 				}
 			} else {
@@ -308,7 +315,7 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 		log.Info(fmt.Sprintf("Copy of %v stopped", state.currentTableName))
 		return errors.New("CopyAll was interrupted due to context expiration")
 	default:
-		if err := vc.runPostCopyActionsAndDeleteCopyState(ctx, state.currentTableName); err != nil {
+		if err := vc.runPostCopyActionsAndDeleteCopyState(ctx, stopCtx, state.currentTableName); err != nil {
 			return err
 		}
 		if err := vc.updatePos(ctx, gtid); err != nil {
@@ -322,8 +329,8 @@ func (vc *vcopier) copyAll(ctx context.Context, settings binlogplayer.VRSettings
 // runPostCopyActionsAndDeleteCopyState runs post copy actions and deletes the
 // copy state entry for a table, signifying that the copy phase is complete for
 // that table.
-func (vc *vcopier) runPostCopyActionsAndDeleteCopyState(ctx context.Context, tableName string) error {
-	if err := vc.vr.execPostCopyActions(ctx, tableName); err != nil {
+func (vc *vcopier) runPostCopyActionsAndDeleteCopyState(ctx, stopCtx context.Context, tableName string) error {
+	if err := vc.vr.execPostCopyActions(ctx, stopCtx, tableName); err != nil {
 		return vterrors.Wrapf(err, "failed to execute post copy actions for table %q", tableName)
 	}
 	log.Info("Deleting copy state and post copy actions for table " + tableName)

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -923,6 +923,10 @@ func (vr *vreplicator) getTableSecondaryKeys(ctx context.Context, tableName stri
 	return secondaryKeys, err
 }
 
+// killActionsConnectionTimeout bounds the single attempt to kill the
+// connection executing the post copy actions when interrupted.
+const killActionsConnectionTimeout = 10 * time.Second
+
 // execPostCopyActions executes any post copy actions recorded for the given
 // table, e.g. re-adding deferred secondary keys. ctx bounds the work itself
 // and typically carries the copy phase duration timeout, whose expiry must
@@ -1017,12 +1021,26 @@ func (vr *vreplicator) execPostCopyActions(ctx, stopCtx context.Context, tableNa
 		if connID < 1 {
 			return fmt.Errorf("invalid connection ID found (%d) when attempting to kill the connection executing post copy actions", connID)
 		}
-		killdbc := vr.vre.dbClientFactoryDba()
-		if err := killdbc.Connect(); err != nil {
+		// The attempt is bounded: the connection setup honors the
+		// context, and if the KILL query itself stalls the goroutine
+		// below closes the connection, which unblocks it. We don't
+		// parent this context on the ones whose cancellation got us
+		// here -- they are already done -- but we keep their values.
+		killCtx, cancel := context.WithTimeout(context.WithoutCancel(stopCtx), killActionsConnectionTimeout)
+		defer cancel()
+		killdbc, err := vr.mysqld.GetDbaConnection(killCtx)
+		if err != nil {
 			return fmt.Errorf("unable to connect to the database when attempting to kill the connection executing post copy actions: %v", err)
 		}
 		defer killdbc.Close()
-		_, kerr := killdbc.ExecuteFetch(fmt.Sprintf("kill %d", connID), 1)
+		go func() {
+			// killCtx is always cancelled when the attempt returns, so
+			// this goroutine cannot leak. Close is idempotent and safe
+			// to call concurrently with an in-flight query.
+			<-killCtx.Done()
+			killdbc.Close()
+		}()
+		_, kerr := killdbc.ExecuteFetch(fmt.Sprintf("kill %d", connID), 1, false)
 		return kerr
 	}
 	go func() {

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -923,17 +923,6 @@ func (vr *vreplicator) getTableSecondaryKeys(ctx context.Context, tableName stri
 	return secondaryKeys, err
 }
 
-const (
-	// How many times to attempt to kill the connection executing the
-	// post copy actions when interrupted, how long to wait between
-	// attempts, and how long a single attempt may take. The kill must
-	// eventually succeed for the controller to stop promptly, so
-	// transient failures are worth retrying, but only for so long.
-	killActionsConnectionRetries        = 10
-	killActionsConnectionRetryDelay     = 1 * time.Second
-	killActionsConnectionAttemptTimeout = 5 * time.Second
-)
-
 // execPostCopyActions executes any post copy actions recorded for the given
 // table, e.g. re-adding deferred secondary keys. ctx bounds the work itself
 // and typically carries the copy phase duration timeout, whose expiry must
@@ -1054,44 +1043,18 @@ func (vr *vreplicator) execPostCopyActions(ctx, stopCtx context.Context, tableNa
 			slog.String("workflow", vr.WorkflowName),
 			slog.String("reason", reason),
 		)
-		// The KILL can fail transiently, e.g. on a failure to open the
-		// DBA connection. Giving up would leave the controller blocked
-		// until the in-flight action completes -- the very hang the
-		// kill exists to prevent -- so retry a bounded number of times,
-		// stopping early if the actions complete on their own.
-		for attempt := 1; ; attempt++ {
-			// The DBA connection setup and the KILL query have no
-			// inherent timeouts, so bound each attempt as well: a
-			// single hung attempt must not prevent further ones.
-			attemptResult := make(chan error, 1)
-			go func() { attemptResult <- killActionsConnection() }()
-			var err error
-			select {
-			case err = <-attemptResult:
-			case <-time.After(killActionsConnectionAttemptTimeout):
-				err = fmt.Errorf("the attempt timed out after %v", killActionsConnectionAttemptTimeout)
-			case <-done:
-				// The actions completed on their own.
-				return
-			}
-			if err == nil {
-				return
-			}
+		// We make a single kill attempt: retrying a failed kill could
+		// exhaust DB connections when the DBA path is stalled -- the
+		// very state a failed kill tends to indicate. On failure we log
+		// the error and leave the in-flight action to complete, as it
+		// would have before the interruption support existed, and the
+		// interrupted operation can be retried by the user/caller.
+		if err := killActionsConnection(); err != nil {
 			log.Error("Failed to kill the connection executing post copy actions",
 				slog.String("table", tableName),
 				slog.String("workflow", vr.WorkflowName),
-				slog.Int("attempt", attempt),
 				slog.Any("error", err),
 			)
-			if attempt == killActionsConnectionRetries {
-				return
-			}
-			select {
-			case <-done:
-				// The actions completed on their own.
-				return
-			case <-time.After(killActionsConnectionRetryDelay):
-			}
 		}
 	}()
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -922,7 +922,17 @@ func (vr *vreplicator) getTableSecondaryKeys(ctx context.Context, tableName stri
 	return secondaryKeys, err
 }
 
-func (vr *vreplicator) execPostCopyActions(ctx context.Context, tableName string) error {
+// execPostCopyActions executes any post copy actions recorded for the given
+// table, e.g. re-adding deferred secondary keys. ctx bounds the work itself
+// and typically carries the copy phase duration timeout, whose expiry must
+// NOT interrupt an action already in progress (it would prevent actions that
+// take longer than the copy phase duration from ever completing). stopCtx's
+// cancellation means that the controller is stopping -- because the engine
+// is closing or the workflow is being stopped, deleted, or updated -- and
+// any in-flight action is then killed so that the controller shuts down
+// promptly instead of blocking, e.g. a PRS or a workflow delete, until the
+// action completes. A killed action is retried when the workflow restarts.
+func (vr *vreplicator) execPostCopyActions(ctx, stopCtx context.Context, tableName string) error {
 	defer vr.stats.PhaseTimings.Record("postCopyActions", time.Now())
 
 	// Use a new DB client to avoid interfering with open transactions
@@ -982,12 +992,15 @@ func (vr *vreplicator) execPostCopyActions(ctx context.Context, tableName string
 	}
 
 	// This could take hours so we start a monitoring goroutine to
-	// listen for context cancellation, which would indicate that
-	// the controller is stopping due to engine shutdown (tablet
-	// shutdown or transition). If that happens we attempt to KILL
-	// the running ALTER statement using a DBA connection.
+	// listen for the cancellations which indicate that the controller
+	// is stopping: engine shutdown (tablet shutdown or transition) or
+	// controller stop (the workflow is being stopped, deleted, or
+	// updated). If either happens we attempt to KILL the running ALTER
+	// statement using a DBA connection.
 	// If we don't do this then we could e.g. cause a PRS to fail as
-	// the running ALTER will block setting [super_]read_only.
+	// the running ALTER will block setting [super_]read_only, or cause
+	// a workflow delete to time out as the engine cannot process it
+	// until the controller has stopped.
 	// A failed/killed ALTER will be tried again when the copy
 	// phase starts up again on the (new) PRIMARY.
 	var action PostCopyAction
@@ -1012,17 +1025,21 @@ func (vr *vreplicator) execPostCopyActions(ctx context.Context, tableName string
 		return nil
 	}
 	go func() {
+		var reason string
 		select {
-		// Only cancel an ongoing ALTER if the engine is closing.
+		// Only cancel an ongoing ALTER if the engine is closing
+		// or the controller is stopping.
 		case <-vr.vre.ctx.Done():
-			log.Info(fmt.Sprintf("Copy of the %q table stopped when performing the following post copy action in the %q VReplication workflow: %+v", tableName, vr.WorkflowName, action))
-			if err := killAction(action); err != nil {
-				log.Error(fmt.Sprintf("Failed to kill post copy action on the %q table in the %q VReplication workflow: %v", tableName, vr.WorkflowName, err))
-			}
-			return
+			reason = "the engine is closing"
+		case <-stopCtx.Done():
+			reason = "the controller is stopping"
 		case <-done:
 			// We're done, so no longer need to listen for cancellation.
 			return
+		}
+		log.Info(fmt.Sprintf("Copy of the %q table stopped as %s when performing the following post copy action in the %q VReplication workflow: %+v", tableName, reason, vr.WorkflowName, action))
+		if err := killAction(action); err != nil {
+			log.Error(fmt.Sprintf("Failed to kill post copy action on the %q table in the %q VReplication workflow: %v", tableName, vr.WorkflowName, err))
 		}
 	}()
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"sort"
 	"strconv"
@@ -922,6 +923,16 @@ func (vr *vreplicator) getTableSecondaryKeys(ctx context.Context, tableName stri
 	return secondaryKeys, err
 }
 
+const (
+	// How many times to attempt to kill the connection executing the
+	// post copy actions when interrupted, and how long to wait between
+	// attempts. The kill must eventually succeed for the controller to
+	// stop promptly, so transient failures are worth retrying, but only
+	// for so long.
+	killActionsConnectionRetries    = 10
+	killActionsConnectionRetryDelay = 1 * time.Second
+)
+
 // execPostCopyActions executes any post copy actions recorded for the given
 // table, e.g. re-adding deferred secondary keys. ctx bounds the work itself
 // and typically carries the copy phase duration timeout, whose expiry must
@@ -1037,9 +1048,36 @@ func (vr *vreplicator) execPostCopyActions(ctx, stopCtx context.Context, tableNa
 			// We're done, so no longer need to listen for cancellation.
 			return
 		}
-		log.Info(fmt.Sprintf("Post copy actions on the %q table in the %q VReplication workflow interrupted as %s", tableName, vr.WorkflowName, reason))
-		if err := killActionsConnection(); err != nil {
-			log.Error(fmt.Sprintf("Failed to kill the connection executing post copy actions on the %q table in the %q VReplication workflow: %v", tableName, vr.WorkflowName, err))
+		log.Info("Interrupting post copy actions",
+			slog.String("table", tableName),
+			slog.String("workflow", vr.WorkflowName),
+			slog.String("reason", reason),
+		)
+		// The KILL can fail transiently, e.g. on a failure to open the
+		// DBA connection. Giving up would leave the controller blocked
+		// until the in-flight action completes -- the very hang the
+		// kill exists to prevent -- so retry a bounded number of times,
+		// stopping early if the actions complete on their own.
+		for attempt := 1; ; attempt++ {
+			err := killActionsConnection()
+			if err == nil {
+				return
+			}
+			log.Error("Failed to kill the connection executing post copy actions",
+				slog.String("table", tableName),
+				slog.String("workflow", vr.WorkflowName),
+				slog.Int("attempt", attempt),
+				slog.Any("error", err),
+			)
+			if attempt == killActionsConnectionRetries {
+				return
+			}
+			select {
+			case <-done:
+				// The actions completed on their own.
+				return
+			case <-time.After(killActionsConnectionRetryDelay):
+			}
 		}
 	}()
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -925,12 +925,13 @@ func (vr *vreplicator) getTableSecondaryKeys(ctx context.Context, tableName stri
 
 const (
 	// How many times to attempt to kill the connection executing the
-	// post copy actions when interrupted, and how long to wait between
-	// attempts. The kill must eventually succeed for the controller to
-	// stop promptly, so transient failures are worth retrying, but only
-	// for so long.
-	killActionsConnectionRetries    = 10
-	killActionsConnectionRetryDelay = 1 * time.Second
+	// post copy actions when interrupted, how long to wait between
+	// attempts, and how long a single attempt may take. The kill must
+	// eventually succeed for the controller to stop promptly, so
+	// transient failures are worth retrying, but only for so long.
+	killActionsConnectionRetries        = 10
+	killActionsConnectionRetryDelay     = 1 * time.Second
+	killActionsConnectionAttemptTimeout = 5 * time.Second
 )
 
 // execPostCopyActions executes any post copy actions recorded for the given
@@ -1059,7 +1060,20 @@ func (vr *vreplicator) execPostCopyActions(ctx, stopCtx context.Context, tableNa
 		// kill exists to prevent -- so retry a bounded number of times,
 		// stopping early if the actions complete on their own.
 		for attempt := 1; ; attempt++ {
-			err := killActionsConnection()
+			// The DBA connection setup and the KILL query have no
+			// inherent timeouts, so bound each attempt as well: a
+			// single hung attempt must not prevent further ones.
+			attemptResult := make(chan error, 1)
+			go func() { attemptResult <- killActionsConnection() }()
+			var err error
+			select {
+			case err = <-attemptResult:
+			case <-time.After(killActionsConnectionAttemptTimeout):
+				err = fmt.Errorf("the attempt timed out after %v", killActionsConnectionAttemptTimeout)
+			case <-done:
+				// The actions completed on their own.
+				return
+			}
 			if err == nil {
 				return
 			}

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator.go
@@ -995,40 +995,40 @@ func (vr *vreplicator) execPostCopyActions(ctx, stopCtx context.Context, tableNa
 	// listen for the cancellations which indicate that the controller
 	// is stopping: engine shutdown (tablet shutdown or transition) or
 	// controller stop (the workflow is being stopped, deleted, or
-	// updated). If either happens we attempt to KILL the running ALTER
-	// statement using a DBA connection.
+	// updated). If either happens we KILL the connection being used
+	// to execute the actions, using a DBA connection, so that any
+	// in-flight statement (e.g. an ALTER) is aborted and any
+	// subsequent statement on the connection fails immediately.
 	// If we don't do this then we could e.g. cause a PRS to fail as
 	// the running ALTER will block setting [super_]read_only, or cause
 	// a workflow delete to time out as the engine cannot process it
 	// until the controller has stopped.
 	// A failed/killed ALTER will be tried again when the copy
 	// phase starts up again on the (new) PRIMARY.
-	var action PostCopyAction
 	done := make(chan struct{})
 	defer close(done)
-	killAction := func(ak PostCopyAction) error {
-		// If we're executing an SQL query then KILL the
-		// connection being used to execute it.
-		if ak.Type == PostCopyActionSQL {
-			if connID < 1 {
-				return fmt.Errorf("invalid connection ID found (%d) when attempting to kill %q", connID, ak.Task)
-			}
-			killdbc := vr.vre.dbClientFactoryDba()
-			if err := killdbc.Connect(); err != nil {
-				return fmt.Errorf("unable to connect to the database when attempting to kill %q: %v", ak.Task, err)
-			}
-			defer killdbc.Close()
-			_, err = killdbc.ExecuteFetch(fmt.Sprintf("kill %d", connID), 1)
-			return err
+	// killActionsConnection is deliberately independent of which
+	// action -- if any -- is currently executing so that a
+	// cancellation which arrives between actions cannot be lost.
+	// Non-SQL action types, if ever added, will need their own
+	// interruption mechanism.
+	killActionsConnection := func() error {
+		if connID < 1 {
+			return fmt.Errorf("invalid connection ID found (%d) when attempting to kill the connection executing post copy actions", connID)
 		}
-		// We may support non-SQL actions in the future.
-		return nil
+		killdbc := vr.vre.dbClientFactoryDba()
+		if err := killdbc.Connect(); err != nil {
+			return fmt.Errorf("unable to connect to the database when attempting to kill the connection executing post copy actions: %v", err)
+		}
+		defer killdbc.Close()
+		_, kerr := killdbc.ExecuteFetch(fmt.Sprintf("kill %d", connID), 1)
+		return kerr
 	}
 	go func() {
 		var reason string
 		select {
-		// Only cancel an ongoing ALTER if the engine is closing
-		// or the controller is stopping.
+		// Only kill the connection executing the post copy actions
+		// if the engine is closing or the controller is stopping.
 		case <-vr.vre.ctx.Done():
 			reason = "the engine is closing"
 		case <-stopCtx.Done():
@@ -1037,9 +1037,9 @@ func (vr *vreplicator) execPostCopyActions(ctx, stopCtx context.Context, tableNa
 			// We're done, so no longer need to listen for cancellation.
 			return
 		}
-		log.Info(fmt.Sprintf("Copy of the %q table stopped as %s when performing the following post copy action in the %q VReplication workflow: %+v", tableName, reason, vr.WorkflowName, action))
-		if err := killAction(action); err != nil {
-			log.Error(fmt.Sprintf("Failed to kill post copy action on the %q table in the %q VReplication workflow: %v", tableName, vr.WorkflowName, err))
+		log.Info(fmt.Sprintf("Post copy actions on the %q table in the %q VReplication workflow interrupted as %s", tableName, vr.WorkflowName, reason))
+		if err := killActionsConnection(); err != nil {
+			log.Error(fmt.Sprintf("Failed to kill the connection executing post copy actions on the %q table in the %q VReplication workflow: %v", tableName, vr.WorkflowName, err))
 		}
 	}()
 
@@ -1056,7 +1056,7 @@ func (vr *vreplicator) execPostCopyActions(ctx, stopCtx context.Context, tableNa
 		if err != nil {
 			return err
 		}
-		action = PostCopyAction{}
+		action := PostCopyAction{}
 		actionBytes, err := row["action"].ToBytes()
 		if err != nil {
 			return err

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
@@ -697,29 +697,6 @@ func TestDeferSecondaryKeys(t *testing.T) {
 // copying all rows, is properly killed when the context
 // is cancelled -- e.g. due to the VReplication engine
 // closing for a tablet transition during a PRS.
-type (
-	// failingConnectDBClient fails Connect; no other method is ever
-	// called on it.
-	failingConnectDBClient struct {
-		binlogplayer.DBClient
-	}
-	// hangingConnectDBClient blocks in Connect until the unblock
-	// channel is closed; no other method is ever called on it.
-	hangingConnectDBClient struct {
-		binlogplayer.DBClient
-		unblock chan struct{}
-	}
-)
-
-func (f *failingConnectDBClient) Connect() error {
-	return errors.New("forced DBA connection failure")
-}
-
-func (h *hangingConnectDBClient) Connect() error {
-	<-h.unblock
-	return errors.New("forced hung DBA connection failure")
-}
-
 func TestCancelledDeferSecondaryKeys(t *testing.T) {
 	// Skip the test for MariaDB as it does not have
 	// performance_schema enabled by default.
@@ -755,26 +732,6 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 	err = dbaconn.Connect()
 	require.NoError(t, err)
 	defer dbaconn.Close()
-	// Wrap the engine's DBA client factory -- which is used to kill the
-	// connection executing the post copy actions -- so that test cases
-	// can inject transient connection failures and hangs. When neither
-	// is pending it transparently delegates to the real factory.
-	var dbaConnectFailures, dbaConnectHangs atomic.Int32
-	dbaConnectUnblock := make(chan struct{})
-	defer close(dbaConnectUnblock)
-	realDbaFactory := playerEngine.dbClientFactoryDba
-	playerEngine.dbClientFactoryDba = func() binlogplayer.DBClient {
-		if dbaConnectHangs.Load() > 0 {
-			dbaConnectHangs.Add(-1)
-			return &hangingConnectDBClient{unblock: dbaConnectUnblock}
-		}
-		if dbaConnectFailures.Load() > 0 {
-			dbaConnectFailures.Add(-1)
-			return &failingConnectDBClient{}
-		}
-		return realDbaFactory()
-	}
-	defer func() { playerEngine.dbClientFactoryDba = realDbaFactory }()
 	dbClient := playerEngine.dbClientFactoryFiltered()
 	err = dbClient.Connect()
 	require.NoError(t, err)
@@ -838,34 +795,6 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 				return stopCtx, stopCancel
 			},
 			interruptBeforeStart: true,
-		},
-		{
-			// A transient failure to kill the connection executing the
-			// actions must be retried: giving up would leave the
-			// controller blocked until the in-flight action completes,
-			// which is the very hang the kill exists to prevent.
-			name: "workflow stopped with transient kill failure",
-			setup: func(t *testing.T) (context.Context, func()) {
-				stopCtx, stopCancel := context.WithCancel(t.Context())
-				t.Cleanup(stopCancel)
-				dbaConnectFailures.Store(1)
-				t.Cleanup(func() { dbaConnectFailures.Store(0) })
-				return stopCtx, stopCancel
-			},
-		},
-		{
-			// A kill attempt that never returns -- the DBA connection
-			// setup and the KILL query have no inherent timeouts -- must
-			// not block the retries: each attempt is bounded so that a
-			// single hung attempt cannot leave the controller blocked.
-			name: "workflow stopped with hung kill attempt",
-			setup: func(t *testing.T) (context.Context, func()) {
-				stopCtx, stopCancel := context.WithCancel(t.Context())
-				t.Cleanup(stopCancel)
-				dbaConnectHangs.Store(1)
-				t.Cleanup(func() { dbaConnectHangs.Store(0) })
-				return stopCtx, stopCancel
-			},
 		},
 		{
 			// The engine's context is cancelled on tablet shutdown or

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
@@ -767,6 +767,11 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 		// the function which triggers the interruption of the in-flight
 		// post copy action.
 		setup func(t *testing.T) (stopCtx context.Context, interrupt func())
+		// interruptBeforeStart interrupts before execPostCopyActions is
+		// even called rather than while the ALTER is known to be running.
+		// The interruption must not be lost when it arrives while no
+		// action is executing.
+		interruptBeforeStart bool
 	}{
 		{
 			// The stop context is cancelled when the controller is
@@ -777,6 +782,19 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 				t.Cleanup(stopCancel)
 				return stopCtx, stopCancel
 			},
+		},
+		{
+			// A cancellation that arrives when no action is currently
+			// executing must still interrupt the actions promptly. If it
+			// were lost, a subsequently started action would block the
+			// controller with nothing left to interrupt it.
+			name: "workflow stopped before actions started",
+			setup: func(t *testing.T) (context.Context, func()) {
+				stopCtx, stopCancel := context.WithCancel(t.Context())
+				t.Cleanup(stopCancel)
+				return stopCtx, stopCancel
+			},
+			interruptBeforeStart: true,
 		},
 		{
 			// The engine's context is cancelled on tablet shutdown or
@@ -831,21 +849,29 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 				require.NoError(t, err)
 			})
 
+			if tc.interruptBeforeStart {
+				interrupt()
+			}
+
 			// The ALTER should block on the table lock.
 			go func() {
 				defer close(done)
 				errCh <- vr.execPostCopyActions(ctx, stopCtx, tableName)
 			}()
 
-			// Confirm that the expected ALTER query is being attempted.
-			query := fmt.Sprintf("select count(*) from performance_schema.events_statements_current where sql_text = '%s'", alter)
-			waitForQueryResult(t, dbaconn, query, "1")
+			if !tc.interruptBeforeStart {
+				// Confirm that the expected ALTER query is being attempted.
+				query := fmt.Sprintf("select count(*) from performance_schema.events_statements_current where sql_text = '%s'", alter)
+				waitForQueryResult(t, dbaconn, query, "1")
 
-			// Interrupt the post copy action while the ALTER is
-			// running/blocked and wait for it to be KILLed off. Use a
-			// generous CI-safe timeout as resource-starved runners can
+				// Interrupt the post copy action while the ALTER is
+				// running/blocked.
+				interrupt()
+			}
+
+			// Wait for the interrupted execPostCopyActions to return. Use
+			// a generous CI-safe timeout as resource-starved runners can
 			// pause things for multiple seconds.
-			interrupt()
 			require.Eventually(t, func() bool {
 				select {
 				case <-done:
@@ -856,8 +882,10 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 			}, 30*time.Second, 10*time.Millisecond)
 			actionErr := <-errCh
 			require.Error(t, actionErr)
-			assert.True(t, strings.EqualFold(actionErr.Error(), "EOF (errno 2013) (sqlstate HY000) during query: "+alter),
-				"unexpected error: %v", actionErr)
+			if !tc.interruptBeforeStart {
+				assert.True(t, strings.EqualFold(actionErr.Error(), "EOF (errno 2013) (sqlstate HY000) during query: "+alter),
+					"unexpected error: %v", actionErr)
+			}
 
 			_, err = dbaconn.ExecuteFetch("unlock tables", 1)
 			require.NoError(t, err)
@@ -869,7 +897,7 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 				"Expected: %s\n     Got: %s", forError(withoutPKs), forError(currentDDL))
 
 			// Confirm that we successfully attempted to kill it.
-			query = "select count(*) from performance_schema.events_statements_history where digest_text = 'KILL ?' and errors = 0"
+			query := "select count(*) from performance_schema.events_statements_history where digest_text = 'KILL ?' and errors = 0"
 			res, err := dbaconn.ExecuteFetch(query, 1)
 			require.NoError(t, err)
 			assert.Len(t, res.Rows, 1)

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
@@ -37,6 +37,7 @@ import (
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/dbconnpool"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/schemadiff"
 	vttablet "vitess.io/vitess/go/vt/vttablet/common"
@@ -697,6 +698,23 @@ func TestDeferSecondaryKeys(t *testing.T) {
 // copying all rows, is properly killed when the context
 // is cancelled -- e.g. due to the VReplication engine
 // closing for a tablet transition during a PRS.
+type (
+	// stalledDbaDaemon simulates a stalled DBA connection setup:
+	// GetDbaConnection blocks until the given context is done -- so an
+	// unbounded context would block it forever -- and attemptDone is
+	// closed when the attempt ends.
+	stalledDbaDaemon struct {
+		mysqlctl.MysqlDaemon
+		attemptDone chan struct{}
+	}
+)
+
+func (d *stalledDbaDaemon) GetDbaConnection(ctx context.Context) (*dbconnpool.DBConnection, error) {
+	defer close(d.attemptDone)
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
 func TestCancelledDeferSecondaryKeys(t *testing.T) {
 	// Skip the test for MariaDB as it does not have
 	// performance_schema enabled by default.
@@ -772,6 +790,11 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 		// The interruption must not be lost when it arrives while no
 		// action is executing.
 		interruptBeforeStart bool
+		// stalledKill simulates a stalled DBA connection setup during
+		// the kill attempt. The attempt must fail once its timeout
+		// expires -- rather than blocking forever -- after which the
+		// in-flight action is simply left to complete.
+		stalledKill bool
 	}{
 		{
 			// The stop context is cancelled when the controller is
@@ -795,6 +818,17 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 				return stopCtx, stopCancel
 			},
 			interruptBeforeStart: true,
+		},
+		{
+			// A stalled DBA connection setup must not leave the kill
+			// attempt blocked forever.
+			name: "workflow stopped with stalled kill connection",
+			setup: func(t *testing.T) (context.Context, func()) {
+				stopCtx, stopCancel := context.WithCancel(t.Context())
+				t.Cleanup(stopCancel)
+				return stopCtx, stopCancel
+			},
+			stalledKill: true,
 		},
 		{
 			// The engine's context is cancelled on tablet shutdown or
@@ -824,6 +858,13 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 			require.NoError(t, err)
 
 			stopCtx, interrupt := tc.setup(t)
+
+			var killAttemptDone chan struct{}
+			if tc.stalledKill {
+				killAttemptDone = make(chan struct{})
+				vr.mysqld = &stalledDbaDaemon{MysqlDaemon: env.Mysqld, attemptDone: killAttemptDone}
+				t.Cleanup(func() { vr.mysqld = env.Mysqld })
+			}
 
 			done := make(chan struct{})
 			errCh := make(chan error, 1)
@@ -869,9 +910,28 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 				interrupt()
 			}
 
-			// Wait for the interrupted execPostCopyActions to return. Use
-			// a generous CI-safe timeout as resource-starved runners can
-			// pause things for multiple seconds.
+			if tc.stalledKill {
+				// The kill attempt is bounded, so the stalled connection
+				// setup must fail on its own once the attempt's timeout
+				// expires.
+				require.Eventually(t, func() bool {
+					select {
+					case <-killAttemptDone:
+						return true
+					default:
+						return false
+					}
+				}, 30*time.Second, 10*time.Millisecond)
+				// The kill failed and there are no retries, so the ALTER
+				// remains; unlock the table to let it -- and with it the
+				// post copy actions -- complete.
+				_, err = dbaconn.ExecuteFetch("unlock tables", 1)
+				require.NoError(t, err)
+			}
+
+			// Wait for execPostCopyActions to return. Use a generous
+			// CI-safe timeout as resource-starved runners can pause
+			// things for multiple seconds.
 			require.Eventually(t, func() bool {
 				select {
 				case <-done:
@@ -881,20 +941,32 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 				}
 			}, 30*time.Second, 10*time.Millisecond)
 			actionErr := <-errCh
-			require.Error(t, actionErr)
-			if !tc.interruptBeforeStart {
-				assert.True(t, strings.EqualFold(actionErr.Error(), "EOF (errno 2013) (sqlstate HY000) during query: "+alter),
-					"unexpected error: %v", actionErr)
+			if tc.stalledKill {
+				// The actions completed normally after the failed kill.
+				require.NoError(t, actionErr)
+			} else {
+				require.Error(t, actionErr)
+				if !tc.interruptBeforeStart {
+					assert.True(t, strings.EqualFold(actionErr.Error(), "EOF (errno 2013) (sqlstate HY000) during query: "+alter),
+						"unexpected error: %v", actionErr)
+				}
 			}
 
 			_, err = dbaconn.ExecuteFetch("unlock tables", 1)
 			require.NoError(t, err)
 
-			// Confirm that the ALTER to re-add the secondary keys
-			// did not succeed.
 			currentDDL := getCurrentDDL(tableName)
-			assert.True(t, strings.EqualFold(stripCruft(withoutPKs), stripCruft(currentDDL)),
-				"Expected: %s\n     Got: %s", forError(withoutPKs), forError(currentDDL))
+			if tc.stalledKill {
+				// Confirm that the ALTER to re-add the secondary keys
+				// succeeded as it was never killed.
+				assert.False(t, strings.EqualFold(stripCruft(withoutPKs), stripCruft(currentDDL)),
+					"Expected the secondary keys to have been re-added, got: %s", forError(currentDDL))
+			} else {
+				// Confirm that the ALTER to re-add the secondary keys
+				// did not succeed.
+				assert.True(t, strings.EqualFold(stripCruft(withoutPKs), stripCruft(currentDDL)),
+					"Expected: %s\n     Got: %s", forError(withoutPKs), forError(currentDDL))
+			}
 
 			// Confirm that we successfully attempted to kill it.
 			query := "select count(*) from performance_schema.events_statements_history where digest_text = 'KILL ?' and errors = 0"
@@ -904,11 +976,16 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 			// TODO: figure out why the KILL never shows up...
 			// require.Equal(t, "1", res.Rows[0][0].ToString())
 
-			// Confirm that the post copy action record still exists
-			// so it will later be retried.
 			res, err = dbClient.ExecuteFetch(fmt.Sprintf(getActionsSQLf, id, tableName), 1)
 			require.NoError(t, err)
-			require.Len(t, res.Rows, 1)
+			if tc.stalledKill {
+				// The completed actions deleted their record.
+				require.Empty(t, res.Rows)
+			} else {
+				// Confirm that the post copy action record still exists
+				// so it will later be retried.
+				require.Len(t, res.Rows, 1)
+			}
 		})
 	}
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
@@ -703,10 +703,21 @@ type (
 	failingConnectDBClient struct {
 		binlogplayer.DBClient
 	}
+	// hangingConnectDBClient blocks in Connect until the unblock
+	// channel is closed; no other method is ever called on it.
+	hangingConnectDBClient struct {
+		binlogplayer.DBClient
+		unblock chan struct{}
+	}
 )
 
 func (f *failingConnectDBClient) Connect() error {
 	return errors.New("forced DBA connection failure")
+}
+
+func (h *hangingConnectDBClient) Connect() error {
+	<-h.unblock
+	return errors.New("forced hung DBA connection failure")
 }
 
 func TestCancelledDeferSecondaryKeys(t *testing.T) {
@@ -746,11 +757,17 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 	defer dbaconn.Close()
 	// Wrap the engine's DBA client factory -- which is used to kill the
 	// connection executing the post copy actions -- so that test cases
-	// can inject transient connection failures. When no failures are
-	// pending it transparently delegates to the real factory.
-	var dbaConnectFailures atomic.Int32
+	// can inject transient connection failures and hangs. When neither
+	// is pending it transparently delegates to the real factory.
+	var dbaConnectFailures, dbaConnectHangs atomic.Int32
+	dbaConnectUnblock := make(chan struct{})
+	defer close(dbaConnectUnblock)
 	realDbaFactory := playerEngine.dbClientFactoryDba
 	playerEngine.dbClientFactoryDba = func() binlogplayer.DBClient {
+		if dbaConnectHangs.Load() > 0 {
+			dbaConnectHangs.Add(-1)
+			return &hangingConnectDBClient{unblock: dbaConnectUnblock}
+		}
 		if dbaConnectFailures.Load() > 0 {
 			dbaConnectFailures.Add(-1)
 			return &failingConnectDBClient{}
@@ -833,6 +850,20 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 				t.Cleanup(stopCancel)
 				dbaConnectFailures.Store(1)
 				t.Cleanup(func() { dbaConnectFailures.Store(0) })
+				return stopCtx, stopCancel
+			},
+		},
+		{
+			// A kill attempt that never returns -- the DBA connection
+			// setup and the KILL query have no inherent timeouts -- must
+			// not block the retries: each attempt is bounded so that a
+			// single hung attempt cannot leave the controller blocked.
+			name: "workflow stopped with hung kill attempt",
+			setup: func(t *testing.T) (context.Context, func()) {
+				stopCtx, stopCancel := context.WithCancel(t.Context())
+				t.Cleanup(stopCancel)
+				dbaConnectHangs.Store(1)
+				t.Cleanup(func() { dbaConnectHangs.Store(0) })
 				return stopCtx, stopCancel
 			},
 		},

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -521,7 +520,7 @@ func TestDeferSecondaryKeys(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				err = myvr.execPostCopyActions(ctx, "t1")
+				err = myvr.execPostCopyActions(ctx, ctx, "t1")
 				if err != nil {
 					return err
 				}
@@ -663,7 +662,7 @@ func TestDeferSecondaryKeys(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err = vr.execPostCopyActions(ctx, tcase.tableName)
+			err = vr.execPostCopyActions(ctx, ctx, tcase.tableName)
 			expectedPostCopyActionRecs := 0
 			if tcase.wantExecErr != "" {
 				require.Contains(t, err.Error(), tcase.wantExecErr)
@@ -762,57 +761,128 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 	withoutPKs := "create table t1 (id int not null, c1 int default null, c2 int default null, primary key(id))"
 	alter := fmt.Sprintf("alter table %s.t1 add key c1 (c1), add key c2 (c2)", dbName)
 
-	// Create the table.
-	_, err = dbClient.ExecuteFetch(ddl, 1)
-	require.NoError(t, err)
+	testCases := []struct {
+		name string
+		// setup returns the stopCtx to pass to execPostCopyActions and
+		// the function which triggers the interruption of the in-flight
+		// post copy action.
+		setup func(t *testing.T) (stopCtx context.Context, interrupt func())
+	}{
+		{
+			// The stop context is cancelled when the controller is
+			// stopped, e.g. when stopping or deleting the workflow.
+			name: "workflow stopped",
+			setup: func(t *testing.T) (context.Context, func()) {
+				stopCtx, stopCancel := context.WithCancel(t.Context())
+				t.Cleanup(stopCancel)
+				return stopCtx, stopCancel
+			},
+		},
+		{
+			// The engine's context is cancelled on tablet shutdown or
+			// transition. This case must run last as the shared test
+			// engine cannot be re-opened within this test.
+			name: "engine closed",
+			setup: func(t *testing.T) (context.Context, func()) {
+				return t.Context(), func() { playerEngine.cancel() }
+			},
+		},
+	}
 
-	// Setup the ALTER work.
-	err = vr.stashSecondaryKeys(ctx, tableName)
-	require.NoError(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create the table.
+			_, err = dbClient.ExecuteFetch(ddl, 1)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_, err := dbClient.ExecuteFetch(fmt.Sprintf("drop table %s.%s", dbName, tableName), 1)
+				require.NoError(t, err)
+				_, err = dbClient.ExecuteFetch(fmt.Sprintf("delete from _vt.post_copy_action where vrepl_id=%d", id), 1)
+				require.NoError(t, err)
+			})
 
-	// Lock the table to block execution of the ALTER so
-	// that we can be sure that it runs and we can KILL it.
-	_, err = dbaconn.ExecuteFetch(fmt.Sprintf("lock table %s.%s write", dbName, tableName), 1)
-	require.NoError(t, err)
+			// Setup the ALTER work.
+			err = vr.stashSecondaryKeys(ctx, tableName)
+			require.NoError(t, err)
 
-	// The ALTER should block on the table lock.
-	wg := sync.WaitGroup{}
-	wg.Go(func() {
-		err := vr.execPostCopyActions(ctx, tableName)
-		assert.True(t, strings.EqualFold(err.Error(), "EOF (errno 2013) (sqlstate HY000) during query: "+alter))
-	})
+			stopCtx, interrupt := tc.setup(t)
 
-	// Confirm that the expected ALTER query is being attempted.
-	query := fmt.Sprintf("select count(*) from performance_schema.events_statements_current where sql_text = '%s'", alter)
-	waitForQueryResult(t, dbaconn, query, "1")
+			done := make(chan struct{})
+			errCh := make(chan error, 1)
+			t.Cleanup(func() {
+				// If the test failed before execPostCopyActions returned,
+				// wait for it here -- after the cleanup below has unlocked
+				// the tables -- as it uses the shared dbClient connection
+				// on its way out and would otherwise corrupt it for the
+				// cleanups and test cases that follow.
+				select {
+				case <-done:
+				case <-time.After(30 * time.Second):
+				}
+			})
 
-	// Cancel the context while the ALTER is running/blocked
-	// and wait for it to be KILLed off.
-	playerEngine.cancel()
-	wg.Wait()
+			// Lock the table to block execution of the ALTER so
+			// that we can be sure that it runs and we can KILL it.
+			_, err = dbaconn.ExecuteFetch(fmt.Sprintf("lock table %s.%s write", dbName, tableName), 1)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				// A no-op if the test already unlocked them.
+				_, err := dbaconn.ExecuteFetch("unlock tables", 1)
+				require.NoError(t, err)
+			})
 
-	_, err = dbaconn.ExecuteFetch("unlock tables", 1)
-	require.NoError(t, err)
+			// The ALTER should block on the table lock.
+			go func() {
+				defer close(done)
+				errCh <- vr.execPostCopyActions(ctx, stopCtx, tableName)
+			}()
 
-	// Confirm that the ALTER to re-add the secondary keys
-	// did not succeed.
-	currentDDL := getCurrentDDL(tableName)
-	assert.True(t, strings.EqualFold(stripCruft(withoutPKs), stripCruft(currentDDL)),
-		"Expected: %s\n     Got: %s", forError(withoutPKs), forError(currentDDL))
+			// Confirm that the expected ALTER query is being attempted.
+			query := fmt.Sprintf("select count(*) from performance_schema.events_statements_current where sql_text = '%s'", alter)
+			waitForQueryResult(t, dbaconn, query, "1")
 
-	// Confirm that we successfully attempted to kill it.
-	query = "select count(*) from performance_schema.events_statements_history where digest_text = 'KILL ?' and errors = 0"
-	res, err := dbaconn.ExecuteFetch(query, 1)
-	require.NoError(t, err)
-	assert.Len(t, res.Rows, 1)
-	// TODO: figure out why the KILL never shows up...
-	// require.Equal(t, "1", res.Rows[0][0].ToString())
+			// Interrupt the post copy action while the ALTER is
+			// running/blocked and wait for it to be KILLed off. Use a
+			// generous CI-safe timeout as resource-starved runners can
+			// pause things for multiple seconds.
+			interrupt()
+			require.Eventually(t, func() bool {
+				select {
+				case <-done:
+					return true
+				default:
+					return false
+				}
+			}, 30*time.Second, 10*time.Millisecond)
+			actionErr := <-errCh
+			require.Error(t, actionErr)
+			assert.True(t, strings.EqualFold(actionErr.Error(), "EOF (errno 2013) (sqlstate HY000) during query: "+alter),
+				"unexpected error: %v", actionErr)
 
-	// Confirm that the post copy action record still exists
-	// so it will later be retried.
-	res, err = dbClient.ExecuteFetch(fmt.Sprintf(getActionsSQLf, id, tableName), 1)
-	require.NoError(t, err)
-	require.Len(t, res.Rows, 1)
+			_, err = dbaconn.ExecuteFetch("unlock tables", 1)
+			require.NoError(t, err)
+
+			// Confirm that the ALTER to re-add the secondary keys
+			// did not succeed.
+			currentDDL := getCurrentDDL(tableName)
+			assert.True(t, strings.EqualFold(stripCruft(withoutPKs), stripCruft(currentDDL)),
+				"Expected: %s\n     Got: %s", forError(withoutPKs), forError(currentDDL))
+
+			// Confirm that we successfully attempted to kill it.
+			query = "select count(*) from performance_schema.events_statements_history where digest_text = 'KILL ?' and errors = 0"
+			res, err := dbaconn.ExecuteFetch(query, 1)
+			require.NoError(t, err)
+			assert.Len(t, res.Rows, 1)
+			// TODO: figure out why the KILL never shows up...
+			// require.Equal(t, "1", res.Rows[0][0].ToString())
+
+			// Confirm that the post copy action record still exists
+			// so it will later be retried.
+			res, err = dbClient.ExecuteFetch(fmt.Sprintf(getActionsSQLf, id, tableName), 1)
+			require.NoError(t, err)
+			require.Len(t, res.Rows, 1)
+		})
+	}
 }
 
 // TestResumingFromPreviousWorkflowKeepingRowsCopied tests that when you

--- a/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vreplicator_test.go
@@ -697,6 +697,18 @@ func TestDeferSecondaryKeys(t *testing.T) {
 // copying all rows, is properly killed when the context
 // is cancelled -- e.g. due to the VReplication engine
 // closing for a tablet transition during a PRS.
+type (
+	// failingConnectDBClient fails Connect; no other method is ever
+	// called on it.
+	failingConnectDBClient struct {
+		binlogplayer.DBClient
+	}
+)
+
+func (f *failingConnectDBClient) Connect() error {
+	return errors.New("forced DBA connection failure")
+}
+
 func TestCancelledDeferSecondaryKeys(t *testing.T) {
 	// Skip the test for MariaDB as it does not have
 	// performance_schema enabled by default.
@@ -732,6 +744,20 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 	err = dbaconn.Connect()
 	require.NoError(t, err)
 	defer dbaconn.Close()
+	// Wrap the engine's DBA client factory -- which is used to kill the
+	// connection executing the post copy actions -- so that test cases
+	// can inject transient connection failures. When no failures are
+	// pending it transparently delegates to the real factory.
+	var dbaConnectFailures atomic.Int32
+	realDbaFactory := playerEngine.dbClientFactoryDba
+	playerEngine.dbClientFactoryDba = func() binlogplayer.DBClient {
+		if dbaConnectFailures.Load() > 0 {
+			dbaConnectFailures.Add(-1)
+			return &failingConnectDBClient{}
+		}
+		return realDbaFactory()
+	}
+	defer func() { playerEngine.dbClientFactoryDba = realDbaFactory }()
 	dbClient := playerEngine.dbClientFactoryFiltered()
 	err = dbClient.Connect()
 	require.NoError(t, err)
@@ -795,6 +821,20 @@ func TestCancelledDeferSecondaryKeys(t *testing.T) {
 				return stopCtx, stopCancel
 			},
 			interruptBeforeStart: true,
+		},
+		{
+			// A transient failure to kill the connection executing the
+			// actions must be retried: giving up would leave the
+			// controller blocked until the in-flight action completes,
+			// which is the very hang the kill exists to prevent.
+			name: "workflow stopped with transient kill failure",
+			setup: func(t *testing.T) (context.Context, func()) {
+				stopCtx, stopCancel := context.WithCancel(t.Context())
+				t.Cleanup(stopCancel)
+				dbaConnectFailures.Store(1)
+				t.Cleanup(func() { dbaConnectFailures.Store(0) })
+				return stopCtx, stopCancel
+			},
 		},
 		{
 			// The engine's context is cancelled on tablet shutdown or


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

Stopping or deleting a workflow could not complete while a target primary was executing a post copy action — e.g. the `ALTER TABLE` that re-adds deferred secondary keys, which can run for hours. The vreplication engine stops the workflow's controller while holding the engine lock, but nothing interrupted the in-flight action, so the stop — and every other vreplication RPC on that tablet — was blocked behind it until the client deadline expired, leaving the streams in place.

We now pass the controller-level context down to the post copy action execution and extend the existing KILL mechanism — which previously only fired on engine shutdown — so that stopping the controller also kills the connection executing the actions. The kill is independent of which action, if any, is currently in flight, so a cancellation cannot be lost, and a killed action is simply retried if the workflow is later restarted.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/20898

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

I worked with Claude and Fable 5 on this.
