### PR TITLE
go-upgrade: pin the multi-platform index digest of the Go image

### DIFF
--- a/go/tools/go-upgrade/go-upgrade.go
+++ b/go/tools/go-upgrade/go-upgrade.go
@@ -32,7 +32,6 @@ import (
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/crane"
-	gocr "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/hashicorp/go-version"
 	"github.com/spf13/cobra"
 )
@@ -40,10 +39,12 @@ import (
 const (
 	goDevAPI = "https://go.dev/dl/?mode=json"
 
-	// dockerPlatformOS is the target OS for the Go base image.
-	dockerPlatformOS = "linux"
+	// golangImageRepository is the Docker Hub repository of the official Go images.
+	golangImageRepository = "golang"
 
-	// dockerPlatformArch is the target architecture for the Go base image.
+	// dockerPlatformOS and dockerPlatformArch identify the only explicit --platform
+	// the Go image rewrite recognizes in FROM lines.
+	dockerPlatformOS   = "linux"
 	dockerPlatformArch = "amd64"
 
 	// regexpFindBootstrapVersion greps the current bootstrap version from the Makefile. The bootstrap
@@ -474,7 +475,7 @@ func replaceGolangImageReferences(content string, goVersion *version.Version) (s
 			continue
 		}
 
-		digest, err := resolveGolangImageDigest(goVersion, distro)
+		digest, err := resolveGolangImageDigest(golangImageRepository, goVersion, distro)
 		if err != nil {
 			return "", err
 		}
@@ -512,10 +513,15 @@ func replaceGolangImageReferences(content string, goVersion *version.Version) (s
 }
 
 // resolveGolangImageDigest resolves the pinned digest for the given Go version and distro.
-func resolveGolangImageDigest(goVersion *version.Version, distro string) (string, error) {
-	ref := "golang:" + golangDockerTag(goVersion, distro)
+//
+// The digest is the one the tag itself points to, which for the official Go images is a
+// multi-platform index. Pinning the index keeps the Dockerfiles buildable on every
+// architecture, whereas pinning a single platform's manifest would break native builds
+// on the others.
+func resolveGolangImageDigest(repository string, goVersion *version.Version, distro string) (string, error) {
+	ref := repository + ":" + golangDockerTag(goVersion, distro)
 
-	digest, err := crane.Digest(ref, crane.WithPlatform(&gocr.Platform{OS: dockerPlatformOS, Architecture: dockerPlatformArch}))
+	digest, err := crane.Digest(ref)
 	if err != nil {
 		return "", fmt.Errorf("resolve golang digest for %s: %w", ref, err)
 	}

--- a/go/tools/go-upgrade/go-upgrade_test.go
+++ b/go/tools/go-upgrade/go-upgrade_test.go
@@ -17,11 +17,20 @@ limitations under the License.
 package main
 
 import (
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	gocr "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
 )
@@ -221,4 +230,38 @@ func TestUpgradeGoModFiles(t *testing.T) {
 	got, err := os.ReadFile(currentTool)
 	require.NoError(t, err)
 	require.Equal(t, currentContent, got)
+}
+
+// TestResolveGolangImageDigestPinsMultiPlatformIndex publishes a golang tag whose manifest is a
+// multi-platform index and checks that the resolver pins the index itself rather than one of its
+// per-platform children. A per-platform pin cannot be built natively on any other architecture.
+func TestResolveGolangImageDigestPinsMultiPlatformIndex(t *testing.T) {
+	srv := httptest.NewServer(registry.New())
+	t.Cleanup(srv.Close)
+	registryURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	var idx gocr.ImageIndex = empty.Index
+	for _, arch := range []string{"amd64", "arm64"} {
+		img, err := random.Image(256, 1)
+		require.NoError(t, err)
+		idx = mutate.AppendManifests(idx, mutate.IndexAddendum{
+			Add:      img,
+			Platform: &gocr.Platform{OS: "linux", Architecture: arch},
+		})
+	}
+
+	goVersion, err := version.NewVersion("1.27.1")
+	require.NoError(t, err)
+	repository := registryURL.Host + "/golang"
+	ref, err := name.ParseReference(repository + ":" + golangDockerTag(goVersion, "bookworm"))
+	require.NoError(t, err)
+	require.NoError(t, remote.WriteIndex(ref, idx))
+
+	want, err := idx.Digest()
+	require.NoError(t, err)
+
+	got, err := resolveGolangImageDigest(repository, goVersion, "bookworm")
+	require.NoError(t, err)
+	require.Equal(t, want.String(), got)
 }


### PR DESCRIPTION
## Description

The Go upgrade tool resolved every `golang:<version>-<distro>` tag for `linux/amd64` explicitly, so each bump pinned the amd64 child manifest rather than the multi-platform index the tag points to. `docker/lite` and `docker/vttestserver` build for the host platform, so right after a bump those images can't be built natively on arm64 anymore. This was flagged on #20981, and it's also why dependabot kept "correcting" the pins a few days after each bump (#20968 undid the ones written by #20875).

`resolveGolangImageDigest` now calls `crane.Digest` without a platform, so it returns the index digest. That builds everywhere, including under the explicit `--platform=linux/amd64` that `docker/bootstrap/build.sh` uses, and it matches what dependabot writes, so the churn stops.

The new test publishes a two-platform index to an in-memory registry and checks that the resolver pins the index rather than one of its children. It fails against the old code.

I also ran the fixed tool against Docker Hub in a scratch copy of the repo: it writes `sha256:648f440f…` for `1.27.1-bookworm` and `sha256:9baa6b41…` for `1.27.1-trixie`, which are exactly the digests those tags resolve to. #20981 will be updated with those separately.

**Backport justification:** the same upgrade workflow and the same resolver run on `release-23.0` and `release-24.0`, so every Go patch bump there produces the same amd64-only pins.

## Related Issue(s)

- #20981

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None, this only affects the tool that prepares Go upgrade PRs.

### AI Disclosure

Most of this was written by Claude Code, I just provided direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WFEQBZgAgYxc3sPhdZeQp