### PR TITLE
Instruct coding agents not to add bug fixes to the release summary

### DIFF
--- a/changelog/AGENTS.md
+++ b/changelog/AGENTS.md
@@ -1,0 +1,7 @@
+## Changelog
+
+**Bug fixes should not be included in the release summary
+
+- PRs that are fixing a bug -- rather than making an enhancement, feature request, or deprecation/removal -- should NOT be included in any release summary (summary.md)
+- These issues will be later included in the full release changelog when the release is cut in GitHub
+

--- a/changelog/AGENTS.md
+++ b/changelog/AGENTS.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-**Bug fixes should not be included in the release summary
+**Bug fixes should not be included in the release summary**
 
 - PRs that are fixing a bug -- rather than making an enhancement, feature request, or deprecation/removal -- should NOT be included in any release summary (summary.md)
 - These issues will be later included in the full release changelog when the release is cut in GitHub


### PR DESCRIPTION
## Description

Coding agents seem to insist on doing this and I'm tired of requesting it be removed in PR reviews. :-) 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
