### PR TITLE
vttablet: publish the start of the current primary term as a gauge

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -41,6 +41,7 @@
         - [Replicas are placed in a crash-safe state before shutdown](#vttablet-replica-crash-safe-shutdown)
         - [Skip MySQL version check when restoring from a mysql-shell backup](#vttablet-mysql-shell-restore-skip-version-check)
         - [ApplySchema session variables](#vttablet-applyschema-session-variables)
+        - [New `PrimaryTermStartTimeSeconds` metric](#vttablet-primary-term-start-time-metric)
     - **[VTCtld](#minor-changes-vtctld)**
         - [MySQL version-aware reparent candidate election](#vtctld-version-aware-reparent)
     - **[Backup/Restore](#minor-changes-backup)**
@@ -406,6 +407,27 @@ Upgrade vtctld, vtctldclient, vtgate and vttablet before executing a schema
 change with `--session-variable`.
 
 See [#20654](https://github.com/vitessio/vitess/pull/20654) for details.
+
+#### <a id="vttablet-primary-term-start-time-metric"/>New `PrimaryTermStartTimeSeconds` metric</a>
+
+VTTablet now exports `PrimaryTermStartTimeSeconds`, a gauge holding the Unix time
+at which this tablet's current primary term began, and `0` when the tablet is not
+the primary. It is published to Prometheus as
+`vttablet_primary_term_start_time_seconds`.
+
+Existing reparent signals are counters and timings, so the time at which a
+reparent happened can only be narrowed to the scrape interval that observed the
+increment. This gauge's value is itself a timestamp, taken from the tablet's
+topology record rather than sampled when the tablet is scraped, so a reparent can
+be placed on a time axis regardless of scrape frequency. That makes it usable for
+annotating dashboards and correlating a latency change with a change of primary.
+
+The gauge is maintained for `PlannedReparentShard`, `EmergencyReparentShard`,
+`TabletExternallyReparented` and the initial primary election alike, since all of
+them set `primary_term_start_time` on the tablet record. A tablet that is already
+the primary when it starts up publishes its term as well.
+
+See [#20907](https://github.com/vitessio/vitess/pull/20907) for details.
 
 ### <a id="minor-changes-vtctld"/>VTCtld</a>
 

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -404,8 +404,8 @@ func stopInterrupted(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		return true
 	}
-	var sqlErr *sqlerror.SQLError
-	if errors.As(err, &sqlErr) {
+
+	if sqlErr, ok := errors.AsType[*sqlerror.SQLError](err); ok {
 		switch sqlErr.Number() {
 		case sqlerror.ERStopReplicaIOThreadTimeout, sqlerror.ERStopReplicaSQLThreadTimeout:
 			// rpl_stop_replica_timeout fired: the stop remains in effect.

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -135,6 +135,10 @@ var (
 	// statsTabletTags is set to 1 (true) if a tablet tag exists.
 	statsTabletTags *stats.GaugesWithMultiLabels
 
+	// statsPrimaryTermStartTime is the start of the tablet's current primary
+	// term, or 0 when the tablet is not the primary.
+	statsPrimaryTermStartTime *stats.Gauge
+
 	statsKeyspace      = stats.NewString("TabletKeyspace")
 	statsShard         = stats.NewString("TabletShard")
 	statsKeyRangeStart = stats.NewString("TabletKeyRangeStart")
@@ -155,6 +159,7 @@ func init() {
 	statsBackupIsRunning = stats.NewGaugesWithMultiLabels("BackupIsRunning", "Whether a backup is running", []string{"mode"})
 	statsIsInSrvKeyspace = stats.NewGauge("IsInSrvKeyspace", "Whether the vttablet is in the serving keyspace (1 = true / 0 = false)")
 	statsTabletTags = stats.NewGaugesWithMultiLabels("TabletTags", "Tablet tags key/values", []string{"key", "value"})
+	statsPrimaryTermStartTime = stats.NewGauge("PrimaryTermStartTimeSeconds", "Unix time at which the current primary term of this tablet began, or 0 if this tablet is not the primary")
 }
 
 // TabletManager is the main class for the tablet manager.

--- a/go/vt/vttablet/tabletmanager/tm_state.go
+++ b/go/vt/vttablet/tabletmanager/tm_state.go
@@ -519,6 +519,14 @@ func (ts *tmState) publishForDisplay() {
 	defer ts.displayState.mu.Unlock()
 	ts.displayState.tablet = ts.tablet.CloneVT()
 	ts.displayState.deniedTables = ts.deniedTables[ts.tablet.Type]
+
+	// Set here rather than in ChangeTabletType so that a tablet which is
+	// already the primary at startup publishes its term as well.
+	var primaryTermStart int64
+	if ts.tablet.PrimaryTermStartTime != nil {
+		primaryTermStart = protoutil.TimeFromProto(ts.tablet.PrimaryTermStartTime).Unix()
+	}
+	statsPrimaryTermStartTime.Set(primaryTermStart)
 }
 
 func (ts *tmState) Tablet() *topodatapb.Tablet {

--- a/go/vt/vttablet/tabletmanager/tm_state_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_state_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/test/utils"
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/mysqlctl"
@@ -481,6 +482,62 @@ func TestStateChangeTabletTypeWithFailure(t *testing.T) {
 	assert.Equal(t, "spare", statsTabletType.Get())
 	assert.Len(t, statsTabletTypeCount.Counts(), 3)
 	assert.Equal(t, int64(1), statsTabletTypeCount.Counts()["spare"])
+}
+
+// TestStatePrimaryTermStartTime verifies that the tablet publishes the start of
+// its current primary term, and clears it on demotion. The value is what lets a
+// reparent be located on a time axis independently of the scrape interval.
+func TestStatePrimaryTermStartTime(t *testing.T) {
+	ctx := t.Context()
+	ts := memorytopo.NewServer(ctx, "cell1")
+
+	// Seed a bogus value so that the assertions below prove the tablet set the
+	// gauge, rather than that it happened to already be zero.
+	statsPrimaryTermStartTime.Set(1)
+
+	tm := newTestTM(t, ts, 2, "ks", "0", nil)
+	defer tm.Stop()
+
+	alias := &topodatapb.TabletAlias{
+		Cell: "cell1",
+		Uid:  2,
+	}
+
+	// A replica holds no primary term.
+	assert.Equal(t, int64(0), statsPrimaryTermStartTime.Get())
+
+	err := tm.tmState.ChangeTabletType(ctx, topodatapb.TabletType_PRIMARY, DBActionSetReadWrite)
+	require.NoError(t, err)
+	ti, err := ts.GetTablet(ctx, alias)
+	require.NoError(t, err)
+	require.NotNil(t, ti.PrimaryTermStartTime)
+	assert.Equal(t, protoutil.TimeFromProto(ti.PrimaryTermStartTime).Unix(), statsPrimaryTermStartTime.Get())
+
+	// Demotion clears the term, marking the far edge of a reparent window.
+	err = tm.tmState.ChangeTabletType(ctx, topodatapb.TabletType_REPLICA, DBActionNone)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), statsPrimaryTermStartTime.Get())
+}
+
+// TestStatePrimaryTermStartTimeOnOpen verifies that a tablet which is already
+// the primary when it starts up publishes its primary term, even though no
+// tablet type change occurs in this process. This is the vttablet restart case,
+// and it is why the gauge cannot be maintained from ChangeTabletType alone.
+func TestStatePrimaryTermStartTimeOnOpen(t *testing.T) {
+	ctx := t.Context()
+	ts := memorytopo.NewServer(ctx, "cell1")
+	tm := newTestTM(t, ts, 1, "ks", "0", nil)
+	defer tm.Stop()
+
+	primaryTermStart := time.Now().Add(-time.Hour)
+	tm.tmState.mu.Lock()
+	tm.tmState.tablet.Type = topodatapb.TabletType_PRIMARY
+	tm.tmState.tablet.PrimaryTermStartTime = protoutil.TimeToProto(primaryTermStart)
+	err := tm.tmState.updateLocked(ctx)
+	tm.tmState.mu.Unlock()
+	require.NoError(t, err)
+
+	assert.Equal(t, primaryTermStart.Unix(), statsPrimaryTermStartTime.Get())
 }
 
 // TestChangeTypeErrorWhileWritingToTopo tests the case where we fail while writing to the topo-server


### PR DESCRIPTION
## Description

VTTablet doesn't currently expose *when* it became the primary. The existing reparent signals are counters and timings, so the best you can do is narrow a reparent to whichever scrape interval saw the increment.

This adds `PrimaryTermStartTimeSeconds`, a gauge holding the Unix time at which the tablet's current primary term began, and `0` when the tablet isn't the primary. In Prometheus it lands as `vttablet_primary_term_start_time_seconds`.

The useful property is that the value is *itself* a timestamp, read from the tablet's topology record rather than sampled at scrape time. So a reparent can be placed on a time axis regardless of scrape frequency: `changes()` over the gauge tells you one happened, and the gauge's value is when. That makes it usable for annotating dashboards and lining a latency change up against a change of primary.

It's maintained for `PlannedReparentShard`, `EmergencyReparentShard`, `TabletExternallyReparented` and the initial primary election alike, since all of them set `primary_term_start_time` on the tablet record. On demotion it returns to `0`, marking the other edge of the window.

One implementation choice worth a reviewer's eye: it's published from `publishForDisplay` rather than from `ChangeTabletType`. `publishForDisplay` is the single point where `ts.tablet` is snapshotted for observers and it runs on every path, including `Open`, which is what covers a `vttablet` that is *already* the primary when it starts up and so never goes through a type change in-process. There's a test pinning that case specifically; it fails if the gauge is maintained from `ChangeTabletType` alone.

Two known caveats:

- `stats.Gauge` is `int64`, so this is second resolution. That matches the `process_start_time_seconds` idiom, but two reparents inside the same second are indistinguishable.
- The gauge is process-global, so under vtcombo it reflects whichever tablet published last. That's already true of `TabletType` and `IsInSrvKeyspace`, so it's consistent with its neighbours rather than a new wart.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/20916

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches — not applicable, this is new functionality and should land on `main` only
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description — n/a
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI? — passing locally; CI pending on this PR
-   [x] Documentation was added or is not required — a release notes entry will follow in a second commit once this PR has a number to link to. Let me know if the metric also warrants a `vitessio/website` change.

## Deployment Notes

No flags, no behaviour change, no schema or topology changes. Purely additive: one new time series per vttablet, with no new labels.

### AI Disclosure

This PR was written with the help of Claude Code. I provided the direction and the design decisions, and reviewed the result.
