### PR TITLE
vdiff: persist the real error, not the echoed failing query

### DIFF
--- a/go/vt/vttablet/tabletmanager/vdiff/table_differ.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/table_differ.go
@@ -805,7 +805,7 @@ func (td *tableDiffer) updateTableProgress(dbClient binlogplayer.DBClient, dr *D
 		}
 	}
 	if _, err := dbClient.ExecuteFetch(query, 1); err != nil {
-		return err
+		return vterrors.Wrapf(errWithoutQueryEcho(err), "failed to save diff report for table %s", td.table.Name)
 	}
 
 	td.wd.ct.TableDiffRowCounts.Add(td.table.Name, dr.ProcessedRows)
@@ -851,7 +851,7 @@ func (td *tableDiffer) updateTableStateAndReport(ctx context.Context, dbClient b
 		return err
 	}
 	if _, err = dbClient.ExecuteFetch(query, 1); err != nil {
-		return err
+		return vterrors.Wrapf(errWithoutQueryEcho(err), "failed to save diff report for table %s", td.table.Name)
 	}
 	insertVDiffLog(ctx, dbClient, td.wd.ct.id, fmt.Sprintf("%s: table %s", state, encodeString(td.table.Name)))
 

--- a/go/vt/vttablet/tabletmanager/vdiff/table_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/table_differ_test.go
@@ -18,10 +18,12 @@ package vdiff
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
@@ -160,4 +162,92 @@ func TestGetSourcePKCols_TableDroppedOnSource(t *testing.T) {
 	err := td.getSourcePKCols()
 	require.NoError(t, err)
 	require.Nil(t, td.tablePlan.sourcePkCols)
+}
+
+// TestUpdateTableProgressDropsQueryEcho confirms that updateTableProgress strips
+// the echoed failing statement from any SQL error raised while persisting the
+// report: the returned error names the table and keeps the SQL error's
+// message/errno/sqlstate, but never carries the (potentially huge) report
+// payload that the statement echoed. The stripping is unconditional (it does not
+// key off the errno); max_allowed_packet (errno 1153) is the motivating case --
+// the one where carrying the echo would make the error itself unpersistable --
+// so it is what this test exercises.
+func TestUpdateTableProgressDropsQueryEcho(t *testing.T) {
+	wd := &workflowDiffer{
+		ct: &controller{
+			id:                 1,
+			TableDiffRowCounts: stats.NewCountersWithSingleLabel("", "", "Rows"),
+		},
+		opts: &tabletmanagerdatapb.VDiffOptions{
+			CoreOptions: &tabletmanagerdatapb.VDiffCoreOptions{},
+		},
+	}
+	table := &tabletmanagerdatapb.TableDefinition{Name: "test"}
+	td := &tableDiffer{
+		wd:        wd,
+		table:     table,
+		tablePlan: &tablePlan{table: table},
+	}
+	dr := &DiffReport{TableName: table.Name, ProcessedRows: 1000}
+
+	huge := strings.Repeat("x", 200000)
+	sqlErr := &sqlerror.SQLError{
+		Num:     sqlerror.ERNetPacketTooLarge,
+		State:   "08S01",
+		Message: "Got a packet bigger than 'max_allowed_packet' bytes",
+		Query:   "update _vt.vdiff_table set rows_compared = 1000, report = '" + huge + "' where vdiff_id = 1 and table_name = 'test'",
+	}
+
+	dbc := binlogplayer.NewMockDBClient(t)
+	dbc.ExpectRequestRE("update _vt.vdiff_table set rows_compared = .*", &sqltypes.Result{}, sqlErr)
+
+	// lastRow == nil exercises the no-lastpk progress update.
+	err := td.updateTableProgress(dbc, dr, nil)
+	require.ErrorContains(t, err, "failed to save diff report for table test")
+	require.ErrorContains(t, err, "Got a packet bigger than 'max_allowed_packet' bytes")
+	require.ErrorContains(t, err, "(errno 1153)")
+	require.NotContains(t, err.Error(), huge, "the report payload must not be carried in the persisted error")
+	dbc.Wait()
+}
+
+// TestUpdateTableStateAndReportDropsQueryEcho is the completion-path counterpart
+// of TestUpdateTableProgressDropsQueryEcho: updateTableStateAndReport also
+// persists the (potentially large) report, so it likewise strips the echoed
+// statement from any SQL error the report write raises. As above, the
+// max_allowed_packet failure is the motivating case exercised here.
+func TestUpdateTableStateAndReportDropsQueryEcho(t *testing.T) {
+	wd := &workflowDiffer{
+		ct: &controller{
+			id:                 1,
+			TableDiffRowCounts: stats.NewCountersWithSingleLabel("", "", "Rows"),
+		},
+		opts: &tabletmanagerdatapb.VDiffOptions{
+			CoreOptions: &tabletmanagerdatapb.VDiffCoreOptions{},
+		},
+	}
+	table := &tabletmanagerdatapb.TableDefinition{Name: "test"}
+	td := &tableDiffer{
+		wd:        wd,
+		table:     table,
+		tablePlan: &tablePlan{table: table},
+	}
+	dr := &DiffReport{TableName: table.Name, ProcessedRows: 1000}
+
+	huge := strings.Repeat("x", 200000)
+	sqlErr := &sqlerror.SQLError{
+		Num:     sqlerror.ERNetPacketTooLarge,
+		State:   "08S01",
+		Message: "Got a packet bigger than 'max_allowed_packet' bytes",
+		Query:   "update _vt.vdiff_table set state = 'completed', rows_compared = 1000, report = '" + huge + "' where vdiff_id = 1 and table_name = 'test'",
+	}
+
+	dbc := binlogplayer.NewMockDBClient(t)
+	dbc.ExpectRequestRE("update _vt.vdiff_table set state = .*", &sqltypes.Result{}, sqlErr)
+
+	err := td.updateTableStateAndReport(t.Context(), dbc, CompletedState, dr)
+	require.ErrorContains(t, err, "failed to save diff report for table test")
+	require.ErrorContains(t, err, "Got a packet bigger than 'max_allowed_packet' bytes")
+	require.ErrorContains(t, err, "(errno 1153)")
+	require.NotContains(t, err.Error(), huge, "the report payload must not be carried in the persisted error")
+	dbc.Wait()
 }

