### PR TITLE
Update e2e operator yaml

### DIFF
--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -8668,9 +8668,7 @@ spec:
         - vitess-operator
         env:
         - name: WATCH_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: "default,example"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: etcdlockservers.planetscale.com
 spec:
   group: planetscale.com
@@ -11,325 +11,342 @@ spec:
     listKind: EtcdLockserverList
     plural: etcdlockservers
     shortNames:
-      - etcdls
+    - etcdls
     singular: etcdlockserver
   scope: Namespaced
   versions:
-    - name: v2
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                advertisePeerURLs:
-                  items:
-                    type: string
-                  maxItems: 3
-                  minItems: 3
-                  type: array
-                affinity:
-                  x-kubernetes-preserve-unknown-fields: true
-                annotations:
-                  additionalProperties:
-                    type: string
-                  type: object
-                clientService:
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    clusterIP:
+  - name: v2
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              advertisePeerURLs:
+                items:
+                  type: string
+                maxItems: 3
+                minItems: 3
+                type: array
+              affinity:
+                x-kubernetes-preserve-unknown-fields: true
+              annotations:
+                additionalProperties:
+                  type: string
+                type: object
+              clientService:
+                properties:
+                  annotations:
+                    additionalProperties:
                       type: string
-                  type: object
-                createClientService:
-                  type: boolean
-                createPDB:
-                  type: boolean
-                createPeerService:
-                  type: boolean
-                dataVolumeClaimTemplate:
-                  properties:
-                    accessModes:
-                      items:
-                        type: string
-                      type: array
-                      x-kubernetes-list-type: atomic
-                    dataSource:
-                      properties:
-                        apiGroup:
-                          type: string
-                        kind:
-                          type: string
-                        name:
-                          type: string
-                      required:
-                        - kind
-                        - name
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    dataSourceRef:
-                      properties:
-                        apiGroup:
-                          type: string
-                        kind:
-                          type: string
-                        name:
-                          type: string
-                        namespace:
-                          type: string
-                      required:
-                        - kind
-                        - name
-                      type: object
-                    resources:
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          type: object
-                      type: object
-                    selector:
-                      properties:
-                        matchExpressions:
-                          items:
-                            properties:
-                              key:
-                                type: string
-                              operator:
-                                type: string
-                              values:
-                                items:
-                                  type: string
-                                type: array
-                                x-kubernetes-list-type: atomic
-                            required:
-                              - key
-                              - operator
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        matchLabels:
-                          additionalProperties:
-                            type: string
-                          type: object
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    storageClassName:
-                      type: string
-                    volumeAttributesClassName:
-                      type: string
-                    volumeMode:
-                      type: string
-                    volumeName:
-                      type: string
-                  type: object
-                extraEnv:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                      value:
-                        type: string
-                      valueFrom:
-                        properties:
-                          configMapKeyRef:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                default: ""
-                                type: string
-                              optional:
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          fieldRef:
-                            properties:
-                              apiVersion:
-                                type: string
-                              fieldPath:
-                                type: string
-                            required:
-                              - fieldPath
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          resourceFieldRef:
-                            properties:
-                              containerName:
-                                type: string
-                              divisor:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              resource:
-                                type: string
-                            required:
-                              - resource
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          secretKeyRef:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                default: ""
-                                type: string
-                              optional:
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                            x-kubernetes-map-type: atomic
-                        type: object
-                    required:
-                      - name
                     type: object
-                  type: array
-                extraFlags:
-                  additionalProperties:
+                  clusterIP:
                     type: string
-                  type: object
-                extraLabels:
-                  additionalProperties:
-                    type: string
-                  type: object
-                extraVolumeMounts:
-                  items:
+                type: object
+              createClientService:
+                type: boolean
+              createPDB:
+                type: boolean
+              createPeerService:
+                type: boolean
+              dataVolumeClaimTemplate:
+                properties:
+                  accessModes:
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  dataSource:
                     properties:
-                      mountPath:
+                      apiGroup:
                         type: string
-                      mountPropagation:
+                      kind:
                         type: string
                       name:
-                        type: string
-                      readOnly:
-                        type: boolean
-                      recursiveReadOnly:
-                        type: string
-                      subPath:
-                        type: string
-                      subPathExpr:
                         type: string
                     required:
-                      - mountPath
-                      - name
-                    type: object
-                  type: array
-                extraVolumes:
-                  x-kubernetes-preserve-unknown-fields: true
-                image:
-                  type: string
-                imagePullPolicy:
-                  type: string
-                imagePullSecrets:
-                  items:
-                    properties:
-                      name:
-                        default: ""
-                        type: string
+                    - kind
+                    - name
                     type: object
                     x-kubernetes-map-type: atomic
-                  type: array
-                initContainers:
-                  x-kubernetes-preserve-unknown-fields: true
-                localMemberIndex:
-                  format: int32
-                  maximum: 3
-                  minimum: 1
-                  type: integer
-                peerService:
-                  properties:
-                    annotations:
-                      additionalProperties:
+                  dataSourceRef:
+                    properties:
+                      apiGroup:
                         type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                  resources:
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  selector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  storageClassName:
+                    type: string
+                  volumeAttributesClassName:
+                    type: string
+                  volumeMode:
+                    type: string
+                  volumeName:
+                    type: string
+                type: object
+              extraEnv:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                    valueFrom:
+                      properties:
+                        configMapKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          properties:
+                            apiVersion:
+                              type: string
+                            fieldPath:
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            optional:
+                              default: false
+                              type: boolean
+                            path:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          properties:
+                            containerName:
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
                       type: object
-                    clusterIP:
+                  required:
+                  - name
+                  type: object
+                type: array
+              extraFlags:
+                additionalProperties:
+                  type: string
+                type: object
+              extraLabels:
+                additionalProperties:
+                  type: string
+                type: object
+              extraVolumeMounts:
+                items:
+                  properties:
+                    mountPath:
+                      type: string
+                    mountPropagation:
+                      type: string
+                    name:
+                      type: string
+                    readOnly:
+                      type: boolean
+                    recursiveReadOnly:
+                      type: string
+                    subPath:
+                      type: string
+                    subPathExpr:
+                      type: string
+                  required:
+                  - mountPath
+                  - name
+                  type: object
+                type: array
+              extraVolumes:
+                x-kubernetes-preserve-unknown-fields: true
+              image:
+                type: string
+              imagePullPolicy:
+                type: string
+              imagePullSecrets:
+                items:
+                  properties:
+                    name:
+                      default: ""
                       type: string
                   type: object
-                resources:
-                  properties:
-                    claims:
-                      items:
-                        properties:
-                          name:
-                            type: string
-                          request:
-                            type: string
-                        required:
-                          - name
-                        type: object
-                      type: array
-                      x-kubernetes-list-map-keys:
-                        - name
-                      x-kubernetes-list-type: map
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
+                  x-kubernetes-map-type: atomic
+                type: array
+              initContainers:
+                x-kubernetes-preserve-unknown-fields: true
+              localMemberIndex:
+                format: int32
+                maximum: 3
+                minimum: 1
+                type: integer
+              peerService:
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  clusterIP:
+                    type: string
+                type: object
+              resources:
+                properties:
+                  claims:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        request:
+                          type: string
+                      required:
+                      - name
                       type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      type: object
-                  type: object
-                sidecarContainers:
-                  x-kubernetes-preserve-unknown-fields: true
-                tolerations:
-                  x-kubernetes-preserve-unknown-fields: true
-                zone:
-                  type: string
-              type: object
-            status:
-              properties:
-                available:
-                  type: string
-                clientServiceName:
-                  type: string
-                observedGeneration:
-                  format: int64
-                  type: integer
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    type: object
+                type: object
+              sidecarContainers:
+                x-kubernetes-preserve-unknown-fields: true
+              tolerations:
+                x-kubernetes-preserve-unknown-fields: true
+              zone:
+                type: string
+            type: object
+          status:
+            properties:
+              available:
+                type: string
+              clientServiceName:
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: vitessbackups.planetscale.com
 spec:
   group: planetscale.com
@@ -338,50 +355,50 @@ spec:
     listKind: VitessBackupList
     plural: vitessbackups
     shortNames:
-      - vtb
+    - vtb
     singular: vitessbackup
   scope: Namespaced
   versions:
-    - name: v2
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              type: object
-            status:
-              properties:
-                complete:
-                  type: boolean
-                engine:
-                  type: string
-                finishedTime:
-                  format: date-time
-                  type: string
-                position:
-                  type: string
-                startTime:
-                  format: date-time
-                  type: string
-                storageDirectory:
-                  type: string
-                storageName:
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
+  - name: v2
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+          status:
+            properties:
+              complete:
+                type: boolean
+              engine:
+                type: string
+              finishedTime:
+                format: date-time
+                type: string
+              position:
+                type: string
+              startTime:
+                format: date-time
+                type: string
+              storageDirectory:
+                type: string
+              storageName:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: vitessbackupschedules.planetscale.com
 spec:
   group: planetscale.com
@@ -413,6 +430,12 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              backupMethod:
+                default: vtbackup
+                enum:
+                - vtbackup
+                - vtctldclient
+                type: string
               cluster:
                 type: string
               concurrencyPolicy:
@@ -515,6 +538,8 @@ spec:
                 type: integer
               suspend:
                 type: boolean
+              tolerations:
+                x-kubernetes-preserve-unknown-fields: true
             required:
             - cluster
             - name
@@ -571,7 +596,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: vitessbackupstorages.planetscale.com
 spec:
   group: planetscale.com
@@ -580,166 +605,166 @@ spec:
     listKind: VitessBackupStorageList
     plural: vitessbackupstorages
     shortNames:
-      - vtbs
+    - vtbs
     singular: vitessbackupstorage
   scope: Namespaced
   versions:
-    - name: v2
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                location:
-                  properties:
-                    annotations:
-                      additionalProperties:
+  - name: v2
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              location:
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  azblob:
+                    properties:
+                      account:
+                        minLength: 1
                         type: string
-                      type: object
-                    azblob:
-                      properties:
-                        account:
-                          minLength: 1
-                          type: string
-                        authSecret:
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                            volumeName:
-                              type: string
-                          required:
-                            - key
-                          type: object
-                        container:
-                          minLength: 1
-                          type: string
-                        keyPrefix:
-                          maxLength: 256
-                          pattern: ^[^\r\n]*$
-                          type: string
-                      required:
-                        - account
-                        - authSecret
-                        - container
-                      type: object
-                    ceph:
-                      properties:
-                        authSecret:
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                            volumeName:
-                              type: string
-                          required:
-                            - key
-                          type: object
-                      required:
-                        - authSecret
-                      type: object
-                    gcs:
-                      properties:
-                        authSecret:
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                            volumeName:
-                              type: string
-                          required:
-                            - key
-                          type: object
-                        bucket:
-                          minLength: 1
-                          type: string
-                        keyPrefix:
-                          maxLength: 256
-                          pattern: ^[^\r\n]*$
-                          type: string
-                      required:
-                        - bucket
-                      type: object
-                    name:
-                      maxLength: 63
-                      pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
-                      type: string
-                    s3:
-                      properties:
-                        authSecret:
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                            volumeName:
-                              type: string
-                          required:
-                            - key
-                          type: object
-                        bucket:
-                          minLength: 1
-                          type: string
-                        endpoint:
-                          type: string
-                        forcePathStyle:
-                          type: boolean
-                        keyPrefix:
-                          maxLength: 256
-                          pattern: ^[^\r\n]*$
-                          type: string
-                        minPartSize:
-                          format: int64
-                          type: integer
-                        region:
-                          minLength: 1
-                          type: string
-                      required:
-                        - bucket
-                        - region
-                      type: object
-                    volume:
-                      x-kubernetes-preserve-unknown-fields: true
-                    volumeSubPath:
-                      type: string
-                  type: object
-                subcontroller:
-                  properties:
-                    serviceAccountName:
-                      type: string
-                  type: object
-              required:
-                - location
-              type: object
-            status:
-              properties:
-                observedGeneration:
-                  format: int64
-                  type: integer
-                totalBackupCount:
-                  format: int32
-                  type: integer
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                      authSecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          volumeName:
+                            type: string
+                        required:
+                        - key
+                        type: object
+                      container:
+                        minLength: 1
+                        type: string
+                      keyPrefix:
+                        maxLength: 256
+                        pattern: ^[^\r\n]*$
+                        type: string
+                    required:
+                    - account
+                    - authSecret
+                    - container
+                    type: object
+                  ceph:
+                    properties:
+                      authSecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          volumeName:
+                            type: string
+                        required:
+                        - key
+                        type: object
+                    required:
+                    - authSecret
+                    type: object
+                  gcs:
+                    properties:
+                      authSecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          volumeName:
+                            type: string
+                        required:
+                        - key
+                        type: object
+                      bucket:
+                        minLength: 1
+                        type: string
+                      keyPrefix:
+                        maxLength: 256
+                        pattern: ^[^\r\n]*$
+                        type: string
+                    required:
+                    - bucket
+                    type: object
+                  name:
+                    maxLength: 63
+                    pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
+                    type: string
+                  s3:
+                    properties:
+                      authSecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          volumeName:
+                            type: string
+                        required:
+                        - key
+                        type: object
+                      bucket:
+                        minLength: 1
+                        type: string
+                      endpoint:
+                        type: string
+                      forcePathStyle:
+                        type: boolean
+                      keyPrefix:
+                        maxLength: 256
+                        pattern: ^[^\r\n]*$
+                        type: string
+                      minPartSize:
+                        format: int64
+                        type: integer
+                      region:
+                        minLength: 1
+                        type: string
+                    required:
+                    - bucket
+                    - region
+                    type: object
+                  volume:
+                    x-kubernetes-preserve-unknown-fields: true
+                  volumeSubPath:
+                    type: string
+                type: object
+              subcontroller:
+                properties:
+                  serviceAccountName:
+                    type: string
+                type: object
+            required:
+            - location
+            type: object
+          status:
+            properties:
+              observedGeneration:
+                format: int64
+                type: integer
+              totalBackupCount:
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: vitesscells.planetscale.com
 spec:
   group: planetscale.com
