### PR TITLE
vtgate: drop join predicates pushed into UNION branches on merge

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/predicates/tracker.go
+++ b/go/vt/vtgate/planbuilder/operators/predicates/tracker.go
@@ -29,6 +29,10 @@ type (
 	Tracker struct {
 		lastID      ID
 		expressions map[ID]sqlparser.Expr
+
+		// derived maps a predicate to the predicates split out of it, so that skipping the
+		// original also skips the copies. A UNION splits one per source.
+		derived map[ID][]ID
 	}
 
 	// ID is a unique key that references the current expression a join predicate represents.
@@ -38,6 +42,7 @@ type (
 func NewTracker() *Tracker {
 	return &Tracker{
 		expressions: make(map[ID]sqlparser.Expr),
+		derived:     make(map[ID][]ID),
 	}
 }
 
@@ -68,6 +73,17 @@ func (t *Tracker) Get(id ID) (sqlparser.Expr, error) {
 	return expr, nil
 }
 
+// NewDerivedJoinPredicate creates a predicate that is a rewritten copy of the one identified by
+// parent, and that must stop being rendered whenever the parent does.
+func (t *Tracker) NewDerivedJoinPredicate(parent ID, org sqlparser.Expr) *JoinPredicate {
+	jp := t.NewJoinPredicate(org)
+	t.derived[parent] = append(t.derived[parent], jp.ID)
+	return jp
+}
+
 func (t *Tracker) Skip(id ID) {
 	t.expressions[id] = nil
+	for _, derivedID := range t.derived[id] {
+		t.Skip(derivedID)
+	}
 }

--- a/go/vt/vtgate/planbuilder/operators/predicates/tracker_test.go
+++ b/go/vt/vtgate/planbuilder/operators/predicates/tracker_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+func parseExpr(t *testing.T, in string) sqlparser.Expr {
+	t.Helper()
+	expr, err := sqlparser.NewTestParser().ParseExpr(in)
+	require.NoError(t, err)
+	return expr
+}
+
+// TestSkipCascadesToDerivedPredicates covers the shape a UNION produces: one predicate split
+// into a copy per branch. Once the outer query takes ownership of the original, none of the
+// copies may render, or the query is left referencing join bind variables nothing binds.
+func TestSkipCascadesToDerivedPredicates(t *testing.T) {
+	tracker := NewTracker()
+	original := tracker.NewJoinPredicate(parseExpr(t, ":user_id = sub.c"))
+	first := tracker.NewDerivedJoinPredicate(original.ID, parseExpr(t, ":user_id = 1"))
+	second := tracker.NewDerivedJoinPredicate(original.ID, parseExpr(t, ":user_id = 2"))
+
+	tracker.Skip(original.ID)
+
+	assert.Nil(t, original.Current())
+	assert.Nil(t, first.Current())
+	assert.Nil(t, second.Current())
+}
+
+// TestSkipCascadesThroughNestedDerivedPredicates covers a UNION nested inside another UNION,
+// which splits an already-split predicate again. The copies then form a chain rather than a
+// flat list, so skipping has to follow it all the way down.
+func TestSkipCascadesThroughNestedDerivedPredicates(t *testing.T) {
+	tracker := NewTracker()
+	original := tracker.NewJoinPredicate(parseExpr(t, ":user_id = sub.c"))
+	branch := tracker.NewDerivedJoinPredicate(original.ID, parseExpr(t, ":user_id = i1.c"))
+	leaf := tracker.NewDerivedJoinPredicate(branch.ID, parseExpr(t, ":user_id = 1"))
+
+	tracker.Skip(original.ID)
+
+	assert.Nil(t, original.Current())
+	assert.Nil(t, branch.Current())
+	assert.Nil(t, leaf.Current())
+}
+
+// TestSkipDerivedPredicateDoesNotAffectItsOrigin checks that the cascade only runs downwards.
+// Skipping one branch's copy says nothing about the original or about the sibling branches.
+func TestSkipDerivedPredicateDoesNotAffectItsOrigin(t *testing.T) {
+	tracker := NewTracker()
+	original := tracker.NewJoinPredicate(parseExpr(t, ":user_id = sub.c"))
+	first := tracker.NewDerivedJoinPredicate(original.ID, parseExpr(t, ":user_id = 1"))
+	second := tracker.NewDerivedJoinPredicate(original.ID, parseExpr(t, ":user_id = 2"))
+
+	tracker.Skip(first.ID)
+
+	assert.Nil(t, first.Current())
+	assert.Equal(t, ":user_id = sub.c", sqlparser.String(original.Current()))
+	assert.Equal(t, ":user_id = 2", sqlparser.String(second.Current()))
+}
+
+// TestSetDoesNotCascadeToDerivedPredicates pins a deliberate asymmetry with Skip. Set restores
+// the original, outer-scope shape of a predicate - `user.id = sub.c` - which references a column
+// that is not in scope inside a UNION branch. Each copy has been rewritten to the expressions of
+// the branch it was pushed into, and has to keep that rewrite.
+func TestSetDoesNotCascadeToDerivedPredicates(t *testing.T) {
+	tracker := NewTracker()
+	original := tracker.NewJoinPredicate(parseExpr(t, ":user_id = sub.c"))
+	branch := tracker.NewDerivedJoinPredicate(original.ID, parseExpr(t, ":user_id = 1"))
+
+	tracker.Set(original.ID, parseExpr(t, "user.id = sub.c"))
+
+	assert.Equal(t, "`user`.id = sub.c", sqlparser.String(original.Current()))
+	assert.Equal(t, ":user_id = 1", sqlparser.String(branch.Current()))
+}

--- a/go/vt/vtgate/planbuilder/operators/union.go
+++ b/go/vt/vtgate/planbuilder/operators/union.go
@@ -120,10 +120,13 @@ func (u *Union) predicatePerSource(ctx *plancontext.PlanningContext, expr sqlpar
 		predicate := expr
 
 		if jp, ok := predicate.(*predicates.JoinPredicate); ok {
-			// Create a new JoinPredicate for each source to keep tracking working
-			// We can't use `*JoinPredicate.Clone` here as that would update the tracker and overwrite
-			// the expression for the original predicate
-			predicate = ctx.PredTracker.NewJoinPredicate(jp.Current())
+			// Each source needs its own copy, since the column references below are rewritten to
+			// that source's expressions. We can't use `*JoinPredicate.Clone` here as that would
+			// update the tracker and overwrite the expression for the original predicate. The copy
+			// is registered against the original so that skipping the original skips it too -
+			// otherwise a join that later merges into a single route leaves these copies behind,
+			// referencing join bind variables that nothing binds.
+			predicate = ctx.PredTracker.NewDerivedJoinPredicate(jp.ID, jp.Current())
 		}
 
 		predicate = sqlparser.CopyOnRewrite(predicate, nil, func(cursor *sqlparser.CopyOnWriteCursor) {

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -4932,6 +4932,76 @@
     }
   },
   {
+    "comment": "a nested UNION splits the predicate twice, and both levels of copies are dropped on merge",
+    "query": "select user.col from user join ((select 1 as c from dual union all select 2 from dual) union all select 3 from dual) as sub on user.id = sub.c",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select user.col from user join ((select 1 as c from dual union all select 2 from dual) union all select 3 from dual) as sub on user.id = sub.c",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select `user`.col from `user`, (select 1 as c from dual where 1 != 1 union all select 2 from dual where 1 != 1 union all select 3 from dual where 1 != 1) as sub where 1 != 1",
+        "Query": "select `user`.col from `user`, (select 1 as c from dual union all select 2 from dual union all select 3 from dual) as sub where `user`.id = sub.c"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "the copies pushed into the UNION branches are kept when the join does not merge, since they are the only place the predicate is applied",
+    "query": "select unsharded.col from unsharded join (select id as c from user union all select user_id from user_extra) as sub on unsharded.id = sub.c",
+    "plan": {
+      "Type": "Join",
+      "QueryType": "SELECT",
+      "Original": "select unsharded.col from unsharded join (select id as c from user union all select user_id from user_extra) as sub on unsharded.id = sub.c",
+      "Instructions": {
+        "OperatorType": "Join",
+        "Variant": "Join",
+        "JoinColumnIndexes": "L:0",
+        "JoinVars": {
+          "unsharded_id": 1
+        },
+        "Inputs": [
+          {
+            "OperatorType": "Route",
+            "Variant": "Unsharded",
+            "Keyspace": {
+              "Name": "main",
+              "Sharded": false
+            },
+            "FieldQuery": "select unsharded.col, unsharded.id from unsharded where 1 != 1",
+            "Query": "select unsharded.col, unsharded.id from unsharded"
+          },
+          {
+            "OperatorType": "Route",
+            "Variant": "EqualUnique",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select 1 from (select id as c from `user` where 1 != 1 union all select user_id from user_extra where 1 != 1) as sub where 1 != 1",
+            "Query": "select 1 from (select id as c from `user` where id = :unsharded_id union all select user_id from user_extra where user_id = :unsharded_id) as sub",
+            "Values": [
+              ":unsharded_id"
+            ],
+            "Vindex": "user_index"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "main.unsharded",
+        "user.user",
+        "user.user_extra"
+      ]
+    }
+  },
+  {
     "comment": "a predicate local to the UNION is still pushed into its branches",
     "query": "select user.col from user join (select 1 as c from dual union all select 2 from dual) as sub on sub.c = 1",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/from_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/from_cases.json
@@ -4842,5 +4842,115 @@
         "Query": "select information_schema.`table`.col from information_schema.`table` order by information_schema.`table`.`name` asc"
       }
     }
+  },
+  {
+    "comment": "a join predicate pushed into the branches of a UNION is dropped again when the join merges into a single route",
+    "query": "select user.col from user join (select 1 as c from dual union all select 2 from dual) as sub on user.id = sub.c",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select user.col from user join (select 1 as c from dual union all select 2 from dual) as sub on user.id = sub.c",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select `user`.col from `user`, (select 1 as c from dual where 1 != 1 union all select 2 from dual where 1 != 1) as sub where 1 != 1",
+        "Query": "select `user`.col from `user`, (select 1 as c from dual union all select 2 from dual) as sub where `user`.id = sub.c"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "the same with three branches",
+    "query": "select user.col from user join (select 1 as c from dual union all select 2 from dual union all select 3 from dual) as sub on user.id = sub.c",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select user.col from user join (select 1 as c from dual union all select 2 from dual union all select 3 from dual) as sub on user.id = sub.c",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select `user`.col from `user`, (select 1 as c from dual where 1 != 1 union all select 2 from dual where 1 != 1 union all select 3 from dual where 1 != 1) as sub where 1 != 1",
+        "Query": "select `user`.col from `user`, (select 1 as c from dual union all select 2 from dual union all select 3 from dual) as sub where `user`.id = sub.c"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "the same for UNION DISTINCT",
+    "query": "select user.col from user join (select 1 as c from dual union select 2 from dual) as sub on user.id = sub.c",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select user.col from user join (select 1 as c from dual union select 2 from dual) as sub on user.id = sub.c",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select `user`.col from `user`, (select 1 as c from dual where 1 != 1 union select 2 from dual where 1 != 1) as sub where 1 != 1",
+        "Query": "select `user`.col from `user`, (select 1 as c from dual union select 2 from dual) as sub where `user`.id = sub.c"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "the same for a LEFT JOIN",
+    "query": "select user.col from user left join (select 1 as c from dual union all select 2 from dual) as sub on user.id = sub.c",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select user.col from user left join (select 1 as c from dual union all select 2 from dual) as sub on user.id = sub.c",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select `user`.col from `user` left join (select 1 as c from dual where 1 != 1 union all select 2 from dual where 1 != 1) as sub on `user`.id = sub.c where 1 != 1",
+        "Query": "select `user`.col from `user` left join (select 1 as c from dual union all select 2 from dual) as sub on `user`.id = sub.c"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
+  },
+  {
+    "comment": "a predicate local to the UNION is still pushed into its branches",
+    "query": "select user.col from user join (select 1 as c from dual union all select 2 from dual) as sub on sub.c = 1",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select user.col from user join (select 1 as c from dual union all select 2 from dual) as sub on sub.c = 1",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select `user`.col from `user`, (select 1 as c from dual where 1 != 1 union all select 2 from dual where 1 != 1) as sub where 1 != 1",
+        "Query": "select `user`.col from `user`, (select 1 as c from dual where 1 = 1 union all select 2 from dual where 2 = 1) as sub"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Description

A join predicate pushed into the branches of a `UNION` was never removed when the join later merged into a single `Route`, so the generated query referenced join bind variables that the plan never binds.

```sql
select user.col from user join (select 1 as c from dual union all select 2 from dual) as sub on user.id = sub.c
```

Before, note `:user_id` and `:sub_c` in a single `Route` with no `JoinVars`:

```sql
select `user`.col from `user`, (select 1 as c from dual where :user_id = :sub_c /* INT64 */
                                union all select 2 from dual where :user_id = :sub_c /* INT64 */) as sub
                   where `user`.id = sub.c
```

After, matching what the equivalent non-union derived table already produced:

```sql
select `user`.col from `user`, (select 1 as c from dual union all select 2 from dual) as sub
                   where `user`.id = sub.c
```

### How it works

`predicates.Tracker` is already built for this: a `JoinPredicate` renders through `tracker.expressions[ID]`, so one `Skip` stops every copy from rendering, and `buildApplyJoin` calls `Skip` when it puts the original predicate back in the outer query.

The gap was that `Union.predicatePerSource` mints a fresh ID per branch (each branch rewrites the column references to its own expressions) without linking those IDs back to the original, so only the original was ever skipped. This registers each copy against the original and cascades `Skip` to them.

`Union` is the only operator that fans one predicate out into several copies, so this is the only place that needs the link.

`Set` is deliberately **not** cascaded, it restores the original expression, and pushing `user.id = sub.c` into a branch would reference a column that is not in scope there. It also runs speculatively: `tryMergeApplyJoin` sets the original shape and puts the old one back on `NoRewrite`, and that restore only knows about the IDs it captured. `Skip` is the right semantic: the outer query has taken ownership of the predicate, so the copies should stop rendering.

The recursion terminates by construction: `NewDerivedJoinPredicate` always allocates from `nextID()`, so a copy's ID is strictly greater than its parent's and no cycle can form.

### Testing

Seven golden plan cases in `from_cases.json`:

-   two, three and `DISTINCT` branches, and `LEFT JOIN`. These four fail without the fix.
-   a nested `UNION` (`((a union all b) union all c)`), which splits an already-split predicate. It is the only case that covers the recursion in `Skip`: it fails without the fix, and it still fails if the cascade is flattened to a single level.
-   a join that does **not** merge (`unsharded` against a `UNION` over `user`/`user_extra`). The copies are then the only place the predicate is applied, so they have to survive. The plan pins `JoinVars`, both branch predicates, and the branch route's `EqualUnique` + `Values`, which are all derived from a copy. This is the case that fails if `Skip` ever over-cascades.
-   a predicate local to the union (`on sub.c = 1`). This one never becomes a `JoinPredicate` at all, so it does not exercise the cascade, it just pins that ordinary union predicate pushing is untouched.

`operators/predicates` had no tests at all, so there are now unit tests for the tracker: the one-level cascade, the transitive cascade, that the cascade only runs downwards, and that `Set` is not cascaded. That last one is the only part of the design that the golden plans cannot show.

No existing golden plan changed, which also explains how this survived: nothing in `testdata` covered the shape.

## Related Issue(s)

Fixes #20955

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

### Backport justification

The planner emits a query containing bind variables that nothing binds, so the query fails at execution rather than returning wrong rows. `predicates.Tracker` was introduced in #17877, which shipped in v22, so every release since has this bug. v22 is out of support, hence `release-23.0` and `release-24.0`.

## Deployment Notes

None.

### AI Disclosure

Written with the help of Claude Code. I provided the direction and the review.
