### PR TITLE
VTGate: Route single-valued information_schema IN predicates like equality

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -267,6 +267,16 @@ because the routing rewrite cannot carry a multi-schema filter. Split the
 query per schema or use equality predicates as a workaround; issue #20974
 tracks restoring support for that shape.
 
+Two `=` behaviors change as well. Contradictory predicates on the same
+table-name column (`table_name = 'a' AND table_name = 'b'`) previously collapsed
+to the last value and returned its rows; they now return the empty result they
+describe. A query with several table-name predicates naming routed tables
+(routing rules, or tables mid-`MoveTables`) previously honored only whichever
+predicate it evaluated first and left the other names unrewritten. Every routed
+name is now rewritten, so tables in one keyspace return complete results, and
+tables in different keyspaces fail with an explicit `cannot send the query to
+multiple keyspace` error instead of routing unpredictably.
+
 #### <a id="vtgate-streamexecute-real-errors"/>Streaming errors no longer surface as connection loss</a>
 
 Streaming queries (under `SET workload = 'OLAP'`, multi-statement batches, and prepared-statement execution) previously returned `ERROR 2013 (HY000): Lost connection to MySQL server during query` and tore down the underlying TCP connection whenever the streaming handler returned an error *after* the first row or field packet had been emitted. VTGate now writes a proper ERR packet in place of the result-set terminator, so the real error code and message reach the client and the connection remains usable for subsequent queries.