@@ -748,1158 +773,1215 @@ spec:
     listKind: VitessCellList
     plural: vitesscells
     shortNames:
-      - vtc
+    - vtc
     singular: vitesscell
   scope: Namespaced
   versions:
-    - name: v2
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                allCells:
-                  items:
-                    type: string
-                  type: array
-                extraVitessFlags:
-                  additionalProperties:
-                    type: string
-                  type: object
-                gateway:
-                  properties:
-                    affinity:
-                      x-kubernetes-preserve-unknown-fields: true
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    authentication:
-                      properties:
-                        static:
-                          properties:
-                            secret:
-                              properties:
-                                key:
-                                  type: string
-                                name:
-                                  type: string
-                                volumeName:
-                                  type: string
-                              required:
-                                - key
-                              type: object
-                          type: object
-                      type: object
-                    autoscaler:
-                      properties:
-                        behavior:
-                          properties:
-                            scaleDown:
-                              properties:
-                                policies:
-                                  items:
-                                    properties:
-                                      periodSeconds:
-                                        format: int32
-                                        type: integer
-                                      type:
-                                        type: string
-                                      value:
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - periodSeconds
-                                      - type
-                                      - value
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                selectPolicy:
-                                  type: string
-                                stabilizationWindowSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            scaleUp:
-                              properties:
-                                policies:
-                                  items:
-                                    properties:
-                                      periodSeconds:
-                                        format: int32
-                                        type: integer
-                                      type:
-                                        type: string
-                                      value:
-                                        format: int32
-                                        type: integer
-                                    required:
-                                      - periodSeconds
-                                      - type
-                                      - value
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                selectPolicy:
-                                  type: string
-                                stabilizationWindowSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                          type: object
-                        maxReplicas:
-                          format: int32
-                          minimum: 0
-                          type: integer
-                        metrics:
-                          items:
+  - name: v2
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              allCells:
+                items:
+                  type: string
+                type: array
+              extraVitessFlags:
+                additionalProperties:
+                  type: string
+                type: object
+              gateway:
+                properties:
+                  affinity:
+                    x-kubernetes-preserve-unknown-fields: true
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  authentication:
+                    properties:
+                      static:
+                        properties:
+                          secret:
                             properties:
-                              containerResource:
-                                properties:
-                                  container:
-                                    type: string
-                                  name:
-                                    type: string
-                                  target:
-                                    properties:
-                                      averageUtilization:
-                                        format: int32
-                                        type: integer
-                                      averageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type:
-                                        type: string
-                                      value:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - type
-                                    type: object
-                                required:
-                                  - container
-                                  - name
-                                  - target
-                                type: object
-                              external:
-                                properties:
-                                  metric:
-                                    properties:
-                                      name:
-                                        type: string
-                                      selector:
-                                        properties:
-                                          matchExpressions:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                    required:
-                                      - name
-                                    type: object
-                                  target:
-                                    properties:
-                                      averageUtilization:
-                                        format: int32
-                                        type: integer
-                                      averageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type:
-                                        type: string
-                                      value:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - type
-                                    type: object
-                                required:
-                                  - metric
-                                  - target
-                                type: object
-                              object:
-                                properties:
-                                  describedObject:
-                                    properties:
-                                      apiVersion:
-                                        type: string
-                                      kind:
-                                        type: string
-                                      name:
-                                        type: string
-                                    required:
-                                      - kind
-                                      - name
-                                    type: object
-                                  metric:
-                                    properties:
-                                      name:
-                                        type: string
-                                      selector:
-                                        properties:
-                                          matchExpressions:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                    required:
-                                      - name
-                                    type: object
-                                  target:
-                                    properties:
-                                      averageUtilization:
-                                        format: int32
-                                        type: integer
-                                      averageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type:
-                                        type: string
-                                      value:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - type
-                                    type: object
-                                required:
-                                  - describedObject
-                                  - metric
-                                  - target
-                                type: object
-                              pods:
-                                properties:
-                                  metric:
-                                    properties:
-                                      name:
-                                        type: string
-                                      selector:
-                                        properties:
-                                          matchExpressions:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                    required:
-                                      - name
-                                    type: object
-                                  target:
-                                    properties:
-                                      averageUtilization:
-                                        format: int32
-                                        type: integer
-                                      averageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type:
-                                        type: string
-                                      value:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - type
-                                    type: object
-                                required:
-                                  - metric
-                                  - target
-                                type: object
-                              resource:
-                                properties:
-                                  name:
-                                    type: string
-                                  target:
-                                    properties:
-                                      averageUtilization:
-                                        format: int32
-                                        type: integer
-                                      averageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type:
-                                        type: string
-                                      value:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    required:
-                                      - type
-                                    type: object
-                                required:
-                                  - name
-                                  - target
-                                type: object
-                              type:
+                              key:
                                 type: string
-                            required:
-                              - type
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        minReplicas:
-                          format: int32
-                          minimum: 0
-                          type: integer
-                      type: object
-                    extraEnv:
-                      items:
-                        properties:
-                          name:
-                            type: string
-                          value:
-                            type: string
-                          valueFrom:
-                            properties:
-                              configMapKeyRef:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    default: ""
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              fieldRef:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  fieldPath:
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              resourceFieldRef:
-                                properties:
-                                  containerName:
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              secretKeyRef:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    default: ""
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    extraFlags:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    extraLabels:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    extraVolumeMounts:
-                      items:
-                        properties:
-                          mountPath:
-                            type: string
-                          mountPropagation:
-                            type: string
-                          name:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          recursiveReadOnly:
-                            type: string
-                          subPath:
-                            type: string
-                          subPathExpr:
-                            type: string
-                        required:
-                          - mountPath
-                          - name
-                        type: object
-                      type: array
-                    extraVolumes:
-                      x-kubernetes-preserve-unknown-fields: true
-                    initContainers:
-                      x-kubernetes-preserve-unknown-fields: true
-                    lifecycle:
-                      properties:
-                        postStart:
-                          properties:
-                            exec:
-                              properties:
-                                command:
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              type: object
-                            httpGet:
-                              properties:
-                                host:
-                                  type: string
-                                httpHeaders:
-                                  items:
-                                    properties:
-                                      name:
-                                        type: string
-                                      value:
-                                        type: string
-                                    required:
-                                      - name
-                                      - value
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                path:
-                                  type: string
-                                port:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  x-kubernetes-int-or-string: true
-                                scheme:
-                                  type: string
-                              required:
-                                - port
-                              type: object
-                            sleep:
-                              properties:
-                                seconds:
-                                  format: int64
-                                  type: integer
-                              required:
-                                - seconds
-                              type: object
-                            tcpSocket:
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  x-kubernetes-int-or-string: true
-                              required:
-                                - port
-                              type: object
-                          type: object
-                        preStop:
-                          properties:
-                            exec:
-                              properties:
-                                command:
-                                  items:
-                                    type: string
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              type: object
-                            httpGet:
-                              properties:
-                                host:
-                                  type: string
-                                httpHeaders:
-                                  items:
-                                    properties:
-                                      name:
-                                        type: string
-                                      value:
-                                        type: string
-                                    required:
-                                      - name
-                                      - value
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                path:
-                                  type: string
-                                port:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  x-kubernetes-int-or-string: true
-                                scheme:
-                                  type: string
-                              required:
-                                - port
-                              type: object
-                            sleep:
-                              properties:
-                                seconds:
-                                  format: int64
-                                  type: integer
-                              required:
-                                - seconds
-                              type: object
-                            tcpSocket:
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  x-kubernetes-int-or-string: true
-                              required:
-                                - port
-                              type: object
-                          type: object
-                      type: object
-                    replicas:
-                      format: int32
-                      minimum: 0
-                      type: integer
-                    resources:
-                      properties:
-                        claims:
-                          items:
-                            properties:
                               name:
                                 type: string
-                              request:
+                              volumeName:
                                 type: string
                             required:
-                              - name
+                            - key
                             type: object
-                          type: array
-                          x-kubernetes-list-map-keys:
-                            - name
-                          x-kubernetes-list-type: map
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  autoscaler:
+                    properties:
+                      behavior:
+                        properties:
+                          scaleDown:
+                            properties:
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
+                              tolerance:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          scaleUp:
+                            properties:
+                              policies:
+                                items:
+                                  properties:
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      type: string
+                                    value:
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              selectPolicy:
+                                type: string
+                              stabilizationWindowSeconds:
+                                format: int32
+                                type: integer
+                              tolerance:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                      maxReplicas:
+                        format: int32
+                        minimum: 0
+                        type: integer
+                      metrics:
+                        items:
+                          properties:
+                            containerResource:
+                              properties:
+                                container:
+                                  type: string
+                                name:
+                                  type: string
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type:
+                                      type: string
+                                    value:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - container
+                              - name
+                              - target
+                              type: object
+                            external:
+                              properties:
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type:
+                                      type: string
+                                    value:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - metric
+                              - target
+                              type: object
+                            object:
+                              properties:
+                                describedObject:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type:
+                                      type: string
+                                    value:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - describedObject
+                              - metric
+                              - target
+                              type: object
+                            pods:
+                              properties:
+                                metric:
+                                  properties:
+                                    name:
+                                      type: string
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type:
+                                      type: string
+                                    value:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - metric
+                              - target
+                              type: object
+                            resource:
+                              properties:
+                                name:
+                                  type: string
+                                target:
+                                  properties:
+                                    averageUtilization:
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type:
+                                      type: string
+                                    value:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - name
+                              - target
+                              type: object
+                            type:
+                              type: string
+                          required:
+                          - type
                           type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          type: object
-                      type: object
-                    secureTransport:
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      minReplicas:
+                        format: int32
+                        minimum: 0
+                        type: integer
+                    type: object
+                  extraEnv:
+                    items:
                       properties:
-                        required:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                        valueFrom:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  extraFlags:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  extraLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  extraVolumeMounts:
+                    items:
+                      properties:
+                        mountPath:
+                          type: string
+                        mountPropagation:
+                          type: string
+                        name:
+                          type: string
+                        readOnly:
                           type: boolean
-                        tls:
-                          properties:
-                            certSecret:
-                              properties:
-                                key:
-                                  type: string
-                                name:
-                                  type: string
-                                volumeName:
-                                  type: string
-                              required:
-                                - key
-                              type: object
-                            clientCACertSecret:
-                              properties:
-                                key:
-                                  type: string
-                                name:
-                                  type: string
-                                volumeName:
-                                  type: string
-                              required:
-                                - key
-                              type: object
-                            keySecret:
-                              properties:
-                                key:
-                                  type: string
-                                name:
-                                  type: string
-                                volumeName:
-                                  type: string
-                              required:
-                                - key
-                              type: object
-                          type: object
-                      type: object
-                    service:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        clusterIP:
+                        recursiveReadOnly:
                           type: string
+                        subPath:
+                          type: string
+                        subPathExpr:
+                          type: string
+                      required:
+                      - mountPath
+                      - name
                       type: object
-                    sidecarContainers:
-                      x-kubernetes-preserve-unknown-fields: true
-                    strategy:
-                      properties:
-                        rollingUpdate:
-                          properties:
-                            maxSurge:
-                              anyOf:
+                    type: array
+                  extraVolumes:
+                    x-kubernetes-preserve-unknown-fields: true
+                  initContainers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  lifecycle:
+                    properties:
+                      postStart:
+                        properties:
+                          exec:
+                            properties:
+                              command:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          httpGet:
+                            properties:
+                              host:
+                                type: string
+                              httpHeaders:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              path:
+                                type: string
+                              port:
+                                anyOf:
                                 - type: integer
                                 - type: string
-                              x-kubernetes-int-or-string: true
-                            maxUnavailable:
-                              anyOf:
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          sleep:
+                            properties:
+                              seconds:
+                                format: int64
+                                type: integer
+                            required:
+                            - seconds
+                            type: object
+                          tcpSocket:
+                            properties:
+                              host:
+                                type: string
+                              port:
+                                anyOf:
                                 - type: integer
                                 - type: string
-                              x-kubernetes-int-or-string: true
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                      preStop:
+                        properties:
+                          exec:
+                            properties:
+                              command:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          httpGet:
+                            properties:
+                              host:
+                                type: string
+                              httpHeaders:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              path:
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          sleep:
+                            properties:
+                              seconds:
+                                format: int64
+                                type: integer
+                            required:
+                            - seconds
+                            type: object
+                          tcpSocket:
+                            properties:
+                              host:
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                      stopSignal:
+                        type: string
+                    type: object
+                  replicas:
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  resources:
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
                           type: object
-                        type:
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  secureTransport:
+                    properties:
+                      required:
+                        type: boolean
+                      tls:
+                        properties:
+                          certSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                            - key
+                            type: object
+                          clientCACertSecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                            - key
+                            type: object
+                          keySecret:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  service:
+                    properties:
+                      annotations:
+                        additionalProperties:
                           type: string
