### PR TITLE
VReplication: don't count throttled time in the vplayer stall deadline

### DIFF
--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -404,8 +404,7 @@ func stopInterrupted(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		return true
 	}
-	var sqlErr *sqlerror.SQLError
-	if errors.As(err, &sqlErr) {
+	if sqlErr, ok := errors.AsType[*sqlerror.SQLError](err); ok {
 		switch sqlErr.Number() {
 		case sqlerror.ERStopReplicaIOThreadTimeout, sqlerror.ERStopReplicaSQLThreadTimeout:
 			// rpl_stop_replica_timeout fired: the stop remains in effect.

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -124,15 +124,15 @@ type journalEvent struct {
 	shardGTIDs   map[string]*binlogdatapb.ShardGtid
 }
 
-// throttleChecker is what the engine needs from the tablet throttler: a
-// single check that either passes or briefly waits and denies. It is an
-// interface -- rather than the *throttle.Client that production always
-// installs -- so that tests can inject throttler behavior.
-type throttleChecker interface {
-	ThrottleCheckOKOrWaitAppName(ctx context.Context, appName throttlerapp.Name) (checkResult *throttle.CheckResult, throttleCheckOK bool)
-}
-
 type (
+	// throttleChecker is what the engine needs from the tablet throttler:
+	// a single check that either passes or briefly waits and denies. It
+	// is an interface -- rather than the *throttle.Client that production
+	// always installs -- so that tests can inject throttler behavior.
+	throttleChecker interface {
+		ThrottleCheckOKOrWaitAppName(ctx context.Context, appName throttlerapp.Name) (checkResult *throttle.CheckResult, throttleCheckOK bool)
+	}
+
 	PostCopyActionType int
 	PostCopyAction     struct {
 		Type PostCopyActionType `json:"type"`

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -107,7 +107,7 @@ type Engine struct {
 	journaler map[string]*journalEvent
 	ec        *externalConnector
 
-	throttlerClient *throttle.Client
+	throttlerClient ThrottleChecker
 
 	// This should only be set in Test Engines in order to short
 	// circuit functions as needed in unit tests. It's automatically
@@ -122,6 +122,12 @@ type journalEvent struct {
 	journal      *binlogdatapb.Journal
 	participants map[string]int32
 	shardGTIDs   map[string]*binlogdatapb.ShardGtid
+}
+
+// ThrottleChecker is what the engine needs from the tablet throttler: a
+// single check that either passes or briefly waits and denies.
+type ThrottleChecker interface {
+	ThrottleCheckOKOrWaitAppName(ctx context.Context, appName throttlerapp.Name) (checkResult *throttle.CheckResult, throttleCheckOK bool)
 }
 
 type (
@@ -178,6 +184,7 @@ func NewTestEngine(ts *topo.Server, cell string, mysqld mysqlctl.MysqlDaemon, db
 		dbName:                  dbname,
 		journaler:               make(map[string]*journalEvent),
 		ec:                      newExternalConnector(env, externalConfig),
+		throttlerClient:         throttle.NewBackgroundClient(nil, throttlerapp.VReplicationName, base.UndefinedScope),
 	}
 	return vre
 }
@@ -197,6 +204,7 @@ func NewSimpleTestEngine(ts *topo.Server, cell string, mysqld mysqlctl.MysqlDaem
 		dbName:                  dbname,
 		journaler:               make(map[string]*journalEvent),
 		ec:                      newExternalConnector(env, externalConfig),
+		throttlerClient:         throttle.NewBackgroundClient(nil, throttlerapp.VReplicationName, base.UndefinedScope),
 		shortcircuit:            true,
 	}
 	return vre
@@ -232,7 +240,7 @@ func (vre *Engine) Open(ctx context.Context) {
 	log.Info("VReplication engine opened successfully")
 }
 
-func (vre *Engine) ThrottlerClient() *throttle.Client {
+func (vre *Engine) ThrottlerClient() ThrottleChecker {
 	return vre.throttlerClient
 }
 

--- a/go/vt/vttablet/tabletmanager/vreplication/engine.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/engine.go
@@ -107,7 +107,7 @@ type Engine struct {
 	journaler map[string]*journalEvent
 	ec        *externalConnector
 
-	throttlerClient ThrottleChecker
+	throttlerClient throttleChecker
 
 	// This should only be set in Test Engines in order to short
 	// circuit functions as needed in unit tests. It's automatically
@@ -124,9 +124,11 @@ type journalEvent struct {
 	shardGTIDs   map[string]*binlogdatapb.ShardGtid
 }
 
-// ThrottleChecker is what the engine needs from the tablet throttler: a
-// single check that either passes or briefly waits and denies.
-type ThrottleChecker interface {
+// throttleChecker is what the engine needs from the tablet throttler: a
+// single check that either passes or briefly waits and denies. It is an
+// interface -- rather than the *throttle.Client that production always
+// installs -- so that tests can inject throttler behavior.
+type throttleChecker interface {
 	ThrottleCheckOKOrWaitAppName(ctx context.Context, appName throttlerapp.Name) (checkResult *throttle.CheckResult, throttleCheckOK bool)
 }
 
@@ -240,8 +242,15 @@ func (vre *Engine) Open(ctx context.Context) {
 	log.Info("VReplication engine opened successfully")
 }
 
-func (vre *Engine) ThrottlerClient() ThrottleChecker {
-	return vre.throttlerClient
+// ThrottlerClient returns the engine's throttle client when it is backed
+// by one. The internal field is a throttleChecker so tests can inject
+// throttler behavior; a non-Client checker maps to nil here, which is safe
+// for callers as *throttle.Client methods accept a nil receiver.
+func (vre *Engine) ThrottlerClient() *throttle.Client {
+	if client, ok := vre.throttlerClient.(*throttle.Client); ok {
+		return client
+	}
+	return nil
 }
 
 func (vre *Engine) openLocked(ctx context.Context) error {

--- a/go/vt/vttablet/tabletmanager/vreplication/relaylog.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/relaylog.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"vitess.io/vitess/go/vt/vterrors"
@@ -33,6 +34,12 @@ type relayLog struct {
 	ctx      context.Context
 	maxItems int
 	maxSize  int
+	// lastThrottledNano is the applier's report (as unix nanoseconds) of
+	// when it was last denied by the throttler. A throttle-denied applier
+	// does not drain the relay log, so a full relay log is expected
+	// backpressure then: time within vplayerProgressDeadline of the last
+	// denial does not count toward the stall verdict.
+	lastThrottledNano *atomic.Int64
 
 	// mu controls all variables below and is shared by canAccept and hasItems.
 	// Broadcasting must be done while holding mu. This is mainly necessary because both
@@ -47,11 +54,12 @@ type relayLog struct {
 	hasItems sync.Cond
 }
 
-func newRelayLog(ctx context.Context, maxItems, maxSize int) *relayLog {
+func newRelayLog(ctx context.Context, maxItems, maxSize int, lastThrottledNano *atomic.Int64) *relayLog {
 	rl := &relayLog{
-		ctx:      ctx,
-		maxItems: maxItems,
-		maxSize:  maxSize,
+		ctx:               ctx,
+		maxItems:          maxItems,
+		maxSize:           maxSize,
+		lastThrottledNano: lastThrottledNano,
 	}
 	rl.canAccept.L = &rl.mu
 	rl.hasItems.L = &rl.mu
@@ -131,23 +139,56 @@ func (rl *relayLog) checkDone() error {
 // block forever if the vplayer cannot process the previous relay log
 // contents in a timely manner; allowing us to provide the user with a
 // helpful error message.
+// A throttle-denied applier deliberately does not drain the relay log,
+// so time near a throttler denial does not count toward the deadline:
+// the timer defers the stall verdict until a full vplayerProgressDeadline
+// has elapsed since the applier was last denied.
 func (rl *relayLog) startSendTimer() (cancel func()) {
 	timer := time.NewTimer(vplayerProgressDeadline)
 	timerDone := make(chan struct{})
 	go func() {
-		select {
-		case <-timer.C:
-			rl.mu.Lock()
-			defer rl.mu.Unlock()
-			rl.timedout = true
-			rl.canAccept.Broadcast()
-		case <-timerDone:
+		defer timer.Stop()
+		for {
+			select {
+			case <-timer.C:
+				if deferral := rl.stallDeferral(); deferral > 0 {
+					timer.Reset(deferral)
+					continue
+				}
+				rl.mu.Lock()
+				rl.timedout = true
+				rl.canAccept.Broadcast()
+				rl.mu.Unlock()
+				return
+			case <-timerDone:
+				return
+			}
 		}
 	}()
 	return func() {
-		timer.Stop()
 		close(timerDone)
 	}
+}
+
+// stallDeferral returns how long the stall verdict must be deferred so
+// that only un-throttled time counts toward it: the remainder of a full
+// vplayerProgressDeadline since the applier was last denied by the
+// throttler, capped at vplayerProgressDeadline so that an unusual
+// timestamp (e.g. clock skew) degrades to periodic re-evaluation rather
+// than an unbounded deferral. Zero means the stall verdict is due.
+func (rl *relayLog) stallDeferral() time.Duration {
+	if rl.lastThrottledNano == nil {
+		return 0
+	}
+	last := rl.lastThrottledNano.Load()
+	if last == 0 {
+		return 0
+	}
+	since := time.Since(time.Unix(0, last))
+	if since >= vplayerProgressDeadline {
+		return 0
+	}
+	return min(vplayerProgressDeadline-since, vplayerProgressDeadline)
 }
 
 // startFetchTimer starts a timer that will wake up the fetcher after

--- a/go/vt/vttablet/tabletmanager/vreplication/relaylog.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/relaylog.go
@@ -34,11 +34,12 @@ type relayLog struct {
 	ctx      context.Context
 	maxItems int
 	maxSize  int
-	// lastThrottledNano is the applier's report (as unix nanoseconds) of
-	// when it was last denied by the throttler. A throttle-denied applier
-	// does not drain the relay log, so a full relay log is expected
-	// backpressure then: time within vplayerProgressDeadline of the last
-	// denial does not count toward the stall verdict.
+	// lastThrottledNano is the applier's report of when it was last
+	// denied by the throttler, as monotonic nanoseconds since
+	// vplayerThrottleEpoch. A throttle-denied applier does not drain the
+	// relay log, so a full relay log is expected backpressure then: time
+	// within vplayerProgressDeadline of the last denial does not count
+	// toward the stall verdict.
 	lastThrottledNano *atomic.Int64
 
 	// mu controls all variables below and is shared by canAccept and hasItems.
@@ -176,10 +177,10 @@ func (rl *relayLog) startSendTimer() (cancel func()) {
 
 // stallDeferral returns how long the stall verdict must be deferred so
 // that only un-throttled time counts toward it: the remainder of a full
-// deadline since the applier was last denied by the throttler, capped at
-// the deadline so that an unusual timestamp (e.g. clock skew) degrades to
-// periodic re-evaluation rather than an unbounded deferral. Zero means
-// the stall verdict is due.
+// deadline since the applier was last denied by the throttler. Both
+// sides of the comparison are monotonic readings against
+// vplayerThrottleEpoch, so wall clock steps cannot skew the verdict in
+// either direction. Zero means the stall verdict is due.
 func (rl *relayLog) stallDeferral(deadline time.Duration) time.Duration {
 	if rl.lastThrottledNano == nil {
 		return 0
@@ -188,7 +189,7 @@ func (rl *relayLog) stallDeferral(deadline time.Duration) time.Duration {
 	if last == 0 {
 		return 0
 	}
-	since := time.Since(time.Unix(0, last))
+	since := time.Since(vplayerThrottleEpoch) - time.Duration(last)
 	if since >= deadline {
 		return 0
 	}

--- a/go/vt/vttablet/tabletmanager/vreplication/relaylog.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/relaylog.go
@@ -144,14 +144,18 @@ func (rl *relayLog) checkDone() error {
 // the timer defers the stall verdict until a full vplayerProgressDeadline
 // has elapsed since the applier was last denied.
 func (rl *relayLog) startSendTimer() (cancel func()) {
-	timer := time.NewTimer(vplayerProgressDeadline)
+	// Capture the deadline once, on the caller's goroutine: the timer
+	// goroutine below must not read the package var again, as tests
+	// mutate it.
+	deadline := vplayerProgressDeadline
+	timer := time.NewTimer(deadline)
 	timerDone := make(chan struct{})
 	go func() {
 		defer timer.Stop()
 		for {
 			select {
 			case <-timer.C:
-				if deferral := rl.stallDeferral(); deferral > 0 {
+				if deferral := rl.stallDeferral(deadline); deferral > 0 {
 					timer.Reset(deferral)
 					continue
 				}
@@ -172,11 +176,11 @@ func (rl *relayLog) startSendTimer() (cancel func()) {
 
 // stallDeferral returns how long the stall verdict must be deferred so
 // that only un-throttled time counts toward it: the remainder of a full
-// vplayerProgressDeadline since the applier was last denied by the
-// throttler, capped at vplayerProgressDeadline so that an unusual
-// timestamp (e.g. clock skew) degrades to periodic re-evaluation rather
-// than an unbounded deferral. Zero means the stall verdict is due.
-func (rl *relayLog) stallDeferral() time.Duration {
+// deadline since the applier was last denied by the throttler, capped at
+// the deadline so that an unusual timestamp (e.g. clock skew) degrades to
+// periodic re-evaluation rather than an unbounded deferral. Zero means
+// the stall verdict is due.
+func (rl *relayLog) stallDeferral(deadline time.Duration) time.Duration {
 	if rl.lastThrottledNano == nil {
 		return 0
 	}
@@ -185,10 +189,10 @@ func (rl *relayLog) stallDeferral() time.Duration {
 		return 0
 	}
 	since := time.Since(time.Unix(0, last))
-	if since >= vplayerProgressDeadline {
+	if since >= deadline {
 		return 0
 	}
-	return min(vplayerProgressDeadline-since, vplayerProgressDeadline)
+	return min(deadline-since, deadline)
 }
 
 // startFetchTimer starts a timer that will wake up the fetcher after

--- a/go/vt/vttablet/tabletmanager/vreplication/relaylog_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/relaylog_test.go
@@ -53,10 +53,10 @@ func TestRelayLogSendStallDeferredWhileThrottled(t *testing.T) {
 	require.NoError(t, rl.Send(events))
 
 	// Simulate an applier that is continuously denied by the throttler: a
-	// denial timestamp that stays fresh for the whole phase. A future
-	// instant is used instead of a timestamp-updater goroutine, which a
+	// denial offset that stays fresh for the whole phase. A far-future
+	// offset is used instead of a timestamp-updater goroutine, which a
 	// paused CI runner could starve into recording a false stall.
-	lastThrottledNano.Store(time.Now().Add(time.Hour).UnixNano())
+	lastThrottledNano.Store(int64(time.Since(vplayerThrottleEpoch) + time.Hour))
 
 	sendResult := make(chan error, 1)
 	go func() {
@@ -76,7 +76,7 @@ func TestRelayLogSendStallDeferredWhileThrottled(t *testing.T) {
 	// The throttling ends: the denial timestamp goes stale. The applier
 	// still isn't draining the log, so the stall must now fire once a full
 	// deadline of un-throttled time has passed.
-	lastThrottledNano.Store(time.Now().UnixNano())
+	lastThrottledNano.Store(int64(time.Since(vplayerThrottleEpoch)))
 	var sendErr error
 	require.Eventually(t, func() bool {
 		select {

--- a/go/vt/vttablet/tabletmanager/vreplication/relaylog_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/relaylog_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vreplication
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+)
+
+// TestRelayLogSendStallDeferredWhileThrottled guards against the vplayer
+// stall detector firing while the applier is throttled
+// (https://github.com/vitessio/vitess/issues/20922). While the vplayer is
+// denied by the throttler it does not drain the relay log, so a full relay
+// log is expected backpressure, not a stall: the stall verdict must be
+// deferred until a full vplayerProgressDeadline has elapsed without the
+// applier being throttled. Once the throttling ends, a genuinely stuck
+// applier must still produce the stall error (the behavior TestPlayerStalls
+// pins end to end).
+func TestRelayLogSendStallDeferredWhileThrottled(t *testing.T) {
+	oldProgressDeadline := vplayerProgressDeadline
+	defer func() { vplayerProgressDeadline = oldProgressDeadline }()
+	vplayerProgressDeadline = 2 * time.Second
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	var lastThrottledNano atomic.Int64
+	rl := newRelayLog(ctx, 1, 10, &lastThrottledNano)
+
+	events := []*binlogdatapb.VEvent{{Type: binlogdatapb.VEventType_GTID}}
+	// Fill the log: with maxItems=1 the next Send blocks until a Fetch,
+	// which -- as for a throttle-denied vplayer -- never comes.
+	require.NoError(t, rl.Send(events))
+
+	// Simulate an applier that is continuously denied by the throttler: a
+	// denial timestamp that stays fresh for the whole phase. A future
+	// instant is used instead of a timestamp-updater goroutine, which a
+	// paused CI runner could starve into recording a false stall.
+	lastThrottledNano.Store(time.Now().Add(time.Hour).UnixNano())
+
+	sendResult := make(chan error, 1)
+	go func() {
+		sendResult <- rl.Send(events)
+	}()
+
+	// The stall deadline must not fire while the applier is throttled:
+	// well after several deadlines' worth of wall time, Send must still be
+	// waiting.
+	select {
+	case err := <-sendResult:
+		require.Failf(t, "premature Send return",
+			"Send returned (err: %v) while the applier was throttled; the stall deadline should have been deferred", err)
+	case <-time.After(3 * vplayerProgressDeadline):
+	}
+
+	// The throttling ends: the denial timestamp goes stale. The applier
+	// still isn't draining the log, so the stall must now fire once a full
+	// deadline of un-throttled time has passed.
+	lastThrottledNano.Store(time.Now().UnixNano())
+	var sendErr error
+	require.Eventually(t, func() bool {
+		select {
+		case sendErr = <-sendResult:
+			return true
+		default:
+			return false
+		}
+	}, 30*time.Second, 10*time.Millisecond)
+	// vterrors.Wrap does not support errors.Is chain traversal, so match by
+	// message, as the rest of the stall handling does.
+	require.ErrorContains(t, sendErr, errVPlayerStalled.Error())
+	require.ErrorContains(t, sendErr, relayLogIOStalledMsg)
+}

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -25,6 +25,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"vitess.io/vitess/go/mysql/replication"
@@ -92,6 +93,11 @@ type vplayer struct {
 	phase string
 
 	throttlerAppName string
+	// lastThrottledNano is when (as unix nanoseconds) applyEvents was last
+	// denied by the throttler. The relay log uses it to defer the stall
+	// verdict: a throttle-denied applier does not drain the relay log, so
+	// that time must not count toward vplayerProgressDeadline.
+	lastThrottledNano atomic.Int64
 
 	// See updateFKCheck for more details on how the two fields below are used.
 
@@ -273,7 +279,7 @@ func (vp *vplayer) fetchAndApply(ctx context.Context) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	relay := newRelayLog(ctx, vp.vr.workflowConfig.RelayLogMaxItems, vp.vr.workflowConfig.RelayLogMaxSize)
+	relay := newRelayLog(ctx, vp.vr.workflowConfig.RelayLogMaxItems, vp.vr.workflowConfig.RelayLogMaxSize, &vp.lastThrottledNano)
 
 	streamErr := make(chan error, 1)
 	go func() {
@@ -550,6 +556,10 @@ func (vp *vplayer) applyEvents(ctx context.Context, relay *relayLog) error {
 		}
 		// Check throttler.
 		if checkResult, ok := vp.vr.vre.throttlerClient.ThrottleCheckOKOrWaitAppName(ctx, throttlerapp.Name(vp.throttlerAppName)); !ok {
+			// While denied we are deliberately not draining the relay log,
+			// so this time must not count toward the relay log's stall
+			// deadline.
+			vp.lastThrottledNano.Store(time.Now().UnixNano())
 			_ = vp.vr.updateTimeThrottled(throttlerapp.VPlayerName, checkResult.Summary())
 			estimateLag()
 			continue

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer.go
@@ -51,6 +51,11 @@ var (
 
 	// The error to return when we have detected a stall in the vplayer.
 	errVPlayerStalled = errors.New("progress stalled; vplayer was unable to replicate the transaction in a timely manner; examine the target mysqld instance health and the replicated queries' EXPLAIN output to see why queries are taking unusually long")
+
+	// vplayerThrottleEpoch is the reference instant for throttle-denial
+	// offsets: it carries a monotonic clock reading, so durations measured
+	// against it are immune to wall clock steps in either direction.
+	vplayerThrottleEpoch = time.Now()
 )
 
 // vplayer replays binlog events by pulling them from a vstreamer.
@@ -93,10 +98,11 @@ type vplayer struct {
 	phase string
 
 	throttlerAppName string
-	// lastThrottledNano is when (as unix nanoseconds) applyEvents was last
-	// denied by the throttler. The relay log uses it to defer the stall
-	// verdict: a throttle-denied applier does not drain the relay log, so
-	// that time must not count toward vplayerProgressDeadline.
+	// lastThrottledNano is when applyEvents was last denied by the
+	// throttler, as monotonic nanoseconds since vplayerThrottleEpoch.
+	// The relay log uses it to defer the stall verdict: a
+	// throttle-denied applier does not drain the relay log, so that
+	// time must not count toward vplayerProgressDeadline.
 	lastThrottledNano atomic.Int64
 
 	// See updateFKCheck for more details on how the two fields below are used.
@@ -559,7 +565,7 @@ func (vp *vplayer) applyEvents(ctx context.Context, relay *relayLog) error {
 			// While denied we are deliberately not draining the relay log,
 			// so this time must not count toward the relay log's stall
 			// deadline.
-			vp.lastThrottledNano.Store(time.Now().UnixNano())
+			vp.lastThrottledNano.Store(int64(time.Since(vplayerThrottleEpoch)))
 			_ = vp.vr.updateTimeThrottled(throttlerapp.VPlayerName, checkResult.Summary())
 			estimateLag()
 			continue

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -4289,8 +4289,11 @@ type fakeThrottleChecker struct {
 func (f *fakeThrottleChecker) ThrottleCheckOKOrWaitAppName(_ context.Context, appName throttlerapp.Name) (*throttle.CheckResult, bool) {
 	if f.deny.Load() {
 		// Mimic the real client's denial pacing so the caller's check
-		// loop does not spin hot.
-		time.Sleep(100 * time.Millisecond)
+		// loop does not spin hot, but pace faster than the real client:
+		// the vplayer refreshes its denial timestamp once per check, and
+		// a wide refresh-to-deadline margin keeps a paused CI runner
+		// from letting the stall timer see a stale denial.
+		time.Sleep(50 * time.Millisecond)
 		return &throttle.CheckResult{
 			ResponseCode: tabletmanagerdatapb.CheckThrottlerResponseCode_THRESHOLD_EXCEEDED,
 			AppName:      appName.String(),
@@ -4329,8 +4332,12 @@ func TestPlayerNoStallWhileThrottled(t *testing.T) {
 		drainDBQueries()
 	}()
 	// Shorten the stall deadline so that an undeferred stall would fire
-	// well within the test's throttled window.
-	vplayerProgressDeadline = 2 * time.Second
+	// well within the test's throttled window, but keep a wide margin
+	// (100x) over the fake checker's denial pacing: a spurious stall
+	// would need a full-process pause longer than the deadline between
+	// two denial-timestamp refreshes, which even a resource-starved CI
+	// runner should not produce.
+	vplayerProgressDeadline = 5 * time.Second
 	// Make each relay log batch a single transaction so the relay log
 	// fills -- and its Send blocks, starting the stall timer -- as soon as
 	// events arrive while the applier is denied.

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -49,6 +49,34 @@ import (
 	qh "vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication/queryhistory"
 )
 
+type (
+	// fakeThrottleChecker is a throttleChecker whose verdict the test
+	// controls: while deny is set every check is refused, as for a tablet
+	// whose lag-gated throttler checks are being denied.
+	fakeThrottleChecker struct {
+		deny atomic.Bool
+	}
+)
+
+func (f *fakeThrottleChecker) ThrottleCheckOKOrWaitAppName(_ context.Context, appName throttlerapp.Name) (*throttle.CheckResult, bool) {
+	if f.deny.Load() {
+		// Mimic the real client's denial pacing so the caller's check
+		// loop does not spin hot, but pace faster than the real client:
+		// the vplayer refreshes its denial timestamp once per check, and
+		// a wide refresh-to-deadline margin keeps a paused CI runner
+		// from letting the stall timer see a stale denial.
+		time.Sleep(50 * time.Millisecond)
+		return &throttle.CheckResult{
+			ResponseCode: tabletmanagerdatapb.CheckThrottlerResponseCode_THRESHOLD_EXCEEDED,
+			AppName:      appName.String(),
+		}, false
+	}
+	return &throttle.CheckResult{
+		ResponseCode: tabletmanagerdatapb.CheckThrottlerResponseCode_OK,
+		AppName:      appName.String(),
+	}, true
+}
+
 var testGTIDCounter atomic.Uint64
 
 func uniqueTestGTID() string {
@@ -4277,32 +4305,6 @@ func drainDBQueries() {
 			return
 		}
 	}
-}
-
-// fakeThrottleChecker is a ThrottleChecker whose verdict the test controls:
-// while deny is set every check is refused, as for a tablet whose lag-gated
-// throttler checks are being denied.
-type fakeThrottleChecker struct {
-	deny atomic.Bool
-}
-
-func (f *fakeThrottleChecker) ThrottleCheckOKOrWaitAppName(_ context.Context, appName throttlerapp.Name) (*throttle.CheckResult, bool) {
-	if f.deny.Load() {
-		// Mimic the real client's denial pacing so the caller's check
-		// loop does not spin hot, but pace faster than the real client:
-		// the vplayer refreshes its denial timestamp once per check, and
-		// a wide refresh-to-deadline margin keeps a paused CI runner
-		// from letting the stall timer see a stale denial.
-		time.Sleep(50 * time.Millisecond)
-		return &throttle.CheckResult{
-			ResponseCode: tabletmanagerdatapb.CheckThrottlerResponseCode_THRESHOLD_EXCEEDED,
-			AppName:      appName.String(),
-		}, false
-	}
-	return &throttle.CheckResult{
-		ResponseCode: tabletmanagerdatapb.CheckThrottlerResponseCode_OK,
-		AppName:      appName.String(),
-	}, true
 }
 
 // TestPlayerNoStallWhileThrottled exercises the production handoff for

--- a/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
+++ b/go/vt/vttablet/tabletmanager/vreplication/vplayer_flaky_test.go
@@ -40,9 +40,12 @@ import (
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logutil"
 	vttablet "vitess.io/vitess/go/vt/vttablet/common"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/throttle"
+	"vitess.io/vitess/go/vt/vttablet/tabletserver/throttle/throttlerapp"
 	"vitess.io/vitess/go/vt/vttablet/tabletserver/vstreamer/testenv"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	tabletmanagerdatapb "vitess.io/vitess/go/vt/proto/tabletmanagerdata"
 	qh "vitess.io/vitess/go/vt/vttablet/tabletmanager/vreplication/queryhistory"
 )
 
@@ -4274,4 +4277,144 @@ func drainDBQueries() {
 			return
 		}
 	}
+}
+
+// fakeThrottleChecker is a ThrottleChecker whose verdict the test controls:
+// while deny is set every check is refused, as for a tablet whose lag-gated
+// throttler checks are being denied.
+type fakeThrottleChecker struct {
+	deny atomic.Bool
+}
+
+func (f *fakeThrottleChecker) ThrottleCheckOKOrWaitAppName(_ context.Context, appName throttlerapp.Name) (*throttle.CheckResult, bool) {
+	if f.deny.Load() {
+		// Mimic the real client's denial pacing so the caller's check
+		// loop does not spin hot.
+		time.Sleep(100 * time.Millisecond)
+		return &throttle.CheckResult{
+			ResponseCode: tabletmanagerdatapb.CheckThrottlerResponseCode_THRESHOLD_EXCEEDED,
+			AppName:      appName.String(),
+		}, false
+	}
+	return &throttle.CheckResult{
+		ResponseCode: tabletmanagerdatapb.CheckThrottlerResponseCode_OK,
+		AppName:      appName.String(),
+	}, true
+}
+
+// TestPlayerNoStallWhileThrottled exercises the production handoff for
+// https://github.com/vitessio/vitess/issues/20922 end to end: a
+// throttler-denied vplayer reports its denials (vplayer.lastThrottledNano)
+// to the relay log, which defers the stall verdict, so sustained throttling
+// must not produce the relay log I/O stall error -- and replication must
+// resume normally once the throttler allows it again.
+func TestPlayerNoStallWhileThrottled(t *testing.T) {
+	defer deleteTablet(addTablet(100))
+
+	// Capture the error log so we can assert the stall message is absent.
+	ole := log.Error
+	logger := logutil.NewMemoryLogger()
+	log.Error = func(msg string, _ ...slog.Attr) {
+		logger.Errorf("%s", msg)
+	}
+
+	oldProgressDeadline := vplayerProgressDeadline
+	oldRelayLogMaxItems := vttablet.DefaultVReplicationConfig.RelayLogMaxItems
+	oldThrottlerClient := playerEngine.throttlerClient
+	defer func() {
+		log.Error = ole
+		vplayerProgressDeadline = oldProgressDeadline
+		vttablet.DefaultVReplicationConfig.RelayLogMaxItems = oldRelayLogMaxItems
+		playerEngine.throttlerClient = oldThrottlerClient
+		drainDBQueries()
+	}()
+	// Shorten the stall deadline so that an undeferred stall would fire
+	// well within the test's throttled window.
+	vplayerProgressDeadline = 2 * time.Second
+	// Make each relay log batch a single transaction so the relay log
+	// fills -- and its Send blocks, starting the stall timer -- as soon as
+	// events arrive while the applier is denied.
+	vttablet.DefaultVReplicationConfig.RelayLogMaxItems = 1
+
+	// Start with the throttler allowing, so the stream starts up cleanly;
+	// the fake's verdict is flipped to denied before any row events flow.
+	throttler := &fakeThrottleChecker{}
+	playerEngine.throttlerClient = throttler
+
+	execStatements(t, []string{
+		"create table t1(id bigint, val1 varchar(128), primary key(id))",
+		fmt.Sprintf("create table %s.t1(id bigint, val1 varchar(128), primary key(id))", vrepldb),
+	})
+	defer execStatements(t, []string{
+		"drop table t1",
+		fmt.Sprintf("drop table %s.t1", vrepldb),
+	})
+
+	// Note: TestPlayerStalls uses an empty filter, which in its STATEMENT
+	// binlog_format scenarios passes statements through wholesale. Here we
+	// replicate default ROW events, which an empty filter would drop, so
+	// match the table explicitly.
+	filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match: "/.*",
+		}},
+	}
+	bls := &binlogdatapb.BinlogSource{
+		Keyspace: env.KeyspaceName,
+		Shard:    env.ShardName,
+		Filter:   filter,
+		OnDdl:    binlogdatapb.OnDDLAction_IGNORE,
+	}
+	// Create the stream via the engine directly rather than through
+	// startVReplication: this test makes no assertions on the shared
+	// globalDBQueries channel -- the throttled window produces a
+	// nondeterministic mix of time_throttled/heartbeat updates -- so
+	// teardown must not expect a consumed channel either. The final
+	// deferred drain leaves the channel empty for subsequent tests.
+	defer drainDBQueries()
+	query := binlogplayer.CreateVReplication("test", bls, primaryPosition(t), 9223372036854775807, 9223372036854775807, 0, vrepldb, binlogdatapb.VReplicationWorkflowType_MoveTables, 0, false)
+	qr, err := playerEngine.Exec(query)
+	require.NoError(t, err)
+	defer func() {
+		_, err := playerEngine.Exec(fmt.Sprintf("delete from _vt.vreplication where id = %d", qr.InsertID))
+		require.NoError(t, err)
+	}()
+
+	// Deny all throttler checks from here on: the vplayer stops draining
+	// the relay log, so the row events below fill it and block the
+	// vstreamer's Send, which starts the stall timer.
+	throttler.deny.Store(true)
+	execStatements(t, []string{
+		"insert into t1(id, val1) values (1, 'aaa')",
+		"insert into t1(id, val1) values (2, 'bbb')",
+		"insert into t1(id, val1) values (3, 'ccc')",
+	})
+
+	// Wait out several stall deadlines' worth of denied time: without the
+	// denial handoff to the relay log, the stall fires within
+	// vplayerProgressDeadline and errors the stream.
+	time.Sleep(3 * vplayerProgressDeadline)
+	log.Flush()
+	require.NotContains(t, logger.String(), relayLogIOStalledMsg,
+		"the stall detector fired while the vplayer was throttled")
+
+	dbc := playerEngine.dbClientFactoryFiltered()
+	require.NoError(t, dbc.Connect())
+	defer dbc.Close()
+	waitForQueryResult(t, dbc, fmt.Sprintf("select state from _vt.vreplication where id = %d", qr.InsertID), "Running")
+
+	// Once the throttler allows again, the stream must drain the relay log
+	// and apply the queued rows: it was healthy all along. Use a generous
+	// CI-safe window: the backlog drains one single-item batch at a time
+	// with RelayLogMaxItems=1.
+	throttler.deny.Store(false)
+	countQuery := fmt.Sprintf("select count(*) from %s.t1", vrepldb)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := dbc.ExecuteFetch(countQuery, 1)
+		require.NoError(c, err)
+		require.Len(c, res.Rows, 1)
+		assert.Equal(c, "3", res.Rows[0][0].ToString())
+	}, 30*time.Second, 100*time.Millisecond, "the queued rows were not applied after the throttler allowed again")
+	log.Flush()
+	require.NotContains(t, logger.String(), relayLogIOStalledMsg)
 }


### PR DESCRIPTION
## Description

The vplayer stall detector could fire from throttling alone. While the vplayer's throttler check is denied it deliberately does not drain the relay log, but the vstreamer keeps filling it, so the relay log's `Send()` blocks and its 5 minute progress deadline (`vplayerProgressDeadline`) runs out on a perfectly healthy stream. With `--vreplication-max-time-to-retry-on-error` set, a throttling window longer than that value converts the recurring stall error into a terminal one — and for vreplication-based Online DDL migrations the executor then cancels the migration and marks it `failed`, discarding a fully resumable copy (a plain `Workflow start` resumes it from the stored lastpk). See #20922 for the full incident analysis, where routine node replacements caused multi-day migrations to be falsely failed.

The fix makes the stall deadline throttle-aware: the vplayer records when it was last denied by the throttler, and the relay log's stall timer defers its verdict until a full `vplayerProgressDeadline` has elapsed since that last denial. A stall is now only declared after 5 minutes of continuously un-throttled non-progress. Genuine stall detection (#15797) is unchanged, as is `MigrationType` handling and everything on the vstreamer side.

## Related Issue(s)

- Fixes: https://github.com/vitessio/vitess/issues/20922
- Follow-up work tracked separately: https://github.com/vitessio/vitess/issues/20926 (Online DDL error classification), https://github.com/vitessio/vitess/issues/20927 (throttler grace for freshly restored replicas)

## Backport justification

This is a false-failure bug that potentially destroys days of migration work in production: any sustained throttling window (e.g. a restored replica catching up) combined with `--vreplication-max-time-to-retry-on-error` terminally fails healthy workflows and vreplication-based Online DDL migrations on affected shards. The relevant code paths are unchanged since v22, the fix is small and contained to the vplayer/relay log, and it introduces no behavior change outside the false-positive case.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None: no flags, defaults, or persisted formats change. Streams that previously errored with "relay log I/O stalled" during sustained throttling will now simply remain running and throttled.

### AI Disclosure

I worked with Claude and Fable 5 on this, along with Codex and GPT-5.6 for reviews.