--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -249,11 +249,14 @@ The VTGate flag prevents cross-keyspace reads globally, regardless of per-keyspa
 An `IN` predicate on `table_schema` or `table_name` in an `information_schema`
 query previously bypassed schema-name routing entirely and silently returned
 an empty or incomplete result (issue #20878) — the form ORMs such as Rails
-now generate. A single-valued `IN` (literal list of one, or a bound list with
-one value) now routes exactly like the equivalent `=` predicate. A bound
-`IN` list (the form produced by vtgate's query normalization) naming more
-than one schema cannot be routed to a single keyspace and now fails with an
-explicit `VT12001` error instead of returning wrong rows.
+now generate. A single-valued `IN` (a literal list of one, a bound list with
+one value, or a prepared statement's `IN (?)`) now routes exactly like the
+equivalent `=` predicate, including routed-table handling for `table_name`.
+Any predicate naming more than one schema — a multi-value `IN` list in any of
+those forms, or an `OR` of schema equalities, which plans identically — cannot
+be routed to a single keyspace and now fails with an explicit `VT12001` error
+instead of returning wrong rows. Multi-value `table_name` lists are unaffected
+and keep working as plain filters.
 
 #### <a id="vtgate-streamexecute-real-errors"/>Streaming errors no longer surface as connection loss</a>
 

--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -252,11 +252,14 @@ an empty or incomplete result (issue #20878) — the form ORMs such as Rails
 now generate. A single-valued `IN` (a literal list of one, a bound list with
 one value, or a prepared statement's `IN (?)`) now routes exactly like the
 equivalent `=` predicate, including routed-table handling for `table_name`.
-Any predicate naming more than one schema — a multi-value `IN` list in any of
-those forms, or an `OR` of schema equalities, which plans identically — cannot
-be routed to a single keyspace and now fails with an explicit `VT12001` error
-instead of returning wrong rows. Multi-value `table_name` lists are unaffected
-and keep working as plain filters.
+A multi-value `IN` list routes when the query's schema predicates taken together
+still name exactly one schema (duplicates and `NULL` elements do not count, and
+another predicate such as `table_schema = 'ks'` narrows the list). When they
+name more than one — a multi-value `IN` list in any of those forms, or an `OR`
+of schema equalities, which plans identically — the query cannot be routed to a
+single keyspace and now fails with an explicit `VT12001` error instead of
+returning wrong rows. Multi-value `table_name` lists are unaffected and keep
+working as plain filters.
 
 One narrow shape that previously worked is currently rejected as well: a
 multi-value `IN` list naming only system schemas (e.g. `table_schema IN

--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -250,9 +250,10 @@ An `IN` predicate on `table_schema` or `table_name` in an `information_schema`
 query previously bypassed schema-name routing entirely and silently returned
 an empty or incomplete result (issue #20878) — the form ORMs such as Rails
 now generate. A single-valued `IN` (literal list of one, or a bound list with
-one value) now routes exactly like the equivalent `=` predicate. An `IN` list
-naming more than one schema cannot be routed to a single keyspace and now
-fails with an explicit `VT12001` error instead of returning wrong rows.
+one value) now routes exactly like the equivalent `=` predicate. A bound
+`IN` list (the form produced by vtgate's query normalization) naming more
+than one schema cannot be routed to a single keyspace and now fails with an
+explicit `VT12001` error instead of returning wrong rows.
 
 #### <a id="vtgate-streamexecute-real-errors"/>Streaming errors no longer surface as connection loss</a>
 

--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -257,7 +257,8 @@ A multi-value `IN` list routes when it names exactly one schema (duplicates and
 those forms, or an `OR` of schema equalities, which plans identically — cannot
 be routed to a single keyspace and now fails with an explicit `VT12001` error
 instead of returning wrong rows. Multi-value `table_name` lists are unaffected
-and keep working as plain filters.
+and keep working as plain filters, and a list containing `database()` or
+`schema()` is left for the tablet to evaluate, as `= database()` always has been.
 
 One narrow shape that previously worked is currently rejected as well: a
 multi-value `IN` list naming only system schemas (e.g. `table_schema IN

--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -258,6 +258,13 @@ be routed to a single keyspace and now fails with an explicit `VT12001` error
 instead of returning wrong rows. Multi-value `table_name` lists are unaffected
 and keep working as plain filters.
 
+One narrow shape that previously worked is currently rejected as well: a
+multi-value `IN` list naming only system schemas (e.g. `table_schema IN
+('information_schema', 'performance_schema')`) now returns the same `VT12001`,
+because the routing rewrite cannot carry a multi-schema filter. Split the
+query per schema or use equality predicates as a workaround; issue #20974
+tracks restoring support for that shape.
+
 #### <a id="vtgate-streamexecute-real-errors"/>Streaming errors no longer surface as connection loss</a>
 
 Streaming queries (under `SET workload = 'OLAP'`, multi-statement batches, and prepared-statement execution) previously returned `ERROR 2013 (HY000): Lost connection to MySQL server during query` and tore down the underlying TCP connection whenever the streaming handler returned an error *after* the first row or field packet had been emitted. VTGate now writes a proper ERR packet in place of the result-set terminator, so the real error code and message reach the client and the connection remains usable for subsequent queries.

--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -25,6 +25,7 @@
     - **[VTGate](#minor-changes-vtgate)**
         - [Ingress bytes in query LogStats](#vtgate-logstats-ingress-bytes)
         - [New controls for cross-keyspace reads](#vtgate-cross-keyspace-reads)
+        - [information_schema queries with IN predicates route correctly](#information-schema-in-routing)
         - [Streaming errors no longer surface as connection loss](#vtgate-streamexecute-real-errors)
         - [SHA256-hashed passwords in the static gRPC auth plugin](#vtgate-grpc-static-auth-sha256)
         - [PREPARE statements no longer report the prepared statement's tables](#vtgate-prepare-tables-used)
@@ -242,6 +243,16 @@ When enabled, the planner will reject queries that require joining or combining 
 ```
 
 The VTGate flag prevents cross-keyspace reads globally, regardless of per-keyspace VSchema settings.
+
+#### <a id="information-schema-in-routing"/>`information_schema` queries with IN predicates route correctly</a>
+
+An `IN` predicate on `table_schema` or `table_name` in an `information_schema`
+query previously bypassed schema-name routing entirely and silently returned
+an empty or incomplete result (issue #20878) — the form ORMs such as Rails
+now generate. A single-valued `IN` (literal list of one, or a bound list with
+one value) now routes exactly like the equivalent `=` predicate. An `IN` list
+naming more than one schema cannot be routed to a single keyspace and now
+fails with an explicit `VT12001` error instead of returning wrong rows.
 
 #### <a id="vtgate-streamexecute-real-errors"/>Streaming errors no longer surface as connection loss</a>
 

--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -252,14 +252,12 @@ an empty or incomplete result (issue #20878) — the form ORMs such as Rails
 now generate. A single-valued `IN` (a literal list of one, a bound list with
 one value, or a prepared statement's `IN (?)`) now routes exactly like the
 equivalent `=` predicate, including routed-table handling for `table_name`.
-A multi-value `IN` list routes when the query's schema predicates taken together
-still name exactly one schema (duplicates and `NULL` elements do not count, and
-another predicate such as `table_schema = 'ks'` narrows the list). When they
-name more than one — a multi-value `IN` list in any of those forms, or an `OR`
-of schema equalities, which plans identically — the query cannot be routed to a
-single keyspace and now fails with an explicit `VT12001` error instead of
-returning wrong rows. Multi-value `table_name` lists are unaffected and keep
-working as plain filters.
+A multi-value `IN` list routes when it names exactly one schema (duplicates and
+`NULL` elements do not count). A list naming more than one schema — in any of
+those forms, or an `OR` of schema equalities, which plans identically — cannot
+be routed to a single keyspace and now fails with an explicit `VT12001` error
+instead of returning wrong rows. Multi-value `table_name` lists are unaffected
+and keep working as plain filters.
 
 One narrow shape that previously worked is currently rejected as well: a
 multi-value `IN` list naming only system schemas (e.g. `table_schema IN

--- a/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
+++ b/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
@@ -331,6 +331,11 @@ func TestInformationSchemaWithInPredicate(t *testing.T) {
 	_, err := mcmp.VtConn.ExecuteFetch("select table_name from information_schema.tables where table_schema in ('ks', 'other')", 100, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "VT12001")
+
+	// a multi-value table_name IN keeps working as a plain filter: the schema
+	// routes, the list filters, no error
+	multiName := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema = database() and table_name in ('t1', 't7_xxhash')")
+	require.Len(t, multiName.Rows, 2)
 }
 
 func TestJoinWithSingleShardQueryOnRHS(t *testing.T) {

--- a/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
+++ b/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
@@ -330,10 +330,6 @@ func TestInformationSchemaWithInPredicate(t *testing.T) {
 	inDup := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema in ('ks', 'ks', null) and table_name = 't1'")
 	require.Equal(t, eq.Rows, inDup.Rows)
 
-	// another schema predicate narrows the list to one schema
-	inNarrowed := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema = 'ks' and table_schema in ('ks', 'other') and table_name = 't1'")
-	require.Equal(t, eq.Rows, inNarrowed.Rows)
-
 	// multi-value table_name IN stays a plain filter
 	multiName := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema = database() and table_name in ('t1', 't7_xxhash')")
 	require.Len(t, multiName.Rows, 2)

--- a/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
+++ b/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
@@ -306,10 +306,7 @@ WHERE TABLE_SCHEMA = 'ks' AND TABLE_NAME = 't2';
 }
 
 // TestInformationSchemaWithInPredicate reproduces
-// https://github.com/vitessio/vitess/issues/20878: IN predicates on
-// table_schema/table_name must route like their equality forms instead of
-// silently returning an empty set, and a multi-value schema IN must fail
-// loudly rather than return wrong rows.
+// https://github.com/vitessio/vitess/issues/20878.
 func TestInformationSchemaWithInPredicate(t *testing.T) {
 	if clusterInstance.HasPartialKeyspaces {
 		t.Skip("test can randomly select one of the shards, and the shards are in different keyspaces")
@@ -317,23 +314,27 @@ func TestInformationSchemaWithInPredicate(t *testing.T) {
 	mcmp, closer := start(t)
 	defer closer()
 
-	// equality and single-element IN must agree (both non-empty)
 	eq := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema = database() and table_name = 't1'")
 	in := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema in (database()) and table_name in ('t1')")
 	require.NotEmpty(t, eq.Rows)
 	require.Equal(t, eq.Rows, in.Rows)
 
-	// the issue's literal repro: schema named by literal IN
+	// the issue's literal repro
 	inLit := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema in ('ks') and table_name = 't1'")
 	require.Equal(t, eq.Rows, inLit.Rows)
 
-	// multi-value schema IN fails loudly instead of returning empty/wrong rows
 	_, err := mcmp.VtConn.ExecuteFetch("select table_name from information_schema.tables where table_schema in ('ks', 'other')", 100, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "VT12001")
 
-	// a multi-value table_name IN keeps working as a plain filter: the schema
-	// routes, the list filters, no error
+	inDup := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema in ('ks', 'ks', null) and table_name = 't1'")
+	require.Equal(t, eq.Rows, inDup.Rows)
+
+	// another schema predicate narrows the list to one schema
+	inNarrowed := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema = 'ks' and table_schema in ('ks', 'other') and table_name = 't1'")
+	require.Equal(t, eq.Rows, inNarrowed.Rows)
+
+	// multi-value table_name IN stays a plain filter
 	multiName := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema = database() and table_name in ('t1', 't7_xxhash')")
 	require.Len(t, multiName.Rows, 2)
 }

--- a/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
+++ b/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
@@ -305,6 +305,34 @@ WHERE TABLE_SCHEMA = 'ks' AND TABLE_NAME = 't2';
 	)
 }
 
+// TestInformationSchemaWithInPredicate reproduces
+// https://github.com/vitessio/vitess/issues/20878: IN predicates on
+// table_schema/table_name must route like their equality forms instead of
+// silently returning an empty set, and a multi-value schema IN must fail
+// loudly rather than return wrong rows.
+func TestInformationSchemaWithInPredicate(t *testing.T) {
+	if clusterInstance.HasPartialKeyspaces {
+		t.Skip("test can randomly select one of the shards, and the shards are in different keyspaces")
+	}
+	mcmp, closer := start(t)
+	defer closer()
+
+	// equality and single-element IN must agree (both non-empty)
+	eq := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema = database() and table_name = 't1'")
+	in := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema in (database()) and table_name in ('t1')")
+	require.NotEmpty(t, eq.Rows)
+	require.Equal(t, eq.Rows, in.Rows)
+
+	// the issue's literal repro: schema named by literal IN
+	inLit := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema in ('ks') and table_name = 't1'")
+	require.Equal(t, eq.Rows, inLit.Rows)
+
+	// multi-value schema IN fails loudly instead of returning empty/wrong rows
+	_, err := mcmp.VtConn.ExecuteFetch("select table_name from information_schema.tables where table_schema in ('ks', 'other')", 100, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "VT12001")
+}
+
 func TestJoinWithSingleShardQueryOnRHS(t *testing.T) {
 	// This test checks that we can run queries like this, where the RHS is a single shard query
 	mcmp, closer := start(t)

--- a/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
+++ b/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
@@ -331,6 +331,13 @@ func TestInformationSchemaWithInPredicate(t *testing.T) {
 	require.Equal(t, eq.Rows, inDup.Rows)
 	utils.AssertResultIsEmpty(t, mcmp.VtConn, "table_schema = 'ks' and table_schema in (null, null)")
 
+	// database() evaluates to the connected keyspace at vtgate
+	inDB := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema in (database(), 'ks') and table_name = 't1'")
+	require.Equal(t, eq.Rows, inDB.Rows)
+	_, err = mcmp.VtConn.ExecuteFetch("select table_name from information_schema.tables where table_schema in (database(), 'other')", 100, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "VT12001")
+
 	// multi-value table_name IN stays a plain filter
 	multiName := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema = database() and table_name in ('t1', 't7_xxhash')")
 	require.Len(t, multiName.Rows, 2)

--- a/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
+++ b/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
@@ -329,6 +329,7 @@ func TestInformationSchemaWithInPredicate(t *testing.T) {
 
 	inDup := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema in ('ks', 'ks', null) and table_name = 't1'")
 	require.Equal(t, eq.Rows, inDup.Rows)
+	utils.AssertResultIsEmpty(t, mcmp.VtConn, "table_schema = 'ks' and table_schema in (null, null)")
 
 	// multi-value table_name IN stays a plain filter
 	multiName := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema = database() and table_name in ('t1', 't7_xxhash')")

--- a/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
+++ b/go/test/endtoend/vtgate/queries/informationschema/informationschema_test.go
@@ -331,12 +331,11 @@ func TestInformationSchemaWithInPredicate(t *testing.T) {
 	require.Equal(t, eq.Rows, inDup.Rows)
 	utils.AssertResultIsEmpty(t, mcmp.VtConn, "table_schema = 'ks' and table_schema in (null, null)")
 
-	// database() evaluates to the connected keyspace at vtgate
+	// a list containing database() is left for the tablet to evaluate, like = database()
 	inDB := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema in (database(), 'ks') and table_name = 't1'")
 	require.Equal(t, eq.Rows, inDB.Rows)
-	_, err = mcmp.VtConn.ExecuteFetch("select table_name from information_schema.tables where table_schema in (database(), 'other')", 100, false)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "VT12001")
+	inDBSys := utils.Exec(t, mcmp.VtConn, "select table_schema from information_schema.tables where table_schema in (database(), 'information_schema') and table_name in ('t1', 'TABLES')")
+	require.Len(t, inDBSys.Rows, 2)
 
 	// multi-value table_name IN stays a plain filter
 	multiName := utils.Exec(t, mcmp.VtConn, "select table_name from information_schema.tables where table_schema = database() and table_name in ('t1', 't7_xxhash')")

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -22,6 +22,8 @@ import (
 	"strconv"
 	"testing"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -262,6 +264,82 @@ func TestSystemTableSchemaInMultiValueErrors(t *testing.T) {
 	_, err := sel.TryExecute(t.Context(), vc, bindVars, false)
 	require.ErrorContains(t, err, "VT12001")
 	assert.Equal(t, vtrpcpb.Code_UNIMPLEMENTED, vterrors.Code(err))
+}
+
+// sysTableNameInRoute builds a DBA route whose SysTableTableName entry came
+// from a `table_name IN ::tables` predicate: keyed by the list bind
+// variable's own name, evaluating to a tuple, with the predicate left in the
+// query unrewritten.
+func sysTableNameInRoute() *Route {
+	return &Route{
+		RoutingParameters: &RoutingParameters{
+			Opcode: DBA,
+			Keyspace: &vindexes.Keyspace{
+				Name:    "ks",
+				Sharded: false,
+			},
+			SysTableTableName: map[string]evalengine.Expr{
+				"tables": evalengine.NewBindVarTuple("tables", collations.SystemCollation.Collation),
+			},
+		},
+		Query:      "dummy_select",
+		FieldQuery: "dummy_select_field",
+	}
+}
+
+func TestSystemTableTableNameInSingleValueRoutedRewrite(t *testing.T) {
+	// A one-element table-name list routes like the equality form, including
+	// routed-table handling — and because the query still references the
+	// list bind variable, the rewritten value must stay a TUPLE.
+	sel := sysTableNameInRoute()
+	vc := &loggingVCursor{
+		shards:  []string{"1"},
+		results: []*sqltypes.Result{defaultSelectResult},
+		tableRoutes: tableRoutes{
+			tbl: &vindexes.BaseTable{
+				Name:     sqlparser.NewIdentifierCS("routedTable"),
+				Keyspace: &vindexes.Keyspace{Name: "routedKeyspace"},
+			},
+		},
+	}
+	bindVars := map[string]*querypb.BindVariable{
+		"tables": sqltypes.TestBindVariable([]any{"tableName"}),
+	}
+
+	_, err := sel.TryExecute(t.Context(), vc, bindVars, false)
+	require.NoError(t, err)
+	require.NotNil(t, bindVars["tables"])
+	assert.Equal(t, querypb.Type_TUPLE, bindVars["tables"].Type,
+		"the query still says `in ::tables`, so the rewritten bind variable must remain a tuple")
+	vc.ExpectLog(t, []string{
+		"FindTable(tableName)",
+		"ResolveDestinations routedKeyspace [] Destinations:DestinationAnyShard()",
+		fmt.Sprintf("ExecuteMultiShard routedKeyspace.1: dummy_select {__vtschemaname: type:VARCHAR tables: %v} false false", sqltypes.TestBindVariable([]any{"routedTable"})),
+	})
+}
+
+func TestSystemTableTableNameInMultiValueStaysUnrouted(t *testing.T) {
+	// A multi-element table-name list cannot pick a route, but it works as
+	// the pushed-down filter it already is: no error, no bind variable
+	// rewrite, default routing.
+	sel := sysTableNameInRoute()
+	vc := &loggingVCursor{
+		shards:  []string{"1"},
+		results: []*sqltypes.Result{defaultSelectResult},
+	}
+	original := sqltypes.TestBindVariable([]any{"t1", "t2"})
+	bindVars := map[string]*querypb.BindVariable{
+		"tables": original,
+	}
+
+	_, err := sel.TryExecute(t.Context(), vc, bindVars, false)
+	require.NoError(t, err)
+	assert.True(t, proto.Equal(original, bindVars["tables"]),
+		"a multi-element table-name list must keep its original bind variable untouched")
+	vc.ExpectLog(t, []string{
+		"ResolveDestinations ks [] Destinations:DestinationAnyShard()",
+		fmt.Sprintf("ExecuteMultiShard ks.1: dummy_select {__vtschemaname: type:VARCHAR tables: %v} false false", original),
+	})
 }
 
 func TestSelectScatter(t *testing.T) {

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -274,6 +274,17 @@ func TestSystemTableSchemaLists(t *testing.T) {
 		},
 		wantErr: "VT12001",
 	}, {
+		name:    "list naming no schema makes the query match nothing despite a scalar",
+		schemas: []evalengine.Expr{literal("myKeyspace"), tuple("schemas")},
+		bindVars: map[string]*querypb.BindVariable{
+			"schemas": sqltypes.TestBindVariable([]any{nil}),
+		},
+		expectedLog: []string{
+			"ResolveDestinations ks [] Destinations:DestinationAnyShard()",
+			fmt.Sprintf("ExecuteMultiShard ks.1: dummy_select {__vtschemaname: type:VARCHAR schemas: %v} false false",
+				sqltypes.TestBindVariable([]any{nil})),
+		},
+	}, {
 		name:    "scalar and list naming different schemas error",
 		schemas: []evalengine.Expr{literal("myKeyspace"), tuple("schemas")},
 		bindVars: map[string]*querypb.BindVariable{

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -267,9 +267,11 @@ func TestSystemTableSchemaInMultiValueErrors(t *testing.T) {
 }
 
 // sysTableNameInRoute builds a DBA route whose SysTableTableName entry came
-// from a `table_name IN ::tables` predicate: keyed by the list bind
-// variable's own name, evaluating to a tuple, with the predicate left in the
-// query unrewritten.
+// from a `table_name IN ::tables` predicate: keyed by a dedicated,
+// vtgate-owned list variable (the rewritten query references ::vttables),
+// while the stored expression still reads the client's ::tables list — which
+// the normalizer may share between predicates, so it must never be rewritten
+// in place.
 func sysTableNameInRoute() *Route {
 	return &Route{
 		RoutingParameters: &RoutingParameters{
@@ -279,7 +281,7 @@ func sysTableNameInRoute() *Route {
 				Sharded: false,
 			},
 			SysTableTableName: map[string]evalengine.Expr{
-				"tables": evalengine.NewBindVarTuple("tables", collations.SystemCollation.Collation),
+				"vttables": evalengine.NewBindVarTuple("tables", collations.SystemCollation.Collation),
 			},
 		},
 		Query:      "dummy_select",
@@ -302,19 +304,22 @@ func TestSystemTableTableNameInSingleValueRoutedRewrite(t *testing.T) {
 			},
 		},
 	}
+	original := sqltypes.TestBindVariable([]any{"tableName"})
 	bindVars := map[string]*querypb.BindVariable{
-		"tables": sqltypes.TestBindVariable([]any{"tableName"}),
+		"tables": original,
 	}
 
 	_, err := sel.TryExecute(t.Context(), vc, bindVars, false)
 	require.NoError(t, err)
-	require.NotNil(t, bindVars["tables"])
-	assert.Equal(t, querypb.Type_TUPLE, bindVars["tables"].Type,
-		"the query still says `in ::tables`, so the rewritten bind variable must remain a tuple")
+	require.NotNil(t, bindVars["vttables"])
+	assert.Equal(t, querypb.Type_TUPLE, bindVars["vttables"].Type,
+		"the rewritten query says `in ::vttables`, so the dedicated bind variable must be a tuple")
+	assert.True(t, proto.Equal(original, bindVars["tables"]),
+		"the client's list bind variable may be shared with other predicates and must never be rewritten")
 	vc.ExpectLog(t, []string{
 		"FindTable(tableName)",
 		"ResolveDestinations routedKeyspace [] Destinations:DestinationAnyShard()",
-		fmt.Sprintf("ExecuteMultiShard routedKeyspace.1: dummy_select {__vtschemaname: type:VARCHAR tables: %v} false false", sqltypes.TestBindVariable([]any{"routedTable"})),
+		fmt.Sprintf("ExecuteMultiShard routedKeyspace.1: dummy_select {__vtschemaname: type:VARCHAR tables: %v vttables: %v} false false", original, sqltypes.TestBindVariable([]any{"routedTable"})),
 	})
 }
 
@@ -336,9 +341,13 @@ func TestSystemTableTableNameInMultiValueStaysUnrouted(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, proto.Equal(original, bindVars["tables"]),
 		"a multi-element table-name list must keep its original bind variable untouched")
+	require.NotNil(t, bindVars["vttables"],
+		"the rewritten query references the dedicated variable, so it must be populated even when the list contributes nothing to routing")
+	assert.Equal(t, original.Values, bindVars["vttables"].Values,
+		"a multi-element list is copied into the dedicated variable unchanged")
 	vc.ExpectLog(t, []string{
 		"ResolveDestinations ks [] Destinations:DestinationAnyShard()",
-		fmt.Sprintf("ExecuteMultiShard ks.1: dummy_select {__vtschemaname: type:VARCHAR tables: %v} false false", original),
+		fmt.Sprintf("ExecuteMultiShard ks.1: dummy_select {__vtschemaname: type:VARCHAR tables: %v vttables: %v} false false", original, bindVars["vttables"]),
 	})
 }
 

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -198,6 +198,72 @@ func TestInformationSchemaWithTableAndSchemaWithRoutedTables(t *testing.T) {
 	}
 }
 
+func TestSystemTableSchemaInSingleValueRoutes(t *testing.T) {
+	// SysTableTableSchema holding a list bindvar with ONE value must route
+	// exactly like the scalar equality form: same keyspace resolution, same
+	// :__vtschemaname bindvar.
+	sel := &Route{
+		RoutingParameters: &RoutingParameters{
+			Opcode: DBA,
+			Keyspace: &vindexes.Keyspace{
+				Name:    "ks",
+				Sharded: false,
+			},
+			SysTableTableSchema: []evalengine.Expr{
+				evalengine.NewBindVarTuple("schemas", collations.SystemCollation.Collation),
+			},
+		},
+		Query:      "dummy_select",
+		FieldQuery: "dummy_select_field",
+	}
+	vc := &loggingVCursor{
+		shards:  []string{"1"},
+		results: []*sqltypes.Result{defaultSelectResult},
+	}
+	bindVars := map[string]*querypb.BindVariable{
+		"schemas": sqltypes.TestBindVariable([]any{"myKeyspace"}),
+	}
+
+	_, err := sel.TryExecute(t.Context(), vc, bindVars, false)
+	require.NoError(t, err)
+	vc.ExpectLog(t, []string{
+		"ResolveDestinations myKeyspace [] Destinations:DestinationAnyShard()",
+		fmt.Sprintf("ExecuteMultiShard myKeyspace.1: dummy_select {__replacevtschemaname: %v schemas: %v} false false",
+			sqltypes.Int64BindVariable(1), sqltypes.TestBindVariable([]any{"myKeyspace"})),
+	})
+}
+
+func TestSystemTableSchemaInMultiValueErrors(t *testing.T) {
+	// A multi-value schema list cannot be resolved to one keyspace: the
+	// query must fail loudly (VT12001), never fall through to the default
+	// keyspace and return silently wrong rows.
+	sel := &Route{
+		RoutingParameters: &RoutingParameters{
+			Opcode: DBA,
+			Keyspace: &vindexes.Keyspace{
+				Name:    "ks",
+				Sharded: false,
+			},
+			SysTableTableSchema: []evalengine.Expr{
+				evalengine.NewBindVarTuple("schemas", collations.SystemCollation.Collation),
+			},
+		},
+		Query:      "dummy_select",
+		FieldQuery: "dummy_select_field",
+	}
+	vc := &loggingVCursor{
+		shards:  []string{"1"},
+		results: []*sqltypes.Result{defaultSelectResult},
+	}
+	bindVars := map[string]*querypb.BindVariable{
+		"schemas": sqltypes.TestBindVariable([]any{"ks1", "ks2"}),
+	}
+
+	_, err := sel.TryExecute(t.Context(), vc, bindVars, false)
+	require.ErrorContains(t, err, "VT12001")
+	assert.Equal(t, vtrpcpb.Code_UNIMPLEMENTED, vterrors.Code(err))
+}
+
 func TestSelectScatter(t *testing.T) {
 	sel := NewRoute(
 		Scatter,

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -236,9 +236,9 @@ func TestSystemTableSchemaInSingleValueRoutes(t *testing.T) {
 }
 
 func TestSystemTableSchemaInMultiValueErrors(t *testing.T) {
-	// A multi-value schema list cannot be resolved to one keyspace: the
-	// query must fail loudly (VT12001), never fall through to the default
-	// keyspace and return silently wrong rows.
+	// A schema list with more than one DISTINCT value cannot be resolved to
+	// one keyspace: the query must fail loudly (VT12001), never fall
+	// through to the default keyspace and return silently wrong rows.
 	sel := &Route{
 		RoutingParameters: &RoutingParameters{
 			Opcode: DBA,
@@ -264,6 +264,41 @@ func TestSystemTableSchemaInMultiValueErrors(t *testing.T) {
 	_, err := sel.TryExecute(t.Context(), vc, bindVars, false)
 	require.ErrorContains(t, err, "VT12001")
 	assert.Equal(t, vtrpcpb.Code_UNIMPLEMENTED, vterrors.Code(err))
+}
+
+func TestSystemTableSchemaInDuplicateValuesRoute(t *testing.T) {
+	// Duplicates do not change IN semantics: a schema list whose elements
+	// all name the same keyspace targets exactly one schema, and must route
+	// like the equality form instead of failing the query.
+	sel := &Route{
+		RoutingParameters: &RoutingParameters{
+			Opcode: DBA,
+			Keyspace: &vindexes.Keyspace{
+				Name:    "ks",
+				Sharded: false,
+			},
+			SysTableTableSchema: []evalengine.Expr{
+				evalengine.NewBindVarTuple("schemas", collations.SystemCollation.Collation),
+			},
+		},
+		Query:      "dummy_select",
+		FieldQuery: "dummy_select_field",
+	}
+	vc := &loggingVCursor{
+		shards:  []string{"1"},
+		results: []*sqltypes.Result{defaultSelectResult},
+	}
+	bindVars := map[string]*querypb.BindVariable{
+		"schemas": sqltypes.TestBindVariable([]any{"myKeyspace", "myKeyspace"}),
+	}
+
+	_, err := sel.TryExecute(t.Context(), vc, bindVars, false)
+	require.NoError(t, err)
+	vc.ExpectLog(t, []string{
+		"ResolveDestinations myKeyspace [] Destinations:DestinationAnyShard()",
+		fmt.Sprintf("ExecuteMultiShard myKeyspace.1: dummy_select {__replacevtschemaname: %v schemas: %v} false false",
+			sqltypes.Int64BindVariable(1), sqltypes.TestBindVariable([]any{"myKeyspace", "myKeyspace"})),
+	})
 }
 
 // sysTableNameInRoute builds a DBA route whose SysTableTableName entry came

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -334,6 +334,42 @@ func TestSystemTableSchemaLists(t *testing.T) {
 	}
 }
 
+// TestSystemTableRoutedTableRewritesEveryTableName pins that every routed
+// table-name predicate is rewritten to its physical name, not just the first.
+func TestSystemTableRoutedTableRewritesEveryTableName(t *testing.T) {
+	sel := &Route{
+		RoutingParameters: &RoutingParameters{
+			Opcode:              DBA,
+			Keyspace:            &vindexes.Keyspace{Name: "ks"},
+			SysTableTableSchema: []evalengine.Expr{evalengine.NewLiteralString([]byte("schema"), collations.SystemCollation)},
+			SysTableTableName: map[string]evalengine.Expr{
+				"t1": evalengine.NewLiteralString([]byte("a"), collations.SystemCollation),
+				"t2": evalengine.NewLiteralString([]byte("b"), collations.SystemCollation),
+			},
+		},
+		Query:      "dummy_select",
+		FieldQuery: "dummy_select_field",
+	}
+	vc := &loggingVCursor{
+		shards:  []string{"1"},
+		results: []*sqltypes.Result{defaultSelectResult},
+		tableRoutes: tableRoutes{
+			tbl: &vindexes.BaseTable{
+				Name:     sqlparser.NewIdentifierCS("routedTable"),
+				Keyspace: &vindexes.Keyspace{Name: "routedKeyspace"},
+			},
+		},
+	}
+	bindVars := map[string]*querypb.BindVariable{}
+
+	_, err := sel.TryExecute(t.Context(), vc, bindVars, false)
+	require.NoError(t, err)
+	want := sqltypes.StringBindVariable("routedTable")
+	assert.True(t, proto.Equal(want, bindVars["t1"]), "t1 = %v", bindVars["t1"])
+	assert.True(t, proto.Equal(want, bindVars["t2"]), "t2 = %v", bindVars["t2"])
+	assert.Contains(t, vc.log, "ResolveDestinations routedKeyspace [] Destinations:DestinationAnyShard()")
+}
+
 // sysTableNameInRoute builds a DBA route for `table_name IN ::tables`, keyed by
 // the dedicated ::vttables while the expression reads the client's ::tables.
 func sysTableNameInRoute() *Route {

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -200,113 +200,145 @@ func TestInformationSchemaWithTableAndSchemaWithRoutedTables(t *testing.T) {
 	}
 }
 
-func TestSystemTableSchemaInSingleValueRoutes(t *testing.T) {
-	// SysTableTableSchema holding a list bindvar with ONE value must route
-	// exactly like the scalar equality form: same keyspace resolution, same
-	// :__vtschemaname bindvar.
-	sel := &Route{
-		RoutingParameters: &RoutingParameters{
-			Opcode: DBA,
-			Keyspace: &vindexes.Keyspace{
-				Name:    "ks",
-				Sharded: false,
-			},
-			SysTableTableSchema: []evalengine.Expr{
-				evalengine.NewBindVarTuple("schemas", collations.SystemCollation.Collation),
-			},
+// TestSystemTableSchemaLists covers schema predicates that evaluate to a list
+// (IN tuples), alone and intersected with other schema predicates.
+func TestSystemTableSchemaLists(t *testing.T) {
+	tuple := func(name string) evalengine.Expr {
+		return evalengine.NewBindVarTuple(name, collations.SystemCollation.Collation)
+	}
+	literal := func(v string) evalengine.Expr {
+		return evalengine.NewLiteralString([]byte(v), collations.SystemCollation)
+	}
+	replace := sqltypes.Int64BindVariable(1)
+	tests := []struct {
+		name        string
+		schemas     []evalengine.Expr
+		bindVars    map[string]*querypb.BindVariable
+		expectedLog []string
+		wantErr     string
+	}{{
+		name:    "single value routes like equality",
+		schemas: []evalengine.Expr{tuple("schemas")},
+		bindVars: map[string]*querypb.BindVariable{
+			"schemas": sqltypes.TestBindVariable([]any{"myKeyspace"}),
 		},
-		Query:      "dummy_select",
-		FieldQuery: "dummy_select_field",
+		expectedLog: []string{
+			"ResolveDestinations myKeyspace [] Destinations:DestinationAnyShard()",
+			fmt.Sprintf("ExecuteMultiShard myKeyspace.1: dummy_select {__replacevtschemaname: %v schemas: %v} false false",
+				replace, sqltypes.TestBindVariable([]any{"myKeyspace"})),
+		},
+	}, {
+		name:    "duplicate values route like equality",
+		schemas: []evalengine.Expr{tuple("schemas")},
+		bindVars: map[string]*querypb.BindVariable{
+			"schemas": sqltypes.TestBindVariable([]any{"myKeyspace", "myKeyspace"}),
+		},
+		expectedLog: []string{
+			"ResolveDestinations myKeyspace [] Destinations:DestinationAnyShard()",
+			fmt.Sprintf("ExecuteMultiShard myKeyspace.1: dummy_select {__replacevtschemaname: %v schemas: %v} false false",
+				replace, sqltypes.TestBindVariable([]any{"myKeyspace", "myKeyspace"})),
+		},
+	}, {
+		name:    "NULL elements are ignored",
+		schemas: []evalengine.Expr{tuple("schemas")},
+		bindVars: map[string]*querypb.BindVariable{
+			"schemas": sqltypes.TestBindVariable([]any{"myKeyspace", nil}),
+		},
+		expectedLog: []string{
+			"ResolveDestinations myKeyspace [] Destinations:DestinationAnyShard()",
+			fmt.Sprintf("ExecuteMultiShard myKeyspace.1: dummy_select {__replacevtschemaname: %v schemas: %v} false false",
+				replace, sqltypes.TestBindVariable([]any{"myKeyspace", nil})),
+		},
+	}, {
+		name:    "all NULL matches nothing",
+		schemas: []evalengine.Expr{tuple("schemas")},
+		bindVars: map[string]*querypb.BindVariable{
+			"schemas": sqltypes.TestBindVariable([]any{nil, nil}),
+		},
+		expectedLog: []string{
+			"ResolveDestinations ks [] Destinations:DestinationAnyShard()",
+			fmt.Sprintf("ExecuteMultiShard ks.1: dummy_select {__vtschemaname: type:VARCHAR schemas: %v} false false",
+				sqltypes.TestBindVariable([]any{nil, nil})),
+		},
+	}, {
+		name:    "distinct values error",
+		schemas: []evalengine.Expr{tuple("schemas")},
+		bindVars: map[string]*querypb.BindVariable{
+			"schemas": sqltypes.TestBindVariable([]any{"ks1", "ks2"}),
+		},
+		wantErr: "VT12001",
+	}, {
+		name:    "scalar narrows a list to one destination",
+		schemas: []evalengine.Expr{literal("myKeyspace"), tuple("schemas")},
+		bindVars: map[string]*querypb.BindVariable{
+			"schemas": sqltypes.TestBindVariable([]any{"myKeyspace", "other"}),
+		},
+		expectedLog: []string{
+			"ResolveDestinations myKeyspace [] Destinations:DestinationAnyShard()",
+			fmt.Sprintf("ExecuteMultiShard myKeyspace.1: dummy_select {__replacevtschemaname: %v schemas: %v} false false",
+				replace, sqltypes.TestBindVariable([]any{"myKeyspace", "other"})),
+		},
+	}, {
+		name:    "list narrows a scalar it does not contain to nothing",
+		schemas: []evalengine.Expr{literal("myKeyspace"), tuple("schemas")},
+		bindVars: map[string]*querypb.BindVariable{
+			"schemas": sqltypes.TestBindVariable([]any{"ks1", "ks2"}),
+		},
+		wantErr: "specifying two different database in the query is not supported",
+	}, {
+		name:    "two lists intersect",
+		schemas: []evalengine.Expr{tuple("s1"), tuple("s2")},
+		bindVars: map[string]*querypb.BindVariable{
+			"s1": sqltypes.TestBindVariable([]any{"ks1", "myKeyspace"}),
+			"s2": sqltypes.TestBindVariable([]any{"myKeyspace", "ks2"}),
+		},
+		expectedLog: []string{
+			"ResolveDestinations myKeyspace [] Destinations:DestinationAnyShard()",
+			fmt.Sprintf("ExecuteMultiShard myKeyspace.1: dummy_select {__replacevtschemaname: %v s1: %v s2: %v} false false",
+				replace, sqltypes.TestBindVariable([]any{"ks1", "myKeyspace"}), sqltypes.TestBindVariable([]any{"myKeyspace", "ks2"})),
+		},
+	}, {
+		name:    "two lists with more than one common value error",
+		schemas: []evalengine.Expr{tuple("s1"), tuple("s2")},
+		bindVars: map[string]*querypb.BindVariable{
+			"s1": sqltypes.TestBindVariable([]any{"ks1", "ks2", "ks3"}),
+			"s2": sqltypes.TestBindVariable([]any{"ks2", "ks3"}),
+		},
+		wantErr: "VT12001",
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sel := &Route{
+				RoutingParameters: &RoutingParameters{
+					Opcode: DBA,
+					Keyspace: &vindexes.Keyspace{
+						Name:    "ks",
+						Sharded: false,
+					},
+					SysTableTableSchema: tc.schemas,
+				},
+				Query:      "dummy_select",
+				FieldQuery: "dummy_select_field",
+			}
+			vc := &loggingVCursor{
+				shards:  []string{"1"},
+				results: []*sqltypes.Result{defaultSelectResult},
+			}
+			_, err := sel.TryExecute(t.Context(), vc, tc.bindVars, false)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				assert.Equal(t, vtrpcpb.Code_UNIMPLEMENTED, vterrors.Code(err))
+				return
+			}
+			require.NoError(t, err)
+			vc.ExpectLog(t, tc.expectedLog)
+		})
 	}
-	vc := &loggingVCursor{
-		shards:  []string{"1"},
-		results: []*sqltypes.Result{defaultSelectResult},
-	}
-	bindVars := map[string]*querypb.BindVariable{
-		"schemas": sqltypes.TestBindVariable([]any{"myKeyspace"}),
-	}
-
-	_, err := sel.TryExecute(t.Context(), vc, bindVars, false)
-	require.NoError(t, err)
-	vc.ExpectLog(t, []string{
-		"ResolveDestinations myKeyspace [] Destinations:DestinationAnyShard()",
-		fmt.Sprintf("ExecuteMultiShard myKeyspace.1: dummy_select {__replacevtschemaname: %v schemas: %v} false false",
-			sqltypes.Int64BindVariable(1), sqltypes.TestBindVariable([]any{"myKeyspace"})),
-	})
 }
 
-func TestSystemTableSchemaInMultiValueErrors(t *testing.T) {
-	// A schema list with more than one DISTINCT value cannot be resolved to
-	// one keyspace: the query must fail loudly (VT12001), never fall
-	// through to the default keyspace and return silently wrong rows.
-	sel := &Route{
-		RoutingParameters: &RoutingParameters{
-			Opcode: DBA,
-			Keyspace: &vindexes.Keyspace{
-				Name:    "ks",
-				Sharded: false,
-			},
-			SysTableTableSchema: []evalengine.Expr{
-				evalengine.NewBindVarTuple("schemas", collations.SystemCollation.Collation),
-			},
-		},
-		Query:      "dummy_select",
-		FieldQuery: "dummy_select_field",
-	}
-	vc := &loggingVCursor{
-		shards:  []string{"1"},
-		results: []*sqltypes.Result{defaultSelectResult},
-	}
-	bindVars := map[string]*querypb.BindVariable{
-		"schemas": sqltypes.TestBindVariable([]any{"ks1", "ks2"}),
-	}
-
-	_, err := sel.TryExecute(t.Context(), vc, bindVars, false)
-	require.ErrorContains(t, err, "VT12001")
-	assert.Equal(t, vtrpcpb.Code_UNIMPLEMENTED, vterrors.Code(err))
-}
-
-func TestSystemTableSchemaInDuplicateValuesRoute(t *testing.T) {
-	// Duplicates do not change IN semantics: a schema list whose elements
-	// all name the same keyspace targets exactly one schema, and must route
-	// like the equality form instead of failing the query.
-	sel := &Route{
-		RoutingParameters: &RoutingParameters{
-			Opcode: DBA,
-			Keyspace: &vindexes.Keyspace{
-				Name:    "ks",
-				Sharded: false,
-			},
-			SysTableTableSchema: []evalengine.Expr{
-				evalengine.NewBindVarTuple("schemas", collations.SystemCollation.Collation),
-			},
-		},
-		Query:      "dummy_select",
-		FieldQuery: "dummy_select_field",
-	}
-	vc := &loggingVCursor{
-		shards:  []string{"1"},
-		results: []*sqltypes.Result{defaultSelectResult},
-	}
-	bindVars := map[string]*querypb.BindVariable{
-		"schemas": sqltypes.TestBindVariable([]any{"myKeyspace", "myKeyspace"}),
-	}
-
-	_, err := sel.TryExecute(t.Context(), vc, bindVars, false)
-	require.NoError(t, err)
-	vc.ExpectLog(t, []string{
-		"ResolveDestinations myKeyspace [] Destinations:DestinationAnyShard()",
-		fmt.Sprintf("ExecuteMultiShard myKeyspace.1: dummy_select {__replacevtschemaname: %v schemas: %v} false false",
-			sqltypes.Int64BindVariable(1), sqltypes.TestBindVariable([]any{"myKeyspace", "myKeyspace"})),
-	})
-}
-
-// sysTableNameInRoute builds a DBA route whose SysTableTableName entry came
-// from a `table_name IN ::tables` predicate: keyed by a dedicated,
-// vtgate-owned list variable (the rewritten query references ::vttables),
-// while the stored expression still reads the client's ::tables list — which
-// the normalizer may share between predicates, so it must never be rewritten
-// in place.
+// sysTableNameInRoute builds a DBA route for a `table_name IN ::tables`
+// predicate: keyed by the dedicated ::vttables the rewritten query references,
+// while the expression reads the client's ::tables.
 func sysTableNameInRoute() *Route {
 	return &Route{
 		RoutingParameters: &RoutingParameters{
@@ -325,9 +357,6 @@ func sysTableNameInRoute() *Route {
 }
 
 func TestSystemTableTableNameInSingleValueRoutedRewrite(t *testing.T) {
-	// A one-element table-name list routes like the equality form, including
-	// routed-table handling — and because the query still references the
-	// list bind variable, the rewritten value must stay a TUPLE.
 	sel := sysTableNameInRoute()
 	vc := &loggingVCursor{
 		shards:  []string{"1"},
@@ -359,9 +388,6 @@ func TestSystemTableTableNameInSingleValueRoutedRewrite(t *testing.T) {
 }
 
 func TestSystemTableTableNameInMultiValueStaysUnrouted(t *testing.T) {
-	// A multi-element table-name list cannot pick a route, but it works as
-	// the pushed-down filter it already is: no error, no bind variable
-	// rewrite, default routing.
 	sel := sysTableNameInRoute()
 	vc := &loggingVCursor{
 		shards:  []string{"1"},

--- a/go/vt/vtgate/engine/route_test.go
+++ b/go/vt/vtgate/engine/route_test.go
@@ -200,8 +200,6 @@ func TestInformationSchemaWithTableAndSchemaWithRoutedTables(t *testing.T) {
 	}
 }
 
-// TestSystemTableSchemaLists covers schema predicates that evaluate to a list
-// (IN tuples), alone and intersected with other schema predicates.
 func TestSystemTableSchemaLists(t *testing.T) {
 	tuple := func(name string) evalengine.Expr {
 		return evalengine.NewBindVarTuple(name, collations.SystemCollation.Collation)
@@ -268,43 +266,32 @@ func TestSystemTableSchemaLists(t *testing.T) {
 		},
 		wantErr: "VT12001",
 	}, {
-		name:    "scalar narrows a list to one destination",
+		// predicates may be on different schema columns (KEY_COLUMN_USAGE has three)
+		name:    "multi-name list errors even when another predicate names one of them",
 		schemas: []evalengine.Expr{literal("myKeyspace"), tuple("schemas")},
 		bindVars: map[string]*querypb.BindVariable{
 			"schemas": sqltypes.TestBindVariable([]any{"myKeyspace", "other"}),
 		},
-		expectedLog: []string{
-			"ResolveDestinations myKeyspace [] Destinations:DestinationAnyShard()",
-			fmt.Sprintf("ExecuteMultiShard myKeyspace.1: dummy_select {__replacevtschemaname: %v schemas: %v} false false",
-				replace, sqltypes.TestBindVariable([]any{"myKeyspace", "other"})),
-		},
+		wantErr: "VT12001",
 	}, {
-		name:    "list narrows a scalar it does not contain to nothing",
+		name:    "scalar and list naming different schemas error",
 		schemas: []evalengine.Expr{literal("myKeyspace"), tuple("schemas")},
 		bindVars: map[string]*querypb.BindVariable{
-			"schemas": sqltypes.TestBindVariable([]any{"ks1", "ks2"}),
+			"schemas": sqltypes.TestBindVariable([]any{"ks1"}),
 		},
 		wantErr: "specifying two different database in the query is not supported",
 	}, {
-		name:    "two lists intersect",
+		name:    "lists agreeing after duplicates and NULLs route",
 		schemas: []evalengine.Expr{tuple("s1"), tuple("s2")},
 		bindVars: map[string]*querypb.BindVariable{
-			"s1": sqltypes.TestBindVariable([]any{"ks1", "myKeyspace"}),
-			"s2": sqltypes.TestBindVariable([]any{"myKeyspace", "ks2"}),
+			"s1": sqltypes.TestBindVariable([]any{"myKeyspace", nil}),
+			"s2": sqltypes.TestBindVariable([]any{"myKeyspace", "myKeyspace"}),
 		},
 		expectedLog: []string{
 			"ResolveDestinations myKeyspace [] Destinations:DestinationAnyShard()",
 			fmt.Sprintf("ExecuteMultiShard myKeyspace.1: dummy_select {__replacevtschemaname: %v s1: %v s2: %v} false false",
-				replace, sqltypes.TestBindVariable([]any{"ks1", "myKeyspace"}), sqltypes.TestBindVariable([]any{"myKeyspace", "ks2"})),
+				replace, sqltypes.TestBindVariable([]any{"myKeyspace", nil}), sqltypes.TestBindVariable([]any{"myKeyspace", "myKeyspace"})),
 		},
-	}, {
-		name:    "two lists with more than one common value error",
-		schemas: []evalengine.Expr{tuple("s1"), tuple("s2")},
-		bindVars: map[string]*querypb.BindVariable{
-			"s1": sqltypes.TestBindVariable([]any{"ks1", "ks2", "ks3"}),
-			"s2": sqltypes.TestBindVariable([]any{"ks2", "ks3"}),
-		},
-		wantErr: "VT12001",
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -336,9 +323,8 @@ func TestSystemTableSchemaLists(t *testing.T) {
 	}
 }
 
-// sysTableNameInRoute builds a DBA route for a `table_name IN ::tables`
-// predicate: keyed by the dedicated ::vttables the rewritten query references,
-// while the expression reads the client's ::tables.
+// sysTableNameInRoute builds a DBA route for `table_name IN ::tables`, keyed by
+// the dedicated ::vttables while the expression reads the client's ::tables.
 func sysTableNameInRoute() *Route {
 	return &Route{
 		RoutingParameters: &RoutingParameters{

--- a/go/vt/vtgate/engine/routing.go
+++ b/go/vt/vtgate/engine/routing.go
@@ -23,6 +23,7 @@ import (
 	"maps"
 	"strconv"
 
+	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/log"
@@ -205,37 +206,34 @@ func (rp *RoutingParameters) routeInfoSchemaQuery(ctx context.Context, vcursor V
 	}
 
 	env := evalengine.NewExpressionEnv(ctx, bindVars, vcursor)
-	var specifiedKS string
-	for idx, tableSchema := range rp.SysTableTableSchema {
+	// Intersect the schema names the table_schema predicates admit.
+	var candidates map[string]struct{}
+	for _, tableSchema := range rp.SysTableTableSchema {
 		result, err := env.Evaluate(tableSchema)
 		if err != nil {
 			return nil, err
 		}
-		var ks string
-		if tuple := result.TupleValues(); tuple != nil {
-			// A list bindvar from an IN predicate: elements that all name
-			// the same schema route exactly like the equality form —
-			// duplicates do not change IN semantics — while distinct names
-			// cannot name one keyspace, and falling through would silently
-			// query the wrong one.
-			if len(tuple) == 0 {
-				return nil, vterrors.VT12001("empty IN list for the schema name in an information_schema query")
-			}
-			ks = tuple[0].ToString()
-			for _, val := range tuple[1:] {
-				if val.ToString() != ks {
-					return nil, vterrors.VT12001("IN list with more than one distinct schema name in an information_schema query")
-				}
-			}
-		} else {
-			ks = result.Value(vcursor.ConnCollation()).ToString()
+		names := schemaNames(result, vcursor.ConnCollation())
+		if candidates == nil {
+			candidates = names
+			continue
 		}
-		switch {
-		case idx == 0:
-			specifiedKS = ks
-		case specifiedKS != ks:
-			return nil, vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "specifying two different database in the query is not supported")
+		for name := range candidates {
+			if _, ok := names[name]; !ok {
+				delete(candidates, name)
+			}
 		}
+	}
+	var specifiedKS string
+	switch {
+	case len(candidates) > 1:
+		return nil, vterrors.VT12001("IN list with more than one distinct schema name in an information_schema query")
+	case len(candidates) == 1:
+		for name := range candidates {
+			specifiedKS = name
+		}
+	case candidates != nil:
+		return nil, vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "specifying two different database in the query is not supported")
 	}
 
 	bindVars[sqltypes.BvSchemaName] = sqltypes.StringBindVariable(specifiedKS)
@@ -248,19 +246,10 @@ func (rp *RoutingParameters) routeInfoSchemaQuery(ctx context.Context, vcursor V
 		}
 		var tabName string
 		if tuple := val.TupleValues(); tuple != nil {
-			// A table-name list from an IN predicate. The expression reads
-			// the CLIENT's list bind variable — which the normalizer may
-			// share between identical IN tuples on other columns — while
-			// tblBvName is the dedicated, vtgate-owned list variable the
-			// rewritten query references, so the client's variable is never
-			// written. One name routes like the equality form (including
-			// routed-table handling below); any other length contributes
-			// nothing to routing and the predicate keeps working as the
-			// pushed-down filter it already is.
+			// tblBvName is the dedicated list variable the rewritten query
+			// references; the client's list may be shared and is never written.
+			// Only a one-element list contributes to routing.
 			if len(tuple) != 1 {
-				// The rewritten query still references the dedicated
-				// variable, so it must be populated: copy the client's
-				// values unchanged.
 				bindVars[tblBvName] = tupleBindVariable(tuple)
 				continue
 			}
@@ -346,10 +335,8 @@ func (rp *RoutingParameters) routedTable(ctx context.Context, vcursor VCursor, b
 	return nil, nil
 }
 
-// setSysTableNameBindVar sets a system-table name bind variable, preserving
-// its shape: a name that came from a one-element IN list is a vtgate-owned
-// TUPLE variable (the rewritten query says `in ::name`), while everything
-// else is the scalar the query's `= :name` expects.
+// setSysTableNameBindVar sets a table name bind variable, keeping the TUPLE
+// shape a rewritten `in ::name` predicate expects.
 func setSysTableNameBindVar(bindVars map[string]*querypb.BindVariable, name, value string) {
 	if bv, ok := bindVars[name]; ok && bv.Type == querypb.Type_TUPLE {
 		bindVars[name] = tupleOfOneBindVariable(value)
@@ -358,8 +345,7 @@ func setSysTableNameBindVar(bindVars map[string]*querypb.BindVariable, name, val
 	bindVars[name] = sqltypes.StringBindVariable(value)
 }
 
-// tupleOfOneBindVariable builds the one-element TUPLE bind variable a
-// rewritten `in ::name` list predicate expects.
+// tupleOfOneBindVariable builds a one-element TUPLE bind variable.
 func tupleOfOneBindVariable(value string) *querypb.BindVariable {
 	return &querypb.BindVariable{
 		Type:   querypb.Type_TUPLE,
@@ -374,6 +360,27 @@ func tupleBindVariable(values []sqltypes.Value) *querypb.BindVariable {
 		bv.Values = append(bv.Values, sqltypes.ValueToProto(value))
 	}
 	return bv
+}
+
+// schemaNames returns the schema names a table_schema predicate admits. NULL
+// list elements are skipped; a list naming no schema matches nothing, like
+// `= NULL`, which the empty name expresses.
+func schemaNames(result evalengine.EvalResult, coll collations.ID) map[string]struct{} {
+	names := map[string]struct{}{}
+	tuple := result.TupleValues()
+	if tuple == nil {
+		names[result.Value(coll).ToString()] = struct{}{}
+		return names
+	}
+	for _, val := range tuple {
+		if !val.IsNull() {
+			names[val.ToString()] = struct{}{}
+		}
+	}
+	if len(names) == 0 {
+		names[""] = struct{}{}
+	}
+	return names
 }
 
 func (rp *RoutingParameters) anyShard(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable) ([]*srvtopo.ResolvedShard, []map[string]*querypb.BindVariable, error) {

--- a/go/vt/vtgate/engine/routing.go
+++ b/go/vt/vtgate/engine/routing.go
@@ -211,7 +211,18 @@ func (rp *RoutingParameters) routeInfoSchemaQuery(ctx context.Context, vcursor V
 		if err != nil {
 			return nil, err
 		}
-		ks := result.Value(vcursor.ConnCollation()).ToString()
+		var ks string
+		if tuple := result.TupleValues(); tuple != nil {
+			// A list bindvar from an IN predicate: a single element is an
+			// equality and routes; anything else cannot name one keyspace, and
+			// falling through would silently query the wrong one.
+			if len(tuple) != 1 {
+				return nil, vterrors.VT12001("IN list with multiple schema names in an information_schema query")
+			}
+			ks = tuple[0].ToString()
+		} else {
+			ks = result.Value(vcursor.ConnCollation()).ToString()
+		}
 		switch {
 		case idx == 0:
 			specifiedKS = ks

--- a/go/vt/vtgate/engine/routing.go
+++ b/go/vt/vtgate/engine/routing.go
@@ -305,29 +305,28 @@ func (rp *RoutingParameters) routedTable(ctx context.Context, vcursor VCursor, b
 		if err != nil {
 			return nil, err
 		}
-
-		if routedTable != nil {
-			// if we were able to find information about this table, let's use it
-
-			// check if the query is send to single keyspace.
-			if routedKs == nil {
-				routedKs = routedTable.Keyspace
-			}
-			if routedKs.Name != routedTable.Keyspace.Name {
-				return nil, vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "cannot send the query to multiple keyspace due to different table_name: %s, %s", routedKs.Name, routedTable.Keyspace.Name)
-			}
-
-			shards, _, err := vcursor.ResolveDestinations(ctx, routedTable.Keyspace.Name, nil, []key.ShardDestination{key.DestinationAnyShard{}})
-			setSysTableNameBindVar(bindVars, tblBvName, routedTable.Name.String())
-			if tableSchema != "" {
-				setReplaceSchemaName(bindVars)
-			}
-			return shards, err
+		if routedTable == nil {
+			// no routed table info found. we'll return nil and check on the outside if we can find the table_schema
+			setSysTableNameBindVar(bindVars, tblBvName, tableName)
+			continue
 		}
-		// no routed table info found. we'll return nil and check on the outside if we can find the table_schema
-		setSysTableNameBindVar(bindVars, tblBvName, tableName)
+		// check if the query is send to single keyspace.
+		if routedKs == nil {
+			routedKs = routedTable.Keyspace
+		}
+		if routedKs.Name != routedTable.Keyspace.Name {
+			return nil, vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "cannot send the query to multiple keyspace due to different table_name: %s, %s", routedKs.Name, routedTable.Keyspace.Name)
+		}
+		setSysTableNameBindVar(bindVars, tblBvName, routedTable.Name.String())
 	}
-	return nil, nil
+	if routedKs == nil {
+		return nil, nil
+	}
+	shards, _, err := vcursor.ResolveDestinations(ctx, routedKs.Name, nil, []key.ShardDestination{key.DestinationAnyShard{}})
+	if tableSchema != "" {
+		setReplaceSchemaName(bindVars)
+	}
+	return shards, err
 }
 
 // setSysTableNameBindVar keeps the TUPLE shape an `in ::name` predicate expects.

--- a/go/vt/vtgate/engine/routing.go
+++ b/go/vt/vtgate/engine/routing.go
@@ -241,20 +241,29 @@ func (rp *RoutingParameters) routeInfoSchemaQuery(ctx context.Context, vcursor V
 		}
 		var tabName string
 		if tuple := val.TupleValues(); tuple != nil {
-			// A table-name list bindvar from an IN predicate: one name routes
-			// like the equality form (including routed-table handling below);
-			// any other length contributes nothing to routing and the
-			// predicate keeps working as the pushed-down filter it already
-			// is, so its bind variable stays untouched.
+			// A table-name list from an IN predicate. The expression reads
+			// the CLIENT's list bind variable — which the normalizer may
+			// share between identical IN tuples on other columns — while
+			// tblBvName is the dedicated, vtgate-owned list variable the
+			// rewritten query references, so the client's variable is never
+			// written. One name routes like the equality form (including
+			// routed-table handling below); any other length contributes
+			// nothing to routing and the predicate keeps working as the
+			// pushed-down filter it already is.
 			if len(tuple) != 1 {
+				// The rewritten query still references the dedicated
+				// variable, so it must be populated: copy the client's
+				// values unchanged.
+				bindVars[tblBvName] = tupleBindVariable(tuple)
 				continue
 			}
 			tabName = tuple[0].ToString()
+			bindVars[tblBvName] = tupleOfOneBindVariable(tabName)
 		} else {
 			tabName = val.Value(vcursor.ConnCollation()).ToString()
+			bindVars[tblBvName] = sqltypes.StringBindVariable(tabName)
 		}
 		tableNames[tblBvName] = tabName
-		setSysTableNameBindVar(bindVars, tblBvName, tabName)
 	}
 
 	// if the table_schema is system schema, route to default keyspace.
@@ -331,18 +340,33 @@ func (rp *RoutingParameters) routedTable(ctx context.Context, vcursor VCursor, b
 }
 
 // setSysTableNameBindVar sets a system-table name bind variable, preserving
-// its shape: a name that arrived as a one-element IN list bindvar must stay a
-// TUPLE value, because the query still references it as a list bind variable
-// (`in ::name`); everything else is the scalar the query's `= :name` expects.
+// its shape: a name that came from a one-element IN list is a vtgate-owned
+// TUPLE variable (the rewritten query says `in ::name`), while everything
+// else is the scalar the query's `= :name` expects.
 func setSysTableNameBindVar(bindVars map[string]*querypb.BindVariable, name, value string) {
 	if bv, ok := bindVars[name]; ok && bv.Type == querypb.Type_TUPLE {
-		bindVars[name] = &querypb.BindVariable{
-			Type:   querypb.Type_TUPLE,
-			Values: []*querypb.Value{{Type: querypb.Type_VARCHAR, Value: []byte(value)}},
-		}
+		bindVars[name] = tupleOfOneBindVariable(value)
 		return
 	}
 	bindVars[name] = sqltypes.StringBindVariable(value)
+}
+
+// tupleOfOneBindVariable builds the one-element TUPLE bind variable a
+// rewritten `in ::name` list predicate expects.
+func tupleOfOneBindVariable(value string) *querypb.BindVariable {
+	return &querypb.BindVariable{
+		Type:   querypb.Type_TUPLE,
+		Values: []*querypb.Value{{Type: querypb.Type_VARCHAR, Value: []byte(value)}},
+	}
+}
+
+// tupleBindVariable builds a TUPLE bind variable holding the given values.
+func tupleBindVariable(values []sqltypes.Value) *querypb.BindVariable {
+	bv := &querypb.BindVariable{Type: querypb.Type_TUPLE}
+	for _, value := range values {
+		bv.Values = append(bv.Values, sqltypes.ValueToProto(value))
+	}
+	return bv
 }
 
 func (rp *RoutingParameters) anyShard(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable) ([]*srvtopo.ResolvedShard, []map[string]*querypb.BindVariable, error) {

--- a/go/vt/vtgate/engine/routing.go
+++ b/go/vt/vtgate/engine/routing.go
@@ -217,7 +217,7 @@ func (rp *RoutingParameters) routeInfoSchemaQuery(ctx context.Context, vcursor V
 			// equality and routes; anything else cannot name one keyspace, and
 			// falling through would silently query the wrong one.
 			if len(tuple) != 1 {
-				return nil, vterrors.VT12001("IN list with multiple schema names in an information_schema query")
+				return nil, vterrors.VT12001("IN list with other than one schema name in an information_schema query")
 			}
 			ks = tuple[0].ToString()
 		} else {

--- a/go/vt/vtgate/engine/routing.go
+++ b/go/vt/vtgate/engine/routing.go
@@ -239,9 +239,22 @@ func (rp *RoutingParameters) routeInfoSchemaQuery(ctx context.Context, vcursor V
 		if err != nil {
 			return nil, err
 		}
-		tabName := val.Value(vcursor.ConnCollation()).ToString()
+		var tabName string
+		if tuple := val.TupleValues(); tuple != nil {
+			// A table-name list bindvar from an IN predicate: one name routes
+			// like the equality form (including routed-table handling below);
+			// any other length contributes nothing to routing and the
+			// predicate keeps working as the pushed-down filter it already
+			// is, so its bind variable stays untouched.
+			if len(tuple) != 1 {
+				continue
+			}
+			tabName = tuple[0].ToString()
+		} else {
+			tabName = val.Value(vcursor.ConnCollation()).ToString()
+		}
 		tableNames[tblBvName] = tabName
-		bindVars[tblBvName] = sqltypes.StringBindVariable(tabName)
+		setSysTableNameBindVar(bindVars, tblBvName, tabName)
 	}
 
 	// if the table_schema is system schema, route to default keyspace.
@@ -305,16 +318,31 @@ func (rp *RoutingParameters) routedTable(ctx context.Context, vcursor VCursor, b
 			}
 
 			shards, _, err := vcursor.ResolveDestinations(ctx, routedTable.Keyspace.Name, nil, []key.ShardDestination{key.DestinationAnyShard{}})
-			bindVars[tblBvName] = sqltypes.StringBindVariable(routedTable.Name.String())
+			setSysTableNameBindVar(bindVars, tblBvName, routedTable.Name.String())
 			if tableSchema != "" {
 				setReplaceSchemaName(bindVars)
 			}
 			return shards, err
 		}
 		// no routed table info found. we'll return nil and check on the outside if we can find the table_schema
-		bindVars[tblBvName] = sqltypes.StringBindVariable(tableName)
+		setSysTableNameBindVar(bindVars, tblBvName, tableName)
 	}
 	return nil, nil
+}
+
+// setSysTableNameBindVar sets a system-table name bind variable, preserving
+// its shape: a name that arrived as a one-element IN list bindvar must stay a
+// TUPLE value, because the query still references it as a list bind variable
+// (`in ::name`); everything else is the scalar the query's `= :name` expects.
+func setSysTableNameBindVar(bindVars map[string]*querypb.BindVariable, name, value string) {
+	if bv, ok := bindVars[name]; ok && bv.Type == querypb.Type_TUPLE {
+		bindVars[name] = &querypb.BindVariable{
+			Type:   querypb.Type_TUPLE,
+			Values: []*querypb.Value{{Type: querypb.Type_VARCHAR, Value: []byte(value)}},
+		}
+		return
+	}
+	bindVars[name] = sqltypes.StringBindVariable(value)
 }
 
 func (rp *RoutingParameters) anyShard(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable) ([]*srvtopo.ResolvedShard, []map[string]*querypb.BindVariable, error) {

--- a/go/vt/vtgate/engine/routing.go
+++ b/go/vt/vtgate/engine/routing.go
@@ -213,13 +213,20 @@ func (rp *RoutingParameters) routeInfoSchemaQuery(ctx context.Context, vcursor V
 		}
 		var ks string
 		if tuple := result.TupleValues(); tuple != nil {
-			// A list bindvar from an IN predicate: a single element is an
-			// equality and routes; anything else cannot name one keyspace, and
-			// falling through would silently query the wrong one.
-			if len(tuple) != 1 {
-				return nil, vterrors.VT12001("IN list with other than one schema name in an information_schema query")
+			// A list bindvar from an IN predicate: elements that all name
+			// the same schema route exactly like the equality form —
+			// duplicates do not change IN semantics — while distinct names
+			// cannot name one keyspace, and falling through would silently
+			// query the wrong one.
+			if len(tuple) == 0 {
+				return nil, vterrors.VT12001("empty IN list for the schema name in an information_schema query")
 			}
 			ks = tuple[0].ToString()
+			for _, val := range tuple[1:] {
+				if val.ToString() != ks {
+					return nil, vterrors.VT12001("IN list with more than one distinct schema name in an information_schema query")
+				}
+			}
 		} else {
 			ks = result.Value(vcursor.ConnCollation()).ToString()
 		}

--- a/go/vt/vtgate/engine/routing.go
+++ b/go/vt/vtgate/engine/routing.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"slices"
 	"strconv"
 
 	"vitess.io/vitess/go/mysql/collations"
@@ -206,8 +207,8 @@ func (rp *RoutingParameters) routeInfoSchemaQuery(ctx context.Context, vcursor V
 	}
 
 	env := evalengine.NewExpressionEnv(ctx, bindVars, vcursor)
-	var specifiedKS string
-	for idx, tableSchema := range rp.SysTableTableSchema {
+	names := make([]string, 0, len(rp.SysTableTableSchema))
+	for _, tableSchema := range rp.SysTableTableSchema {
 		result, err := env.Evaluate(tableSchema)
 		if err != nil {
 			return nil, err
@@ -216,11 +217,18 @@ func (rp *RoutingParameters) routeInfoSchemaQuery(ctx context.Context, vcursor V
 		if err != nil {
 			return nil, err
 		}
-		switch {
-		case idx == 0:
-			specifiedKS = ks
-		case specifiedKS != ks:
-			return nil, vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "specifying two different database in the query is not supported")
+		names = append(names, ks)
+	}
+	// A predicate naming no schema ("") makes the query match nothing;
+	// otherwise all predicates must name the same schema.
+	var specifiedKS string
+	if !slices.Contains(names, "") {
+		for _, ks := range names {
+			if specifiedKS == "" {
+				specifiedKS = ks
+			} else if ks != specifiedKS {
+				return nil, vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "specifying two different database in the query is not supported")
+			}
 		}
 	}
 

--- a/go/vt/vtgate/engine/routing.go
+++ b/go/vt/vtgate/engine/routing.go
@@ -206,34 +206,22 @@ func (rp *RoutingParameters) routeInfoSchemaQuery(ctx context.Context, vcursor V
 	}
 
 	env := evalengine.NewExpressionEnv(ctx, bindVars, vcursor)
-	// Intersect the schema names the table_schema predicates admit.
-	var candidates map[string]struct{}
-	for _, tableSchema := range rp.SysTableTableSchema {
+	var specifiedKS string
+	for idx, tableSchema := range rp.SysTableTableSchema {
 		result, err := env.Evaluate(tableSchema)
 		if err != nil {
 			return nil, err
 		}
-		names := schemaNames(result, vcursor.ConnCollation())
-		if candidates == nil {
-			candidates = names
-			continue
+		ks, err := schemaName(result, vcursor.ConnCollation())
+		if err != nil {
+			return nil, err
 		}
-		for name := range candidates {
-			if _, ok := names[name]; !ok {
-				delete(candidates, name)
-			}
+		switch {
+		case idx == 0:
+			specifiedKS = ks
+		case specifiedKS != ks:
+			return nil, vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "specifying two different database in the query is not supported")
 		}
-	}
-	var specifiedKS string
-	switch {
-	case len(candidates) > 1:
-		return nil, vterrors.VT12001("IN list with more than one distinct schema name in an information_schema query")
-	case len(candidates) == 1:
-		for name := range candidates {
-			specifiedKS = name
-		}
-	case candidates != nil:
-		return nil, vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "specifying two different database in the query is not supported")
 	}
 
 	bindVars[sqltypes.BvSchemaName] = sqltypes.StringBindVariable(specifiedKS)
@@ -246,9 +234,8 @@ func (rp *RoutingParameters) routeInfoSchemaQuery(ctx context.Context, vcursor V
 		}
 		var tabName string
 		if tuple := val.TupleValues(); tuple != nil {
-			// tblBvName is the dedicated list variable the rewritten query
-			// references; the client's list may be shared and is never written.
-			// Only a one-element list contributes to routing.
+			// Write the dedicated tblBvName, never the client's (possibly
+			// shared) list. Only a one-element list routes.
 			if len(tuple) != 1 {
 				bindVars[tblBvName] = tupleBindVariable(tuple)
 				continue
@@ -335,8 +322,7 @@ func (rp *RoutingParameters) routedTable(ctx context.Context, vcursor VCursor, b
 	return nil, nil
 }
 
-// setSysTableNameBindVar sets a table name bind variable, keeping the TUPLE
-// shape a rewritten `in ::name` predicate expects.
+// setSysTableNameBindVar keeps the TUPLE shape an `in ::name` predicate expects.
 func setSysTableNameBindVar(bindVars map[string]*querypb.BindVariable, name, value string) {
 	if bv, ok := bindVars[name]; ok && bv.Type == querypb.Type_TUPLE {
 		bindVars[name] = tupleOfOneBindVariable(value)
@@ -362,25 +348,28 @@ func tupleBindVariable(values []sqltypes.Value) *querypb.BindVariable {
 	return bv
 }
 
-// schemaNames returns the schema names a table_schema predicate admits. NULL
-// list elements are skipped; a list naming no schema matches nothing, like
-// `= NULL`, which the empty name expresses.
-func schemaNames(result evalengine.EvalResult, coll collations.ID) map[string]struct{} {
-	names := map[string]struct{}{}
+// schemaName returns the one schema name a predicate admits, skipping NULL list
+// elements (an all-NULL list yields "", matching nothing like `= NULL`). A list
+// naming several schemas is rejected: predicates may be on different schema
+// columns, so no other predicate can narrow it.
+func schemaName(result evalengine.EvalResult, coll collations.ID) (string, error) {
 	tuple := result.TupleValues()
 	if tuple == nil {
-		names[result.Value(coll).ToString()] = struct{}{}
-		return names
+		return result.Value(coll).ToString(), nil
 	}
+	var name string
+	found := false
 	for _, val := range tuple {
-		if !val.IsNull() {
-			names[val.ToString()] = struct{}{}
+		if val.IsNull() {
+			continue
+		}
+		if s := val.ToString(); !found {
+			name, found = s, true
+		} else if s != name {
+			return "", vterrors.VT12001("IN list with more than one distinct schema name in an information_schema query")
 		}
 	}
-	if len(names) == 0 {
-		names[""] = struct{}{}
-	}
-	return names
+	return name, nil
 }
 
 func (rp *RoutingParameters) anyShard(ctx context.Context, vcursor VCursor, bindVars map[string]*querypb.BindVariable) ([]*srvtopo.ResolvedShard, []map[string]*querypb.BindVariable, error) {

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -99,9 +99,17 @@ func (isr *InfoSchemaRouting) updateRoutingLogic(ctx *plancontext.PlanningContex
 			}
 		}
 		isr.SysTableTableSchema = append(isr.SysTableTableSchema, out)
-	} else {
-		isr.SysTableTableName[bvName] = out
+		return isr
 	}
+	if existing, ok := isr.SysTableTableName[bvName]; ok && !sqlparser.Equals.Expr(existing, out) {
+		// The column's bind variable already carries a different value; a
+		// second one cannot share it, so this predicate stays a plain filter.
+		if cmp, ok := expr.(*sqlparser.ComparisonExpr); ok {
+			cmp.Right = out
+		}
+		return isr
+	}
+	isr.SysTableTableName[bvName] = out
 	return isr
 }
 

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -139,23 +139,42 @@ func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlp
 	switch cmp.Operator {
 	case sqlparser.EqualOp:
 	case sqlparser.InOp:
-		// A single-element IN list is an equality: only one destination is
-		// named, so the predicate routes exactly like `=` (mirrors
-		// ShardedRouting.planInOp). Guard BEFORE mutating: an element the
-		// equality path would refuse (e.g. database(), which must stay in the
-		// query untouched) must leave the IN exactly as written.
-		tuple, ok := cmp.Right.(sqlparser.ValTuple)
-		if !ok || len(tuple) != 1 || !shouldRewrite(tuple[0]) {
+		switch rhs := cmp.Right.(type) {
+		case sqlparser.ValTuple:
+			// A single-element IN list is an equality: only one destination is
+			// named, so the predicate routes exactly like `=` (mirrors
+			// ShardedRouting.planInOp). Guard BEFORE mutating: an element the
+			// equality path would refuse (e.g. database(), which must stay in the
+			// query untouched) must leave the IN exactly as written.
+			if len(rhs) != 1 || !shouldRewrite(rhs[0]) {
+				return false, "", nil
+			}
+			// Only routable columns get the equality rewrite: a single-element IN
+			// on any other column must stay exactly as written.
+			col, isSchema, isTable := IsTableSchemaOrName(cmp.Left, ctx.VSchema.Environment().MySQLVersion())
+			if col == nil || (!isSchema && !isTable) {
+				return false, "", nil
+			}
+			cmp.Operator = sqlparser.EqualOp
+			cmp.Right = rhs[0]
+		case sqlparser.ListArg:
+			// The normalizer turns `in ('x')` into a list bindvar whose length
+			// is unknown until execution. Extract it for the schema column and
+			// let routeInfoSchemaQuery unwrap a 1-element list or error on a
+			// longer one; rewriting to equality here is correct for the only
+			// length that routes. table_name lists are deliberately NOT
+			// extracted: they already work as pushed-down filters once the
+			// schema routes, for any length.
+			col, isSchema, _ := IsTableSchemaOrName(cmp.Left, ctx.VSchema.Environment().MySQLVersion())
+			if col == nil || !isSchema {
+				return false, "", nil
+			}
+			cmp.Operator = sqlparser.EqualOp
+			cmp.Right = sqlparser.NewTypedArgument(sqltypes.BvSchemaName, sqltypes.VarChar)
+			return true, sqltypes.BvSchemaName, rhs
+		default:
 			return false, "", nil
 		}
-		// Only routable columns get the equality rewrite: a single-element IN
-		// on any other column must stay exactly as written.
-		col, isSchema, isTable := IsTableSchemaOrName(cmp.Left, ctx.VSchema.Environment().MySQLVersion())
-		if col == nil || (!isSchema && !isTable) {
-			return false, "", nil
-		}
-		cmp.Operator = sqlparser.EqualOp
-		cmp.Right = tuple[0]
 	default:
 		return false, "", nil
 	}

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -139,52 +139,67 @@ func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlp
 	switch cmp.Operator {
 	case sqlparser.EqualOp:
 	case sqlparser.InOp:
-		switch rhs := cmp.Right.(type) {
-		case sqlparser.ValTuple:
-			// A single-element IN list is an equality: only one destination is
-			// named, so the predicate routes exactly like `=` (mirrors
-			// ShardedRouting.planInOp). Guard BEFORE mutating: an element the
-			// equality path would refuse (e.g. database(), which must stay in the
-			// query untouched) must leave the IN exactly as written.
-			if len(rhs) != 1 || !shouldRewrite(rhs[0]) {
-				return false, "", nil
-			}
-			// Only routable columns get the equality rewrite: a single-element IN
-			// on any other column must stay exactly as written.
-			col, isSchema, isTable := IsTableSchemaOrName(cmp.Left, ctx.VSchema.Environment().MySQLVersion())
-			if col == nil || (!isSchema && !isTable) {
-				return false, "", nil
-			}
-			// Guard BEFORE mutating: if the element can't be translated to an
-			// evalengine expression, we won't be able to route on it, so the IN
-			// must be left exactly as written instead of being cosmetically
-			// rewritten to `=` (same Config as the shared translatability check
-			// below).
-			_, err := evalengine.Translate(rhs[0], &evalengine.Config{
+		// Only routable columns are ever touched: an IN on any other column
+		// must stay exactly as written. All guards run BEFORE any mutation.
+		col, isSchema, isTable := IsTableSchemaOrName(cmp.Left, ctx.VSchema.Environment().MySQLVersion())
+		if col == nil || (!isSchema && !isTable) {
+			return false, "", nil
+		}
+		translates := func(e sqlparser.Expr) bool {
+			// same Config as the shared translatability check below
+			_, err := evalengine.Translate(e, &evalengine.Config{
 				Collation:     collations.SystemCollation.Collation,
 				ResolveColumn: NotImplementedSchemaInfoResolver,
 				Environment:   ctx.VSchema.Environment(),
 			})
-			if err != nil {
-				return false, "", nil
+			return err == nil
+		}
+		switch rhs := cmp.Right.(type) {
+		case sqlparser.ValTuple:
+			if len(rhs) == 1 {
+				// A single-element IN list is an equality: only one destination
+				// is named, so the predicate routes exactly like `=` (mirrors
+				// ShardedRouting.planInOp). An element the equality path would
+				// refuse (e.g. database(), which must stay in the query
+				// untouched) leaves the IN exactly as written.
+				if !shouldRewrite(rhs[0]) || !translates(rhs[0]) {
+					return false, "", nil
+				}
+				cmp.Operator = sqlparser.EqualOp
+				cmp.Right = rhs[0]
+				break // continue into the shared equality tail below
 			}
-			cmp.Operator = sqlparser.EqualOp
-			cmp.Right = rhs[0]
-		case sqlparser.ListArg:
-			// The normalizer turns `in ('x')` into a list bindvar whose length
-			// is unknown until execution. Extract it for the schema column and
-			// let routeInfoSchemaQuery unwrap a 1-element list or error on a
-			// longer one; rewriting to equality here is correct for the only
-			// length that routes. table_name lists are deliberately NOT
-			// extracted: they already work as pushed-down filters once the
-			// schema routes, for any length.
-			col, isSchema, _ := IsTableSchemaOrName(cmp.Left, ctx.VSchema.Environment().MySQLVersion())
-			if col == nil || !isSchema {
+			// A multi-element schema list — a literal list with normalization
+			// disabled, or a prepared statement's `IN (?, ?)` — cannot name
+			// one keyspace. Carry the whole tuple so routeInfoSchemaQuery's
+			// cardinality guard rejects it loudly at execution instead of the
+			// query silently running against the default keyspace. The
+			// equality rewrite below is safe: execution always errors on the
+			// tuple before the rewritten query can be sent anywhere.
+			// Multi-element table_name lists are left alone: they already
+			// work as pushed-down filters once the schema routes.
+			if !isSchema || !translates(rhs) {
 				return false, "", nil
 			}
 			cmp.Operator = sqlparser.EqualOp
 			cmp.Right = sqlparser.NewTypedArgument(sqltypes.BvSchemaName, sqltypes.VarChar)
 			return true, sqltypes.BvSchemaName, rhs
+		case sqlparser.ListArg:
+			// The normalizer turns `in ('x')` into a list bindvar whose length
+			// is unknown until execution, so routeInfoSchemaQuery decides
+			// there: for the schema column one value routes and any other
+			// length errors, so the predicate is rewritten to the equality
+			// form up front. For the table_name column one value contributes
+			// routed-table handling while other lengths keep working as the
+			// pushed-down filter, so the predicate must stay exactly as
+			// written: it is keyed by the list's own bind variable name and
+			// the engine rewrites that variable's value in place.
+			if isSchema {
+				cmp.Operator = sqlparser.EqualOp
+				cmp.Right = sqlparser.NewTypedArgument(sqltypes.BvSchemaName, sqltypes.VarChar)
+				return true, sqltypes.BvSchemaName, rhs
+			}
+			return false, string(rhs), rhs
 		default:
 			return false, "", nil
 		}

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -139,14 +139,12 @@ func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlp
 	switch cmp.Operator {
 	case sqlparser.EqualOp:
 	case sqlparser.InOp:
-		// Only routable columns are ever touched: an IN on any other column
-		// must stay exactly as written. All guards run BEFORE any mutation.
+		// Guard before mutating: an IN on a non-routable column stays as written.
 		col, isSchema, isTable := IsTableSchemaOrName(cmp.Left, ctx.VSchema.Environment().MySQLVersion())
 		if col == nil || (!isSchema && !isTable) {
 			return false, "", nil
 		}
 		translates := func(e sqlparser.Expr) bool {
-			// same Config as the shared translatability check below
 			_, err := evalengine.Translate(e, &evalengine.Config{
 				Collation:     collations.SystemCollation.Collation,
 				ResolveColumn: NotImplementedSchemaInfoResolver,
@@ -157,31 +155,17 @@ func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlp
 		switch rhs := cmp.Right.(type) {
 		case sqlparser.ValTuple:
 			if len(rhs) == 1 {
-				// A single-element IN list is an equality: only one destination
-				// is named, so the predicate routes exactly like `=` (mirrors
-				// ShardedRouting.planInOp). An element the equality path would
-				// refuse (e.g. database(), which must stay in the query
-				// untouched) leaves the IN exactly as written.
+				// A one-element IN is an equality (mirrors ShardedRouting.planInOp).
 				if !shouldRewrite(rhs[0]) || !translates(rhs[0]) {
 					return false, "", nil
 				}
 				cmp.Operator = sqlparser.EqualOp
 				cmp.Right = rhs[0]
-				break // continue into the shared equality tail below
+				break
 			}
-			// A multi-element schema list — a literal list with normalization
-			// disabled, or a prepared statement's `IN (?, ?)` — routes only
-			// if every element resolves to the same schema (duplicates do
-			// not change IN semantics). Carry the whole tuple so
-			// routeInfoSchemaQuery decides at execution: elements that all
-			// name one schema route like equality, distinct names are
-			// rejected loudly instead of the query silently running against
-			// the default keyspace. The equality rewrite below is safe
-			// either way: the engine substitutes the resolved value, or
-			// errors on the tuple before the rewritten query can be sent
-			// anywhere.
-			// Multi-element table_name lists are left alone: they already
-			// work as pushed-down filters once the schema routes.
+			// Multi-element schema lists are resolved at execution, where they
+			// are intersected with the other schema predicates. table_name
+			// lists already work as pushed-down filters.
 			if !isSchema || !translates(rhs) {
 				return false, "", nil
 			}
@@ -189,33 +173,16 @@ func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlp
 			cmp.Right = sqlparser.NewTypedArgument(sqltypes.BvSchemaName, sqltypes.VarChar)
 			return true, sqltypes.BvSchemaName, rhs
 		case sqlparser.ListArg:
-			// The normalizer turns `in ('x')` into a list bindvar whose length
-			// is unknown until execution, so routeInfoSchemaQuery decides
-			// there: for the schema column one value routes and any other
-			// length errors, so the predicate is rewritten to the equality
-			// form up front. For the table_name column one value contributes
-			// routed-table handling while other lengths keep working as the
-			// pushed-down filter, so the predicate keeps its IN shape but is
-			// re-pointed at a dedicated, vtgate-owned list variable that the
-			// engine populates at execution — see below.
+			// The list's length is only known at execution.
 			if isSchema {
 				cmp.Operator = sqlparser.EqualOp
 				cmp.Right = sqlparser.NewTypedArgument(sqltypes.BvSchemaName, sqltypes.VarChar)
 				return true, sqltypes.BvSchemaName, rhs
 			}
-			// The client's list may be shared: the normalizer reuses one list
-			// bind variable for identical IN tuples across predicates, so the
-			// engine must never write it. Re-point this predicate at a
-			// dedicated, vtgate-owned list variable; the stored expression
-			// still reads the client's list, and the engine populates the
-			// dedicated one (with the routed table name when applicable).
-			//
-			// The rewrite must be idempotent: resetRoutingLogic replays
-			// seenPredicates, which hold this same, already-mutated node.
-			// A replay that reserved yet another name would store an
-			// expression reading a variable nothing populates (the issue
-			// #20972 hazard class), so recognize our own dedicated variable
-			// and recover the client's original list from the reservations.
+			// The normalizer shares one list bindvar between identical IN tuples,
+			// so the engine writes a dedicated variable instead of the client's.
+			// resetRoutingLogic replays this already-rewritten node: recognize
+			// the dedicated variable and recover the client's list (#20972).
 			for original, name := range ctx.ReservedArguments {
 				if name != string(rhs) {
 					continue

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -191,9 +191,9 @@ func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlp
 			// length errors, so the predicate is rewritten to the equality
 			// form up front. For the table_name column one value contributes
 			// routed-table handling while other lengths keep working as the
-			// pushed-down filter, so the predicate must stay exactly as
-			// written: it is keyed by the list's own bind variable name and
-			// the engine rewrites that variable's value in place.
+			// pushed-down filter, so the predicate keeps its IN shape but is
+			// re-pointed at a dedicated, vtgate-owned list variable that the
+			// engine populates at execution — see below.
 			if isSchema {
 				cmp.Operator = sqlparser.EqualOp
 				cmp.Right = sqlparser.NewTypedArgument(sqltypes.BvSchemaName, sqltypes.VarChar)

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -165,7 +165,7 @@ func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlp
 			}
 			// Multi-element schema lists are resolved at execution. table_name
 			// lists already work as pushed-down filters.
-			if !isSchema || !translates(rhs) {
+			if !isSchema || !translates(rhs) || slices.ContainsFunc(rhs, func(e sqlparser.Expr) bool { return !shouldRewrite(e) }) {
 				return false, "", nil
 			}
 			cmp.Operator = sqlparser.EqualOp

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -199,7 +199,15 @@ func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlp
 				cmp.Right = sqlparser.NewTypedArgument(sqltypes.BvSchemaName, sqltypes.VarChar)
 				return true, sqltypes.BvSchemaName, rhs
 			}
-			return false, string(rhs), rhs
+			// The client's list may be shared: the normalizer reuses one list
+			// bind variable for identical IN tuples across predicates, so the
+			// engine must never write it. Re-point this predicate at a
+			// dedicated, vtgate-owned list variable; the stored expression
+			// still reads the client's list, and the engine populates the
+			// dedicated one (with the routed table name when applicable).
+			bvName := ctx.GetReservedArgumentFor(rhs)
+			cmp.Right = sqlparser.ListArg(bvName)
+			return false, bvName, rhs
 		default:
 			return false, "", nil
 		}

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -148,6 +148,12 @@ func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlp
 		if !ok || len(tuple) != 1 || !shouldRewrite(tuple[0]) {
 			return false, "", nil
 		}
+		// Only routable columns get the equality rewrite: a single-element IN
+		// on any other column must stay exactly as written.
+		col, isSchema, isTable := IsTableSchemaOrName(cmp.Left, ctx.VSchema.Environment().MySQLVersion())
+		if col == nil || (!isSchema && !isTable) {
+			return false, "", nil
+		}
 		cmp.Operator = sqlparser.EqualOp
 		cmp.Right = tuple[0]
 	default:

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -170,12 +170,16 @@ func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlp
 				break // continue into the shared equality tail below
 			}
 			// A multi-element schema list — a literal list with normalization
-			// disabled, or a prepared statement's `IN (?, ?)` — cannot name
-			// one keyspace. Carry the whole tuple so routeInfoSchemaQuery's
-			// cardinality guard rejects it loudly at execution instead of the
-			// query silently running against the default keyspace. The
-			// equality rewrite below is safe: execution always errors on the
-			// tuple before the rewritten query can be sent anywhere.
+			// disabled, or a prepared statement's `IN (?, ?)` — routes only
+			// if every element resolves to the same schema (duplicates do
+			// not change IN semantics). Carry the whole tuple so
+			// routeInfoSchemaQuery decides at execution: elements that all
+			// name one schema route like equality, distinct names are
+			// rejected loudly instead of the query silently running against
+			// the default keyspace. The equality rewrite below is safe
+			// either way: the engine substitutes the resolved value, or
+			// errors on the tuple before the rewritten query can be sent
+			// anywhere.
 			// Multi-element table_name lists are left alone: they already
 			// work as pushed-down filters once the schema routes.
 			if !isSchema || !translates(rhs) {

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -163,8 +163,7 @@ func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlp
 				cmp.Right = rhs[0]
 				break
 			}
-			// Multi-element schema lists are resolved at execution, where they
-			// are intersected with the other schema predicates. table_name
+			// Multi-element schema lists are resolved at execution. table_name
 			// lists already work as pushed-down filters.
 			if !isSchema || !translates(rhs) {
 				return false, "", nil
@@ -179,10 +178,9 @@ func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlp
 				cmp.Right = sqlparser.NewTypedArgument(sqltypes.BvSchemaName, sqltypes.VarChar)
 				return true, sqltypes.BvSchemaName, rhs
 			}
-			// The normalizer shares one list bindvar between identical IN tuples,
-			// so the engine writes a dedicated variable instead of the client's.
-			// resetRoutingLogic replays this already-rewritten node: recognize
-			// the dedicated variable and recover the client's list (#20972).
+			// The normalizer shares list bindvars between identical IN tuples, so
+			// the engine writes a dedicated variable. On replay (resetRoutingLogic)
+			// recognize it and recover the client's list (#20972).
 			for original, name := range ctx.ReservedArguments {
 				if name != string(rhs) {
 					continue

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -133,7 +133,24 @@ func (isr *InfoSchemaRouting) Keyspace() *vindexes.Keyspace {
 
 func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlparser.Expr) (bool, string, sqlparser.Expr) {
 	cmp, ok := in.(*sqlparser.ComparisonExpr)
-	if !ok || cmp.Operator != sqlparser.EqualOp {
+	if !ok {
+		return false, "", nil
+	}
+	switch cmp.Operator {
+	case sqlparser.EqualOp:
+	case sqlparser.InOp:
+		// A single-element IN list is an equality: only one destination is
+		// named, so the predicate routes exactly like `=` (mirrors
+		// ShardedRouting.planInOp). Guard BEFORE mutating: an element the
+		// equality path would refuse (e.g. database(), which must stay in the
+		// query untouched) must leave the IN exactly as written.
+		tuple, ok := cmp.Right.(sqlparser.ValTuple)
+		if !ok || len(tuple) != 1 || !shouldRewrite(tuple[0]) {
+			return false, "", nil
+		}
+		cmp.Operator = sqlparser.EqualOp
+		cmp.Right = tuple[0]
+	default:
 		return false, "", nil
 	}
 

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -205,6 +205,21 @@ func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlp
 			// dedicated, vtgate-owned list variable; the stored expression
 			// still reads the client's list, and the engine populates the
 			// dedicated one (with the routed table name when applicable).
+			//
+			// The rewrite must be idempotent: resetRoutingLogic replays
+			// seenPredicates, which hold this same, already-mutated node.
+			// A replay that reserved yet another name would store an
+			// expression reading a variable nothing populates (the issue
+			// #20972 hazard class), so recognize our own dedicated variable
+			// and recover the client's original list from the reservations.
+			for original, name := range ctx.ReservedArguments {
+				if name != string(rhs) {
+					continue
+				}
+				if clientList, ok := original.(sqlparser.ListArg); ok {
+					return false, name, clientList
+				}
+			}
 			bvName := ctx.GetReservedArgumentFor(rhs)
 			cmp.Right = sqlparser.ListArg(bvName)
 			return false, bvName, rhs

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -155,6 +155,19 @@ func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlp
 			if col == nil || (!isSchema && !isTable) {
 				return false, "", nil
 			}
+			// Guard BEFORE mutating: if the element can't be translated to an
+			// evalengine expression, we won't be able to route on it, so the IN
+			// must be left exactly as written instead of being cosmetically
+			// rewritten to `=` (same Config as the shared translatability check
+			// below).
+			_, err := evalengine.Translate(rhs[0], &evalengine.Config{
+				Collation:     collations.SystemCollation.Collation,
+				ResolveColumn: NotImplementedSchemaInfoResolver,
+				Environment:   ctx.VSchema.Environment(),
+			})
+			if err != nil {
+				return false, "", nil
+			}
 			cmp.Operator = sqlparser.EqualOp
 			cmp.Right = rhs[0]
 		case sqlparser.ListArg:

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -102,8 +102,7 @@ func (isr *InfoSchemaRouting) updateRoutingLogic(ctx *plancontext.PlanningContex
 		return isr
 	}
 	if existing, ok := isr.SysTableTableName[bvName]; ok && !sqlparser.Equals.Expr(existing, out) {
-		// The column's bind variable already carries a different value; a
-		// second one cannot share it, so this predicate stays a plain filter.
+		// Another value already owns this column's bind variable: stay a filter.
 		if cmp, ok := expr.(*sqlparser.ComparisonExpr); ok {
 			cmp.Right = out
 		}
@@ -173,7 +172,7 @@ func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlp
 			}
 			// Multi-element schema lists are resolved at execution. table_name
 			// lists already work as pushed-down filters.
-			if !isSchema || !translates(rhs) || slices.ContainsFunc(rhs, func(e sqlparser.Expr) bool { return !shouldRewrite(e) }) {
+			if !isSchema || !translates(rhs) {
 				return false, "", nil
 			}
 			cmp.Operator = sqlparser.EqualOp

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning.go
@@ -171,8 +171,9 @@ func extractInfoSchemaRoutingPredicate(ctx *plancontext.PlanningContext, in sqlp
 				break
 			}
 			// Multi-element schema lists are resolved at execution. table_name
-			// lists already work as pushed-down filters.
-			if !isSchema || !translates(rhs) {
+			// lists already work as pushed-down filters. Lists containing
+			// database()/schema() stay with the tablet, like = database().
+			if !isSchema || !translates(rhs) || slices.ContainsFunc(rhs, func(e sqlparser.Expr) bool { return !shouldRewrite(e) }) {
 				return false, "", nil
 			}
 			cmp.Operator = sqlparser.EqualOp

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning_test.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning_test.go
@@ -28,9 +28,8 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/semantics"
 )
 
-// environmentOnlyVSchema stubs the one plancontext.VSchema method the
-// extraction code touches; every other method panics via the embedded nil
-// interface, which is exactly what a unit test wants.
+// environmentOnlyVSchema stubs the one plancontext.VSchema method extraction
+// touches.
 type environmentOnlyVSchema struct {
 	plancontext.VSchema
 }
@@ -39,15 +38,9 @@ func (environmentOnlyVSchema) Environment() *vtenv.Environment {
 	return vtenv.NewTestEnv()
 }
 
-// TestExtractInfoSchemaRoutingPredicateListArgReplay pins the idempotence of
-// the table_name IN ::list extraction. resetRoutingLogic replays
-// seenPredicates, which hold the SAME comparison node a previous extraction
-// already re-pointed at a dedicated, vtgate-owned list variable. The replayed
-// extraction must recognize its own variable: reuse the same name, recover
-// the CLIENT's original list as the routing source, and leave the predicate
-// untouched. Reserving another name would store an expression that reads a
-// variable nothing populates, failing execution with a missing-argument
-// error (the hazard class of issue #20972, which this arm must not extend).
+// TestExtractInfoSchemaRoutingPredicateListArgReplay pins that re-extracting an
+// already-rewritten `table_name IN ::list` node (as resetRoutingLogic does) is
+// idempotent: same dedicated variable, client's list recovered, no re-mutation.
 func TestExtractInfoSchemaRoutingPredicateListArgReplay(t *testing.T) {
 	ctx := &plancontext.PlanningContext{
 		ReservedVars:      sqlparser.NewReservedVars("vtg", sqlparser.BindVars{"tables": {}}),

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning_test.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operators
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtenv"
+	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
+	"vitess.io/vitess/go/vt/vtgate/semantics"
+)
+
+// environmentOnlyVSchema stubs the one plancontext.VSchema method the
+// extraction code touches; every other method panics via the embedded nil
+// interface, which is exactly what a unit test wants.
+type environmentOnlyVSchema struct {
+	plancontext.VSchema
+}
+
+func (environmentOnlyVSchema) Environment() *vtenv.Environment {
+	return vtenv.NewTestEnv()
+}
+
+// TestExtractInfoSchemaRoutingPredicateListArgReplay pins the idempotence of
+// the table_name IN ::list extraction. resetRoutingLogic replays
+// seenPredicates, which hold the SAME comparison node a previous extraction
+// already re-pointed at a dedicated, vtgate-owned list variable. The replayed
+// extraction must recognize its own variable: reuse the same name, recover
+// the CLIENT's original list as the routing source, and leave the predicate
+// untouched. Reserving another name would store an expression that reads a
+// variable nothing populates, failing execution with a missing-argument
+// error (the hazard class of issue #20972, which this arm must not extend).
+func TestExtractInfoSchemaRoutingPredicateListArgReplay(t *testing.T) {
+	ctx := &plancontext.PlanningContext{
+		ReservedVars:      sqlparser.NewReservedVars("vtg", sqlparser.BindVars{"tables": {}}),
+		ReservedArguments: map[sqlparser.Expr]string{},
+		SemTable:          semantics.EmptySemTable(),
+		VSchema:           environmentOnlyVSchema{},
+	}
+	cmp := &sqlparser.ComparisonExpr{
+		Operator: sqlparser.InOp,
+		Left:     sqlparser.NewColName("table_name"),
+		Right:    sqlparser.ListArg("tables"),
+	}
+
+	isSchema, bvName, out := extractInfoSchemaRoutingPredicate(ctx, cmp)
+	require.False(t, isSchema)
+	require.Equal(t, sqlparser.ListArg("tables"), out)
+	require.NotEqual(t, "tables", bvName, "the predicate must be re-pointed at a dedicated variable")
+	require.Equal(t, sqlparser.ListArg(bvName), cmp.Right)
+
+	isSchema2, bvName2, out2 := extractInfoSchemaRoutingPredicate(ctx, cmp)
+	require.False(t, isSchema2)
+	assert.Equal(t, bvName, bvName2, "replay must reuse the dedicated variable, not reserve another")
+	assert.Equal(t, sqlparser.ListArg("tables"), out2, "replay must recover the client's original list")
+	assert.Equal(t, sqlparser.ListArg(bvName), cmp.Right, "replay must not mutate the predicate again")
+}

--- a/go/vt/vtgate/planbuilder/operators/info_schema_planning_test.go
+++ b/go/vt/vtgate/planbuilder/operators/info_schema_planning_test.go
@@ -39,8 +39,7 @@ func (environmentOnlyVSchema) Environment() *vtenv.Environment {
 }
 
 // TestExtractInfoSchemaRoutingPredicateListArgReplay pins that re-extracting an
-// already-rewritten `table_name IN ::list` node (as resetRoutingLogic does) is
-// idempotent: same dedicated variable, client's list recovered, no re-mutation.
+// already-rewritten `table_name IN ::list` node is idempotent.
 func TestExtractInfoSchemaRoutingPredicateListArgReplay(t *testing.T) {
 	ctx := &plancontext.PlanningContext{
 		ReservedVars:      sqlparser.NewReservedVars("vtg", sqlparser.BindVars{"tables": {}}),

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -1228,5 +1228,45 @@
         "Query": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where `engine` in ('InnoDB')"
       }
     }
+  },
+  {
+    "comment": "IN with a list bindvar on table_schema is extracted; length is enforced at execution time",
+    "query": "select table_name from information_schema.tables where table_schema in ::schemas",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema in ::schemas",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
+        "SysTableTableSchema": "[::schemas]"
+      }
+    }
+  },
+  {
+    "comment": "IN with a list bindvar on table_name stays a plain filter (multi-name INs work as filters once the schema routes)",
+    "query": "select column_name from information_schema.statistics where table_schema = 'user' and table_name in ::tables",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select column_name from information_schema.statistics where table_schema = 'user' and table_name in ::tables",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `column_name` from information_schema.statistics where 1 != 1",
+        "Query": "select `column_name` from information_schema.statistics where table_schema = :__vtschemaname /* VARCHAR */ and `table_name` in ::tables",
+        "SysTableTableSchema": "['user']"
+      }
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -1212,6 +1212,25 @@
     }
   },
   {
+    "comment": "multi-element IN containing database() is left alone",
+    "query": "select table_name from information_schema.tables where table_schema in (database(), 'vt_main')",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema in (database(), 'vt_main')",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where table_schema in (database(), 'vt_main')"
+      }
+    }
+  },
+  {
     "comment": "single-element IN on a non-routing column is left alone",
     "query": "select * from information_schema.tables where engine in ('InnoDB')",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -1094,7 +1094,7 @@
     }
   },
   {
-    "comment": "table_schema OR predicate # rewritten to IN and carried: more than one schema name errors loudly at execution instead of silently querying the default keyspace",
+    "comment": "table_schema OR predicate # rewritten to IN and resolved at execution",
     "query": "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'ks' OR TABLE_SCHEMA = 'main'",
     "plan": {
       "Type": "Passthrough",
@@ -1212,7 +1212,7 @@
     }
   },
   {
-    "comment": "single-element IN on a non-routing column is left alone, no equality rewrite",
+    "comment": "single-element IN on a non-routing column is left alone",
     "query": "select * from information_schema.tables where engine in ('InnoDB')",
     "plan": {
       "Type": "Passthrough",
@@ -1231,7 +1231,7 @@
     }
   },
   {
-    "comment": "IN with a list bindvar on table_schema is extracted; length is enforced at execution time",
+    "comment": "list bindvar IN on table_schema is resolved at execution",
     "query": "select table_name from information_schema.tables where table_schema in ::schemas",
     "plan": {
       "Type": "Passthrough",
@@ -1251,7 +1251,7 @@
     }
   },
   {
-    "comment": "IN with a list bindvar on table_name is extracted without rewriting the predicate; one value routes (incl. routed tables), more stay a working filter",
+    "comment": "list bindvar IN on table_name is re-pointed at a dedicated variable",
     "query": "select column_name from information_schema.statistics where table_schema = 'user' and table_name in ::tables",
     "plan": {
       "Type": "Passthrough",
@@ -1272,7 +1272,7 @@
     }
   },
   {
-    "comment": "a list bindvar shared between predicates (the normalizer dedupes identical IN tuples): only the table_name predicate is re-pointed at the dedicated variable; the shared client variable stays untouched in the other predicate",
+    "comment": "a list bindvar shared between predicates: only the table_name predicate is re-pointed",
     "query": "select column_name from information_schema.statistics where table_schema = 'user' and table_name in ::names and index_name in ::names",
     "plan": {
       "Type": "Passthrough",
@@ -1293,7 +1293,7 @@
     }
   },
   {
-    "comment": "multi-element literal IN on table_schema is carried for the execution-time guard (errors there; never silently unrouted)",
+    "comment": "multi-element literal IN on table_schema is resolved at execution",
     "query": "select table_name from information_schema.tables where table_schema in ('a', 'b')",
     "plan": {
       "Type": "Passthrough",
@@ -1313,7 +1313,7 @@
     }
   },
   {
-    "comment": "prepared-statement IN on table_schema (tuple of arguments) is carried for the execution-time guard",
+    "comment": "prepared-statement IN on table_schema is resolved at execution",
     "query": "select table_name from information_schema.tables where table_schema in (:v1, :v2)",
     "plan": {
       "Type": "Passthrough",
@@ -1333,7 +1333,7 @@
     }
   },
   {
-    "comment": "single-element IN with an untranslatable element is left alone (extraction must fail before any rewrite)",
+    "comment": "single-element IN with an untranslatable element is left alone",
     "query": "select * from information_schema.tables where table_schema in (table_name)",
     "plan": {
       "Type": "Passthrough",
@@ -1352,7 +1352,7 @@
     }
   },
   {
-    "comment": "NOT IN on table_schema is left alone, no rewrite",
+    "comment": "NOT IN on table_schema is left alone",
     "query": "select table_name from information_schema.tables where table_schema not in ('user')",
     "plan": {
       "Type": "Passthrough",
@@ -1371,7 +1371,7 @@
     }
   },
   {
-    "comment": "single-element list bindvar on a non-routing column is left alone, no equality rewrite",
+    "comment": "single-element list bindvar on a non-routing column is left alone",
     "query": "select * from information_schema.tables where engine in ::x",
     "plan": {
       "Type": "Passthrough",

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -1212,7 +1212,7 @@
     }
   },
   {
-    "comment": "multi-element IN containing database() is left alone",
+    "comment": "multi-element IN containing database() is resolved at execution, database() evaluating to the connected keyspace",
     "query": "select table_name from information_schema.tables where table_schema in (database(), 'vt_main')",
     "plan": {
       "Type": "Passthrough",
@@ -1226,7 +1226,8 @@
           "Sharded": false
         },
         "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
-        "Query": "select `table_name` from information_schema.`tables` where table_schema in (database(), 'vt_main')"
+        "Query": "select `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
+        "SysTableTableSchema": "[(database(), 'vt_main')]"
       }
     }
   },

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -951,8 +951,8 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1",
-                    "Query": "select 1 as `found` from information_schema.`tables` where `table_name` = :table_name1 /* VARCHAR */ and `table_name` = :table_name1 /* VARCHAR */ limit :__upper_limit",
-                    "SysTableTableName": "[table_name1:'Music']"
+                    "Query": "select 1 as `found` from information_schema.`tables` where `table_name` = :table_name1 /* VARCHAR */ and `table_name` = 'Music' limit :__upper_limit",
+                    "SysTableTableName": "[table_name1:'music']"
                   },
                   {
                     "OperatorType": "Route",
@@ -962,8 +962,8 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select 1 as `found` from information_schema.views where 1 != 1",
-                    "Query": "select 1 as `found` from information_schema.views where `table_name` = :table_name2 /* VARCHAR */ and `table_name` = :table_name2 /* VARCHAR */ limit :__upper_limit",
-                    "SysTableTableName": "[table_name2:'user']"
+                    "Query": "select 1 as `found` from information_schema.views where `table_name` = :table_name2 /* VARCHAR */ and `table_name` = 'user' limit :__upper_limit",
+                    "SysTableTableName": "[table_name2:'music']"
                   }
                 ]
               }
@@ -978,8 +978,8 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1",
-            "Query": "select 1 as `found` from information_schema.`tables` where `table_name` = :table_name /* VARCHAR */ and `table_name` = :table_name /* VARCHAR */ and :__sq_has_values",
-            "SysTableTableName": "[table_name:'Music']"
+            "Query": "select 1 as `found` from information_schema.`tables` where `table_name` = :table_name /* VARCHAR */ and `table_name` = 'Music' and :__sq_has_values",
+            "SysTableTableName": "[table_name:'music']"
           }
         ]
       }
@@ -1227,6 +1227,46 @@
         },
         "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
         "Query": "select `table_name` from information_schema.`tables` where table_schema in (database(), 'vt_main')"
+      }
+    }
+  },
+  {
+    "comment": "a second, different table_name value stays a plain filter instead of overwriting the routing source",
+    "query": "select table_name from information_schema.tables where table_name = 't1' and table_name = 't2'",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_name = 't1' and table_name = 't2'",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where `table_name` = :table_name /* VARCHAR */ and `table_name` = 't2'",
+        "SysTableTableName": "[table_name:'t1']"
+      }
+    }
+  },
+  {
+    "comment": "a second, different table_name value from a single-element IN stays a plain filter",
+    "query": "select table_name from information_schema.tables where table_name = 't1' and table_name in ('t2')",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_name = 't1' and table_name in ('t2')",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where `table_name` = :table_name /* VARCHAR */ and `table_name` = 't2'",
+        "SysTableTableName": "[table_name:'t1']"
       }
     }
   },

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -1094,7 +1094,7 @@
     }
   },
   {
-    "comment": "table_schema OR predicate\n# It is unsupported because we do not route queries to multiple keyspaces right now",
+    "comment": "table_schema OR predicate # rewritten to IN and carried: more than one schema name errors loudly at execution instead of silently querying the default keyspace",
     "query": "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'ks' OR TABLE_SCHEMA = 'main'",
     "plan": {
       "Type": "Passthrough",
@@ -1108,7 +1108,8 @@
           "Sharded": false
         },
         "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
-        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = 'ks' or TABLE_SCHEMA = 'main'"
+        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = :__vtschemaname /* VARCHAR */",
+        "SysTableTableSchema": "[('ks', 'main')]"
       }
     }
   },
@@ -1250,7 +1251,7 @@
     }
   },
   {
-    "comment": "IN with a list bindvar on table_name stays a plain filter (multi-name INs work as filters once the schema routes)",
+    "comment": "IN with a list bindvar on table_name is extracted without rewriting the predicate; one value routes (incl. routed tables), more stay a working filter",
     "query": "select column_name from information_schema.statistics where table_schema = 'user' and table_name in ::tables",
     "plan": {
       "Type": "Passthrough",
@@ -1265,7 +1266,48 @@
         },
         "FieldQuery": "select `column_name` from information_schema.statistics where 1 != 1",
         "Query": "select `column_name` from information_schema.statistics where table_schema = :__vtschemaname /* VARCHAR */ and `table_name` in ::tables",
-        "SysTableTableSchema": "['user']"
+        "SysTableTableSchema": "['user']",
+        "SysTableTableName": "[tables:::tables]"
+      }
+    }
+  },
+  {
+    "comment": "multi-element literal IN on table_schema is carried for the execution-time guard (errors there; never silently unrouted)",
+    "query": "select table_name from information_schema.tables where table_schema in ('a', 'b')",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema in ('a', 'b')",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
+        "SysTableTableSchema": "[('a', 'b')]"
+      }
+    }
+  },
+  {
+    "comment": "prepared-statement IN on table_schema (tuple of arguments) is carried for the execution-time guard",
+    "query": "select table_name from information_schema.tables where table_schema in (:v1, :v2)",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema in (:v1, :v2)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
+        "SysTableTableSchema": "[(:v1, :v2)]"
       }
     }
   },

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -1212,7 +1212,7 @@
     }
   },
   {
-    "comment": "multi-element IN containing database() is resolved at execution, database() evaluating to the connected keyspace",
+    "comment": "multi-element IN containing database() is left alone for the tablet to evaluate, like = database()",
     "query": "select table_name from information_schema.tables where table_schema in (database(), 'vt_main')",
     "plan": {
       "Type": "Passthrough",
@@ -1226,8 +1226,7 @@
           "Sharded": false
         },
         "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
-        "Query": "select `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
-        "SysTableTableSchema": "[(database(), 'vt_main')]"
+        "Query": "select `table_name` from information_schema.`tables` where table_schema in (database(), 'vt_main')"
       }
     }
   },

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -1268,5 +1268,62 @@
         "SysTableTableSchema": "['user']"
       }
     }
+  },
+  {
+    "comment": "single-element IN with an untranslatable element is left alone (extraction must fail before any rewrite)",
+    "query": "select * from information_schema.tables where table_schema in (table_name)",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select * from information_schema.tables where table_schema in (table_name)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where 1 != 1",
+        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where table_schema in (`table_name`)"
+      }
+    }
+  },
+  {
+    "comment": "NOT IN on table_schema is left alone, no rewrite",
+    "query": "select table_name from information_schema.tables where table_schema not in ('user')",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema not in ('user')",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where table_schema not in ('user')"
+      }
+    }
+  },
+  {
+    "comment": "single-element list bindvar on a non-routing column is left alone, no equality rewrite",
+    "query": "select * from information_schema.tables where engine in ::x",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select * from information_schema.tables where engine in ::x",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where 1 != 1",
+        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where `engine` in ::x"
+      }
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -1149,5 +1149,65 @@
         "Query": "select c.`column_name` from (select `table_name` from information_schema.`tables` where table_schema != 'information_schema' limit 1) as `tables`, information_schema.`columns` as c where `tables`.`table_name` = c.`table_name`"
       }
     }
+  },
+  {
+    "comment": "single-element IN on table_schema routes like equality",
+    "query": "select table_name from information_schema.tables where table_schema in ('user')",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema in ('user')",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
+        "SysTableTableSchema": "['user']"
+      }
+    }
+  },
+  {
+    "comment": "single-element IN on table_name routes like equality",
+    "query": "select column_name from information_schema.statistics where table_schema = 'user' and table_name in ('user_extra')",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select column_name from information_schema.statistics where table_schema = 'user' and table_name in ('user_extra')",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `column_name` from information_schema.statistics where 1 != 1",
+        "Query": "select `column_name` from information_schema.statistics where table_schema = :__vtschemaname /* VARCHAR */ and `table_name` = :table_name /* VARCHAR */",
+        "SysTableTableName": "[table_name:'user_extra']",
+        "SysTableTableSchema": "['user']"
+      }
+    }
+  },
+  {
+    "comment": "single-element IN containing database() is left alone, like = database()",
+    "query": "select table_name from information_schema.tables where table_schema in (database())",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema in (database())",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where table_schema in (database())"
+      }
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -1265,9 +1265,30 @@
           "Sharded": false
         },
         "FieldQuery": "select `column_name` from information_schema.statistics where 1 != 1",
-        "Query": "select `column_name` from information_schema.statistics where table_schema = :__vtschemaname /* VARCHAR */ and `table_name` in ::tables",
+        "Query": "select `column_name` from information_schema.statistics where table_schema = :__vtschemaname /* VARCHAR */ and `table_name` in ::__tables",
         "SysTableTableSchema": "['user']",
-        "SysTableTableName": "[tables:::tables]"
+        "SysTableTableName": "[__tables:::tables]"
+      }
+    }
+  },
+  {
+    "comment": "a list bindvar shared between predicates (the normalizer dedupes identical IN tuples): only the table_name predicate is re-pointed at the dedicated variable; the shared client variable stays untouched in the other predicate",
+    "query": "select column_name from information_schema.statistics where table_schema = 'user' and table_name in ::names and index_name in ::names",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select column_name from information_schema.statistics where table_schema = 'user' and table_name in ::names and index_name in ::names",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `column_name` from information_schema.statistics where 1 != 1",
+        "Query": "select `column_name` from information_schema.statistics where table_schema = :__vtschemaname /* VARCHAR */ and `table_name` in ::__names and index_name in ::names",
+        "SysTableTableName": "[__names:::names]",
+        "SysTableTableSchema": "['user']"
       }
     }
   },

--- a/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema57_cases.json
@@ -1209,5 +1209,24 @@
         "Query": "select `table_name` from information_schema.`tables` where table_schema in (database())"
       }
     }
+  },
+  {
+    "comment": "single-element IN on a non-routing column is left alone, no equality rewrite",
+    "query": "select * from information_schema.tables where engine in ('InnoDB')",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select * from information_schema.tables where engine in ('InnoDB')",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where 1 != 1",
+        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where `engine` in ('InnoDB')"
+      }
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -1368,5 +1368,45 @@
         "Query": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where `engine` in ('InnoDB')"
       }
     }