-                      type: object
-                    terminationGracePeriodSeconds:
-                      format: int64
-                      type: integer
-                    tolerations:
-                      x-kubernetes-preserve-unknown-fields: true
-                    topologySpreadConstraints:
-                      x-kubernetes-preserve-unknown-fields: true
-                  type: object
-                globalLockserver:
+                        type: object
+                      clusterIP:
+                        type: string
+                    type: object
+                  sidecarContainers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  strategy:
+                    properties:
+                      rollingUpdate:
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        type: string
+                    type: object
+                  terminationGracePeriodSeconds:
+                    format: int64
+                    type: integer
+                  tolerations:
+                    x-kubernetes-preserve-unknown-fields: true
+                  topologySpreadConstraints:
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              globalLockserver:
+                properties:
+                  address:
+                    type: string
+                  implementation:
+                    type: string
+                  rootPath:
+                    type: string
+                required:
+                - address
+                - implementation
+                - rootPath
+                type: object
+              imagePullPolicies:
+                properties:
+                  mysqld:
+                    type: string
+                  mysqldExporter:
+                    type: string
+                  vtadmin:
+                    type: string
+                  vtbackup:
+                    type: string
+                  vtctld:
+                    type: string
+                  vtgate:
+                    type: string
+                  vtorc:
+                    type: string
+                  vttablet:
+                    type: string
+                type: object
+              imagePullSecrets:
+                items:
                   properties:
-                    address:
+                    name:
+                      default: ""
                       type: string
-                    implementation:
-                      type: string
-                    rootPath:
-                      type: string
-                  required:
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              images:
+                properties:
+                  vtgate:
+                    type: string
+                type: object
+              lockserver:
+                properties:
+                  cellInfoAddress:
+                    type: string
+                  etcd:
+                    properties:
+                      advertisePeerURLs:
+                        items:
+                          type: string
+                        maxItems: 3
+                        minItems: 3
+                        type: array
+                      affinity:
+                        x-kubernetes-preserve-unknown-fields: true
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      clientService:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          clusterIP:
+                            type: string
+                        type: object
+                      createClientService:
+                        type: boolean
+                      createPDB:
+                        type: boolean
+                      createPeerService:
+                        type: boolean
+                      dataVolumeClaimTemplate:
+                        properties:
+                          accessModes:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          dataSource:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSourceRef:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          selector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          storageClassName:
+                            type: string
+                          volumeAttributesClassName:
+                            type: string
+                          volumeMode:
+                            type: string
+                          volumeName:
+                            type: string
+                        type: object
+                      extraEnv:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      extraFlags:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      extraLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      extraVolumeMounts:
+                        items:
+                          properties:
+                            mountPath:
+                              type: string
+                            mountPropagation:
+                              type: string
+                            name:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            recursiveReadOnly:
+                              type: string
+                            subPath:
+                              type: string
+                            subPathExpr:
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                      extraVolumes:
+                        x-kubernetes-preserve-unknown-fields: true
+                      image:
+                        type: string
+                      imagePullPolicy:
+                        type: string
+                      imagePullSecrets:
+                        items:
+                          properties:
+                            name:
+                              default: ""
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      initContainers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      localMemberIndex:
+                        format: int32
+                        maximum: 3
+                        minimum: 1
+                        type: integer
+                      peerService:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          clusterIP:
+                            type: string
+                        type: object
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                request:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                      sidecarContainers:
+                        x-kubernetes-preserve-unknown-fields: true
+                      tolerations:
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  external:
+                    properties:
+                      address:
+                        type: string
+                      implementation:
+                        type: string
+                      rootPath:
+                        type: string
+                    required:
                     - address
                     - implementation
                     - rootPath
+                    type: object
+                type: object
+              name:
+                maxLength: 63
+                minLength: 1
+                pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
+                type: string
+              tabletRefreshInterval:
+                type: string
+                x-kubernetes-validations:
+                - message: tabletRefreshInterval must be a valid duration of at least
+                    1s using s, m, or h units
+                  rule: self.matches('^([0-9]+([.][0-9]+)?(s|m|h))+$') && duration(self)
+                    >= duration('1s')
+              topologyReconciliation:
+                properties:
+                  pruneCells:
+                    type: boolean
+                  pruneKeyspaces:
+                    type: boolean
+                  pruneShardCells:
+                    type: boolean
+                  pruneShards:
+                    type: boolean
+                  pruneSrvKeyspaces:
+                    type: boolean
+                  pruneTablets:
+                    type: boolean
+                  registerCells:
+                    type: boolean
+                  registerCellsAliases:
+                    type: boolean
+                type: object
+              zone:
+                type: string
+            required:
+            - allCells
+            - globalLockserver
+            - name
+            type: object
+          status:
+            properties:
+              gateway:
+                properties:
+                  available:
+                    type: string
+                  labelSelector:
+                    type: string
+                  replicas:
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  serviceName:
+                    type: string
+                  tabletRefreshInterval:
+                    type: string
+                type: object
+              idle:
+                type: string
+              keyspaces:
+                additionalProperties:
                   type: object
-                imagePullPolicies:
-                  properties:
-                    mysqld:
-                      type: string
-                    mysqldExporter:
-                      type: string
-                    vtadmin:
-                      type: string
-                    vtbackup:
-                      type: string
-                    vtctld:
-                      type: string
-                    vtgate:
-                      type: string
-                    vtorc:
-                      type: string
-                    vttablet:
-                      type: string
-                  type: object
-                imagePullSecrets:
-                  items:
+                type: object
+              lockserver:
+                properties:
+                  etcd:
                     properties:
-                      name:
-                        default: ""
+                      available:
                         type: string
+                      clientServiceName:
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        type: integer
                     type: object
-                    x-kubernetes-map-type: atomic
-                  type: array
-                images:
-                  properties:
-                    vtgate:
-                      type: string
-                  type: object
-                lockserver:
-                  properties:
-                    cellInfoAddress:
-                      type: string
-                    etcd:
-                      properties:
-                        advertisePeerURLs:
-                          items:
-                            type: string
-                          maxItems: 3
-                          minItems: 3
-                          type: array
-                        affinity:
-                          x-kubernetes-preserve-unknown-fields: true
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        clientService:
-                          properties:
-                            annotations:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            clusterIP:
-                              type: string
-                          type: object
-                        createClientService:
-                          type: boolean
-                        createPDB:
-                          type: boolean
-                        createPeerService:
-                          type: boolean
-                        dataVolumeClaimTemplate:
-                          properties:
-                            accessModes:
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            dataSource:
-                              properties:
-                                apiGroup:
-                                  type: string
-                                kind:
-                                  type: string
-                                name:
-                                  type: string
-                              required:
-                                - kind
-                                - name
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            dataSourceRef:
-                              properties:
-                                apiGroup:
-                                  type: string
-                                kind:
-                                  type: string
-                                name:
-                                  type: string
-                                namespace:
-                                  type: string
-                              required:
-                                - kind
-                                - name
-                              type: object
-                            resources:
-                              properties:
-                                limits:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  type: object
-                                requests:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  type: object
-                              type: object
-                            selector:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                    required:
-                                      - key
-                                      - operator
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            storageClassName:
-                              type: string
-                            volumeAttributesClassName:
-                              type: string
-                            volumeMode:
-                              type: string
-                            volumeName:
-                              type: string
-                          type: object
-                        extraEnv:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              value:
-                                type: string
-                              valueFrom:
-                                properties:
-                                  configMapKeyRef:
-                                    properties:
-                                      key:
-                                        type: string
-                                      name:
-                                        default: ""
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  fieldRef:
-                                    properties:
-                                      apiVersion:
-                                        type: string
-                                      fieldPath:
-                                        type: string
-                                    required:
-                                      - fieldPath
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  resourceFieldRef:
-                                    properties:
-                                      containerName:
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        type: string
-                                    required:
-                                      - resource
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  secretKeyRef:
-                                    properties:
-                                      key:
-                                        type: string
-                                      name:
-                                        default: ""
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                type: object
-                            required:
-                              - name
-                            type: object
-                          type: array
-                        extraFlags:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        extraLabels:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        extraVolumeMounts:
-                          items:
-                            properties:
-                              mountPath:
-                                type: string
-                              mountPropagation:
-                                type: string
-                              name:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              recursiveReadOnly:
-                                type: string
-                              subPath:
-                                type: string
-                              subPathExpr:
-                                type: string
-                            required:
-                              - mountPath
-                              - name
-                            type: object
-                          type: array
-                        extraVolumes:
-                          x-kubernetes-preserve-unknown-fields: true
-                        image:
-                          type: string
-                        imagePullPolicy:
-                          type: string
-                        imagePullSecrets:
-                          items:
-                            properties:
-                              name:
-                                default: ""
-                                type: string
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          type: array
-                        initContainers:
-                          x-kubernetes-preserve-unknown-fields: true
-                        localMemberIndex:
-                          format: int32
-                          maximum: 3
-                          minimum: 1
-                          type: integer
-                        peerService:
-                          properties:
-                            annotations:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            clusterIP:
-                              type: string
-                          type: object
-                        resources:
-                          properties:
-                            claims:
-                              items:
-                                properties:
-                                  name:
-                                    type: string
-                                  request:
-                                    type: string
-                                required:
-                                  - name
-                                type: object
-                              type: array
-                              x-kubernetes-list-map-keys:
-                                - name
-                              x-kubernetes-list-type: map
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              type: object
-                          type: object
-                        sidecarContainers:
-                          x-kubernetes-preserve-unknown-fields: true
-                        tolerations:
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                    external:
-                      properties:
-                        address:
-                          type: string
-                        implementation:
-                          type: string
-                        rootPath:
-                          type: string
-                      required:
-                        - address
-                        - implementation
-                        - rootPath
-                      type: object
-                  type: object
-                name:
-                  maxLength: 63
-                  minLength: 1
-                  pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
-                  type: string
-                topologyReconciliation:
-                  properties:
-                    pruneCells:
-                      type: boolean
-                    pruneKeyspaces:
-                      type: boolean
-                    pruneShardCells:
-                      type: boolean
-                    pruneShards:
-                      type: boolean
-                    pruneSrvKeyspaces:
-                      type: boolean
-                    pruneTablets:
-                      type: boolean
-                    registerCells:
-                      type: boolean
-                    registerCellsAliases:
-                      type: boolean
-                  type: object
-                zone:
-                  type: string
-              required:
-                - allCells
-                - globalLockserver
-                - name
-              type: object
-            status:
-              properties:
-                gateway:
-                  properties:
-                    available:
-                      type: string
-                    labelSelector:
-                      type: string
-                    replicas:
-                      format: int32
-                      minimum: 0
-                      type: integer
-                    serviceName:
-                      type: string
-                  type: object
-                idle:
-                  type: string
-                keyspaces:
-                  additionalProperties:
-                    type: object
-                  type: object
-                lockserver:
-                  properties:
-                    etcd:
-                      properties:
-                        available:
-                          type: string
-                        clientServiceName:
-                          type: string
-                        observedGeneration:
-                          format: int64
-                          type: integer
-                      type: object
-                  type: object
-                observedGeneration:
-                  format: int64
-                  type: integer
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        scale:
-          labelSelectorPath: .status.gateway.labelSelector
-          specReplicasPath: .spec.gateway.replicas
-          statusReplicasPath: .status.gateway.replicas
-        status: {}
+                type: object
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.gateway.labelSelector
+        specReplicasPath: .spec.gateway.replicas
+        statusReplicasPath: .status.gateway.replicas
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: vitessclusters.planetscale.com
 spec:
   group: planetscale.com
@@ -2063,6 +2145,12 @@ spec:
                           additionalProperties:
                             type: string
                           type: object
+                        backupMethod:
+                          default: vtbackup
+                          enum:
+                          - vtbackup
+                          - vtctldclient
+                          type: string
                         concurrencyPolicy:
                           default: Forbid
                           enum:
@@ -2159,6 +2247,8 @@ spec:
                           type: integer
                         suspend:
                           type: boolean
+                        tolerations:
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - name
                       - resources
@@ -4117,6 +4207,104 @@ spec:
                                       - cell
                                       - name
                                       x-kubernetes-list-type: map
+                                    vtbackup:
+                                      properties:
+                                        dataVolumeClaimTemplate:
+                                          properties:
+                                            accessModes:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            dataSource:
+                                              properties:
+                                                apiGroup:
+                                                  type: string
+                                                kind:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              - name
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            dataSourceRef:
+                                              properties:
+                                                apiGroup:
+                                                  type: string
+                                                kind:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              - name
+                                              type: object
+                                            resources:
+                                              properties:
+                                                limits:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  type: object
+                                                requests:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  type: object
+                                              type: object
+                                            selector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            storageClassName:
+                                              type: string
+                                            volumeAttributesClassName:
+                                              type: string
+                                            volumeMode:
+                                              type: string
+                                            volumeName:
+                                              type: string
+                                          type: object
+                                        useEmptyDirForInitialBackup:
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: useEmptyDirForInitialBackup and dataVolumeClaimTemplate
+                                          are mutually exclusive
+                                        rule: '!(has(self.useEmptyDirForInitialBackup)
+                                          && self.useEmptyDirForInitialBackup && has(self.dataVolumeClaimTemplate))'
                                   required:
                                   - databaseInitScriptSecret
                                   - keyRange
@@ -4587,6 +4775,104 @@ spec:
                                     - cell
                                     - name
                                     x-kubernetes-list-type: map
+                                  vtbackup:
+                                    properties:
+                                      dataVolumeClaimTemplate:
+                                        properties:
+                                          accessModes:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          dataSource:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                            - kind
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          dataSourceRef:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                            required:
+                                            - kind
+                                            - name
+                                            type: object
+                                          resources:
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          selector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          storageClassName:
+                                            type: string
+                                          volumeAttributesClassName:
+                                            type: string
+                                          volumeMode:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        type: object
+                                      useEmptyDirForInitialBackup:
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-validations:
+                                    - message: useEmptyDirForInitialBackup and dataVolumeClaimTemplate
+                                        are mutually exclusive
+                                      rule: '!(has(self.useEmptyDirForInitialBackup)
+                                        && self.useEmptyDirForInitialBackup && has(self.dataVolumeClaimTemplate))'
                                 required:
                                 - databaseInitScriptSecret
                                 type: object
