### PR TITLE
vtgate: merge ordered scatter result runs

### DIFF
--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -1038,7 +1038,7 @@ func (cached *Route) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(128)
+		size += int64(112)
 	}
 	// field Query string
 	size += hack.RuntimeAllocSize(int64(len(cached.Query)))

--- a/go/vt/vtgate/engine/cached_size.go
+++ b/go/vt/vtgate/engine/cached_size.go
@@ -1038,7 +1038,7 @@ func (cached *Route) CachedSize(alloc bool) int64 {
 	}
 	size := int64(0)
 	if alloc {
-		size += int64(112)
+		size += int64(128)
 	}
 	// field Query string
 	size += hack.RuntimeAllocSize(int64(len(cached.Query)))

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -177,6 +177,10 @@ type (
 		ExecutedPrimitive() Primitive
 	}
 
+	resultRunExecutor interface {
+		ExecuteMultiShardWithResultRuns(ctx context.Context, primitive Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, rollbackOnError, canAutocommit, fetchLastInsertID bool) (*sqltypes.Result, []*sqltypes.Result, []error)
+	}
+
 	// SessionActions gives primitives ability to interact with the session state
 	SessionActions interface {
 		// RecordWarning stores the given warning in the current session

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -70,9 +70,6 @@ type (
 		// merge-sorted.
 		OrderBy evalengine.Comparison
 
-		// ShardResultIsSorted is set by the planner when Query orders every shard result by OrderBy.
-		ShardResultIsSorted bool
-
 		// TruncateColumnCount specifies the number of columns to return
 		// in the final result. Rest of the columns are truncated
 		// from the result received. If 0, no truncation happens.
@@ -83,6 +80,9 @@ type (
 
 		// ScatterErrorsAsWarnings is true if results should be returned even if some shards have an error
 		ScatterErrorsAsWarnings bool
+
+		// ShardResultIsSorted is set by the planner when Query orders every shard result by OrderBy.
+		ShardResultIsSorted bool
 
 		// RoutingParameters parameters required for query routing.
 		*RoutingParameters

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -43,7 +43,7 @@ import (
 var _ Primitive = (*Route)(nil)
 
 type (
-	resultRunVCursor interface {
+	resultRunExecutor interface {
 		ExecuteMultiShardWithResultRuns(ctx context.Context, primitive Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, rollbackOnError, canAutocommit, fetchLastInsertID bool) (*sqltypes.Result, []*sqltypes.Result, []error)
 	}
 
@@ -201,8 +201,8 @@ func (route *Route) executeShards(
 		errs       []error
 	)
 	if route.ShardResultIsSorted && len(route.OrderBy) > 0 && len(rss) > 1 {
-		if resultRunsVCursor, ok := vcursor.(resultRunVCursor); ok {
-			result, resultRuns, errs = resultRunsVCursor.ExecuteMultiShardWithResultRuns(ctx, route, rss, queries, false /*rollbackOnError*/, false /*canAutocommit*/, route.FetchLastInsertID)
+		if executor, ok := vcursor.(resultRunExecutor); ok {
+			result, resultRuns, errs = executor.ExecuteMultiShardWithResultRuns(ctx, route, rss, queries, false /*rollbackOnError*/, false /*canAutocommit*/, route.FetchLastInsertID)
 		} else {
 			result, errs = vcursor.ExecuteMultiShard(ctx, route, rss, queries, false /*rollbackOnError*/, false /*canAutocommit*/, route.FetchLastInsertID)
 		}

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -42,63 +42,6 @@ import (
 
 var _ Primitive = (*Route)(nil)
 
-type (
-	resultRunExecutor interface {
-		ExecuteMultiShardWithResultRuns(ctx context.Context, primitive Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, rollbackOnError, canAutocommit, fetchLastInsertID bool) (*sqltypes.Result, []*sqltypes.Result, []error)
-	}
-
-	// Route represents the instructions to route a read query to
-	// one or many vttablets.
-	Route struct {
-		// Route does not take inputs
-		noInputs
-
-		// Route does not need transaction handling
-		noTxNeeded
-
-		// Query specifies the query to be executed.
-		Query string
-
-		// QueryStatement is the parsed AST of Query
-		QueryStatement sqlparser.Statement
-
-		// FieldQuery specifies the query to be executed for a GetFieldInfo request.
-		FieldQuery string
-
-		// OrderBy specifies the key order for merge sorting. This will be
-		// set only for scatter queries that need the results to be
-		// merge-sorted.
-		OrderBy evalengine.Comparison
-
-		// TruncateColumnCount specifies the number of columns to return
-		// in the final result. Rest of the columns are truncated
-		// from the result received. If 0, no truncation happens.
-		TruncateColumnCount int
-
-		// QueryTimeout contains the optional timeout (in milliseconds) to apply to this query
-		QueryTimeout int
-
-		// ScatterErrorsAsWarnings is true if results should be returned even if some shards have an error
-		ScatterErrorsAsWarnings bool
-
-		// ShardResultIsSorted is set by the planner when Query orders every shard result by OrderBy.
-		ShardResultIsSorted bool
-
-		// RoutingParameters parameters required for query routing.
-		*RoutingParameters
-
-		// NoRoutesSpecialHandling will make the route send a query to arbitrary shard if the routing logic can't find
-		// the correct shard. This is important for queries where no matches does not mean empty result - examples would be:
-		// select count(*) from tbl where lookupColumn = 'not there'
-		// select exists(<subq>)
-		NoRoutesSpecialHandling bool
-
-		FetchLastInsertID bool
-	}
-
-	cxtKey int
-)
-
 // mergeMinRowsPerRun is the largest average run size with no consistent merge
 // latency win. A full sort handles these small results without a merge tree.
 const mergeMinRowsPerRun = 4
@@ -130,6 +73,55 @@ var replicaWarmingReadsErrors = stats.NewCountersWithMultiLabels(
 	[]string{"Keyspace", "Code"},
 )
 
+// Route represents the instructions to route a read query to
+// one or many vttablets.
+type Route struct {
+	// Route does not take inputs
+	noInputs
+
+	// Route does not need transaction handling
+	noTxNeeded
+
+	// Query specifies the query to be executed.
+	Query string
+
+	// QueryStatement is the parsed AST of Query
+	QueryStatement sqlparser.Statement
+
+	// FieldQuery specifies the query to be executed for a GetFieldInfo request.
+	FieldQuery string
+
+	// OrderBy specifies the key order for merge sorting. This will be
+	// set only for scatter queries that need the results to be
+	// merge-sorted.
+	OrderBy evalengine.Comparison
+
+	// TruncateColumnCount specifies the number of columns to return
+	// in the final result. Rest of the columns are truncated
+	// from the result received. If 0, no truncation happens.
+	TruncateColumnCount int
+
+	// QueryTimeout contains the optional timeout (in milliseconds) to apply to this query
+	QueryTimeout int
+
+	// ScatterErrorsAsWarnings is true if results should be returned even if some shards have an error
+	ScatterErrorsAsWarnings bool
+
+	// ShardResultIsSorted is set by the planner when Query orders every shard result by OrderBy.
+	ShardResultIsSorted bool
+
+	// RoutingParameters parameters required for query routing.
+	*RoutingParameters
+
+	// NoRoutesSpecialHandling will make the route send a query to arbitrary shard if the routing logic can't find
+	// the correct shard. This is important for queries where no matches does not mean empty result - examples would be:
+	// select count(*) from tbl where lookupColumn = 'not there'
+	// select exists(<subq>)
+	NoRoutesSpecialHandling bool
+
+	FetchLastInsertID bool
+}
+
 // NewRoute creates a Route.
 func NewRoute(opcode Opcode, keyspace *vindexes.Keyspace, query, fieldQuery string) *Route {
 	return &Route{
@@ -153,6 +145,8 @@ func (route *Route) TryExecute(ctx context.Context, vcursor VCursor, bindVars ma
 
 	return route.executeShards(ctx, vcursor, bindVars, wantfields, rss, bvs)
 }
+
+type cxtKey int
 
 const (
 	IgnoreReserveTxn cxtKey = iota

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -42,6 +42,14 @@ import (
 
 var _ Primitive = (*Route)(nil)
 
+type resultRunVCursor interface {
+	ExecuteMultiShardWithResultRuns(ctx context.Context, primitive Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, rollbackOnError, canAutocommit, fetchLastInsertID bool) (*sqltypes.Result, []*sqltypes.Result, []error)
+}
+
+// mergeMinRowsPerRun is the largest average run size with no consistent merge
+// latency win. A full sort handles these small results without a merge tree.
+const mergeMinRowsPerRun = 4
+
 // WarmingReadsBaseWeight is the base semaphore weight for a warming read.
 // The actual weight is WarmingReadsBaseWeight + priority, where priority 0
 // (highest priority) gets the lowest weight and is least likely to be shed.
@@ -91,6 +99,9 @@ type Route struct {
 	// set only for scatter queries that need the results to be
 	// merge-sorted.
 	OrderBy evalengine.Comparison
+
+	// ShardResultIsSorted is set by the planner when Query orders every shard result by OrderBy.
+	ShardResultIsSorted bool
 
 	// TruncateColumnCount specifies the number of columns to return
 	// in the final result. Rest of the columns are truncated
@@ -182,7 +193,20 @@ func (route *Route) executeShards(
 	}
 
 	queries := getQueries(route.Query, bvs)
-	result, errs := vcursor.ExecuteMultiShard(ctx, route, rss, queries, false /*rollbackOnError*/, false /*canAutocommit*/, route.FetchLastInsertID)
+	var (
+		result     *sqltypes.Result
+		resultRuns []*sqltypes.Result
+		errs       []error
+	)
+	if route.ShardResultIsSorted && len(route.OrderBy) > 0 && len(rss) > 1 {
+		if resultRunsVCursor, ok := vcursor.(resultRunVCursor); ok {
+			result, resultRuns, errs = resultRunsVCursor.ExecuteMultiShardWithResultRuns(ctx, route, rss, queries, false /*rollbackOnError*/, false /*canAutocommit*/, route.FetchLastInsertID)
+		} else {
+			result, errs = vcursor.ExecuteMultiShard(ctx, route, rss, queries, false /*rollbackOnError*/, false /*canAutocommit*/, route.FetchLastInsertID)
+		}
+	} else {
+		result, errs = vcursor.ExecuteMultiShard(ctx, route, rss, queries, false /*rollbackOnError*/, false /*canAutocommit*/, route.FetchLastInsertID)
+	}
 
 	route.executeWarmingReplicaRead(ctx, vcursor, bindVars, queries)
 
@@ -201,10 +225,19 @@ func (route *Route) executeShards(
 	}
 
 	if len(route.OrderBy) > 0 && len(rss) > 1 {
+		merged := false
 		var err error
-		result, err = route.sort(result)
-		if err != nil {
-			return nil, err
+		if route.ShardResultIsSorted && len(resultRuns) == len(rss) {
+			result, merged, err = route.mergeResultRuns(result, resultRuns)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if !merged {
+			result, err = route.sort(result)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -379,6 +412,93 @@ func (route *Route) sort(in *sqltypes.Result) (*sqltypes.Result, error) {
 
 	err := route.OrderBy.SortResult(out)
 	return out, err
+}
+
+// mergeResultRuns materializes sorted shard result runs into the combined result.
+func (route *Route) mergeResultRuns(in *sqltypes.Result, runs []*sqltypes.Result) (out *sqltypes.Result, merged bool, err error) {
+	if in == nil || len(runs) == 0 {
+		return in, false, nil
+	}
+
+	rows := 0
+	active := 0
+	for _, run := range runs {
+		if run != nil && len(run.Rows) > 0 {
+			active++
+			rows += len(run.Rows)
+		}
+	}
+	if rows != len(in.Rows) {
+		return in, false, nil
+	}
+	if active > 1 && rows <= active*mergeMinRowsPerRun {
+		return in, false, nil
+	}
+
+	out = in.ShallowCopy()
+	defer evalengine.PanicHandler(&err)
+	route.OrderBy.ApplyTinyWeights(out)
+	if active <= 1 {
+		return out, true, nil
+	}
+	ordered := true
+	havePrevious := false
+	var previous sqltypes.Row
+	for _, run := range runs {
+		if run == nil || len(run.Rows) == 0 {
+			continue
+		}
+		if havePrevious && route.OrderBy.Compare(previous, run.Rows[0]) > 0 {
+			ordered = false
+			break
+		}
+		previous = run.Rows[len(run.Rows)-1]
+		havePrevious = true
+	}
+	if ordered {
+		// Runs follow shard order, while in.Rows follows response completion
+		// order. Rebuild the row slice even though no comparisons remain.
+		position := 0
+		for _, run := range runs {
+			if run != nil {
+				position += copy(out.Rows[position:], run.Rows)
+			}
+		}
+		return out, true, nil
+	}
+
+	merge := evalengine.NewMerger(route.OrderBy, active)
+	positions := make([]int, len(runs))
+	for source, run := range runs {
+		if run == nil || len(run.Rows) == 0 {
+			continue
+		}
+		merge.Push(run.Rows[0], source)
+		positions[source] = 1
+	}
+	merge.Init()
+
+	for output := 0; output < len(out.Rows); output++ {
+		row, source := merge.Peek()
+		out.Rows[output] = row
+		next := positions[source]
+		if next == len(runs[source].Rows) {
+			merge.Pop()
+			if merge.Len() == 1 {
+				// The last run is already sorted. Copy its remaining tail
+				// without one heap repair for every row.
+				row, source = merge.Peek()
+				out.Rows[output+1] = row
+				copy(out.Rows[output+2:], runs[source].Rows[positions[source]:])
+				break
+			}
+			continue
+		}
+		merge.ReplaceMin(runs[source].Rows[next], source)
+		positions[source] = next + 1
+	}
+
+	return out, true, nil
 }
 
 func (route *Route) description() PrimitiveDescription {

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -42,9 +42,62 @@ import (
 
 var _ Primitive = (*Route)(nil)
 
-type resultRunVCursor interface {
-	ExecuteMultiShardWithResultRuns(ctx context.Context, primitive Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, rollbackOnError, canAutocommit, fetchLastInsertID bool) (*sqltypes.Result, []*sqltypes.Result, []error)
-}
+type (
+	resultRunVCursor interface {
+		ExecuteMultiShardWithResultRuns(ctx context.Context, primitive Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, rollbackOnError, canAutocommit, fetchLastInsertID bool) (*sqltypes.Result, []*sqltypes.Result, []error)
+	}
+
+	// Route represents the instructions to route a read query to
+	// one or many vttablets.
+	Route struct {
+		// Route does not take inputs
+		noInputs
+
+		// Route does not need transaction handling
+		noTxNeeded
+
+		// Query specifies the query to be executed.
+		Query string
+
+		// QueryStatement is the parsed AST of Query
+		QueryStatement sqlparser.Statement
+
+		// FieldQuery specifies the query to be executed for a GetFieldInfo request.
+		FieldQuery string
+
+		// OrderBy specifies the key order for merge sorting. This will be
+		// set only for scatter queries that need the results to be
+		// merge-sorted.
+		OrderBy evalengine.Comparison
+
+		// ShardResultIsSorted is set by the planner when Query orders every shard result by OrderBy.
+		ShardResultIsSorted bool
+
+		// TruncateColumnCount specifies the number of columns to return
+		// in the final result. Rest of the columns are truncated
+		// from the result received. If 0, no truncation happens.
+		TruncateColumnCount int
+
+		// QueryTimeout contains the optional timeout (in milliseconds) to apply to this query
+		QueryTimeout int
+
+		// ScatterErrorsAsWarnings is true if results should be returned even if some shards have an error
+		ScatterErrorsAsWarnings bool
+
+		// RoutingParameters parameters required for query routing.
+		*RoutingParameters
+
+		// NoRoutesSpecialHandling will make the route send a query to arbitrary shard if the routing logic can't find
+		// the correct shard. This is important for queries where no matches does not mean empty result - examples would be:
+		// select count(*) from tbl where lookupColumn = 'not there'
+		// select exists(<subq>)
+		NoRoutesSpecialHandling bool
+
+		FetchLastInsertID bool
+	}
+
+	cxtKey int
+)
 
 // mergeMinRowsPerRun is the largest average run size with no consistent merge
 // latency win. A full sort handles these small results without a merge tree.
@@ -77,55 +130,6 @@ var replicaWarmingReadsErrors = stats.NewCountersWithMultiLabels(
 	[]string{"Keyspace", "Code"},
 )
 
-// Route represents the instructions to route a read query to
-// one or many vttablets.
-type Route struct {
-	// Route does not take inputs
-	noInputs
-
-	// Route does not need transaction handling
-	noTxNeeded
-
-	// Query specifies the query to be executed.
-	Query string
-
-	// QueryStatement is the parsed AST of Query
-	QueryStatement sqlparser.Statement
-
-	// FieldQuery specifies the query to be executed for a GetFieldInfo request.
-	FieldQuery string
-
-	// OrderBy specifies the key order for merge sorting. This will be
-	// set only for scatter queries that need the results to be
-	// merge-sorted.
-	OrderBy evalengine.Comparison
-
-	// ShardResultIsSorted is set by the planner when Query orders every shard result by OrderBy.
-	ShardResultIsSorted bool
-
-	// TruncateColumnCount specifies the number of columns to return
-	// in the final result. Rest of the columns are truncated
-	// from the result received. If 0, no truncation happens.
-	TruncateColumnCount int
-
-	// QueryTimeout contains the optional timeout (in milliseconds) to apply to this query
-	QueryTimeout int
-
-	// ScatterErrorsAsWarnings is true if results should be returned even if some shards have an error
-	ScatterErrorsAsWarnings bool
-
-	// RoutingParameters parameters required for query routing.
-	*RoutingParameters
-
-	// NoRoutesSpecialHandling will make the route send a query to arbitrary shard if the routing logic can't find
-	// the correct shard. This is important for queries where no matches does not mean empty result - examples would be:
-	// select count(*) from tbl where lookupColumn = 'not there'
-	// select exists(<subq>)
-	NoRoutesSpecialHandling bool
-
-	FetchLastInsertID bool
-}
-
 // NewRoute creates a Route.
 func NewRoute(opcode Opcode, keyspace *vindexes.Keyspace, query, fieldQuery string) *Route {
 	return &Route{
@@ -149,8 +153,6 @@ func (route *Route) TryExecute(ctx context.Context, vcursor VCursor, bindVars ma
 
 	return route.executeShards(ctx, vcursor, bindVars, wantfields, rss, bvs)
 }
-
-type cxtKey int
 
 const (
 	IgnoreReserveTxn cxtKey = iota

--- a/go/vt/vtgate/engine/route_result_runs_test.go
+++ b/go/vt/vtgate/engine/route_result_runs_test.go
@@ -32,15 +32,17 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
 )
 
-type resultRunsVCursor struct {
-	*loggingVCursor
+type (
+	resultRunsVCursor struct {
+		*loggingVCursor
 
-	result          *sqltypes.Result
-	runs            []*sqltypes.Result
-	errs            []error
-	multiShardCalls int
-	resultRunsCalls int
-}
+		result          *sqltypes.Result
+		runs            []*sqltypes.Result
+		errs            []error
+		multiShardCalls int
+		resultRunsCalls int
+	}
+)
 
 func (vc *resultRunsVCursor) ExecuteMultiShard(
 	context.Context,
@@ -156,11 +158,46 @@ func TestRouteMergeResultRunsBoundaries(t *testing.T) {
 		require.True(t, merged)
 		expectResult(t, got, combineResultRuns(runs...))
 	})
+
+	t.Run("empty and exhausted runs", func(t *testing.T) {
+		runs := []*sqltypes.Result{
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64")),
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "0"),
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "3", "5", "7", "9", "11", "13", "15"),
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "2", "4", "6", "8", "10", "12", "14", "16"),
+		}
+		route := newResultRunsRoute()
+		flat := combineResultRuns(runs[3], runs[2], runs[1])
+		want, err := route.sort(flat.Copy())
+		require.NoError(t, err)
+
+		got, merged, err := route.mergeResultRuns(flat, runs)
+		require.NoError(t, err)
+		require.True(t, merged)
+		expectResult(t, got, want)
+	})
 }
 
 // TestRouteMergeResultRunsPartialAndFallback proves partial results and missing
 // run data keep the existing warning and full-sort behavior.
 func TestRouteMergeResultRunsPartialAndFallback(t *testing.T) {
+	t.Run("falls back for missing or mismatched run data", func(t *testing.T) {
+		route := newResultRunsRoute()
+
+		got, merged, err := route.mergeResultRuns(nil, nil)
+		require.NoError(t, err)
+		require.False(t, merged)
+		require.Nil(t, got)
+
+		flat := sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "3", "1", "2")
+		got, merged, err = route.mergeResultRuns(flat, []*sqltypes.Result{
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "2"),
+		})
+		require.NoError(t, err)
+		require.False(t, merged)
+		require.Same(t, flat, got)
+	})
+
 	t.Run("partial success truncates merged rows and records warnings", func(t *testing.T) {
 		runs := []*sqltypes.Result{
 			sqltypes.MakeTestResult(sqltypes.MakeTestFields("id|sort_key", "int64|int64"), "1|10", "3|30"),
@@ -201,6 +238,43 @@ func TestRouteMergeResultRunsPartialAndFallback(t *testing.T) {
 		require.Equal(t, 1, vc.resultRunsCalls)
 		require.Equal(t, 0, vc.multiShardCalls)
 		expectResult(t, got, sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "2", "3"))
+	})
+
+	t.Run("marked route falls back when the VCursor cannot return runs", func(t *testing.T) {
+		route := newResultRunsRoute()
+		vc := &loggingVCursor{
+			shards: []string{"-80", "80-"},
+			results: []*sqltypes.Result{
+				sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "3", "1", "2"),
+			},
+		}
+
+		got, err := route.TryExecute(t.Context(), vc, map[string]*querypb.BindVariable{}, false)
+		require.NoError(t, err)
+		expectResult(t, got, sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "2", "3"))
+	})
+
+	t.Run("returns merge comparison errors", func(t *testing.T) {
+		runs := []*sqltypes.Result{
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("name", "varchar"), "a", "c", "e", "g", "i"),
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("name", "varchar"), "b", "d", "f", "h", "j"),
+		}
+		route := newResultRunsRoute()
+		route.OrderBy = evalengine.Comparison{{
+			Col:             0,
+			WeightStringCol: -1,
+			Type:            evalengine.NewType(sqltypes.VarChar, collations.Unknown),
+			CollationEnv:    collations.MySQL8(),
+		}}
+		vc := &resultRunsVCursor{
+			loggingVCursor: &loggingVCursor{shards: []string{"-80", "80-"}},
+			result:         combineResultRuns(runs[1], runs[0]),
+			runs:           runs,
+		}
+
+		got, err := route.TryExecute(t.Context(), vc, map[string]*querypb.BindVariable{}, false)
+		require.EqualError(t, err, "cannot compare strings, collation is unknown or unsupported (collation ID: 0)")
+		require.Nil(t, got)
 	})
 
 	t.Run("unmarked routes use the original flat-result path", func(t *testing.T) {

--- a/go/vt/vtgate/engine/route_result_runs_test.go
+++ b/go/vt/vtgate/engine/route_result_runs_test.go
@@ -18,7 +18,9 @@ package engine
 
 import (
 	"context"
+	"slices"
 	"testing"
+	"testing/quick"
 
 	"github.com/stretchr/testify/require"
 
@@ -374,6 +376,50 @@ func TestRouteMergeResultRunsComparison(t *testing.T) {
 			expectResult(t, got, want)
 		})
 	}
+}
+
+// TestRouteMergeResultRunsMatchesFullSort proves the merge and full-sort paths
+// produce the same ordered rows for random shard-sorted inputs.
+func TestRouteMergeResultRunsMatchesFullSort(t *testing.T) {
+	property := func(values []int64, shardByte uint8) bool {
+		shards := int(shardByte%7) + 2
+		if len(values) > 256 {
+			values = values[:256]
+		}
+		values = slices.Clone(values)
+		for len(values) < shards*(mergeMinRowsPerRun+1) {
+			values = append(values, int64(len(values)))
+		}
+
+		fields := sqltypes.MakeTestFields("id", "int64")
+		valuesByShard := make([][]int64, shards)
+		for i, value := range values {
+			valuesByShard[i%shards] = append(valuesByShard[i%shards], value)
+		}
+		runs := make([]*sqltypes.Result, shards)
+		for shard, shardValues := range valuesByShard {
+			slices.Sort(shardValues)
+			run := &sqltypes.Result{Fields: fields, Rows: make([]sqltypes.Row, len(shardValues))}
+			for row, value := range shardValues {
+				run.Rows[row] = sqltypes.Row{sqltypes.NewInt64(value)}
+			}
+			runs[shard] = run
+		}
+
+		flat := new(sqltypes.Result)
+		for shard := len(runs) - 1; shard >= 0; shard-- {
+			flat.AppendResult(runs[shard])
+		}
+		route := newResultRunsRoute()
+		want, err := route.sort(flat.Copy())
+		if err != nil {
+			return false
+		}
+		got, merged, err := route.mergeResultRuns(flat, runs)
+		return err == nil && merged && got.Equal(want)
+	}
+
+	require.NoError(t, quick.Check(property, nil))
 }
 
 func requireResultRowsOrdered(t *testing.T, orderBy evalengine.Comparison, rows []sqltypes.Row) {

--- a/go/vt/vtgate/engine/route_result_runs_test.go
+++ b/go/vt/vtgate/engine/route_result_runs_test.go
@@ -359,7 +359,7 @@ func TestRouteMergeResultRunsComparison(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			route := newResultRunsRoute()
 			route.OrderBy = tt.orderBy
-			runs := copyResultRuns(tt.runs)
+			runs := tt.runs
 			flat := combineResultRuns(runs...)
 			want, err := route.sort(flat.Copy())
 			require.NoError(t, err)
@@ -444,14 +444,4 @@ func combineResultRuns(runs ...*sqltypes.Result) *sqltypes.Result {
 		}
 	}
 	return result
-}
-
-func copyResultRuns(runs []*sqltypes.Result) []*sqltypes.Result {
-	copies := make([]*sqltypes.Result, len(runs))
-	for i, run := range runs {
-		if run != nil {
-			copies[i] = run.Copy()
-		}
-	}
-	return copies
 }

--- a/go/vt/vtgate/engine/route_result_runs_test.go
+++ b/go/vt/vtgate/engine/route_result_runs_test.go
@@ -1,0 +1,337 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/sqltypes"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/srvtopo"
+	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate/evalengine"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+)
+
+type resultRunsVCursor struct {
+	*loggingVCursor
+
+	result          *sqltypes.Result
+	runs            []*sqltypes.Result
+	errs            []error
+	multiShardCalls int
+	resultRunsCalls int
+}
+
+func (vc *resultRunsVCursor) ExecuteMultiShard(
+	context.Context,
+	Primitive,
+	[]*srvtopo.ResolvedShard,
+	[]*querypb.BoundQuery,
+	bool,
+	bool,
+	bool,
+) (*sqltypes.Result, []error) {
+	vc.multiShardCalls++
+	return vc.result, vc.errs
+}
+
+func (vc *resultRunsVCursor) ExecuteMultiShardWithResultRuns(
+	context.Context,
+	Primitive,
+	[]*srvtopo.ResolvedShard,
+	[]*querypb.BoundQuery,
+	bool,
+	bool,
+	bool,
+) (*sqltypes.Result, []*sqltypes.Result, []error) {
+	vc.resultRunsCalls++
+	return vc.result, vc.runs, vc.errs
+}
+
+// TestRouteMergeResultRuns proves a marked route merges shard-sorted runs.
+func TestRouteMergeResultRuns(t *testing.T) {
+	runs := []*sqltypes.Result{
+		sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "0", "2", "4", "6", "8"),
+		sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "3", "5", "7", "9"),
+	}
+	route := newResultRunsRoute()
+	vc := &resultRunsVCursor{
+		loggingVCursor: &loggingVCursor{shards: []string{"-80", "80-"}},
+		result:         combineResultRuns(runs[1], runs[0]),
+		runs:           runs,
+	}
+
+	got, err := route.TryExecute(t.Context(), vc, map[string]*querypb.BindVariable{}, false)
+	require.NoError(t, err)
+	require.Equal(t, 1, vc.resultRunsCalls)
+	expectResult(t, got, sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"))
+}
+
+// TestRouteMergeResultRunsBoundaries proves the full-sort crossover and the
+// cases that need no merge tree.
+func TestRouteMergeResultRunsBoundaries(t *testing.T) {
+	t.Run("small multi-run result", func(t *testing.T) {
+		runs := []*sqltypes.Result{
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "0", "2", "4", "6"),
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "3", "5", "7"),
+		}
+		route := newResultRunsRoute()
+		flat := combineResultRuns(runs[1], runs[0])
+
+		got, merged, err := route.mergeResultRuns(flat, runs)
+		require.NoError(t, err)
+		require.False(t, merged)
+		require.Same(t, flat, got)
+
+		vc := &resultRunsVCursor{
+			loggingVCursor: &loggingVCursor{shards: []string{"-80", "80-"}},
+			result:         flat,
+			runs:           runs,
+		}
+		got, err = route.TryExecute(t.Context(), vc, map[string]*querypb.BindVariable{}, false)
+		require.NoError(t, err)
+		expectResult(t, got, sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "0", "1", "2", "3", "4", "5", "6", "7"))
+	})
+
+	t.Run("large dominant run copies the remaining tail", func(t *testing.T) {
+		runs := []*sqltypes.Result{
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "0", "2", "4", "6", "8", "10", "12", "14", "16", "18", "20", "22", "24", "26", "28", "30", "32", "34", "36", "38"),
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "3", "5", "7"),
+		}
+		route := newResultRunsRoute()
+		flat := combineResultRuns(runs...)
+
+		want, err := route.sort(flat.Copy())
+		require.NoError(t, err)
+		got, merged, err := route.mergeResultRuns(flat, runs)
+		require.NoError(t, err)
+		require.True(t, merged)
+		expectResult(t, got, want)
+	})
+
+	t.Run("single non-empty run", func(t *testing.T) {
+		runs := []*sqltypes.Result{
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64")),
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "2", "3", "4"),
+		}
+		route := newResultRunsRoute()
+		flat := combineResultRuns(runs...)
+
+		got, merged, err := route.mergeResultRuns(flat, runs)
+		require.NoError(t, err)
+		require.True(t, merged)
+		expectResult(t, got, flat)
+	})
+
+	t.Run("globally ordered runs", func(t *testing.T) {
+		runs := []*sqltypes.Result{
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "0", "1", "2", "3", "4"),
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "5", "6", "7", "8", "9"),
+		}
+		route := newResultRunsRoute()
+		flat := combineResultRuns(runs[1], runs[0])
+
+		got, merged, err := route.mergeResultRuns(flat, runs)
+		require.NoError(t, err)
+		require.True(t, merged)
+		expectResult(t, got, combineResultRuns(runs...))
+	})
+}
+
+// TestRouteMergeResultRunsPartialAndFallback proves partial results and missing
+// run data keep the existing warning and full-sort behavior.
+func TestRouteMergeResultRunsPartialAndFallback(t *testing.T) {
+	t.Run("partial success truncates merged rows and records warnings", func(t *testing.T) {
+		runs := []*sqltypes.Result{
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("id|sort_key", "int64|int64"), "1|10", "3|30"),
+			nil,
+			sqltypes.MakeTestResult(sqltypes.MakeTestFields("id|sort_key", "int64|int64"), "2|20", "4|40"),
+		}
+		route := newResultRunsRoute()
+		route.OrderBy[0].Col = 1
+		route.TruncateColumnCount = 1
+		route.ScatterErrorsAsWarnings = true
+		vc := &resultRunsVCursor{
+			loggingVCursor: &loggingVCursor{shards: []string{"-80", "80-c0", "c0-"}},
+			result:         combineResultRuns(runs[0], runs[2]),
+			runs:           runs,
+			errs:           []error{vterrors.New(vtrpcpb.Code_INTERNAL, "shard failed")},
+		}
+
+		got, err := route.TryExecute(t.Context(), vc, map[string]*querypb.BindVariable{}, false)
+		require.NoError(t, err)
+		require.Equal(t, 1, vc.resultRunsCalls)
+		require.Len(t, vc.warnings, 1)
+		expectResult(t, got, sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "2", "3", "4"))
+	})
+
+	t.Run("falls back to a full sort when runs are unavailable or incomplete", func(t *testing.T) {
+		route := newResultRunsRoute()
+		vc := &resultRunsVCursor{
+			loggingVCursor: &loggingVCursor{shards: []string{"-80", "80-"}},
+			result: sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"),
+				"3", "1", "2"),
+			runs: []*sqltypes.Result{
+				sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "3", "1", "2"),
+			},
+		}
+
+		got, err := route.TryExecute(t.Context(), vc, map[string]*querypb.BindVariable{}, false)
+		require.NoError(t, err)
+		require.Equal(t, 1, vc.resultRunsCalls)
+		require.Equal(t, 0, vc.multiShardCalls)
+		expectResult(t, got, sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "2", "3"))
+	})
+
+	t.Run("unmarked routes use the original flat-result path", func(t *testing.T) {
+		route := newResultRunsRoute()
+		route.ShardResultIsSorted = false
+		vc := &resultRunsVCursor{
+			loggingVCursor: &loggingVCursor{shards: []string{"-80", "80-"}},
+			result: sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"),
+				"3", "1", "2"),
+		}
+
+		got, err := route.TryExecute(t.Context(), vc, map[string]*querypb.BindVariable{}, false)
+		require.NoError(t, err)
+		require.Equal(t, 0, vc.resultRunsCalls)
+		require.Equal(t, 1, vc.multiShardCalls)
+		expectResult(t, got, sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "2", "3"))
+	})
+}
+
+// TestRouteMergeResultRunsComparison proves the merge uses each supported
+// ordering comparison in the same way as a full sort.
+func TestRouteMergeResultRunsComparison(t *testing.T) {
+	collationID, _ := collations.MySQL8().LookupID("utf8mb4_hu_0900_ai_ci")
+	tests := []struct {
+		name    string
+		orderBy evalengine.Comparison
+		runs    []*sqltypes.Result
+		hasTies bool
+	}{
+		{
+			name: "ascending duplicate keys and empty shard",
+			orderBy: evalengine.Comparison{{
+				Col:             1,
+				WeightStringCol: -1,
+			}},
+			runs: []*sqltypes.Result{
+				sqltypes.MakeTestResult(sqltypes.MakeTestFields("id|sort_key", "int64|int64"), "10|1", "30|3", "31|3", "50|5", "70|7"),
+				sqltypes.MakeTestResult(sqltypes.MakeTestFields("id|sort_key", "int64|int64"), "20|2", "32|3", "40|4", "60|6", "80|8"),
+				sqltypes.MakeTestResult(sqltypes.MakeTestFields("id|sort_key", "int64|int64")),
+			},
+			hasTies: true,
+		},
+		{
+			name: "descending",
+			orderBy: evalengine.Comparison{{
+				Col:             0,
+				WeightStringCol: -1,
+				Desc:            true,
+			}},
+			runs: []*sqltypes.Result{
+				sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "9", "7", "5", "3", "1"),
+				sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "10", "8", "6", "4", "2"),
+			},
+		},
+		{
+			name: "weight strings",
+			orderBy: evalengine.Comparison{{
+				Col:             1,
+				WeightStringCol: 0,
+			}},
+			runs: []*sqltypes.Result{
+				sqltypes.MakeTestResult(sqltypes.MakeTestFields("weight_string|name", "varbinary|varchar"), "a|a", "f|p", "k|q", "p|r", "v|x"),
+				sqltypes.MakeTestResult(sqltypes.MakeTestFields("weight_string|name", "varbinary|varchar"), "c|t", "g|d", "l|e", "q|f", "w|g"),
+			},
+		},
+		{
+			name: "collation",
+			orderBy: evalengine.Comparison{{
+				Col:  0,
+				Type: evalengine.NewType(sqltypes.VarChar, collationID),
+			}},
+			runs: []*sqltypes.Result{
+				sqltypes.MakeTestResult(sqltypes.MakeTestFields("name", "varchar"), "c", "cs", "d", "e", "f"),
+				sqltypes.MakeTestResult(sqltypes.MakeTestFields("name", "varchar"), "c", "cs", "d", "e", "f"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			route := newResultRunsRoute()
+			route.OrderBy = tt.orderBy
+			runs := copyResultRuns(tt.runs)
+			flat := combineResultRuns(runs...)
+			want, err := route.sort(flat.Copy())
+			require.NoError(t, err)
+
+			got, merged, err := route.mergeResultRuns(flat, runs)
+			require.NoError(t, err)
+			require.True(t, merged)
+			if tt.hasTies {
+				require.Equal(t, want.Fields, got.Fields)
+				require.ElementsMatch(t, want.Rows, got.Rows)
+				requireResultRowsOrdered(t, route.OrderBy, got.Rows)
+				return
+			}
+			expectResult(t, got, want)
+		})
+	}
+}
+
+func requireResultRowsOrdered(t *testing.T, orderBy evalengine.Comparison, rows []sqltypes.Row) {
+	t.Helper()
+	for row := 1; row < len(rows); row++ {
+		require.LessOrEqual(t, orderBy.Compare(rows[row-1], rows[row]), 0)
+	}
+}
+
+func newResultRunsRoute() *Route {
+	route := NewRoute(Scatter, &vindexes.Keyspace{Name: "ks", Sharded: true}, "select id from user order by id", "select id from user where 1 != 1")
+	route.OrderBy = evalengine.Comparison{{Col: 0, WeightStringCol: -1}}
+	route.ShardResultIsSorted = true
+	return route
+}
+
+func combineResultRuns(runs ...*sqltypes.Result) *sqltypes.Result {
+	result := new(sqltypes.Result)
+	for _, run := range runs {
+		if run != nil {
+			result.AppendResult(run)
+		}
+	}
+	return result
+}
+
+func copyResultRuns(runs []*sqltypes.Result) []*sqltypes.Result {
+	copies := make([]*sqltypes.Result, len(runs))
+	for i, run := range runs {
+		if run != nil {
+			copies[i] = run.Copy()
+		}
+	}
+	return copies
+}

