### PR TITLE
fix(vdiff): store lastpk as mediumblob to match copy_state

### DIFF
--- a/go/vt/sidecardb/schema/vdiff/vdiff_table.sql
+++ b/go/vt/sidecardb/schema/vdiff/vdiff_table.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS vdiff_table
     `vdiff_id`      bigint(20)     NOT NULL,
     `table_name`    varbinary(128) NOT NULL,
     `state`         varbinary(64)           DEFAULT NULL,
-    `lastpk`        varbinary(2000)         DEFAULT NULL,
+    `lastpk`        mediumblob              DEFAULT NULL,
     `table_rows`    bigint(20)     NOT NULL DEFAULT '0',
     `rows_compared` bigint(20)     NOT NULL DEFAULT '0',
     `mismatch`      tinyint(1)     NOT NULL DEFAULT '0',

--- a/go/vt/sidecardb/sidecardb_test.go
+++ b/go/vt/sidecardb/sidecardb_test.go
@@ -390,3 +390,25 @@ func TestTableSchemaDiff(t *testing.T) {
 		})
 	}
 }
+
+// TestVDiffTableLastPKIsBlob asserts vdiff_table.lastpk is a blob type (not a
+// fixed-length varbinary) so large serialized VDiff checkpoints are not truncated (see #20900).
+func TestVDiffTableLastPKIsBlob(t *testing.T) {
+	schema, err := schemaLocation.ReadFile("schema/vdiff/vdiff_table.sql")
+	require.NoError(t, err)
+	stmt, err := sqlparser.NewTestParser().ParseStrictDDL(string(schema))
+	require.NoError(t, err)
+	ct, ok := stmt.(*sqlparser.CreateTable)
+	require.True(t, ok)
+
+	var lastpk *sqlparser.ColumnDefinition
+	for _, col := range ct.TableSpec.Columns {
+		if col.Name.EqualString("lastpk") {
+			lastpk = col
+			break
+		}
+	}
+	require.NotNil(t, lastpk, "lastpk column not found in vdiff_table schema")
+	require.Equal(t, "mediumblob", strings.ToLower(lastpk.Type.Type),
+		"vdiff_table.lastpk must be a blob type matching copy_state.lastpk; a fixed-length varbinary truncates large checkpoints")
+}


### PR DESCRIPTION
## Description

`_vt.vdiff_table.lastpk` is declared `varbinary(2000)`, but the value stored there is a `prototext.Marshal` of a `tabletmanagerdatapb.VDiffTableLastPK` wrapping one or two `querypb.QueryResult`s (a `Target`, plus a `Source` when the source/target PK column order differs), each carrying the full per-column `Fields` metadata (`name`/`table`/`org_table`/`database`/`org_name`/`column_length`/`charset`/`flags`) for every PK column. It is built in [`lastPKFromRow`](https://github.com/vitessio/vitess/blob/main/go/vt/vttablet/tabletmanager/vdiff/table_differ.go#L875).

This is the **same** serialization used for `_vt.copy_state.lastpk` ([`vcopier.go`](https://github.com/vitessio/vitess/blob/main/go/vt/vttablet/tabletmanager/vreplication/vcopier.go#L654)), which is already declared [`mediumblob`](https://github.com/vitessio/vitess/blob/main/go/vt/sidecardb/schema/vreplication/copy_state.sql#L22).

For a table with a wide composite PK and/or long identifiers, that serialized lastpk exceeds 2000 bytes, so the checkpoint `update _vt.vdiff_table set ... lastpk = ...` fails with `Data too long for column 'lastpk'` (errno 1406, sqlstate 22001) and the table diff — and therefore the whole VDiff — errors out. Since VDiff's lastpk can carry both `Target` and `Source`, it is equal-or-larger than copy_state's for the same table, yet had the smaller column type.

## The fix

Widen `vdiff_table.lastpk` from `varbinary(2000)` to `mediumblob`, matching `copy_state.lastpk`. This is a pure column widening; the sidecar schema diff applies the `ALTER` on upgrade and existing rows are unaffected.

## Related Issue(s)

Fixes #20900

## Backport

Requesting backport to `release-23.0` and `release-24.0`: on released versions this bug makes VDiff error out permanently for any table whose serialized lastpk exceeds 2000 bytes (wide composite PK and/or long identifiers), which blocks using VDiff as a resharding / MoveTables validation gate for those tables.

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported
- [x] A justification for the backport is included above (`NeedsBackportReason`)
- [x] Tests: schema-only change (sidecar column widening), verified by reproducing the errno 1406 failure and confirming `mediumblob` stores the full checkpoint; no unit test added, consistent with other sidecar column definitions.