@@ -4781,6 +5067,13 @@ spec:
                   - partitionings
                   type: object
                 type: array
+              tabletRefreshInterval:
+                type: string
+                x-kubernetes-validations:
+                - message: tabletRefreshInterval must be a valid duration of at least
+                    1s using s, m, or h units
+                  rule: self.matches('^([0-9]+([.][0-9]+)?(s|m|h))+$') && duration(self)
+                    >= duration('1s')
               tabletService:
                 properties:
                   annotations:
@@ -5248,6 +5541,8 @@ spec:
                       type: string
                     pendingChanges:
                       type: string
+                    tabletRefreshInterval:
+                      type: string
                   type: object
                 type: object
               gatewayServiceName:
@@ -5289,6 +5584,8 @@ spec:
                     shards:
                       format: int32
                       type: integer
+                    tabletRefreshInterval:
+                      type: string
                     tablets:
                       format: int32
                       type: integer
@@ -5352,7 +5649,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: vitesskeyspaces.planetscale.com
 spec:
   group: planetscale.com
@@ -5361,691 +5658,229 @@ spec:
     listKind: VitessKeyspaceList
     plural: vitesskeyspaces
     shortNames:
-      - vtk
+    - vtk
     singular: vitesskeyspace
   scope: Namespaced
   versions:
-    - name: v2
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                annotations:
-                  additionalProperties:
-                    type: string
-                  type: object
-                backupEngine:
+  - name: v2
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              annotations:
+                additionalProperties:
                   type: string
-                backupLocations:
-                  items:
-                    properties:
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      azblob:
-                        properties:
-                          account:
-                            minLength: 1
-                            type: string
-                          authSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                              - key
-                            type: object
-                          container:
-                            minLength: 1
-                            type: string
-                          keyPrefix:
-                            maxLength: 256
-                            pattern: ^[^\r\n]*$
-                            type: string
-                        required:
-                          - account
-                          - authSecret
-                          - container
-                        type: object
-                      ceph:
-                        properties:
-                          authSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                              - key
-                            type: object
-                        required:
-                          - authSecret
-                        type: object
-                      gcs:
-                        properties:
-                          authSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                              - key
-                            type: object
-                          bucket:
-                            minLength: 1
-                            type: string
-                          keyPrefix:
-                            maxLength: 256
-                            pattern: ^[^\r\n]*$
-                            type: string
-                        required:
-                          - bucket
-                        type: object
-                      name:
-                        maxLength: 63
-                        pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
-                        type: string
-                      s3:
-                        properties:
-                          authSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                              - key
-                            type: object
-                          bucket:
-                            minLength: 1
-                            type: string
-                          endpoint:
-                            type: string
-                          forcePathStyle:
-                            type: boolean
-                          keyPrefix:
-                            maxLength: 256
-                            pattern: ^[^\r\n]*$
-                            type: string
-                          minPartSize:
-                            format: int64
-                            type: integer
-                          region:
-                            minLength: 1
-                            type: string
-                        required:
-                          - bucket
-                          - region
-                        type: object
-                      volume:
-                        x-kubernetes-preserve-unknown-fields: true
-                      volumeSubPath:
-                        type: string
-                    type: object
-                  type: array
-                databaseName:
-                  type: string
-                durabilityPolicy:
-                  type: string
-                extraVitessFlags:
-                  additionalProperties:
-                    type: string
-                  type: object
-                globalLockserver:
+                type: object
+              backupEngine:
+                type: string
+              backupLocations:
+                items:
                   properties:
-                    address:
-                      type: string
-                    implementation:
-                      type: string
-                    rootPath:
-                      type: string
-                  required:
-                    - address
-                    - implementation
-                    - rootPath
-                  type: object
-                imagePullPolicies:
-                  properties:
-                    mysqld:
-                      type: string
-                    mysqldExporter:
-                      type: string
-                    vtadmin:
-                      type: string
-                    vtbackup:
-                      type: string
-                    vtctld:
-                      type: string
-                    vtgate:
-                      type: string
-                    vtorc:
-                      type: string
-                    vttablet:
-                      type: string
-                  type: object
-                imagePullSecrets:
-                  items:
-                    properties:
-                      name:
-                        default: ""
+                    annotations:
+                      additionalProperties:
                         type: string
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  type: array
-                images:
-                  properties:
-                    mysqld:
-                      properties:
-                        mariadb103Compatible:
-                          type: string
-                        mariadbCompatible:
-                          type: string
-                        mysql56Compatible:
-                          type: string
-                        mysql80Compatible:
-                          type: string
                       type: object
-                    mysqldExporter:
+                    azblob:
+                      properties:
+                        account:
+                          minLength: 1
+                          type: string
+                        authSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                          - key
+                          type: object
+                        container:
+                          minLength: 1
+                          type: string
+                        keyPrefix:
+                          maxLength: 256
+                          pattern: ^[^\r\n]*$
+                          type: string
+                      required:
+                      - account
+                      - authSecret
+                      - container
+                      type: object
+                    ceph:
+                      properties:
+                        authSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                          - key
+                          type: object
+                      required:
+                      - authSecret
+                      type: object
+                    gcs:
+                      properties:
+                        authSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                          - key
+                          type: object
+                        bucket:
+                          minLength: 1
+                          type: string
+                        keyPrefix:
+                          maxLength: 256
+                          pattern: ^[^\r\n]*$
+                          type: string
+                      required:
+                      - bucket
+                      type: object
+                    name:
+                      maxLength: 63
+                      pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
                       type: string
-                    vtbackup:
-                      type: string
-                    vtorc:
-                      type: string
-                    vttablet:
+                    s3:
+                      properties:
+                        authSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                          - key
+                          type: object
+                        bucket:
+                          minLength: 1
+                          type: string
+                        endpoint:
+                          type: string
+                        forcePathStyle:
+                          type: boolean
+                        keyPrefix:
+                          maxLength: 256
+                          pattern: ^[^\r\n]*$
+                          type: string
+                        minPartSize:
+                          format: int64
+                          type: integer
+                        region:
+                          minLength: 1
+                          type: string
+                      required:
+                      - bucket
+                      - region
+                      type: object
+                    volume:
+                      x-kubernetes-preserve-unknown-fields: true
+                    volumeSubPath:
                       type: string
                   type: object
-                name:
-                  maxLength: 63
-                  minLength: 1
-                  pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
+                type: array
+              databaseName:
+                type: string
+              durabilityPolicy:
+                type: string
+              extraVitessFlags:
+                additionalProperties:
                   type: string
-                partitionings:
-                  items:
+                type: object
+              globalLockserver:
+                properties:
+                  address:
+                    type: string
+                  implementation:
+                    type: string
+                  rootPath:
+                    type: string
+                required:
+                - address
+                - implementation
+                - rootPath
+                type: object
+              imagePullPolicies:
+                properties:
+                  mysqld:
+                    type: string
+                  mysqldExporter:
+                    type: string
+                  vtadmin:
+                    type: string
+                  vtbackup:
+                    type: string
+                  vtctld:
+                    type: string
+                  vtgate:
+                    type: string
+                  vtorc:
+                    type: string
+                  vttablet:
+                    type: string
+                type: object
+              imagePullSecrets:
+                items:
+                  properties:
+                    name:
+                      default: ""
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              images:
+                properties:
+                  mysqld:
                     properties:
-                      custom:
-                        properties:
-                          shards:
-                            items:
-                              properties:
-                                annotations:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                databaseInitScriptSecret:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    volumeName:
-                                      type: string
-                                  required:
-                                    - key
-                                  type: object
-                                keyRange:
-                                  properties:
-                                    end:
-                                      pattern: ^([0-9a-f][0-9a-f])*$
-                                      type: string
-                                    start:
-                                      pattern: ^([0-9a-f][0-9a-f])*$
-                                      type: string
-                                  type: object
-                                replication:
-                                  properties:
-                                    initializeBackup:
-                                      type: boolean
-                                    initializeMaster:
-                                      type: boolean
-                                    recoverRestartedMaster:
-                                      type: boolean
-                                  type: object
-                                tabletPools:
-                                  items:
-                                    properties:
-                                      affinity:
-                                        x-kubernetes-preserve-unknown-fields: true
-                                      annotations:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                      backupLocationName:
-                                        type: string
-                                      cell:
-                                        maxLength: 63
-                                        minLength: 1
-                                        pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
-                                        type: string
-                                      dataVolumeClaimTemplate:
-                                        properties:
-                                          accessModes:
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          dataSource:
-                                            properties:
-                                              apiGroup:
-                                                type: string
-                                              kind:
-                                                type: string
-                                              name:
-                                                type: string
-                                            required:
-                                              - kind
-                                              - name
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          dataSourceRef:
-                                            properties:
-                                              apiGroup:
-                                                type: string
-                                              kind:
-                                                type: string
-                                              name:
-                                                type: string
-                                              namespace:
-                                                type: string
-                                            required:
-                                              - kind
-                                              - name
-                                            type: object
-                                          resources:
-                                            properties:
-                                              limits:
-                                                additionalProperties:
-                                                  anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                type: object
-                                              requests:
-                                                additionalProperties:
-                                                  anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                type: object
-                                            type: object
-                                          selector:
-                                            properties:
-                                              matchExpressions:
-                                                items:
-                                                  properties:
-                                                    key:
-                                                      type: string
-                                                    operator:
-                                                      type: string
-                                                    values:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                      x-kubernetes-list-type: atomic
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                                x-kubernetes-list-type: atomic
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                type: object
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          storageClassName:
-                                            type: string
-                                          volumeAttributesClassName:
-                                            type: string
-                                          volumeMode:
-                                            type: string
-                                          volumeName:
-                                            type: string
-                                        type: object
-                                      externalDatastore:
-                                        properties:
-                                          credentialsSecret:
-                                            properties:
-                                              key:
-                                                type: string
-                                              name:
-                                                type: string
-                                              volumeName:
-                                                type: string
-                                            required:
-                                              - key
-                                            type: object
-                                          database:
-                                            type: string
-                                          host:
-                                            type: string
-                                          port:
-                                            format: int32
-                                            maximum: 65535
-                                            minimum: 1
-                                            type: integer
-                                          serverCACertSecret:
-                                            properties:
-                                              key:
-                                                type: string
-                                              name:
-                                                type: string
-                                              volumeName:
-                                                type: string
-                                            required:
-                                              - key
-                                            type: object
-                                          user:
-                                            type: string
-                                        required:
-                                          - credentialsSecret
-                                          - database
-                                          - host
-                                          - port
-                                          - user
-                                        type: object
-                                      extraEnv:
-                                        items:
-                                          properties:
-                                            name:
-                                              type: string
-                                            value:
-                                              type: string
-                                            valueFrom:
-                                              properties:
-                                                configMapKeyRef:
-                                                  properties:
-                                                    key:
-                                                      type: string
-                                                    name:
-                                                      default: ""
-                                                      type: string
-                                                    optional:
-                                                      type: boolean
-                                                  required:
-                                                    - key
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                fieldRef:
-                                                  properties:
-                                                    apiVersion:
-                                                      type: string
-                                                    fieldPath:
-                                                      type: string
-                                                  required:
-                                                    - fieldPath
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                resourceFieldRef:
-                                                  properties:
-                                                    containerName:
-                                                      type: string
-                                                    divisor:
-                                                      anyOf:
-                                                        - type: integer
-                                                        - type: string
-                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                      x-kubernetes-int-or-string: true
-                                                    resource:
-                                                      type: string
-                                                  required:
-                                                    - resource
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                                secretKeyRef:
-                                                  properties:
-                                                    key:
-                                                      type: string
-                                                    name:
-                                                      default: ""
-                                                      type: string
-                                                    optional:
-                                                      type: boolean
-                                                  required:
-                                                    - key
-                                                  type: object
-                                                  x-kubernetes-map-type: atomic
-                                              type: object
-                                          required:
-                                            - name
-                                          type: object
-                                        type: array
-                                      extraLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                      extraVolumeMounts:
-                                        items:
-                                          properties:
-                                            mountPath:
-                                              type: string
-                                            mountPropagation:
-                                              type: string
-                                            name:
-                                              type: string
-                                            readOnly:
-                                              type: boolean
-                                            recursiveReadOnly:
-                                              type: string
-                                            subPath:
-                                              type: string
-                                            subPathExpr:
-                                              type: string
-                                          required:
-                                            - mountPath
-                                            - name
-                                          type: object
-                                        type: array
-                                      extraVolumes:
-                                        x-kubernetes-preserve-unknown-fields: true
-                                      initContainers:
-                                        x-kubernetes-preserve-unknown-fields: true
-                                      mysqld:
-                                        properties:
-                                          configOverrides:
-                                            type: string
-                                          resources:
-                                            properties:
-                                              claims:
-                                                items:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    request:
-                                                      type: string
-                                                  required:
-                                                    - name
-                                                  type: object
-                                                type: array
-                                                x-kubernetes-list-map-keys:
-                                                  - name
-                                                x-kubernetes-list-type: map
-                                              limits:
-                                                additionalProperties:
-                                                  anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                type: object
-                                              requests:
-                                                additionalProperties:
-                                                  anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                type: object
-                                            type: object
-                                        required:
-                                          - resources
-                                        type: object
-                                      mysqldExporter:
-                                        properties:
-                                          extraFlags:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
-                                          resources:
-                                            properties:
-                                              claims:
-                                                items:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    request:
-                                                      type: string
-                                                  required:
-                                                    - name
-                                                  type: object
-                                                type: array
-                                                x-kubernetes-list-map-keys:
-                                                  - name
-                                                x-kubernetes-list-type: map
-                                              limits:
-                                                additionalProperties:
-                                                  anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                type: object
-                                              requests:
-                                                additionalProperties:
-                                                  anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                type: object
-                                            type: object
-                                        type: object
-                                      name:
-                                        default: ""
-                                        type: string
-                                      replicas:
-                                        format: int32
-                                        minimum: 0
-                                        type: integer
-                                      sidecarContainers:
-                                        x-kubernetes-preserve-unknown-fields: true
-                                      tolerations:
-                                        x-kubernetes-preserve-unknown-fields: true
-                                      topologySpreadConstraints:
-                                        x-kubernetes-preserve-unknown-fields: true
-                                      type:
-                                        enum:
-                                          - replica
-                                          - rdonly
-                                          - externalmaster
-                                          - externalreplica
-                                          - externalrdonly
-                                        type: string
-                                      vttablet:
-                                        properties:
-                                          extraFlags:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
-                                          vtbackupExtraFlags:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
-                                          lifecycle:
-                                            x-kubernetes-preserve-unknown-fields: true
-                                          resources:
-                                            properties:
-                                              claims:
-                                                items:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    request:
-                                                      type: string
-                                                  required:
-                                                    - name
-                                                  type: object
-                                                type: array
-                                                x-kubernetes-list-map-keys:
-                                                  - name
-                                                x-kubernetes-list-type: map
-                                              limits:
-                                                additionalProperties:
-                                                  anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                type: object
-                                              requests:
-                                                additionalProperties:
-                                                  anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                type: object
-                                            type: object
-                                          terminationGracePeriodSeconds:
-                                            format: int64
-                                            type: integer
-                                        required:
-                                          - resources
-                                        type: object
-                                    required:
-                                      - cell
-                                      - replicas
-                                      - type
-                                      - vttablet
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-map-keys:
-                                    - type
-                                    - cell
-                                    - name
-                                  x-kubernetes-list-type: map
-                              required:
-                                - databaseInitScriptSecret
-                                - keyRange
-                              type: object
-                            type: array
-                        required:
-                          - shards
-                        type: object
-                      equal:
-                        properties:
-                          hexWidth:
-                            default: 0
-                            format: int32
-                            maximum: 65536
-                            minimum: 0
-                            type: integer
-                          parts:
-                            format: int32
-                            maximum: 65536
-                            minimum: 1
-                            type: integer
-                          shardTemplate:
+                      mariadb103Compatible:
+                        type: string
+                      mariadbCompatible:
+                        type: string
+                      mysql56Compatible:
+                        type: string
+                      mysql80Compatible:
+                        type: string
+                    type: object
+                  mysqldExporter:
+                    type: string
+                  vtbackup:
+                    type: string
+                  vtorc:
+                    type: string
+                  vttablet:
+                    type: string
+                type: object
+              name:
+                maxLength: 63
+                minLength: 1
+                pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
+                type: string
+              partitionings:
+                items:
+                  properties:
+                    custom:
+                      properties:
+                        shards:
+                          items:
                             properties:
                               annotations:
                                 additionalProperties:
@@ -6060,7 +5895,16 @@ spec:
                                   volumeName:
                                     type: string
                                 required:
-                                  - key
+                                - key
+                                type: object
+                              keyRange:
+                                properties:
+                                  end:
+                                    pattern: ^([0-9a-f][0-9a-f])*$
+                                    type: string
+                                  start:
+                                    pattern: ^([0-9a-f][0-9a-f])*$
+                                    type: string
                                 type: object
                               replication:
                                 properties:
@@ -6103,8 +5947,8 @@ spec:
                                             name:
                                               type: string
                                           required:
-                                            - kind
-                                            - name
+                                          - kind
+                                          - name
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
@@ -6118,24 +5962,24 @@ spec:
                                             namespace:
                                               type: string
                                           required:
-                                            - kind
-                                            - name
+                                          - kind
+                                          - name
                                           type: object
                                         resources:
                                           properties:
                                             limits:
                                               additionalProperties:
                                                 anyOf:
-                                                  - type: integer
-                                                  - type: string
+                                                - type: integer
+                                                - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               type: object
                                             requests:
                                               additionalProperties:
                                                 anyOf:
-                                                  - type: integer
-                                                  - type: string
+                                                - type: integer
+                                                - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               type: object
@@ -6155,8 +5999,8 @@ spec:
                                                     type: array
                                                     x-kubernetes-list-type: atomic
                                                 required:
-                                                  - key
-                                                  - operator
+                                                - key
+                                                - operator
                                                 type: object
                                               type: array
                                               x-kubernetes-list-type: atomic
@@ -6186,7 +6030,7 @@ spec:
                                             volumeName:
                                               type: string
                                           required:
-                                            - key
+                                          - key
                                           type: object
                                         database:
                                           type: string
@@ -6206,16 +6050,16 @@ spec:
                                             volumeName:
                                               type: string
                                           required:
-                                            - key
+                                          - key
                                           type: object
                                         user:
                                           type: string
                                       required:
-                                        - credentialsSecret
-                                        - database
-                                        - host
-                                        - port
-                                        - user
+                                      - credentialsSecret
+                                      - database
+                                      - host
+                                      - port
+                                      - user
                                       type: object
                                     extraEnv:
                                       items:
@@ -6236,7 +6080,7 @@ spec:
                                                   optional:
                                                     type: boolean
                                                 required:
-                                                  - key
+                                                - key
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               fieldRef:
@@ -6246,7 +6090,24 @@ spec:
                                                   fieldPath:
                                                     type: string
                                                 required:
-                                                  - fieldPath
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resourceFieldRef:
@@ -6255,14 +6116,14 @@ spec:
                                                     type: string
                                                   divisor:
                                                     anyOf:
-                                                      - type: integer
-                                                      - type: string
+                                                    - type: integer
+                                                    - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
                                                   resource:
                                                     type: string
                                                 required:
-                                                  - resource
+                                                - resource
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               secretKeyRef:
@@ -6275,12 +6136,12 @@ spec:
                                                   optional:
                                                     type: boolean
                                                 required:
-                                                  - key
+                                                - key
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                             type: object
                                         required:
-                                          - name
+                                        - name
                                         type: object
                                       type: array
                                     extraLabels:
@@ -6305,8 +6166,8 @@ spec:
                                           subPathExpr:
                                             type: string
                                         required:
-                                          - mountPath
-                                          - name
+                                        - mountPath
+                                        - name
                                         type: object
                                       type: array
                                     extraVolumes:
@@ -6327,31 +6188,31 @@ spec:
                                                   request:
                                                     type: string
                                                 required:
-                                                  - name
+                                                - name
                                                 type: object
                                               type: array
                                               x-kubernetes-list-map-keys:
-                                                - name
+                                              - name
                                               x-kubernetes-list-type: map
                                             limits:
                                               additionalProperties:
                                                 anyOf:
-                                                  - type: integer
-                                                  - type: string
+                                                - type: integer
+                                                - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               type: object
                                             requests:
                                               additionalProperties:
                                                 anyOf:
-                                                  - type: integer
-                                                  - type: string
+                                                - type: integer
+                                                - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               type: object
                                           type: object
                                       required:
-                                        - resources
+                                      - resources
                                       type: object
                                     mysqldExporter:
                                       properties:
@@ -6369,25 +6230,25 @@ spec:
                                                   request:
                                                     type: string
                                                 required:
-                                                  - name
+                                                - name
                                                 type: object
                                               type: array
                                               x-kubernetes-list-map-keys:
-                                                - name
+                                              - name
                                               x-kubernetes-list-type: map
                                             limits:
                                               additionalProperties:
                                                 anyOf:
-                                                  - type: integer
-                                                  - type: string
+                                                - type: integer
+                                                - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               type: object
                                             requests:
                                               additionalProperties:
                                                 anyOf:
-                                                  - type: integer
-                                                  - type: string
+                                                - type: integer
+                                                - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               type: object
@@ -6408,19 +6269,15 @@ spec:
                                       x-kubernetes-preserve-unknown-fields: true
                                     type:
                                       enum:
-                                        - replica
-                                        - rdonly
-                                        - externalmaster
-                                        - externalreplica
-                                        - externalrdonly
+                                      - replica
+                                      - rdonly
+                                      - externalmaster
+                                      - externalreplica
+                                      - externalrdonly
                                       type: string
                                     vttablet:
                                       properties:
                                         extraFlags:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                        vtbackupExtraFlags:
                                           additionalProperties:
                                             type: string
                                           type: object
@@ -6436,25 +6293,25 @@ spec:
                                                   request:
                                                     type: string
                                                 required:
-                                                  - name
+                                                - name
                                                 type: object
                                               type: array
                                               x-kubernetes-list-map-keys:
-                                                - name
+                                              - name
                                               x-kubernetes-list-type: map
                                             limits:
                                               additionalProperties:
                                                 anyOf:
-                                                  - type: integer
-                                                  - type: string
+                                                - type: integer
+                                                - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               type: object
                                             requests:
                                               additionalProperties:
                                                 anyOf:
-                                                  - type: integer
-                                                  - type: string
+                                                - type: integer
+                                                - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               type: object
@@ -6462,368 +6319,1065 @@ spec:
                                         terminationGracePeriodSeconds:
                                           format: int64
                                           type: integer
+                                        vtbackupExtraFlags:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
                                       required:
-                                        - resources
+                                      - resources
                                       type: object
                                   required:
-                                    - cell
-                                    - replicas
-                                    - type
-                                    - vttablet
+                                  - cell
+                                  - replicas
+                                  - type
+                                  - vttablet
                                   type: object
                                 type: array
                                 x-kubernetes-list-map-keys:
-                                  - type
-                                  - cell
-                                  - name
+                                - type
+                                - cell
+                                - name
                                 x-kubernetes-list-type: map
+                              vtbackup:
+                                properties:
+                                  dataVolumeClaimTemplate:
+                                    properties:
+                                      accessModes:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      dataSource:
+                                        properties:
+                                          apiGroup:
+                                            type: string
+                                          kind:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      dataSourceRef:
+                                        properties:
+                                          apiGroup:
+                                            type: string
+                                          kind:
+                                            type: string
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      resources:
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      selector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      storageClassName:
+                                        type: string
+                                      volumeAttributesClassName:
+                                        type: string
+                                      volumeMode:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    type: object
+                                  useEmptyDirForInitialBackup:
+                                    type: boolean
+                                type: object
+                                x-kubernetes-validations:
+                                - message: useEmptyDirForInitialBackup and dataVolumeClaimTemplate
+                                    are mutually exclusive
+                                  rule: '!(has(self.useEmptyDirForInitialBackup) &&
+                                    self.useEmptyDirForInitialBackup && has(self.dataVolumeClaimTemplate))'
                             required:
-                              - databaseInitScriptSecret
+                            - databaseInitScriptSecret
+                            - keyRange
                             type: object
-                        required:
-                          - hexWidth
-                          - parts
-                        type: object
-                    type: object
-                  maxItems: 2
-                  minItems: 1
-                  type: array
-                sidecarDbName:
-                  type: string
-                topologyReconciliation:
-                  properties:
-                    pruneCells:
-                      type: boolean
-                    pruneKeyspaces:
-                      type: boolean
-                    pruneShardCells:
-                      type: boolean
-                    pruneShards:
-                      type: boolean
-                    pruneSrvKeyspaces:
-                      type: boolean
-                    pruneTablets:
-                      type: boolean
-                    registerCells:
-                      type: boolean
-                    registerCellsAliases:
-                      type: boolean
-                  type: object
-                turndownPolicy:
-                  enum:
-                    - RequireIdle
-                    - Immediate
-                  type: string
-                updateStrategy:
-                  properties:
-                    external:
-                      properties:
-                        allowResourceChanges:
-                          items:
-                            type: string
                           type: array
+                      required:
+                      - shards
                       type: object
-                    type:
-                      enum:
-                        - External
-                        - Immediate
-                      type: string
-                  type: object
-                vitessOrchestrator:
-                  properties:
-                    affinity:
-                      x-kubernetes-preserve-unknown-fields: true
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    extraEnv:
-                      items:
-                        properties:
-                          name:
-                            type: string
-                          value:
-                            type: string
-                          valueFrom:
-                            properties:
-                              configMapKeyRef:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    default: ""
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              fieldRef:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  fieldPath:
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              resourceFieldRef:
-                                properties:
-                                  containerName:
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              secretKeyRef:
-                                properties:
-                                  key:
-                                    type: string
-                                  name:
-                                    default: ""
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    extraFlags:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    extraLabels:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    extraVolumeMounts:
-                      items:
-                        properties:
-                          mountPath:
-                            type: string
-                          mountPropagation:
-                            type: string
-                          name:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          recursiveReadOnly:
-                            type: string
-                          subPath:
-                            type: string
-                          subPathExpr:
-                            type: string
-                        required:
-                          - mountPath
-                          - name
-                        type: object
-                      type: array
-                    extraVolumes:
-                      x-kubernetes-preserve-unknown-fields: true
-                    initContainers:
-                      x-kubernetes-preserve-unknown-fields: true
-                    resources:
+                    equal:
                       properties:
-                        claims:
-                          items:
-                            properties:
-                              name:
+                        hexWidth:
+                          default: 0
+                          format: int32
+                          maximum: 65536
+                          minimum: 0
+                          type: integer
+                        parts:
+                          format: int32
+                          maximum: 65536
+                          minimum: 1
+                          type: integer
+                        shardTemplate:
+                          properties:
+                            annotations:
+                              additionalProperties:
                                 type: string