--- a/go/vt/vttablet/tabletmanager/vdiff/utils.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/utils.go
@@ -18,6 +18,7 @@ package vdiff
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -26,6 +27,7 @@ import (
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/log"
 
+	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/sqltypes"
 
 	"vitess.io/vitess/go/mysql/collations"
@@ -67,6 +69,27 @@ func pkColsToGroupByParams(pkCols []int, collationEnv *collations.Environment) [
 		res = append(res, &engine.GroupByParams{KeyCol: col, WeightStringCol: -1, CollationEnv: collationEnv})
 	}
 	return res
+}
+
+// errWithoutQueryEcho returns err with the echoed failing statement removed from
+// its SQL error. A *sqlerror.SQLError keeps the human message, errno and sqlstate
+// separate from the echoed query, and only that query echo is unbounded -- it can
+// be arbitrarily large when the statement embeds a big payload such as a VDiff
+// report. The echo is dropped for any *sqlerror.SQLError that carries one,
+// regardless of the errno; it is applied at the report-write sites so the failure
+// can be recorded without the recording statement (last_error / vdiff_log) itself
+// exceeding max_allowed_packet -- the case (errno 1153) that motivates it. Non-SQL
+// errors, and SQL errors without a query echo, are returned unchanged.
+func errWithoutQueryEcho(err error) error {
+	sqlErr, ok := errors.AsType[*sqlerror.SQLError](err)
+	if !ok || sqlErr.Query == "" {
+		return err
+	}
+	// Clear the echoed query on a copy so SQLError.Error() emits only the message,
+	// errno and sqlstate (it appends " during query: ..." only when Query is set).
+	redacted := *sqlErr
+	redacted.Query = ""
+	return &redacted
 }
 
 func insertVDiffLog(ctx context.Context, dbClient binlogplayer.DBClient, vdiffID int64, message string) {

--- a/go/vt/vttablet/tabletmanager/vdiff/utils_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/utils_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vdiff
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/sqlerror"
+)
+
+// TestErrWithoutQueryEcho confirms that the echoed failing statement (which can
+// be arbitrarily large, e.g. when it embeds a big VDiff report) is dropped while
+// the actionable message/errno/sqlstate are preserved. This is what keeps a
+// persisted error small enough that the recording statement does not itself
+// exceed max_allowed_packet.
+func TestErrWithoutQueryEcho(t *testing.T) {
+	huge := strings.Repeat("x", 200000)
+	sqlErr := &sqlerror.SQLError{
+		Num:     sqlerror.ERNetPacketTooLarge,
+		State:   "08S01",
+		Message: "Got a packet bigger than 'max_allowed_packet' bytes",
+		Query:   "update _vt.vdiff_table set report = '" + huge + "'",
+	}
+	// Sanity: the raw SQL error echoes the (huge) failing query.
+	require.ErrorContains(t, sqlErr, huge)
+
+	got := errWithoutQueryEcho(sqlErr)
+	require.ErrorContains(t, got, "Got a packet bigger than 'max_allowed_packet' bytes")
+	require.ErrorContains(t, got, "(errno 1153)")
+	require.ErrorContains(t, got, "(sqlstate 08S01)")
+	require.NotContains(t, got.Error(), huge, "the query echo (payload) must not be carried in the error")
+
+	// A SQL error without a query echo is returned unchanged.
+	noEcho := &sqlerror.SQLError{Num: sqlerror.ERNetPacketTooLarge, State: "08S01", Message: "boom"}
+	require.Same(t, noEcho, errWithoutQueryEcho(noEcho))
+
+	// Non-SQL errors pass through unchanged.
+	plain := errors.New("plain error")
+	require.Equal(t, plain, errWithoutQueryEcho(plain))
+}

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"reflect"
 	"slices"
 	"strings"