+  },
+  {
+    "comment": "IN with a list bindvar on table_schema is extracted; length is enforced at execution time",
+    "query": "select table_name from information_schema.tables where table_schema in ::schemas",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema in ::schemas",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
+        "SysTableTableSchema": "[::schemas]"
+      }
+    }
+  },
+  {
+    "comment": "IN with a list bindvar on table_name stays a plain filter (multi-name INs work as filters once the schema routes)",
+    "query": "select column_name from information_schema.statistics where table_schema = 'user' and table_name in ::tables",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select column_name from information_schema.statistics where table_schema = 'user' and table_name in ::tables",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `column_name` from information_schema.statistics where 1 != 1",
+        "Query": "select `column_name` from information_schema.statistics where table_schema = :__vtschemaname /* VARCHAR */ and `table_name` in ::tables",
+        "SysTableTableSchema": "['user']"
+      }
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -1352,6 +1352,25 @@
     }
   },
   {
+    "comment": "multi-element IN containing database() is left alone",
+    "query": "select table_name from information_schema.tables where table_schema in (database(), 'vt_main')",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema in (database(), 'vt_main')",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where table_schema in (database(), 'vt_main')"
+      }
+    }
+  },
+  {
     "comment": "single-element IN on a non-routing column is left alone",
     "query": "select * from information_schema.tables where engine in ('InnoDB')",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -1405,9 +1405,30 @@
           "Sharded": false
         },
         "FieldQuery": "select `column_name` from information_schema.statistics where 1 != 1",
