### PR TITLE
ci: bump the removed libtinfo5 pin to 6.3-2ubuntu0.3

### DIFF
--- a/.github/actions/setup-mysql/action.yml
+++ b/.github/actions/setup-mysql/action.yml
@@ -89,14 +89,14 @@ runs:
             # libtinfo5 is also needed for older MySQL 5.7 builds. Separate
             # statements for the same fail-fast reason as libaio1 above.
             download_with_ip_failover \
-              https://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.2_amd64.deb \
-              libtinfo5_6.3-2ubuntu0.2_amd64.deb || {
+              https://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.3_amd64.deb \
+              libtinfo5_6.3-2ubuntu0.3_amd64.deb || {
               echo "Failed to download libtinfo5. The pinned version may have been superseded and removed from archive.ubuntu.com; check https://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/ for the current version."
               exit 1
             }
-            echo "b9bb64e716a7d9de05b1b33992763142ca81bcae3a7f8ce7e29fa3c6fd32f1e8  libtinfo5_6.3-2ubuntu0.2_amd64.deb" | sha256sum --check
-            sudo dpkg -i libtinfo5_6.3-2ubuntu0.2_amd64.deb
-            rm libtinfo5_6.3-2ubuntu0.2_amd64.deb
+            echo "4df4288404108f1a156d014e8764a064e977e34e6d44931ab60451694c03c90d  libtinfo5_6.3-2ubuntu0.3_amd64.deb" | sha256sum --check
+            sudo dpkg -i libtinfo5_6.3-2ubuntu0.3_amd64.deb
+            rm libtinfo5_6.3-2ubuntu0.3_amd64.deb
             sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-client=5.7* mysql-community-server=5.7* mysql-server=5.7* libncurses6
           elif [[ "$FLAVOR" == "mysql-8.0" ]]; then
             echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections


### PR DESCRIPTION
## Description

Both `mysql57` unit-test jobs (`Unit Test (mysql57)`, `Unit Test (evalengine_mysql57)`) fail on every PR today, before running a single test:

```
curl: (22) The requested URL returned error: 404
All resolved IPs for archive.ubuntu.com failed
Failed to download libtinfo5. The pinned version may have been superseded and removed from archive.ubuntu.com; ...
```

Same pin rot as #20481: Ubuntu published `libtinfo5 6.3-2ubuntu0.3` and dropped `6.3-2ubuntu0.2` from the pool, so the pinned URL in the `setup-mysql` action is gone. This bumps the pin and its sha256 to the current version. Nothing else changes.

The fail-fast added in #20481 did its job: the error message pointed straight at the culprit.

## Related Issue(s)

None filed; CI-only breakage. Seen on all PRs from around 09:20 UTC today.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required (CI-only change; downloaded the new deb and verified the sha256 line in the action against it)
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None, CI infrastructure only. Backport justification: the mysql57 jobs run on the release branches too and are broken there the same way.

### AI Disclosure

Diagnosed and written by Claude Code, with direction and review from me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017s4WWSQw4BtrDMWgY53RCf