@@ -362,7 +363,10 @@ func (wd *workflowDiffer) diff(ctx context.Context) (err error) {
 // markTableErrored returns diffErr; a failure marking the table errored (e.g. a closed connection) must not shadow it.
 func (wd *workflowDiffer) markTableErrored(ctx context.Context, dbClient binlogplayer.DBClient, td *tableDiffer, diffErr error) error {
 	if stateErr := td.updateTableState(ctx, dbClient, ErrorState); stateErr != nil {
-		log.Error(fmt.Sprintf("failed to mark table %s as errored for vdiff %s: %v", td.table.Name, wd.ct.uuid, stateErr))
+		log.Error("failed to mark table as errored",
+			slog.String("table", td.table.Name),
+			slog.String("vdiff", wd.ct.uuid),
+			slog.Any("error", stateErr))
 	}
 	insertVDiffLog(ctx, dbClient, wd.ct.id, fmt.Sprintf("Table %s Error: %s", td.table.Name, diffErr))
 	return diffErr

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ.go
@@ -346,8 +346,8 @@ func (wd *workflowDiffer) diff(ctx context.Context) (err error) {
 
 		log.Info(fmt.Sprintf("Starting diff of table %s for vdiff %s", td.table.Name, wd.ct.uuid))
 		if err := wd.diffTable(ctx, dbClient, td); err != nil {
-			if err := td.updateTableState(ctx, dbClient, ErrorState); err != nil {
-				return err
+			if stateErr := td.updateTableState(ctx, dbClient, ErrorState); stateErr != nil {
+				log.Error(fmt.Sprintf("failed to mark table %s as errored for vdiff %s: %v", td.table.Name, wd.ct.uuid, stateErr))
 			}
 			insertVDiffLog(ctx, dbClient, wd.ct.id, fmt.Sprintf("Table %s Error: %s", td.table.Name, err))
 			return err

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ.go
@@ -346,11 +346,7 @@ func (wd *workflowDiffer) diff(ctx context.Context) (err error) {
 
 		log.Info(fmt.Sprintf("Starting diff of table %s for vdiff %s", td.table.Name, wd.ct.uuid))
 		if err := wd.diffTable(ctx, dbClient, td); err != nil {
-			if stateErr := td.updateTableState(ctx, dbClient, ErrorState); stateErr != nil {
-				log.Error(fmt.Sprintf("failed to mark table %s as errored for vdiff %s: %v", td.table.Name, wd.ct.uuid, stateErr))
-			}
-			insertVDiffLog(ctx, dbClient, wd.ct.id, fmt.Sprintf("Table %s Error: %s", td.table.Name, err))
-			return err
+			return wd.markTableErrored(ctx, dbClient, td, err)
 		}
 		if err := td.updateTableState(ctx, dbClient, CompletedState); err != nil {
 			return err
@@ -361,6 +357,15 @@ func (wd *workflowDiffer) diff(ctx context.Context) (err error) {
 		return err
 	}
 	return nil
+}
+
+// markTableErrored returns diffErr; a failure marking the table errored (e.g. a closed connection) must not shadow it.
+func (wd *workflowDiffer) markTableErrored(ctx context.Context, dbClient binlogplayer.DBClient, td *tableDiffer, diffErr error) error {
+	if stateErr := td.updateTableState(ctx, dbClient, ErrorState); stateErr != nil {
+		log.Error(fmt.Sprintf("failed to mark table %s as errored for vdiff %s: %v", td.table.Name, wd.ct.uuid, stateErr))
+	}
+	insertVDiffLog(ctx, dbClient, wd.ct.id, fmt.Sprintf("Table %s Error: %s", td.table.Name, diffErr))
+	return diffErr
 }
 
 func (wd *workflowDiffer) markIfCompleted(ctx context.Context, dbClient binlogplayer.DBClient) error {

--- a/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
+++ b/go/vt/vttablet/tabletmanager/vdiff/workflow_differ_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/mysql/sqlerror"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/binlog/binlogplayer"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -1115,4 +1116,36 @@ func TestBuildPlanFailure(t *testing.T) {
 		err = wd.buildPlan(dbc, filter, testSchema)
 		assert.EqualError(t, err, tcase.err, tcase.input)
 	}
+}
+
+// TestMarkTableErroredPreservesOriginalError verifies that when marking a table
+// errored fails -- e.g. the report write failed with errno 1153, closing the
+// MySQL connection, so the follow-up state update fails with errno 2006 -- the
+// original errno-1153 error is returned rather than the shadowing 2006.
+func TestMarkTableErroredPreservesOriginalError(t *testing.T) {
+	wd := &workflowDiffer{ct: &controller{id: 1}}
+	table := &tabletmanagerdatapb.TableDefinition{Name: "test"}
+	td := &tableDiffer{wd: wd, table: table}
+
+	diffErr := &sqlerror.SQLError{
+		Num:     sqlerror.ERNetPacketTooLarge,
+		State:   "08S01",
+		Message: "Got a packet bigger than 'max_allowed_packet' bytes",
+	}
+	connErr := &sqlerror.SQLError{
+		Num:     sqlerror.CRServerGone,
+		State:   "HY000",
+		Message: "MySQL server has gone away",
+	}
+
+	dbc := binlogplayer.NewMockDBClient(t)
+	// updateTableState(ErrorState) fails because the connection is gone.
+	dbc.ExpectRequestRE("update _vt.vdiff_table set state = 'error'", &sqltypes.Result{}, connErr)
+	// insertVDiffLog then runs (its own failure is swallowed).
+	dbc.ExpectRequestRE("insert into _vt.vdiff_log", &sqltypes.Result{}, nil)
+
+	err := wd.markTableErrored(t.Context(), dbc, td, diffErr)
+	require.ErrorContains(t, err, "(errno 1153)")
+	require.NotContains(t, err.Error(), "errno 2006")
+	dbc.Wait()
 }


### PR DESCRIPTION
## Description

When persisting a table's diff report to `_vt.vdiff_table` exceeds `max_allowed_packet` (errno 1153), the SQL error text echoes the entire failing statement (`SQLError.Error()` appends ` during query: <query>`), which embeds the large report. That oversized error string was then embedded verbatim into the statements used to record it — `update _vt.vdiff set state='error', last_error=left(%s,1024)` and `insert into _vt.vdiff_log(...)`. `left()` bounds only the stored value, not the statement, so those recording statements also exceeded `max_allowed_packet` and could never be sent (errno 2006/1153). `saveErrorState` retried indefinitely and the VDiff was left stuck in `started` with an empty `last_error`.

This change, at the two report-write sites (`updateTableProgress`, `updateTableStateAndReport`), rebuilds the error from the structured `*sqlerror.SQLError` fields by clearing the echoed `Query` (reusing `SQLError.Error()` so nothing is truncated and no format is duplicated), and names the failing table via `vterrors.Wrapf`. The recorded error is now small and meaningful, so the VDiff transitions to `error` with an informative `last_error` instead of silently looping.

## Related Issue(s)

Fixes #20908

## Testing

- `TestErrWithoutQueryEcho` — the redactor keeps message/errno/sqlstate and drops the (large) query echo; a SQL error with no echo and non-SQL errors pass through unchanged.
- `TestUpdateTableProgressDropsQueryEcho` — the progress-write path failing with errno 1153 (whose error echoes a large statement) persists an error that names the table and omits the payload.
- `TestUpdateTableStateAndReportDropsQueryEcho` — the completion path (final state/report write) applies the same redaction: the persisted error names the table, keeps errno 1153, and drops the report payload.
- `TestMarkTableErroredPreservesOriginalError` — when marking a table errored, the original diff error (errno 1153) is preserved rather than the follow-on errno 2006 from the failing recording statement.

All fail if the redaction/preservation is reverted.

## Backport

Candidates: `release-23.0`, `release-24.0`.