-        "Query": "select `column_name` from information_schema.statistics where table_schema = :__vtschemaname /* VARCHAR */ and `table_name` in ::tables",
+        "Query": "select `column_name` from information_schema.statistics where table_schema = :__vtschemaname /* VARCHAR */ and `table_name` in ::__tables",
         "SysTableTableSchema": "['user']",
-        "SysTableTableName": "[tables:::tables]"
+        "SysTableTableName": "[__tables:::tables]"
+      }
+    }
+  },
+  {
+    "comment": "a list bindvar shared between predicates (the normalizer dedupes identical IN tuples): only the table_name predicate is re-pointed at the dedicated variable; the shared client variable stays untouched in the other predicate",
+    "query": "select column_name from information_schema.statistics where table_schema = 'user' and table_name in ::names and index_name in ::names",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select column_name from information_schema.statistics where table_schema = 'user' and table_name in ::names and index_name in ::names",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `column_name` from information_schema.statistics where 1 != 1",
+        "Query": "select `column_name` from information_schema.statistics where table_schema = :__vtschemaname /* VARCHAR */ and `table_name` in ::__names and index_name in ::names",
+        "SysTableTableName": "[__names:::names]",
+        "SysTableTableSchema": "['user']"
       }
     }
   },

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -1408,5 +1408,62 @@
         "SysTableTableSchema": "['user']"
       }
     }
