### PR TITLE
`EmergencyReparentShard`: consolidate candidate state

### DIFF
--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"slices"
 	"strings"
 	"sync"
@@ -47,6 +46,18 @@ import (
 	replicationdatapb "vitess.io/vitess/go/vt/proto/replicationdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
+)
+
+// counters for Emergency Reparent Shard
+var (
+	ersCounter = stats.NewCountersWithMultiLabels(
+		"EmergencyReparentCounts", "Number of times Emergency Reparent Shard has been run",
+		[]string{"Keyspace", "Shard", "Result"},
+	)
+	ersSplitBrainOverrides = stats.NewCountersWithMultiLabels(
+		"EmergencyReparentSplitBrainOverrides", "Number of Emergency Reparent Shard split-brain promotions completed for an explicitly selected primary",
+		[]string{"Keyspace", "Shard"},
+	)
 )
 
 // EmergencyReparenter performs EmergencyReparentShard operations.
@@ -76,35 +87,94 @@ type EmergencyReparentOptions struct {
 	durability policy.Durabler
 }
 
+// ersCandidate is one ERS promotion candidate and its per-tablet pipeline state.
+//
+// buildERSCandidates is the only place that builds these, and it builds exactly one
+// per tablet for the whole run. Every later stage filters that pool into new slices
+// without ever rebuilding a candidate, so a *ersCandidate is a stable identity for
+// its tablet and set membership can be tested by pointer. Anything that builds a
+// second candidate for a tablet already in the pool breaks that, so don't.
+type ersCandidate struct {
+	info      *topo.TabletInfo
+	positions *RelayLogPositions
+
+	mysqlVersion    mysqlctl.ServerVersion
+	mysqlFlavor     mysqlctl.MySQLFlavor
+	hasMySQLVersion bool
+
+	// stopStatus is nil for a tablet that reported itself as primary rather than
+	// stopping replication, which is how the pipeline tells the two apart.
+	stopStatus   *replicationdatapb.StopReplicationStatus
+	takingBackup bool
+
+	// reparentJournalLen is filled in during errant-GTID detection.
+	reparentJournalLen int32
+}
+
+func (c *ersCandidate) alias() string {
+	return topoproto.TabletAliasString(c.info.Alias)
+}
+
+func (c *ersCandidate) tablet() *topodatapb.Tablet {
+	return c.info.Tablet
+}
+
+// isSameTablet reports whether two candidates are the same tablet. Within a single
+// ERS run pointer equality would do, but comparing aliases keeps the answer correct
+// for a caller that built its candidate elsewhere. A candidate without an alias has
+// no identity to match on, so it is never the same tablet as anything, including
+// another candidate without an alias.
+func (c *ersCandidate) isSameTablet(other *ersCandidate) bool {
+	if c == nil || other == nil || c.info == nil || other.info == nil {
+		return false
+	}
+	if topoproto.TabletAliasIsZero(c.info.Alias) || topoproto.TabletAliasIsZero(other.info.Alias) {
+		return false
+	}
+
+	return topoproto.TabletAliasEqual(c.info.Alias, other.info.Alias)
+}
+
 // relayLogResult is a single tablet's result from waiting on its relay logs to apply.
 type relayLogResult struct {
-	alias string
-	err   error
+	candidate *ersCandidate
+	err       error
 }
 
 // relayLogWaitResult is the per-tablet outcome of waitForRelayLogsToApply.
 type relayLogWaitResult struct {
 	// applied are the tablets that finished applying their relay logs.
-	applied []string
+	applied []*ersCandidate
+
 	// failed are the tablets that couldn't apply their relay logs (RPC error, MySQL
 	// error or timeout).
-	failed []string
+	failed []*ersCandidate
+
 	// cancelled are the tablets we stopped waiting on, because a peer finished or failed
 	// first, or the reparent was aborted. We know nothing about their apply progress.
-	cancelled []string
+	cancelled []*ersCandidate
 }
 
-// counters for Emergency Reparent Shard
-var (
-	ersCounter = stats.NewCountersWithMultiLabels(
-		"EmergencyReparentCounts", "Number of times Emergency Reparent Shard has been run",
-		[]string{"Keyspace", "Shard", "Result"},
-	)
-	ersSplitBrainOverrides = stats.NewCountersWithMultiLabels(
-		"EmergencyReparentSplitBrainOverrides", "Number of Emergency Reparent Shard split-brain promotions completed for an explicitly selected primary",
-		[]string{"Keyspace", "Shard"},
-	)
-)
+// findERSCandidateByAlias returns a single *ersCandidate by tablet alias.
+func findERSCandidateByAlias(candidates []*ersCandidate, alias *topodatapb.TabletAlias) *ersCandidate {
+	for _, candidate := range candidates {
+		if topoproto.TabletAliasEqual(candidate.info.Alias, alias) {
+			return candidate
+		}
+	}
+
+	return nil
+}
+
+// ersCandidateAliases returns a slice of tablet alias strings of candidates.
+func ersCandidateAliases(candidates []*ersCandidate) []string {
+	aliases := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		aliases = append(aliases, candidate.alias())
+	}
+
+	return aliases
+}
 
 // NewEmergencyReparenter returns a new EmergencyReparenter object, ready to
 // perform EmergencyReparentShard operations using the given topo.Server,
@@ -204,11 +274,10 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 		shardInfo                  *topo.ShardInfo
 		prevPrimary                *topodatapb.Tablet
 		tabletMap                  map[string]*topo.TabletInfo
-		validCandidates            map[string]*RelayLogPositions
-		intermediateSource         *topodatapb.Tablet
-		validCandidateTablets      []*topodatapb.Tablet
-		validReplacementCandidates []*topodatapb.Tablet
-		betterCandidate            *topodatapb.Tablet
+		candidates                 []*ersCandidate
+		intermediateSource         *ersCandidate
+		validReplacementCandidates []*ersCandidate
+		betterCandidate            *ersCandidate
 		isIdeal                    bool
 		isGTIDBased                bool
 	)
@@ -303,16 +372,12 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 		return vterrors.Wrap(err, lostTopologyLockMsg)
 	}
 
-	// find the positions of all the valid candidates.
-	validCandidates, isGTIDBased, err = FindPositionsOfAllCandidates(stoppedReplicationSnapshot.statusMap, stoppedReplicationSnapshot.primaryStatusMap)
+	// Find the positions of all the valid candidates.
+	candidates, isGTIDBased, err = buildERSCandidates(stoppedReplicationSnapshot, tabletMap)
 	if err != nil {
 		return err
 	}
