### PR TITLE
VReplication: LookupVindex streams must not follow TABLES journals

### DIFF
--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -404,8 +404,7 @@ func stopInterrupted(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		return true
 	}
-	var sqlErr *sqlerror.SQLError
-	if errors.As(err, &sqlErr) {
+	if sqlErr, ok := errors.AsType[*sqlerror.SQLError](err); ok {
 		switch sqlErr.Number() {
 		case sqlerror.ERStopReplicaIOThreadTimeout, sqlerror.ERStopReplicaSQLThreadTimeout:
 			// rpl_stop_replica_timeout fired: the stop remains in effect.

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -582,6 +582,15 @@ func (vre *Engine) registerJournal(journal *binlogdatapb.Journal, id int32) erro
 	}
 
 	workflow := vre.controllers[id].workflow
+	// Insurance against callers that bypass the vplayer's gate (see the
+	// VEventType_JOURNAL handling): lookup vindex backfill streams must
+	// never be transitioned by a TABLES journal, as their keyspace_id()
+	// filter is not expressible in another keyspace. transitionJournal
+	// would otherwise irrecoverably delete the streams.
+	if journal.MigrationType == binlogdatapb.MigrationType_TABLES &&
+		binlogdatapb.VReplicationWorkflowType(vre.controllers[id].workflowType) == binlogdatapb.VReplicationWorkflowType_CreateLookupIndex {
+		return fmt.Errorf("cannot follow TABLES journal %d for lookup vindex workflow %s: lookup backfill streams cannot be retargeted to another keyspace", journal.Id, workflow)
+	}
 	key := fmt.Sprintf("%s:%d", workflow, journal.Id)
 	ks := fmt.Sprintf("%s:%s", vre.controllers[id].source.Keyspace, vre.controllers[id].source.Shard)
 	log.Info(fmt.Sprintf("Journal encountered for (%s %s): %v", key, ks, journal))

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -589,7 +589,7 @@ func (vre *Engine) registerJournal(journal *binlogdatapb.Journal, id int32) erro
 	// would otherwise irrecoverably delete the streams.
 	if journal.MigrationType == binlogdatapb.MigrationType_TABLES &&
 		binlogdatapb.VReplicationWorkflowType(vre.controllers[id].workflowType) == binlogdatapb.VReplicationWorkflowType_CreateLookupIndex {
-		return fmt.Errorf("cannot follow TABLES journal %d for lookup vindex workflow %s: lookup backfill streams cannot be retargeted to another keyspace", journal.Id, workflow)
+		return vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "cannot follow TABLES journal %d for lookup vindex workflow %s: lookup backfill streams cannot be retargeted to another keyspace", journal.Id, workflow)
 	}
 	key := fmt.Sprintf("%s:%d", workflow, journal.Id)
 	ks := fmt.Sprintf("%s:%s", vre.controllers[id].source.Keyspace, vre.controllers[id].source.Shard)

--- a/go/vt/vttablet/tabletmanager/vreplication/journal_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/journal_test.go
@@ -20,6 +20,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
 	qh "vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication/queryhistory"
 )