+  },
+  {
+    "comment": "single-element IN with an untranslatable element is left alone (extraction must fail before any rewrite)",
+    "query": "select * from information_schema.tables where table_schema in (table_name)",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select * from information_schema.tables where table_schema in (table_name)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where 1 != 1",
+        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where table_schema in (`table_name`)"
+      }
+    }
+  },
+  {
+    "comment": "NOT IN on table_schema is left alone, no rewrite",
+    "query": "select table_name from information_schema.tables where table_schema not in ('user')",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema not in ('user')",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where table_schema not in ('user')"
+      }
+    }
+  },
+  {
+    "comment": "single-element list bindvar on a non-routing column is left alone, no equality rewrite",
+    "query": "select * from information_schema.tables where engine in ::x",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select * from information_schema.tables where engine in ::x",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where 1 != 1",
+        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where `engine` in ::x"
+      }
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -1157,7 +1157,7 @@
     }
   },
   {
-    "comment": "table_schema OR predicate\n# It is unsupported because we do not route queries to multiple keyspaces right now",
+    "comment": "table_schema OR predicate # rewritten to IN and carried: more than one schema name errors loudly at execution instead of silently querying the default keyspace",
     "query": "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'ks' OR TABLE_SCHEMA = 'main'",
     "plan": {
       "Type": "Passthrough",
@@ -1171,7 +1171,8 @@
           "Sharded": false
         },
         "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where 1 != 1",
-        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = 'ks' or TABLE_SCHEMA = 'main'"
+        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from INFORMATION_SCHEMA.`TABLES` where TABLE_SCHEMA = :__vtschemaname /* VARCHAR */",
+        "SysTableTableSchema": "[('ks', 'main')]"
       }
     }
   },
