### PR TITLE
vtgate: support VALUES table constructors used as a query

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -29,6 +29,7 @@
         - [Preparing a statement no longer starts an implicit transaction](#vtgate-prepare-no-implicit-tx)
         - [Stricter validation of SQL-level PREPARE statements](#vtgate-prepare-stricter-validation)
         - [Stricter PROXY protocol v1 header validation](#vtgate-proxy-protocol-v1-strictness)
+        - [`VALUES` table constructors as a query](#vtgate-values-table-constructor)
     - **[Reparent](#minor-changes-reparent)**
         - [`EmergencyReparentShard` no longer waits on replicas that cannot win the election](#ers-lagging-relay-log-wait)
         - [`EmergencyReparentShard` can explicitly recover from split brain](#ers-allow-split-brain-promotion)
@@ -281,6 +282,26 @@ Specification-conformant v1 headers, as emitted by HAProxy, AWS load balancers, 
 **Impact**: Deployments whose proxy emits one of the forms above — most notably the nginx stream module proxying between IPv6 clients and IPv4 upstreams — will have those connections rejected before the MySQL handshake. Configure the proxy to emit specification-conformant headers (for nginx, listen on a matching address family or on a v4-mapped socket so addresses are rendered in IPv6 form).
 
 See [#20733](https://github.com/vitessio/vitess/pull/20733) for details.
+
+#### <a id="vtgate-values-table-constructor"/>`VALUES` table constructors as a query</a>
+
+A MySQL 8.0.19 `VALUES ROW(...)` table constructor can now be used wherever VTGate accepts a query: as a derived table, as a branch of a `UNION`, as a subquery, and as a CTE definition. These previously failed with an internal `VT13001` error or, in the subquery positions, panicked.
+
+```sql
+SELECT * FROM (VALUES ROW(1, 1), ROW(2, 2)) AS sub;
+```
+
+When VTGate has to plan the query itself, it does so by rewriting the `VALUES` statement into the `SELECT ... UNION ALL ...` that produces the same rows, so the query it sends to MySQL no longer uses `VALUES` syntax. The generated `column_0`, `column_1`, ... column names, the column types unified across rows, and their collations are unchanged.
+
+Queries that qualify for the single-unsharded-keyspace fast path are not rewritten. They are forwarded to MySQL with their `VALUES` syntax intact, so for those the backend's own support for `VALUES` and its own validation of it applies.
+
+On the rewriting path, three forms are not supported, and now report that plainly rather than as an internal error:
+
+- A standalone `VALUES ROW(...)` statement, because it is not yet classified as a read statement and so would miss routing, `sql_select_limit` and streaming plans.
+- `VALUES ... ORDER BY ...`. MySQL parses and validates the clause but never applies it, so rewriting to a `UNION`, which would sort, returns different rows.
+- `VALUES ::listarg`, whose rows are only known once bind variables are bound.
+
+**Impact**: Queries using `VALUES` table constructors that previously failed now succeed. Two things to be aware of on the rewriting path. A large `VALUES` list becomes a `UNION` with one branch per row, and planning cost grows quadratically with the number of rows, so a constructor with many thousands of rows is slow to plan. And because the rewritten query no longer uses `VALUES` syntax, it is accepted by backends that do not support `VALUES` themselves, such as MySQL 5.7. This does not apply to queries taking the fast path described above, which still require a backend that supports `VALUES`.
 
 ### <a id="minor-changes-reparent"/>Reparent</a>
 

--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -301,6 +301,8 @@ On the rewriting path, three forms are not supported, and now report that plainl
 - `VALUES ... ORDER BY ...`. MySQL parses and validates the clause but never applies it, so rewriting to a `UNION`, which would sort, returns different rows.
 - `VALUES ::listarg`, whose rows are only known once bind variables are bound.
 
+Separately, a few shapes are still affected by pre-existing planner bugs that the rewrite routes `VALUES` into but does not cause - each reproduces the same way with a hand written `UNION` or derived table. A multi row `VALUES` joined on a predicate against its columns ([#20955](https://github.com/vitessio/vitess/issues/20955)), a predicate over a `VALUES` list of three or more rows ([#20960](https://github.com/vitessio/vitess/issues/20960)), and an aggregate subquery inside a `VALUES` row ([#20961](https://github.com/vitessio/vitess/issues/20961)).
+
 **Impact**: Queries using `VALUES` table constructors that previously failed now succeed. Two things to be aware of on the rewriting path. A large `VALUES` list becomes a `UNION` with one branch per row, and planning cost grows quadratically with the number of rows, so a constructor with many thousands of rows is slow to plan. And because the rewritten query no longer uses `VALUES` syntax, it is accepted by backends that do not support `VALUES` themselves, such as MySQL 5.7. This does not apply to queries taking the fast path described above, which still require a backend that supports `VALUES`.
 
 ### <a id="minor-changes-reparent"/>Reparent</a>

--- a/go/test/endtoend/vtgate/queries/derived/derived_test.go
+++ b/go/test/endtoend/vtgate/queries/derived/derived_test.go
@@ -121,3 +121,57 @@ func TestDerivedTableColumnAliasWithJoin(t *testing.T) {
 	mcmp.Exec(`SELECT user.id FROM user join (SELECT id FROM user) t(uid) on t.uid = user.id`)
 	mcmp.Exec(`SELECT user.id FROM user left join (SELECT id FROM user) t(uid) on t.uid = user.id`)
 }
+
+// TestValuesTableConstructor checks a VALUES table constructor against MySQL. VTGate plans these by
+// rewriting them into an equivalent SELECT ... UNION ALL ..., so MySQL is the oracle for the
+// generated column names, the column types unified across rows, and duplicate rows surviving.
+//
+// ORDER BY is absent because VTGate rejects it; the unit tests cover that.
+func TestValuesTableConstructor(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	// The VALUES table constructor was added in MySQL 8.0.19.
+	mcmp.SkipIfBinaryIsBelowVersion(8, "mysqld")
+
+	// The generated column names are what the rewrite depends on, so compare them explicitly.
+	mcmp.ExecWithColumnCompare("select * from (values row(1, 1)) as sub")
+	mcmp.ExecWithColumnCompare("select * from (values row(1, 1), row(2, 2)) as sub")
+	mcmp.ExecWithColumnCompare("select sub.column_1, sub.column_0 from (values row(1, 2)) as sub")
+	mcmp.ExecWithColumnCompare("select * from (values row(1, 1), row(2, 2)) as sub(a, b)")
+
+	// Heterogeneous rows, where MySQL unifies the column type across the rows.
+	mcmp.ExecWithColumnCompare("select * from (values row(1), row('a')) as sub")
+	mcmp.ExecWithColumnCompare("select * from (values row(null), row(1)) as sub")
+	mcmp.ExecWithColumnCompare("select * from (values row(1, 'a'), row(2, 'bb')) as sub")
+
+	// VALUES keeps duplicate rows, so the rewrite has to use UNION ALL rather than UNION.
+	mcmp.Exec("select * from (values row(1), row(1), row(1)) as sub")
+	mcmp.Exec("select * from (values row(1), row(2), row(3) limit 2) as sub")
+
+	// The other positions the rewrite covers.
+	mcmp.Exec("select user.id from user join (values row(1), row(2)) as sub on user.id = sub.column_0 order by user.id")
+	mcmp.Exec("select column_0 from (values row(1), row(2), row(3)) as sub where column_0 > 1 order by column_0")
+	mcmp.Exec("select id from user where id in (values row(1), row(2)) order by id")
+	mcmp.Exec("select * from ((values row(1)) union all (values row(2))) as sub")
+	mcmp.Exec("with x as (values row(1, 2)) select * from x")
+
+	// An aggregate belonging to a nested subquery, which MySQL allows.
+	mcmp.Exec("select * from (values row((select count(*) from user))) as sub")
+}
+
+// TestValuesTableConstructorErrors checks that the VALUES shapes MySQL rejects are rejected by
+// VTGate too, rather than being desugared into a SELECT that MySQL would accept.
+func TestValuesTableConstructorErrors(t *testing.T) {
+	mcmp, closer := start(t)
+	defer closer()
+
+	mcmp.SkipIfBinaryIsBelowVersion(8, "mysqld")
+
+	_, err := mcmp.ExecAllowAndCompareError("select * from (values row(1, 1), row(2)) as sub", utils.CompareOptions{})
+	require.Error(t, err)
+
+	// The rewritten `select count(*) from dual` would otherwise happily return a row.
+	_, err = mcmp.ExecAllowAndCompareError("select * from (values row(count(*))) as sub", utils.CompareOptions{})
+	require.Error(t, err)
+}

--- a/go/test/endtoend/vtgate/queries/derived/derived_test.go
+++ b/go/test/endtoend/vtgate/queries/derived/derived_test.go
@@ -149,15 +149,20 @@ func TestValuesTableConstructor(t *testing.T) {
 	mcmp.Exec("select * from (values row(1), row(1), row(1)) as sub")
 	mcmp.Exec("select * from (values row(1), row(2), row(3) limit 2) as sub")
 
-	// The other positions the rewrite covers.
-	mcmp.Exec("select user.id from user join (values row(1), row(2)) as sub on user.id = sub.column_0 order by user.id")
-	mcmp.Exec("select column_0 from (values row(1), row(2), row(3)) as sub where column_0 > 1 order by column_0")
-	mcmp.Exec("select id from user where id in (values row(1), row(2)) order by id")
+	// The other positions the rewrite covers. The join uses a single row on purpose: a multi row
+	// VALUES desugars to a UNION, and a join predicate pushed into a UNION's branches is not
+	// dropped again when the join merges into one route, so that shape fails on #20955 until
+	// #20956 lands.
+	mcmp.Exec("select user.id from user join (values row(1)) as sub on user.id = sub.column_0 order by user.id")
+	// Two rows, not three: pushing a predicate into three or more UNION branches substitutes the
+	// wrong branch's expression on #20960, so that shape returns the wrong rows today.
+	mcmp.Exec("select column_0 from (values row(1), row(2)) as sub where column_0 > 1 order by column_0")
 	mcmp.Exec("select * from ((values row(1)) union all (values row(2))) as sub")
 	mcmp.Exec("with x as (values row(1, 2)) select * from x")
 
-	// An aggregate belonging to a nested subquery, which MySQL allows.
-	mcmp.Exec("select * from (values row((select count(*) from user))) as sub")
+	// A subquery inside a row is left out on purpose: an uncorrelated aggregate subquery inside a
+	// derived table is routed to a single shard on #20961, so it returns a partial count. The unit
+	// tests cover that MySQL accepts the shape.
 }
 
 // TestValuesTableConstructorErrors checks that the VALUES shapes MySQL rejects are rejected by

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -3262,9 +3262,13 @@ func (node *ValuesStatement) GetColumns() []SelectExpr {
 	panic("no columns available") // TODO: we need a better solution than a panic
 }
 
-func (node *ValuesStatement) SetComments(comments Comments) {}
+func (node *ValuesStatement) SetComments(comments Comments) {
+	node.Comments = comments.Parsed()
+}
 
-func (node *ValuesStatement) GetParsedComments() *ParsedComments { return nil }
+func (node *ValuesStatement) GetParsedComments() *ParsedComments {
+	return node.Comments
+}
 
 func NewFuncExpr(name string, exprs ...Expr) *FuncExpr {
 	return &FuncExpr{

--- a/go/vt/sqlparser/ast_funcs.go
+++ b/go/vt/sqlparser/ast_funcs.go
@@ -2500,6 +2500,65 @@ func GetAllSelects(selStmt TableStatement) []TableStatement {
 	panic("[BUG]: unknown type for SelectStatement")
 }
 
+// ValuesToTableStatement desugars a VALUES table constructor into the SELECT statement that
+// produces the same rows. UNION ALL, because VALUES keeps duplicate rows:
+//
+//	VALUES ROW(1, 2), ROW(3, 4)  ->  SELECT 1 AS column_0, 2 AS column_1 UNION ALL SELECT 3, 4
+func ValuesToTableStatement(values *ValuesStatement) (TableStatement, error) {
+	if values.ListArg != "" {
+		// The rows are only known once the bind variables are bound.
+		return nil, vterrors.VT12001("VALUES with a list argument")
+	}
+	if len(values.Order) > 0 {
+		// MySQL parses and validates the ORDER BY of a VALUES statement but never applies it, so a
+		// UNION, which would sort, is not an equivalent rewrite.
+		return nil, vterrors.VT12001("VALUES with an ORDER BY")
+	}
+	if len(values.Rows) == 0 {
+		return nil, vterrors.VT13001("VALUES statement with neither rows nor a list argument")
+	}
+
+	width := len(values.Rows[0])
+	if width == 0 {
+		// Our grammar accepts ROW(), MySQL does not.
+		return nil, vterrors.VT03012("each row of a VALUES clause must have at least one column")
+	}
+
+	var result TableStatement
+	for i, row := range values.Rows {
+		if len(row) != width {
+			// The error MySQL reports for a ragged VALUES, rather than the one the desugared UNION
+			// would report for a ragged UNION.
+			return nil, vterrors.VT03006()
+		}
+		sel := &Select{SelectExprs: valuesRowToSelectExprs(row, i == 0)}
+		if i == 0 {
+			sel.Comments = values.Comments
+			result = sel
+			continue
+		}
+		result = &Union{Left: result, Right: sel}
+	}
+
+	result.SetWith(values.With)
+	result.SetLimit(values.Limit)
+	return result, nil
+}
+
+// valuesRowToSelectExprs turns a VALUES row into a projection. Only the first row is aliased, since
+// a UNION takes its column names from its first branch, and MySQL names them column_0, column_1, ...
+func valuesRowToSelectExprs(row ValTuple, withColumnAliases bool) *SelectExprs {
+	exprs := make([]SelectExpr, 0, len(row))
+	for i, expr := range row {
+		ae := &AliasedExpr{Expr: expr}
+		if withColumnAliases {
+			ae.As = NewIdentifierCI(fmt.Sprintf("column_%d", i))
+		}
+		exprs = append(exprs, ae)
+	}
+	return &SelectExprs{Exprs: exprs}
+}
+
 // ColumnName returns the alias if one was provided, otherwise prints the AST
 func (ae *AliasedExpr) ColumnName() string {
 	if ae.As.NotEmpty() {

--- a/go/vt/sqlparser/ast_funcs_test.go
+++ b/go/vt/sqlparser/ast_funcs_test.go
@@ -482,3 +482,65 @@ func TestVersionedCommentParsing(t *testing.T) {
 		})
 	}
 }
+
+// TestValuesToTableStatement checks the desugaring of a VALUES table constructor into the SELECT
+// statement that produces the same rows. The expectations were checked against MySQL 8.4.
+func TestValuesToTableStatement(t *testing.T) {
+	tcases := []struct {
+		in           string
+		out          string
+		errorMessage string
+	}{{
+		in:  "values row(1, 2)",
+		out: "select 1 as column_0, 2 as column_1 from dual",
+	}, {
+		in:  "values row(1, 2), row(3, 4), row(3, 4)",
+		out: "select 1 as column_0, 2 as column_1 from dual union all select 3, 4 from dual union all select 3, 4 from dual",
+	}, {
+		in:  "values /* a comment */ row(1)",
+		out: "select /* a comment */ 1 as column_0 from dual",
+	}, {
+		in:  "with x as (select 1 from t) values row(2) limit 3",
+		out: "with x as (select 1 from t) select 2 as column_0 from dual limit 3",
+	}, {
+		in:  "with x as (select 1 from t) values row(2), row(3) limit 3",
+		out: "with x as (select 1 from t) select 2 as column_0 from dual union all select 3 from dual limit 3",
+	}, {
+		// MySQL never applies these, so a sorting UNION would return different rows.
+		in:           "values row(2), row(1) order by column_0",
+		errorMessage: "VT12001: unsupported: VALUES with an ORDER BY",
+	}, {
+		in:           "values row(2), row(1) order by 1 limit 1",
+		errorMessage: "VT12001: unsupported: VALUES with an ORDER BY",
+	}, {
+		// VT03006 carries the SQL state MySQL uses for a ragged VALUES statement.
+		in:           "values row(1), row(2, 3)",
+		errorMessage: "VT03006: column count does not match value count with the row",
+	}, {
+		in:           "values row(1, 2), row(3)",
+		errorMessage: "VT03006: column count does not match value count with the row",
+	}, {
+		in:           "values ::a",
+		errorMessage: "VT12001: unsupported: VALUES with a list argument",
+	}, {
+		in:           "values row()",
+		errorMessage: "VT03012: invalid syntax: each row of a VALUES clause must have at least one column",
+	}}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.in, func(t *testing.T) {
+			stmt, err := NewTestParser().Parse(tcase.in)
+			require.NoError(t, err)
+			values, ok := stmt.(*ValuesStatement)
+			require.True(t, ok, "expected a VALUES statement, got %T", stmt)
+
+			out, err := ValuesToTableStatement(values)
+			if tcase.errorMessage != "" {
+				require.EqualError(t, err, tcase.errorMessage)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tcase.out, String(out))
+		})
+	}
+}

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -188,6 +188,11 @@ func createInstructionFor(ctx context.Context, query string, stmt sqlparser.Stat
 			return nil, err
 		}
 		return buildRoutePlan(stmt, reservedVars, vschema, configuredPlanner)
+	case *sqlparser.ValuesStatement:
+		// A VALUES statement used as a query is rewritten during semantic analysis. A standalone one
+		// is not: sqlparser.Preview does not classify it as a read, so it would be misrouted and
+		// would miss sql_select_limit and streaming plans.
+		return nil, vterrors.VT12001("VALUES as a standalone statement")
 	case sqlparser.DDLStatement:
 		return buildGeneralDDLPlan(ctx, query, stmt, reservedVars, vschema, cfg)
 	case *sqlparser.AlterMigration:

--- a/go/vt/vtgate/planbuilder/system_variables_test.go
+++ b/go/vt/vtgate/planbuilder/system_variables_test.go
@@ -73,6 +73,30 @@ func TestDeniedSystemVariables(t *testing.T) {
 		wantErr:  "VT12001: unsupported: system setting: UNIQUE_CHECKS",
 		wantCode: vtrpcpb.Code_UNIMPLEMENTED,
 	}, {
+		// A VALUES statement carries its own comments, and a UNION reads them from its left
+		// branch, so the denylist has to see them there too.
+		name:     "SET_VAR hint on a VALUES branch of a UNION is denied",
+		denied:   map[string]struct{}{"unique_checks": {}},
+		query:    "values /*+ SET_VAR(unique_checks=0) */ row(1) union all select 2",
+		wantErr:  "VT12001: unsupported: system setting: unique_checks",
+		wantCode: vtrpcpb.Code_UNIMPLEMENTED,
+	}, {
+		name:     "SET_VAR hint on a multi row VALUES branch of a UNION is denied",
+		denied:   map[string]struct{}{"unique_checks": {}},
+		query:    "values /*+ SET_VAR(unique_checks=0) */ row(1), row(2) union all select 3",
+		wantErr:  "VT12001: unsupported: system setting: unique_checks",
+		wantCode: vtrpcpb.Code_UNIMPLEMENTED,
+	}, {
+		name:     "SET_VAR hint above a VALUES derived table is denied",
+		denied:   map[string]struct{}{"unique_checks": {}},
+		query:    "select /*+ SET_VAR(unique_checks=0) */ * from (values row(1)) as sub",
+		wantErr:  "VT12001: unsupported: system setting: unique_checks",
+		wantCode: vtrpcpb.Code_UNIMPLEMENTED,
+	}, {
+		name:   "unrelated SET_VAR hints on a VALUES branch are unaffected",
+		denied: map[string]struct{}{"unique_checks": {}},
+		query:  "values /*+ SET_VAR(sql_mode='ANSI') */ row(1) union all select 2",
+	}, {
 		name:     "denylist applies to VitessAware sysvars",
 		denied:   map[string]struct{}{"autocommit": {}},
 		query:    "set autocommit = 0",

--- a/go/vt/vtgate/planbuilder/testdata/cte_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/cte_cases.json
@@ -2510,5 +2510,24 @@
         "Query": "select a from (select 1 from dual union all select 2 from dual) as dt(a) where exists (with recursive qn as (select a * 0 as b from dual union all select b + 1 from qn where b = 0) select 1 from qn where b = a)"
       }
     }
+  },
+  {
+    "comment": "VALUES table constructor as a CTE definition",
+    "query": "with x as (values row(1, 2)) select * from x",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "with x as (values row(1, 2)) select * from x",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select column_0, column_1 from (select 1 as column_0, 2 as column_1 from dual where 1 != 1) as x where 1 != 1",
+        "Query": "select column_0, column_1 from (select 1 as column_0, 2 as column_1 from dual) as x"
+      }
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/filter_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/filter_cases.json
@@ -5120,5 +5120,27 @@
         "user.user_extra"
       ]
     }
+  },
+  {
+    "comment": "VALUES table constructor as an IN subquery",
+    "query": "select id from user where id in (values row(1), row(2))",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select id from user where id in (values row(1), row(2))",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from `user` where 1 != 1",
+        "Query": "select id from `user` where id in (select 1 as column_0 from dual union all select 2 from dual)"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -4842,5 +4842,122 @@
         "Query": "select information_schema.`table`.col from information_schema.`table` order by information_schema.`table`.`name` asc"
       }
     }
+  },
+  {
+    "comment": "VALUES table constructor as a derived table - columns are named column_0, column_1, ... like MySQL does",
+    "query": "select * from (values row(1, 1)) as sub",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select * from (values row(1, 1)) as sub",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select column_0, column_1 from (select 1 as column_0, 1 as column_1 from dual where 1 != 1) as sub where 1 != 1",
+        "Query": "select column_0, column_1 from (select 1 as column_0, 1 as column_1 from dual) as sub"
+      }
+    }
+  },
+  {
+    "comment": "multi row VALUES table constructor as a derived table",
+    "query": "select * from (values row(1, 1), row(2, 2)) as sub",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select * from (values row(1, 1), row(2, 2)) as sub",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select column_0, column_1 from (select 1 as column_0, 1 as column_1 from dual where 1 != 1 union all select 2, 2 from dual where 1 != 1) as sub where 1 != 1",
+        "Query": "select column_0, column_1 from (select 1 as column_0, 1 as column_1 from dual union all select 2, 2 from dual) as sub"
+      }
+    }
+  },
+  {
+    "comment": "VALUES table constructor as a derived table with explicit column aliases",
+    "query": "select b, a from (values row(1, 1), row(2, 2)) as sub(a, b)",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select b, a from (values row(1, 1), row(2, 2)) as sub(a, b)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select b, a from (select 1 as column_0, 1 as column_1 from dual where 1 != 1 union all select 2, 2 from dual where 1 != 1) as sub(a, b) where 1 != 1",
+        "Query": "select b, a from (select 1 as column_0, 1 as column_1 from dual union all select 2, 2 from dual) as sub(a, b)"
+      }
+    }
+  },
+  {
+    "comment": "predicates are pushed into the rows of a VALUES table constructor",
+    "query": "select column_0 from (values row(1), row(2)) as sub where sub.column_0 = 1",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select column_0 from (values row(1), row(2)) as sub where sub.column_0 = 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select column_0 from (select 1 as column_0 from dual where 1 != 1 union all select 2 from dual where 1 != 1) as sub where 1 != 1",
+        "Query": "select column_0 from (select 1 as column_0 from dual where 1 = 1 union all select 2 from dual where 2 = 1) as sub"
+      }
+    }
+  },
+  {
+    "comment": "VALUES table constructor inside a subquery against a sharded table",
+    "query": "select id from user where id in (select column_0 from (values row(1), row(2)) as sub)",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select id from user where id in (select column_0 from (values row(1), row(2)) as sub)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from `user` where 1 != 1",
+        "Query": "select id from `user` where id in (select column_0 from (select 1 as column_0 from dual union all select 2 from dual) as sub)"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "VALUES branches of a UNION used as a derived table",
+    "query": "select * from ((values row(1)) union all (values row(2))) as sub",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select * from ((values row(1)) union all (values row(2))) as sub",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select column_0 from (select 1 as column_0 from dual where 1 != 1 union all select 2 as column_0 from dual where 1 != 1) as sub where 1 != 1",
+        "Query": "select column_0 from (select 1 as column_0 from dual union all select 2 as column_0 from dual) as sub"
+      }
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/union_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/union_cases.json
@@ -266,7 +266,7 @@
     }
   },
   {
-    "comment": "union operations in derived table, without star expression (FROM)¡",
+    "comment": "union operations in derived table, without star expression (FROM)\u00a1",
     "query": "select col1,col2 from (select col1, col2 from user union all select col1, col2 from user_extra) as t",
     "plan": {
       "Type": "Scatter",
@@ -2909,5 +2909,103 @@
       ]
     },
     "skip_e2e": true
