### PR TITLE
fix(vstreamer): bound rowstreamer per-stream row buffer retention

### DIFF
--- a/go/vt/vttablet/tabletserver/vstreamer/packet_size.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/packet_size.go
@@ -111,6 +111,9 @@ type dynamicPacketSizer struct {
 	// grow is the growth rate with which we adjust the packet size
 	grow int
 
+	// maxSize bounds candidateSize growth; see #20954.
+	maxSize int
+
 	// calls is the amount of calls to the packet sizer
 	calls int
 
@@ -121,6 +124,8 @@ type dynamicPacketSizer struct {
 	elapsed time.Duration
 }
 
+const dynamicPacketSizerMaxGrowthFactor = 16
+
 func newDynamicPacketSizer(baseSize int) PacketSizer {
 	return &dynamicPacketSizer{
 		currentSize:      baseSize,
@@ -128,6 +133,14 @@ func newDynamicPacketSizer(baseSize int) PacketSizer {
 		candidateMetrics: &mathstats.Sample{},
 		candidateSize:    baseSize,
 		grow:             baseSize / 4,
+		maxSize:          baseSize * dynamicPacketSizerMaxGrowthFactor,
+	}
+}
+
+func (ps *dynamicPacketSizer) growCandidate() {
+	ps.candidateSize += ps.grow
+	if ps.maxSize > 0 && ps.candidateSize > ps.maxSize {
+		ps.candidateSize = ps.maxSize
 	}
 }
 
@@ -209,7 +222,7 @@ func (ps *dynamicPacketSizer) Record(byteCount int, d time.Duration) {
 				ps.settled = true
 			} else {
 				if change == notChanging && ps.calls%GrowthFrequency == 0 {
-					ps.candidateSize += ps.grow
+					ps.growCandidate()
 				}
 			}
 
@@ -217,7 +230,7 @@ func (ps *dynamicPacketSizer) Record(byteCount int, d time.Duration) {
 			ps.candidateMetrics, ps.currentMetrics = ps.currentMetrics, ps.candidateMetrics
 			ps.candidateMetrics.Clear()
 
-			ps.candidateSize += ps.grow
+			ps.growCandidate()
 			ps.currentSize = ps.candidateSize
 		}
 	}

--- a/go/vt/vttablet/tabletserver/vstreamer/packet_size_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/packet_size_test.go
@@ -23,7 +23,18 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestDynamicPacketSizerMaxSize(t *testing.T) {
+	base := 25000
+	ps := newDynamicPacketSizer(base).(*dynamicPacketSizer)
+	for range 1000 {
+		ps.growCandidate()
+	}
+	require.Equal(t, base*dynamicPacketSizerMaxGrowthFactor, ps.candidateSize)
+	require.LessOrEqual(t, ps.candidateSize, ps.maxSize)
+}
 
 type polynomial []float64
 

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer.go
@@ -45,6 +45,8 @@ import (
 
 var rowStreamertHeartbeatInterval = 10 * time.Second
 
+const maxRetainedPoolBytes = 4 << 20 // 4 MiB; see #20954
+
 type RowStreamerMode int32
 
 const (
@@ -424,10 +426,11 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 	}()
 
 	var (
-		response binlogdatapb.VStreamRowsResponse
-		rows     []*querypb.Row
-		rowCount int
-		mysqlrow []sqltypes.Value
+		response  binlogdatapb.VStreamRowsResponse
+		rows      []*querypb.Row
+		rowCount  int
+		mysqlrow  []sqltypes.Value
+		poolBytes int // retained cap (Values + Lengths) across the reused rows
 	)
 
 	lastpk := make([]sqltypes.Value, len(rs.pkColumns))
@@ -477,7 +480,9 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 			if rowCount >= len(rows) {
 				rows = append(rows, &querypb.Row{})
 			}
+			prevCap := cap(rows[rowCount].Values) + cap(rows[rowCount].Lengths)*8
 			byteCount += sqltypes.RowToProto3Inplace(filtered, rows[rowCount])
+			poolBytes += cap(rows[rowCount].Values) + cap(rows[rowCount].Lengths)*8 - prevCap
 			rowCount++
 		}
 
@@ -495,6 +500,10 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 			rs.pktsize.Record(byteCount, time.Since(startSend))
 			rowCount = 0
 			byteCount = 0
+			var dropped bool
+			if rows, poolBytes, dropped = trimRowPool(rows, poolBytes, maxRetainedPoolBytes); dropped {
+				response.Rows = nil // release the dropped pool's backing array
+			}
 		}
 	}
 
@@ -510,6 +519,15 @@ func (rs *rowStreamer) streamQuery(send func(*binlogdatapb.VStreamRowsResponse) 
 	}
 
 	return nil