@@ -1390,7 +1391,7 @@
     }
   },
   {
-    "comment": "IN with a list bindvar on table_name stays a plain filter (multi-name INs work as filters once the schema routes)",
+    "comment": "IN with a list bindvar on table_name is extracted without rewriting the predicate; one value routes (incl. routed tables), more stay a working filter",
     "query": "select column_name from information_schema.statistics where table_schema = 'user' and table_name in ::tables",
     "plan": {
       "Type": "Passthrough",
@@ -1405,7 +1406,48 @@
         },
         "FieldQuery": "select `column_name` from information_schema.statistics where 1 != 1",
         "Query": "select `column_name` from information_schema.statistics where table_schema = :__vtschemaname /* VARCHAR */ and `table_name` in ::tables",
-        "SysTableTableSchema": "['user']"
+        "SysTableTableSchema": "['user']",
+        "SysTableTableName": "[tables:::tables]"
+      }
+    }
+  },
+  {
+    "comment": "multi-element literal IN on table_schema is carried for the execution-time guard (errors there; never silently unrouted)",
+    "query": "select table_name from information_schema.tables where table_schema in ('a', 'b')",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema in ('a', 'b')",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
+        "SysTableTableSchema": "[('a', 'b')]"
+      }
+    }
+  },
+  {
+    "comment": "prepared-statement IN on table_schema (tuple of arguments) is carried for the execution-time guard",
+    "query": "select table_name from information_schema.tables where table_schema in (:v1, :v2)",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema in (:v1, :v2)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
+        "SysTableTableSchema": "[(:v1, :v2)]"
       }
     }
   },

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -1289,5 +1289,65 @@
         "SysTableTableSchema": "['ks']"
       }
     }