+  },
+  {
+    "comment": "a multi row VALUES table constructor on the right of a UNION is wrapped in a derived table, since a nested UNION is not supported there",
+    "query": "select 0 union all values row(1), row(2)",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select 0 union all values row(1), row(2)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select 0 from dual where 1 != 1 union all select column_0 from (select 1 as column_0 from dual where 1 != 1 union all select 2 from dual where 1 != 1) as dt where 1 != 1",
+        "Query": "select 0 from dual union all select column_0 from (select 1 as column_0 from dual union all select 2 from dual) as dt"
+      }
+    }
+  },
+  {
+    "comment": "the same for UNION DISTINCT, where reassociating instead of wrapping would change the result",
+    "query": "select 0 union values row(1), row(2)",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select 0 union values row(1), row(2)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select 0 from dual where 1 != 1 union select column_0 from (select 1 as column_0 from dual where 1 != 1 union all select 2 from dual where 1 != 1) as dt where 1 != 1",
+        "Query": "select 0 from dual union select column_0 from (select 1 as column_0 from dual union all select 2 from dual) as dt"
+      }
+    }
+  },
+  {
+    "comment": "a single row VALUES table constructor needs no wrapping",
+    "query": "select 0 union all values row(1)",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select 0 union all values row(1)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select 0 from dual where 1 != 1 union all select 1 as column_0 from dual where 1 != 1",
+        "Query": "select 0 from dual union all select 1 as column_0 from dual"
+      }
+    }
+  },
+  {
+    "comment": "a VALUES table constructor on the left of a UNION needs no wrapping",
+    "query": "values row(1), row(2) union all select 0",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "values row(1), row(2) union all select 0",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Reference",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select 1 as column_0 from dual where 1 != 1 union all select 2 from dual where 1 != 1 union all select 0 from dual where 1 != 1",
+        "Query": "select 1 as column_0 from dual union all select 2 from dual union all select 0 from dual"
+      }
+    }
+  },
+  {
+    "comment": "VALUES table constructor unioned with a sharded table",
+    "query": "select id from user union all values row(1), row(2)",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select id from user union all values row(1), row(2)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select id from `user` where 1 != 1 union all select column_0 from (select 1 as column_0 from dual where 1 != 1 union all select 2 from dual where 1 != 1) as dt where 1 != 1",
+        "Query": "select id from `user` union all select column_0 from (select 1 as column_0 from dual union all select 2 from dual) as dt"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -443,5 +443,25 @@
     "comment": "window function in derived table on scatter route",
     "query": "select * from (select rank() over (partition by col) as r from user) as t",
     "plan": "VT12001: unsupported: window functions are only supported for single-shard queries"
+  },
+  {
+    "comment": "the rows of a VALUES list argument are only known at execution time, so it cannot be planned as a derived table",
+    "query": "select * from (values ::a) as sub",
+    "plan": "VT12001: unsupported: VALUES with a list argument"
+  },
+  {
+    "comment": "a VALUES row with no columns has no valid SELECT equivalent",
+    "query": "select * from (values row()) as sub",
+    "plan": "VT03012: invalid syntax: each row of a VALUES clause must have at least one column"
+  },
+  {
+    "comment": "a standalone VALUES statement is not classified as a read by sqlparser.Preview, so it is not planned yet",
+    "query": "values row(1, 2)",
+    "plan": "VT12001: unsupported: VALUES as a standalone statement"
+  },
+  {
+    "comment": "all rows of a VALUES table constructor must have the same number of columns",
+    "query": "select * from (values row(1, 1), row(2)) as sub",
+    "plan": "VT03006: column count does not match value count with the row"
   }
 ]

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package semantics
 
 import (
+	"fmt"
 	"slices"
 
 	"vitess.io/vitess/go/mysql/collations"
@@ -423,6 +424,7 @@ func rewriteValuesStatements(statement sqlparser.Statement) error {
 		if err != nil {
 			return false
 		}
+		rewritten = wrapValuesOnUnionRHS(cursor.Parent(), values, rewritten)
 		// Revisit, so the walk continues into the replacement instead of the VALUES statement.
 		cursor.ReplaceAndRevisit(rewritten)
 		return true
@@ -457,6 +459,32 @@ func rowContainsAggregation(expr sqlparser.Expr) bool {
 		return true, nil
 	}, expr)
 	return found
+}
+
+// wrapValuesOnUnionRHS wraps a desugared VALUES statement in a derived table when it desugared to a
+// UNION sitting on the right hand side of another UNION, which the operator planner rejects. It
+// wraps rather than reassociating because `a UNION (b UNION ALL c)` and `(a UNION b) UNION ALL c`
+// do not return the same rows when the two UNIONs differ in whether they are DISTINCT.
+func wrapValuesOnUnionRHS(parent sqlparser.SQLNode, values *sqlparser.ValuesStatement, rewritten sqlparser.TableStatement) sqlparser.TableStatement {
+	union, isUnion := parent.(*sqlparser.Union)
+	if !isUnion || union.Right != sqlparser.TableStatement(values) {
+		return rewritten
+	}
+	if _, wasSplit := rewritten.(*sqlparser.Union); !wasSplit {
+		return rewritten
+	}
+
+	exprs := make([]sqlparser.SelectExpr, 0, len(values.Rows[0]))
+	for i := range values.Rows[0] {
+		exprs = append(exprs, &sqlparser.AliasedExpr{Expr: sqlparser.NewColName(fmt.Sprintf("column_%d", i))})
+	}
+	return &sqlparser.Select{
+		SelectExprs: &sqlparser.SelectExprs{Exprs: exprs},
+		From: []sqlparser.TableExpr{&sqlparser.AliasedTableExpr{
+			Expr: &sqlparser.DerivedTable{Select: rewritten},
+			As:   sqlparser.NewIdentifierCS("dt"),
+		}},
+	}
 }
 
 // valuesIsUsedAsQuery reports whether a VALUES statement hanging off this node is a query, rather