+}
+
+// trimRowPool drops the whole reused row pool once retained capacity exceeds
+// budget (an O(1) reset, not a walk). Call only after the packet is sent.
+func trimRowPool(rows []*querypb.Row, poolBytes, budget int) (_ []*querypb.Row, newPoolBytes int, dropped bool) {
+	if poolBytes <= budget {
+		return rows, poolBytes, false
+	}
+	return nil, 0, true
 }
 
 func GetVReplicationMaxExecutionTimeQueryHint(copyPhaseDuration time.Duration) string {

--- a/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
+++ b/go/vt/vttablet/tabletserver/vstreamer/rowstreamer_test.go
@@ -36,6 +36,7 @@ import (
 	vttablet "vitess.io/vitess/go/vt/vttablet/common"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	querypb "vitess.io/vitess/go/vt/proto/query"
 )
 
 // TestRowStreamerQuery validates that the correct force index hint and order by is added to the rowstreamer query.
@@ -770,4 +771,20 @@ func expectStreamError(t *testing.T, query string, want string) {
 		return nil
 	}, nil)
 	require.EqualError(t, err, want, "Got incorrect error")
+}
+
+func TestTrimRowPool(t *testing.T) {
+	rows := []*querypb.Row{{Values: make([]byte, 0, 1024)}, {Values: make([]byte, 0, 2048)}}
+
+	// Under budget: the pool and poolBytes are unchanged, not dropped.
+	kept, poolBytes, dropped := trimRowPool(rows, 3072, 4096)
+	require.False(t, dropped)
+	require.Equal(t, 3072, poolBytes)
+	require.Len(t, kept, 2)
+
+	// Over budget: the whole pool is dropped and poolBytes resets to 0.
+	kept, poolBytes, dropped = trimRowPool(rows, 5000, 4096)
+	require.True(t, dropped)
+	require.Equal(t, 0, poolBytes)
+	require.Nil(t, kept)
 }


### PR DESCRIPTION
## Description

Prototype fix for #20954.

A tablet serving `VStreamRows` (`rowStreamer.streamQuery`) keeps a grow-only `rows []*querypb.Row` pool for the lifetime of the stream and reuses each `*querypb.Row` in place via `sqltypes.RowToProto3Inplace`, which resets slice length but keeps capacity. So each pooled slot retains the high-water mark of every row it has ever encoded, and total retention becomes Σ(per-slot max) rather than ~one packet. On wide-row tables (mix of small and large JSON/BLOB rows) this grows to many multiples of the working set and is not GC-reclaimable while the stream runs.

This affects the tablet being streamed from: the source shard in a VReplication/Reshard copy, and both the source and target shard tablets during a VDiff.

## Changes

- **`rowstreamer.go`**: after each `safeSend` (which has serialized the response), release the backing arrays of any pooled `Row` whose `Values` capacity exceeds `maxRetainedRowBufferBytes` (1 MiB). Sub-threshold rows keep their buffers, preserving the in-place encoding reuse for the common small-row case; only oversized outliers are shed. Safe because the send serializes before returning — the same invariant the code already relies on to reuse `rows` on the next packet.
- **`packet_size.go`**: clamp the dynamic packet sizer so `candidateSize` cannot grow without bound (`candidateSize += grow` at two sites had no upper limit). Bounded at `dynamicPacketSizerMaxGrowthFactor` (16x) the base size.

## Reproduction

Self-contained repro (links the real, unmodified `sqltypes.RowToProto3Inplace`): https://gist.github.com/pedroalb/f34053445f80e61e50877682fe9a3f1a — buggy path retains 162x the working set; the trim keeps it at ~1x.

## Tests

- `TestReleaseOversizedRows` — sub-threshold and at-threshold buffers kept, oversized released.
- `TestDynamicPacketSizerMaxSize` — `candidateSize` growth is clamped at `maxSize`.

## Notes / open questions for reviewers

- **Draft**: seeking direction before finalizing.
- The 1 MiB threshold and the 16x packet-size clamp are first-pass constants — open to tying the threshold to the configured packet size, and to a different clamp bound.
- The `vstreamer` package's `TestMain` starts MySQL, so the two new unit tests are compile-verified locally and run in CI.

### Backport reason

This is a memory-safety fix for a long-standing over-retention in the row streamer that can drive a tablet serving `VStreamRows` toward OOM during VReplication/Reshard copy phases and VDiffs on wide-row tables. The tablet at risk is the one being streamed from — the source shard in a copy, and both the source and target shard tablets during a VDiff.

The affected code path (`RowToProto3Inplace` in-place reuse plus the grow-only `rows[]` pool) is present unchanged on `release-23.0` and `release-24.0`, and the bug reproduces on each (`make repro REF=release-23.0` / `release-24.0`). It should be backported to both supported branches: covering both means an upgrade from an older release lands on a version that already has the fix, so the OOM does not reappear on upgrade (a fix present on only some supported branches would itself be an upgrade regression).

The change is low-risk and self-contained — no API, wire, schema, or flag change, and it preserves the in-place encoding benefit for the common small-row case — so backport risk is low.
