### PR TITLE
vtbackup/clone: disable super_read_only before CLONE INSTANCE

### DIFF
--- a/go/test/endtoend/backup/clone/backup_test.go
+++ b/go/test/endtoend/backup/clone/backup_test.go
@@ -130,9 +130,7 @@ func vtbackupWithClone(t *testing.T) error {
 	// Boot the recipient mysqld with super-read-only enabled, mirroring the
 	// stock mycnf templates used in production. The init_db file restores the
 	// boot value at the end of initialization, so the recipient is read-only
-	// when the clone starts. CLONE INSTANCE is a write statement that
-	// super_read_only blocks for every user, so this exercises ExecuteClone
-	// disabling super_read_only before cloning.
+	// when the clone starts.
 	sroCnf := path.Join(t.TempDir(), "super_read_only.cnf")
 	require.NoError(t, os.WriteFile(sroCnf, []byte("super-read-only = 1\n"), 0o666))
 	extraMyCnf := sroCnf
@@ -141,6 +139,13 @@ func vtbackupWithClone(t *testing.T) error {
 		extraMyCnf = existing + ":" + sroCnf
 	}
 	t.Setenv("EXTRA_MY_CNF", extraMyCnf)
+
+	// Build a recipient-specific init DB file that also creates an extra user
+	// database, reproducing the production failure mode: a recipient initialized
+	// with --init-db-sql-file containing CREATE DATABASE boots super-read-only,
+	// and CLONE INSTANCE cannot drop the database (errno 1290). Without the
+	// fix to disable super_read_only before cloning, this test fails.
+	vtbackupInitDB := buildVtbackupInitDBFile(t, newInitDBFile)
 
 	extraArgs := []string{
 		"--allow-first-backup",
@@ -158,7 +163,30 @@ func vtbackupWithClone(t *testing.T) error {
 	}
 
 	log.Info(fmt.Sprintf("Starting vtbackup with clone args: %v", extraArgs))
-	return localCluster.StartVtbackup(newInitDBFile, false, keyspaceName, shardName, cell, extraArgs...)
+	return localCluster.StartVtbackup(vtbackupInitDB, false, keyspaceName, shardName, cell, extraArgs...)
+}
+
+// buildVtbackupInitDBFile creates a copy of the base init DB file that also
+// creates an extra user database, mirroring an operator-supplied
+// --init-db-sql-file with a CREATE DATABASE statement. The database is
+// created while super_read_only is OFF (during init), then super_read_only is
+// restored to the boot value, so CLONE INSTANCE must drop it under
+// super_read_only.
+func buildVtbackupInitDBFile(t *testing.T, baseFile string) string {
+	content, err := os.ReadFile(baseFile)
+	require.NoError(t, err)
+
+	const restoreStmt = "SET GLOBAL super_read_only=IFNULL(@original_super_read_only, 'ON')"
+	idx := strings.LastIndex(string(content), restoreStmt)
+	require.NotEqual(t, -1, idx, "could not find super_read_only restore in init DB file")
+
+	updated := string(content[:idx]) +
+		"CREATE DATABASE IF NOT EXISTS extra_clone_test;\n" +
+		string(content[idx:])
+
+	vtbackupInitDB := path.Join(t.TempDir(), "init_db_vtbackup.sql")
+	require.NoError(t, os.WriteFile(vtbackupInitDB, []byte(updated), 0o666))
+	return vtbackupInitDB
 }
 
 func verifyBackupCount(t *testing.T, shardKsName string, expected int) []string {

--- a/go/test/endtoend/backup/clone/backup_test.go
+++ b/go/test/endtoend/backup/clone/backup_test.go
@@ -19,6 +19,7 @@ package clone
 import (
 	"fmt"
 	"os"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -125,6 +126,21 @@ func vtbackupWithClone(t *testing.T) error {
 	mysqlSocket, err := os.CreateTemp("", "vtbackup_clone_test_mysql.sock")
 	require.NoError(t, err)
 	defer os.Remove(mysqlSocket.Name())
+
+	// Boot the recipient mysqld with super-read-only enabled, mirroring the
+	// stock mycnf templates used in production. The init_db file restores the
+	// boot value at the end of initialization, so the recipient is read-only
+	// when the clone starts. CLONE INSTANCE is a write statement that
+	// super_read_only blocks for every user, so this exercises ExecuteClone
+	// disabling super_read_only before cloning.
+	sroCnf := path.Join(t.TempDir(), "super_read_only.cnf")
+	require.NoError(t, os.WriteFile(sroCnf, []byte("super-read-only = 1\n"), 0o666))
+	extraMyCnf := sroCnf
+	if existing := os.Getenv("EXTRA_MY_CNF"); existing != "" {
+		// Append last so super-read-only wins over any earlier settings.
+		extraMyCnf = existing + ":" + sroCnf
+	}
+	t.Setenv("EXTRA_MY_CNF", extraMyCnf)
 
 	extraArgs := []string{
 		"--allow-first-backup",

--- a/go/vt/mysqlctl/clone.go
+++ b/go/vt/mysqlctl/clone.go
@@ -300,6 +300,18 @@ func (c *CloneExecutor) ExecuteClone(ctx context.Context, mysqld MysqlDaemon, my
 
 	log.Info(fmt.Sprintf("Starting CLONE REMOTE from %s:%d", c.DonorHost, c.DonorPort))
 
+	// CLONE INSTANCE is a write statement on the recipient, and super_read_only
+	// blocks it for every user — no privilege (SUPER, CONNECTION_ADMIN, ...)
+	// bypasses it. The recipient commonly boots read-only: the stock mycnf
+	// templates enable super-read-only, and init_db scripts restore that value
+	// at the end of initialization. Disable it explicitly before cloning rather
+	// than relying on the init flow to leave the instance writable. There is no
+	// need to restore it afterwards: mysqld restarts when CLONE completes, which
+	// re-applies the configured value.
+	if _, err := mysqld.SetSuperReadOnly(ctx, false); err != nil {
+		return vterrors.Wrap(err, "failed to disable super_read_only before clone")
+	}
+
 	// Set the valid donor list
 	donorAddr := fmt.Sprintf("%s:%d", c.DonorHost, c.DonorPort)
 	setDonorListQuery := fmt.Sprintf("SET GLOBAL clone_valid_donor_list = '%s'", donorAddr)

--- a/go/vt/mysqlctl/clone.go
+++ b/go/vt/mysqlctl/clone.go
@@ -301,15 +301,28 @@ func (c *CloneExecutor) ExecuteClone(ctx context.Context, mysqld MysqlDaemon, my
 	log.Info(fmt.Sprintf("Starting CLONE REMOTE from %s:%d", c.DonorHost, c.DonorPort))
 
 	// CLONE INSTANCE is a write statement on the recipient, and super_read_only
-	// blocks it for every user — no privilege (SUPER, CONNECTION_ADMIN, ...)
-	// bypasses it. The recipient commonly boots read-only: the stock mycnf
-	// templates enable super-read-only, and init_db scripts restore that value
-	// at the end of initialization. Disable it explicitly before cloning rather
-	// than relying on the init flow to leave the instance writable. There is no
-	// need to restore it afterwards: mysqld restarts when CLONE completes, which
-	// re-applies the configured value.
-	if _, err := mysqld.SetSuperReadOnly(ctx, false); err != nil {
+	// blocks it for every user with no privilege (SUPER, CONNECTION_ADMIN, ...)
+	// bypass. The recipient commonly boots read-only: the stock mycnf templates
+	// enable super-read-only, and init_db scripts restore that value at the end
+	// of initialization. Disable it explicitly before cloning rather than
+	// relying on the init flow to leave the instance writable.
+	//
+	// Defer the reset closure so a failure before mysqld restarts (e.g. setting
+	// clone_valid_donor_list, or CLONE INSTANCE being rejected) restores the
+	// original super_read_only value instead of leaving the recipient writable
+	// while the tablet restore path aborts back to serving. After a successful
+	// CLONE, mysqld restarts and re-applies the configured value from my.cnf, so
+	// restoring the captured value is harmless.
+	resetSuperReadOnly, err := mysqld.SetSuperReadOnly(ctx, false)
+	if err != nil {
 		return vterrors.Wrap(err, "failed to disable super_read_only before clone")
+	}
+	if resetSuperReadOnly != nil {
+		defer func() {
+			if err := resetSuperReadOnly(); err != nil {
+				log.Error("failed to restore super_read_only after clone", slog.Any("error", err))
+			}
+		}()
 	}
 
 	// Set the valid donor list

--- a/go/vt/mysqlctl/clone_test.go
+++ b/go/vt/mysqlctl/clone_test.go
@@ -705,6 +705,38 @@ func TestCloneFromDonor(t *testing.T) {
 			wantErr:         false,
 		},
 		{
+			name:            "disables super_read_only before clone",
+			cloneFromTablet: "cell1-100",
+			setup: func(t *testing.T, env *cloneFromDonorTestEnv) {
+				// The recipient booted read-only (e.g. super-read-only in my.cnf,
+				// restored at the end of init_db.sql). CLONE INSTANCE is a write
+				// statement that super_read_only blocks for every user, so
+				// ExecuteClone must disable it before cloning.
+				env.mysqld.SuperReadOnly.Store(true)
+				env.mysqld.ReadOnly = true
+				env.mysqld.ExecuteSuperQueryListCallback = func() {
+					// Fires for SET GLOBAL clone_valid_donor_list and for the
+					// CLONE command: super_read_only must already be off.
+					assert.False(t, env.mysqld.SuperReadOnly.Load(), "super_read_only must be disabled before CLONE runs")
+				}
+			},
+			wantErr: false,
+			assertResult: func(t *testing.T, env *cloneFromDonorTestEnv) {
+				assert.False(t, env.mysqld.SuperReadOnly.Load())
+			},
+		},
+		{
+			name:            "fails when super_read_only cannot be disabled",
+			cloneFromTablet: "cell1-100",
+			setup: func(t *testing.T, env *cloneFromDonorTestEnv) {
+				env.mysqld.SetSuperReadOnlyError = assert.AnError
+				// Neither the donor-list SET nor the CLONE command may execute.
+				env.mysqld.ExpectedExecuteSuperQueryList = []string{}
+			},
+			wantErr:         true,
+			wantErrContains: "failed to disable super_read_only before clone",
+		},
+		{
 			name:            "ERRestartServerFailed triggers manual restart and succeeds",
 			cloneFromTablet: "cell1-100",
 			setup: func(t *testing.T, env *cloneFromDonorTestEnv) {

--- a/go/vt/mysqlctl/clone_test.go
+++ b/go/vt/mysqlctl/clone_test.go
@@ -722,7 +722,28 @@ func TestCloneFromDonor(t *testing.T) {
 			},
 			wantErr: false,
 			assertResult: func(t *testing.T, env *cloneFromDonorTestEnv) {
-				assert.False(t, env.mysqld.SuperReadOnly.Load())
+				// super_read_only is restored to its original (boot) value once the
+				// clone finishes and mysqld restarts, re-applying the configured
+				// value from my.cnf.
+				assert.True(t, env.mysqld.SuperReadOnly.Load())
+			},
+		},
+		{
+			name:            "restores super_read_only when donor list set fails",
+			cloneFromTablet: "cell1-100",
+			setup: func(t *testing.T, env *cloneFromDonorTestEnv) {
+				env.mysqld.SuperReadOnly.Store(true)
+				env.mysqld.ReadOnly = true
+				donorListQuery := fmt.Sprintf("SET GLOBAL clone_valid_donor_list = '%s:%d'", env.donorHost, env.donorPort)
+				env.mysqld.ExpectedExecuteSuperQueryList = []string{}
+				env.mysqld.ExecuteSuperQueryErrorMap = map[string]error{
+					donorListQuery: assert.AnError,
+				}
+			},
+			wantErr:         true,
+			wantErrContains: "failed to set clone_valid_donor_list",
+			assertResult: func(t *testing.T, env *cloneFromDonorTestEnv) {
+				assert.True(t, env.mysqld.SuperReadOnly.Load(), "super_read_only must be restored when the clone aborts before mysqld restarts")
 			},
 		},
 		{


### PR DESCRIPTION
## Description

`CLONE INSTANCE` replaces all data on the recipient, so it needs to drop any existing databases. `super_read_only` blocks that for every user with no privilege bypass, so the clone fails with errno 1290 whenever the recipient boots read-only with user databases present.

OSS testing never hit this because the default `config/mycnf/` templates boot `super-read-only` but no extra databases are created, so there is nothing for CLONE to drop. In production, operators commonly pass `--init-db-sql-file` with a `CREATE DATABASE` statement, and CLONE then fails trying to drop it.

This PR disables `super_read_only` before executing `CLONE INSTANCE`, matching the existing patterns in vtbackup's `initial_backup` path, `ExecuteBackupInitSQL`, and the mysqlshell backup engine. No restore is needed afterwards: mysqld restarts when CLONE completes and re-applies the configured value from my.cnf.

## Related Issue(s)

Fixes #21000

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be backported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

`vtbackup --restore-with-clone` now succeeds on recipients that boot with `super-read-only` enabled and have user databases (e.g. from `--init-db-sql-file` with `CREATE DATABASE`). Previously this failed deterministically with errno 1290. The recipient is briefly writable while the CLONE runs, then mysqld restarts and re-applies the configured `super_read_only` value from my.cnf.

### AI Disclosure

Most of this was written by Claude Code. I provided direction.