--- a/go/vt/vtgate/semantics/analyzer.go
+++ b/go/vt/vtgate/semantics/analyzer.go
@@ -17,6 +17,8 @@ limitations under the License.
 package semantics
 
 import (
+	"slices"
+
 	"vitess.io/vitess/go/mysql/collations"
 	vschemapb "vitess.io/vitess/go/vt/proto/vschema"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -385,9 +387,87 @@ func (a *analyzer) analyze(statement sqlparser.Statement) error {
 		return nil
 	}
 
+	if err := rewriteValuesStatements(statement); err != nil {
+		return err
+	}
+
 	a.lateInit()
 
 	return a.lateAnalyze(statement)
+}
+
+// rewriteValuesStatements desugars every VALUES table constructor used as a query - a derived
+// table, a UNION branch, a subquery or a CTE definition - into its SELECT equivalent, since nothing
+// downstream knows how to plan a *sqlparser.ValuesStatement.
+//
+// This cannot be a case in the early rewriter: checkForInvalidConstructs inspects a UNION or a
+// Subquery on the way down, before the walk reaches the VALUES statement hanging off it. It runs
+// after canShortCut so that a query forwarded to MySQL untouched keeps the VALUES syntax as written.
+func rewriteValuesStatements(statement sqlparser.Statement) error {
+	var err error
+	_ = sqlparser.Rewrite(statement, func(cursor *sqlparser.Cursor) bool {
+		if err != nil {
+			return false
+		}
+		values, ok := cursor.Node().(*sqlparser.ValuesStatement)
+		if !ok || !valuesIsUsedAsQuery(cursor.Parent()) {
+			return true
+		}
+
+		if err = checkValuesRows(values); err != nil {
+			return false
+		}
+
+		var rewritten sqlparser.TableStatement
+		rewritten, err = sqlparser.ValuesToTableStatement(values)
+		if err != nil {
+			return false
+		}
+		// Revisit, so the walk continues into the replacement instead of the VALUES statement.
+		cursor.ReplaceAndRevisit(rewritten)
+		return true
+	}, nil)
+	return err
+}
+
+// checkValuesRows rejects an aggregate in a VALUES row, which MySQL reports as
+// ER_INVALID_GROUP_FUNC_USE. The desugared `select count(*) from dual` would happily return a row.
+func checkValuesRows(values *sqlparser.ValuesStatement) error {
+	for _, row := range values.Rows {
+		if slices.ContainsFunc(row, rowContainsAggregation) {
+			return &InvalidUseOfGroupFunction{}
+		}
+	}
+	return nil
+}
+
+// rowContainsAggregation reports whether a VALUES row aggregates in its own right.
+// sqlparser.ContainsAggregation cannot be used because it descends into subqueries, where MySQL
+// does allow an aggregate: `VALUES ROW((SELECT COUNT(*) FROM t))` is legal.
+func rowContainsAggregation(expr sqlparser.Expr) bool {
+	found := false
+	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+		switch node.(type) {
+		case *sqlparser.Subquery:
+			return false, nil
+		case sqlparser.AggrFunc:
+			found = true
+			return false, nil
+		}
+		return true, nil
+	}, expr)
+	return found
+}
+
+// valuesIsUsedAsQuery reports whether a VALUES statement hanging off this node is a query, rather
+// than INSERT rows or a view definition, which keep their own meaning.
+func valuesIsUsedAsQuery(parent sqlparser.SQLNode) bool {
+	switch parent.(type) {
+	case *sqlparser.DerivedTable, *sqlparser.Union, *sqlparser.Subquery, *sqlparser.CommonTableExpr:
+		return true
+	default:
+		return false
+	}
 }
 
 func (a *analyzer) lateAnalyze(statement sqlparser.SQLNode) error {

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -28,6 +28,135 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
+// TestRewriteValuesStatements checks that a VALUES table constructor used as a query is desugared
+// into the SELECT that produces the same rows, in every position it can be used as one. The
+// expectations were checked against MySQL 8.4.
+func TestRewriteValuesStatements(t *testing.T) {
+	tcases := []struct {
+		query        string
+		rewritten    string
+		errorMessage string
+	}{{
+		query:     "select * from (values row(1, 1)) as sub",
+		rewritten: "select column_0, column_1 from (select 1 as column_0, 1 as column_1 from dual) as sub",
+	}, {
+		query:     "select sub.column_0 from (values row(1, 1)) as sub",
+		rewritten: "select sub.column_0 from (select 1 as column_0, 1 as column_1 from dual) as sub",
+	}, {
+		query:     "select * from (values row(1, 1), row(2, 2)) as sub",
+		rewritten: "select column_0, column_1 from (select 1 as column_0, 1 as column_1 from dual union all select 2, 2 from dual) as sub",
+	}, {
+		// UNION ALL, not UNION: VALUES keeps duplicate rows.
+		query:     "select * from (values row(1), row(1)) as sub",
+		rewritten: "select column_0 from (select 1 as column_0 from dual union all select 1 from dual) as sub",
+	}, {
+		query:     "select * from (values row(1, 1), row(2, 2)) as sub(a, b)",
+		rewritten: "select a, b from (select 1 as column_0, 1 as column_1 from dual union all select 2, 2 from dual) as sub(a, b)",
+	}, {
+		query:     "select * from (values row(2), row(1) limit 1) as sub",
+		rewritten: "select column_0 from (select 2 as column_0 from dual union all select 1 from dual limit 1) as sub",
+	}, {
+		// MySQL never applies these, so a sorting UNION would return different rows.
+		query:        "select * from (values row(2), row(1) order by column_0) as sub",
+		errorMessage: "VT12001: unsupported: VALUES with an ORDER BY",
+	}, {
+		query:        "select * from (values row(2), row(1) order by 1) as sub",
+		errorMessage: "VT12001: unsupported: VALUES with an ORDER BY",
+	}, {
+		query:        "select * from (values row(2), row(1) order by column_0 limit 1) as sub",
+		errorMessage: "VT12001: unsupported: VALUES with an ORDER BY",
+	}, {
+		query:     "select * from ((values row(1)) union all (values row(2))) as sub",
+		rewritten: "select column_0 from (select 1 as column_0 from dual union all select 2 as column_0 from dual) as sub",
+	}, {
+		query:     "select * from (values row(1) union values row(2)) as sub",
+		rewritten: "select column_0 from (select 1 as column_0 from dual union select 2 as column_0 from dual) as sub",
+	}, {
+		query:     "select id from t where id in (values row(1))",
+		rewritten: "select id from t where id in (select 1 as column_0 from dual)",
+	}, {
+		query:     "select exists (values row(1)) from t",
+		rewritten: "select exists (select 1 as column_0 from dual) from t",
+	}, {
+		query:     "with x as (values row(1, 2)) select * from x",
+		rewritten: "select column_0, column_1 from (select 1 as column_0, 2 as column_1 from dual) as x",
+	}, {
+		query:     "select * from (values row((select id from t))) as sub",
+		rewritten: "select column_0 from (select (select id from t) as column_0 from dual) as sub",
+	}, {
+		// The CTE stays available to the rows.
+		query:     "select * from (with x as (select id from t) values row((select count(*) from x))) as sub",
+		rewritten: "select column_0 from (select (select count(*) from (select id from t) as x) as column_0 from dual) as sub",
+	}, {
+		query:     "insert into t(a, b) values row(1, 2)",
+		rewritten: "insert into t(a, b) values row(1, 2)",
+	}, {
+		// MySQL accepts an aggregate that belongs to a nested subquery.
+		query:     "select * from (values row((select count(*) from t))) as sub",
+		rewritten: "select column_0 from (select (select count(*) from t) as column_0 from dual) as sub",
+	}, {
+		query:        "select * from (values ::a) as sub",
+		errorMessage: "VT12001: unsupported: VALUES with a list argument",
+	}, {
+		query:        "select * from (values row()) as sub",
+		errorMessage: "VT03012: invalid syntax: each row of a VALUES clause must have at least one column",
+	}, {
+		query:        "select * from (values row(1), row(2, 2)) as sub",
+		errorMessage: "VT03006: column count does not match value count with the row",
+	}, {
+		query:        "select * from (values row(1, 1), row(2)) as sub",
+		errorMessage: "VT03006: column count does not match value count with the row",
+	}, {
+		query:        "select * from (values row(count(*))) as sub",
+		errorMessage: "Invalid use of group function",
+	}, {
+		query:        "select * from (values row(1), row(max(id))) as sub",
+		errorMessage: "Invalid use of group function",
+	}}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.query, func(t *testing.T) {
+			parse, err := sqlparser.NewTestParser().Parse(tcase.query)
+			require.NoError(t, err)
+
+			_, err = Analyze(parse, "user", &FakeSI{
+				Tables: map[string]*vindexes.BaseTable{
+					"t": {Name: sqlparser.NewIdentifierCS("t"), Keyspace: ks2},
+				},
+			})
+
+			if tcase.errorMessage != "" {
+				require.EqualError(t, err, tcase.errorMessage)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tcase.rewritten, sqlparser.String(parse))
+		})
+	}
+}
+
+// TestRewriteValuesStatementsLeavesOtherPositionsAlone pins the exclusion half of
+// valuesIsUsedAsQuery: rewriting INSERT rows changes how they are planned, and rewriting a view
+// definition would change what gets stored in the schema.
+func TestRewriteValuesStatementsLeavesOtherPositionsAlone(t *testing.T) {
+	queries := []string{
+		"insert into t(a, b) values row(1, 2)",
+		"create view v as values row(1, 2)",
+		"alter view v as values row(1, 2)",
+		"create table t2 as values row(1, 2)",
+	}
+
+	for _, query := range queries {
+		t.Run(query, func(t *testing.T) {
+			parse, err := sqlparser.NewTestParser().Parse(query)
+			require.NoError(t, err)
+
+			require.NoError(t, rewriteValuesStatements(parse))
+			assert.Equal(t, query, sqlparser.String(parse))
+		})
+	}
+}
+
 var NoTables TableSet
 
 var (

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -78,6 +78,21 @@ func TestRewriteValuesStatements(t *testing.T) {
 		query:     "select exists (values row(1)) from t",
 		rewritten: "select exists (select 1 as column_0 from dual) from t",
 	}, {
+		// A multi row VALUES on the right of a UNION is wrapped, since the operator planner rejects
+		// a UNION nested there. A single row desugars to a SELECT and needs no wrapping, and the
+		// left hand side allows nesting.
+		query:     "select 0 union all values row(1), row(2)",
+		rewritten: "select 0 from dual union all select column_0 from (select 1 as column_0 from dual union all select 2 from dual) as dt",
+	}, {
+		query:     "select 0, 0 union values row(1, 2), row(3, 4)",
+		rewritten: "select 0, 0 from dual union select column_0, column_1 from (select 1 as column_0, 2 as column_1 from dual union all select 3, 4 from dual) as dt",
+	}, {
+		query:     "select 0 union all values row(1)",
+		rewritten: "select 0 from dual union all select 1 as column_0 from dual",
+	}, {
+		query:     "values row(1), row(2) union all select 0",
+		rewritten: "select 1 as column_0 from dual union all select 2 from dual union all select 0 from dual",
+	}, {
 		query:     "with x as (values row(1, 2)) select * from x",
 		rewritten: "select column_0, column_1 from (select 1 as column_0, 2 as column_1 from dual) as x",
 	}, {

--- a/go/vt/vtgate/semantics/table_collector.go
+++ b/go/vt/vtgate/semantics/table_collector.go
@@ -441,7 +441,7 @@ func (tc *tableCollector) handleDerivedTable(node *sqlparser.AliasedTableExpr, t
 	case *sqlparser.Union:
 		return tc.addUnionDerivedTable(sel, node, node.Columns, node.As)
 	default:
-		return vterrors.VT13001("[BUG] %T in a derived table", sel)
+		return vterrors.VT13001(fmt.Sprintf("%T in a derived table", sel))
 	}
 }
 


### PR DESCRIPTION
## Description

`SELECT * FROM (VALUES ROW(1, 1)) AS sub` is valid MySQL 8.0.19+ syntax, and on `main` it returns an internal error with a raw format specifier in it:

```
VT13001: [BUG] [BUG] %T in a derived table%!(EXTRA *sqlparser.ValuesStatement=&{...})
```

`VALUES ROW(...)` has been parsed into a `*sqlparser.ValuesStatement` since #17500, but that PR was parsing only, outside `go/vt/sqlparser/` there was no non-generated reference to the type anywhere, so the semantic analyzer, the planner and the engine had never heard of it.

This PR teaches VTGate to plan a `VALUES` statement used as a query, as a derived table, as a branch of a `UNION`, as a subquery, and as a CTE definition, by rewriting it into the `SELECT ... UNION ALL ...` that produces the same rows.

### Why a rewrite

Two earlier attempts, #20208 and #20209, taught the semantic analyzer, the operators, the SQL builder and the tablet planbuilder about `ValuesStatement` directly, preserving the `VALUES` syntax end to end. #20209 reached 58 files and +2474 lines and stalled with a long tail of edge cases.

Desugaring instead reuses the derived-table and union paths that have been in production for years, and dissolves several of those edge cases rather than solving them, a subquery inside a row becomes an ordinary projection subquery and gets planned, routed and ACL-checked normally. `UNION ALL` because `VALUES` keeps duplicate rows; only the first row is aliased because a `UNION` takes its column names from its first branch, which reproduces MySQL's `column_0`, `column_1`, ... naming.

I checked against a real MySQL 8.4 rather than asserted in comments. The two forms agree on the generated column names, on the unified column types across heterogeneous rows and on their collations, and on `LIMIT`.

### Where the rewrite hooks in

It is its own pass before `lateAnalyze` rather than a case in the early rewriter, because `checkForInvalidConstructs` inspects a `UNION` or a `Subquery` on the way *down*, before the walk reaches the `VALUES` statement hanging off it, so a hook inside the main walk is always one node too late. It uses `ReplaceAndRevisit` rather than `Replace`, since the generated walker keeps descending into its local node variable after `pre` returns.

### Deliberately not in this PR

- **A standalone `VALUES ROW(1)` statement.** `sqlparser.Preview` matches on the first keyword only and has no `values` case, so it comes back `StmtUnknown`. Adding it to the planbuilder switch without fixing that would misroute it and skip `sql_select_limit`, streaming plans and directives. It now returns `VT12001` instead of a `[BUG]`, and the real fix wants its own PR.
- **A row-count cap.** Planning is quadratic in the number of rows. A hand-written N-branch `UNION ALL` measures identically, so this is a pre-existing property of union planning rather than something the rewrite introduces, but it does change exposure, since a large `VALUES` list is a more natural client-side shape than a 20k-branch `UNION`. Documented under **Impact** in the changelog rather than guarded, so a maintainer can make that call knowingly.
- **`ValuesStatement.GetColumns()`/`GetColumnCount()`** still panic. Unreachable from the query path now that no `ValuesStatement` survives into the planner, and unreachable at the top level because the planbuilder rejects a standalone one before semantics runs, but a live trap for whoever does the first-class work.

### Shapes still blocked by other bugs

Three shapes still fail, on pre-existing bugs that the rewrite routes `VALUES` into but does not cause, each reproduces identically with a hand-written `UNION` or derived table on `main`. They were found by the end-to-end test in this PR, are filed separately, and are called out in the changelog:

- #20955 — a join predicate pushed into `UNION` branches is not dropped when the join merges into one route (fixed by #20956)
- #20960 — predicate pushdown into three or more branches substitutes the wrong branch's expression
- #20961 — an aggregate subquery inside a derived table is routed to a single shard, returning a partial result

Also worth knowing: MySQL's own multi-row `IN (VALUES ...)` is degenerate — `SELECT 99 IN (VALUES ROW(1), ROW(2), ROW(3))` returns true on 8.0.46. Vitess returns the sensible answer after the rewrite, so that shape is deliberately not compared end to end.

### Testing

- `go/vt/sqlparser` — unit tests for the desugaring itself, including everything hanging off the `VALUES` statement and each rejected form.
- `go/vt/vtgate/semantics` — the rewrite in every position it applies, plus the four positions it must leave alone.
- `go/vt/vtgate/planbuilder` — golden plans across `from_cases`, `filter_cases`, `cte_cases`, `union_cases` and `unsupported_cases`, and four cases added to `TestDeniedSystemVariables`.
- `go/test/endtoend/vtgate/queries/derived` — `mcmp` comparisons against a real MySQL for the claims the rewrite rests on: the generated column names (compared explicitly), the column types unified across heterogeneous rows, duplicate rows surviving, `LIMIT`, and the forms MySQL rejects. Run locally against MySQL 8.0.46 as well as in CI.

## Related Issue(s)

The goal with this is to solve the problem described in #20057

Previous attempts, all closed: #20062 (the desugaring approach, derived tables only), #20208 and #20209 (first-class support).

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

On backports: the earlier attempts requested `release-23.0` and `release-24.0`, and this does fix a user-visible error on valid MySQL syntax. But it also changes which queries VTGate accepts, which is closer to a feature than a fix, so I have not added the labels, happy to if maintainers want it.

## Deployment Notes

None. No flags, no protobuf changes, no changes to `_vt` tables or RPCs.

### AI Disclosure

This was written with the help of Claude Code, I provided the direction and the review. The MySQL behavior described above was measured against real 8.4 and 8.0.46 servers rather than assumed.