+  },
+  {
+    "comment": "single-element IN on table_schema routes like equality",
+    "query": "select table_name from information_schema.tables where table_schema in ('user')",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema in ('user')",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
+        "SysTableTableSchema": "['user']"
+      }
+    }
+  },
+  {
+    "comment": "single-element IN on table_name routes like equality",
+    "query": "select column_name from information_schema.statistics where table_schema = 'user' and table_name in ('user_extra')",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select column_name from information_schema.statistics where table_schema = 'user' and table_name in ('user_extra')",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `column_name` from information_schema.statistics where 1 != 1",
+        "Query": "select `column_name` from information_schema.statistics where table_schema = :__vtschemaname /* VARCHAR */ and `table_name` = :table_name /* VARCHAR */",
+        "SysTableTableName": "[table_name:'user_extra']",
+        "SysTableTableSchema": "['user']"
+      }
+    }
+  },
+  {
+    "comment": "single-element IN containing database() is left alone, like = database()",
+    "query": "select table_name from information_schema.tables where table_schema in (database())",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_schema in (database())",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where table_schema in (database())"
+      }
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -1349,5 +1349,24 @@
         "Query": "select `table_name` from information_schema.`tables` where table_schema in (database())"
       }
     }
+  },
+  {
+    "comment": "single-element IN on a non-routing column is left alone, no equality rewrite",
+    "query": "select * from information_schema.tables where engine in ('InnoDB')",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select * from information_schema.tables where engine in ('InnoDB')",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where 1 != 1",
+        "Query": "select TABLE_CATALOG, TABLE_SCHEMA, `TABLE_NAME`, TABLE_TYPE, `ENGINE`, VERSION, `ROW_FORMAT`, TABLE_ROWS, `AVG_ROW_LENGTH`, DATA_LENGTH, MAX_DATA_LENGTH, INDEX_LENGTH, DATA_FREE, `AUTO_INCREMENT`, CREATE_TIME, UPDATE_TIME, CHECK_TIME, TABLE_COLLATION, `CHECKSUM`, CREATE_OPTIONS, TABLE_COMMENT from information_schema.`tables` where `engine` in ('InnoDB')"
+      }
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -1014,8 +1014,8 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1",
-                    "Query": "select 1 as `found` from information_schema.`tables` where `table_name` = :table_name1 /* VARCHAR */ and `table_name` = :table_name1 /* VARCHAR */ limit :__upper_limit",
-                    "SysTableTableName": "[table_name1:'Music']"
+                    "Query": "select 1 as `found` from information_schema.`tables` where `table_name` = :table_name1 /* VARCHAR */ and `table_name` = 'Music' limit :__upper_limit",
+                    "SysTableTableName": "[table_name1:'music']"
                   },
                   {
                     "OperatorType": "Route",
@@ -1025,8 +1025,8 @@
                       "Sharded": false
                     },
                     "FieldQuery": "select 1 as `found` from information_schema.views where 1 != 1",