@@ -313,4 +316,135 @@ func TestJournalTableMixed(t *testing.T) {
 	// Delete all vreplication streams. There should be only one, but we don't know its id.
 	deleteAllVReplicationStreams(t)
 	expectDeleteQueries(t)
+}
+
+// TestJournalTablesLookupVindexIgnored guards against resharding journals
+// written by MoveTables SwitchTraffic/ReverseTraffic destroying lookup
+// vindex backfill streams (https://github.com/vitessio/vitess/issues/20915).
+// A CreateLookupIndex stream must ignore a TABLES journal -- its
+// keyspace_id() filter cannot be planned in another keyspace -- and keep
+// replicating from its current source, which the paired workflow keeps
+// feeding after the switch. SHARDS (Reshard) journals are still followed;
+// that behavior is pinned by TestJournalOneToOne/TestJournalOneToMany.
+func TestJournalTablesLookupVindexIgnored(t *testing.T) {
+	if runNoBlobTest {
+		t.Skip("CreateLookupIndex workflows do not support binlog_row_image=noblob")
+	}
+	defer deleteTablet(addTablet(100))
+	defer deleteTablet(addOtherTablet(101, "other_keyspace", "0"))
+
+	execStatements(t, []string{
+		"create table t(id int, val varbinary(128), primary key(id))",
+		fmt.Sprintf("create table %s.t(id int, val varbinary(128), primary key(id))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table t",
+		fmt.Sprintf("drop table %s.t", vrepldb),
+	})
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match: "t",
+		}},
+	}
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
+	}
+	cancel, _ := startVReplicationWithWorkflowType(t, bls, "", binlogdatapb.VReplicationWorkflowType_CreateLookupIndex)
+	defer cancel()
+
+	journal := &binlogdatapb.Journal{
+		Id:            1,
+		MigrationType: binlogdatapb.MigrationType_TABLES,
+		Participants: []*binlogdatapb.KeyspaceShard{{
+			Keyspace: "vttest",
+			Shard:    "0",
+		}},
+		Tables: []string{"t"},
+		ShardGtids: []*binlogdatapb.ShardGtid{{
+			Keyspace: "other_keyspace",
+			Shard:    "0",
+			Gtid:     "MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:1-10",
+		}},
+	}
+	query := fmt.Sprintf("insert into _vt.resharding_journal(id, db_name, val) values (1, 'vttest', %v)", encodeString(journal.String()))
+	execStatements(t, []string{query})
+	defer execStatements(t, []string{"delete from _vt.resharding_journal"})
+
+	// The journal must be ignored: no stream deletion/recreation. The
+	// stream must still be replicating from the original source, which
+	// this insert proves end to end.
+	execStatements(t, []string{"insert into t values(1, 'aaa')"})
+	expectDBClientQueries(t, qh.Expect(
+		"begin",
+		"insert into t(id,val) values (1,_binary'aaa')",
+		"/update _vt.vreplication set pos=",
+		"commit",
+	))
+}
+
+// TestJournalRegisterLookupVindexRefused guards the engine-side insurance
+// for https://github.com/vitessio/vitess/issues/20915: even if a future
+// caller bypasses the vplayer's TABLES-journal gate, registerJournal must
+// refuse to transition a lookup vindex workflow rather than let
+// transitionJournal destroy its streams.
+func TestJournalRegisterLookupVindexRefused(t *testing.T) {
+	if runNoBlobTest {
+		t.Skip("CreateLookupIndex workflows do not support binlog_row_image=noblob")
+	}
+	defer deleteTablet(addTablet(100))
+	defer deleteTablet(addOtherTablet(101, "other_keyspace", "0"))
+
+	execStatements(t, []string{
+		"create table t(id int, val varbinary(128), primary key(id))",
+		fmt.Sprintf("create table %s.t(id int, val varbinary(128), primary key(id))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table t",
+		fmt.Sprintf("drop table %s.t", vrepldb),
+	})
+
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match: "t",
+		}},
+	}
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
+	}
+	cancel, id := startVReplicationWithWorkflowType(t, bls, "", binlogdatapb.VReplicationWorkflowType_CreateLookupIndex)
+	defer cancel()
+
+	journal := &binlogdatapb.Journal{
+		Id:            2,
+		MigrationType: binlogdatapb.MigrationType_TABLES,
+		Participants: []*binlogdatapb.KeyspaceShard{{
+			Keyspace: "vttest",
+			Shard:    "0",
+		}},
+		Tables: []string{"t"},
+		ShardGtids: []*binlogdatapb.ShardGtid{{
+			Keyspace: "other_keyspace",
+			Shard:    "0",
+			Gtid:     "MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:1-10",
+		}},
+	}
+
+	err := playerEngine.registerJournal(journal, int32(id))
+	require.ErrorContains(t, err, "lookup vindex")
+
+	// The stream must be untouched: no journaler entry queued, no
+	// transition, the controller still registered.
+	playerEngine.mu.Lock()
+	_, ok := playerEngine.controllers[int32(id)]
+	journalerEmpty := len(playerEngine.journaler) == 0
+	playerEngine.mu.Unlock()
+	assert.True(t, ok, "controller was removed")
+	assert.True(t, journalerEmpty, "journaler entry was created")
 }