-                              request:
-                                type: string
-                            required:
+                              type: object
+                            databaseInitScriptSecret:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                              - key
+                              type: object
+                            replication:
+                              properties:
+                                initializeBackup:
+                                  type: boolean
+                                initializeMaster:
+                                  type: boolean
+                                recoverRestartedMaster:
+                                  type: boolean
+                              type: object
+                            tabletPools:
+                              items:
+                                properties:
+                                  affinity:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  backupLocationName:
+                                    type: string
+                                  cell:
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
+                                    type: string
+                                  dataVolumeClaimTemplate:
+                                    properties:
+                                      accessModes:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      dataSource:
+                                        properties:
+                                          apiGroup:
+                                            type: string
+                                          kind:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      dataSourceRef:
+                                        properties:
+                                          apiGroup:
+                                            type: string
+                                          kind:
+                                            type: string
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      resources:
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      selector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      storageClassName:
+                                        type: string
+                                      volumeAttributesClassName:
+                                        type: string
+                                      volumeMode:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    type: object
+                                  externalDatastore:
+                                    properties:
+                                      credentialsSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        type: object
+                                      database:
+                                        type: string
+                                      host:
+                                        type: string
+                                      port:
+                                        format: int32
+                                        maximum: 65535
+                                        minimum: 1
+                                        type: integer
+                                      serverCACertSecret:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        type: object
+                                      user:
+                                        type: string
+                                    required:
+                                    - credentialsSecret
+                                    - database
+                                    - host
+                                    - port
+                                    - user
+                                    type: object
+                                  extraEnv:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            configMapKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  extraLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  extraVolumeMounts:
+                                    items:
+                                      properties:
+                                        mountPath:
+                                          type: string
+                                        mountPropagation:
+                                          type: string
+                                        name:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        recursiveReadOnly:
+                                          type: string
+                                        subPath:
+                                          type: string
+                                        subPathExpr:
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  extraVolumes:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  initContainers:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  mysqld:
+                                    properties:
+                                      configOverrides:
+                                        type: string
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                    required:
+                                    - resources
+                                    type: object
+                                  mysqldExporter:
+                                    properties:
+                                      extraFlags:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                    type: object
+                                  name:
+                                    default: ""
+                                    type: string
+                                  replicas:
+                                    format: int32
+                                    minimum: 0
+                                    type: integer
+                                  sidecarContainers:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  tolerations:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  topologySpreadConstraints:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  type:
+                                    enum:
+                                    - replica
+                                    - rdonly
+                                    - externalmaster
+                                    - externalreplica
+                                    - externalrdonly
+                                    type: string
+                                  vttablet:
+                                    properties:
+                                      extraFlags:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      lifecycle:
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      resources:
+                                        properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                request:
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        format: int64
+                                        type: integer
+                                      vtbackupExtraFlags:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    required:
+                                    - resources
+                                    type: object
+                                required:
+                                - cell
+                                - replicas
+                                - type
+                                - vttablet
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - type
+                              - cell
                               - name
-                            type: object
-                          type: array
-                          x-kubernetes-list-map-keys:
-                            - name
-                          x-kubernetes-list-type: map
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
+                              x-kubernetes-list-type: map
+                            vtbackup:
+                              properties:
+                                dataVolumeClaimTemplate:
+                                  properties:
+                                    accessModes:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    dataSource:
+                                      properties:
+                                        apiGroup:
+                                          type: string
+                                        kind:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    dataSourceRef:
+                                      properties:
+                                        apiGroup:
+                                          type: string
+                                        kind:
+                                          type: string
+                                        name:
+                                          type: string
+                                        namespace:
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    resources:
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    storageClassName:
+                                      type: string
+                                    volumeAttributesClassName:
+                                      type: string
+                                    volumeMode:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  type: object
+                                useEmptyDirForInitialBackup:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-validations:
+                              - message: useEmptyDirForInitialBackup and dataVolumeClaimTemplate
+                                  are mutually exclusive
+                                rule: '!(has(self.useEmptyDirForInitialBackup) &&
+                                  self.useEmptyDirForInitialBackup && has(self.dataVolumeClaimTemplate))'
+                          required:
+                          - databaseInitScriptSecret
                           type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          type: object
+                      required:
+                      - parts
                       type: object
-                    service:
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        clusterIP:
-                          type: string
-                      type: object
-                    sidecarContainers:
-                      x-kubernetes-preserve-unknown-fields: true
-                    tolerations:
-                      x-kubernetes-preserve-unknown-fields: true
                   type: object
-                zoneMap:
-                  additionalProperties:
-                    type: string
-                  type: object
-              required:
-                - globalLockserver
-                - name
-                - partitionings
-                - zoneMap
-              type: object
-            status:
-              properties:
-                conditions:
-                  items:
+                maxItems: 2
+                minItems: 1
+                type: array
+              sidecarDbName:
+                type: string
+              tabletRefreshInterval:
+                type: string
+                x-kubernetes-validations:
+                - message: tabletRefreshInterval must be a valid duration of at least
+                    1s using s, m, or h units
+                  rule: self.matches('^([0-9]+([.][0-9]+)?(s|m|h))+$') && duration(self)
+                    >= duration('1s')
+              topologyReconciliation:
+                properties:
+                  pruneCells:
+                    type: boolean
+                  pruneKeyspaces:
+                    type: boolean
+                  pruneShardCells:
+                    type: boolean
+                  pruneShards:
+                    type: boolean
+                  pruneSrvKeyspaces:
+                    type: boolean
+                  pruneTablets:
+                    type: boolean
+                  registerCells:
+                    type: boolean
+                  registerCellsAliases:
+                    type: boolean
+                type: object
+              turndownPolicy:
+                enum:
+                - RequireIdle
+                - Immediate
+                type: string
+              updateStrategy:
+                properties:
+                  external:
                     properties:
-                      lastTransitionTime:
-                        format: date-time
-                        type: string
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                      status:
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        type: string
-                    required:
-                      - status
-                      - type
-                    type: object
-                  type: array
-                idle:
-                  type: string
-                observedGeneration:
-                  format: int64
-                  type: integer
-                orphanedShards:
-                  additionalProperties:
-                    properties:
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                    required:
-                      - message
-                      - reason
-                    type: object
-                  type: object
-                partitionings:
-                  items:
-                    properties:
-                      desiredShards:
-                        format: int32
-                        type: integer
-                      desiredTablets:
-                        format: int32
-                        type: integer
-                      readyShards:
-                        format: int32
-                        type: integer
-                      readyTablets:
-                        format: int32
-                        type: integer
-                      servingWrites:
-                        type: string
-                      shardNames:
+                      allowResourceChanges:
                         items:
                           type: string
                         type: array
-                      tablets:
-                        format: int32
-                        type: integer
-                      updatedTablets:
-                        format: int32
-                        type: integer
                     type: object
-                  type: array
-                resharding:
-                  properties:
-                    copyProgress:
-                      type: integer
-                    sourceShards:
-                      items:
-                        type: string
-                      type: array
-                    state:
+                  type:
+                    enum:
+                    - External
+                    - Immediate
+                    type: string
+                type: object
+              vitessOrchestrator:
+                properties:
+                  affinity:
+                    x-kubernetes-preserve-unknown-fields: true
+                  annotations:
+                    additionalProperties:
                       type: string
-                    targetShards:
-                      items:
+                    type: object
+                  extraEnv:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                        valueFrom:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  extraFlags:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  extraLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  extraVolumeMounts:
+                    items:
+                      properties:
+                        mountPath:
+                          type: string
+                        mountPropagation:
+                          type: string
+                        name:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        recursiveReadOnly:
+                          type: string
+                        subPath:
+                          type: string
+                        subPathExpr:
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                  extraVolumes:
+                    x-kubernetes-preserve-unknown-fields: true
+                  initContainers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  resources:
+                    properties:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  service:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      clusterIP:
                         type: string
-                      type: array
-                    workflow:
+                    type: object
+                  sidecarContainers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  tolerations:
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              zoneMap:
+                additionalProperties:
+                  type: string
+                type: object
+            required:
+            - globalLockserver
+            - name
+            - partitionings
+            - zoneMap
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
                       type: string
                   required:
-                    - state
-                    - workflow
+                  - status
+                  - type
                   type: object
-                shards:
-                  additionalProperties:
-                    properties:
-                      cells:
-                        items:
-                          type: string
-                        type: array
-                      desiredTablets:
-                        format: int32
-                        type: integer
-                      hasMaster:
-                        type: string
-                      pendingChanges:
-                        type: string
-                      readyTablets:
-                        format: int32
-                        type: integer
-                      servingWrites:
-                        type: string
-                      tablets:
-                        format: int32
-                        type: integer
-                      updatedTablets:
-                        format: int32
-                        type: integer
-                    type: object
+                type: array
+              idle:
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+              orphanedShards:
+                additionalProperties:
+                  properties:
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                  required:
+                  - message
+                  - reason
                   type: object
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: object
+              partitionings:
+                items:
+                  properties:
+                    desiredShards:
+                      format: int32
+                      type: integer
+                    desiredTablets:
+                      format: int32
+                      type: integer
+                    readyShards:
+                      format: int32
+                      type: integer
+                    readyTablets:
+                      format: int32
+                      type: integer
+                    servingWrites:
+                      type: string
+                    shardNames:
+                      items:
+                        type: string
+                      type: array
+                    tablets:
+                      format: int32
+                      type: integer
+                    updatedTablets:
+                      format: int32
+                      type: integer
+                  type: object
+                type: array
+              resharding:
+                properties:
+                  copyProgress:
+                    type: integer
+                  sourceShards:
+                    items:
+                      type: string
+                    type: array
+                  state:
+                    type: string
+                  targetShards:
+                    items:
+                      type: string
+                    type: array
+                  workflow:
+                    type: string
+                required:
+                - state
+                - workflow
+                type: object
+              shards:
+                additionalProperties:
+                  properties:
+                    cells:
+                      items:
+                        type: string
+                      type: array
+                    desiredTablets:
+                      format: int32
+                      type: integer
+                    hasMaster:
+                      type: string
+                    pendingChanges:
+                      type: string
+                    readyTablets:
+                      format: int32
+                      type: integer
+                    servingWrites:
+                      type: string
+                    tabletRefreshInterval:
+                      type: string
+                    tablets:
+                      format: int32
+                      type: integer
+                    updatedTablets:
+                      format: int32
+                      type: integer
+                  type: object
+                type: object
+              tabletRefreshInterval:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: vitessshards.planetscale.com
 spec:
   group: planetscale.com
@@ -6832,693 +7386,391 @@ spec:
     listKind: VitessShardList
     plural: vitessshards
     shortNames:
-      - vts
+    - vts
     singular: vitessshard
   scope: Namespaced
   versions:
-    - name: v2
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                annotations:
-                  additionalProperties:
-                    type: string
-                  type: object
-                backupEngine:
+  - name: v2
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              annotations:
+                additionalProperties:
                   type: string
-                backupLocations:
-                  items:
-                    properties:
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      azblob:
-                        properties:
-                          account:
-                            minLength: 1
-                            type: string
-                          authSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                              - key
-                            type: object
-                          container:
-                            minLength: 1
-                            type: string
-                          keyPrefix:
-                            maxLength: 256
-                            pattern: ^[^\r\n]*$
-                            type: string
-                        required:
-                          - account
-                          - authSecret
-                          - container
-                        type: object
-                      ceph:
-                        properties:
-                          authSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                              - key
-                            type: object
-                        required:
-                          - authSecret
-                        type: object
-                      gcs:
-                        properties:
-                          authSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                              - key
-                            type: object
-                          bucket:
-                            minLength: 1
-                            type: string
-                          keyPrefix:
-                            maxLength: 256
-                            pattern: ^[^\r\n]*$
-                            type: string
-                        required:
-                          - bucket
-                        type: object
-                      name:
-                        maxLength: 63
-                        pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
-                        type: string
-                      s3:
-                        properties:
-                          authSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                              - key
-                            type: object
-                          bucket:
-                            minLength: 1
-                            type: string
-                          endpoint:
-                            type: string
-                          forcePathStyle:
-                            type: boolean
-                          keyPrefix:
-                            maxLength: 256
-                            pattern: ^[^\r\n]*$
-                            type: string
-                          minPartSize:
-                            format: int64
-                            type: integer
-                          region:
-                            minLength: 1
-                            type: string
-                        required:
-                          - bucket
-                          - region
-                        type: object
-                      volume:
-                        x-kubernetes-preserve-unknown-fields: true
-                      volumeSubPath:
-                        type: string
-                    type: object
-                  type: array
-                databaseInitScriptSecret:
+                type: object
+              backupEngine:
+                type: string
+              backupLocations:
+                items:
                   properties:
-                    key:
-                      type: string
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    azblob:
+                      properties:
+                        account:
+                          minLength: 1
+                          type: string
+                        authSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                          - key
+                          type: object
+                        container:
+                          minLength: 1
+                          type: string
+                        keyPrefix:
+                          maxLength: 256
+                          pattern: ^[^\r\n]*$
+                          type: string
+                      required:
+                      - account
+                      - authSecret
+                      - container
+                      type: object
+                    ceph:
+                      properties:
+                        authSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                          - key
+                          type: object
+                      required:
+                      - authSecret
+                      type: object
+                    gcs:
+                      properties:
+                        authSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                          - key
+                          type: object
+                        bucket:
+                          minLength: 1
+                          type: string
+                        keyPrefix:
+                          maxLength: 256
+                          pattern: ^[^\r\n]*$
+                          type: string
+                      required:
+                      - bucket
+                      type: object
                     name:
+                      maxLength: 63
+                      pattern: ^[A-Za-z0-9]([A-Za-z0-9-_.]*[A-Za-z0-9])?$
                       type: string
-                    volumeName:
+                    s3:
+                      properties:
+                        authSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                          - key
+                          type: object
+                        bucket:
+                          minLength: 1
+                          type: string
+                        endpoint:
+                          type: string
+                        forcePathStyle:
+                          type: boolean
+                        keyPrefix:
+                          maxLength: 256
+                          pattern: ^[^\r\n]*$
+                          type: string
+                        minPartSize:
+                          format: int64
+                          type: integer
+                        region:
+                          minLength: 1
+                          type: string
+                      required:
+                      - bucket
+                      - region
+                      type: object
+                    volume:
+                      x-kubernetes-preserve-unknown-fields: true
+                    volumeSubPath:
                       type: string
-                  required:
-                    - key
                   type: object
-                databaseName:
-                  type: string
-                extraVitessFlags:
-                  additionalProperties:
+                type: array
+              databaseInitScriptSecret:
+                properties:
+                  key:
                     type: string
-                  type: object
-                globalLockserver:
-                  properties:
-                    address:
-                      type: string
-                    implementation:
-                      type: string
-                    rootPath:
-                      type: string
-                  required:
-                    - address
-                    - implementation
-                    - rootPath
-                  type: object
-                imagePullPolicies:
-                  properties:
-                    mysqld:
-                      type: string
-                    mysqldExporter:
-                      type: string
-                    vtadmin:
-                      type: string
-                    vtbackup:
-                      type: string
-                    vtctld:
-                      type: string
-                    vtgate:
-                      type: string
-                    vtorc:
-                      type: string
-                    vttablet:
-                      type: string
-                  type: object
-                imagePullSecrets:
-                  items:
-                    properties:
-                      name:
-                        default: ""
-                        type: string
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  type: array
-                images:
-                  properties:
-                    mysqld:
-                      properties:
-                        mariadb103Compatible:
-                          type: string
-                        mariadbCompatible:
-                          type: string
-                        mysql56Compatible:
-                          type: string
-                        mysql80Compatible:
-                          type: string
-                      type: object
-                    mysqldExporter:
-                      type: string
-                    vtbackup:
-                      type: string
-                    vtorc:
-                      type: string
-                    vttablet:
-                      type: string
-                  type: object
-                keyRange:
-                  properties:
-                    end:
-                      pattern: ^([0-9a-f][0-9a-f])*$
-                      type: string
-                    start:
-                      pattern: ^([0-9a-f][0-9a-f])*$
-                      type: string
-                  type: object
-                name:
+                  name:
+                    type: string
+                  volumeName:
+                    type: string
+                required:
+                - key
+                type: object
+              databaseName:
+                type: string
+              extraVitessFlags:
+                additionalProperties:
                   type: string
-                replication:
+                type: object
+              globalLockserver:
+                properties:
+                  address:
+                    type: string
+                  implementation:
+                    type: string
+                  rootPath:
+                    type: string
+                required:
+                - address
+                - implementation
+                - rootPath
+                type: object
+              imagePullPolicies:
+                properties:
+                  mysqld:
+                    type: string
+                  mysqldExporter:
+                    type: string
+                  vtadmin:
+                    type: string
+                  vtbackup:
+                    type: string
+                  vtctld:
+                    type: string
+                  vtgate:
+                    type: string
+                  vtorc:
+                    type: string
+                  vttablet:
+                    type: string
+                type: object
+              imagePullSecrets:
+                items:
                   properties:
-                    initializeBackup:
-                      type: boolean
-                    initializeMaster:
-                      type: boolean
-                    recoverRestartedMaster:
-                      type: boolean
-                  type: object
-                tabletPools:
-                  items:
-                    properties:
-                      affinity:
-                        x-kubernetes-preserve-unknown-fields: true
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      backupLocationName:
-                        type: string
-                      cell:
-                        maxLength: 63
-                        minLength: 1
-                        pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
-                        type: string
-                      dataVolumeClaimTemplate:
-                        properties:
-                          accessModes:
-                            items:
-                              type: string
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          dataSource:
-                            properties:
-                              apiGroup:
-                                type: string
-                              kind:
-                                type: string
-                              name:
-                                type: string
-                            required:
-                              - kind
-                              - name
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          dataSourceRef:
-                            properties:
-                              apiGroup:
-                                type: string
-                              kind:
-                                type: string
-                              name:
-                                type: string
-                              namespace:
-                                type: string
-                            required:
-                              - kind
-                              - name
-                            type: object
-                          resources:
-                            properties:
-                              limits:
-                                additionalProperties:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type: object
-                            type: object
-                          selector:
-                            properties:
-                              matchExpressions:
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    operator:
-                                      type: string
-                                    values:
-                                      items:
-                                        type: string
-                                      type: array
-                                      x-kubernetes-list-type: atomic
-                                  required:
-                                    - key
-                                    - operator
-                                  type: object
-                                type: array
-                                x-kubernetes-list-type: atomic
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          storageClassName:
-                            type: string
-                          volumeAttributesClassName:
-                            type: string
-                          volumeMode:
-                            type: string
-                          volumeName:
-                            type: string
-                        type: object
-                      externalDatastore:
-                        properties:
-                          credentialsSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                              - key
-                            type: object
-                          database:
-                            type: string
-                          host:
-                            type: string
-                          port:
-                            format: int32
-                            maximum: 65535
-                            minimum: 1
-                            type: integer
-                          serverCACertSecret:
-                            properties:
-                              key:
-                                type: string
-                              name:
-                                type: string
-                              volumeName:
-                                type: string
-                            required:
-                              - key
-                            type: object
-                          user:
-                            type: string
-                        required:
-                          - credentialsSecret
-                          - database
-                          - host
-                          - port
-                          - user
-                        type: object
-                      extraEnv:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                            valueFrom:
-                              properties:
-                                configMapKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      default: ""
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                fieldRef:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    fieldPath:
-                                      type: string
-                                  required:
-                                    - fieldPath
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                resourceFieldRef:
-                                  properties:
-                                    containerName:
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      type: string
-                                  required:
-                                    - resource
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                secretKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      default: ""
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                              type: object
-                          required:
-                            - name
-                          type: object
-                        type: array
-                      extraLabels:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      extraVolumeMounts:
-                        items:
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            recursiveReadOnly:
-                              type: string
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                          required:
-                            - mountPath
-                            - name
-                          type: object
-                        type: array
-                      extraVolumes:
-                        x-kubernetes-preserve-unknown-fields: true
-                      initContainers:
-                        x-kubernetes-preserve-unknown-fields: true
-                      mysqld:
-                        properties:
-                          configOverrides:
-                            type: string
-                          resources:
-                            properties:
-                              claims:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    request:
-                                      type: string
-                                  required:
-                                    - name
-                                  type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                  - name
-                                x-kubernetes-list-type: map
-                              limits:
-                                additionalProperties:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type: object
-                            type: object
-                        required:
-                          - resources
-                        type: object
-                      mysqldExporter:
-                        properties:
-                          extraFlags:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          resources:
-                            properties:
-                              claims:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    request:
-                                      type: string
-                                  required:
-                                    - name
-                                  type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                  - name
-                                x-kubernetes-list-type: map
-                              limits:
-                                additionalProperties:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type: object
-                            type: object
-                        type: object
-                      name:
-                        default: ""
-                        type: string
-                      replicas:
-                        format: int32
-                        minimum: 0
-                        type: integer
-                      sidecarContainers:
-                        x-kubernetes-preserve-unknown-fields: true
-                      tolerations:
-                        x-kubernetes-preserve-unknown-fields: true
-                      topologySpreadConstraints:
-                        x-kubernetes-preserve-unknown-fields: true
-                      type:
-                        enum:
-                          - replica
-                          - rdonly
-                          - externalmaster
-                          - externalreplica
-                          - externalrdonly
-                        type: string
-                      vttablet:
-                        properties:
-                          extraFlags:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          vtbackupExtraFlags:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          lifecycle:
-                            x-kubernetes-preserve-unknown-fields: true
-                          resources:
-                            properties:
-                              claims:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    request:
-                                      type: string
-                                  required:
-                                    - name
-                                  type: object
-                                type: array
-                                x-kubernetes-list-map-keys:
-                                  - name
-                                x-kubernetes-list-type: map
-                              limits:
-                                additionalProperties:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type: object
-                            type: object
-                          terminationGracePeriodSeconds:
-                            format: int64
-                            type: integer
-                        required:
-                          - resources
-                        type: object
-                    required:
-                      - cell
-                      - replicas
-                      - type
-                      - vttablet
-                    type: object
-                  type: array
-                  x-kubernetes-list-map-keys:
-                    - type
-                    - cell
-                    - name
-                  x-kubernetes-list-type: map
-                topologyReconciliation:
-                  properties:
-                    pruneCells:
-                      type: boolean
-                    pruneKeyspaces:
-                      type: boolean
-                    pruneShardCells:
-                      type: boolean
-                    pruneShards:
-                      type: boolean
-                    pruneSrvKeyspaces:
-                      type: boolean
-                    pruneTablets:
-                      type: boolean
-                    registerCells:
-                      type: boolean
-                    registerCellsAliases:
-                      type: boolean
-                  type: object
-                updateStrategy:
-                  properties:
-                    external:
-                      properties:
-                        allowResourceChanges:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    type:
-                      enum:
-                        - External
-                        - Immediate
+                    name:
+                      default: ""
                       type: string
                   type: object
-                vitessOrchestrator:
+                  x-kubernetes-map-type: atomic
+                type: array
+              images:
+                properties:
+                  mysqld:
+                    properties:
+                      mariadb103Compatible:
+                        type: string
+                      mariadbCompatible:
+                        type: string
+                      mysql56Compatible:
+                        type: string
+                      mysql80Compatible:
+                        type: string
+                    type: object
+                  mysqldExporter:
+                    type: string
+                  vtbackup:
+                    type: string
+                  vtorc:
+                    type: string
+                  vttablet:
+                    type: string
+                type: object
+              keyRange:
+                properties:
+                  end:
+                    pattern: ^([0-9a-f][0-9a-f])*$
+                    type: string
+                  start:
+                    pattern: ^([0-9a-f][0-9a-f])*$
+                    type: string
+                type: object
+              name:
+                type: string
+              replication:
+                properties:
+                  initializeBackup:
+                    type: boolean
+                  initializeMaster:
+                    type: boolean
+                  recoverRestartedMaster:
+                    type: boolean
+                type: object
+              tabletPools:
+                items:
                   properties:
                     affinity:
                       x-kubernetes-preserve-unknown-fields: true
                     annotations:
                       additionalProperties:
                         type: string
+                      type: object
+                    backupLocationName:
+                      type: string
+                    cell:
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[A-Za-z0-9]([_.A-Za-z0-9]*[A-Za-z0-9])?$
+                      type: string
+                    dataVolumeClaimTemplate:
+                      properties:
+                        accessModes:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        dataSource:
+                          properties:
+                            apiGroup:
+                              type: string
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        dataSourceRef:
+                          properties:
+                            apiGroup:
+                              type: string
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        selector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        storageClassName:
+                          type: string
+                        volumeAttributesClassName:
+                          type: string
+                        volumeMode:
+                          type: string
+                        volumeName:
+                          type: string
+                      type: object
+                    externalDatastore:
+                      properties:
+                        credentialsSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                          - key
+                          type: object
+                        database:
+                          type: string
+                        host:
+                          type: string
+                        port:
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        serverCACertSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                          - key
+                          type: object
+                        user:
+                          type: string
+                      required:
+                      - credentialsSecret
+                      - database
+                      - host
+                      - port
+                      - user
                       type: object
                     extraEnv:
                       items:
@@ -7539,7 +7791,7 @@ spec:
                                   optional:
                                     type: boolean
                                 required:
-                                  - key
+                                - key
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fieldRef:
@@ -7549,7 +7801,24 @@ spec:
                                   fieldPath:
                                     type: string
                                 required:
-                                  - fieldPath
+                                - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                - volumeName
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -7558,14 +7827,14 @@ spec:
                                     type: string
                                   divisor:
                                     anyOf:
-                                      - type: integer
-                                      - type: string
+                                    - type: integer
+                                    - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
                                     type: string
                                 required:
-                                  - resource
+                                - resource
                                 type: object
                                 x-kubernetes-map-type: atomic
                               secretKeyRef:
@@ -7578,18 +7847,14 @@ spec:
                                   optional:
                                     type: boolean
                                 required:
-                                  - key
+                                - key
                                 type: object
                                 x-kubernetes-map-type: atomic
                             type: object
                         required:
-                          - name
+                        - name
                         type: object
                       type: array
-                    extraFlags:
-                      additionalProperties:
-                        type: string
-                      type: object
                     extraLabels:
                       additionalProperties:
                         type: string
@@ -7612,181 +7877,611 @@ spec:
                           subPathExpr:
                             type: string
                         required:
-                          - mountPath
-                          - name
+                        - mountPath
+                        - name
                         type: object
                       type: array
                     extraVolumes:
                       x-kubernetes-preserve-unknown-fields: true
                     initContainers:
                       x-kubernetes-preserve-unknown-fields: true
-                    resources:
+                    mysqld:
                       properties:
-                        claims:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              request:
-                                type: string
-                            required:
+                        configOverrides:
+                          type: string
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
                               - name
-                            type: object
-                          type: array
-                          x-kubernetes-list-map-keys:
-                            - name
-                          x-kubernetes-list-type: map
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
                           type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          type: object
+                      required:
+                      - resources
                       type: object