-                    "Query": "select 1 as `found` from information_schema.views where `table_name` = :table_name2 /* VARCHAR */ and `table_name` = :table_name2 /* VARCHAR */ limit :__upper_limit",
-                    "SysTableTableName": "[table_name2:'user']"
+                    "Query": "select 1 as `found` from information_schema.views where `table_name` = :table_name2 /* VARCHAR */ and `table_name` = 'user' limit :__upper_limit",
+                    "SysTableTableName": "[table_name2:'music']"
                   }
                 ]
               }
@@ -1041,8 +1041,8 @@
               "Sharded": false
             },
             "FieldQuery": "select 1 as `found` from information_schema.`tables` where 1 != 1",
-            "Query": "select 1 as `found` from information_schema.`tables` where `table_name` = :table_name /* VARCHAR */ and `table_name` = :table_name /* VARCHAR */ and :__sq_has_values",
-            "SysTableTableName": "[table_name:'Music']"
+            "Query": "select 1 as `found` from information_schema.`tables` where `table_name` = :table_name /* VARCHAR */ and `table_name` = 'Music' and :__sq_has_values",
+            "SysTableTableName": "[table_name:'music']"
           }
         ]
       }
@@ -1367,6 +1367,46 @@
         },
         "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
         "Query": "select `table_name` from information_schema.`tables` where table_schema in (database(), 'vt_main')"
+      }
+    }
+  },
+  {
+    "comment": "a second, different table_name value stays a plain filter instead of overwriting the routing source",
+    "query": "select table_name from information_schema.tables where table_name = 't1' and table_name = 't2'",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_name = 't1' and table_name = 't2'",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where `table_name` = :table_name /* VARCHAR */ and `table_name` = 't2'",
+        "SysTableTableName": "[table_name:'t1']"
+      }
+    }
+  },
+  {
+    "comment": "a second, different table_name value from a single-element IN stays a plain filter",
+    "query": "select table_name from information_schema.tables where table_name = 't1' and table_name in ('t2')",
+    "plan": {
+      "Type": "Passthrough",
+      "QueryType": "SELECT",
+      "Original": "select table_name from information_schema.tables where table_name = 't1' and table_name in ('t2')",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "DBA",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        },
+        "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
+        "Query": "select `table_name` from information_schema.`tables` where `table_name` = :table_name /* VARCHAR */ and `table_name` = 't2'",
+        "SysTableTableName": "[table_name:'t1']"
       }
     }
   },

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -1352,7 +1352,7 @@
     }
   },
   {
-    "comment": "multi-element IN containing database() is left alone",
+    "comment": "multi-element IN containing database() is resolved at execution, database() evaluating to the connected keyspace",
     "query": "select table_name from information_schema.tables where table_schema in (database(), 'vt_main')",
     "plan": {
       "Type": "Passthrough",
@@ -1366,7 +1366,8 @@
           "Sharded": false
         },
         "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
-        "Query": "select `table_name` from information_schema.`tables` where table_schema in (database(), 'vt_main')"
+        "Query": "select `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
+        "SysTableTableSchema": "[(database(), 'vt_main')]"
       }
     }
   },

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -1352,7 +1352,7 @@
     }
   },
   {
-    "comment": "multi-element IN containing database() is resolved at execution, database() evaluating to the connected keyspace",
+    "comment": "multi-element IN containing database() is left alone for the tablet to evaluate, like = database()",
     "query": "select table_name from information_schema.tables where table_schema in (database(), 'vt_main')",
     "plan": {
       "Type": "Passthrough",
@@ -1366,8 +1366,7 @@
           "Sharded": false
         },
         "FieldQuery": "select `table_name` from information_schema.`tables` where 1 != 1",
-        "Query": "select `table_name` from information_schema.`tables` where table_schema = :__vtschemaname /* VARCHAR */",
-        "SysTableTableSchema": "[(database(), 'vt_main')]"
+        "Query": "select `table_name` from information_schema.`tables` where table_schema in (database(), 'vt_main')"
       }
     }
   },

--- a/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/info_schema80_cases.json
@@ -1157,7 +1157,7 @@
     }
   },
   {
-    "comment": "table_schema OR predicate # rewritten to IN and carried: more than one schema name errors loudly at execution instead of silently querying the default keyspace",
+    "comment": "table_schema OR predicate # rewritten to IN and resolved at execution",
     "query": "SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'ks' OR TABLE_SCHEMA = 'main'",
     "plan": {
       "Type": "Passthrough",
@@ -1352,7 +1352,7 @@
     }
   },
   {
-    "comment": "single-element IN on a non-routing column is left alone, no equality rewrite",
+    "comment": "single-element IN on a non-routing column is left alone",
     "query": "select * from information_schema.tables where engine in ('InnoDB')",
     "plan": {
       "Type": "Passthrough",
@@ -1371,7 +1371,7 @@
     }
   },
   {
-    "comment": "IN with a list bindvar on table_schema is extracted; length is enforced at execution time",
+    "comment": "list bindvar IN on table_schema is resolved at execution",
     "query": "select table_name from information_schema.tables where table_schema in ::schemas",
     "plan": {
       "Type": "Passthrough",
@@ -1391,7 +1391,7 @@
     }
   },
   {
-    "comment": "IN with a list bindvar on table_name is extracted without rewriting the predicate; one value routes (incl. routed tables), more stay a working filter",
+    "comment": "list bindvar IN on table_name is re-pointed at a dedicated variable",
     "query": "select column_name from information_schema.statistics where table_schema = 'user' and table_name in ::tables",
     "plan": {
       "Type": "Passthrough",
@@ -1412,7 +1412,7 @@
     }
   },
   {
-    "comment": "a list bindvar shared between predicates (the normalizer dedupes identical IN tuples): only the table_name predicate is re-pointed at the dedicated variable; the shared client variable stays untouched in the other predicate",
+    "comment": "a list bindvar shared between predicates: only the table_name predicate is re-pointed",
     "query": "select column_name from information_schema.statistics where table_schema = 'user' and table_name in ::names and index_name in ::names",
     "plan": {
       "Type": "Passthrough",
@@ -1433,7 +1433,7 @@
     }
   },
   {
-    "comment": "multi-element literal IN on table_schema is carried for the execution-time guard (errors there; never silently unrouted)",
+    "comment": "multi-element literal IN on table_schema is resolved at execution",
     "query": "select table_name from information_schema.tables where table_schema in ('a', 'b')",
     "plan": {
       "Type": "Passthrough",
@@ -1453,7 +1453,7 @@
     }
   },
   {
-    "comment": "prepared-statement IN on table_schema (tuple of arguments) is carried for the execution-time guard",
+    "comment": "prepared-statement IN on table_schema is resolved at execution",
     "query": "select table_name from information_schema.tables where table_schema in (:v1, :v2)",
     "plan": {
       "Type": "Passthrough",
@@ -1473,7 +1473,7 @@
     }
   },
   {
-    "comment": "single-element IN with an untranslatable element is left alone (extraction must fail before any rewrite)",
+    "comment": "single-element IN with an untranslatable element is left alone",
     "query": "select * from information_schema.tables where table_schema in (table_name)",
     "plan": {
       "Type": "Passthrough",
@@ -1492,7 +1492,7 @@
     }
   },
   {
-    "comment": "NOT IN on table_schema is left alone, no rewrite",
+    "comment": "NOT IN on table_schema is left alone",
     "query": "select table_name from information_schema.tables where table_schema not in ('user')",
     "plan": {
       "Type": "Passthrough",
@@ -1511,7 +1511,7 @@
     }
   },
   {
-    "comment": "single-element list bindvar on a non-routing column is left alone, no equality rewrite",
+    "comment": "single-element list bindvar on a non-routing column is left alone",
     "query": "select * from information_schema.tables where engine in ::x",
     "plan": {
       "Type": "Passthrough",


### PR DESCRIPTION
## Description

`information_schema` queries using an `IN` predicate on `table_schema`/`table_name` bypassed schema-name routing entirely and silently returned empty or incomplete results — the query shape Rails now generates for all of its schema readers.

The planner now treats a single-valued `IN` as the equality it is: a one-element literal list is unwrapped at plan time, and a bound list (what vtgate's normalizer produces — its length is unknown until execution) is extracted and resolved at execution time, where one value routes exactly like `=` and anything else fails with an explicit `VT12001` error instead of silently querying the wrong keyspace. Multi-value `table_name IN` lists are deliberately left as pushed-down filters, since they already work correctly once the schema routes. No normalizer changes were needed, so one cached plan serves any list length.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/issues/20878

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

I used Claude with Fable5 for the work and Codex with GPT-5.6 for reviews.