-	// Restrict the valid candidates list. We remove any tablet which is of the type DRAINED, RESTORE or BACKUP.
-	validCandidates, err = restrictValidCandidates(validCandidates, tabletMap)
-	if err != nil {
-		return err
-	} else if len(validCandidates) == 0 {
+	if len(candidates) == 0 {
 		return vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no valid candidates for emergency reparent")
 	}
 
@@ -323,21 +388,21 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 	// can't hold up or fail the reparent. For non-GTID-based shards (FilePos, MariaDB) the
 	// Combined position only reflects what is executed, so we keep the previous behaviour
 	// of waiting for every candidate and failing on any error.
-	waitCandidates := validCandidates
+	waitCandidates := candidates
 	requireAll := true
 	splitBrainOverrideActive := false
-	var suspectedSplitBrainCandidates map[string]*RelayLogPositions
+	var suspectedSplitBrainCandidates []*ersCandidate
 	if isGTIDBased {
-		waitCandidates = filterToMostAdvancedCombined(validCandidates, erp.logger)
+		waitCandidates = filterToMostAdvancedCombined(candidates, erp.logger)
 		requireAll = !hasUniformCombinedPosition(waitCandidates)
 		if requireAll {
 			leadingPositions := describeCombinedPositions(waitCandidates)
 			if !opts.AllowSplitBrainPromotion {
-				suspectedSplitBrainCandidates = maps.Clone(waitCandidates)
+				suspectedSplitBrainCandidates = slices.Clone(waitCandidates)
 			} else {
 				requestedPrimary := topoproto.TabletAliasString(opts.NewPrimaryAlias)
-				requestedCandidate, ok := waitCandidates[requestedPrimary]
-				if !ok {
+				requestedCandidate := findERSCandidateByAlias(waitCandidates, opts.NewPrimaryAlias)
+				if requestedCandidate == nil {
 					return vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "requested primary %s is not a leading candidate in the suspected split-brain: %s", requestedPrimary, leadingPositions)
 				}
 
@@ -349,22 +414,18 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 				// skip, and the election all operate on that one tablet: only it needs to apply
 				// its relay logs, so a wedged losing branch cannot block the recovery this
 				// override exists for.
-				validCandidates = map[string]*RelayLogPositions{requestedPrimary: requestedCandidate}
-				waitCandidates = validCandidates
+				candidates = []*ersCandidate{requestedCandidate}
+				waitCandidates = candidates
 			}
 		}
 	}
-
-	// Keep the pre-wait candidates around: tablets that fail the wait are removed from
-	// candidacy, but their received positions still corroborate errant GTID detection
-	preWaitCandidates := validCandidates
 
 	// The wait budget also covers the possible second wait after errant GTID detection
 	// below, so ERS spends at most WaitReplicasTimeout in total waiting for relay logs
 	// to apply. Time spent in errant GTID detection doesn't count against it
 	waitStart := time.Now()
 	var waitResult *relayLogWaitResult
-	validCandidates, waitResult, err = erp.applyRelayLogsAndReconcile(ctx, waitCandidates, validCandidates, tabletMap, stoppedReplicationSnapshot.statusMap, opts.WaitReplicasTimeout, requireAll, isGTIDBased)
+	candidates, waitResult, err = erp.applyRelayLogsAndReconcile(ctx, waitCandidates, candidates, opts.WaitReplicasTimeout, requireAll, isGTIDBased)
 	if err != nil {
 		return err
 	}
@@ -374,7 +435,7 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 	// count as a semi-sync acker in the forward-progress checks below; promoting a
 	// primary whose only acker is broken would wedge it waiting for an ACK. Cancelled
 	// waits say nothing about the tablet and stay counted
-	nonAckers := slices.Clone(waitResult.failed)
+	nonAckers := ersCandidateAliases(waitResult.failed)
 
 	// Tablets whose replication was fully stopped before the reparent are repointed
 	// without being started, so they can't send semi-sync ACKs either until an operator
@@ -395,18 +456,21 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 		// Failed waiters are only ever removed from a uniform leading group (a
 		// requireAll wait aborts on failure instead of removing anyone), so a failed
 		// tablet received exactly what the surviving leaders received, including every
-		// reparent journal entry: its evidence is max-journal-grade by construction
+		// reparent journal entry: its evidence is max-journal-grade by construction.
+		// A failed waiter was dropped from the candidates but is still in this list, so
+		// its position survives the reconcile that removed it
 		var failedEvidence []replication.Position
-		for _, alias := range waitResult.failed {
-			if pos := preWaitCandidates[alias]; pos != nil && !pos.IsZero() {
-				failedEvidence = append(failedEvidence, pos.Combined)
+		for _, failedCandidate := range waitResult.failed {
+			if failedCandidate.positions != nil && !failedCandidate.positions.IsZero() {
+				failedEvidence = append(failedEvidence, failedCandidate.positions.Combined)
 			}
 		}
-		var starved []string
-		validCandidates, starved, err = erp.findErrantGTIDs(ctx, validCandidates, stoppedReplicationSnapshot.statusMap, tabletMap, opts.WaitReplicasTimeout, failedEvidence, shardNeverInitialized)
+		var starved []*ersCandidate
+		candidates, starved, err = erp.findErrantGTIDs(ctx, candidates, opts.WaitReplicasTimeout, failedEvidence, shardNeverInitialized)
 		if err != nil {
 			return err
 		}
+		starvedAliases := ersCandidateAliases(starved)
 
 		// A candidate accepted without any evidence may be a blind spot of our own
 		// making: reparent journal counts only advance when relay logs are applied, so
@@ -417,15 +481,15 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 		// count and detection has evidence, so this only triggers when ERS runs shortly
 		// after a previous reparent
 		if len(starved) > 0 {
-			rescueCandidates := make(map[string]*RelayLogPositions)
-			for alias, pos := range validCandidates {
-				if _, waited := waitCandidates[alias]; waited {
+			rescueCandidates := make([]*ersCandidate, 0, len(candidates))
+			for _, candidate := range candidates {
+				if slices.Contains(waitCandidates, candidate) {
 					continue
 				}
-				if _, ok := stoppedReplicationSnapshot.statusMap[alias]; !ok {
+				if candidate.stopStatus == nil {
 					continue
 				}
-				rescueCandidates[alias] = pos
+				rescueCandidates = append(rescueCandidates, candidate)
 			}
 			if len(rescueCandidates) > 0 && relayLogBudgetLeft <= 0 {
 				// The blind spot only exists because we skipped these peers in the relay
@@ -434,9 +498,9 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 				// the missing evidence wasn't of our own making, which could mean electing
 				// a leader with an errant GTID that a peer would have exposed. Fail closed
 				// rather than run a doomed zero-budget wait or accept it unconfirmed.
-				return vterrors.Errorf(vtrpc.Code_DEADLINE_EXCEEDED, "errant GTID detection could not corroborate %v and the relay log wait budget (%s) was exhausted before the skipped candidates could apply their relay logs", starved, opts.WaitReplicasTimeout)
+				return vterrors.Errorf(vtrpc.Code_DEADLINE_EXCEEDED, "errant GTID detection could not corroborate %v and the relay log wait budget (%s) was exhausted before the skipped candidates could apply their relay logs", starvedAliases, opts.WaitReplicasTimeout)
 			} else if len(rescueCandidates) > 0 {
-				erp.logger.Warningf("errant GTID detection had no evidence to corroborate %v; waiting for the skipped candidates to apply their relay logs and re-running the detection", starved)
+				erp.logger.Warningf("errant GTID detection had no evidence to corroborate %v; waiting for the skipped candidates to apply their relay logs and re-running the detection", starvedAliases)
 				// A dominated rescue candidate can't hold a journal entry its dominator
 				// lacks, so only the most-advanced skipped candidates are waited on: a
 				// stuck straggler must not abort the reparent from the rescue path.
@@ -447,19 +511,19 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 				requireAll = !hasUniformCombinedPosition(rescueCandidates)
 				rescueStart := time.Now()
 				var rescueResult *relayLogWaitResult
-				validCandidates, rescueResult, err = erp.applyRelayLogsAndReconcile(ctx, rescueCandidates, validCandidates, tabletMap, stoppedReplicationSnapshot.statusMap, relayLogBudgetLeft, requireAll, true /* isGTIDBased */)
+				candidates, rescueResult, err = erp.applyRelayLogsAndReconcile(ctx, rescueCandidates, candidates, relayLogBudgetLeft, requireAll, true /* isGTIDBased */)
 				if err != nil {
 					return err
 				}
 				relayLogBudgetLeft = max(relayLogBudgetLeft-time.Since(rescueStart), 0)
-				nonAckers = append(nonAckers, rescueResult.failed...)
+				nonAckers = append(nonAckers, ersCandidateAliases(rescueResult.failed)...)
 				waitResult.applied = append(waitResult.applied, rescueResult.applied...)
 
 				// If a candidate still has no evidence now that the counts are
 				// truthful, the other candidates genuinely lack journal entries and
 				// there is nothing more to compare against, same as before this
 				// optimization: accept it
-				validCandidates, _, err = erp.findErrantGTIDs(ctx, validCandidates, stoppedReplicationSnapshot.statusMap, tabletMap, opts.WaitReplicasTimeout, failedEvidence, shardNeverInitialized)
+				candidates, _, err = erp.findErrantGTIDs(ctx, candidates, opts.WaitReplicasTimeout, failedEvidence, shardNeverInitialized)
 				if err != nil {
 					return err
 				}
@@ -468,8 +532,8 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 
 		if len(suspectedSplitBrainCandidates) > 0 {
 			survivingLeaders := 0
-			for alias := range suspectedSplitBrainCandidates {
-				if _, ok := validCandidates[alias]; ok {
+			for _, suspectedCandidate := range suspectedSplitBrainCandidates {
+				if slices.Contains(candidates, suspectedCandidate) {
 					survivingLeaders++
 				}
 			}
@@ -478,7 +542,7 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 			}
 		}
 
-		if len(validCandidates) == 0 {
+		if len(candidates) == 0 {
 			return vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no valid candidates for emergency reparent: all candidates have errant GTIDs")
 		}
 
@@ -487,21 +551,21 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 		// survivors before electing one; we never promote a tablet that hasn't applied
 		// everything it received
 		var appliedSurvived bool
-		for _, alias := range waitResult.applied {
-			if _, ok := validCandidates[alias]; ok {
+		for _, appliedCandidate := range waitResult.applied {
+			if slices.Contains(candidates, appliedCandidate) {
 				appliedSurvived = true
 				break
 			}
 		}
 		if !appliedSurvived {
-			rewaitCandidates := filterToMostAdvancedCombined(validCandidates, erp.logger)
+			rewaitCandidates := filterToMostAdvancedCombined(candidates, erp.logger)
 			// A leading survivor that is in the status map still has relay logs to apply;
 			// promoting it without waiting would violate the received-but-unapplied rule.
 			// A demoted former primary is absent from the status map and is exempt (its
 			// received and executed positions are equal), so it needs no wait.
 			needsWait := false
-			for alias := range rewaitCandidates {
-				if _, ok := stoppedReplicationSnapshot.statusMap[alias]; ok {
+			for _, candidate := range rewaitCandidates {
+				if candidate.stopStatus != nil {
 					needsWait = true
 					break
 				}
@@ -516,11 +580,11 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 				erp.logger.Warningf("no candidate that applied its relay logs survived errant GTID detection; waiting for the remaining candidates to apply their relay logs")
 				requireAll = !hasUniformCombinedPosition(rewaitCandidates)
 				var rewaitResult *relayLogWaitResult
-				validCandidates, rewaitResult, err = erp.applyRelayLogsAndReconcile(ctx, rewaitCandidates, validCandidates, tabletMap, stoppedReplicationSnapshot.statusMap, relayLogBudgetLeft, requireAll, true /* isGTIDBased */)
+				candidates, rewaitResult, err = erp.applyRelayLogsAndReconcile(ctx, rewaitCandidates, candidates, relayLogBudgetLeft, requireAll, true /* isGTIDBased */)
 				if err != nil {
 					return err
 				}
-				nonAckers = append(nonAckers, rewaitResult.failed...)
+				nonAckers = append(nonAckers, ersCandidateAliases(rewaitResult.failed)...)
 			}
 		}
 	}
@@ -528,44 +592,28 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 	// Find the intermediate source for replication that we want other tablets to replicate from.
 	// This step chooses the most advanced tablet. Further ties are broken by using the promotion rule.
 	// In case the user has specified a tablet specifically, then it is selected, as long as it is the most advanced.
-	// Version-aware election is restricted to GTID-based (MySQL/Percona) shards. For non-GTID
-	// flavors (MariaDB, file-position), candidate positions are compared on their executed
-	// position and are not reconciled to a common applied position after the relay-log wait, so
-	// two equally-advanced candidates need not compare equal — falling through to a version
-	// tiebreak there would change long-standing election behavior. Passing nil version/flavor
-	// maps disables version-aware ordering for those shards.
-	versionMap := stoppedReplicationSnapshot.mysqlVersions
-	flavorMap := stoppedReplicationSnapshot.mysqlFlavors
-	if !isGTIDBased {
-		versionMap = nil
-		flavorMap = nil
-	}
-
 	// Here we also check for split brain scenarios and check that the selected replica must be more advanced than all the other valid candidates.
 	// We fail in case there is a split brain detected.
-	// The validCandidateTablets list is sorted by the replication positions with ties broken by promotion rules.
-	// Version-aware election is scoped per candidate set: each step below applies the flavor-family guard
-	// to the tablets it actually chooses among, so a non-candidate tablet elsewhere in the shard does not
-	// disable version comparison for the real candidates.
-	intermediateSource, validCandidateTablets, err = erp.findMostAdvanced(validCandidates, tabletMap, versionMap, flavorMap, opts)
+	// The candidates are sorted by replication position with ties broken by promotion rules.
+	intermediateSource, candidates, err = erp.findMostAdvanced(candidates, opts)
 	if err != nil {
 		return err
 	}
-	erp.logger.Infof("intermediate source selected - %v", intermediateSource.Alias)
+	erp.logger.Infof("intermediate source selected - %s", intermediateSource.alias())
 
 	// After finding the intermediate source, we want to filter the valid candidate list by the following criteria -
 	// 1. Only keep the tablets which can make progress after being promoted (have sufficient reachable semi-sync ackers)
 	// 2. Remove the tablets with the Must_not promote rule
 	// 3. Remove cross-cell tablets if PreventCrossCellPromotion is specified
 	// Our final primary candidate MUST belong to this list of valid candidates
-	validCandidateTablets, err = erp.filterValidCandidates(validCandidateTablets, stoppedReplicationSnapshot.reachableTablets, nonAckers, stoppedReplicationSnapshot.tabletsBackupState, prevPrimary, opts)
+	candidates, err = erp.filterValidCandidates(candidates, stoppedReplicationSnapshot.reachableTablets, nonAckers, prevPrimary, opts)
 	if err != nil {
 		return err
 	}
 
 	// Check whether the intermediate source candidate selected is ideal or if it can be improved later.
 	// If the intermediateSource is ideal, then we can be certain that it is part of the valid candidates list.
-	isIdeal, err = erp.isIntermediateSourceIdeal(intermediateSource, validCandidateTablets, tabletMap, versionMap, flavorMap, opts)
+	isIdeal, err = erp.isIntermediateSourceIdeal(intermediateSource, candidates, opts)
 	if err != nil {
 		return err
 	}
@@ -585,9 +633,9 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 	if !isIdeal {
 		// we now reparent all the tablets to start replicating from the intermediate source
 		// we do not promote the tablet or change the shard record. We only change the replication for all the other tablets
-		// it also returns the list of the tablets that started replication successfully including itself part of the validCandidateTablets list.
+		// It also returns the candidates that started replication successfully, including the intermediate source.
 		// These are the candidates that we can use to find a replacement.
-		validReplacementCandidates, err = erp.promoteIntermediateSource(ctx, ev, intermediateSource, tabletMap, stoppedReplicationSnapshot.statusMap, validCandidateTablets, opts)
+		validReplacementCandidates, err = erp.promoteIntermediateSource(ctx, ev, intermediateSource, candidates, stoppedReplicationSnapshot.statusMap, opts)
 		if err != nil {
 			return err
 		}
@@ -595,14 +643,14 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 		// try to find a better candidate using the list we got back
 		// We prefer to choose a candidate which is in the same cell as our previous primary and of the best possible durability rule.
 		// However, if there is an explicit request from the user to promote a specific tablet, then we choose that tablet.
-		betterCandidate, err = erp.identifyPrimaryCandidate(intermediateSource, validReplacementCandidates, tabletMap, versionMap, flavorMap, opts)
+		betterCandidate, err = erp.identifyPrimaryCandidate(intermediateSource, validReplacementCandidates, opts)
 		if err != nil {
 			return err
 		}
 
 		// if our better candidate is different from our intermediate source, then we wait for it to catch up to the intermediate source
-		if !topoproto.TabletAliasEqual(betterCandidate.Alias, intermediateSource.Alias) {
-			err = waitForCatchUp(ctx, erp.tmc, erp.logger, betterCandidate, intermediateSource, opts.WaitReplicasTimeout)
+		if !topoproto.TabletAliasEqual(betterCandidate.tablet().Alias, intermediateSource.tablet().Alias) {
+			err = waitForCatchUp(ctx, erp.tmc, erp.logger, betterCandidate.tablet(), intermediateSource.tablet(), opts.WaitReplicasTimeout)
 			if err != nil {
 				return err
 			}
@@ -614,21 +662,21 @@ func (erp *EmergencyReparenter) reparentShardLocked(ctx context.Context, ev *eve
 		}
 	}
 
-	// The new primary which will be promoted will always belong to the validCandidateTablets list because -
-	// 	1. 	if the intermediate source is ideal - then we know the intermediate source was in the validCandidateTablets list
+	// The new primary which will be promoted will always belong to the valid candidates because -
+	// 	1. 	if the intermediate source is ideal - then we know the intermediate source was in the valid candidates
 	// 		since we used that list
-	//	2. 	if the intermediate source isn't ideal - we take the intersection of the validCandidateTablets list and the one we
+	//	2. 	if the intermediate source isn't ideal - we take the intersection of the valid candidates and the ones we
 	//		were able to reach during the promotion of intermediate source, as possible candidates. So the final candidate (even if
 	//		it is the intermediate source itself) will belong to the list
-	// Since the new primary tablet belongs to the validCandidateTablets list, we no longer need any additional constraint checks
+	// Since the new primary belongs to the valid candidates, we no longer need any additional constraint checks
 
 	// Final step is to promote our primary candidate
-	_, err = erp.reparentReplicas(ctx, ev, newPrimary, tabletMap, stoppedReplicationSnapshot.statusMap, opts, nonAckers, splitBrainOverrideActive, false /* intermediateReparent */)
+	_, err = erp.reparentReplicas(ctx, ev, newPrimary.tablet(), tabletMap, stoppedReplicationSnapshot.statusMap, opts, nonAckers, splitBrainOverrideActive, false /* intermediateReparent */)
 	if err != nil {
 		return err
 	}
 
-	ev.NewPrimary = newPrimary.CloneVT()
+	ev.NewPrimary = newPrimary.tablet().CloneVT()
 	return err
 }
 
@@ -678,30 +726,25 @@ func (erp *EmergencyReparenter) restartReplicationOnStoppedReplicas(
 // applying wins and the remaining waits are cancelled.
 func (erp *EmergencyReparenter) waitForRelayLogsToApply(
 	ctx context.Context,
-	validCandidates map[string]*RelayLogPositions,
-	tabletMap map[string]*topo.TabletInfo,
-	statusMap map[string]*replicationdatapb.StopReplicationStatus,
+	candidates []*ersCandidate,
 	waitReplicasTimeout time.Duration,
 	requireAll bool,
 ) (*relayLogWaitResult, error) {
-	resultCh := make(chan relayLogResult, len(validCandidates))
+	resultCh := make(chan relayLogResult, len(candidates))
 
 	groupCtx, groupCancel := context.WithTimeout(ctx, waitReplicasTimeout)
 	defer groupCancel()
 
 	waiterCount := 0
 
-	for candidate := range validCandidates {
-		// When we called stopReplicationAndBuildStatusMaps, we got back two
-		// maps: (1) the StopReplicationStatus of any replicas that actually
-		// stopped replication; and (2) the PrimaryStatus of anything that
-		// returned ErrNotReplica, which is a tablet that is either the current
-		// primary or is stuck thinking it is a PRIMARY but is not in actuality.
+	for _, candidate := range candidates {
+		// stopStatus is set for replicas that stopped replication. It is nil for
+		// anything that returned ErrNotReplica, which is either the current primary
+		// or a tablet that is stuck thinking it is PRIMARY but is not in actuality.
 		//
-		// If we have a tablet in the validCandidates map that does not appear
-		// in the statusMap, then we have either (a) the current primary, which
-		// is not replicating, so it is not applying relay logs; or (b) a tablet
-		// that is stuck thinking it is PRIMARY but is not in actuality. In that
+		// If stopStatus is nil, we have either (a) the current primary, which is
+		// not replicating, so it is not applying relay logs; or (b) a tablet that
+		// is stuck thinking it is PRIMARY but is not in actuality. In that
 		// second case - (b) - we will most likely find that the stuck PRIMARY
 		// does not have a winning position, and fail the ERS. If, on the other
 		// hand, it does have a winning position, we are trusting the operator
@@ -709,18 +752,17 @@ func (erp *EmergencyReparenter) waitForRelayLogsToApply(
 		// tablet. In either case, it does not make sense to wait for relay logs
 		// to apply on a tablet that was never applying relay logs in the first
 		// place, so we skip it, and log that we did.
-		status, ok := statusMap[candidate]
-		if !ok {
-			erp.logger.Infof("EmergencyReparent candidate %v not in replica status map; this means it was not running replication (because it was formerly PRIMARY), so skipping WaitForRelayLogsToApply step for this candidate", candidate)
+		if candidate.stopStatus == nil {
+			erp.logger.Infof("EmergencyReparent candidate %s not in replica status map; this means it was not running replication (because it was formerly PRIMARY), so skipping WaitForRelayLogsToApply step for this candidate", candidate.alias())
 			continue
 		}
 
-		go func(alias string, status *replicationdatapb.StopReplicationStatus) {
+		go func(candidate *ersCandidate) {
 			resultCh <- relayLogResult{
-				alias: alias,
-				err:   WaitForRelayLogsToApply(groupCtx, erp.tmc, tabletMap[alias], status),
+				candidate: candidate,
+				err:       WaitForRelayLogsToApply(groupCtx, erp.tmc, candidate.info, candidate.stopStatus),
 			}
-		}(candidate, status)
+		}(candidate)
 
 		waiterCount++
 	}
@@ -741,7 +783,7 @@ func (erp *EmergencyReparenter) waitForRelayLogsToApply(
 		res := <-resultCh
 		switch {
 		case res.err == nil:
-			result.applied = append(result.applied, res.alias)
+			result.applied = append(result.applied, res.candidate)
 			if !requireAll && !weCancelled {
 				// one of the candidates finished applying. the others received the same
 				// changes and can't do better, so stop waiting on them
@@ -752,10 +794,10 @@ func (erp *EmergencyReparenter) waitForRelayLogsToApply(
 			// we stopped waiting on this tablet on purpose (or the reparent was
 			// explicitly aborted), it didn't fail. a parent deadline expiry is not
 			// intentional: the tablet didn't finish in budget and counts as failed below
-			result.cancelled = append(result.cancelled, res.alias)
+			result.cancelled = append(result.cancelled, res.candidate)
 		default:
-			result.failed = append(result.failed, res.alias)
-			erp.logger.Warningf("EmergencyReparent candidate %v failed to apply relay logs: %v", res.alias, res.err)
+			result.failed = append(result.failed, res.candidate)
+			erp.logger.Warningf("EmergencyReparent candidate %s failed to apply relay logs: %v", res.candidate.alias(), res.err)
 			if firstFailure == nil {
 				firstFailure = res.err
 				if requireAll {
@@ -803,93 +845,64 @@ func (erp *EmergencyReparenter) waitForRelayLogsToApply(
 // unwaited former primary.
 func (erp *EmergencyReparenter) applyRelayLogsAndReconcile(
 	ctx context.Context,
-	waitCandidates map[string]*RelayLogPositions,
-	validCandidates map[string]*RelayLogPositions,
-	tabletMap map[string]*topo.TabletInfo,
-	statusMap map[string]*replicationdatapb.StopReplicationStatus,
+	waitCandidates []*ersCandidate,
+	validCandidates []*ersCandidate,
 	waitReplicasTimeout time.Duration,
 	requireAll bool,
 	isGTIDBased bool,
-) (map[string]*RelayLogPositions, *relayLogWaitResult, error) {
-	waitResult, err := erp.waitForRelayLogsToApply(ctx, waitCandidates, tabletMap, statusMap, waitReplicasTimeout, requireAll)
+) ([]*ersCandidate, *relayLogWaitResult, error) {
+	waitResult, err := erp.waitForRelayLogsToApply(ctx, waitCandidates, waitReplicasTimeout, requireAll)
 	if err != nil {
 		return validCandidates, waitResult, err
 	}
 
-	reconciled := maps.Clone(validCandidates)
-	for _, alias := range waitResult.failed {
-		erp.logger.Warningf("EmergencyReparent candidate %v failed to apply its relay logs and cannot be promoted; removing it from the valid candidates", alias)
-		delete(reconciled, alias)
+	reconciled := make([]*ersCandidate, 0, len(validCandidates))
+	for _, candidate := range validCandidates {
+		if slices.Contains(waitResult.failed, candidate) {
+			erp.logger.Warningf("EmergencyReparent candidate %s failed to apply its relay logs and cannot be promoted; removing it from the valid candidates", candidate.alias())
+			continue
+		}
+		reconciled = append(reconciled, candidate)
 	}
-	for _, alias := range waitResult.applied {
-		if pos, ok := reconciled[alias]; ok {
-			erp.logger.Infof("EmergencyReparent candidate %v applied all of its received relay logs", alias)
-			if isGTIDBased {
-				pos.Executed = pos.Combined
-			}
+	for _, candidate := range waitResult.applied {
+		if !slices.Contains(reconciled, candidate) {
+			continue
+		}
+		erp.logger.Infof("EmergencyReparent candidate %s applied all of its received relay logs", candidate.alias())
+		if isGTIDBased {
+			candidate.positions.Executed = candidate.positions.Combined
 		}
 	}
-	for _, alias := range waitResult.cancelled {
-		erp.logger.Infof("EmergencyReparent candidate %v had its relay log wait cancelled after a peer finished applying; keeping its received position", alias)
+	for _, candidate := range waitResult.cancelled {
+		erp.logger.Infof("EmergencyReparent candidate %s had its relay log wait cancelled after a peer finished applying; keeping its received position", candidate.alias())
 	}
 
 	return reconciled, waitResult, nil
 }
 
 // findMostAdvanced finds the intermediate source for ERS. We always choose the most advanced one from our valid candidates list. Further ties are broken by looking at the promotion rules.
-//
-// versionMap and flavorMap are keyed by tablet alias over all reachable tablets;
-// the flavor-family guard is applied over only the candidates being sorted here.
+// It sorts validCandidates in place and returns that same slice, so the caller's ordering
+// is replaced by the promotion order rather than preserved.
 func (erp *EmergencyReparenter) findMostAdvanced(
-	validCandidates map[string]*RelayLogPositions,
-	tabletMap map[string]*topo.TabletInfo,
-	versionMap map[string]mysqlctl.ServerVersion,
-	flavorMap map[string]mysqlctl.MySQLFlavor,
+	validCandidates []*ersCandidate,
 	opts EmergencyReparentOptions,
-) (*topodatapb.Tablet, []*topodatapb.Tablet, error) {
+) (*ersCandidate, []*ersCandidate, error) {
 	erp.logger.Infof("started finding the intermediate source")
 	if len(validCandidates) == 0 {
 		return nil, nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no valid candidates for emergency reparent")
 	}
-	// convert the valid candidates into a list so that we can use it for sorting
-	validTablets, tabletPositions, err := getValidCandidatesAndPositionsAsList(validCandidates, tabletMap)
-	if err != nil {
-		return nil, nil, err
-	}
 
-	// Scope the flavor-family guard to the candidates actually being sorted;
-	// scopedVersion is nil (disabling version ordering) when they span more than
-	// one family.
-	scopedVersion := scopedVersionMap(validTablets, versionMap, flavorMap)
-	if scopedVersion == nil && len(versionMap) > 0 {
+	// Version ordering is disabled when the candidates span flavor families.
+	if mixedFlavorFamilies := sortERSCandidates(validCandidates, opts.durability); mixedFlavorFamilies {
 		erp.logger.Warningf("reparent candidates span multiple MySQL flavor families; skipping version-aware election")
 	}
-
-	// build the version slice for sorting; nil scopedVersion disables version ordering
-	var mysqlVersions []mysqlctl.ServerVersion
-	if len(scopedVersion) > 0 {
-		mysqlVersions = make([]mysqlctl.ServerVersion, len(validTablets))
-		for i, tablet := range validTablets {
-			v, ok := scopedVersion[topoproto.TabletAliasString(tablet.Alias)]
-			if !ok {
-				v = unknownVersion
-			}
-			mysqlVersions[i] = v
-		}
-	}
-
-	// sort the tablets for finding the best intermediate source in ERS — position first to minimize data loss
-	err = sortTabletsForReparent(validTablets, tabletPositions, nil, mysqlVersions, opts.durability, SortByPosition)
-	if err != nil {
-		return nil, nil, err
-	}
-	for _, tablet := range validTablets {
-		erp.logger.Infof("finding intermediate source - sorted replica: %v", tablet.Alias)
+	for _, candidate := range validCandidates {
+		erp.logger.Infof("finding intermediate source - sorted replica: %s", candidate.alias())
 	}
 
 	// The first tablet in the sorted list will be the most eligible candidate unless explicitly asked for some other tablet
-	winningPrimaryTablet := validTablets[0]
-	winningPosition := tabletPositions[0]
+	winningCandidate := validCandidates[0]
+	winningPosition := winningCandidate.positions
 
 	// We have already removed the tablets with errant GTIDs before calling this function. At this point our winning position must be a
 	// superset of all the other valid positions. If any position is incomparable with it, then we have a split brain scenario, and we
@@ -898,17 +911,18 @@ func (erp *EmergencyReparenter) findMostAdvanced(
 	// Reciprocally contained but unequal positions are divergent too, containment just can't order them (MariaDB GTID containment
 	// ignores the origin server), so they must also fail closed. The divergent pair can sit behind a candidate that dominates both
 	// of them, so reciprocal containment is checked between every pair of candidates, not just against the winning position
-	for i, position := range tabletPositions {
+	for i, candidate := range validCandidates {
+		position := candidate.positions
 		if haveIncomparablePositions(winningPosition.Combined, position.Combined) {
-			return nil, nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "split brain detected between servers - %s and %s", topoproto.TabletAliasString(winningPrimaryTablet.Alias), topoproto.TabletAliasString(validTablets[i].Alias))
+			return nil, nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "split brain detected between servers - %s and %s", winningCandidate.alias(), candidate.alias())
 		}
 		// Keep the sort's maximum-at-index-zero guarantee as a defense-in-depth invariant.
 		if hasDominantReparentPosition(position, winningPosition) {
-			return nil, nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "candidate sorting error: %s has a more advanced position than the chosen candidate %s", topoproto.TabletAliasString(validTablets[i].Alias), topoproto.TabletAliasString(winningPrimaryTablet.Alias))
+			return nil, nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "candidate sorting error: %s has a more advanced position than the chosen candidate %s", candidate.alias(), winningCandidate.alias())
 		}
-		for j := i + 1; j < len(tabletPositions); j++ {
-			if haveReciprocallyContainedPositions(position.Combined, tabletPositions[j].Combined) {
-				return nil, nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "split brain detected between servers - %s and %s", topoproto.TabletAliasString(validTablets[i].Alias), topoproto.TabletAliasString(validTablets[j].Alias))
+		for j := i + 1; j < len(validCandidates); j++ {
+			if haveReciprocallyContainedPositions(position.Combined, validCandidates[j].positions.Combined) {
+				return nil, nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "split brain detected between servers - %s and %s", candidate.alias(), validCandidates[j].alias())
 			}
 		}
 	}
@@ -917,22 +931,18 @@ func (erp *EmergencyReparenter) findMostAdvanced(
 	// candidate (non-zero position, no errant GTIDs)
 	if opts.NewPrimaryAlias != nil {
 		requestedPrimaryAlias := topoproto.TabletAliasString(opts.NewPrimaryAlias)
-		pos, ok := validCandidates[requestedPrimaryAlias]
-		if !ok {
+		requestedCandidate := findERSCandidateByAlias(validCandidates, opts.NewPrimaryAlias)
+		if requestedCandidate == nil {
 			return nil, nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "requested primary elect %v has errant GTIDs", requestedPrimaryAlias)
 		}
 		// if the requested tablet is as advanced as the most advanced tablet, then we can just use it for promotion.
 		// otherwise, we should let it catchup to the most advanced tablet and not change the intermediate source
-		if pos.AtLeast(winningPosition) {
-			requestedPrimaryInfo, isFound := tabletMap[requestedPrimaryAlias]
-			if !isFound {
-				return nil, nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "candidate %v not found in the tablet map; this an impossible situation", requestedPrimaryAlias)
-			}
-			winningPrimaryTablet = requestedPrimaryInfo.Tablet
+		if requestedCandidate.positions.AtLeast(winningPosition) {
+			winningCandidate = requestedCandidate
 		}
 	}
 
-	return winningPrimaryTablet, validTablets, nil
+	return winningCandidate, validCandidates, nil
 }
 
 // promoteIntermediateSource reparents all the other tablets to start replicating from the intermediate source.
@@ -940,38 +950,39 @@ func (erp *EmergencyReparenter) findMostAdvanced(
 func (erp *EmergencyReparenter) promoteIntermediateSource(
 	ctx context.Context,
 	ev *events.Reparent,
-	source *topodatapb.Tablet,
-	tabletMap map[string]*topo.TabletInfo,
+	source *ersCandidate,
+	validCandidates []*ersCandidate,
 	statusMap map[string]*replicationdatapb.StopReplicationStatus,
-	validCandidateTablets []*topodatapb.Tablet,
 	opts EmergencyReparentOptions,
-) ([]*topodatapb.Tablet, error) {
+) ([]*ersCandidate, error) {
 	// Create a tablet map from all the valid replicas
 	validTabletMap := map[string]*topo.TabletInfo{}
-	for _, candidate := range validCandidateTablets {
-		alias := topoproto.TabletAliasString(candidate.Alias)
-		validTabletMap[alias] = tabletMap[alias]
+	for _, candidate := range validCandidates {
+		validTabletMap[candidate.alias()] = candidate.info
 	}
 
 	// we reparent all the other valid tablets to start replication from our new source
 	// we wait for all the replicas so that we can choose a better candidate from the ones that started replication later
 	// The intermediate reparent doesn't run the acker quorum gate, so it has no
 	// non-ackers to exclude.
-	reachableTablets, err := erp.reparentReplicas(ctx, ev, source, validTabletMap, statusMap, opts, nil /* nonAckers */, false /* splitBrainOverrideActive */, true /* intermediateReparent */)
+	reachableTablets, err := erp.reparentReplicas(ctx, ev, source.tablet(), validTabletMap, statusMap, opts, nil /* nonAckers */, false /* splitBrainOverrideActive */, true /* intermediateReparent */)
 	if err != nil {
 		return nil, err
 	}
 
 	// also include the current tablet for being considered as part of valid candidates for ERS promotion
-	reachableTablets = append(reachableTablets, source)
+	reachableTablets = append(reachableTablets, source.tablet())
+	reachableAliases := sets.New[string]()
+	for _, tablet := range reachableTablets {
+		reachableAliases.Insert(topoproto.TabletAliasString(tablet.Alias))
+	}
 
 	// The only valid candidates for improvement are the ones which are reachable and part of the valid candidate list.
-	// Here we need to be careful not to mess up the ordering of tablets in validCandidateTablets, since the list is sorted by the
-	// replication positions.
-	var validCandidatesForImprovement []*topodatapb.Tablet
-	for _, tablet := range validCandidateTablets {
-		if topoproto.IsTabletInList(tablet, reachableTablets) {
-			validCandidatesForImprovement = append(validCandidatesForImprovement, tablet)
+	// Preserve candidate order here because the slice is already sorted by replication position.
+	validCandidatesForImprovement := make([]*ersCandidate, 0, len(validCandidates))
+	for _, candidate := range validCandidates {
+		if reachableAliases.Has(candidate.alias()) {
+			validCandidatesForImprovement = append(validCandidatesForImprovement, candidate)
 		}
 	}
 	return validCandidatesForImprovement, nil
@@ -1247,36 +1258,30 @@ func (erp *EmergencyReparenter) reparentReplicas(
 
 // isIntermediateSourceIdeal is used to find whether the intermediate source that ERS chose is also the ideal one or not
 func (erp *EmergencyReparenter) isIntermediateSourceIdeal(
-	intermediateSource *topodatapb.Tablet,
-	validCandidates []*topodatapb.Tablet,
-	tabletMap map[string]*topo.TabletInfo,
-	versionMap map[string]mysqlctl.ServerVersion,
-	flavorMap map[string]mysqlctl.MySQLFlavor,
+	intermediateSource *ersCandidate,
+	validCandidates []*ersCandidate,
 	opts EmergencyReparentOptions,
 ) (bool, error) {
-	candidate, err := erp.identifyPrimaryCandidate(intermediateSource, validCandidates, tabletMap, versionMap, flavorMap, opts)
+	// we try to find a better candidate with the current list of valid candidates, and if it matches our current primary candidate, then we return true
+	candidate, err := erp.identifyPrimaryCandidate(intermediateSource, validCandidates, opts)
 	if err != nil {
 		return false, err
 	}
-	return candidate == intermediateSource, nil
+	return candidate.isSameTablet(intermediateSource), nil
 }
 
 // identifyPrimaryCandidate is used to find the final candidate for ERS promotion.
 //
-// versionMap and flavorMap are keyed by tablet alias over all reachable tablets;
-// the flavor-family guard is applied over only the candidates considered in each
-// promotion tier.
+// Version and flavor state travels with each candidate, and the flavor-family
+// guard is scoped to the candidates considered in each promotion tier.
 func (erp *EmergencyReparenter) identifyPrimaryCandidate(
-	intermediateSource *topodatapb.Tablet,
-	validCandidates []*topodatapb.Tablet,
-	tabletMap map[string]*topo.TabletInfo,
-	versionMap map[string]mysqlctl.ServerVersion,
-	flavorMap map[string]mysqlctl.MySQLFlavor,
+	intermediateSource *ersCandidate,
+	validCandidates []*ersCandidate,
 	opts EmergencyReparentOptions,
-) (candidate *topodatapb.Tablet, err error) {
+) (candidate *ersCandidate, err error) {
 	defer func() {
 		if candidate != nil {
-			erp.logger.Infof("found better candidate - %v", candidate.Alias)
+			erp.logger.Infof("found better candidate - %s", candidate.alias())
 		}
 	}()
 
@@ -1286,15 +1291,11 @@ func (erp *EmergencyReparenter) identifyPrimaryCandidate(
 
 	if opts.NewPrimaryAlias != nil {
 		// explicit request to promote a specific tablet
-		requestedPrimaryAlias := topoproto.TabletAliasString(opts.NewPrimaryAlias)
-		requestedPrimaryInfo, isFound := tabletMap[requestedPrimaryAlias]
-		if !isFound {
-			return nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "candidate %v not found in the tablet map; this an impossible situation", requestedPrimaryAlias)
+		requestedCandidate := findERSCandidateByAlias(validCandidates, opts.NewPrimaryAlias)
+		if requestedCandidate != nil {
+			return requestedCandidate, nil
 		}
-		if topoproto.IsTabletInList(requestedPrimaryInfo.Tablet, validCandidates) {
-			return requestedPrimaryInfo.Tablet, nil
-		}
-		return nil, vterrors.Errorf(vtrpc.Code_ABORTED, "requested candidate %v is not in valid candidates list", requestedPrimaryAlias)
+		return nil, vterrors.Errorf(vtrpc.Code_ABORTED, "requested candidate %v is not in valid candidates list", topoproto.TabletAliasString(opts.NewPrimaryAlias))
 	}
 
 	// We have already selected an intermediate source which was selected based on the replication position
@@ -1309,10 +1310,7 @@ func (erp *EmergencyReparenter) identifyPrimaryCandidate(
 	// If versions are equal, we still prefer the intermediate source to avoid catch-up.
 	for _, promotionRule := range promotionrule.AllPromotionRules() {
 		candidates := getTabletsWithPromotionRules(opts.durability, validCandidates, promotionRule)
-		// Scope the flavor-family guard to this tier's candidates: nil disables
-		// version comparison when they span more than one family.
-		scopedVersion := scopedVersionMap(candidates, versionMap, flavorMap)
-		candidate = findCandidate(intermediateSource, candidates, scopedVersion)
+		candidate = findCandidate(intermediateSource, candidates)
 		if candidate != nil {
 			return candidate, nil
 		}
@@ -1323,16 +1321,17 @@ func (erp *EmergencyReparenter) identifyPrimaryCandidate(
 	return nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "unreachable - did not find a valid primary candidate even though the valid candidate list was non-empty")
 }
 
-// filterValidCandidates filters valid tablets, keeping only the ones which can successfully be promoted without any
+// filterValidCandidates filters valid candidates, keeping only the ones which can successfully be promoted without any
 // constraint failures and can make forward progress on being promoted. It will filter out candidates taking backups
 // if possible. The nonAckers are reachable tablets that won't be able to send semi-sync ACKs after the promotion,
 // so they don't count towards a candidate's forward progress; they were still reached, so a non-acker remains
 // individually promotable.
-func (erp *EmergencyReparenter) filterValidCandidates(validTablets []*topodatapb.Tablet, tabletsReachable []*topodatapb.Tablet, nonAckers []string, tabletsBackupState map[string]bool, prevPrimary *topodatapb.Tablet, opts EmergencyReparentOptions) ([]*topodatapb.Tablet, error) {
+func (erp *EmergencyReparenter) filterValidCandidates(validCandidates []*ersCandidate, tabletsReachable []*topodatapb.Tablet, nonAckers []string, prevPrimary *topodatapb.Tablet, opts EmergencyReparentOptions) ([]*ersCandidate, error) {
 	ackersReachable := removeTabletsByAlias(tabletsReachable, nonAckers)
-	restrictedValidTablets := make([]*topodatapb.Tablet, 0, len(validTablets))
-	notPreferredValidTablets := make([]*topodatapb.Tablet, 0, len(validTablets))
-	for _, tablet := range validTablets {
+	restrictedValidCandidates := make([]*ersCandidate, 0, len(validCandidates))
+	notPreferredValidCandidates := make([]*ersCandidate, 0, len(validCandidates))
+	for _, candidate := range validCandidates {
+		tablet := candidate.tablet()
 		tabletAliasStr := topoproto.TabletAliasString(tablet.Alias)
 		// Remove tablets which have MustNot promote rule since they must never be promoted
 		if policy.PromotionRule(opts.durability, tablet) == promotionrule.MustNot {
@@ -1365,19 +1364,26 @@ func (erp *EmergencyReparenter) filterValidCandidates(validTablets []*topodatapb
 			continue
 		}
 		// Put candidates that are running a backup in a separate list
-		backingUp, ok := tabletsBackupState[tabletAliasStr]
-		if ok && backingUp {
+		if candidate.takingBackup {
 			erp.logger.Infof("Setting %s in list of valid candidates taking a backup", tabletAliasStr)
-			notPreferredValidTablets = append(notPreferredValidTablets, tablet)
+			notPreferredValidCandidates = append(notPreferredValidCandidates, candidate)
 		} else {
-			restrictedValidTablets = append(restrictedValidTablets, tablet)
+			restrictedValidCandidates = append(restrictedValidCandidates, candidate)
 		}
 	}
-	if len(restrictedValidTablets) > 0 {
-		return restrictedValidTablets, nil
+	if len(restrictedValidCandidates) > 0 {
+		// A backup only costs a candidate its place when a preferred one exists, so this
+		// is the first point where we know the requested primary is actually being
+		// dropped. Say why here: otherwise it resurfaces as a bare "not in valid
+		// candidates list" from identifyPrimaryCandidate, which names the consequence
+		// and not the cause
+		if opts.NewPrimaryAlias != nil && findERSCandidateByAlias(notPreferredValidCandidates, opts.NewPrimaryAlias) != nil {
+			return nil, vterrors.Errorf(vtrpc.Code_ABORTED, "proposed primary %s is taking a backup and other candidates are available", topoproto.TabletAliasString(opts.NewPrimaryAlias))
+		}
+		return restrictedValidCandidates, nil
 	}
 
-	return notPreferredValidTablets, nil
+	return notPreferredValidCandidates, nil
 }
 
 // findErrantGTIDs tries to find errant GTIDs for the valid candidates and returns the updated list of valid candidates.
@@ -1391,16 +1397,14 @@ func (erp *EmergencyReparenter) filterValidCandidates(validTablets []*topodatapb
 // reparentShardLocked).
 func (erp *EmergencyReparenter) findErrantGTIDs(
 	ctx context.Context,
-	validCandidates map[string]*RelayLogPositions,
-	statusMap map[string]*replicationdatapb.StopReplicationStatus,
-	tabletMap map[string]*topo.TabletInfo,
+	validCandidates []*ersCandidate,
 	waitReplicasTimeout time.Duration,
 	extraEvidence []replication.Position,
 	shardNeverInitialized bool,
-) (map[string]*RelayLogPositions, []string, error) {
+) ([]*ersCandidate, []*ersCandidate, error) {
 	allPositionsZero := len(validCandidates) > 0
-	for _, positions := range validCandidates {
-		if positions == nil || !positions.IsZero() {
+	for _, candidate := range validCandidates {
+		if candidate.positions == nil || !candidate.positions.IsZero() {
 			allPositionsZero = false
 			break
 		}
@@ -1414,15 +1418,14 @@ func (erp *EmergencyReparenter) findErrantGTIDs(
 	// A missing journal table is only tolerated when the topology says never initialized
 	// and no candidate has any GTIDs; a nonzero position anywhere proves history, so an
 	// unreadable journal depth must fail the gather
-	reparentJournalLen, err := erp.gatherReparentJournalInfo(ctx, validCandidates, tabletMap, waitReplicasTimeout, shardNeverInitialized && allPositionsZero)
-	if err != nil {
+	if err := erp.gatherReparentJournalInfo(ctx, validCandidates, waitReplicasTimeout, shardNeverInitialized && allPositionsZero); err != nil {
 		return nil, nil, err
 	}
 
 	// Find the maximum length of the reparent journal among all the candidates.
 	var maxLen int32
-	for _, length := range reparentJournalLen {
-		maxLen = max(maxLen, length)
+	for _, candidate := range validCandidates {
+		maxLen = max(maxLen, candidate.reparentJournalLen)
 	}
 
 	// A shard where every candidate has an empty GTID position and an empty reparent
@@ -1436,43 +1439,40 @@ func (erp *EmergencyReparenter) findErrantGTIDs(
 		if !shardNeverInitialized {
 			return nil, nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "every candidate reports an empty GTID position and an empty reparent journal, but the shard topology records a previous primary: refusing to re-initialize a shard that has history to protect; restore a tablet with the shard's data before retrying")
 		}
-		return maps.Clone(validCandidates), nil, nil
+		return slices.Clone(validCandidates), nil, nil
 	}
 
 	// A tablet with nil or zero positions has no GTIDs to corroborate anyone and can't be
 	// promoted over tablets with real history, so it is dropped from candidacy up front.
-	nonZeroCandidates := make(map[string]*RelayLogPositions, len(validCandidates))
-	for alias, positions := range validCandidates {
-		if positions == nil || positions.IsZero() {
-			erp.logger.Warningf("skipping candidate %s during errant GTID detection: nil or zero positions", alias)
+	nonZeroCandidates := make([]*ersCandidate, 0, len(validCandidates))
+	for _, candidate := range validCandidates {
+		if candidate.positions == nil || candidate.positions.IsZero() {
+			erp.logger.Warningf("skipping candidate %s during errant GTID detection: nil or zero positions", candidate.alias())
 			continue
 		}
-		nonZeroCandidates[alias] = positions
+		nonZeroCandidates = append(nonZeroCandidates, candidate)
 	}
 
 	// Find the candidates with the maximum length of the reparent journal. A dropped
 	// zero-position tablet can't be part of the evidence tier: it has no GTIDs to
 	// compare anyone against.
-	var maxLenCandidates []string
-	for alias, length := range reparentJournalLen {
-		if length != maxLen {
+	maxLenCandidates := make([]*ersCandidate, 0, len(nonZeroCandidates))
+	for _, candidate := range nonZeroCandidates {
+		if candidate.reparentJournalLen != maxLen {
 			continue
 		}
-		if _, ok := nonZeroCandidates[alias]; !ok {
-			continue
-		}
-		maxLenCandidates = append(maxLenCandidates, alias)
+		maxLenCandidates = append(maxLenCandidates, candidate)
 	}
 
 	// If every tablet holding the latest reparent journal history had its GTID state
 	// wiped, the surviving candidates provably missed a promotion and no evidence is
 	// left to prove what it contained. Promoting one of them could silently discard
 	// the missed history, so fail closed and leave the decision to an operator.
-	if len(maxLenCandidates) == 0 && len(reparentJournalLen) > 0 {
+	if len(maxLenCandidates) == 0 && len(validCandidates) > 0 {
 		var wipedLeaders []string
-		for alias, length := range reparentJournalLen {
-			if length == maxLen {
-				wipedLeaders = append(wipedLeaders, alias)
+		for _, candidate := range validCandidates {
+			if candidate.reparentJournalLen == maxLen {
+				wipedLeaders = append(wipedLeaders, candidate.alias())
 			}
 		}
 		slices.Sort(wipedLeaders)
@@ -1481,12 +1481,11 @@ func (erp *EmergencyReparenter) findErrantGTIDs(
 
 	// We use all the candidates with the maximum length of the reparent journal to find the errant GTIDs amongst them.
 	var maxLenPositions []replication.Position
-	var starvedCandidates []string
-	updatedValidCandidates := make(map[string]*RelayLogPositions)
+	var starvedCandidates []*ersCandidate
+	updatedValidCandidateSet := sets.New[*ersCandidate]()
 	for _, candidate := range maxLenCandidates {
-		candidatePositions := nonZeroCandidates[candidate]
-		status, ok := statusMap[candidate]
-		if !ok {
+		candidatePositions := candidate.positions
+		if candidate.stopStatus == nil {
 			// If the tablet is not in the status map, and has the maximum length of the reparent journal,
 			// then it should be the latest primary and we don't need to run any errant GTID detection on it!
 			// There is a very unlikely niche case that can happen where we see two tablets report themselves as having
@@ -1498,7 +1497,7 @@ func (erp *EmergencyReparenter) findErrantGTIDs(
 			// Even in this case, the best we can do is not run errant GTID detection on either, and let the split brain detection code
 			// deal with it, if A in fact has errant GTIDs.
 			maxLenPositions = append(maxLenPositions, candidatePositions.Combined)
-			updatedValidCandidates[candidate] = candidatePositions
+			updatedValidCandidateSet.Insert(candidate)
 			continue
 		}
 		// Store all the other candidate's positions so that we can run errant GTID detection using them.
@@ -1507,7 +1506,7 @@ func (erp *EmergencyReparenter) findErrantGTIDs(
 			if otherCandidate == candidate {
 				continue
 			}
-			otherPositions = append(otherPositions, nonZeroCandidates[otherCandidate].Combined)
+			otherPositions = append(otherPositions, otherCandidate.positions.Combined)
 		}
 		otherPositions = append(otherPositions, extraEvidence...)
 		// FindErrantGTIDs accepts a candidate's GTID set as-is when there is nothing to
@@ -1517,17 +1516,17 @@ func (erp *EmergencyReparenter) findErrantGTIDs(
 			starvedCandidates = append(starvedCandidates, candidate)
 		}
 		// Run errant GTID detection and throw away any tablet that has errant GTIDs.
-		afterStatus := replication.ProtoToReplicationStatus(status.After)
+		afterStatus := replication.ProtoToReplicationStatus(candidate.stopStatus.After)
 		errantGTIDs, err := replication.FindErrantGTIDs(afterStatus.RelayLogPosition, afterStatus.SourceUUID, otherPositions)
 		if err != nil {
 			return nil, nil, err
 		}
 		if errantGTIDs != nil {
-			log.Error(fmt.Sprintf("skipping %v with GTIDSet:%v because we detected errant GTIDs - %v", candidate, afterStatus.RelayLogPosition.GTIDSet, errantGTIDs))
+			log.Error(fmt.Sprintf("skipping %s with GTIDSet:%v because we detected errant GTIDs - %v", candidate.alias(), afterStatus.RelayLogPosition.GTIDSet, errantGTIDs))
 			continue
 		}
 		maxLenPositions = append(maxLenPositions, candidatePositions.Combined)
-		updatedValidCandidates[candidate] = candidatePositions
+		updatedValidCandidateSet.Insert(candidate)
 	}
 
 	// The extra evidence positions also corroborate the lagged tablets below.
@@ -1536,8 +1535,8 @@ func (erp *EmergencyReparenter) findErrantGTIDs(
 	// For all the other tablets, that are lagged enough that they haven't seen all the reparent journal entries,
 	// we run errant GTID detection by using the tablets with the maximum length of the reparent journal.
 	// We throw away any tablet that has errant GTIDs.
-	for alias, length := range reparentJournalLen {
-		if length == maxLen {
+	for _, candidate := range nonZeroCandidates {
+		if candidate.reparentJournalLen == maxLen {
 			continue
 		}
 		// Here we don't want to send the source UUID. The reason is that all of these tablets are lagged,
@@ -1555,19 +1554,23 @@ func (erp *EmergencyReparenter) findErrantGTIDs(
 		// This exact scenario outlined above, can be found in the test for this function, subtest `Case 5a`.
 		// The idea is that if the tablet is lagged, then even the server UUID that it is replicating from
 		// should not be considered a valid source of writes that no other tablet has.
-		candidatePositions, ok := nonZeroCandidates[alias]
-		if !ok {
-			continue
-		}
+		candidatePositions := candidate.positions
 		errantGTIDs, err := replication.FindErrantGTIDs(candidatePositions.Combined, replication.SID{}, maxLenPositions)
 		if err != nil {
 			return nil, nil, err
 		}
 		if errantGTIDs != nil {
-			log.Error(fmt.Sprintf("skipping %v with GTIDSet:%v because we detected errant GTIDs - %v", alias, candidatePositions, errantGTIDs))
+			log.Error(fmt.Sprintf("skipping %s with GTIDSet:%v because we detected errant GTIDs - %v", candidate.alias(), candidatePositions, errantGTIDs))
 			continue
 		}
-		updatedValidCandidates[alias] = candidatePositions
+		updatedValidCandidateSet.Insert(candidate)
+	}
+
+	updatedValidCandidates := make([]*ersCandidate, 0, len(updatedValidCandidateSet))
+	for _, candidate := range validCandidates {
+		if updatedValidCandidateSet.Has(candidate) {
+			updatedValidCandidates = append(updatedValidCandidates, candidate)
+		}
 	}
 
 	return updatedValidCandidates, starvedCandidates, nil
@@ -1576,13 +1579,10 @@ func (erp *EmergencyReparenter) findErrantGTIDs(
 // gatherReparentJournalInfo reads the reparent journal information from all the tablets in the valid candidates list.
 func (erp *EmergencyReparenter) gatherReparentJournalInfo(
 	ctx context.Context,
-	validCandidates map[string]*RelayLogPositions,
-	tabletMap map[string]*topo.TabletInfo,
+	validCandidates []*ersCandidate,
 	waitReplicasTimeout time.Duration,
 	tolerateMissingJournal bool,
-) (map[string]int32, error) {
-	reparentJournalLen := make(map[string]int32)
-	var mu sync.Mutex
+) error {
 	errCh := make(chan concurrency.Error)
 	defer close(errCh)
 
@@ -1591,8 +1591,8 @@ func (erp *EmergencyReparenter) gatherReparentJournalInfo(
 
 	waiterCount := 0
 
-	for candidate := range validCandidates {
-		go func(alias string) {
+	for _, candidate := range validCandidates {
+		go func(candidate *ersCandidate) {
 			var err error
 			var length int32
 			defer func() {
@@ -1600,19 +1600,17 @@ func (erp *EmergencyReparenter) gatherReparentJournalInfo(
 					Err: err,
 				}
 			}()
-			length, err = erp.tmc.ReadReparentJournalInfo(groupCtx, tabletMap[alias].Tablet)
+			length, err = erp.tmc.ReadReparentJournalInfo(groupCtx, candidate.tablet())
 			if err != nil && tolerateMissingJournal {
 				// A brand-new shard has no sidecar tables yet: treat a missing journal
 				// table as zero entries so ERS can still initialize it
 				if sqlErr, ok := sqlerror.NewSQLErrorFromError(err).(*sqlerror.SQLError); ok &&
 					(sqlErr.Number() == sqlerror.ERNoSuchTable || sqlErr.Number() == sqlerror.ERBadDb) {
-					erp.logger.Warningf("treating missing reparent journal table on %s as zero entries during errant GTID detection: %v", alias, err)
+					erp.logger.Warningf("treating missing reparent journal table on %s as zero entries during errant GTID detection: %v", candidate.alias(), err)
 					length, err = 0, nil
 				}
 			}
-			mu.Lock()
-			defer mu.Unlock()
-			reparentJournalLen[alias] = length
+			candidate.reparentJournalLen = length
 		}(candidate)
 
 		waiterCount++
@@ -1626,8 +1624,8 @@ func (erp *EmergencyReparenter) gatherReparentJournalInfo(
 	rec := errgroup.Wait(groupCancel, errCh)
 
 	if len(rec.Errors) != 0 {
-		return nil, vterrors.Wrapf(rec.Error(), "could not read reparent journal information within the provided waitReplicasTimeout (%s)", waitReplicasTimeout)
+		return vterrors.Wrapf(rec.Error(), "could not read reparent journal information within the provided waitReplicasTimeout (%s)", waitReplicasTimeout)
 	}
 
-	return reparentJournalLen, nil
+	return nil
 }

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -119,11 +119,7 @@ func (c *ersCandidate) tablet() *topodatapb.Tablet {
 	return c.info.Tablet
 }
 
-// isSameTablet reports whether two candidates are the same tablet. Within a single
-// ERS run pointer equality would do, but comparing aliases keeps the answer correct
-// for a caller that built its candidate elsewhere. A candidate without an alias has
-// no identity to match on, so it is never the same tablet as anything, including
-// another candidate without an alias.
+// isSameTablet compares aliases; a candidate without one never matches.
 func (c *ersCandidate) isSameTablet(other *ersCandidate) bool {
 	if c == nil || other == nil || c.info == nil || other.info == nil {
 		return false
@@ -892,9 +888,15 @@ func (erp *EmergencyReparenter) findMostAdvanced(
 		return nil, nil, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "no valid candidates for emergency reparent")
 	}
 
-	// Version ordering is disabled when the candidates span flavor families.
-	if mixedFlavorFamilies := sortERSCandidates(validCandidates, opts.durability); mixedFlavorFamilies {
+	// Version ordering is disabled when the candidates span flavor families. The guard is
+	// scoped to the candidates being sorted, so a tablet elsewhere in the shard that is
+	// not a candidate cannot disable version comparison for the ones being elected among.
+	mysqlVersions, mixedFlavorFamilies := usableERSCandidateMySQLVersions(validCandidates)
+	if mixedFlavorFamilies {
 		erp.logger.Warningf("reparent candidates span multiple MySQL flavor families; skipping version-aware election")
+	}
+	if err := sortERSCandidates(validCandidates, mysqlVersions, opts.durability); err != nil {
+		return nil, nil, err
 	}
 	for _, candidate := range validCandidates {
 		erp.logger.Infof("finding intermediate source - sorted replica: %s", candidate.alias())
@@ -1482,7 +1484,9 @@ func (erp *EmergencyReparenter) findErrantGTIDs(
 	// We use all the candidates with the maximum length of the reparent journal to find the errant GTIDs amongst them.
 	var maxLenPositions []replication.Position
 	var starvedCandidates []*ersCandidate
-	updatedValidCandidateSet := sets.New[*ersCandidate]()
+	// Survivor order carries no contract: findMostAdvanced sorts these again, with a
+	// tablet-alias tiebreak, before anything is elected
+	var updatedValidCandidates []*ersCandidate
 	for _, candidate := range maxLenCandidates {
 		candidatePositions := candidate.positions
 		if candidate.stopStatus == nil {
@@ -1497,7 +1501,7 @@ func (erp *EmergencyReparenter) findErrantGTIDs(
 			// Even in this case, the best we can do is not run errant GTID detection on either, and let the split brain detection code
 			// deal with it, if A in fact has errant GTIDs.
 			maxLenPositions = append(maxLenPositions, candidatePositions.Combined)
-			updatedValidCandidateSet.Insert(candidate)
+			updatedValidCandidates = append(updatedValidCandidates, candidate)
 			continue
 		}
 		// Store all the other candidate's positions so that we can run errant GTID detection using them.
@@ -1526,7 +1530,7 @@ func (erp *EmergencyReparenter) findErrantGTIDs(
 			continue
 		}
 		maxLenPositions = append(maxLenPositions, candidatePositions.Combined)
-		updatedValidCandidateSet.Insert(candidate)
+		updatedValidCandidates = append(updatedValidCandidates, candidate)
 	}
 
 	// The extra evidence positions also corroborate the lagged tablets below.
@@ -1563,14 +1567,7 @@ func (erp *EmergencyReparenter) findErrantGTIDs(
 			log.Error(fmt.Sprintf("skipping %s with GTIDSet:%v because we detected errant GTIDs - %v", candidate.alias(), candidatePositions, errantGTIDs))
 			continue
 		}
-		updatedValidCandidateSet.Insert(candidate)
-	}
-
-	updatedValidCandidates := make([]*ersCandidate, 0, len(updatedValidCandidateSet))
-	for _, candidate := range validCandidates {
-		if updatedValidCandidateSet.Has(candidate) {
-			updatedValidCandidates = append(updatedValidCandidates, candidate)
-		}
+		updatedValidCandidates = append(updatedValidCandidates, candidate)
 	}
 
 	return updatedValidCandidates, starvedCandidates, nil

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -87,13 +87,9 @@ type EmergencyReparentOptions struct {
 	durability policy.Durabler
 }
 
-// ersCandidate is one ERS promotion candidate and its per-tablet pipeline state.
-//
-// buildERSCandidates is the only place that builds these, and it builds exactly one
-// per tablet for the whole run. Every later stage filters that pool into new slices
-// without ever rebuilding a candidate, so a *ersCandidate is a stable identity for
-// its tablet and set membership can be tested by pointer. Anything that builds a
-// second candidate for a tablet already in the pool breaks that, so don't.
+// ersCandidate holds the state ERS tracks for one promotion candidate. It is
+// built once, then reused as the candidate pool is filtered, so its pointer is a
+// stable identity for the whole run.
 type ersCandidate struct {
 	info      *topo.TabletInfo
 	positions *RelayLogPositions

--- a/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter_test.go
@@ -19,7 +19,6 @@ package reparentutil
 import (
 	"context"
 	"errors"
-	"maps"
 	"slices"
 	"strings"
 	"sync"
@@ -55,6 +54,141 @@ import (
 	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
 	"vitess.io/vitess/go/vt/proto/vtrpc"
 )
+
+func ersCandidatesFromPositionsForTest(
+	t *testing.T,
+	positions map[string]*RelayLogPositions,
+	tabletMap map[string]*topo.TabletInfo,
+	statusMap map[string]*replicationdatapb.StopReplicationStatus,
+) []*ersCandidate {
+	t.Helper()
+
+	candidates := make([]*ersCandidate, 0, len(positions))
+	for alias, candidatePositions := range positions {
+		info := tabletMap[alias]
+		require.NotNil(t, info)
+		candidates = append(candidates, &ersCandidate{
+			info:       info,
+			positions:  candidatePositions,
+			stopStatus: statusMap[alias],
+		})
+	}
+
+	return candidates
+}
+
+func ersCandidatesFromTabletsForTest(
+	tablets []*topodatapb.Tablet,
+	tabletMap map[string]*topo.TabletInfo,
+	statusMap map[string]*replicationdatapb.StopReplicationStatus,
+	tabletsTakingBackup map[string]bool,
+) []*ersCandidate {
+	candidates := make([]*ersCandidate, 0, len(tablets))
+	for _, tablet := range tablets {
+		alias := topoproto.TabletAliasString(tablet.Alias)
+		info := tabletMap[alias]
+		if info == nil {
+			info = &topo.TabletInfo{Tablet: tablet}
+		}
+		candidates = append(candidates, &ersCandidate{
+			info:         info,
+			stopStatus:   statusMap[alias],
+			takingBackup: tabletsTakingBackup[alias],
+		})
+	}
+
+	return candidates
+}
+
+func setERSCandidateVersionsForTest(
+	candidates []*ersCandidate,
+	versionMap map[string]mysqlctl.ServerVersion,
+	flavorMap map[string]mysqlctl.MySQLFlavor,
+) {
+	for _, candidate := range candidates {
+		alias := candidate.alias()
+		candidate.mysqlVersion, candidate.hasMySQLVersion = versionMap[alias]
+		candidate.mysqlFlavor = flavorMap[alias]
+	}
+}
+
+func ersCandidateForTabletForTest(candidates []*ersCandidate, tablet *topodatapb.Tablet) *ersCandidate {
+	if tablet == nil {
+		return nil
+	}
+	if candidate := findERSCandidateByAlias(candidates, tablet.Alias); candidate != nil {
+		return candidate
+	}
+	return &ersCandidate{info: &topo.TabletInfo{Tablet: tablet}}
+}
+
+func ersCandidateByAliasForTest(t *testing.T, candidates []*ersCandidate, alias string) *ersCandidate {
+	t.Helper()
+
+	for _, candidate := range candidates {
+		if candidate.alias() == alias {
+			return candidate
+		}
+	}
+	require.FailNow(t, "candidate not found", "alias: %s", alias)
+	return nil
+}
+
+func ersCandidatesByAliasForTest(t *testing.T, candidates []*ersCandidate, aliases ...string) []*ersCandidate {
+	t.Helper()
+
+	result := make([]*ersCandidate, 0, len(aliases))
+	for _, alias := range aliases {
+		result = append(result, ersCandidateByAliasForTest(t, candidates, alias))
+	}
+	return result
+}
+
+func ersCandidateTabletsForTest(candidates []*ersCandidate) []*topodatapb.Tablet {
+	tablets := make([]*topodatapb.Tablet, 0, len(candidates))
+	for _, candidate := range candidates {
+		tablets = append(tablets, candidate.tablet())
+	}
+	return tablets
+}
+
+func TestERSCandidateIsSameTablet(t *testing.T) {
+	t.Parallel()
+
+	withAlias := func(cell string, uid uint32) *ersCandidate {
+		return &ersCandidate{info: &topo.TabletInfo{Tablet: &topodatapb.Tablet{
+			Alias: &topodatapb.TabletAlias{Cell: cell, Uid: uid},
+		}}}
+	}
+
+	candidate := withAlias("zone1", 100)
+	var nilCandidate *ersCandidate
+
+	t.Run("same tablet built separately", func(t *testing.T) {
+		assert.True(t, candidate.isSameTablet(withAlias("zone1", 100)))
+	})
+
+	t.Run("different tablets", func(t *testing.T) {
+		assert.False(t, candidate.isSameTablet(withAlias("zone1", 101)))
+		assert.False(t, candidate.isSameTablet(withAlias("zone2", 100)))
+	})
+
+	// a candidate with no alias has no identity to match on, so it matches nothing.
+	// two of them must not compare equal either: isIntermediateSourceIdeal reads a
+	// true here as "no better candidate exists" and skips the intermediate promotion
+	t.Run("candidates without an identity match nothing", func(t *testing.T) {
+		noInfo := &ersCandidate{}
+		noAlias := &ersCandidate{info: &topo.TabletInfo{Tablet: &topodatapb.Tablet{}}}
+
+		for _, other := range []*ersCandidate{nilCandidate, noInfo, noAlias} {
+			assert.False(t, candidate.isSameTablet(other))
+			assert.False(t, other.isSameTablet(candidate))
+		}
+		assert.False(t, nilCandidate.isSameTablet(nilCandidate))
+		assert.False(t, noInfo.isSameTablet(noInfo))
+		assert.False(t, noAlias.isSameTablet(noAlias))
+	})
+}
 
 func TestNewEmergencyReparenter(t *testing.T) {
 	t.Parallel()
@@ -6812,7 +6946,8 @@ func TestEmergencyReparenter_waitForRelayLogsToApply(t *testing.T) {
 			}
 
 			erp := NewEmergencyReparenter(nil, tt.tmc, logger)
-			result, err := erp.waitForRelayLogsToApply(cellCtx, tt.candidates, tt.tabletMap, tt.statusMap, cellTimeout, tt.requireAll)
+			candidates := ersCandidatesFromPositionsForTest(t, tt.candidates, tt.tabletMap, tt.statusMap)
+			result, err := erp.waitForRelayLogsToApply(cellCtx, candidates, cellTimeout, tt.requireAll)
 			if tt.shouldErr {
 				require.Error(t, err)
 				if tt.errContains != "" {
@@ -6824,9 +6959,9 @@ func TestEmergencyReparenter_waitForRelayLogsToApply(t *testing.T) {
 
 			if tt.checkOutcome {
 				require.NotNil(t, result)
-				assert.ElementsMatch(t, tt.wantApplied, result.applied, "applied mismatch")
-				assert.ElementsMatch(t, tt.wantFailed, result.failed, "failed mismatch")
-				assert.ElementsMatch(t, tt.wantCancelled, result.cancelled, "cancelled mismatch")
+				assert.ElementsMatch(t, tt.wantApplied, ersCandidateAliases(result.applied), "applied mismatch")
+				assert.ElementsMatch(t, tt.wantFailed, ersCandidateAliases(result.failed), "failed mismatch")
+				assert.ElementsMatch(t, tt.wantCancelled, ersCandidateAliases(result.cancelled), "cancelled mismatch")
 			}
 		})
 	}
@@ -6876,14 +7011,6 @@ func TestEmergencyReparenter_applyRelayLogsAndReconcile(t *testing.T) {
 			},
 		}
 	}
-	waitCandidatesOf := func(candidates map[string]*RelayLogPositions) map[string]*RelayLogPositions {
-		return map[string]*RelayLogPositions{
-			"zone1-0000000100": candidates["zone1-0000000100"],
-			"zone1-0000000101": candidates["zone1-0000000101"],
-			"zone1-0000000102": candidates["zone1-0000000102"],
-		}
-	}
-
 	t.Run("applied bumped, failed removed, cancelled and unwaited untouched", func(t *testing.T) {
 		t.Parallel()
 
@@ -6898,25 +7025,30 @@ func TestEmergencyReparenter_applyRelayLogsAndReconcile(t *testing.T) {
 			},
 		}
 
-		candidates := newCandidates(t)
+		candidatePositions := newCandidates(t)
+		candidates := ersCandidatesFromPositionsForTest(t, candidatePositions, tabletMap, statusMap)
+		waitCandidates := ersCandidatesByAliasForTest(t, candidates, "zone1-0000000100", "zone1-0000000101", "zone1-0000000102")
 		erp := NewEmergencyReparenter(nil, tmc, logger)
-		reconciled, waitResult, err := erp.applyRelayLogsAndReconcile(t.Context(), waitCandidatesOf(candidates), candidates, tabletMap, statusMap, waitReplicasTimeout, false, true)
+		reconciled, waitResult, err := erp.applyRelayLogsAndReconcile(t.Context(), waitCandidates, candidates, waitReplicasTimeout, false, true)
 		require.NoError(t, err)
 		require.NotNil(t, waitResult)
 
-		assert.ElementsMatch(t, []string{"zone1-0000000100"}, waitResult.applied)
-		assert.ElementsMatch(t, []string{"zone1-0000000101"}, waitResult.failed)
-		assert.ElementsMatch(t, []string{"zone1-0000000102"}, waitResult.cancelled)
+		assert.ElementsMatch(t, []string{"zone1-0000000100"}, ersCandidateAliases(waitResult.applied))
+		assert.ElementsMatch(t, []string{"zone1-0000000101"}, ersCandidateAliases(waitResult.failed))
+		assert.ElementsMatch(t, []string{"zone1-0000000102"}, ersCandidateAliases(waitResult.cancelled))
 
 		// the failed candidate is no longer promotable
-		assert.NotContains(t, reconciled, "zone1-0000000101")
+		assert.NotContains(t, ersCandidateAliases(reconciled), "zone1-0000000101")
 
 		// the applied candidate has fully executed what it received
-		assert.True(t, reconciled["zone1-0000000100"].Executed.Equal(reconciled["zone1-0000000100"].Combined))
+		applied := ersCandidateByAliasForTest(t, reconciled, "zone1-0000000100")
+		assert.True(t, applied.positions.Executed.Equal(applied.positions.Combined))
 
 		// the cancelled and unwaited candidates keep their received positions
-		assert.True(t, reconciled["zone1-0000000102"].Executed.Equal(mustPosition(t, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-6")))
-		assert.True(t, reconciled["zone1-0000000103"].Executed.Equal(mustPosition(t, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-3")))
+		cancelled := ersCandidateByAliasForTest(t, reconciled, "zone1-0000000102")
+		assert.True(t, cancelled.positions.Executed.Equal(mustPosition(t, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-6")))
+		unwaited := ersCandidateByAliasForTest(t, reconciled, "zone1-0000000103")
+		assert.True(t, unwaited.positions.Executed.Equal(mustPosition(t, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-3")))
 	})
 
 	t.Run("wait error leaves the candidates unmutated", func(t *testing.T) {
@@ -6930,14 +7062,17 @@ func TestEmergencyReparenter_applyRelayLogsAndReconcile(t *testing.T) {
 			},
 		}
 
-		candidates := newCandidates(t)
+		candidatePositions := newCandidates(t)
+		candidates := ersCandidatesFromPositionsForTest(t, candidatePositions, tabletMap, statusMap)
+		waitCandidates := ersCandidatesByAliasForTest(t, candidates, "zone1-0000000100", "zone1-0000000101", "zone1-0000000102")
 		erp := NewEmergencyReparenter(nil, tmc, logger)
-		reconciled, _, err := erp.applyRelayLogsAndReconcile(t.Context(), waitCandidatesOf(candidates), candidates, tabletMap, statusMap, waitReplicasTimeout, true, true)
+		reconciled, _, err := erp.applyRelayLogsAndReconcile(t.Context(), waitCandidates, candidates, waitReplicasTimeout, true, true)
 		require.ErrorContains(t, err, "could not apply all relay logs")
 
 		// on error the caller's candidates come back as-is: nothing removed, nothing bumped
 		assert.Len(t, reconciled, 4)
-		assert.True(t, reconciled["zone1-0000000100"].Executed.Equal(mustPosition(t, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5")))
+		candidate := ersCandidateByAliasForTest(t, reconciled, "zone1-0000000100")
+		assert.True(t, candidate.positions.Executed.Equal(mustPosition(t, "3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5")))
 	})
 
 	t.Run("non-GTID candidates never get their Executed position bumped", func(t *testing.T) {
@@ -6956,19 +7091,20 @@ func TestEmergencyReparenter_applyRelayLogsAndReconcile(t *testing.T) {
 		// replica would sort ahead of an equal-position former primary
 		filePos, err := replication.DecodePosition("FilePos/binlog.000001:1000")
 		require.NoError(t, err)
-		candidates := map[string]*RelayLogPositions{
+		candidatePositions := map[string]*RelayLogPositions{
 			"zone1-0000000100": {Combined: filePos},
 			"zone1-0000000101": {Combined: filePos},
 			"zone1-0000000102": {Combined: filePos},
 		}
+		candidates := ersCandidatesFromPositionsForTest(t, candidatePositions, tabletMap, statusMap)
 		erp := NewEmergencyReparenter(nil, tmc, logger)
-		reconciled, waitResult, err := erp.applyRelayLogsAndReconcile(t.Context(), maps.Clone(candidates), candidates, tabletMap, statusMap, waitReplicasTimeout, true, false)
+		reconciled, waitResult, err := erp.applyRelayLogsAndReconcile(t.Context(), slices.Clone(candidates), candidates, waitReplicasTimeout, true, false)
 		require.NoError(t, err)
 		require.NotNil(t, waitResult)
 		assert.Len(t, waitResult.applied, 3)
 
-		for alias, pos := range reconciled {
-			assert.True(t, pos.Executed.IsZero(), "%s Executed should stay zero, got %v", alias, pos.Executed)
+		for _, candidate := range reconciled {
+			assert.True(t, candidate.positions.Executed.IsZero(), "%s Executed should stay zero, got %v", candidate.alias(), candidate.positions.Executed)
 		}
 	})
 }
@@ -7704,13 +7840,15 @@ func TestEmergencyReparenter_findMostAdvanced(t *testing.T) {
 			erp := NewEmergencyReparenter(nil, nil, logutil.NewMemoryLogger())
 
 			test.emergencyReparentOps.durability = durability
-			winningTablet, _, err := erp.findMostAdvanced(test.validCandidates, test.tabletMap, test.versionMap, test.flavorMap, test.emergencyReparentOps)
+			candidates := ersCandidatesFromPositionsForTest(t, test.validCandidates, test.tabletMap, nil)
+			setERSCandidateVersionsForTest(candidates, test.versionMap, test.flavorMap)
+			winningCandidate, _, err := erp.findMostAdvanced(candidates, test.emergencyReparentOps)
 			if test.err != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), test.err)
 			} else {
 				require.NoError(t, err)
-				assert.True(t, topoproto.TabletAliasEqual(test.result.Alias, winningTablet.Alias))
+				assert.True(t, topoproto.TabletAliasEqual(test.result.Alias, winningCandidate.tablet().Alias))
 			}
 		})
 	}
@@ -8802,12 +8940,13 @@ func TestEmergencyReparenter_promoteIntermediateSource(t *testing.T) {
 					require.NoError(t, lerr, "could not unlock %s/%s after test", tt.keyspace, tt.shard)
 				}()
 			}
-			tabletInfo := tt.tabletMap[tt.newSourceTabletAlias]
 
 			tt.emergencyReparentOps.durability = durability
 
 			erp := NewEmergencyReparenter(ts, tt.tmc, logger)
-			res, err := erp.promoteIntermediateSource(ctx, ev, tabletInfo.Tablet, tt.tabletMap, tt.statusMap, tt.validCandidateTablets, tt.emergencyReparentOps)
+			candidates := ersCandidatesFromTabletsForTest(tt.validCandidateTablets, tt.tabletMap, tt.statusMap, nil)
+			source := ersCandidateByAliasForTest(t, candidates, tt.newSourceTabletAlias)
+			res, err := erp.promoteIntermediateSource(ctx, ev, source, candidates, tt.statusMap, tt.emergencyReparentOps)
 			if tt.shouldErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errShouldContain)
@@ -8816,8 +8955,8 @@ func TestEmergencyReparenter_promoteIntermediateSource(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Len(t, res, len(tt.result))
-			for idx, tablet := range res {
-				assert.Equal(t, topoproto.TabletAliasString(tt.result[idx].Alias), topoproto.TabletAliasString(tablet.Alias))
+			for idx, candidate := range res {
+				assert.Equal(t, topoproto.TabletAliasString(tt.result[idx].Alias), candidate.alias())
 			}
 		})
 	}
@@ -8896,23 +9035,6 @@ func TestEmergencyReparenter_identifyPrimaryCandidate(t *testing.T) {
 				},
 			},
 			err: "requested candidate zone1-0000000100 is not in valid candidates list",
-		}, {
-			name: "explicit request for a primary tablet not in tablet map",
-			emergencyReparentOps: EmergencyReparentOptions{NewPrimaryAlias: &topodatapb.TabletAlias{
-				Cell: "zone1",
-				Uid:  100,
-			}},
-			intermediateSource: nil,
-			validCandidates: []*topodatapb.Tablet{
-				{
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone1",
-						Uid:  100,
-					},
-				},
-			},
-			tabletMap: map[string]*topo.TabletInfo{},
-			err:       "candidate zone1-0000000100 not found in the tablet map; this an impossible situation",
 		}, {
 			name:                 "preferred candidate in the valid list with the best promote rule",
 			emergencyReparentOps: EmergencyReparentOptions{},
@@ -9033,11 +9155,10 @@ func TestEmergencyReparenter_identifyPrimaryCandidate(t *testing.T) {
 		}, {
 			// Regression for the mixed-flavor-family case. The intermediate source is
 			// the MariaDB tablet (10.6, uid 100); the other candidate is MySQL 8.4
-			// (uid 101). identifyPrimaryCandidate is given the raw (unguarded) version
-			// and flavor maps, so its internal scopedVersionMap must detect the mixed
-			// families and disable version comparison. Without that guard, findCandidate
-			// would compute 8.4 < 10.6 and pull the election to the MySQL tablet — the
-			// incompatible choice; with it, the MariaDB intermediate source is kept.
+			// (uid 101). Each candidate carries its version and flavor, so findCandidate
+			// must detect the mixed families and disable version comparison. Without
+			// that guard, it would compute 8.4 < 10.6 and pull the election to the MySQL
+			// tablet — the incompatible choice; with it, the MariaDB source is kept.
 			name:               "mixed flavor families disable version comparison in final election",
 			intermediateSource: &topodatapb.Tablet{Alias: &topodatapb.TabletAlias{Cell: "zone1", Uid: 100}},
 			validCandidates: []*topodatapb.Tablet{
@@ -9067,13 +9188,16 @@ func TestEmergencyReparenter_identifyPrimaryCandidate(t *testing.T) {
 			logger := logutil.NewMemoryLogger()
 
 			erp := NewEmergencyReparenter(nil, nil, logger)
-			res, err := erp.identifyPrimaryCandidate(test.intermediateSource, test.validCandidates, test.tabletMap, test.versionMap, test.flavorMap, test.emergencyReparentOps)
+			candidates := ersCandidatesFromTabletsForTest(test.validCandidates, test.tabletMap, nil, nil)
+			setERSCandidateVersionsForTest(candidates, test.versionMap, test.flavorMap)
+			intermediateSource := ersCandidateForTabletForTest(candidates, test.intermediateSource)
+			res, err := erp.identifyPrimaryCandidate(intermediateSource, candidates, test.emergencyReparentOps)
 			if test.err != "" {
 				assert.EqualError(t, err, test.err)
 				return
 			}
 			require.NoError(t, err)
-			assert.True(t, topoproto.TabletAliasEqual(res.Alias, test.result.Alias))
+			assert.True(t, topoproto.TabletAliasEqual(res.tablet().Alias, test.result.Alias))
 		})
 	}
 }
@@ -9233,6 +9357,31 @@ func TestEmergencyReparenter_filterValidCandidates(t *testing.T) {
 			tabletsTakingBackup: replicaTakingBackup,
 			filteredTablets:     []*topodatapb.Tablet{replicaTablet},
 		}, {
+			// the requested primary loses to a preferred candidate here, so the operator
+			// must be told the backup is why rather than left with a bare "not in valid
+			// candidates list" from identifyPrimaryCandidate later on
+			name:                "requested primary taking a backup is rejected naming the backup",
+			durability:          policy.DurabilityNone,
+			validTablets:        allTablets,
+			tabletsReachable:    []*topodatapb.Tablet{replicaTablet, replicaCrossCellTablet, rdonlyTablet, rdonlyCrossCellTablet},
+			tabletsTakingBackup: replicaTakingBackup,
+			opts: EmergencyReparentOptions{
+				NewPrimaryAlias: replicaTablet.Alias,
+			},
+			errShouldContain: "proposed primary zone-1-0000000002 is taking a backup and other candidates are available",
+		}, {
+			// but a backup is only a preference: with nothing better to promote, the
+			// requested primary still wins and ERS must not refuse it
+			name:                "requested primary taking a backup is kept when there are no other candidates",
+			durability:          policy.DurabilityNone,
+			validTablets:        allTablets,
+			tabletsReachable:    []*topodatapb.Tablet{replicaTablet, rdonlyTablet, rdonlyCrossCellTablet},
+			tabletsTakingBackup: replicaTakingBackup,
+			opts: EmergencyReparentOptions{
+				NewPrimaryAlias: replicaTablet.Alias,
+			},
+			filteredTablets: []*topodatapb.Tablet{replicaTablet},
+		}, {
 			name:                "filter cross cell",
 			durability:          policy.DurabilityNone,
 			validTablets:        allTablets,
@@ -9330,13 +9479,14 @@ func TestEmergencyReparenter_filterValidCandidates(t *testing.T) {
 			tt.opts.durability = durability
 			logger := logutil.NewMemoryLogger()
 			erp := NewEmergencyReparenter(nil, nil, logger)
-			tabletList, err := erp.filterValidCandidates(tt.validTablets, tt.tabletsReachable, tt.nonAckers, tt.tabletsTakingBackup, tt.prevPrimary, tt.opts)
+			candidates := ersCandidatesFromTabletsForTest(tt.validTablets, nil, nil, tt.tabletsTakingBackup)
+			candidateList, err := erp.filterValidCandidates(candidates, tt.tabletsReachable, tt.nonAckers, tt.prevPrimary, tt.opts)
 			if tt.errShouldContain != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.errShouldContain)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tt.filteredTablets, tabletList)
+				require.Equal(t, tt.filteredTablets, ersCandidateTabletsForTest(candidateList))
 			}
 		})
 	}
@@ -10262,29 +10412,27 @@ func TestEmergencyReparenterFindErrantGTIDs(t *testing.T) {
 			erp := &EmergencyReparenter{
 				tmc: tt.tmc,
 			}
-			validCandidates, isGtid, err := FindPositionsOfAllCandidates(tt.statusMap, tt.primaryStatusMap)
+			validCandidates, isGtid, err := buildERSCandidates(&replicationSnapshot{
+				statusMap:        tt.statusMap,
+				primaryStatusMap: tt.primaryStatusMap,
+			}, tt.tabletMap)
 			require.NoError(t, err)
 			require.True(t, isGtid)
-			candidates, starved, err := erp.findErrantGTIDs(t.Context(), validCandidates, tt.statusMap, tt.tabletMap, 10*time.Second, nil, false)
+			candidates, starved, err := erp.findErrantGTIDs(t.Context(), validCandidates, 10*time.Second, nil, false)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)
-			assert.ElementsMatch(t, tt.wantStarved, starved)
-			keys := make([]string, 0, len(candidates))
-			for key := range candidates {
-				keys = append(keys, key)
-			}
-			slices.Sort(keys)
-			require.ElementsMatch(t, tt.wantedCandidates, keys)
+			assert.ElementsMatch(t, tt.wantStarved, ersCandidateAliases(starved))
+			require.ElementsMatch(t, tt.wantedCandidates, ersCandidateAliases(candidates))
 
 			dp, err := policy.GetDurabilityPolicy(policy.DurabilitySemiSync)
 			require.NoError(t, err)
 			ers := EmergencyReparenter{logger: logutil.NewCallbackLogger(func(*logutilpb.Event) {})}
-			winningPrimary, _, err := ers.findMostAdvanced(candidates, tt.tabletMap, nil, nil, EmergencyReparentOptions{durability: dp})
+			winningPrimary, _, err := ers.findMostAdvanced(candidates, EmergencyReparentOptions{durability: dp})
 			require.NoError(t, err)
-			require.True(t, slices.Contains(tt.wantMostAdvancedPossible, winningPrimary.Hostname), winningPrimary.Hostname)
+			require.True(t, slices.Contains(tt.wantMostAdvancedPossible, winningPrimary.tablet().Hostname), winningPrimary.tablet().Hostname)
 		})
 	}
 }
@@ -10367,12 +10515,13 @@ func TestEmergencyReparenterFindErrantGTIDs_NilPosition(t *testing.T) {
 		"zone1-0000000104": nil,
 	}
 
-	candidates, starved, err := erp.findErrantGTIDs(t.Context(), validCandidates, statusMap, tabletMap, 10*time.Second, nil, false)
+	inputCandidates := ersCandidatesFromPositionsForTest(t, validCandidates, tabletMap, statusMap)
+	candidates, starved, err := erp.findErrantGTIDs(t.Context(), inputCandidates, 10*time.Second, nil, false)
 	require.NoError(t, err)
-	require.Contains(t, candidates, "zone1-0000000102")
+	require.Contains(t, ersCandidateAliases(candidates), "zone1-0000000102")
 	// the nil peer at maxLen contributed no evidence, so the surviving candidate was
 	// accepted without any comparison
-	assert.ElementsMatch(t, []string{"zone1-0000000102"}, starved)
+	assert.ElementsMatch(t, []string{"zone1-0000000102"}, ersCandidateAliases(starved))
 }
 
 // TestEmergencyReparenter_findMostAdvanced_versionTiebreakerAfterCatchUp is a
@@ -10396,7 +10545,7 @@ func TestEmergencyReparenter_findMostAdvanced_versionTiebreakerAfterCatchUp(t *t
 	// olderReplica: lower version, SQL thread behind pre-wait.
 	// newerReplica: higher version, fully applied pre-wait.
 	// Both have the same combined relay-log position.
-	validCandidates := map[string]*RelayLogPositions{
+	candidatePositions := map[string]*RelayLogPositions{
 		"zone1-0000000100": {Combined: combined, Executed: executedBehind},
 		"zone1-0000000101": {Combined: combined, Executed: executedFull},
 	}
@@ -10411,13 +10560,15 @@ func TestEmergencyReparenter_findMostAdvanced_versionTiebreakerAfterCatchUp(t *t
 
 	durability, err := policy.GetDurabilityPolicy(policy.DurabilityNone)
 	require.NoError(t, err)
+	candidates := ersCandidatesFromPositionsForTest(t, candidatePositions, tabletMap, nil)
+	setERSCandidateVersionsForTest(candidates, versionMap, nil)
 
 	// Before the relay-log wait, the newer tablet looks more advanced on Executed
 	// and would be chosen as the intermediate source.
 	erpBefore := NewEmergencyReparenter(nil, nil, logutil.NewMemoryLogger())
-	intermediateSource, _, err := erpBefore.findMostAdvanced(validCandidates, tabletMap, versionMap, nil, EmergencyReparentOptions{durability: durability})
+	intermediateSource, _, err := erpBefore.findMostAdvanced(candidates, EmergencyReparentOptions{durability: durability})
 	require.NoError(t, err)
-	require.True(t, topoproto.TabletAliasEqual(intermediateSource.Alias, &topodatapb.TabletAlias{Cell: "zone1", Uid: 101}))
+	require.True(t, topoproto.TabletAliasEqual(intermediateSource.tablet().Alias, &topodatapb.TabletAlias{Cell: "zone1", Uid: 101}))
 
 	// Both candidates' SQL threads catch up to the combined relay-log position
 	// during the wait, which reconciles their Executed up to Combined. After that,
@@ -10433,13 +10584,16 @@ func TestEmergencyReparenter_findMostAdvanced_versionTiebreakerAfterCatchUp(t *t
 			"zone1-0000000101": {combinedStr: nil},
 		},
 	}
+	for _, candidate := range candidates {
+		candidate.stopStatus = statusMap[candidate.alias()]
+	}
 	erp := NewEmergencyReparenter(nil, tmc, logutil.NewMemoryLogger())
-	reconciled, _, err := erp.applyRelayLogsAndReconcile(t.Context(), validCandidates, validCandidates, tabletMap, statusMap, 30*time.Second, true /* requireAll */, true /* isGTIDBased */)
+	reconciled, _, err := erp.applyRelayLogsAndReconcile(t.Context(), candidates, candidates, 30*time.Second, true /* requireAll */, true /* isGTIDBased */)
 	require.NoError(t, err)
 
-	intermediateSource, _, err = erp.findMostAdvanced(reconciled, tabletMap, versionMap, nil, EmergencyReparentOptions{durability: durability})
+	intermediateSource, _, err = erp.findMostAdvanced(reconciled, EmergencyReparentOptions{durability: durability})
 	require.NoError(t, err)
-	require.True(t, topoproto.TabletAliasEqual(intermediateSource.Alias, &topodatapb.TabletAlias{Cell: "zone1", Uid: 100}))
+	require.True(t, topoproto.TabletAliasEqual(intermediateSource.tablet().Alias, &topodatapb.TabletAlias{Cell: "zone1", Uid: 100}))
 }
 
 // TestEmergencyReparenterFindErrantGTIDs_EmptyPrimaryPosition is a regression test
@@ -10499,18 +10653,19 @@ func TestEmergencyReparenterFindErrantGTIDs_EmptyPrimaryPosition(t *testing.T) {
 		},
 	}
 
-	candidates, starved, err := erp.findErrantGTIDs(t.Context(), validCandidates, statusMap, tabletMap, 10*time.Second, nil, false)
+	inputCandidates := ersCandidatesFromPositionsForTest(t, validCandidates, tabletMap, statusMap)
+	candidates, starved, err := erp.findErrantGTIDs(t.Context(), inputCandidates, 10*time.Second, nil, false)
 	require.NoError(t, err)
 	// the empty primary contributed no evidence, so the lagged replica must be accepted
 	// as-is rather than have its entire GTID set flagged errant
-	require.Contains(t, candidates, "zone1-0000000101")
+	require.Contains(t, ersCandidateAliases(candidates), "zone1-0000000101")
 	// a candidate with no GTIDs corroborates nothing and cannot be promoted over tablets
 	// with real history, so it is dropped from candidacy
-	assert.NotContains(t, candidates, "zone1-0000000100")
+	assert.NotContains(t, ersCandidateAliases(candidates), "zone1-0000000100")
 	// with the empty primary dropped, the replica forms the evidence tier on its own and
 	// was accepted with nothing to compare against; report it starved so the caller can
 	// decide whether the blind spot is acceptable
-	assert.ElementsMatch(t, []string{"zone1-0000000101"}, starved)
+	assert.ElementsMatch(t, []string{"zone1-0000000101"}, ersCandidateAliases(starved))
 }
 
 // TestEmergencyReparenterFindErrantGTIDs_EmptyPrimaryErrantReplica covers the case where
@@ -10590,13 +10745,14 @@ func TestEmergencyReparenterFindErrantGTIDs_EmptyPrimaryErrantReplica(t *testing
 		},
 	}
 
-	candidates, starved, err := erp.findErrantGTIDs(t.Context(), validCandidates, statusMap, tabletMap, 10*time.Second, nil, false)
+	inputCandidates := ersCandidatesFromPositionsForTest(t, validCandidates, tabletMap, statusMap)
+	candidates, starved, err := erp.findErrantGTIDs(t.Context(), inputCandidates, 10*time.Second, nil, false)
 	require.NoError(t, err)
-	require.Contains(t, candidates, "zone1-0000000101")
+	require.Contains(t, ersCandidateAliases(candidates), "zone1-0000000101")
 	// no other tablet corroborates u3:1, so zone1-0000000102 has an errant GTID and
 	// must not survive detection
-	assert.NotContains(t, candidates, "zone1-0000000102")
-	assert.NotContains(t, candidates, "zone1-0000000100")
+	assert.NotContains(t, ersCandidateAliases(candidates), "zone1-0000000102")
+	assert.NotContains(t, ersCandidateAliases(candidates), "zone1-0000000100")
 	// both replicas had a peer to compare against, so nobody was accepted blindly
 	assert.Empty(t, starved)
 }
@@ -10665,7 +10821,8 @@ func TestEmergencyReparenterFindErrantGTIDs_WipedMaxJournalFailsClosed(t *testin
 		},
 	}
 
-	_, _, err := erp.findErrantGTIDs(t.Context(), validCandidates, statusMap, tabletMap, 10*time.Second, nil, false)
+	inputCandidates := ersCandidatesFromPositionsForTest(t, validCandidates, tabletMap, statusMap)
+	_, _, err := erp.findErrantGTIDs(t.Context(), inputCandidates, 10*time.Second, nil, false)
 	require.ErrorContains(t, err, "cannot be proven to have seen the latest promotion")
 	require.ErrorContains(t, err, "zone1-0000000100")
 }
@@ -10688,7 +10845,8 @@ func TestEmergencyReparenterFindErrantGTIDs_AllZeroPositionsWithJournalHistory(t
 		"zone1-0000000101": {Combined: emptyPos},
 	}
 
-	_, _, err := erp.findErrantGTIDs(t.Context(), validCandidates, map[string]*replicationdatapb.StopReplicationStatus{}, tabletMap, 10*time.Second, nil, false)
+	inputCandidates := ersCandidatesFromPositionsForTest(t, validCandidates, tabletMap, nil)
+	_, _, err := erp.findErrantGTIDs(t.Context(), inputCandidates, 10*time.Second, nil, false)
 	require.ErrorContains(t, err, "cannot be proven to have seen the latest promotion")
 	require.ErrorContains(t, err, "zone1-0000000100")
 }
@@ -10711,10 +10869,11 @@ func TestEmergencyReparenterFindErrantGTIDs_AllZeroPositionsNewShard(t *testing.
 		"zone1-0000000101": {Combined: emptyPos},
 	}
 
-	candidates, starved, err := erp.findErrantGTIDs(t.Context(), validCandidates, map[string]*replicationdatapb.StopReplicationStatus{}, tabletMap, 10*time.Second, nil, true)
+	inputCandidates := ersCandidatesFromPositionsForTest(t, validCandidates, tabletMap, nil)
+	candidates, starved, err := erp.findErrantGTIDs(t.Context(), inputCandidates, 10*time.Second, nil, true)
 	require.NoError(t, err)
-	assert.Contains(t, candidates, "zone1-0000000100")
-	assert.Contains(t, candidates, "zone1-0000000101")
+	assert.Contains(t, ersCandidateAliases(candidates), "zone1-0000000100")
+	assert.Contains(t, ersCandidateAliases(candidates), "zone1-0000000101")
 	assert.Empty(t, starved)
 }
 
@@ -10743,7 +10902,8 @@ func TestEmergencyReparenterFindErrantGTIDs_MissingJournalTableRealPosition(t *t
 		},
 	}
 
-	_, _, err := erp.findErrantGTIDs(t.Context(), validCandidates, map[string]*replicationdatapb.StopReplicationStatus{}, tabletMap, 10*time.Second, nil, false)
+	inputCandidates := ersCandidatesFromPositionsForTest(t, validCandidates, tabletMap, nil)
+	_, _, err := erp.findErrantGTIDs(t.Context(), inputCandidates, 10*time.Second, nil, false)
 	require.ErrorContains(t, err, "could not read reparent journal information")
 }
 
@@ -10767,10 +10927,11 @@ func TestEmergencyReparenterFindErrantGTIDs_MissingJournalTableNewShard(t *testi
 		"zone1-0000000101": {Combined: emptyPos},
 	}
 
-	candidates, starved, err := erp.findErrantGTIDs(t.Context(), validCandidates, map[string]*replicationdatapb.StopReplicationStatus{}, tabletMap, 10*time.Second, nil, true)
+	inputCandidates := ersCandidatesFromPositionsForTest(t, validCandidates, tabletMap, nil)
+	candidates, starved, err := erp.findErrantGTIDs(t.Context(), inputCandidates, 10*time.Second, nil, true)
 	require.NoError(t, err)
-	assert.Contains(t, candidates, "zone1-0000000100")
-	assert.Contains(t, candidates, "zone1-0000000101")
+	assert.Contains(t, ersCandidateAliases(candidates), "zone1-0000000100")
+	assert.Contains(t, ersCandidateAliases(candidates), "zone1-0000000101")
 	assert.Empty(t, starved)
 }
 
@@ -10794,7 +10955,8 @@ func TestEmergencyReparenterFindErrantGTIDs_AllZeroPositionsInitializedShard(t *
 		"zone1-0000000101": {Combined: emptyPos},
 	}
 
-	_, _, err := erp.findErrantGTIDs(t.Context(), validCandidates, map[string]*replicationdatapb.StopReplicationStatus{}, tabletMap, 10*time.Second, nil, false)
+	inputCandidates := ersCandidatesFromPositionsForTest(t, validCandidates, tabletMap, nil)
+	_, _, err := erp.findErrantGTIDs(t.Context(), inputCandidates, 10*time.Second, nil, false)
 	require.ErrorContains(t, err, "topology records a previous primary")
 }
 
@@ -10822,7 +10984,8 @@ func TestEmergencyReparenterFindErrantGTIDs_MissingJournalTableInitializedShard(
 		},
 	}
 
-	_, _, err := erp.findErrantGTIDs(t.Context(), validCandidates, map[string]*replicationdatapb.StopReplicationStatus{}, tabletMap, 10*time.Second, nil, false)
+	inputCandidates := ersCandidatesFromPositionsForTest(t, validCandidates, tabletMap, nil)
+	_, _, err := erp.findErrantGTIDs(t.Context(), inputCandidates, 10*time.Second, nil, false)
 	require.ErrorContains(t, err, "could not read reparent journal information")
 }
 
@@ -10851,6 +11014,7 @@ func TestEmergencyReparenterFindErrantGTIDs_MissingJournalTableMixedStateShard(t
 		},
 	}
 
-	_, _, err := erp.findErrantGTIDs(t.Context(), validCandidates, map[string]*replicationdatapb.StopReplicationStatus{}, tabletMap, 10*time.Second, nil, true)
+	inputCandidates := ersCandidatesFromPositionsForTest(t, validCandidates, tabletMap, nil)
+	_, _, err := erp.findErrantGTIDs(t.Context(), inputCandidates, 10*time.Second, nil, true)
 	require.ErrorContains(t, err, "could not read reparent journal information")
 }

--- a/go/vt/vtctl/reparentutil/reparent_sorter.go
+++ b/go/vt/vtctl/reparentutil/reparent_sorter.go
@@ -21,7 +21,6 @@ import (
 	"sort"
 
 	"vitess.io/vitess/go/vt/mysqlctl"
-	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/vtctl/reparentutil/policy"
 	"vitess.io/vitess/go/vt/vterrors"
 
@@ -74,30 +73,6 @@ func usableMySQLVersions(mysqlVersions []mysqlctl.ServerVersion, flavors []mysql
 		return nil
 	}
 	return mysqlVersions
-}
-
-// scopedVersionMap returns versionMap when it is safe to use as an election
-// tiebreaker for the given candidate set, or nil to disable version-aware
-// ordering when those candidates span more than one flavor family (see
-// sameFlavorFamily).
-//
-// The guard is scoped to the passed candidates specifically — not to every
-// tablet in versionMap/flavorMap — so a non-candidate tablet elsewhere in the
-// shard (e.g. one dropped for errant GTIDs) cannot disable version comparison for
-// the tablets actually being elected among. Used on the ERS election path where
-// versions and flavors are keyed by tablet alias.
-func scopedVersionMap(candidates []*topodatapb.Tablet, versionMap map[string]mysqlctl.ServerVersion, flavorMap map[string]mysqlctl.MySQLFlavor) map[string]mysqlctl.ServerVersion {
-	if len(versionMap) == 0 {
-		return versionMap
-	}
-	flavors := make([]mysqlctl.MySQLFlavor, 0, len(candidates))
-	for _, c := range candidates {
-		flavors = append(flavors, flavorMap[topoproto.TabletAliasString(c.Alias)])
-	}
-	if !sameFlavorFamily(flavors) {
-		return nil
-	}
-	return versionMap
 }
 
 // SortMode controls the priority order used when sorting reparent candidates.
@@ -405,19 +380,25 @@ func usableERSCandidateMySQLVersions(candidates []*ersCandidate) ([]mysqlctl.Ser
 
 // sortERSCandidates orders the ERS promotion candidates in place, most eligible first,
 // by replication position with ties broken by the promotion rules and MySQL version.
-// It returns true when mixed known flavor families disabled version-aware ordering.
-func sortERSCandidates(candidates []*ersCandidate, durability policy.Durabler) bool {
+// Pass the versions from usableERSCandidateMySQLVersions, or nil to sort without a
+// version tiebreak.
+func sortERSCandidates(candidates []*ersCandidate, mysqlVersions []mysqlctl.ServerVersion, durability policy.Durabler) error {
+	// mysqlVersions is positional, so the sorter swaps it alongside the candidates.
+	// fail-safe code prevents an out-of-range swap if the lengths are unequal
+	if len(mysqlVersions) != 0 && len(mysqlVersions) != len(candidates) {
+		return vterrors.Errorf(vtrpcpb.Code_INTERNAL, "unequal number of candidates and mysql versions")
+	}
+
 	tablets := make([]*topodatapb.Tablet, len(candidates))
 	positions := make([]*RelayLogPositions, len(candidates))
 	for i, candidate := range candidates {
 		tablets[i] = candidate.tablet()
 		positions[i] = candidate.positions
 	}
-	mysqlVersions, mixedFlavorFamilies := usableERSCandidateMySQLVersions(candidates)
 
 	sort.Sort(&ersCandidateSorter{
 		candidates: candidates,
 		sorter:     newReparentSorter(tablets, positions, nil, mysqlVersions, durability, SortByPosition),
 	})
-	return mixedFlavorFamilies
+	return nil
 }

--- a/go/vt/vtctl/reparentutil/reparent_sorter.go
+++ b/go/vt/vtctl/reparentutil/reparent_sorter.go
@@ -358,3 +358,66 @@ func sortTabletsForReparent(tablets []*topodatapb.Tablet, positions []*RelayLogP
 	sort.Sort(newReparentSorter(tablets, positions, innodbBufferPool, mysqlVersions, durability, mode))
 	return nil
 }
+
+type ersCandidateSorter struct {
+	candidates []*ersCandidate
+	sorter     *reparentSorter
+}
+
+func (es *ersCandidateSorter) Len() int {
+	return len(es.candidates)
+}
+
+func (es *ersCandidateSorter) Swap(i, j int) {
+	es.candidates[i], es.candidates[j] = es.candidates[j], es.candidates[i]
+	es.sorter.Swap(i, j)
+}
+
+func (es *ersCandidateSorter) Less(i, j int) bool {
+	return es.sorter.Less(i, j)
+}
+
+func usableERSCandidateMySQLVersions(candidates []*ersCandidate) ([]mysqlctl.ServerVersion, bool) {
+	hasMySQLVersion := false
+	for _, candidate := range candidates {
+		if candidate.hasMySQLVersion {
+			hasMySQLVersion = true
+			break
+		}
+	}
+	if !hasMySQLVersion {
+		return nil, false
+	}
+
+	mysqlVersions := make([]mysqlctl.ServerVersion, len(candidates))
+	mysqlFlavors := make([]mysqlctl.MySQLFlavor, len(candidates))
+	for i, candidate := range candidates {
+		mysqlVersions[i] = unknownVersion
+		if candidate.hasMySQLVersion {
+			mysqlVersions[i] = candidate.mysqlVersion
+		}
+		mysqlFlavors[i] = candidate.mysqlFlavor
+	}
+
+	usableVersions := usableMySQLVersions(mysqlVersions, mysqlFlavors)
+	return usableVersions, usableVersions == nil
+}
+
+// sortERSCandidates orders the ERS promotion candidates in place, most eligible first,
+// by replication position with ties broken by the promotion rules and MySQL version.
+// It returns true when mixed known flavor families disabled version-aware ordering.
+func sortERSCandidates(candidates []*ersCandidate, durability policy.Durabler) bool {
+	tablets := make([]*topodatapb.Tablet, len(candidates))
+	positions := make([]*RelayLogPositions, len(candidates))
+	for i, candidate := range candidates {
+		tablets[i] = candidate.tablet()
+		positions[i] = candidate.positions
+	}
+	mysqlVersions, mixedFlavorFamilies := usableERSCandidateMySQLVersions(candidates)
+
+	sort.Sort(&ersCandidateSorter{
+		candidates: candidates,
+		sorter:     newReparentSorter(tablets, positions, nil, mysqlVersions, durability, SortByPosition),
+	})
+	return mixedFlavorFamilies
+}

--- a/go/vt/vtctl/reparentutil/reparent_sorter_test.go
+++ b/go/vt/vtctl/reparentutil/reparent_sorter_test.go
@@ -384,7 +384,9 @@ func TestSortERSCandidates(t *testing.T) {
 		dominator := makeCandidate(102, "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10")
 		candidates := []*ersCandidate{dominated, incomparable, dominator}
 
-		assert.False(t, sortERSCandidates(candidates, durability))
+		mysqlVersions, mixedFlavorFamilies := usableERSCandidateMySQLVersions(candidates)
+		assert.False(t, mixedFlavorFamilies)
+		require.NoError(t, sortERSCandidates(candidates, mysqlVersions, durability))
 		assert.Equal(t, []*ersCandidate{incomparable, dominator, dominated}, candidates)
 	})
 
@@ -399,7 +401,9 @@ func TestSortERSCandidates(t *testing.T) {
 		lowerVersion.hasMySQLVersion = true
 		candidates := []*ersCandidate{higherVersion, lowerVersion}
 
-		assert.False(t, sortERSCandidates(candidates, durability))
+		mysqlVersions, mixedFlavorFamilies := usableERSCandidateMySQLVersions(candidates)
+		assert.False(t, mixedFlavorFamilies)
+		require.NoError(t, sortERSCandidates(candidates, mysqlVersions, durability))
 		assert.Equal(t, []*ersCandidate{lowerVersion, higherVersion}, candidates)
 	})
 
@@ -411,7 +415,9 @@ func TestSortERSCandidates(t *testing.T) {
 		known.hasMySQLVersion = true
 		candidates := []*ersCandidate{unknown, known}
 
-		assert.False(t, sortERSCandidates(candidates, durability))
+		mysqlVersions, mixedFlavorFamilies := usableERSCandidateMySQLVersions(candidates)
+		assert.False(t, mixedFlavorFamilies)
+		require.NoError(t, sortERSCandidates(candidates, mysqlVersions, durability))
 		assert.Equal(t, []*ersCandidate{known, unknown}, candidates)
 	})
 
@@ -426,7 +432,9 @@ func TestSortERSCandidates(t *testing.T) {
 		mysql.hasMySQLVersion = true
 		candidates := []*ersCandidate{mysql, mariaDB}
 
-		assert.True(t, sortERSCandidates(candidates, durability))
+		mysqlVersions, mixedFlavorFamilies := usableERSCandidateMySQLVersions(candidates)
+		assert.True(t, mixedFlavorFamilies)
+		require.NoError(t, sortERSCandidates(candidates, mysqlVersions, durability))
 		assert.Equal(t, []*ersCandidate{mariaDB, mysql}, candidates)
 	})
 }
@@ -724,84 +732,6 @@ func TestUsableMySQLVersions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := usableMySQLVersions(tt.versions, tt.flavors)
-			if tt.wantNil {
-				require.Nil(t, got)
-			} else {
-				require.NotNil(t, got)
-			}
-		})
-	}
-}
-
-// TestScopedVersionMap verifies the map-based family guard used on the ERS
-// election path (findMostAdvanced, identifyPrimaryCandidate). Returning nil for a
-// mixed-family candidate set is what disables version-aware comparison in the
-// final candidate selection, not just the intermediate-source sort. Crucially,
-// the guard is scoped to the passed candidates: a non-candidate tablet elsewhere
-// in the shard must not disable version ordering for the real candidates.
-func TestScopedVersionMap(t *testing.T) {
-	v80 := mysqlctl.ServerVersion{Major: 8, Minor: 0, Patch: 35}
-	v106 := mysqlctl.ServerVersion{Major: 10, Minor: 6}
-
-	tabletA := &topodatapb.Tablet{Alias: &topodatapb.TabletAlias{Cell: "zone1", Uid: 100}}
-	tabletB := &topodatapb.Tablet{Alias: &topodatapb.TabletAlias{Cell: "zone1", Uid: 101}}
-	tabletC := &topodatapb.Tablet{Alias: &topodatapb.TabletAlias{Cell: "zone1", Uid: 102}}
-
-	// A full-shard map where C is a MariaDB tablet, A and B are MySQL/Percona.
-	versionMap := map[string]mysqlctl.ServerVersion{
-		"zone1-0000000100": v80,
-		"zone1-0000000101": v80,
-		"zone1-0000000102": v106,
-	}
-	flavorMap := map[string]mysqlctl.MySQLFlavor{
-		"zone1-0000000100": mysqlctl.FlavorMySQL,
-		"zone1-0000000101": mysqlctl.FlavorPercona,
-		"zone1-0000000102": mysqlctl.FlavorMariaDB,
-	}
-
-	tests := []struct {
-		name       string
-		candidates []*topodatapb.Tablet
-		versionMap map[string]mysqlctl.ServerVersion
-		flavorMap  map[string]mysqlctl.MySQLFlavor
-		wantNil    bool
-	}{
-		{
-			name:       "empty version map stays nil",
-			candidates: []*topodatapb.Tablet{tabletA, tabletB},
-			versionMap: nil,
-			flavorMap:  nil,
-			wantNil:    true,
-		},
-		{
-			name:       "same family candidates are usable",
-			candidates: []*topodatapb.Tablet{tabletA, tabletB},
-			versionMap: versionMap,
-			flavorMap:  flavorMap,
-			wantNil:    false,
-		},
-		{
-			name:       "mixed family candidates disable version ordering",
-			candidates: []*topodatapb.Tablet{tabletA, tabletC},
-			versionMap: versionMap,
-			flavorMap:  flavorMap,
-			wantNil:    true,
-		},
-		{
-			// Point-1 regression: C (MariaDB) is in the shard-wide maps but NOT in
-			// the candidate set. The guard must ignore it and keep version ordering
-			// for the MySQL-only candidates A and B.
-			name:       "non-candidate other-family tablet does not disable ordering",
-			candidates: []*topodatapb.Tablet{tabletA, tabletB},
-			versionMap: versionMap,
-			flavorMap:  flavorMap,
-			wantNil:    false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := scopedVersionMap(tt.candidates, tt.versionMap, tt.flavorMap)
 			if tt.wantNil {
 				require.Nil(t, got)
 			} else {

--- a/go/vt/vtctl/reparentutil/reparent_sorter_test.go
+++ b/go/vt/vtctl/reparentutil/reparent_sorter_test.go
@@ -25,6 +25,7 @@ import (
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/vtctl/reparentutil/policy"
 )
 
@@ -360,6 +361,74 @@ func TestReparentSorter(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestSortERSCandidates(t *testing.T) {
+	makeCandidate := func(uid uint32, position string) *ersCandidate {
+		pos := replication.MustParsePosition(replication.Mysql56FlavorID, position)
+		return &ersCandidate{
+			info: &topo.TabletInfo{Tablet: &topodatapb.Tablet{
+				Alias: &topodatapb.TabletAlias{Cell: "zone1", Uid: uid},
+				Type:  topodatapb.TabletType_REPLICA,
+			}},
+			positions: &RelayLogPositions{Combined: pos, Executed: pos},
+		}
+	}
+
+	durability, err := policy.GetDurabilityPolicy(policy.DurabilityNone)
+	require.NoError(t, err)
+
+	t.Run("position ordering without version data", func(t *testing.T) {
+		dominated := makeCandidate(100, "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5")
+		incomparable := makeCandidate(101, "AAAAAAAA-71CA-11E1-9E33-C80AA9429562:1-10")
+		dominator := makeCandidate(102, "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10")
+		candidates := []*ersCandidate{dominated, incomparable, dominator}
+
+		assert.False(t, sortERSCandidates(candidates, durability))
+		assert.Equal(t, []*ersCandidate{incomparable, dominator, dominated}, candidates)
+	})
+
+	t.Run("lower version breaks an equal-position tie", func(t *testing.T) {
+		higherVersion := makeCandidate(100, "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10")
+		higherVersion.mysqlVersion = mysqlctl.ServerVersion{Major: 8, Minor: 4}
+		higherVersion.mysqlFlavor = mysqlctl.FlavorMySQL
+		higherVersion.hasMySQLVersion = true
+		lowerVersion := makeCandidate(101, "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10")
+		lowerVersion.mysqlVersion = mysqlctl.ServerVersion{Major: 8, Minor: 0, Patch: 35}
+		lowerVersion.mysqlFlavor = mysqlctl.FlavorPercona
+		lowerVersion.hasMySQLVersion = true
+		candidates := []*ersCandidate{higherVersion, lowerVersion}
+
+		assert.False(t, sortERSCandidates(candidates, durability))
+		assert.Equal(t, []*ersCandidate{lowerVersion, higherVersion}, candidates)
+	})
+
+	t.Run("missing version sorts after a known version", func(t *testing.T) {
+		unknown := makeCandidate(100, "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10")
+		known := makeCandidate(101, "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10")
+		known.mysqlVersion = mysqlctl.ServerVersion{Major: 8, Minor: 4}
+		known.mysqlFlavor = mysqlctl.FlavorMySQL
+		known.hasMySQLVersion = true
+		candidates := []*ersCandidate{unknown, known}
+
+		assert.False(t, sortERSCandidates(candidates, durability))
+		assert.Equal(t, []*ersCandidate{known, unknown}, candidates)
+	})
+
+	t.Run("mixed flavor families disable version ordering", func(t *testing.T) {
+		mariaDB := makeCandidate(100, "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10")
+		mariaDB.mysqlVersion = mysqlctl.ServerVersion{Major: 10, Minor: 6}
+		mariaDB.mysqlFlavor = mysqlctl.FlavorMariaDB
+		mariaDB.hasMySQLVersion = true
+		mysql := makeCandidate(101, "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10")
+		mysql.mysqlVersion = mysqlctl.ServerVersion{Major: 8, Minor: 0, Patch: 35}
+		mysql.mysqlFlavor = mysqlctl.FlavorMySQL
+		mysql.hasMySQLVersion = true
+		candidates := []*ersCandidate{mysql, mariaDB}
+
+		assert.True(t, sortERSCandidates(candidates, durability))
+		assert.Equal(t, []*ersCandidate{mariaDB, mysql}, candidates)
+	})
 }
 
 func forEachReparentSorterPermutation(values []int, test func([]int)) {

--- a/go/vt/vtctl/reparentutil/replication.go
+++ b/go/vt/vtctl/reparentutil/replication.go
@@ -108,10 +108,10 @@ func haveReciprocallyContainedPositions(a, b replication.Position) bool {
 	return a.AtLeast(b) && b.AtLeast(a) && !a.Equal(b)
 }
 
-func describeCombinedPositions(candidates map[string]*RelayLogPositions) string {
+func describeCombinedPositions(candidates []*ersCandidate) string {
 	parts := make([]string, 0, len(candidates))
-	for alias, pos := range candidates {
-		parts = append(parts, fmt.Sprintf("%s=%s", alias, pos.Combined.String()))
+	for _, candidate := range candidates {
+		parts = append(parts, fmt.Sprintf("%s=%s", candidate.alias(), candidate.positions.Combined.String()))
 	}
 	slices.Sort(parts)
 	return strings.Join(parts, ", ")
@@ -120,16 +120,16 @@ func describeCombinedPositions(candidates map[string]*RelayLogPositions) string 
 // hasUniformCombinedPosition returns true when every candidate has the same Combined position. On the
 // output of filterToMostAdvancedCombined a false result means the leading candidates have
 // incomparable positions, as the filter already removed anything dominated.
-func hasUniformCombinedPosition(candidates map[string]*RelayLogPositions) bool {
+func hasUniformCombinedPosition(candidates []*ersCandidate) bool {
 	var ref replication.Position
 	var set bool
-	for _, pos := range candidates {
+	for _, candidate := range candidates {
 		if !set {
-			ref = pos.Combined
+			ref = candidate.positions.Combined
 			set = true
 			continue
 		}
-		if !pos.Combined.Equal(ref) {
+		if !candidate.positions.Combined.Equal(ref) {
 			return false
 		}
 	}
@@ -139,40 +139,40 @@ func hasUniformCombinedPosition(candidates map[string]*RelayLogPositions) bool {
 // filterToMostAdvancedCombined returns the candidates that no other candidate dominates on
 // the Combined position. GTID positions are partially ordered, so each candidate is
 // compared against all of the others; two incomparable leaders don't dominate each other
-// and both must be kept, which hasUniformCombinedPosition relies on. The returned map shares the
-// caller's RelayLogPositions structs.
-func filterToMostAdvancedCombined(candidates map[string]*RelayLogPositions, logger logutil.Logger) map[string]*RelayLogPositions {
+// and both must be kept, which hasUniformCombinedPosition relies on. The returned slice shares the
+// caller's candidates.
+func filterToMostAdvancedCombined(candidates []*ersCandidate, logger logutil.Logger) []*ersCandidate {
 	if len(candidates) == 0 {
 		return candidates
 	}
 
-	result := make(map[string]*RelayLogPositions, len(candidates))
-	for alias, pos := range candidates {
+	result := make([]*ersCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
 		var dominated bool
-		for otherAlias, otherPos := range candidates {
-			if otherAlias == alias {
+		for _, otherCandidate := range candidates {
+			if otherCandidate == candidate {
 				continue
 			}
-			if hasDominantPosition(otherPos.Combined, pos.Combined) {
+			if hasDominantPosition(otherCandidate.positions.Combined, candidate.positions.Combined) {
 				dominated = true
 				break
 			}
 		}
 		if !dominated {
-			result[alias] = pos
+			result = append(result, candidate)
 		}
 	}
 
 	if len(result) < len(candidates) {
 		excluded := make([]string, 0, len(candidates)-len(result))
 		kept := make([]string, 0, len(result))
-		for alias := range candidates {
-			if _, ok := result[alias]; !ok {
-				excluded = append(excluded, alias)
+		for _, candidate := range candidates {
+			if !slices.Contains(result, candidate) {
+				excluded = append(excluded, candidate.alias())
 			}
 		}
-		for alias := range result {
-			kept = append(kept, alias)
+		for _, candidate := range result {
+			kept = append(kept, candidate.alias())
 		}
 		slices.Sort(excluded)
 		slices.Sort(kept)
@@ -195,10 +195,7 @@ func hasMysql56GTIDSet(pos replication.Position) bool {
 	return ok
 }
 
-// FindPositionsOfAllCandidates will find candidates for an emergency
-// reparent, and, if successful, return a mapping of those tablet aliases (as
-// raw strings) to their replication positions for later comparison.
-func FindPositionsOfAllCandidates(
+func findPositionsOfAllCandidates(
 	statusMap map[string]*replicationdatapb.StopReplicationStatus,
 	primaryStatusMap map[string]*replicationdatapb.PrimaryStatus,
 ) (map[string]*RelayLogPositions, bool, error) {
@@ -253,11 +250,11 @@ func FindPositionsOfAllCandidates(
 	// flavor-agnostic, so skip it rather than treating it as non-GTID. A typed but
 	// empty set (e.g. "MySQL56/" with no transactions) still identifies the flavor
 	// and is counted.
-	for _, pos := range primaryPositions {
-		if pos.GTIDSet == nil {
+	for _, position := range primaryPositions {
+		if position.GTIDSet == nil {
 			continue
 		}
-		if hasMysql56GTIDSet(pos) {
+		if hasMysql56GTIDSet(position) {
 			isGTIDBased = true
 		} else {
 			isNonGTIDBased = true
@@ -267,7 +264,6 @@ func FindPositionsOfAllCandidates(
 	if isGTIDBased && emptyRelayPosErrorRecorder.HasErrors() {
 		return nil, false, emptyRelayPosErrorRecorder.Error()
 	}
-
 	if isGTIDBased && isNonGTIDBased {
 		return nil, false, vterrors.Errorf(vtrpc.Code_FAILED_PRECONDITION, "encountered mix of GTID-based and non GTID-based relay logs")
 	}
@@ -276,7 +272,6 @@ func FindPositionsOfAllCandidates(
 	for alias, status := range replicationStatusMap {
 		if !isGTIDBased {
 			positionMap[alias] = &RelayLogPositions{Combined: status.Position}
-
 			continue
 		}
 		positionMap[alias] = &RelayLogPositions{
@@ -284,7 +279,6 @@ func FindPositionsOfAllCandidates(
 			Executed: status.Position,
 		}
 	}
-
 	for alias, executedPosition := range primaryPositions {
 		// A demoted/former primary applies no relay log, so its executed position
 		// is authoritative. For GTID-based shards, initialize Executed as well as
@@ -303,6 +297,49 @@ func FindPositionsOfAllCandidates(
 	}
 
 	return positionMap, isGTIDBased, nil
+}
+
+// FindPositionsOfAllCandidates will find candidates for an emergency
+// reparent, and, if successful, return a mapping of those tablet aliases (as
+// raw strings) to their replication positions for later comparison.
+func FindPositionsOfAllCandidates(
+	statusMap map[string]*replicationdatapb.StopReplicationStatus,
+	primaryStatusMap map[string]*replicationdatapb.PrimaryStatus,
+) (map[string]*RelayLogPositions, bool, error) {
+	return findPositionsOfAllCandidates(statusMap, primaryStatusMap)
+}
+
+func buildERSCandidates(snapshot *replicationSnapshot, tabletMap map[string]*topo.TabletInfo) ([]*ersCandidate, bool, error) {
+	positionMap, isGTIDBased, err := findPositionsOfAllCandidates(snapshot.statusMap, snapshot.primaryStatusMap)
+	if err != nil {
+		return nil, false, err
+	}
+
+	candidates := make([]*ersCandidate, 0, len(positionMap))
+	for alias, positions := range positionMap {
+		candidateInfo, ok := tabletMap[alias]
+		if !ok {
+			return nil, false, vterrors.Errorf(vtrpc.Code_INTERNAL, "candidate %v not found in the tablet map; this an impossible situation", alias)
+		}
+		if topoproto.IsTypeInList(candidateInfo.Type, []topodatapb.TabletType{topodatapb.TabletType_BACKUP, topodatapb.TabletType_RESTORE, topodatapb.TabletType_DRAINED}) {
+			continue
+		}
+
+		candidate := &ersCandidate{
+			info:         candidateInfo,
+			positions:    positions,
+			stopStatus:   snapshot.statusMap[alias],
+			takingBackup: snapshot.tabletsBackupState[alias],
+			mysqlFlavor:  mysqlctl.FlavorUnknown,
+		}
+		if isGTIDBased {
+			candidate.mysqlVersion, candidate.hasMySQLVersion = snapshot.mysqlVersions[alias]
+			candidate.mysqlFlavor = snapshot.mysqlFlavors[alias]
+		}
+		candidates = append(candidates, candidate)
+	}
+
+	return candidates, isGTIDBased, nil
 }
 
 // ReplicaWasRunning returns true if a StopReplicationStatus indicates that the

--- a/go/vt/vtctl/reparentutil/replication.go
+++ b/go/vt/vtctl/reparentutil/replication.go
@@ -195,7 +195,10 @@ func hasMysql56GTIDSet(pos replication.Position) bool {
 	return ok
 }
 
-func findPositionsOfAllCandidates(
+// FindPositionsOfAllCandidates will find candidates for an emergency
+// reparent, and, if successful, return a mapping of those tablet aliases (as
+// raw strings) to their replication positions for later comparison.
+func FindPositionsOfAllCandidates(
 	statusMap map[string]*replicationdatapb.StopReplicationStatus,
 	primaryStatusMap map[string]*replicationdatapb.PrimaryStatus,
 ) (map[string]*RelayLogPositions, bool, error) {
@@ -299,18 +302,8 @@ func findPositionsOfAllCandidates(
 	return positionMap, isGTIDBased, nil
 }
 
-// FindPositionsOfAllCandidates will find candidates for an emergency
-// reparent, and, if successful, return a mapping of those tablet aliases (as
-// raw strings) to their replication positions for later comparison.
-func FindPositionsOfAllCandidates(
-	statusMap map[string]*replicationdatapb.StopReplicationStatus,
-	primaryStatusMap map[string]*replicationdatapb.PrimaryStatus,
-) (map[string]*RelayLogPositions, bool, error) {
-	return findPositionsOfAllCandidates(statusMap, primaryStatusMap)
-}
-
 func buildERSCandidates(snapshot *replicationSnapshot, tabletMap map[string]*topo.TabletInfo) ([]*ersCandidate, bool, error) {
-	positionMap, isGTIDBased, err := findPositionsOfAllCandidates(snapshot.statusMap, snapshot.primaryStatusMap)
+	positionMap, isGTIDBased, err := FindPositionsOfAllCandidates(snapshot.statusMap, snapshot.primaryStatusMap)
 	if err != nil {
 		return nil, false, err
 	}

--- a/go/vt/vtctl/reparentutil/replication_test.go
+++ b/go/vt/vtctl/reparentutil/replication_test.go
@@ -41,6 +41,7 @@ import (
 
 	replicationdatapb "vitess.io/vitess/go/vt/proto/replicationdata"
 	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	"vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
 func TestMain(m *testing.M) {
@@ -520,23 +521,192 @@ func TestFindPositionsOfAllCandidates_EmptyMysqlGTIDReplicaStaysGTIDBased(t *tes
 	assert.ErrorContains(t, err, "no relay log position")
 }
 
-// TestFindPositionsOfAllCandidates_ErrorNotDuplicated verifies that when
-// FindPositionsOfAllCandidates wraps an error the underlying cause message is
+func TestBuildERSCandidates(t *testing.T) {
+	t.Run("candidate state", func(t *testing.T) {
+		replicaInfo := &topo.TabletInfo{Tablet: &topodatapb.Tablet{
+			Alias: &topodatapb.TabletAlias{Cell: "zone1", Uid: 100},
+			Type:  topodatapb.TabletType_REPLICA,
+		}}
+		primaryInfo := &topo.TabletInfo{Tablet: &topodatapb.Tablet{
+			Alias: &topodatapb.TabletAlias{Cell: "zone1", Uid: 200},
+			Type:  topodatapb.TabletType_PRIMARY,
+		}}
+		replicaAlias := topoproto.TabletAliasString(replicaInfo.Alias)
+		primaryAlias := topoproto.TabletAliasString(primaryInfo.Alias)
+		replicaVersion := mysqlctl.ServerVersion{Major: 8, Minor: 0, Patch: 35}
+		primaryVersion := mysqlctl.ServerVersion{Major: 8, Minor: 4, Patch: 0}
+		replicaStatus := &replicationdatapb.StopReplicationStatus{After: &replicationdatapb.Status{
+			Position:         "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-3",
+			RelayLogPosition: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5",
+		}}
+		primaryStatus := &replicationdatapb.PrimaryStatus{
+			Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5",
+		}
+		snapshot := &replicationSnapshot{
+			statusMap:          map[string]*replicationdatapb.StopReplicationStatus{replicaAlias: replicaStatus},
+			primaryStatusMap:   map[string]*replicationdatapb.PrimaryStatus{primaryAlias: primaryStatus},
+			tabletsBackupState: map[string]bool{replicaAlias: true},
+			mysqlVersions: map[string]mysqlctl.ServerVersion{
+				replicaAlias: replicaVersion,
+				primaryAlias: primaryVersion,
+			},
+			mysqlFlavors: map[string]mysqlctl.MySQLFlavor{
+				replicaAlias: mysqlctl.FlavorPercona,
+				primaryAlias: mysqlctl.FlavorMySQL,
+			},
+		}
+		tabletMap := map[string]*topo.TabletInfo{
+			replicaAlias: replicaInfo,
+			primaryAlias: primaryInfo,
+		}
+
+		candidates, isGTIDBased, err := buildERSCandidates(snapshot, tabletMap)
+		require.NoError(t, err)
+		require.True(t, isGTIDBased)
+		require.Len(t, candidates, 2)
+
+		replicaCandidate := findERSCandidateByAlias(candidates, replicaInfo.Alias)
+		require.NotNil(t, replicaCandidate)
+		assert.Same(t, replicaInfo, replicaCandidate.info)
+		assert.Same(t, replicaStatus, replicaCandidate.stopStatus)
+		assert.True(t, replicaCandidate.takingBackup)
+		assert.Zero(t, replicaCandidate.reparentJournalLen)
+		assert.True(t, replicaCandidate.hasMySQLVersion)
+		assert.Equal(t, replicaVersion, replicaCandidate.mysqlVersion)
+		assert.Equal(t, mysqlctl.FlavorPercona, replicaCandidate.mysqlFlavor)
+		assert.True(t, replicaCandidate.positions.Combined.Equal(replication.MustParsePosition(replication.Mysql56FlavorID, "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5")))
+		assert.True(t, replicaCandidate.positions.Executed.Equal(replication.MustParsePosition(replication.Mysql56FlavorID, "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-3")))
+
+		primaryCandidate := findERSCandidateByAlias(candidates, primaryInfo.Alias)
+		require.NotNil(t, primaryCandidate)
+		assert.Same(t, primaryInfo, primaryCandidate.info)
+		assert.Nil(t, primaryCandidate.stopStatus)
+		assert.False(t, primaryCandidate.takingBackup)
+		assert.Zero(t, primaryCandidate.reparentJournalLen)
+		assert.True(t, primaryCandidate.hasMySQLVersion)
+		assert.Equal(t, primaryVersion, primaryCandidate.mysqlVersion)
+		assert.Equal(t, mysqlctl.FlavorMySQL, primaryCandidate.mysqlFlavor)
+		assert.True(t, primaryCandidate.positions.Combined.Equal(replication.MustParsePosition(replication.Mysql56FlavorID, "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5")))
+		assert.True(t, primaryCandidate.positions.Executed.Equal(replication.MustParsePosition(replication.Mysql56FlavorID, "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5")))
+	})
+
+	t.Run("non-GTID disables version state", func(t *testing.T) {
+		alias := "zone1-0000000100"
+		version := mysqlctl.ServerVersion{Major: 8, Minor: 0, Patch: 35}
+		snapshot := &replicationSnapshot{
+			statusMap: map[string]*replicationdatapb.StopReplicationStatus{
+				alias: {After: &replicationdatapb.Status{
+					Position:         "FilePos/mysql-bin.000001:10",
+					RelayLogPosition: "FilePos/mysql-bin.000001:10",
+				}},
+			},
+			primaryStatusMap:   map[string]*replicationdatapb.PrimaryStatus{},
+			tabletsBackupState: map[string]bool{},
+			mysqlVersions:      map[string]mysqlctl.ServerVersion{alias: version},
+			mysqlFlavors:       map[string]mysqlctl.MySQLFlavor{alias: mysqlctl.FlavorMySQL},
+		}
+		tabletMap := map[string]*topo.TabletInfo{
+			alias: {Tablet: &topodatapb.Tablet{
+				Alias: &topodatapb.TabletAlias{Cell: "zone1", Uid: 100},
+				Type:  topodatapb.TabletType_REPLICA,
+			}},
+		}
+
+		candidates, isGTIDBased, err := buildERSCandidates(snapshot, tabletMap)
+		require.NoError(t, err)
+		require.False(t, isGTIDBased)
+		require.Len(t, candidates, 1)
+		assert.False(t, candidates[0].hasMySQLVersion)
+		assert.Equal(t, mysqlctl.FlavorUnknown, candidates[0].mysqlFlavor)
+	})
+
+	t.Run("missing tablet", func(t *testing.T) {
+		alias := "zone1-0000000100"
+		snapshot := &replicationSnapshot{
+			statusMap: map[string]*replicationdatapb.StopReplicationStatus{
+				alias: {After: &replicationdatapb.Status{
+					Position:         "FilePos/mysql-bin.000001:10",
+					RelayLogPosition: "FilePos/mysql-bin.000001:10",
+				}},
+			},
+			primaryStatusMap:   map[string]*replicationdatapb.PrimaryStatus{},
+			tabletsBackupState: map[string]bool{},
+		}
+
+		_, _, err := buildERSCandidates(snapshot, map[string]*topo.TabletInfo{})
+		require.Error(t, err)
+		assert.Equal(t, vtrpc.Code_INTERNAL, vterrors.Code(err))
+		assert.EqualError(t, err, "candidate zone1-0000000100 not found in the tablet map; this an impossible situation")
+	})
+
+	t.Run("filters tablet types", func(t *testing.T) {
+		tabletTypes := []struct {
+			tabletType topodatapb.TabletType
+			eligible   bool
+		}{
+			{tabletType: topodatapb.TabletType_PRIMARY, eligible: true},
+			{tabletType: topodatapb.TabletType_RDONLY, eligible: true},
+			{tabletType: topodatapb.TabletType_SPARE, eligible: true},
+			{tabletType: topodatapb.TabletType_RESTORE},
+			{tabletType: topodatapb.TabletType_DRAINED},
+			{tabletType: topodatapb.TabletType_BACKUP},
+		}
+
+		statusMap := make(map[string]*replicationdatapb.StopReplicationStatus, len(tabletTypes))
+		tabletMap := make(map[string]*topo.TabletInfo, len(tabletTypes))
+		expectedAliases := make([]string, 0, len(tabletTypes))
+		for index, tabletType := range tabletTypes {
+			tablet := &topodatapb.Tablet{
+				Alias: &topodatapb.TabletAlias{Cell: "zone1", Uid: uint32(100 + index)},
+				Type:  tabletType.tabletType,
+			}
+			alias := topoproto.TabletAliasString(tablet.Alias)
+			tabletMap[alias] = &topo.TabletInfo{Tablet: tablet}
+			statusMap[alias] = &replicationdatapb.StopReplicationStatus{After: &replicationdatapb.Status{
+				Position:         "FilePos/mysql-bin.000001:10",
+				RelayLogPosition: "FilePos/mysql-bin.000001:10",
+			}}
+			if tabletType.eligible {
+				expectedAliases = append(expectedAliases, alias)
+			}
+		}
+
+		candidates, _, err := buildERSCandidates(&replicationSnapshot{
+			statusMap:          statusMap,
+			primaryStatusMap:   map[string]*replicationdatapb.PrimaryStatus{},
+			tabletsBackupState: map[string]bool{},
+		}, tabletMap)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, expectedAliases, ersCandidateAliases(candidates))
+	})
+}
+
+// TestBuildERSCandidatesErrorNotDuplicated verifies that when
+// buildERSCandidates wraps an error the underlying cause message is
 // not repeated twice in the output. vterrors.Wrapf already appends the cause
 // via "wrapper: cause", so including the cause in the format string would
 // duplicate it.
-func TestFindPositionsOfAllCandidates_ErrorNotDuplicated(t *testing.T) {
+func TestBuildERSCandidatesErrorNotDuplicated(t *testing.T) {
 	t.Parallel()
 
-	_, _, err := FindPositionsOfAllCandidates(
-		map[string]*replicationdatapb.StopReplicationStatus{
-			"r1": {After: &replicationdatapb.Status{
-				SourceUuid:       "3E11FA47-71CA-11E1-9E33-C80AA9429562",
-				RelayLogPosition: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5",
-			}},
+	statusMap := map[string]*replicationdatapb.StopReplicationStatus{
+		"r1": {After: &replicationdatapb.Status{
+			SourceUuid:       "3E11FA47-71CA-11E1-9E33-C80AA9429562",
+			RelayLogPosition: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5",
+		}},
+	}
+	primaryStatusMap := map[string]*replicationdatapb.PrimaryStatus{
+		"p1": {Position: "InvalidFlavor/1234"},
+	}
+	_, _, err := buildERSCandidates(
+		&replicationSnapshot{
+			statusMap:          statusMap,
+			primaryStatusMap:   primaryStatusMap,
+			tabletsBackupState: map[string]bool{},
 		},
-		map[string]*replicationdatapb.PrimaryStatus{
-			"p1": {Position: "InvalidFlavor/1234"},
+		map[string]*topo.TabletInfo{
+			"r1": {Tablet: &topodatapb.Tablet{Alias: &topodatapb.TabletAlias{Cell: "r1", Uid: 100}, Type: topodatapb.TabletType_REPLICA}},
+			"p1": {Tablet: &topodatapb.Tablet{Alias: &topodatapb.TabletAlias{Cell: "p1", Uid: 100}, Type: topodatapb.TabletType_PRIMARY}},
 		},
 	)
 	require.Error(t, err)
@@ -2447,7 +2617,7 @@ func TestHasUniformCombinedPosition(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, hasUniformCombinedPosition(tt.candidates))
+			assert.Equal(t, tt.want, hasUniformCombinedPosition(ersCandidatesFromPositions(t, tt.candidates)))
 		})
 	}
 }
@@ -2467,7 +2637,7 @@ func TestDescribeCombinedPositions(t *testing.T) {
 
 	assert.Equal(t,
 		"zone1-0000000100=3e11fa47-71ca-11e1-9e33-c80aa9429562:1-5, zone1-0000000101=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:1-6, zone2-0000000102=bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb:1-7",
-		describeCombinedPositions(candidates),
+		describeCombinedPositions(ersCandidatesFromPositions(t, candidates)),
 	)
 }
 
@@ -2540,19 +2710,35 @@ func TestFilterToMostAdvancedCombined(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := filterToMostAdvancedCombined(tt.candidates, logutil.NewMemoryLogger())
+			candidates := ersCandidatesFromPositions(t, tt.candidates)
+			result := filterToMostAdvancedCombined(candidates, logutil.NewMemoryLogger())
 
 			kept := make([]string, 0, len(result))
-			for alias := range result {
-				kept = append(kept, alias)
+			for _, candidate := range result {
+				kept = append(kept, candidate.alias())
 			}
 			assert.ElementsMatch(t, tt.wantKept, kept)
 
-			// Survivors must share the caller's position structs (the reconcile
-			// step later mutates them through the returned map).
-			for alias, pos := range result {
-				assert.Same(t, tt.candidates[alias], pos)
+			// The reconcile step later mutates survivors through the returned slice.
+			for _, candidate := range result {
+				assert.Contains(t, candidates, candidate)
+				assert.Same(t, tt.candidates[candidate.alias()], candidate.positions)
 			}
 		})
 	}
+}
+
+func ersCandidatesFromPositions(t *testing.T, positions map[string]*RelayLogPositions) []*ersCandidate {
+	t.Helper()
+
+	candidates := make([]*ersCandidate, 0, len(positions))
+	for aliasString, position := range positions {
+		alias, err := topoproto.ParseTabletAlias(aliasString)
+		require.NoError(t, err)
+		candidates = append(candidates, &ersCandidate{
+			info:      &topo.TabletInfo{Tablet: &topodatapb.Tablet{Alias: alias}},
+			positions: position,
+		})
+	}
+	return candidates
 }

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -401,21 +401,6 @@ func ShardReplicationStatuses(ctx context.Context, ts *topo.Server, tmc tmclient
 	return tablets, result, rec.Error()
 }
 
-// getValidCandidatesAndPositionsAsList converts the valid candidates from a map to a list of tablets, making it easier to sort
-func getValidCandidatesAndPositionsAsList(validCandidates map[string]*RelayLogPositions, tabletMap map[string]*topo.TabletInfo) ([]*topodatapb.Tablet, []*RelayLogPositions, error) {
-	var validTablets []*topodatapb.Tablet
-	var tabletPositions []*RelayLogPositions
-	for tabletAlias, position := range validCandidates {
-		tablet, isFound := tabletMap[tabletAlias]
-		if !isFound {
-			return nil, nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "candidate %v not found in the tablet map; this an impossible situation", tabletAlias)
-		}
-		validTablets = append(validTablets, tablet.Tablet)
-		tabletPositions = append(tabletPositions, position)
-	}
-	return validTablets, tabletPositions, nil
-}
-
 // isCancellationError returns true if err is a context cancellation, either as the
 // sentinel error or as a gRPC code (server-side wrapping loses the sentinel). A deadline
 // expiry isn't a cancellation, that's how a genuinely stuck tablet fails a wait.
@@ -437,23 +422,6 @@ func removeTabletsByAlias(tablets []*topodatapb.Tablet, aliases []string) []*top
 	return result
 }
 
-// restrictValidCandidates is used to restrict some candidates from being considered eligible for becoming the intermediate source or the final promotion candidate
-func restrictValidCandidates(validCandidates map[string]*RelayLogPositions, tabletMap map[string]*topo.TabletInfo) (map[string]*RelayLogPositions, error) {
-	restrictedValidCandidates := make(map[string]*RelayLogPositions)
-	for candidate, position := range validCandidates {
-		candidateInfo, ok := tabletMap[candidate]
-		if !ok {
-			return nil, vterrors.Errorf(vtrpc.Code_INTERNAL, "candidate %v not found in the tablet map; this an impossible situation", candidate)
-		}
-		// We do not allow BACKUP, DRAINED or RESTORE type of tablets to be considered for being the replication source or the candidate for primary
-		if topoproto.IsTypeInList(candidateInfo.Type, []topodatapb.TabletType{topodatapb.TabletType_BACKUP, topodatapb.TabletType_RESTORE, topodatapb.TabletType_DRAINED}) {
-			continue
-		}
-		restrictedValidCandidates[candidate] = position
-	}
-	return restrictedValidCandidates, nil
-}
-
 // findCandidate returns the best promotion candidate from possibleCandidates.
 // possibleCandidates MUST already be sorted by replication position (most
 // advanced first): when there is no version data, or when the lowest-release
@@ -461,18 +429,18 @@ func restrictValidCandidates(validCandidates map[string]*RelayLogPositions, tabl
 // falls back to the position-sorted ordering (the first element, or the
 // intermediate source) rather than re-checking position.
 func findCandidate(
-	intermediateSource *topodatapb.Tablet,
-	possibleCandidates []*topodatapb.Tablet,
-	versionMap map[string]mysqlctl.ServerVersion,
-) *topodatapb.Tablet {
+	intermediateSource *ersCandidate,
+	possibleCandidates []*ersCandidate,
+) *ersCandidate {
 	if len(possibleCandidates) == 0 {
 		return nil
 	}
 
-	if len(versionMap) == 0 {
-		// No version data — fall back to preferring the intermediate source to avoid catch-up.
+	mysqlVersions, _ := usableERSCandidateMySQLVersions(possibleCandidates)
+	if len(mysqlVersions) == 0 {
+		// Version ordering is unavailable, so prefer the intermediate source to avoid catch-up.
 		for _, candidate := range possibleCandidates {
-			if topoproto.TabletAliasEqual(intermediateSource.Alias, candidate.Alias) {
+			if candidate.isSameTablet(intermediateSource) {
 				return candidate
 			}
 		}
@@ -484,41 +452,36 @@ func findCandidate(
 	// ServerVersion.CompareForReplication). Among candidates that compare equal,
 	// prefer the intermediate source to avoid catch-up.
 	//
-	// Note: versionMap is scoped by the caller to a single flavor family for the
-	// tier's candidates, but the intermediate source is frequently NOT in this
-	// tier, so sourceVersion below can be a cross-family version — which
+	// Note: the flavor-family guard above is scoped to the tier's candidates, but
+	// the intermediate source is frequently NOT in this tier, so sourceVersion
+	// below can be a cross-family version — which
 	// CompareForReplication's precondition otherwise forbids. This is deliberately
 	// harmless: the source-preference at the end only takes effect when the source
 	// is actually found in possibleCandidates (and is therefore in-family), so a
 	// cross-family comparison result is always discarded. Keep that invariant if
 	// editing the source-preference block below.
-	sourceAlias := topoproto.TabletAliasString(intermediateSource.Alias)
-	sourceVersion, ok := versionMap[sourceAlias]
-	if !ok {
-		sourceVersion = unknownVersion
+	sourceVersion := unknownVersion
+	if intermediateSource != nil && intermediateSource.hasMySQLVersion {
+		sourceVersion = intermediateSource.mysqlVersion
 	}
 
-	var best *topodatapb.Tablet
+	var best *ersCandidate
 	bestVersion := unknownVersion
-	for _, candidate := range possibleCandidates {
-		alias := topoproto.TabletAliasString(candidate.Alias)
-		v, ok := versionMap[alias]
-		if !ok {
-			v = unknownVersion
-		}
-
+	for i, candidate := range possibleCandidates {
+		candidateVersion := mysqlVersions[i]
 		if best == nil {
 			best = candidate
-			bestVersion = v
+			bestVersion = candidateVersion
 			continue
 		}
 
-		// Keep the lower version; CompareForReplication returns < 0 when v is lower.
-		if v.CompareForReplication(bestVersion) >= 0 {
+		// Keep the lower version; CompareForReplication returns < 0 when
+		// candidateVersion is lower.
+		if candidateVersion.CompareForReplication(bestVersion) >= 0 {
 			continue
 		}
 		best = candidate
-		bestVersion = v
+		bestVersion = candidateVersion
 	}
 
 	// The first loop finds the lowest-version candidate without bias. Now that we know
@@ -526,7 +489,7 @@ func findCandidate(
 	// if so, prefer it because it already holds the most-advanced position and won't need catch-up.
 	if sourceVersion.CompareForReplication(bestVersion) == 0 {
 		for _, candidate := range possibleCandidates {
-			if topoproto.TabletAliasEqual(intermediateSource.Alias, candidate.Alias) {
+			if candidate.isSameTablet(intermediateSource) {
 				return candidate
 			}
 		}
@@ -536,9 +499,9 @@ func findCandidate(
 }
 
 // getTabletsWithPromotionRules gets the tablets with the given promotion rule from the list of tablets
-func getTabletsWithPromotionRules(durability policy.Durabler, tablets []*topodatapb.Tablet, rule promotionrule.CandidatePromotionRule) (res []*topodatapb.Tablet) {
-	for _, candidate := range tablets {
-		promotionRule := policy.PromotionRule(durability, candidate)
+func getTabletsWithPromotionRules(durability policy.Durabler, candidates []*ersCandidate, rule promotionrule.CandidatePromotionRule) (res []*ersCandidate) {
+	for _, candidate := range candidates {
+		promotionRule := policy.PromotionRule(durability, candidate.tablet())
 		if promotionRule == rule {
 			res = append(res, candidate)
 		}

--- a/go/vt/vtctl/reparentutil/util_test.go
+++ b/go/vt/vtctl/reparentutil/util_test.go
@@ -2246,157 +2246,6 @@ func TestFindCurrentPrimary(t *testing.T) {
 	}
 }
 
-func TestGetValidCandidatesAndPositionsAsList(t *testing.T) {
-	sid1 := replication.SID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
-	mysqlGTID1 := replication.Mysql56GTID{
-		Server:   sid1,
-		Sequence: 9,
-	}
-	mysqlGTID2 := replication.Mysql56GTID{
-		Server:   sid1,
-		Sequence: 10,
-	}
-	mysqlGTID3 := replication.Mysql56GTID{
-		Server:   sid1,
-		Sequence: 11,
-	}
-
-	positionMostAdvanced := &RelayLogPositions{
-		Combined: replication.Position{GTIDSet: replication.Mysql56GTIDSet{}},
-		Executed: replication.Position{GTIDSet: replication.Mysql56GTIDSet{}},
-	}
-	positionMostAdvanced.Combined.GTIDSet = positionMostAdvanced.Combined.GTIDSet.AddGTID(mysqlGTID1)
-	positionMostAdvanced.Combined.GTIDSet = positionMostAdvanced.Combined.GTIDSet.AddGTID(mysqlGTID2)
-	positionMostAdvanced.Combined.GTIDSet = positionMostAdvanced.Combined.GTIDSet.AddGTID(mysqlGTID3)
-	positionMostAdvanced.Executed.GTIDSet = positionMostAdvanced.Executed.GTIDSet.AddGTID(mysqlGTID1)
-	positionMostAdvanced.Executed.GTIDSet = positionMostAdvanced.Executed.GTIDSet.AddGTID(mysqlGTID2)
-
-	positionAlmostMostAdvanced := &RelayLogPositions{
-		Combined: replication.Position{GTIDSet: replication.Mysql56GTIDSet{}},
-		Executed: replication.Position{GTIDSet: replication.Mysql56GTIDSet{}},
-	}
-	positionAlmostMostAdvanced.Combined.GTIDSet = positionAlmostMostAdvanced.Combined.GTIDSet.AddGTID(mysqlGTID1)
-	positionAlmostMostAdvanced.Combined.GTIDSet = positionAlmostMostAdvanced.Combined.GTIDSet.AddGTID(mysqlGTID2)
-	positionAlmostMostAdvanced.Combined.GTIDSet = positionAlmostMostAdvanced.Combined.GTIDSet.AddGTID(mysqlGTID3)
-	positionAlmostMostAdvanced.Executed.GTIDSet = positionAlmostMostAdvanced.Executed.GTIDSet.AddGTID(mysqlGTID1)
-
-	positionIntermediate1 := &RelayLogPositions{
-		Combined: replication.Position{GTIDSet: replication.Mysql56GTIDSet{}},
-		Executed: replication.Position{GTIDSet: replication.Mysql56GTIDSet{}},
-	}
-	positionIntermediate1.Combined.GTIDSet = positionIntermediate1.Combined.GTIDSet.AddGTID(mysqlGTID1)
-	positionIntermediate1.Executed.GTIDSet = positionIntermediate1.Executed.GTIDSet.AddGTID(mysqlGTID1)
-
-	positionIntermediate2 := &RelayLogPositions{
-		Combined: replication.Position{GTIDSet: replication.Mysql56GTIDSet{}},
-		Executed: replication.Position{GTIDSet: replication.Mysql56GTIDSet{}},
-	}
-	positionIntermediate2.Combined.GTIDSet = positionIntermediate2.Combined.GTIDSet.AddGTID(mysqlGTID1)
-	positionIntermediate2.Combined.GTIDSet = positionIntermediate2.Combined.GTIDSet.AddGTID(mysqlGTID2)
-	positionIntermediate2.Executed.GTIDSet = positionIntermediate2.Executed.GTIDSet.AddGTID(mysqlGTID2)
-
-	tests := []struct {
-		name            string
-		validCandidates map[string]*RelayLogPositions
-		tabletMap       map[string]*topo.TabletInfo
-		tabletRes       []*topodatapb.Tablet
-	}{
-		{
-			name: "test conversion",
-			validCandidates: map[string]*RelayLogPositions{
-				"zone1-0000000100": positionMostAdvanced,
-				"zone1-0000000101": positionIntermediate1,
-				"zone1-0000000102": positionIntermediate2,
-				"zone1-0000000103": positionAlmostMostAdvanced,
-			},
-			tabletMap: map[string]*topo.TabletInfo{
-				"zone1-0000000100": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  100,
-						},
-						Hostname: "primary-elect",
-					},
-				},
-				"zone1-0000000101": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  101,
-						},
-					},
-				},
-				"zone1-0000000102": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  102,
-						},
-						Hostname: "requires force start",
-					},
-				},
-				"zone1-0000000103": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  103,
-						},
-						Hostname: "2nd primary-elect",
-					},
-				},
-				"zone1-0000000404": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  404,
-						},
-						Hostname: "ignored tablet",
-					},
-				},
-			},
-			tabletRes: []*topodatapb.Tablet{
-				{
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone1",
-						Uid:  100,
-					},
-					Hostname: "primary-elect",
-				}, {
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone1",
-						Uid:  103,
-					},
-					Hostname: "2nd primary-elect",
-				}, {
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone1",
-						Uid:  101,
-					},
-				}, {
-					Alias: &topodatapb.TabletAlias{
-						Cell: "zone1",
-						Uid:  102,
-					},
-					Hostname: "requires force start",
-				},
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			tabletRes, posRes, err := getValidCandidatesAndPositionsAsList(test.validCandidates, test.tabletMap)
-			require.NoError(t, err)
-			assert.ElementsMatch(t, test.tabletRes, tabletRes)
-			assert.Len(t, posRes, len(tabletRes))
-			for i, tablet := range tabletRes {
-				assert.Equal(t, test.validCandidates[topoproto.TabletAliasString(tablet.Alias)], posRes[i])
-			}
-		})
-	}
-}
-
 func TestWaitForCatchUp(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -2514,103 +2363,15 @@ func TestWaitForCatchUp(t *testing.T) {
 	}
 }
 
-func TestRestrictValidCandidates(t *testing.T) {
-	tests := []struct {
-		name            string
-		validCandidates map[string]*RelayLogPositions
-		tabletMap       map[string]*topo.TabletInfo
-		result          map[string]*RelayLogPositions
-	}{
-		{
-			name: "remove invalid tablets",
-			validCandidates: map[string]*RelayLogPositions{
-				"zone1-0000000100": {},
-				"zone1-0000000101": {},
-				"zone1-0000000102": {},
-				"zone1-0000000103": {},
-				"zone1-0000000104": {},
-				"zone1-0000000105": {},
-			},
-			tabletMap: map[string]*topo.TabletInfo{
-				"zone1-0000000100": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  100,
-						},
-						Type: topodatapb.TabletType_PRIMARY,
-					},
-				},
-				"zone1-0000000101": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  101,
-						},
-						Type: topodatapb.TabletType_RDONLY,
-					},
-				},
-				"zone1-0000000102": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  102,
-						},
-						Type: topodatapb.TabletType_RESTORE,
-					},
-				},
-				"zone1-0000000103": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  103,
-						},
-						Type: topodatapb.TabletType_DRAINED,
-					},
-				},
-				"zone1-0000000104": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  104,
-						},
-						Type: topodatapb.TabletType_SPARE,
-					},
-				},
-				"zone1-0000000105": {
-					Tablet: &topodatapb.Tablet{
-						Alias: &topodatapb.TabletAlias{
-							Cell: "zone1",
-							Uid:  103,
-						},
-						Type: topodatapb.TabletType_BACKUP,
-					},
-				},
-			},
-			result: map[string]*RelayLogPositions{
-				"zone1-0000000100": {},
-				"zone1-0000000101": {},
-				"zone1-0000000104": {},
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			res, err := restrictValidCandidates(test.validCandidates, test.tabletMap)
-			require.NoError(t, err)
-			assert.Equal(t, res, test.result)
-		})
-	}
-}
-
 func Test_findCandidate(t *testing.T) {
 	tests := []struct {
-		name               string
-		intermediateSource *topodatapb.Tablet
-		possibleCandidates []*topodatapb.Tablet
-		versionMap         map[string]mysqlctl.ServerVersion
-		candidate          *topodatapb.Tablet
+		name                      string
+		intermediateSource        *topodatapb.Tablet
+		possibleCandidates        []*topodatapb.Tablet
+		versionMap                map[string]mysqlctl.ServerVersion
+		flavorMap                 map[string]mysqlctl.MySQLFlavor
+		candidate                 *topodatapb.Tablet
+		candidateFromPossibleList bool
 	}{
 		{
 			name:      "empty possible candidates list",
@@ -2647,6 +2408,7 @@ func Test_findCandidate(t *testing.T) {
 					Uid:  103,
 				},
 			},
+			candidateFromPossibleList: true,
 		}, {
 			name: "intermediate source not in possible candidates list",
 			intermediateSource: &topodatapb.Tablet{
@@ -2771,90 +2533,122 @@ func Test_findCandidate(t *testing.T) {
 					Uid:  101,
 				},
 			},
+		}, {
+			name: "mixed flavor families prefer intermediate source",
+			intermediateSource: &topodatapb.Tablet{
+				Alias: &topodatapb.TabletAlias{Cell: "zone1", Uid: 100},
+			},
+			possibleCandidates: []*topodatapb.Tablet{
+				{Alias: &topodatapb.TabletAlias{Cell: "zone1", Uid: 101}},
+				{Alias: &topodatapb.TabletAlias{Cell: "zone1", Uid: 100}},
+			},
+			versionMap: map[string]mysqlctl.ServerVersion{
+				"zone1-0000000100": {Major: 10, Minor: 6, Patch: 16},
+				"zone1-0000000101": {Major: 8, Minor: 0, Patch: 35},
+			},
+			flavorMap: map[string]mysqlctl.MySQLFlavor{
+				"zone1-0000000100": mysqlctl.FlavorMariaDB,
+				"zone1-0000000101": mysqlctl.FlavorMySQL,
+			},
+			candidate: &topodatapb.Tablet{
+				Alias: &topodatapb.TabletAlias{Cell: "zone1", Uid: 100},
+			},
+			candidateFromPossibleList: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res := findCandidate(tt.intermediateSource, tt.possibleCandidates, tt.versionMap)
+			possibleCandidates := make([]*ersCandidate, 0, len(tt.possibleCandidates))
+			for _, tablet := range tt.possibleCandidates {
+				candidate := &ersCandidate{info: &topo.TabletInfo{Tablet: tablet}}
+				alias := topoproto.TabletAliasString(tablet.Alias)
+				if version, ok := tt.versionMap[alias]; ok {
+					candidate.mysqlVersion = version
+					candidate.mysqlFlavor = mysqlctl.FlavorMySQL
+					if flavor, ok := tt.flavorMap[alias]; ok {
+						candidate.mysqlFlavor = flavor
+					}
+					candidate.hasMySQLVersion = true
+				}
+				possibleCandidates = append(possibleCandidates, candidate)
+			}
+
+			var intermediateSource *ersCandidate
+			if tt.intermediateSource != nil {
+				intermediateSource = &ersCandidate{info: &topo.TabletInfo{Tablet: tt.intermediateSource}}
+				alias := topoproto.TabletAliasString(tt.intermediateSource.Alias)
+				if version, ok := tt.versionMap[alias]; ok {
+					intermediateSource.mysqlVersion = version
+					intermediateSource.mysqlFlavor = mysqlctl.FlavorMySQL
+					if flavor, ok := tt.flavorMap[alias]; ok {
+						intermediateSource.mysqlFlavor = flavor
+					}
+					intermediateSource.hasMySQLVersion = true
+				}
+			}
+
+			res := findCandidate(intermediateSource, possibleCandidates)
 			if tt.candidate == nil {
 				require.Nil(t, res)
 			} else {
 				require.NotNil(t, res)
-				require.Equal(t, topoproto.TabletAliasString(tt.candidate.Alias), topoproto.TabletAliasString(res.Alias))
+				require.Equal(t, topoproto.TabletAliasString(tt.candidate.Alias), res.alias())
+				if tt.candidateFromPossibleList {
+					require.Same(t, findERSCandidateByAlias(possibleCandidates, tt.candidate.Alias), res)
+				}
 			}
 		})
 	}
 }
 
 func Test_getTabletsWithPromotionRules(t *testing.T) {
-	var (
-		primaryTablet = &topodatapb.Tablet{
-			Alias: &topodatapb.TabletAlias{
-				Cell: "zone-1",
-				Uid:  1,
-			},
-			Type: topodatapb.TabletType_PRIMARY,
+	candidate := func(cell string, uid uint32, tabletType topodatapb.TabletType) *ersCandidate {
+		return &ersCandidate{
+			info: &topo.TabletInfo{Tablet: &topodatapb.Tablet{
+				Alias: &topodatapb.TabletAlias{Cell: cell, Uid: uid},
+				Type:  tabletType,
+			}},
 		}
-		replicaTablet = &topodatapb.Tablet{
-			Alias: &topodatapb.TabletAlias{
-				Cell: "zone-1",
-				Uid:  2,
-			},
-			Type: topodatapb.TabletType_REPLICA,
-		}
-		rdonlyTablet = &topodatapb.Tablet{
-			Alias: &topodatapb.TabletAlias{
-				Cell: "zone-1",
-				Uid:  3,
-			},
-			Type: topodatapb.TabletType_RDONLY,
-		}
-		replicaCrossCellTablet = &topodatapb.Tablet{
-			Alias: &topodatapb.TabletAlias{
-				Cell: "zone-2",
-				Uid:  2,
-			},
-			Type: topodatapb.TabletType_REPLICA,
-		}
-		rdonlyCrossCellTablet = &topodatapb.Tablet{
-			Alias: &topodatapb.TabletAlias{
-				Cell: "zone-2",
-				Uid:  3,
-			},
-			Type: topodatapb.TabletType_RDONLY,
-		}
-	)
-	allTablets := []*topodatapb.Tablet{primaryTablet, replicaTablet, rdonlyTablet, replicaCrossCellTablet, rdonlyCrossCellTablet}
+	}
+	primaryCandidate := candidate("zone-1", 1, topodatapb.TabletType_PRIMARY)
+	replicaCandidate := candidate("zone-1", 2, topodatapb.TabletType_REPLICA)
+	rdonlyCandidate := candidate("zone-1", 3, topodatapb.TabletType_RDONLY)
+	replicaCrossCellCandidate := candidate("zone-2", 2, topodatapb.TabletType_REPLICA)
+	rdonlyCrossCellCandidate := candidate("zone-2", 3, topodatapb.TabletType_RDONLY)
+	allCandidates := []*ersCandidate{primaryCandidate, replicaCandidate, rdonlyCandidate, replicaCrossCellCandidate, rdonlyCrossCellCandidate}
 	tests := []struct {
-		name            string
-		tablets         []*topodatapb.Tablet
-		rule            promotionrule.CandidatePromotionRule
-		filteredTablets []*topodatapb.Tablet
+		name               string
+		candidates         []*ersCandidate
+		rule               promotionrule.CandidatePromotionRule
+		filteredCandidates []*ersCandidate
 	}{
 		{
-			name:            "filter candidates with Neutral promotion rule",
-			tablets:         allTablets,
-			rule:            promotionrule.Neutral,
-			filteredTablets: []*topodatapb.Tablet{primaryTablet, replicaTablet, replicaCrossCellTablet},
+			name:               "filter candidates with Neutral promotion rule",
+			candidates:         allCandidates,
+			rule:               promotionrule.Neutral,
+			filteredCandidates: []*ersCandidate{primaryCandidate, replicaCandidate, replicaCrossCellCandidate},
 		},
 		{
-			name:            "filter candidates with MustNot promotion rule",
-			tablets:         allTablets,
-			rule:            promotionrule.MustNot,
-			filteredTablets: []*topodatapb.Tablet{rdonlyTablet, rdonlyCrossCellTablet},
+			name:               "filter candidates with MustNot promotion rule",
+			candidates:         allCandidates,
+			rule:               promotionrule.MustNot,
+			filteredCandidates: []*ersCandidate{rdonlyCandidate, rdonlyCrossCellCandidate},
 		},
 		{
-			name:            "filter candidates with Must promotion rule",
-			tablets:         allTablets,
-			rule:            promotionrule.Must,
-			filteredTablets: nil,
+			name:       "filter candidates with Must promotion rule",
+			candidates: allCandidates,
+			rule:       promotionrule.Must,
 		},
 	}
-	durability, _ := policy.GetDurabilityPolicy(policy.DurabilityNone)
+	durability, err := policy.GetDurabilityPolicy(policy.DurabilityNone)
+	require.NoError(t, err)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res := getTabletsWithPromotionRules(durability, tt.tablets, tt.rule)
-			require.Equal(t, tt.filteredTablets, res)
+			res := getTabletsWithPromotionRules(durability, tt.candidates, tt.rule)
+			require.Equal(t, tt.filteredCandidates, res)
+			for i := range res {
+				require.Same(t, tt.filteredCandidates[i], res[i])
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Description

ERS candidate state is currently split across six alias-keyed maps and parallel slices. Following a candidate through the selection pipeline means repeatedly joining that state, which adds review toil to changes in this safety-critical code

This PR groups the state in an `ersCandidate` struct and passes ordered candidate slices through relay-log waits, errant-GTID detection and election:

```go
type ersCandidate struct {
	info      *topo.TabletInfo
	positions *RelayLogPositions

	mysqlVersion    mysqlctl.ServerVersion
	mysqlFlavor     mysqlctl.MySQLFlavor
	hasMySQLVersion bool

	// stopStatus is nil for a tablet that reported itself as primary rather than
	// stopping replication, which is how the pipeline tells the two apart.
	stopStatus   *replicationdatapb.StopReplicationStatus
	takingBackup bool

	// reparentJournalLen is filled in during errant-GTID detection.
	reparentJournalLen int32
}
```


The aim is to generally simplify ERS and make future changes easier to reason about and review; candidate-selection behaviour is unchanged, aside from a clearer error when a requested primary is taking a backup and another candidate is available

## Related Issue(s)

N/A

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

### AI Disclosure

Codex wrote most of this PR and prepared this PR summary