--- a/go/vt/vtgate/evalengine/api_compare.go
+++ b/go/vt/vtgate/evalengine/api_compare.go
@@ -377,8 +377,15 @@ type Merger struct {
 func NewMerger(compare Comparison, streams int) *Merger {
 	return &Merger{
 		Compare: compare,
-		keys:    make([]mergeRow, 0, streams),
+		keys:    make([]mergeRow, 0, mergeTreeCapacity(streams)),
 	}
+}
+
+func mergeTreeCapacity(streams int) int {
+	if streams <= 0 {
+		return 0
+	}
+	return 1 << bits.Len(uint(streams-1))
 }
 
 func (m *Merger) Len() int {
@@ -399,7 +406,7 @@ func (m *Merger) Init() {
 	}
 
 	// Round up to next power of 2
-	m.cap = 1 << bits.Len(uint(n-1))
+	m.cap = mergeTreeCapacity(n)
 
 	// Pad keys to capacity; padding entries are sentinel (source < 0)
 	m.keys = slices.Grow(m.keys, m.cap-n)

--- a/go/vt/vtgate/evalengine/api_compare.go
+++ b/go/vt/vtgate/evalengine/api_compare.go
@@ -372,6 +372,15 @@ type Merger struct {
 	count int        // number of active (non-exhausted) streams
 }
 
+// NewMerger creates a merger with room for the expected number of streams.
+// The capacity avoids slice growth while the caller primes the merge tree.
+func NewMerger(compare Comparison, streams int) *Merger {
+	return &Merger{
+		Compare: compare,
+		keys:    make([]mergeRow, 0, streams),
+	}
+}
+
 func (m *Merger) Len() int {
 	return m.count
 }

--- a/go/vt/vtgate/evalengine/api_compare_test.go
+++ b/go/vt/vtgate/evalengine/api_compare_test.go
@@ -1491,6 +1491,20 @@ func TestMerger(t *testing.T) {
 	row := func(v int64) sqltypes.Row {
 		return sqltypes.Row{sqltypes.NewInt64(v)}
 	}
+	cmp := Comparison{{Col: 0, Type: NewType(sqltypes.Int64, collations.CollationBinaryID)}}
+
+	t.Run("constructor reserves padded tree capacity", func(t *testing.T) {
+		assert.Zero(t, cap(NewMerger(cmp, 0).keys))
+
+		merger := NewMerger(cmp, 3)
+		require.Equal(t, 4, cap(merger.keys))
+		for source := range 3 {
+			merger.Push(row(int64(source)), source)
+		}
+		first := &merger.keys[0]
+		merger.Init()
+		assert.Same(t, first, &merger.keys[0])
+	})
 
 	t.Run("single stream", func(t *testing.T) {
 		streams := [][]sqltypes.Row{{row(1), row(2), row(3)}}

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1844,6 +1844,11 @@ func (e *Executor) ExecuteMultiShardPerShard(ctx context.Context, primitive engi
 	return e.scatterConn.ExecuteMultiShardPerShard(ctx, primitive, rss, queries, session, autocommit, resultsObserver, fetchLastInsertID)
 }
 
+// ExecuteMultiShardWithResultRuns executes a scatter query and preserves successful shard result runs.
+func (e *Executor) ExecuteMultiShardWithResultRuns(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, session *econtext.SafeSession, autocommit bool, ignoreMaxMemoryRows bool, resultsObserver econtext.ResultsObserver, fetchLastInsertID bool) (qr *sqltypes.Result, resultRuns []*sqltypes.Result, errs []error) {
+	return e.scatterConn.ExecuteMultiShardWithResultRuns(ctx, primitive, rss, queries, session, autocommit, ignoreMaxMemoryRows, resultsObserver, fetchLastInsertID)
+}
+
 // StreamExecuteMulti implements the IExecutor interface
 func (e *Executor) StreamExecuteMulti(ctx context.Context, primitive engine.Primitive, query string, rss []*srvtopo.ResolvedShard, vars []map[string]*querypb.BindVariable, session *econtext.SafeSession, autocommit bool, callback func(reply *sqltypes.Result) error, resultsObserver econtext.ResultsObserver, fetchLastInsertID bool) []error {
 	return e.scatterConn.StreamExecuteMulti(ctx, primitive, query, rss, vars, session, autocommit, callback, resultsObserver, fetchLastInsertID)

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -1846,7 +1846,7 @@ func (e *Executor) ExecuteMultiShardPerShard(ctx context.Context, primitive engi
 
 // ExecuteMultiShardWithResultRuns executes a scatter query and preserves successful shard result runs.
 func (e *Executor) ExecuteMultiShardWithResultRuns(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, session *econtext.SafeSession, autocommit bool, ignoreMaxMemoryRows bool, resultsObserver econtext.ResultsObserver, fetchLastInsertID bool) (qr *sqltypes.Result, resultRuns []*sqltypes.Result, errs []error) {
-	return e.scatterConn.ExecuteMultiShardWithResultRuns(ctx, primitive, rss, queries, session, autocommit, ignoreMaxMemoryRows, resultsObserver, fetchLastInsertID)
+	return e.scatterConn.executeMultiShardWithResultRuns(ctx, primitive, rss, queries, session, autocommit, ignoreMaxMemoryRows, resultsObserver, fetchLastInsertID)
 }
 
 // StreamExecuteMulti implements the IExecutor interface

--- a/go/vt/vtgate/executor_ordered_scatter_bench_test.go
+++ b/go/vt/vtgate/executor_ordered_scatter_bench_test.go
@@ -1,0 +1,264 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/vt/discovery"
+	"vitess.io/vitess/go/vt/key"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vtgatepb "vitess.io/vitess/go/vt/proto/vtgate"
+	"vitess.io/vitess/go/vt/vttablet/sandboxconn"
+)
+
+// BenchmarkRouteExecuteOrderedScatter measures the large result shapes used to
+// compare a full VTGate sort with a merge of shard-sorted result runs.
+func BenchmarkRouteExecuteOrderedScatter(b *testing.B) {
+	for _, shards := range []int{2, 8, 32} {
+		b.Run(fmt.Sprintf("shards=%d", shards), func(b *testing.B) {
+			for _, rows := range []int{1024, 8192} {
+				b.Run(fmt.Sprintf("rows=%d", rows), func(b *testing.B) {
+					benchmarkRouteExecuteOrderedScatter(b, shards, rows)
+				})
+			}
+		})
+	}
+}
+
+// BenchmarkRouteExecuteOrderedScatterCrossover measures small through medium
+// result shapes so an ordered scatter optimization does not move cost from
+// large results to ordinary small results.
+func BenchmarkRouteExecuteOrderedScatterCrossover(b *testing.B) {
+	for _, shards := range []int{2, 8, 32} {
+		b.Run(fmt.Sprintf("shards=%d", shards), func(b *testing.B) {
+			for _, rowsPerShard := range []int{1, 2, 4, 8, 16, 32, 64, 128, 256, 512} {
+				b.Run(fmt.Sprintf("rows_per_shard=%d", rowsPerShard), func(b *testing.B) {
+					benchmarkRouteExecuteOrderedScatter(b, shards, shards*rowsPerShard)
+				})
+			}
+		})
+	}
+}
+
+// BenchmarkRouteExecuteOrderedScatterSkew measures one large shard while the
+// other shards hold only a few rows. It finds the amount of non-dominant work
+// needed before merging beats repair of the nearly sorted flat result.
+func BenchmarkRouteExecuteOrderedScatterSkew(b *testing.B) {
+	for _, shards := range []int{2, 8, 32} {
+		b.Run(fmt.Sprintf("shards=%d", shards), func(b *testing.B) {
+			for _, averageRows := range []int{5, 16, 256} {
+				b.Run(fmt.Sprintf("average_rows_per_shard=%d", averageRows), func(b *testing.B) {
+					for _, otherRows := range []int{1, 4, 16, 64} {
+						if otherRows > averageRows {
+							continue
+						}
+						b.Run(fmt.Sprintf("other_rows_per_shard=%d", otherRows), func(b *testing.B) {
+							rows := make([]int, shards)
+							for shard := range rows {
+								rows[shard] = otherRows
+							}
+							rows[0] = shards*averageRows - (shards-1)*otherRows
+							benchmarkRouteExecuteOrderedScatterRows(b, rows, true)
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+// BenchmarkRouteExecuteOrderedScatterGloballyOrdered measures runs whose shard
+// order is already the final row order. It checks the boundary fast path that
+// rebuilds response-order rows without a full sort or merge tree.
+func BenchmarkRouteExecuteOrderedScatterGloballyOrdered(b *testing.B) {
+	for _, shards := range []int{2, 8, 32} {
+		b.Run(fmt.Sprintf("shards=%d", shards), func(b *testing.B) {
+			for _, rowsPerShard := range []int{16, 256} {
+				b.Run(fmt.Sprintf("rows_per_shard=%d", rowsPerShard), func(b *testing.B) {
+					rows := make([]int, shards)
+					for shard := range rows {
+						rows[shard] = rowsPerShard
+					}
+					benchmarkRouteExecuteOrderedScatterRows(b, rows, false)
+				})
+			}
+		})
+	}
+}
+
+func benchmarkRouteExecuteOrderedScatter(b *testing.B, shards, rows int) {
+	rowsPerShard := rows / shards
+	if rowsPerShard*shards != rows {
+		b.Fatalf("cannot split %d rows evenly across %d shards", rows, shards)
+	}
+	rowsByShard := make([]int, shards)
+	for shard := range rowsByShard {
+		rowsByShard[shard] = rowsPerShard
+	}
+	benchmarkRouteExecuteOrderedScatterRows(b, rowsByShard, true)
+}
+
+func benchmarkRouteExecuteOrderedScatterRows(b *testing.B, rowsByShard []int, interleave bool) {
+	ctx := b.Context()
+	const cell = "aa"
+	shards := len(rowsByShard)
+	rows := 0
+	for _, shardRows := range rowsByShard {
+		rows += shardRows
+	}
+
+	u := createSandbox(KsTestUnsharded)
+	s := createSandbox(KsTestSharded)
+	s.VSchema = executorVSchema
+	u.VSchema = unshardedVSchema
+	s.ShardSpec = orderedScatterShardSpec(shards)
+
+	hc := discovery.NewFakeHealthCheck(nil)
+	serv := newSandboxForCells(ctx, []string{cell})
+	resolver := newTestResolver(ctx, hc, serv, cell)
+
+	keyRanges, err := getAllShards(s.ShardSpec)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if len(keyRanges) != shards {
+		b.Fatalf("got %d shards, want %d", len(keyRanges), shards)
+	}
+
+	results := orderedScatterBenchmarkResults(rowsByShard, interleave)
+	conns := make([]*sandboxconn.SandboxConn, 0, shards)
+	for shardIdx, keyRange := range keyRanges {
+		shard := key.KeyRangeString(keyRange)
+		sbc := hc.AddTestTablet(cell, shard, 1, KsTestSharded, shard, topodatapb.TabletType_PRIMARY, true, 1, nil)
+		sbc.SetResults([]*sqltypes.Result{results[shardIdx]})
+		conns = append(conns, sbc)
+	}
+
+	executor := createExecutor(ctx, serv, cell, resolver)
+	b.Cleanup(executor.Close)
+
+	query := "select id from user order by id"
+	session := &vtgatepb.Session{TargetString: "@primary"}
+	result, err := executorExec(ctx, executor, session, query, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	validateOrderedScatterBenchmarkResult(b, result, rows)
+
+	for _, conn := range conns {
+		queries := conn.GetQueries()
+		if len(queries) != 1 {
+			b.Fatalf("got %d shard queries, want 1", len(queries))
+		}
+		if !strings.Contains(strings.ToLower(queries[0].Sql), "order by") {
+			b.Fatalf("shard query does not sort locally: %s", queries[0].Sql)
+		}
+	}
+
+	// Reset consumed sandbox results and request logs outside the timer so the
+	// measured path contains VTGate execution, not benchmark-fixture growth.
+	for b.Loop() {
+		b.StopTimer()
+		for shard, conn := range conns {
+			conn.SetResults([]*sqltypes.Result{results[shard]})
+			conn.ClearQueries()
+			conn.ClearOptions()
+		}
+		b.StartTimer()
+		result, err = executorExec(ctx, executor, session, query, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(result.Rows) != rows {
+			b.Fatalf("got %d rows, want %d", len(result.Rows), rows)
+		}
+	}
+}
+
+func orderedScatterShardSpec(shards int) string {
+	boundaries := make([]string, 0, shards+1)
+	boundaries = append(boundaries, "")
+	for shard := 1; shard < shards; shard++ {
+		boundaries = append(boundaries, fmt.Sprintf("%02x", shard*256/shards))
+	}
+	boundaries = append(boundaries, "")
+	return strings.Join(boundaries, "-")
+}
+
+func orderedScatterBenchmarkResults(rowsByShard []int, interleave bool) []*sqltypes.Result {
+	results := make([]*sqltypes.Result, len(rowsByShard))
+	for shard, rows := range rowsByShard {
+		results[shard] = &sqltypes.Result{
+			Fields: []*querypb.Field{{
+				Name:    "id",
+				Type:    sqltypes.Int64,
+				Charset: collations.CollationBinaryID,
+				Flags:   uint32(querypb.MySqlFlag_NUM_FLAG),
+			}},
+			Rows: make([][]sqltypes.Value, rows),
+		}
+	}
+	value := int64(0)
+	if !interleave {
+		for _, result := range results {
+			for row := range result.Rows {
+				result.Rows[row] = []sqltypes.Value{sqltypes.NewInt64(value)}
+				value++
+			}
+		}
+		return results
+	}
+	for row := 0; ; row++ {
+		added := false
+		for _, result := range results {
+			if row >= len(result.Rows) {
+				continue
+			}
+			result.Rows[row] = []sqltypes.Value{sqltypes.NewInt64(value)}
+			value++
+			added = true
+		}
+		if !added {
+			return results
+		}
+	}
+}
+
+func validateOrderedScatterBenchmarkResult(b *testing.B, result *sqltypes.Result, rows int) {
+	b.Helper()
+	if len(result.Rows) != rows {
+		b.Fatalf("got %d rows, want %d", len(result.Rows), rows)
+	}
+	for row, values := range result.Rows {
+		if len(values) != 1 {
+			b.Fatalf("row %d has %d columns, want 1", row, len(values))
+		}
+		value, err := values[0].ToInt64()
+		if err != nil {
+			b.Fatalf("row %d is not an int64: %v", row, err)
+		}
+		if value != int64(row) {
+			b.Fatalf("row %d has id %d, want %d", row, value, row)
+		}
+	}
+}

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -108,6 +108,7 @@ type (
 		Execute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, method string, session *SafeSession, s string, vars map[string]*querypb.BindVariable, prepared bool) (*sqltypes.Result, error)
 		ExecuteMultiShard(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, session *SafeSession, autocommit bool, ignoreMaxMemoryRows bool, resultsObserver ResultsObserver, fetchLastInsertID bool) (qr *sqltypes.Result, errs []error)
 		ExecuteMultiShardPerShard(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, session *SafeSession, autocommit bool, resultsObserver ResultsObserver, fetchLastInsertID bool) (results []*sqltypes.Result, errs []error)
+		ExecuteMultiShardWithResultRuns(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, session *SafeSession, autocommit bool, ignoreMaxMemoryRows bool, resultsObserver ResultsObserver, fetchLastInsertID bool) (qr *sqltypes.Result, resultRuns []*sqltypes.Result, errs []error)
 		StreamExecuteMulti(ctx context.Context, primitive engine.Primitive, query string, rss []*srvtopo.ResolvedShard, vars []map[string]*querypb.BindVariable, session *SafeSession, autocommit bool, callback func(reply *sqltypes.Result) error, observer ResultsObserver, fetchLastInsertID bool) []error
 		ExecuteLock(ctx context.Context, rs *srvtopo.ResolvedShard, query *querypb.BoundQuery, session *SafeSession, lockFuncType sqlparser.LockingFuncType) (*sqltypes.Result, error)
 		Commit(ctx context.Context, safeSession *SafeSession) error
@@ -129,10 +130,6 @@ type (
 		ReadTransaction(ctx context.Context, transactionID string) (*querypb.TransactionMetadata, error)
 		UnresolvedTransactions(ctx context.Context, targets []*querypb.Target) ([]*querypb.TransactionMetadata, error)
 		AddWarningCount(name string, value int64)
-	}
-
-	resultRunExecutor interface {
-		ExecuteMultiShardWithResultRuns(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, session *SafeSession, autocommit bool, ignoreMaxMemoryRows bool, resultsObserver ResultsObserver, fetchLastInsertID bool) (qr *sqltypes.Result, resultRuns []*sqltypes.Result, errs []error)
 	}
 
 	// VSchemaOperator is an interface to Vschema Operations
@@ -911,11 +908,7 @@ func (vc *VCursorImpl) executeMultiShard(ctx context.Context, primitive engine.P
 
 	commentedQueries := commentedShardQueries(queries, vc.marginComments)
 	if withResultRuns {
-		if executor, ok := vc.executor.(resultRunExecutor); ok {
-			qr, resultRuns, errs = executor.ExecuteMultiShardWithResultRuns(ctx, primitive, rss, commentedQueries, vc.SafeSession, canAutocommit, vc.ignoreMaxMemoryRows, vc.observer, fetchLastInsertID)
-		} else {
-			qr, errs = vc.executor.ExecuteMultiShard(ctx, primitive, rss, commentedQueries, vc.SafeSession, canAutocommit, vc.ignoreMaxMemoryRows, vc.observer, fetchLastInsertID)
-		}
+		qr, resultRuns, errs = vc.executor.ExecuteMultiShardWithResultRuns(ctx, primitive, rss, commentedQueries, vc.SafeSession, canAutocommit, vc.ignoreMaxMemoryRows, vc.observer, fetchLastInsertID)
 	} else {
 		qr, errs = vc.executor.ExecuteMultiShard(ctx, primitive, rss, commentedQueries, vc.SafeSession, canAutocommit, vc.ignoreMaxMemoryRows, vc.observer, fetchLastInsertID)
 	}

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -131,6 +131,10 @@ type (
 		AddWarningCount(name string, value int64)
 	}
 
+	iExecuteResultRuns interface {
+		ExecuteMultiShardWithResultRuns(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, session *SafeSession, autocommit bool, ignoreMaxMemoryRows bool, resultsObserver ResultsObserver, fetchLastInsertID bool) (qr *sqltypes.Result, resultRuns []*sqltypes.Result, errs []error)
+	}
+
 	// VSchemaOperator is an interface to Vschema Operations
 	VSchemaOperator interface {
 		GetCurrentSrvVschema() *vschemapb.SrvVSchema
@@ -206,10 +210,6 @@ type (
 		executedPrimitive engine.Primitive
 	}
 )
-
-type iExecuteResultRuns interface {
-	ExecuteMultiShardWithResultRuns(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, session *SafeSession, autocommit bool, ignoreMaxMemoryRows bool, resultsObserver ResultsObserver, fetchLastInsertID bool) (qr *sqltypes.Result, resultRuns []*sqltypes.Result, errs []error)
-}
 
 // NewVCursorImpl creates a VCursorImpl. Before creating this object, you have to separate out any marginComments that came with
 // the query and supply it here. Trailing comments are typically sent by the application for various reasons,

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -131,7 +131,7 @@ type (
 		AddWarningCount(name string, value int64)
 	}
 
-	iExecuteResultRuns interface {
+	resultRunExecutor interface {
 		ExecuteMultiShardWithResultRuns(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, session *SafeSession, autocommit bool, ignoreMaxMemoryRows bool, resultsObserver ResultsObserver, fetchLastInsertID bool) (qr *sqltypes.Result, resultRuns []*sqltypes.Result, errs []error)
 	}
 
@@ -911,7 +911,7 @@ func (vc *VCursorImpl) executeMultiShard(ctx context.Context, primitive engine.P
 
 	commentedQueries := commentedShardQueries(queries, vc.marginComments)
 	if withResultRuns {
-		if executor, ok := vc.executor.(iExecuteResultRuns); ok {
+		if executor, ok := vc.executor.(resultRunExecutor); ok {
 			qr, resultRuns, errs = executor.ExecuteMultiShardWithResultRuns(ctx, primitive, rss, commentedQueries, vc.SafeSession, canAutocommit, vc.ignoreMaxMemoryRows, vc.observer, fetchLastInsertID)
 		} else {
 			qr, errs = vc.executor.ExecuteMultiShard(ctx, primitive, rss, commentedQueries, vc.SafeSession, canAutocommit, vc.ignoreMaxMemoryRows, vc.observer, fetchLastInsertID)

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -207,6 +207,10 @@ type (
 	}
 )
 
+type iExecuteResultRuns interface {
+	ExecuteMultiShardWithResultRuns(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, session *SafeSession, autocommit bool, ignoreMaxMemoryRows bool, resultsObserver ResultsObserver, fetchLastInsertID bool) (qr *sqltypes.Result, resultRuns []*sqltypes.Result, errs []error)
+}
+
 // NewVCursorImpl creates a VCursorImpl. Before creating this object, you have to separate out any marginComments that came with
 // the query and supply it here. Trailing comments are typically sent by the application for various reasons,
 // including as identifying markers. So, they have to be added back to all queries that are executed
@@ -888,20 +892,39 @@ func (vc *VCursorImpl) markSavepoint(ctx context.Context, needsRollbackOnParialE
 
 // ExecuteMultiShard is part of the engine.VCursor interface.
 func (vc *VCursorImpl) ExecuteMultiShard(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, rollbackOnError, canAutocommit, fetchLastInsertID bool) (*sqltypes.Result, []error) {
+	qr, _, errs := vc.executeMultiShard(ctx, primitive, rss, queries, rollbackOnError, canAutocommit, fetchLastInsertID, false)
+	return qr, errs
+}
+
+// ExecuteMultiShardWithResultRuns executes each shard query and preserves successful shard result runs.
+func (vc *VCursorImpl) ExecuteMultiShardWithResultRuns(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, rollbackOnError, canAutocommit, fetchLastInsertID bool) (*sqltypes.Result, []*sqltypes.Result, []error) {
+	return vc.executeMultiShard(ctx, primitive, rss, queries, rollbackOnError, canAutocommit, fetchLastInsertID, true)
+}
+
+func (vc *VCursorImpl) executeMultiShard(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, rollbackOnError, canAutocommit, fetchLastInsertID, withResultRuns bool) (qr *sqltypes.Result, resultRuns []*sqltypes.Result, errs []error) {
 	noOfShards := len(rss)
 	atomic.AddUint64(&vc.logStats.ShardQueries, uint64(noOfShards))
 	err := vc.markSavepoint(ctx, rollbackOnError && (noOfShards > 1), map[string]*querypb.BindVariable{})
 	if err != nil {
-		return nil, []error{err}
+		return nil, nil, []error{err}
 	}
 
-	qr, errs := vc.executor.ExecuteMultiShard(ctx, primitive, rss, commentedShardQueries(queries, vc.marginComments), vc.SafeSession, canAutocommit, vc.ignoreMaxMemoryRows, vc.observer, fetchLastInsertID)
+	commentedQueries := commentedShardQueries(queries, vc.marginComments)
+	if withResultRuns {
+		if executor, ok := vc.executor.(iExecuteResultRuns); ok {
+			qr, resultRuns, errs = executor.ExecuteMultiShardWithResultRuns(ctx, primitive, rss, commentedQueries, vc.SafeSession, canAutocommit, vc.ignoreMaxMemoryRows, vc.observer, fetchLastInsertID)
+		} else {
+			qr, errs = vc.executor.ExecuteMultiShard(ctx, primitive, rss, commentedQueries, vc.SafeSession, canAutocommit, vc.ignoreMaxMemoryRows, vc.observer, fetchLastInsertID)
+		}
+	} else {
+		qr, errs = vc.executor.ExecuteMultiShard(ctx, primitive, rss, commentedQueries, vc.SafeSession, canAutocommit, vc.ignoreMaxMemoryRows, vc.observer, fetchLastInsertID)
+	}
 	vc.setRollbackOnPartialExecIfRequired(len(errs) != len(rss), rollbackOnError)
 	vc.logShardsQueried(primitive, len(rss))
 	if qr != nil && qr.InsertIDUpdated() {
 		vc.SafeSession.LastInsertId = qr.InsertID
 	}
-	return qr, errs
+	return qr, resultRuns, errs
 }
 
 // ExecuteMultiShardPerShard runs one read query per shard and returns each

--- a/go/vt/vtgate/executorcontext/vcursor_impl_test.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl_test.go
@@ -343,6 +343,11 @@ func (f fakeExecutor) ExecuteMultiShardPerShard(ctx context.Context, primitive e
 	panic("implement me")
 }
 
+func (f fakeExecutor) ExecuteMultiShardWithResultRuns(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, session *SafeSession, autocommit bool, ignoreMaxMemoryRows bool, resultsObserver ResultsObserver, fetchLastInsertID bool) (qr *sqltypes.Result, resultRuns []*sqltypes.Result, errs []error) {
+	// TODO implement me
+	panic("implement me")
+}
+
 func (f fakeExecutor) StreamExecuteMulti(ctx context.Context, primitive engine.Primitive, query string, rss []*srvtopo.ResolvedShard, vars []map[string]*querypb.BindVariable, session *SafeSession, autocommit bool, callback func(reply *sqltypes.Result) error, observer ResultsObserver, fetchLastInsertID bool) []error {
 	// TODO implement me
 	panic("implement me")

--- a/go/vt/vtgate/executorcontext/vcursor_result_runs_test.go
+++ b/go/vt/vtgate/executorcontext/vcursor_result_runs_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executorcontext
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/streamlog"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/srvtopo"
+	"vitess.io/vitess/go/vt/vtgate/engine"
+	"vitess.io/vitess/go/vt/vtgate/logstats"
+	"vitess.io/vitess/go/vt/vtgate/vindexes"
+)
+
+type resultRunsExecutor struct {
+	fakeExecutor
+
+	result *sqltypes.Result
+	runs   []*sqltypes.Result
+}
+
+func (executor resultRunsExecutor) ExecuteMultiShardWithResultRuns(
+	context.Context,
+	engine.Primitive,
+	[]*srvtopo.ResolvedShard,
+	[]*querypb.BoundQuery,
+	*SafeSession,
+	bool,
+	bool,
+	ResultsObserver,
+	bool,
+) (*sqltypes.Result, []*sqltypes.Result, []error) {
+	return executor.result, executor.runs, nil
+}
+
+// TestVCursorExecuteMultiShardWithResultRuns proves the VCursor preserves the
+// executor's flat result and aligned shard runs.
+func TestVCursorExecuteMultiShardWithResultRuns(t *testing.T) {
+	result := sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "2")
+	runs := []*sqltypes.Result{result}
+	logStats := logstats.NewLogStats(t.Context(), t.Name(), "select id from user", "", nil, streamlog.NewQueryLogConfigForTest())
+	vc, err := NewVCursorImpl(
+		NewSafeSession(nil),
+		sqlparser.MarginComments{},
+		resultRunsExecutor{result: result, runs: runs},
+		logStats,
+		nil,
+		&vindexes.VSchema{},
+		nil,
+		nil,
+		fakeObserver{},
+		VCursorConfig{},
+		nil,
+	)
+	require.NoError(t, err)
+
+	got, gotRuns, errs := vc.ExecuteMultiShardWithResultRuns(t.Context(), nil, nil, nil, false, false, false)
+	require.Empty(t, errs)
+	require.Same(t, result, got)
+	require.Len(t, gotRuns, 1)
+	require.Same(t, runs[0], gotRuns[0])
+}

--- a/go/vt/vtgate/executorcontext/vcursor_result_runs_test.go
+++ b/go/vt/vtgate/executorcontext/vcursor_result_runs_test.go
@@ -42,12 +42,6 @@ type (
 		runs       []*sqltypes.Result
 		executeErr error
 	}
-
-	flatResultExecutor struct {
-		fakeExecutor
-
-		result *sqltypes.Result
-	}
 )
 
 func (executor resultRunsExecutor) Execute(
@@ -76,20 +70,6 @@ func (executor resultRunsExecutor) ExecuteMultiShardWithResultRuns(
 	return executor.result, executor.runs, nil
 }
 
-func (executor flatResultExecutor) ExecuteMultiShard(
-	context.Context,
-	engine.Primitive,
-	[]*srvtopo.ResolvedShard,
-	[]*querypb.BoundQuery,
-	*SafeSession,
-	bool,
-	bool,
-	ResultsObserver,
-	bool,
-) (*sqltypes.Result, []error) {
-	return executor.result, nil
-}
-
 // TestVCursorExecuteMultiShardWithResultRuns proves the VCursor preserves the
 // executor's flat result and aligned shard runs.
 func TestVCursorExecuteMultiShardWithResultRuns(t *testing.T) {
@@ -104,32 +84,20 @@ func TestVCursorExecuteMultiShardWithResultRuns(t *testing.T) {
 	require.Same(t, runs[0], gotRuns[0])
 }
 
-// TestVCursorExecuteMultiShardWithResultRunsFallbacks proves the optional path
-// keeps the flat-result fallback and savepoint error contract.
-func TestVCursorExecuteMultiShardWithResultRunsFallbacks(t *testing.T) {
-	t.Run("executor without result runs", func(t *testing.T) {
-		result := sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "2")
-		vc := newResultRunsTestVCursor(t, flatResultExecutor{result: result}, NewSafeSession(nil))
+// TestVCursorExecuteMultiShardWithResultRunsSavepointFailure proves the result-run
+// path keeps the existing savepoint error contract.
+func TestVCursorExecuteMultiShardWithResultRunsSavepointFailure(t *testing.T) {
+	wantErr := errors.New("savepoint failed")
+	session := NewSafeSession(nil)
+	session.SetSavepointState(true)
+	vc := newResultRunsTestVCursor(t, resultRunsExecutor{executeErr: wantErr}, session)
+	rss := []*srvtopo.ResolvedShard{{}, {}}
 
-		got, runs, errs := vc.ExecuteMultiShardWithResultRuns(t.Context(), nil, nil, nil, false, false, false)
-		require.Empty(t, errs)
-		require.Same(t, result, got)
-		require.Nil(t, runs)
-	})
-
-	t.Run("savepoint failure", func(t *testing.T) {
-		wantErr := errors.New("savepoint failed")
-		session := NewSafeSession(nil)
-		session.SetSavepointState(true)
-		vc := newResultRunsTestVCursor(t, resultRunsExecutor{executeErr: wantErr}, session)
-		rss := []*srvtopo.ResolvedShard{{}, {}}
-
-		got, runs, errs := vc.ExecuteMultiShardWithResultRuns(t.Context(), nil, rss, nil, true, false, false)
-		require.Nil(t, got)
-		require.Nil(t, runs)
-		require.Len(t, errs, 1)
-		require.ErrorIs(t, errs[0], wantErr)
-	})
+	got, runs, errs := vc.ExecuteMultiShardWithResultRuns(t.Context(), nil, rss, nil, true, false, false)
+	require.Nil(t, got)
+	require.Nil(t, runs)
+	require.Len(t, errs, 1)
+	require.ErrorIs(t, errs[0], wantErr)
 }
 
 func newResultRunsTestVCursor(t *testing.T, executor iExecute, session *SafeSession) *VCursorImpl {

--- a/go/vt/vtgate/executorcontext/vcursor_result_runs_test.go
+++ b/go/vt/vtgate/executorcontext/vcursor_result_runs_test.go
@@ -18,6 +18,7 @@ package executorcontext
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,13 +31,35 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/engine"
 	"vitess.io/vitess/go/vt/vtgate/logstats"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
+	"vitess.io/vitess/go/vt/vtgate/vtgateservice"
 )
 
-type resultRunsExecutor struct {
-	fakeExecutor
+type (
+	resultRunsExecutor struct {
+		fakeExecutor
 
-	result *sqltypes.Result
-	runs   []*sqltypes.Result
+		result     *sqltypes.Result
+		runs       []*sqltypes.Result
+		executeErr error
+	}
+
+	flatResultExecutor struct {
+		fakeExecutor
+
+		result *sqltypes.Result
+	}
+)
+
+func (executor resultRunsExecutor) Execute(
+	context.Context,
+	vtgateservice.MySQLConnection,
+	string,
+	*SafeSession,
+	string,
+	map[string]*querypb.BindVariable,
+	bool,
+) (*sqltypes.Result, error) {
+	return nil, executor.executeErr
 }
 
 func (executor resultRunsExecutor) ExecuteMultiShardWithResultRuns(
@@ -53,16 +76,69 @@ func (executor resultRunsExecutor) ExecuteMultiShardWithResultRuns(
 	return executor.result, executor.runs, nil
 }
 
+func (executor flatResultExecutor) ExecuteMultiShard(
+	context.Context,
+	engine.Primitive,
+	[]*srvtopo.ResolvedShard,
+	[]*querypb.BoundQuery,
+	*SafeSession,
+	bool,
+	bool,
+	ResultsObserver,
+	bool,
+) (*sqltypes.Result, []error) {
+	return executor.result, nil
+}
+
 // TestVCursorExecuteMultiShardWithResultRuns proves the VCursor preserves the
 // executor's flat result and aligned shard runs.
 func TestVCursorExecuteMultiShardWithResultRuns(t *testing.T) {
 	result := sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "2")
 	runs := []*sqltypes.Result{result}
+	vc := newResultRunsTestVCursor(t, resultRunsExecutor{result: result, runs: runs}, NewSafeSession(nil))
+
+	got, gotRuns, errs := vc.ExecuteMultiShardWithResultRuns(t.Context(), nil, nil, nil, false, false, false)
+	require.Empty(t, errs)
+	require.Same(t, result, got)
+	require.Len(t, gotRuns, 1)
+	require.Same(t, runs[0], gotRuns[0])
+}
+
+// TestVCursorExecuteMultiShardWithResultRunsFallbacks proves the optional path
+// keeps the flat-result fallback and savepoint error contract.
+func TestVCursorExecuteMultiShardWithResultRunsFallbacks(t *testing.T) {
+	t.Run("executor without result runs", func(t *testing.T) {
+		result := sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "2")
+		vc := newResultRunsTestVCursor(t, flatResultExecutor{result: result}, NewSafeSession(nil))
+
+		got, runs, errs := vc.ExecuteMultiShardWithResultRuns(t.Context(), nil, nil, nil, false, false, false)
+		require.Empty(t, errs)
+		require.Same(t, result, got)
+		require.Nil(t, runs)
+	})
+
+	t.Run("savepoint failure", func(t *testing.T) {
+		wantErr := errors.New("savepoint failed")
+		session := NewSafeSession(nil)
+		session.SetSavepointState(true)
+		vc := newResultRunsTestVCursor(t, resultRunsExecutor{executeErr: wantErr}, session)
+		rss := []*srvtopo.ResolvedShard{{}, {}}
+
+		got, runs, errs := vc.ExecuteMultiShardWithResultRuns(t.Context(), nil, rss, nil, true, false, false)
+		require.Nil(t, got)
+		require.Nil(t, runs)
+		require.Len(t, errs, 1)
+		require.ErrorIs(t, errs[0], wantErr)
+	})
+}
+
+func newResultRunsTestVCursor(t *testing.T, executor iExecute, session *SafeSession) *VCursorImpl {
+	t.Helper()
 	logStats := logstats.NewLogStats(t.Context(), t.Name(), "select id from user", "", nil, streamlog.NewQueryLogConfigForTest())
 	vc, err := NewVCursorImpl(
-		NewSafeSession(nil),
+		session,
 		sqlparser.MarginComments{},
-		resultRunsExecutor{result: result, runs: runs},
+		executor,
 		logStats,
 		nil,
 		&vindexes.VSchema{},
@@ -73,10 +149,5 @@ func TestVCursorExecuteMultiShardWithResultRuns(t *testing.T) {
 		nil,
 	)
 	require.NoError(t, err)
-
-	got, gotRuns, errs := vc.ExecuteMultiShardWithResultRuns(t.Context(), nil, nil, nil, false, false, false)
-	require.Empty(t, errs)
-	require.Same(t, result, got)
-	require.Len(t, gotRuns, 1)
-	require.Same(t, runs[0], gotRuns[0])
+	return vc
 }

--- a/go/vt/vtgate/planbuilder/operator_transformers.go
+++ b/go/vt/vtgate/planbuilder/operator_transformers.go
@@ -649,6 +649,10 @@ func buildRoutePrimitive(ctx *plancontext.PlanningContext, op *operators.Route, 
 			CollationEnv:    ctx.VSchema.Environment().CollationEnv(),
 		})
 	}
+	// Route.planOffsets omits special expressions such as RAND() because VTGate
+	// cannot merge them. Only preserve runs when every shard ORDER BY expression
+	// has a corresponding route comparator.
+	eroute.ShardResultIsSorted = len(eroute.OrderBy) > 0 && len(eroute.OrderBy) == len(stmt.GetOrderBy())
 
 	prepareTheAST(stmt)
 

--- a/go/vt/vtgate/planbuilder/route_result_runs_test.go
+++ b/go/vt/vtgate/planbuilder/route_result_runs_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/test/vschemawrapper"
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtenv"
+	"vitess.io/vitess/go/vt/vtgate/engine"
+)
+
+// TestRouteShardResultIsSorted proves only routes whose shard query carries the
+// required ordering are marked for result-run merging.
+func TestRouteShardResultIsSorted(t *testing.T) {
+	env := vtenv.NewTestEnv()
+	vschema := loadSchema(t, "vschemas/schema.json", true)
+	vw, err := vschemawrapper.NewVschemaWrapper(env, vschema, TestBuilder)
+	require.NoError(t, err)
+
+	orderedPlan, err := TestBuilder("select id from user order by id", vw, vw.CurrentDb())
+	require.NoError(t, err)
+	orderedRoute := findRoute(t, orderedPlan.Instructions)
+	require.True(t, orderedRoute.ShardResultIsSorted)
+	require.NotEmpty(t, orderedRoute.OrderBy)
+	require.Contains(t, strings.ToLower(orderedRoute.Query), "order by")
+	statement, ok := orderedRoute.QueryStatement.(sqlparser.SelectStatement)
+	require.True(t, ok)
+	require.Len(t, statement.GetOrderBy(), len(orderedRoute.OrderBy))
+
+	unorderedPlan, err := TestBuilder("select id from user", vw, vw.CurrentDb())
+	require.NoError(t, err)
+	unorderedRoute := findRoute(t, unorderedPlan.Instructions)
+	require.False(t, unorderedRoute.ShardResultIsSorted)
+
+	randomPlan, err := TestBuilder("select id from user order by rand(), id", vw, vw.CurrentDb())
+	require.NoError(t, err)
+	randomRoute := findRoute(t, randomPlan.Instructions)
+	require.NotEmpty(t, randomRoute.OrderBy)
+	require.False(t, randomRoute.ShardResultIsSorted)
+	randomStatement, ok := randomRoute.QueryStatement.(sqlparser.SelectStatement)
+	require.True(t, ok)
+	require.Greater(t, len(randomStatement.GetOrderBy()), len(randomRoute.OrderBy))
+}
+
+func findRoute(t *testing.T, primitive engine.Primitive) *engine.Route {
+	t.Helper()
+	found := engine.Find(func(primitive engine.Primitive) bool {
+		_, ok := primitive.(*engine.Route)
+		return ok
+	}, primitive)
+	route, ok := found.(*engine.Route)
+	require.True(t, ok)
+	return route
+}

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -175,6 +175,43 @@ func (stc *ScatterConn) ExecuteMultiShard(
 	return qr, allErrors.GetErrors()
 }
 
+// ExecuteMultiShardWithResultRuns is like ExecuteMultiShard, and also returns
+// successful shard results in the same order as rss.
+func (stc *ScatterConn) ExecuteMultiShardWithResultRuns(
+	ctx context.Context,
+	primitive engine.Primitive,
+	rss []*srvtopo.ResolvedShard,
+	queries []*querypb.BoundQuery,
+	session *econtext.SafeSession,
+	autocommit bool,
+	ignoreMaxMemoryRows bool,
+	resultsObserver econtext.ResultsObserver,
+	fetchLastInsertID bool,
+) (qr *sqltypes.Result, resultRuns []*sqltypes.Result, errs []error) {
+	if len(rss) != len(queries) {
+		return nil, nil, []error{vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG] got mismatched number of queries and shards")}
+	}
+
+	qr = new(sqltypes.Result)
+	resultRuns = make([]*sqltypes.Result, len(rss))
+	allErrors := stc.executeMultiShard(ctx, primitive, rss, queries, session, autocommit, resultsObserver, fetchLastInsertID,
+		func(i int, innerqr *sqltypes.Result) {
+			// Keep result runs aligned with the rows accepted into qr. If the
+			// memory limit rejects qr, neither result form escapes this method.
+			if ignoreMaxMemoryRows || len(qr.Rows) <= maxMemoryRows {
+				qr.AppendResult(innerqr)
+				resultRuns[i] = innerqr
+			}
+		},
+	)
+
+	if !ignoreMaxMemoryRows && len(qr.Rows) > maxMemoryRows {
+		return nil, nil, []error{vterrors.NewErrorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, vterrors.NetPacketTooLarge, "in-memory row count exceeded allowed limit of %d", maxMemoryRows)}
+	}
+
+	return qr, resultRuns, allErrors.GetErrors()
+}
+
 // ExecuteMultiShardPerShard is like ExecuteMultiShard but returns each shard's
 // result separately, aligned by index to rss, instead of merging them into one
 // result. It reuses the same concurrent fan-out, retry, transaction and session

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -175,9 +175,7 @@ func (stc *ScatterConn) ExecuteMultiShard(
 	return qr, allErrors.GetErrors()
 }
 
-// ExecuteMultiShardWithResultRuns is like ExecuteMultiShard, and also returns
-// successful shard results in the same order as rss.
-func (stc *ScatterConn) ExecuteMultiShardWithResultRuns(
+func (stc *ScatterConn) executeMultiShardWithResultRuns(
 	ctx context.Context,
 	primitive engine.Primitive,
 	rss []*srvtopo.ResolvedShard,

--- a/go/vt/vtgate/scatter_conn_result_runs_test.go
+++ b/go/vt/vtgate/scatter_conn_result_runs_test.go
@@ -122,19 +122,19 @@ func TestExecuteMultiShardWithResultRuns(t *testing.T) {
 	select {
 	case <-firstStarted:
 	case <-time.After(30 * time.Second):
-		t.Fatal("first shard did not start")
+		require.FailNow(t, "first shard did not start")
 	}
 	select {
 	case observed := <-observer:
 		require.Same(t, run1, observed)
 	case <-time.After(30 * time.Second):
-		t.Fatal("second shard did not finish")
+		require.FailNow(t, "second shard did not finish")
 	}
 	close(releaseFirst)
 	select {
 	case <-done:
 	case <-time.After(30 * time.Second):
-		t.Fatal("scatter execution did not finish")
+		require.FailNow(t, "scatter execution did not finish")
 	}
 
 	require.Empty(t, errs)

--- a/go/vt/vtgate/scatter_conn_result_runs_test.go
+++ b/go/vt/vtgate/scatter_conn_result_runs_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/test/utils"
+	"vitess.io/vitess/go/vt/discovery"
+	querypb "vitess.io/vitess/go/vt/proto/query"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/srvtopo"
+	econtext "vitess.io/vitess/go/vt/vtgate/executorcontext"
+)
+
+// TestExecuteMultiShardWithResultRuns proves successful shard results stay
+// aligned with shard order while the flat result keeps completion order.
+func TestExecuteMultiShardWithResultRuns(t *testing.T) {
+	ctx := utils.LeakCheckContext(t)
+	const (
+		cell = "aa"
+		ks   = "TestExecuteMultiShardWithResultRuns"
+	)
+
+	createSandbox(ks)
+	hc := discovery.NewFakeHealthCheck(nil)
+	sc := newTestScatterConn(ctx, hc, newSandboxForCells(ctx, []string{cell}), cell)
+	sbc0 := hc.AddTestTablet(cell, "-80", 1, ks, "-80", topodatapb.TabletType_PRIMARY, true, 1, nil)
+	sbc1 := hc.AddTestTablet(cell, "80-", 1, ks, "80-", topodatapb.TabletType_PRIMARY, true, 1, nil)
+	run0 := sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "3")
+	run1 := sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "2", "4")
+	sbc0.SetResults([]*sqltypes.Result{run0})
+	sbc1.SetResults([]*sqltypes.Result{run1})
+
+	rss := []*srvtopo.ResolvedShard{
+		{Target: &querypb.Target{Keyspace: ks, Shard: "-80", TabletType: topodatapb.TabletType_PRIMARY}, Gateway: sbc0},
+		{Target: &querypb.Target{Keyspace: ks, Shard: "80-", TabletType: topodatapb.TabletType_PRIMARY}, Gateway: sbc1},
+	}
+	queries := []*querypb.BoundQuery{{Sql: "select id from user"}, {Sql: "select id from user"}}
+
+	result, runs, errs := sc.ExecuteMultiShardWithResultRuns(ctx, nil, rss, queries, econtext.NewSafeSession(nil), false, false, nullResultsObserver{}, false)
+	require.Empty(t, errs)
+	require.Len(t, result.Rows, 4)
+	require.Len(t, runs, len(rss))
+	require.Same(t, run0, runs[0])
+	require.Same(t, run1, runs[1])
+
+	sbc0.SetResults([]*sqltypes.Result{run0})
+	sbc1.MustFailCodes[vtrpcpb.Code_INTERNAL] = 1
+	result, runs, errs = sc.ExecuteMultiShardWithResultRuns(ctx, nil, rss, queries, econtext.NewSafeSession(nil), false, false, nullResultsObserver{}, false)
+	require.Len(t, errs, 1)
+	require.Len(t, result.Rows, 2)
+	require.Len(t, runs, len(rss))
+	require.Same(t, run0, runs[0])
+	require.Nil(t, runs[1])
+}

--- a/go/vt/vtgate/scatter_conn_result_runs_test.go
+++ b/go/vt/vtgate/scatter_conn_result_runs_test.go
@@ -72,3 +72,17 @@ func TestExecuteMultiShardWithResultRuns(t *testing.T) {
 	require.Same(t, run0, runs[0])
 	require.Nil(t, runs[1])
 }
+
+// TestExecuteMultiShardWithResultRunsRejectsMismatchedInput proves shard and
+// query lists must stay positionally aligned.
+func TestExecuteMultiShardWithResultRunsRejectsMismatchedInput(t *testing.T) {
+	rss := []*srvtopo.ResolvedShard{{}}
+
+	result, runs, errs := new(ScatterConn).ExecuteMultiShardWithResultRuns(
+		t.Context(), nil, rss, nil, nil, false, false, nil, false,
+	)
+	require.Nil(t, result)
+	require.Nil(t, runs)
+	require.Len(t, errs, 1)
+	require.EqualError(t, errs[0], "[BUG] got mismatched number of queries and shards")
+}

--- a/go/vt/vtgate/scatter_conn_result_runs_test.go
+++ b/go/vt/vtgate/scatter_conn_result_runs_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vtgate
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -30,7 +31,41 @@ import (
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/srvtopo"
 	econtext "vitess.io/vitess/go/vt/vtgate/executorcontext"
+	"vitess.io/vitess/go/vt/vttablet/queryservice"
 )
+
+type (
+	blockingGateway struct {
+		srvtopo.Gateway
+		started chan<- struct{}
+		release <-chan struct{}
+	}
+
+	resultObserver chan *sqltypes.Result
+)
+
+func (g *blockingGateway) Execute(
+	ctx context.Context,
+	session queryservice.Session,
+	target *querypb.Target,
+	query string,
+	bindVariables map[string]*querypb.BindVariable,
+	transactionID int64,
+	reservedID int64,
+	options *querypb.ExecuteOptions,
+) (*sqltypes.Result, error) {
+	close(g.started)
+	select {
+	case <-g.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return g.Gateway.Execute(ctx, session, target, query, bindVariables, transactionID, reservedID, options)
+}
+
+func (o resultObserver) Observe(result *sqltypes.Result) {
+	o <- result
+}
 
 // TestExecuteMultiShardWithResultRuns proves successful shard results stay
 // aligned with shard order while the flat result keeps completion order.
@@ -46,7 +81,6 @@ func TestExecuteMultiShardWithResultRuns(t *testing.T) {
 	sc := newTestScatterConn(ctx, hc, newSandboxForCells(ctx, []string{cell}), cell)
 	sbc0 := hc.AddTestTablet(cell, "-80", 1, ks, "-80", topodatapb.TabletType_PRIMARY, true, 1, nil)
 	sbc1 := hc.AddTestTablet(cell, "80-", 1, ks, "80-", topodatapb.TabletType_PRIMARY, true, 1, nil)
-	sbc0.ExecDelayResponse = 10 * time.Millisecond
 	run0 := sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "3")
 	run1 := sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "2", "4")
 	sbc0.SetResults([]*sqltypes.Result{run0})
@@ -58,13 +92,58 @@ func TestExecuteMultiShardWithResultRuns(t *testing.T) {
 	}
 	queries := []*querypb.BoundQuery{{Sql: "select id from user"}, {Sql: "select id from user"}}
 
-	result, runs, errs := sc.ExecuteMultiShardWithResultRuns(ctx, nil, rss, queries, econtext.NewSafeSession(nil), false, false, nullResultsObserver{}, false)
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseFirst:
+		default:
+			close(releaseFirst)
+		}
+	})
+	rss[0].Gateway = &blockingGateway{
+		Gateway: sbc0,
+		started: firstStarted,
+		release: releaseFirst,
+	}
+
+	observer := make(resultObserver, len(rss))
+	var (
+		result *sqltypes.Result
+		runs   []*sqltypes.Result
+		errs   []error
+	)
+	done := make(chan struct{})
+	go func() {
+		result, runs, errs = sc.ExecuteMultiShardWithResultRuns(ctx, nil, rss, queries, econtext.NewSafeSession(nil), false, false, observer, false)
+		close(done)
+	}()
+
+	select {
+	case <-firstStarted:
+	case <-time.After(30 * time.Second):
+		t.Fatal("first shard did not start")
+	}
+	select {
+	case observed := <-observer:
+		require.Same(t, run1, observed)
+	case <-time.After(30 * time.Second):
+		t.Fatal("second shard did not finish")
+	}
+	close(releaseFirst)
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("scatter execution did not finish")
+	}
+
 	require.Empty(t, errs)
 	require.Equal(t, []sqltypes.Row{run1.Rows[0], run1.Rows[1], run0.Rows[0], run0.Rows[1]}, result.Rows)
 	require.Len(t, runs, len(rss))
 	require.Same(t, run0, runs[0])
 	require.Same(t, run1, runs[1])
 
+	rss[0].Gateway = sbc0
 	sbc0.SetResults([]*sqltypes.Result{run0})
 	sbc1.MustFailCodes[vtrpcpb.Code_INTERNAL] = 1
 	result, runs, errs = sc.ExecuteMultiShardWithResultRuns(ctx, nil, rss, queries, econtext.NewSafeSession(nil), false, false, nullResultsObserver{}, false)

--- a/go/vt/vtgate/scatter_conn_result_runs_test.go
+++ b/go/vt/vtgate/scatter_conn_result_runs_test.go
@@ -37,11 +37,10 @@ import (
 type (
 	blockingGateway struct {
 		srvtopo.Gateway
-		started chan<- struct{}
 		release <-chan struct{}
 	}
 
-	resultObserver chan *sqltypes.Result
+	releaseObserver chan struct{}
 )
 
 func (g *blockingGateway) Execute(
@@ -54,7 +53,6 @@ func (g *blockingGateway) Execute(
 	reservedID int64,
 	options *querypb.ExecuteOptions,
 ) (*sqltypes.Result, error) {
-	close(g.started)
 	select {
 	case <-g.release:
 	case <-ctx.Done():
@@ -63,14 +61,18 @@ func (g *blockingGateway) Execute(
 	return g.Gateway.Execute(ctx, session, target, query, bindVariables, transactionID, reservedID, options)
 }
 
-func (o resultObserver) Observe(result *sqltypes.Result) {
-	o <- result
+func (o releaseObserver) Observe(*sqltypes.Result) {
+	select {
+	case <-o:
+	default:
+		close(o)
+	}
 }
 
 // TestExecuteMultiShardWithResultRuns proves successful shard results stay
 // aligned with shard order while the flat result keeps completion order.
 func TestExecuteMultiShardWithResultRuns(t *testing.T) {
-	ctx := utils.LeakCheckContext(t)
+	ctx := utils.LeakCheckContextTimeout(t, 30*time.Second)
 	const (
 		cell = "aa"
 		ks   = "TestExecuteMultiShardWithResultRuns"
@@ -92,50 +94,13 @@ func TestExecuteMultiShardWithResultRuns(t *testing.T) {
 	}
 	queries := []*querypb.BoundQuery{{Sql: "select id from user"}, {Sql: "select id from user"}}
 
-	firstStarted := make(chan struct{})
-	releaseFirst := make(chan struct{})
-	t.Cleanup(func() {
-		select {
-		case <-releaseFirst:
-		default:
-			close(releaseFirst)
-		}
-	})
+	releaseFirst := make(releaseObserver)
 	rss[0].Gateway = &blockingGateway{
 		Gateway: sbc0,
-		started: firstStarted,
 		release: releaseFirst,
 	}
 
-	observer := make(resultObserver, len(rss))
-	var (
-		result *sqltypes.Result
-		runs   []*sqltypes.Result
-		errs   []error
-	)
-	done := make(chan struct{})
-	go func() {
-		result, runs, errs = sc.ExecuteMultiShardWithResultRuns(ctx, nil, rss, queries, econtext.NewSafeSession(nil), false, false, observer, false)
-		close(done)
-	}()
-
-	select {
-	case <-firstStarted:
-	case <-time.After(30 * time.Second):
-		require.FailNow(t, "first shard did not start")
-	}
-	select {
-	case observed := <-observer:
-		require.Same(t, run1, observed)
-	case <-time.After(30 * time.Second):
-		require.FailNow(t, "second shard did not finish")
-	}
-	close(releaseFirst)
-	select {
-	case <-done:
-	case <-time.After(30 * time.Second):
-		require.FailNow(t, "scatter execution did not finish")
-	}
+	result, runs, errs := sc.executeMultiShardWithResultRuns(ctx, nil, rss, queries, econtext.NewSafeSession(nil), false, false, releaseFirst, false)
 
 	require.Empty(t, errs)
 	require.Equal(t, []sqltypes.Row{run1.Rows[0], run1.Rows[1], run0.Rows[0], run0.Rows[1]}, result.Rows)
@@ -146,7 +111,7 @@ func TestExecuteMultiShardWithResultRuns(t *testing.T) {
 	rss[0].Gateway = sbc0
 	sbc0.SetResults([]*sqltypes.Result{run0})
 	sbc1.MustFailCodes[vtrpcpb.Code_INTERNAL] = 1
-	result, runs, errs = sc.ExecuteMultiShardWithResultRuns(ctx, nil, rss, queries, econtext.NewSafeSession(nil), false, false, nullResultsObserver{}, false)
+	result, runs, errs = sc.executeMultiShardWithResultRuns(ctx, nil, rss, queries, econtext.NewSafeSession(nil), false, false, nullResultsObserver{}, false)
 	require.Len(t, errs, 1)
 	require.Len(t, result.Rows, 2)
 	require.Len(t, runs, len(rss))
@@ -159,7 +124,7 @@ func TestExecuteMultiShardWithResultRuns(t *testing.T) {
 func TestExecuteMultiShardWithResultRunsRejectsMismatchedInput(t *testing.T) {
 	rss := []*srvtopo.ResolvedShard{{}}
 
-	result, runs, errs := new(ScatterConn).ExecuteMultiShardWithResultRuns(
+	result, runs, errs := new(ScatterConn).executeMultiShardWithResultRuns(
 		t.Context(), nil, rss, nil, nil, false, false, nil, false,
 	)
 	require.Nil(t, result)

--- a/go/vt/vtgate/scatter_conn_result_runs_test.go
+++ b/go/vt/vtgate/scatter_conn_result_runs_test.go
@@ -18,6 +18,7 @@ package vtgate
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -45,6 +46,7 @@ func TestExecuteMultiShardWithResultRuns(t *testing.T) {
 	sc := newTestScatterConn(ctx, hc, newSandboxForCells(ctx, []string{cell}), cell)
 	sbc0 := hc.AddTestTablet(cell, "-80", 1, ks, "-80", topodatapb.TabletType_PRIMARY, true, 1, nil)
 	sbc1 := hc.AddTestTablet(cell, "80-", 1, ks, "80-", topodatapb.TabletType_PRIMARY, true, 1, nil)
+	sbc0.ExecDelayResponse = 10 * time.Millisecond
 	run0 := sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "1", "3")
 	run1 := sqltypes.MakeTestResult(sqltypes.MakeTestFields("id", "int64"), "2", "4")
 	sbc0.SetResults([]*sqltypes.Result{run0})
@@ -58,7 +60,7 @@ func TestExecuteMultiShardWithResultRuns(t *testing.T) {
 
 	result, runs, errs := sc.ExecuteMultiShardWithResultRuns(ctx, nil, rss, queries, econtext.NewSafeSession(nil), false, false, nullResultsObserver{}, false)
 	require.Empty(t, errs)
-	require.Len(t, result.Rows, 4)
+	require.Equal(t, []sqltypes.Row{run1.Rows[0], run1.Rows[1], run0.Rows[0], run0.Rows[1]}, result.Rows)
 	require.Len(t, runs, len(rss))
 	require.Same(t, run0, runs[0])
 	require.Same(t, run1, runs[1])


### PR DESCRIPTION
## Description

Non-streaming scatter routes currently flatten shard results and sort every returned row in VTGate, even when the planner sends a compatible `ORDER BY` to every shard.

This change keeps each successful shard result as an ordered run and uses the existing VTGate comparison rules to merge those runs. It keeps the current full-sort path when planner proof or complete run data is absent. It also keeps the full sort for small results, skips the merge tree for zero or one active run, rebuilds already global runs in shard order, and copies the last remaining run as one tail.

PR #20670 optimizes the existing streaming `MergeSort` path. This PR optimizes only non-streaming `Route.TryExecute`; the streaming execution path is unchanged.

This contribution comes from the public Perfloop case [Non-streaming scatter ordering resorts already ordered shard runs](https://app.perfloop.ai/t/oss/case_7jxxapcjj5).

Six alternating samples on an Apple M3 Max against the current `main` dependencies produced:

| Shards | Rows | `ns/op` |
| ---: | ---: | ---: |
| 2 | 1,024 | -47.5% |
| 2 | 8,192 | -66.0% |
| 8 | 1,024 | -33.5% |
| 8 | 8,192 | -64.6% |
| 32 | 1,024 | no significant change (`p=0.093`) |
| 32 | 8,192 | -44.0% |

The geometric-mean latency change was -48.4%. The geometric-mean memory changes were +0.33% bytes and +1.12% allocations. The 1, 4, and 8 rows-per-shard crossover points had no significant latency regression. With one row on every non-dominant shard, the path was neutral at 2 shards and faster at 8 and 32 shards.

The proof also includes a `testing/quick` property: merging random shard-sorted runs must equal the existing full sort. A channel-controlled concurrency test proves that flat rows can follow completion order while result runs stay in shard order.

Local checks:

```text
go test ./go/vt/vtgate/engine ./go/vt/vtgate/evalengine ./go/vt/vtgate/executorcontext ./go/vt/vtgate/planbuilder ./go/vt/vtgate -count=1
go vet ./go/vt/vtgate/engine ./go/vt/vtgate/evalengine ./go/vt/vtgate/executorcontext ./go/vt/vtgate/planbuilder ./go/vt/vtgate
go test ./go/vt/vtgate -run '^TestExecuteMultiShardWithResultRuns' -count=100
go test -race ./go/vt/vtgate -run '^TestExecuteMultiShardWithResultRuns' -count=20
tools/check_make_sizegen.sh
```

## Related Issue(s)

Fixes #20951.

## Checklist

- [x] No release backport is requested
- [x] Tests were added
- [x] New and modified tests pass consistently locally
- [x] User documentation is not required for this internal execution optimization

## Deployment Notes

No migration, flag, or deployment action is required. Unsupported or incomplete run data uses the existing full-sort path.

### AI Disclosure

OpenAI Codex generated substantial code, tests, benchmarks, and this pull request description. I directed the scope, inspected the final change, verified it locally, and take responsibility for the code and review feedback.