--- a/go/vt/vttablet/tabletmanager/vreplication/journal_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/journal_test.go
@@ -330,6 +330,9 @@ func TestJournalTablesLookupVindexIgnored(t *testing.T) {
 	if runNoBlobTest {
 		t.Skip("CreateLookupIndex workflows do not support binlog_row_image=noblob")
 	}
+	// This test's teardown uses defer, not t.Cleanup: execStatements and
+	// the other framework helpers run on t.Context(), which is already
+	// canceled by the time t.Cleanup callbacks execute.
 	defer deleteTablet(addTablet(100))
 	defer deleteTablet(addOtherTablet(101, "other_keyspace", "0"))
 
@@ -395,6 +398,9 @@ func TestJournalRegisterLookupVindexRefused(t *testing.T) {
 	if runNoBlobTest {
 		t.Skip("CreateLookupIndex workflows do not support binlog_row_image=noblob")
 	}
+	// This test's teardown uses defer, not t.Cleanup: execStatements and
+	// the other framework helpers run on t.Context(), which is already
+	// canceled by the time t.Cleanup callbacks execute.
 	defer deleteTablet(addTablet(100))
 	defer deleteTablet(addOtherTablet(101, "other_keyspace", "0"))
 

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -859,8 +859,12 @@ func (vp *vplayer) applyEvent(ctx context.Context, event *binlogdatapb.VEvent, m
 			// relocated stream either fails to plan or computes wrong
 			// keyspace_id values and corrupts the lookup table. The
 			// stream's current source keeps receiving the owner table's
-			// writes via the paired workflow after the switch, so we
-			// ignore the journal and keep replicating from it. SHARDS
+			// writes via the paired workflow after the switch -- when
+			// reverse replication is running, which is the default -- so
+			// we ignore the journal and keep replicating from it. With
+			// --enable-reverse-replication=false nothing feeds the
+			// current source and the backfill goes stale until reverse
+			// replication is started or the switch is reversed. SHARDS
 			// (Reshard) journals are still followed: the keyspace -- and
 			// with it the filter's validity -- does not change.
 			if binlogdatapb.VReplicationWorkflowType(vp.vr.WorkflowType) == binlogdatapb.VReplicationWorkflowType_CreateLookupIndex {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -852,6 +852,25 @@ func (vp *vplayer) applyEvent(ctx context.Context, event *binlogdatapb.VEvent, m
 		case binlogdatapb.MigrationType_SHARDS:
 			// All tables of the source were migrated. So, no validation needed.
 		case binlogdatapb.MigrationType_TABLES:
+			// Lookup vindex backfill streams must never follow a TABLES
+			// journal (written by MoveTables SwitchTraffic/ReverseTraffic):
+			// their filter selects keyspace_id(), which the vstreamer
+			// resolves against the serving keyspace's vschema, so a
+			// relocated stream either fails to plan or computes wrong
+			// keyspace_id values and corrupts the lookup table. The
+			// stream's current source keeps receiving the owner table's
+			// writes via the paired workflow after the switch, so we
+			// ignore the journal and keep replicating from it. SHARDS
+			// (Reshard) journals are still followed: the keyspace -- and
+			// with it the filter's validity -- does not change.
+			if binlogdatapb.VReplicationWorkflowType(vp.vr.WorkflowType) == binlogdatapb.VReplicationWorkflowType_CreateLookupIndex {
+				log.Info("Ignoring TABLES journal for lookup vindex workflow",
+					slog.String("workflow", vp.vr.WorkflowName),
+					slog.Int64("journal_id", event.Journal.Id),
+					slog.Any("journal_tables", event.Journal.Tables),
+				)
+				return nil
+			}
 			// Validate that all or none of the tables are in the journal.
 			jtables := make(map[string]bool)
 			for _, table := range event.Journal.Tables {

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -4161,12 +4161,19 @@ func expectJSON(t *testing.T, table string, values [][]string, id int, exec func
 
 func startVReplication(t *testing.T, bls *binlogdatapb.BinlogSource, pos string) (cancelFunc func(), id int) {
 	t.Helper()
+	// fake workflow type as MoveTables so that we can test with "noblob" binlog row image
+	return startVReplicationWithWorkflowType(t, bls, pos, binlogdatapb.VReplicationWorkflowType_MoveTables)
+}
+
+func startVReplicationWithWorkflowType(t *testing.T, bls *binlogdatapb.BinlogSource, pos string,
+	workflowType binlogdatapb.VReplicationWorkflowType,
+) (cancelFunc func(), id int) {
+	t.Helper()
 
 	if pos == "" {
 		pos = primaryPosition(t)
 	}
-	// fake workflow type as MoveTables so that we can test with "noblob" binlog row image
-	query := binlogplayer.CreateVReplication("test", bls, pos, 9223372036854775807, 9223372036854775807, 0, vrepldb, binlogdatapb.VReplicationWorkflowType_MoveTables, 0, false)
+	query := binlogplayer.CreateVReplication("test", bls, pos, 9223372036854775807, 9223372036854775807, 0, vrepldb, workflowType, 0, false)
 	qr, err := playerEngine.Exec(query)
 	require.NoError(t, err)
 	expectDBClientQueries(t, qh.Expect(


### PR DESCRIPTION
## Description

Stopping partway through a `MoveTables` — or completing one — writes a `TABLES` resharding journal on the switch's source shards during `SwitchTraffic`/`ReverseTraffic`. A lookup vindex backfill stream sourcing those shards would follow that journal: its streams were deleted and recreated against the other keyspace, where the stream's `keyspace_id()` filter either cannot be planned at all (no column vindex, e.g. an unsharded MoveTables source) or would silently compute wrong keyspace_id values and corrupt the lookup table. Either way the lookup was irrecoverably broken — the only recovery was to rebuild the vindex from scratch. This could be triggered with the stream running (journal consumed live) or stopped (consumed on any resume, e.g. `LookupVindex internalize` after a `ReverseTraffic` — the rollback path that surfaced this).

The vplayer now ignores `TABLES` journals for `CreateLookupIndex` workflows and keeps replicating from the current source, which the paired workflow continues to feed after the switch — when reverse replication is running, which is the default — so the lookup simply keeps working through traffic switches. `registerJournal` additionally refuses such registrations outright, as insurance against any future caller bypassing the vplayer gate. `SHARDS` (Reshard) journal handling is deliberately unchanged: it's same-keyspace and is what carries lookup backfills across a reshard of the owner keyspace.

Follow-up work for the related-but-separate Materialize case (non-portable `keyspace_id()`/`in_keyrange()` filters, plus validate-before-destroy hardening in `transitionJournal`) is tracked in https://github.com/vitessio/vitess/issues/20918.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/20915

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

Lookup vindex backfill streams no longer auto-migrate when their owner table's keyspace is switched by MoveTables; they continue from their original source keyspace. Complete or externalize lookup vindex backfills before running `MoveTables Complete`, which drops the source tables they read from.

When traffic is switched with `--enable-reverse-replication=false`, nothing feeds the backfill's source keyspace afterward, so an active lookup vindex backfill sourcing it keeps running but silently goes stale. It can catch up only if reverse replication is started (or the switch reversed) while the source tables and the needed binlogs still exist; otherwise the lookup vindex must be rebuilt.

### AI Disclosure

I worked with Claude and Fable 5 on this.
