### PR TITLE
Deprecate MariaDB-backed serving shards

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -16,6 +16,7 @@
         - [VTOrc: `--cells-to-watch` removed in favor of `--cells-no-recovery`](#vtorc-cells-no-recovery)
     - **[Deprecations](#deprecations)**
         - [CLI Flags](#deprecated-cli-flags)
+        - [MariaDB-backed serving shards](#mariadb-serving-shards-deprecation)
         - [Legacy streaming-path plan types in query rules](#deprecated-selectstream-rule-plan)
 - **[Minor Changes](#minor-changes)**
     - **[VReplication](#minor-changes-vreplication)**
@@ -157,6 +158,12 @@ The flag will be removed entirely in v26. This deprecation is tracked in https:/
 The VTTablet flag `--vreplication-enable-http-log` is now deprecated and is a no-op, as the [VRLog feature it enabled has been removed](#vttablet-vrlog-removed). The flag will be removed entirely in v26.
 
 **Impact**: Remove any usage of the `--vreplication-enable-http-log` flag from VTTablet startup scripts or configuration.
+
+#### <a id="mariadb-serving-shards-deprecation"/>MariaDB-backed serving shards</a>
+
+MariaDB support for serving shards is deprecated and will become unsupported in v26. Managed `vttablet` processes and ERS/PRS operations now warn when MariaDB is detected.
+
+MariaDB remains supported as an import source through an unmanaged tablet in an external keyspace.
 
 #### <a id="deprecated-selectstream-rule-plan"/>Legacy streaming-path plan types in query rules</a>
 

--- a/go/vt/vtctl/reparentutil/planned_reparenter.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter.go
@@ -246,6 +246,7 @@ func (pr *PlannedReparenter) performGracefulPromotion(
 	if err != nil {
 		return vterrors.Wrapf(err, "cannot get replication position on current primary %v; current primary must be healthy to perform PlannedReparent", currentPrimary.AliasString())
 	}
+	warnIfMariaDBVersion(pr.logger, "", currentPrimary.AliasString(), snapshotPos)
 
 	// Next, we wait for the primary-elect to catch up to that snapshot point.
 	// If it can catch up within WaitReplicasTimeout, we can be fairly
@@ -280,6 +281,7 @@ func (pr *PlannedReparenter) performGracefulPromotion(
 	if err != nil {
 		return vterrors.Wrapf(err, "failed to DemotePrimary on current primary %v: %v", currentPrimary.AliasString(), err)
 	}
+	warnIfMariaDBVersion(pr.logger, primaryStatus.ServerVersion, currentPrimary.AliasString(), primaryStatus.Position)
 
 	// Wait for the primary-elect to catch up to the position we demoted the
 	// current primary at. If it fails to catch up within WaitReplicasTimeout,
@@ -431,6 +433,7 @@ func (pr *PlannedReparenter) checkPrimaryElectContainsAllPositions(
 					rec.RecordError(vterrors.Wrapf(psErr, "cannot get primary status of non-replicating tablet %v; all tablets must be reachable to safely promote primary-elect %v during initial promotion", alias, primaryElectAliasStr))
 					return
 				}
+				warnIfMariaDBVersion(pr.logger, primaryStatus.ServerVersion, alias, primaryStatus.Position)
 				pos, decErr := replication.DecodePosition(primaryStatus.Position)
 				if decErr != nil {
 					rec.RecordError(vterrors.Wrapf(decErr, "cannot decode replication position (%v) for tablet %v", primaryStatus.Position, alias))
@@ -442,6 +445,8 @@ func (pr *PlannedReparenter) checkPrimaryElectContainsAllPositions(
 				mu.Unlock()
 				return
 			}
+
+			warnIfMariaDBVersion(pr.logger, status.ServerVersion, alias, status.Position, status.RelayLogPosition)
 
 			// The elect is promoted here via InitPrimary, which does NOT apply the
 			// relay log: any received-but-unapplied transactions the elect holds are
@@ -616,6 +621,7 @@ func (pr *PlannedReparenter) performPartialPromotionRecovery(ctx context.Context
 	if err != nil {
 		return "", vterrors.Wrapf(err, "failed to get replication position of current primary %v", topoproto.TabletAliasString(primaryElect.Alias))
 	}
+	warnIfMariaDBVersion(pr.logger, "", topoproto.TabletAliasString(primaryElect.Alias), reparentJournalPosition)
 
 	return reparentJournalPosition, nil
 }
@@ -685,6 +691,7 @@ func (pr *PlannedReparenter) performPotentialPromotion(
 
 				return
 			}
+			warnIfMariaDBVersion(pr.logger, primaryStatus.ServerVersion, alias, primaryStatus.Position)
 
 			pos, err := replication.DecodePosition(primaryStatus.Position)
 			if err != nil {

--- a/go/vt/vtctl/reparentutil/planned_reparenter_flaky_test.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter_flaky_test.go
@@ -1828,12 +1828,11 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 		},
 	}
 
-	logger := logutil.NewMemoryLogger()
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			logger := logutil.NewMemoryLogger()
 			ctx := t.Context()
 			ts := memorytopo.NewServer(ctx, "zone1")
 			defer ts.Close()

--- a/go/vt/vtctl/reparentutil/planned_reparenter_flaky_test.go
+++ b/go/vt/vtctl/reparentutil/planned_reparenter_flaky_test.go
@@ -84,8 +84,9 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 		shard    string
 		opts     PlannedReparentOptions
 
-		expectedEvent *events.Reparent
-		shouldErr     bool
+		expectedEvent        *events.Reparent
+		expectMariaDBWarning bool
+		shouldErr            bool
 	}{
 		{
 			name: "success",
@@ -95,7 +96,7 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 					Error    error
 				}{
 					"zone1-0000000100": {
-						Position: "position1",
+						Position: "MariaDB/0-1-5",
 						Error:    nil,
 					},
 				},
@@ -154,7 +155,8 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 				},
 			},
 
-			shouldErr: false,
+			expectMariaDBWarning: true,
+			shouldErr:            false,
 			expectedEvent: &events.Reparent{
 				ShardInfo: *topo.NewShardInfo("testkeyspace", "-", &topodatapb.Shard{
 					PrimaryAlias: &topodatapb.TabletAlias{
@@ -198,7 +200,8 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 							// this test case, as long as it matches the inner
 							// key of the WaitForPositionResults map for the
 							// primary-elect.
-							Position: "position1",
+							Position:      "position1",
+							ServerVersion: "Ver 10.10.2-MariaDB",
 						},
 						Error: nil,
 					},
@@ -273,7 +276,8 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 			shard:    "-",
 			opts:     PlannedReparentOptions{},
 
-			shouldErr: false,
+			shouldErr:            false,
+			expectMariaDBWarning: true,
 			expectedEvent: &events.Reparent{
 				ShardInfo: *topo.NewShardInfo("testkeyspace", "-", &topodatapb.Shard{
 					PrimaryAlias: &topodatapb.TabletAlias{
@@ -449,12 +453,11 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 		},
 	}
 
-	logger := logutil.NewMemoryLogger()
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			logger := logutil.NewMemoryLogger()
 			ctx := t.Context()
 			ts := memorytopo.NewServer(ctx, "zone1")
 			defer ts.Close()
@@ -478,6 +481,9 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 
 			pr := NewPlannedReparenter(ts, tt.tmc, logger)
 			ev, err := pr.ReparentShard(ctx, tt.keyspace, tt.shard, tt.opts)
+			if tt.expectMariaDBWarning {
+				assert.Contains(t, logger.String(), "MariaDB support for serving shards is deprecated")
+			}
 			if tt.shouldErr {
 				require.Error(t, err)
 				AssertReparentEventsEqual(t, tt.expectedEvent, ev)
@@ -494,6 +500,63 @@ func TestPlannedReparenter_ReparentShard(t *testing.T) {
 			assert.Contains(t, ev.Status, "finished PlannedReparentShard", "expected event status to indicate successful PRS")
 		})
 	}
+}
+
+func TestPlannedReparenter_InitialPromotionWarnsForMariaDB(t *testing.T) {
+	const alias = "zone1-0000000101"
+	tabletAlias := &topodatapb.TabletAlias{Cell: "zone1", Uid: 101}
+	tablet := &topodatapb.Tablet{
+		Alias:    tabletAlias,
+		Type:     topodatapb.TabletType_REPLICA,
+		Keyspace: "testkeyspace",
+		Shard:    "0",
+	}
+	tmc := &testutil.TabletManagerClient{
+		GetGlobalStatusVarsResults: map[string]struct {
+			Statuses map[string]string
+			Error    error
+		}{
+			alias: {Statuses: map[string]string{}},
+		},
+		ReplicationStatusResults: map[string]struct {
+			Position *replicationdatapb.Status
+			Error    error
+		}{
+			alias: {Error: mysql.ErrNotReplica},
+		},
+		PrimaryStatusResults: map[string]struct {
+			Status *replicationdatapb.PrimaryStatus
+			Error  error
+		}{
+			alias: {
+				Status: &replicationdatapb.PrimaryStatus{
+					Position:      "MariaDB/0-1-5",
+					ServerVersion: "Ver 10.10.2-MariaDB",
+				},
+			},
+		},
+		InitPrimaryResults: map[string]struct {
+			Result string
+			Error  error
+		}{
+			alias: {Result: "MariaDB/0-1-6"},
+		},
+		PopulateReparentJournalResults: map[string]error{alias: nil},
+		RefreshStateResults:            map[string]error{alias: nil},
+	}
+	ctx := t.Context()
+	ts := memorytopo.NewServer(ctx, "zone1")
+	t.Cleanup(ts.Close)
+	testutil.AddTablets(ctx, t, ts, nil, tablet)
+	logger := logutil.NewMemoryLogger()
+	pr := NewPlannedReparenter(ts, tmc, logger)
+
+	_, err := pr.ReparentShard(ctx, "testkeyspace", "0", PlannedReparentOptions{
+		NewPrimaryAlias:     tabletAlias,
+		WaitReplicasTimeout: 30 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, logger.String(), "MariaDB support for serving shards is deprecated")
 }
 
 func TestPlannedReparenter_getLockAction(t *testing.T) {
@@ -1221,8 +1284,9 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 		primaryElect   *topodatapb.Tablet
 		opts           PlannedReparentOptions
 
-		expectedEvent *events.Reparent
-		shouldErr     bool
+		expectedEvent        *events.Reparent
+		expectMariaDBWarning bool
+		shouldErr            bool
 		// Optional function to run some additional post-test assertions. Will
 		// be run in the main test body before the common assertions are run,
 		// regardless of the value of tt.shouldErr for that test case.
@@ -1323,7 +1387,7 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 					Error    error
 				}{
 					"zone1-0000000100": {
-						Position: "MySQL56/3E11FA47-71CA-11E1-9E33-C80AA9429562:1-10",
+						Position: "MariaDB/0-1-5",
 					},
 				},
 				SetReplicationSourceResults: map[string]error{
@@ -1347,8 +1411,9 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 					Uid:  200,
 				},
 			},
-			opts:      PlannedReparentOptions{},
-			shouldErr: true,
+			opts:                 PlannedReparentOptions{},
+			expectMariaDBWarning: true,
+			shouldErr:            true,
 		},
 		{
 			name: "primary-elect times out catching up to current primary snapshot position",
@@ -1813,6 +1878,9 @@ func TestPlannedReparenter_performGracefulPromotion(t *testing.T) {
 				tt.opts,
 			)
 
+			if tt.expectMariaDBWarning {
+				assert.Contains(t, logger.String(), "MariaDB support for serving shards is deprecated")
+			}
 			if tt.extraAssertions != nil {
 				tt.extraAssertions(t, err)
 			}

--- a/go/vt/vtctl/reparentutil/replication.go
+++ b/go/vt/vtctl/reparentutil/replication.go
@@ -485,6 +485,7 @@ func stopReplicationAndBuildStatusMaps(
 				m.Lock()
 				res.primaryStatusMap[alias] = primaryStatus
 				res.reachableTablets = append(res.reachableTablets, tabletInfo.Tablet)
+				warnIfMariaDBVersion(logger, primaryStatus.ServerVersion, alias, primaryStatus.Position)
 				if primaryStatus.ServerVersion != "" {
 					if flavor, v, parseErr := mysqlctl.ParseVersionString(primaryStatus.ServerVersion); parseErr == nil {
 						res.mysqlVersions[alias] = v
@@ -515,6 +516,9 @@ func stopReplicationAndBuildStatusMaps(
 			res.tabletsBackupState[alias] = isTakingBackup
 			res.statusMap[alias] = stopReplicationStatus
 			res.reachableTablets = append(res.reachableTablets, tabletInfo.Tablet)
+			if stopReplicationStatus.Before != nil {
+				warnIfMariaDBVersion(logger, stopReplicationStatus.Before.ServerVersion, alias, stopReplicationStatus.Before.Position, stopReplicationStatus.Before.RelayLogPosition)
+			}
 			if stopReplicationStatus.Before != nil && stopReplicationStatus.Before.ServerVersion != "" {
 				if flavor, v, parseErr := mysqlctl.ParseVersionString(stopReplicationStatus.Before.ServerVersion); parseErr == nil {
 					res.mysqlVersions[alias] = v

--- a/go/vt/vtctl/reparentutil/replication_test.go
+++ b/go/vt/vtctl/reparentutil/replication_test.go
@@ -1936,6 +1936,41 @@ func Test_stopReplicationAndBuildStatusMaps(t *testing.T) {
 	}
 }
 
+func TestStopReplicationAndBuildStatusMapsWarnsForMariaDB(t *testing.T) {
+	alias := &topodatapb.TabletAlias{Cell: "zone1", Uid: 100}
+	aliasString := topoproto.TabletAliasString(alias)
+	tmc := &stopReplicationAndBuildStatusMapsTestTMClient{
+		stopReplicationAndGetStatusResults: map[string]*struct {
+			StopStatus *replicationdatapb.StopReplicationStatus
+			Err        error
+		}{
+			aliasString: {
+				StopStatus: &replicationdatapb.StopReplicationStatus{
+					Before: &replicationdatapb.Status{
+						Position: "MariaDB/0-1-5",
+					},
+					After: &replicationdatapb.Status{Position: "MariaDB/0-1-5"},
+				},
+			},
+		},
+	}
+	tabletMap := map[string]*topo.TabletInfo{
+		aliasString: {
+			Tablet: &topodatapb.Tablet{
+				Alias: alias,
+				Type:  topodatapb.TabletType_REPLICA,
+			},
+		},
+	}
+	durability, err := policy.GetDurabilityPolicy(policy.DurabilityNone)
+	require.NoError(t, err)
+	logger := logutil.NewMemoryLogger()
+
+	_, err = stopReplicationAndBuildStatusMaps(t.Context(), tmc, &events.Reparent{}, tabletMap, nil, 30*time.Second, sets.New[string](), nil, durability, true, logger)
+	require.NoError(t, err)
+	assert.Contains(t, logger.String(), "MariaDB support for serving shards is deprecated")
+}
+
 func TestReplicaWasRunning(t *testing.T) {
 	t.Parallel()
 

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -59,7 +59,7 @@ const (
 
 func warnIfMariaDB(logger logutil.Logger, flavor mysqlctl.MySQLFlavor, alias string) {
 	if flavor == mysqlctl.FlavorMariaDB {
-		logger.Warningf("MariaDB support for serving shards is deprecated and will become unsupported in v26.0.0; tablet %v uses MariaDB", alias)
+		logger.Warningf("MariaDB support for serving shards is deprecated and will become unsupported in v26.0.0; tablet %s uses MariaDB", alias)
 	}
 }
 

--- a/go/vt/vtctl/reparentutil/util.go
+++ b/go/vt/vtctl/reparentutil/util.go
@@ -57,6 +57,27 @@ const (
 	lostTopologyLockMsg = "lost topology lock, aborting"
 )
 
+func warnIfMariaDB(logger logutil.Logger, flavor mysqlctl.MySQLFlavor, alias string) {
+	if flavor == mysqlctl.FlavorMariaDB {
+		logger.Warningf("MariaDB support for serving shards is deprecated and will become unsupported in v26.0.0; tablet %v uses MariaDB", alias)
+	}
+}
+
+func warnIfMariaDBVersion(logger logutil.Logger, version, alias string, encodedPositions ...string) {
+	flavor, _, err := mysqlctl.ParseVersionString(version)
+	if err == nil {
+		warnIfMariaDB(logger, flavor, alias)
+		return
+	}
+	for _, encodedPosition := range encodedPositions {
+		position, err := replication.DecodePosition(encodedPosition)
+		if err == nil && position.GTIDSet != nil && position.GTIDSet.Flavor() == replication.MariadbFlavorID {
+			warnIfMariaDB(logger, mysqlctl.FlavorMariaDB, alias)
+			return
+		}
+	}
+}
+
 // ElectNewPrimary finds a tablet that should become a primary after reparent.
 // The criteria for the new primary-elect are (preferably) to be in the same
 // cell as the current primary, and to be different from avoidPrimaryAlias.
@@ -133,6 +154,9 @@ func ElectNewPrimary(
 			pos, replLag, takingBackup, replUnknown, serverVersion, err := findTabletPositionLagBackupStatus(groupCtx, tb, logger, tmc, opts.WaitReplicasTimeout)
 			mu.Lock()
 			defer mu.Unlock()
+			if err == nil {
+				warnIfMariaDBVersion(logger, serverVersion, topoproto.TabletAliasString(tb.Alias), replication.EncodePosition(pos.Executed), replication.EncodePosition(pos.Combined))
+			}
 			if err == nil && (opts.TolerableReplLag == 0 || opts.TolerableReplLag >= replLag) {
 				if takingBackup {
 					fmt.Fprintf(&reasonsToInvalidate, "\n%v is taking a backup", topoproto.TabletAliasString(tablet.Alias))

--- a/go/vt/vtctl/reparentutil/util_test.go
+++ b/go/vt/vtctl/reparentutil/util_test.go
@@ -1716,6 +1716,54 @@ zone1-0000000100 is not a replica`,
 	}
 }
 
+func TestElectNewPrimaryWarnsForMariaDB(t *testing.T) {
+	alias101 := &topodatapb.TabletAlias{Cell: "zone1", Uid: 101}
+	alias102 := &topodatapb.TabletAlias{Cell: "zone1", Uid: 102}
+	tmc := &chooseNewPrimaryTestTMClient{
+		replicationStatuses: map[string]*replicationdatapb.Status{
+			topoproto.TabletAliasString(alias101): {
+				Position:         "MariaDB/0-1-5",
+				RelayLogPosition: "MariaDB/0-1-5",
+			},
+			topoproto.TabletAliasString(alias102): {
+				Position:         "MariaDB/0-1-10",
+				RelayLogPosition: "MariaDB/0-1-10",
+			},
+		},
+	}
+	tabletMap := map[string]*topo.TabletInfo{
+		topoproto.TabletAliasString(alias101): {
+			Tablet: &topodatapb.Tablet{Alias: alias101, Type: topodatapb.TabletType_REPLICA},
+		},
+		topoproto.TabletAliasString(alias102): {
+			Tablet: &topodatapb.Tablet{Alias: alias102, Type: topodatapb.TabletType_REPLICA},
+		},
+	}
+	durability, err := policy.GetDurabilityPolicy(policy.DurabilityNone)
+	require.NoError(t, err)
+	logger := logutil.NewMemoryLogger()
+
+	primary, err := ElectNewPrimary(t.Context(), tmc, topo.NewShardInfo("testkeyspace", "0", &topodatapb.Shard{}, nil), tabletMap, nil, &PlannedReparentOptions{
+		durability:          durability,
+		WaitReplicasTimeout: 30 * time.Second,
+	}, logger)
+	require.NoError(t, err)
+	assert.True(t, topoproto.TabletAliasEqual(alias102, primary))
+	assert.Contains(t, logger.String(), "MariaDB support for serving shards is deprecated")
+
+	for _, status := range tmc.replicationStatuses {
+		status.BackupRunning = true
+		status.ServerVersion = "Ver 10.10.2-MariaDB"
+	}
+	logger = logutil.NewMemoryLogger()
+	_, err = ElectNewPrimary(t.Context(), tmc, topo.NewShardInfo("testkeyspace", "0", &topodatapb.Shard{}, nil), tabletMap, nil, &PlannedReparentOptions{
+		durability:          durability,
+		WaitReplicasTimeout: 30 * time.Second,
+	}, logger)
+	require.ErrorContains(t, err, "cannot find a tablet to reparent to")
+	assert.Contains(t, logger.String(), "MariaDB support for serving shards is deprecated")
+}
+
 func TestFindPositionForTablet(t *testing.T) {
 	t.Parallel()
 

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -114,12 +114,12 @@ func (tm *TabletManager) warnMariaDBDeprecation(version string) {
 	if err != nil || flavor != mysqlctl.FlavorMariaDB {
 		return
 	}
-	tm.mariaDBDeprecationWarning.Do(func() {
+	if tm.mariaDBDeprecationWarned.CompareAndSwap(false, true) {
 		log.Warn("MariaDB support for managed tablets is deprecated and will become unsupported in v26.0.0; use --unmanaged in an external keyspace when importing from MariaDB",
 			slog.String("tablet_alias", topoproto.TabletAliasString(tm.tabletAlias)),
 			slog.String("mysql_version", version),
 		)
-	})
+	}
 }
 
 // maxVersionLookupBudget caps how long a bounded version lookup may run

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -94,6 +94,7 @@ func (tm *TabletManager) getMySQLVersionString(ctx context.Context) string {
 		log.Warn("failed to get MySQL version string", slog.Any("error", err))
 		return ""
 	}
+	tm.warnMariaDBDeprecation(version)
 
 	c.mu.Lock()
 	c.version = version
@@ -101,6 +102,24 @@ func (tm *TabletManager) getMySQLVersionString(ctx context.Context) string {
 	c.mu.Unlock()
 
 	return version
+}
+
+// warnMariaDBDeprecation warns once for managed MariaDB tablets. Unmanaged
+// tablets remain supported as MariaDB import sources.
+func (tm *TabletManager) warnMariaDBDeprecation(version string) {
+	if tm.unmanaged {
+		return
+	}
+	flavor, _, err := mysqlctl.ParseVersionString(version)
+	if err != nil || flavor != mysqlctl.FlavorMariaDB {
+		return
+	}
+	tm.mariaDBDeprecationWarning.Do(func() {
+		log.Warn("MariaDB support for managed tablets is deprecated and will become unsupported in v26.0.0; use --unmanaged in an external keyspace when importing from MariaDB",
+			slog.String("tablet_alias", topoproto.TabletAliasString(tm.tabletAlias)),
+			slog.String("mysql_version", version),
+		)
+	})
 }
 
 // maxVersionLookupBudget caps how long a bounded version lookup may run

--- a/go/vt/vttablet/tabletmanager/rpc_replication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package tabletmanager
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -35,6 +38,7 @@ import (
 	"vitess.io/vitess/go/protoutil"
 	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/dbconfigs"
+	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/mysqlctl"
 	"vitess.io/vitess/go/vt/topo"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
@@ -130,6 +134,7 @@ func TestPrimaryStatusIncludesServerVersion(t *testing.T) {
 
 	fakeMysqlDaemon := tm.MysqlDaemon.(*mysqlctl.FakeMysqlDaemon)
 	fakeMysqlDaemon.Version = "Ver 8.0.35"
+	expireMySQLVersionCache(tm)
 
 	status, err := tm.PrimaryStatus(ctx)
 	require.NoError(t, err)
@@ -144,6 +149,7 @@ func TestReplicationStatusIncludesServerVersion(t *testing.T) {
 
 	fakeMysqlDaemon := tm.MysqlDaemon.(*mysqlctl.FakeMysqlDaemon)
 	fakeMysqlDaemon.Version = "Ver 8.0.35"
+	expireMySQLVersionCache(tm)
 
 	status, err := tm.ReplicationStatus(ctx)
 	require.NoError(t, err)
@@ -222,6 +228,7 @@ func TestDemotePrimaryIncludesServerVersion(t *testing.T) {
 
 	fakeMysqlDaemon := tm.MysqlDaemon.(*mysqlctl.FakeMysqlDaemon)
 	fakeMysqlDaemon.Version = "Ver 8.0.35"
+	expireMySQLVersionCache(tm)
 	fakeMysqlDaemon.DB().SetNeverFail(true)
 
 	tm.SemiSyncMonitor.Open()
@@ -1446,6 +1453,12 @@ type countingVersionDaemon struct {
 	delay time.Duration
 }
 
+func expireMySQLVersionCache(tm *TabletManager) {
+	tm.mysqlVersion.mu.Lock()
+	tm.mysqlVersion.fetchedAt = time.Time{}
+	tm.mysqlVersion.mu.Unlock()
+}
+
 func (d *countingVersionDaemon) GetVersionString(ctx context.Context) (string, error) {
 	d.calls.Add(1)
 	if d.delay > 0 {
@@ -1483,10 +1496,7 @@ func TestGetMySQLVersionStringCache(t *testing.T) {
 		tm := &TabletManager{MysqlDaemon: daemon}
 
 		require.Equal(t, "Ver 8.0.35", tm.getMySQLVersionString(t.Context()))
-		// Expire the cache by backdating the fetch time beyond the TTL.
-		tm.mysqlVersion.mu.Lock()
-		tm.mysqlVersion.fetchedAt = time.Now().Add(-2 * mysqlVersionCacheTTL)
-		tm.mysqlVersion.mu.Unlock()
+		expireMySQLVersionCache(tm)
 
 		require.Equal(t, "Ver 8.0.35", tm.getMySQLVersionString(t.Context()))
 		require.EqualValues(t, 2, daemon.calls.Load(), "should re-query mysqld after the TTL expires")
@@ -1533,6 +1543,56 @@ func TestGetMySQLVersionStringCache(t *testing.T) {
 		require.LessOrEqual(t, daemon.calls.Load(), int64(goroutines))
 		require.GreaterOrEqual(t, daemon.calls.Load(), int64(1))
 	})
+}
+
+func TestMariaDBDeprecationWarning(t *testing.T) {
+	tests := []struct {
+		name             string
+		version          string
+		unmanaged        bool
+		expectedWarnings int
+	}{
+		{
+			name:             "managed MariaDB warns once",
+			version:          "Ver 10.10.2-MariaDB",
+			expectedWarnings: 1,
+		},
+		{
+			name:      "unmanaged MariaDB does not warn",
+			version:   "Ver 10.10.2-MariaDB",
+			unmanaged: true,
+		},
+		{
+			name:    "managed MySQL does not warn",
+			version: "Ver 8.0.35",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logBuffer bytes.Buffer
+			oldLogger := log.SwapLogger(slog.New(slog.NewTextHandler(&logBuffer, nil)))
+			t.Cleanup(func() {
+				log.SwapLogger(oldLogger)
+			})
+
+			daemon := &countingVersionDaemon{
+				FakeMysqlDaemon: newTestMysqlDaemon(t, 1),
+				version:         tt.version,
+			}
+			tm := &TabletManager{
+				MysqlDaemon: daemon,
+				unmanaged:   tt.unmanaged,
+			}
+
+			require.Equal(t, tt.version, tm.getMySQLVersionStringBounded(t.Context()))
+			require.Equal(t, tt.version, tm.getMySQLVersionString(t.Context()))
+			expireMySQLVersionCache(tm)
+			require.Equal(t, tt.version, tm.getMySQLVersionString(t.Context()))
+
+			assert.Equal(t, tt.expectedWarnings, strings.Count(logBuffer.String(), "MariaDB support for managed tablets is deprecated"))
+		})
+	}
 }
 
 func TestGetMySQLVersionStringBounded(t *testing.T) {

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -234,7 +234,9 @@ type TabletManager struct {
 	// mysqlVersion caches the MySQL server version string. It has its own lock
 	// (not tm.mutex) so reads never contend with unrelated TabletManager
 	// operations. See getMySQLVersionString for why this is cached.
-	mysqlVersion mysqlVersionCache
+	mysqlVersion              mysqlVersionCache
+	mariaDBDeprecationWarning sync.Once
+	unmanaged                 bool
 }
 
 // BuildTabletFromInput builds a tablet record from input parameters.
@@ -396,6 +398,7 @@ func (tm *TabletManager) Start(tablet *topodatapb.Tablet, config *tabletenv.Tabl
 	log.Info("TabletManager Start")
 	tm.DBConfigs.DBName = topoproto.TabletDbName(tablet)
 	tm.tabletAlias = tablet.Alias
+	tm.unmanaged = config != nil && config.Unmanaged
 	tm.tmc = tmclient.NewTabletManagerClient()
 
 	// Check if there's an existing tablet record in topology and use it if flag is enabled
@@ -895,6 +898,9 @@ func (tm *TabletManager) checkMysql(ctx context.Context) error {
 				tablet.MysqlPort = mysqlPort
 			})
 		}
+	}
+	if !tm.unmanaged {
+		tm.getMySQLVersionStringBounded(ctx)
 	}
 	return nil
 }

--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -44,6 +44,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -234,9 +235,9 @@ type TabletManager struct {
 	// mysqlVersion caches the MySQL server version string. It has its own lock
 	// (not tm.mutex) so reads never contend with unrelated TabletManager
 	// operations. See getMySQLVersionString for why this is cached.
-	mysqlVersion              mysqlVersionCache
-	mariaDBDeprecationWarning sync.Once
-	unmanaged                 bool
+	mysqlVersion             mysqlVersionCache
+	mariaDBDeprecationWarned atomic.Bool
+	unmanaged                bool
 }
 
 // BuildTabletFromInput builds a tablet record from input parameters.


### PR DESCRIPTION
## Description

MariaDB-backed serving shards will become unsupported in v26, but users currently have no runtime signal that they need to migrate

Without an advance warning, operators could reach v26 with a serving topology that no longer starts. This PR adds v25 deprecation warnings from managed `vttablet` processes and ERS/PRS operations when MariaDB is detected

Unmanaged tablets remain supported as MariaDB import sources in external keyspaces. The warnings reuse existing RPC/status data, so this does not add RPCs or change reparent behaviour

## Related Issue(s)

Related https://github.com/vitessio/vitess/issues/20982 (stage 1 of 2 — this PR adds the v25 warnings; the v26 removal is still open)
## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

### AI Disclosure

Claude Code assisted with development and testing, and prepared this PR summary