-                    service:
+                    mysqldExporter:
                       properties:
-                        annotations:
+                        extraFlags:
                           additionalProperties:
                             type: string
                           type: object
-                        clusterIP:
-                          type: string
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
                       type: object
+                    name:
+                      default: ""
+                      type: string
+                    replicas:
+                      format: int32
+                      minimum: 0
+                      type: integer
                     sidecarContainers:
                       x-kubernetes-preserve-unknown-fields: true
                     tolerations:
                       x-kubernetes-preserve-unknown-fields: true
+                    topologySpreadConstraints:
+                      x-kubernetes-preserve-unknown-fields: true
+                    type:
+                      enum:
+                      - replica
+                      - rdonly
+                      - externalmaster
+                      - externalreplica
+                      - externalrdonly
+                      type: string
+                    vttablet:
+                      properties:
+                        extraFlags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        lifecycle:
+                          x-kubernetes-preserve-unknown-fields: true
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        terminationGracePeriodSeconds:
+                          format: int64
+                          type: integer
+                        vtbackupExtraFlags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      required:
+                      - resources
+                      type: object
+                  required:
+                  - cell
+                  - replicas
+                  - type
+                  - vttablet
                   type: object
-                zoneMap:
-                  additionalProperties:
-                    type: string
-                  type: object
-              required:
-                - databaseInitScriptSecret
-                - globalLockserver
-                - images
-                - keyRange
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                - cell
                 - name
-                - zoneMap
-              type: object
-            status:
-              properties:
-                backupLocations:
-                  items:
+                x-kubernetes-list-type: map
+              tabletRefreshInterval:
+                type: string
+                x-kubernetes-validations:
+                - message: tabletRefreshInterval must be a valid duration of at least
+                    1s using s, m, or h units
+                  rule: self.matches('^([0-9]+([.][0-9]+)?(s|m|h))+$') && duration(self)
+                    >= duration('1s')
+              topologyReconciliation:
+                properties:
+                  pruneCells:
+                    type: boolean
+                  pruneKeyspaces:
+                    type: boolean
+                  pruneShardCells:
+                    type: boolean
+                  pruneShards:
+                    type: boolean
+                  pruneSrvKeyspaces:
+                    type: boolean
+                  pruneTablets:
+                    type: boolean
+                  registerCells:
+                    type: boolean
+                  registerCellsAliases:
+                    type: boolean
+                type: object
+              updateStrategy:
+                properties:
+                  external:
                     properties:
-                      completeBackups:
-                        format: int32
-                        type: integer
-                      incompleteBackups:
-                        format: int32
-                        type: integer
-                      latestCompleteBackupTime:
-                        format: date-time
-                        type: string
-                      name:
-                        type: string
-                    required:
-                      - completeBackups
-                      - incompleteBackups
+                      allowResourceChanges:
+                        items:
+                          type: string
+                        type: array
                     type: object
-                  type: array
-                cells:
-                  items:
+                  type:
+                    enum:
+                    - External
+                    - Immediate
                     type: string
-                  type: array
-                conditions:
-                  additionalProperties:
-                    properties:
-                      lastTransitionTime:
-                        format: date-time
-                        type: string
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                      status:
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                    required:
-                      - status
+                type: object
+              vitessOrchestrator:
+                properties:
+                  affinity:
+                    x-kubernetes-preserve-unknown-fields: true
+                  annotations:
+                    additionalProperties:
+                      type: string
                     type: object
-                  type: object
-                hasInitialBackup:
-                  type: string
-                hasMaster:
-                  type: string
-                idle:
-                  type: string
-                lowestPodGeneration:
-                  format: int64
-                  type: integer
-                masterAlias:
-                  type: string
-                observedGeneration:
-                  format: int64
-                  type: integer
-                orphanedTablets:
-                  additionalProperties:
-                    properties:
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                    required:
-                      - message
-                      - reason
+                  extraEnv:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                        valueFrom:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  extraFlags:
+                    additionalProperties:
+                      type: string
                     type: object
-                  type: object
-                servingWrites:
-                  type: string
-                tablets:
-                  additionalProperties:
+                  extraLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  extraVolumeMounts:
+                    items:
+                      properties:
+                        mountPath:
+                          type: string
+                        mountPropagation:
+                          type: string
+                        name:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        recursiveReadOnly:
+                          type: string
+                        subPath:
+                          type: string
+                        subPathExpr:
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                  extraVolumes:
+                    x-kubernetes-preserve-unknown-fields: true
+                  initContainers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  resources:
                     properties:
-                      available:
-                        type: string
-                      dataVolumeBound:
-                        type: string
-                      index:
-                        format: int32
-                        type: integer
-                      pendingChanges:
-                        type: string
-                      poolType:
-                        type: string
-                      ready:
-                        type: string
-                      running:
-                        type: string
-                      type:
+                      claims:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            request:
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  service:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      clusterIP:
                         type: string
                     type: object
+                  sidecarContainers:
+                    x-kubernetes-preserve-unknown-fields: true
+                  tolerations:
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              vtbackup:
+                properties:
+                  dataVolumeClaimTemplate:
+                    properties:
+                      accessModes:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      dataSource:
+                        properties:
+                          apiGroup:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      dataSourceRef:
+                        properties:
+                          apiGroup:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      resources:
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                      selector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      storageClassName:
+                        type: string
+                      volumeAttributesClassName:
+                        type: string
+                      volumeMode:
+                        type: string
+                      volumeName:
+                        type: string
+                    type: object
+                  useEmptyDirForInitialBackup:
+                    type: boolean
+                type: object
+                x-kubernetes-validations:
+                - message: useEmptyDirForInitialBackup and dataVolumeClaimTemplate
+                    are mutually exclusive
+                  rule: '!(has(self.useEmptyDirForInitialBackup) && self.useEmptyDirForInitialBackup
+                    && has(self.dataVolumeClaimTemplate))'
+              zoneMap:
+                additionalProperties:
+                  type: string
+                type: object
+            required:
+            - databaseInitScriptSecret
+            - globalLockserver
+            - images
+            - keyRange
+            - name
+            - zoneMap
+            type: object
+          status:
+            properties:
+              backupLocations:
+                items:
+                  properties:
+                    completeBackups:
+                      format: int32
+                      type: integer
+                    incompleteBackups:
+                      format: int32
+                      type: integer
+                    latestCompleteBackupTime:
+                      format: date-time
+                      type: string
+                    name:
+                      type: string
+                  required:
+                  - completeBackups
+                  - incompleteBackups
                   type: object
-                vitessOrchestrator:
+                type: array
+              cells:
+                items:
+                  type: string
+                type: array
+              conditions:
+                additionalProperties:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                  required:
+                  - status
+                  type: object
+                type: object
+              hasInitialBackup:
+                type: string
+              hasMaster:
+                type: string
+              idle:
+                type: string
+              lowestPodGeneration:
+                format: int64
+                type: integer
+              masterAlias:
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+              orphanedTablets:
+                additionalProperties:
+                  properties:
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                  required:
+                  - message
+                  - reason
+                  type: object
+                type: object
+              servingWrites:
+                type: string
+              tabletRefreshInterval:
+                type: string
+              tablets:
+                additionalProperties:
                   properties:
                     available:
                       type: string
-                    serviceName:
+                    dataVolumeBound:
+                      type: string
+                    index:
+                      format: int32
+                      type: integer
+                    pendingChanges:
+                      type: string
+                    poolType:
+                      type: string
+                    ready:
+                      type: string
+                    running:
+                      type: string
+                    type:
                       type: string
                   type: object
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: object
+              vitessOrchestrator:
+                properties:
+                  available:
+                    type: string
+                  serviceName:
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -7805,108 +8500,108 @@ metadata:
   name: vitess-operator-backup-storage
   namespace: example
 rules:
-  - apiGroups:
-      - planetscale.com
-    resources:
-      - vitessshards
-      - vitessshards/status
-      - vitessshards/finalizers
-      - vitessbackups
-      - vitessbackups/status
-      - vitessbackups/finalizers
-      - vitessbackupstorages
-      - vitessbackupstorages/status
-      - vitessbackupstorages/finalizers
-    verbs:
-      - '*'
+- apiGroups:
+  - planetscale.com
+  resources:
+  - vitessshards
+  - vitessshards/status
+  - vitessshards/finalizers
+  - vitessbackups
+  - vitessbackups/status
+  - vitessbackups/finalizers
+  - vitessbackupstorages
+  - vitessbackupstorages/status
+  - vitessbackupstorages/finalizers
+  verbs:
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: vitess-operator
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - services
-      - endpoints
-      - persistentvolumeclaims
-      - events
-      - configmaps
-      - secrets
-    verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-    verbs:
-      - get
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-      - daemonsets
-      - replicasets
-      - statefulsets
-    verbs:
-      - '*'
-  - apiGroups:
-      - policy
-    resources:
-      - poddisruptionbudgets
-    verbs:
-      - '*'
-  - apiGroups:
-      - apps
-    resourceNames:
-      - vitess-operator
-    resources:
-      - deployments/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - planetscale.com
-    resources:
-      - vitessclusters
-      - vitessclusters/status
-      - vitessclusters/finalizers
-      - vitesscells
-      - vitesscells/status
-      - vitesscells/finalizers
-      - vitesskeyspaces
-      - vitesskeyspaces/status
-      - vitesskeyspaces/finalizers
-      - vitessshards
-      - vitessshards/status
-      - vitessshards/finalizers
-      - etcdlockservers
-      - etcdlockservers/status
-      - etcdlockservers/finalizers
-      - vitessbackups
-      - vitessbackups/status
-      - vitessbackups/finalizers
-      - vitessbackupstorages
-      - vitessbackupstorages/status
-      - vitessbackupstorages/finalizers
-      - vitessbackupschedules
-      - vitessbackupschedules/status
-      - vitessbackupschedules/finalizers
-    verbs:
-      - '*'
-  - apiGroups:
-      - batch
-    resources:
-      - jobs
-    verbs:
-      - '*'
-  - apiGroups:
-      - autoscaling
-    resources:
-      - horizontalpodautoscalers
-    verbs:
-      - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resourceNames:
+  - vitess-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - planetscale.com
+  resources:
+  - vitessclusters
+  - vitessclusters/status
+  - vitessclusters/finalizers
+  - vitesscells
+  - vitesscells/status
+  - vitesscells/finalizers
+  - vitesskeyspaces
+  - vitesskeyspaces/status
+  - vitesskeyspaces/finalizers
+  - vitessshards
+  - vitessshards/status
+  - vitessshards/finalizers
+  - etcdlockservers
+  - etcdlockservers/status
+  - etcdlockservers/finalizers
+  - vitessbackups
+  - vitessbackups/status
+  - vitessbackups/finalizers
+  - vitessbackupstorages
+  - vitessbackupstorages/status
+  - vitessbackupstorages/finalizers
+  - vitessbackupschedules
+  - vitessbackupschedules/status
+  - vitessbackupschedules/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - '*'
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -7918,9 +8613,9 @@ roleRef:
   kind: Role
   name: vitess-operator-backup-storage
 subjects:
-  - kind: ServiceAccount
-    name: vitess-operator
-    namespace: example
+- kind: ServiceAccount
+  name: vitess-operator
+  namespace: example
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -7931,9 +8626,9 @@ roleRef:
   kind: ClusterRole
   name: vitess-operator
 subjects:
-  - kind: ServiceAccount
-    name: vitess-operator
-    namespace: default
+- kind: ServiceAccount
+  name: vitess-operator
+  namespace: default
 ---
 apiVersion: scheduling.k8s.io/v1
 description: Vitess components (vttablet, vtgate, vtctld, etcd)
@@ -7966,40 +8661,37 @@ spec:
         app: vitess-operator
     spec:
       containers:
-        - args:
-            - --logtostderr
-            - -v=4
-          command:
-            - vitess-operator
-          env:
-            - name: WATCH_NAMESPACE
-              value: "default,example"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: PS_OPERATOR_POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: PS_OPERATOR_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: vitess-operator
-          image: planetscale/vitess-operator:latest
-          name: vitess-operator
-          resources:
-            limits:
-              memory: 512Mi
-            requests:
-              cpu: 100m
-              memory: 128Mi
+      - args:
+        - --logtostderr
+        - -v=4
+        command:
+        - vitess-operator
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: PS_OPERATOR_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PS_OPERATOR_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: vitess-operator
+        image: planetscale/vitess-operator:latest
+        name: vitess-operator
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
       priorityClassName: vitess-operator-control-plane
-      securityContext:
-        # The fsGroup needs to be set to the default fsGroup of Vitess.
-        # It is inherited by the backup subcontroller and allows it to access
-        # the files created by Vitess on the shared persistent volume.
-        fsGroup: 999 # Default fsGroup of Vitess
       serviceAccountName: vitess-operator

--- a/examples/operator/operator.yaml
+++ b/examples/operator/operator.yaml
@@ -8694,4 +8694,9 @@ spec:
             cpu: 100m
             memory: 128Mi
       priorityClassName: vitess-operator-control-plane
+      securityContext:
+        # The fsGroup needs to be set to the default fsGroup of Vitess.
+        # It is inherited by the backup subcontroller and allows it to access
+        # the files created by Vitess on the shared persistent volume.
+        fsGroup: 999 # Default fsGroup of Vitess
       serviceAccountName: vitess-operator


### PR DESCRIPTION
## Description

This updates the vitess-operator CRD after the following PRs were merged:
  - https://github.com/planetscale/vitess-operator/pull/797
  - https://github.com/planetscale/vitess-operator/pull/798

## Related Issue(s)

  - Sibling PR in the vitess-operator repo: https://github.com/planetscale/vitess-operator/pull/815

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
