### PR TITLE
Fix typos in comments

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Plese ensure dev.env is written in a way which is POSIX (bourne)
+# Please ensure dev.env is written in a way which is POSIX (bourne)
 # shell compatible.
 # - Some build systems like rpm require the different scriptlets used
 #   to build a package to be run under a POSIX shell so non-POSIX

--- a/go/vt/vtgate/plan_execute.go
+++ b/go/vt/vtgate/plan_execute.go
@@ -95,7 +95,7 @@ func (e *Executor) newExecute(
 			// -- IF we don't see a newer vschema come in -- affects how long we retry in total and how quickly
 			// we retry the query and (should) succeed when the traffic switch fails or we otherwise hit the
 			// max buffer failover time without resolving the keyspace event and marking it as consistent.
-			// This calculation attemps to ensure that we retry at a sensible interval and number of times
+			// This calculation attempts to ensure that we retry at a sensible interval and number of times
 			// based on the buffering configuration. This way we should be able to perform the max retries
 			// within the given window of time for most queries and we should not end up waiting too long
 			// after the traffic switch fails or the buffer window has ended, retrying old queries.
@@ -118,7 +118,7 @@ func (e *Executor) newExecute(
 		// result of MoveTables SwitchTraffic which does a RebuildSrvVSchema which in turn causes
 		// the vtgate to clear the cached plans when processing the new serving vschema.
 		// When buffering ends, many queries might be getting planned at the same time and we then
-		// take full advatange of the cached plan.
+		// take full advantage of the cached plan.
 		plan, vcursor, stmt, err = e.fetchOrCreatePlan(ctx, safeSession, sql, bindVars, parameterize, prepared, logStats, true)
 		execStart := e.logPlanningFinished(logStats, plan)
 

--- a/go/vt/vtgate/vstream_manager.go
+++ b/go/vt/vtgate/vstream_manager.go
@@ -917,7 +917,7 @@ func (vs *vstream) streamFromTablet(ctx context.Context, sgtid *binlogdatapb.Sha
 						var endTimer *time.Timer
 						if vs.stopOnReshard {
 							// We're going to be ending the tablet stream, along with the VStream, so
-							// we ensure a reasonable minimum amount of time is alloted for clients
+							// we ensure a reasonable minimum amount of time is allotted for clients
 							// to Recv the journal event before the VStream's context is cancelled
 							// (which would cause the grpc SendMsg or RecvMsg to fail). If the client
 							// doesn't Recv the journal event before the VStream ends then they'll
@@ -1022,7 +1022,7 @@ func (vs *vstream) streamFromTablet(ctx context.Context, sgtid *binlogdatapb.Sha
 // maybeUpdateTableNames updates table names when the ExcludeKeyspaceFromTableName flag is disabled.
 // If we're streaming from multiple keyspaces, updating the table names by inserting the keyspace will disambiguate
 // duplicate table names. If we enable the ExcludeKeyspaceFromTableName flag to not update the table names, there is no need to
-// clone the entire event, whcih improves performance. This is typically safely used by clients only streaming one keyspace.
+// clone the entire event, which improves performance. This is typically safely used by clients only streaming one keyspace.
 func maybeUpdateTableName(event *binlogdatapb.VEvent, keyspace string, excludeKeyspaceFromTableName bool,
 	tableNameExtractor func(ev *binlogdatapb.VEvent) *string,
 ) *binlogdatapb.VEvent {

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -330,7 +330,7 @@ func Init(
 	}
 
 	// We need to get the keyspaces and rebuild the keyspace graphs
-	// before we make the topo-server read-only incase we are filtering by
+	// before we make the topo-server read-only in case we are filtering by
 	// keyspaces.
 	var keyspaces []string
 	if discovery.FilteringKeyspaces() {

--- a/tools/e2e_test_cluster.sh
+++ b/tools/e2e_test_cluster.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# These test uses excutables and launch them as process
+# These test uses executables and launch them as process
 # After that all tests run, here we are testing those
 
 # All Go packages with test files.


### PR DESCRIPTION
## Description

Comment-only typo fixes found with codespell. No functional changes; identifiers and user-facing strings are untouched.

- `attemps` -> `attempts`, `advatange` -> `advantage` (go/vt/vtgate/plan_execute.go)
- `alloted` -> `allotted`, `whcih` -> `which` (go/vt/vtgate/vstream_manager.go)
- `incase` -> `in case` (go/vt/vtgate/vtgate.go)
- `excutables` -> `executables` (tools/e2e_test_cluster.sh)
- `Plese` -> `Please` (dev.env)

## Related Issue(s)

N/A

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required