### PR TITLE
docker/bootstrap: default the flavor images' bootstrap_version to the current one

### DIFF
--- a/docker/bootstrap/Dockerfile.mysql80
+++ b/docker/bootstrap/Dockerfile.mysql80
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG bootstrap_version
+ARG bootstrap_version=60
 ARG image="vitess/bootstrap:${bootstrap_version}-common"
 
 FROM $image

--- a/docker/bootstrap/Dockerfile.mysql80
+++ b/docker/bootstrap/Dockerfile.mysql80
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG bootstrap_version=60
+ARG bootstrap_version=61
 ARG image="vitess/bootstrap:${bootstrap_version}-common"
 
 FROM $image

--- a/docker/bootstrap/Dockerfile.mysql84
+++ b/docker/bootstrap/Dockerfile.mysql84
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG bootstrap_version
+ARG bootstrap_version=60
 ARG image="vitess/bootstrap:${bootstrap_version}-common"
 
 FROM $image

--- a/docker/bootstrap/Dockerfile.mysql84
+++ b/docker/bootstrap/Dockerfile.mysql84
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG bootstrap_version=60
+ARG bootstrap_version=61
 ARG image="vitess/bootstrap:${bootstrap_version}-common"
 
 FROM $image

--- a/docker/bootstrap/Dockerfile.percona80
+++ b/docker/bootstrap/Dockerfile.percona80
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG bootstrap_version
+ARG bootstrap_version=60
 ARG image="vitess/bootstrap:${bootstrap_version}-common"
 
 FROM $image

--- a/docker/bootstrap/Dockerfile.percona80
+++ b/docker/bootstrap/Dockerfile.percona80
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG bootstrap_version=60
+ARG bootstrap_version=61
 ARG image="vitess/bootstrap:${bootstrap_version}-common"
 
 FROM $image

--- a/docker/bootstrap/Dockerfile.percona84
+++ b/docker/bootstrap/Dockerfile.percona84
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG bootstrap_version
+ARG bootstrap_version=60
 ARG image="vitess/bootstrap:${bootstrap_version}-common"
 
 FROM $image

--- a/docker/bootstrap/Dockerfile.percona84
+++ b/docker/bootstrap/Dockerfile.percona84
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG bootstrap_version=60
+ARG bootstrap_version=61
 ARG image="vitess/bootstrap:${bootstrap_version}-common"
 
 FROM $image

--- a/go/tools/go-upgrade/go-upgrade.go
+++ b/go/tools/go-upgrade/go-upgrade.go
@@ -534,6 +534,10 @@ func updateBootstrapVersionInCodebase(old, new string, newGoVersion *version.Ver
 	}
 	files, err := getListOfFilesInPaths([]string{
 		"./Makefile",
+		"./docker/bootstrap/Dockerfile.mysql80",
+		"./docker/bootstrap/Dockerfile.mysql84",
+		"./docker/bootstrap/Dockerfile.percona80",
+		"./docker/bootstrap/Dockerfile.percona84",
 	})
 	if err != nil {
 		return err

--- a/go/tools/go-upgrade/go-upgrade_test.go
+++ b/go/tools/go-upgrade/go-upgrade_test.go
@@ -222,3 +222,36 @@ func TestUpgradeGoModFiles(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, currentContent, got)
 }
+
+// TestUpdateBootstrapVersionInCodebaseKeepsDockerfileDefaultsInSync bumps the bootstrap version in a
+// fixture repository and checks that the flavor Dockerfiles' default bootstrap_version follows the
+// Makefile. The default is what lets a plain `docker build` of a flavor find the common image build.sh produces.
+func TestUpdateBootstrapVersionInCodebaseKeepsDockerfileDefaultsInSync(t *testing.T) {
+	dir := t.TempDir()
+	write := func(rel, content string) {
+		p := filepath.Join(dir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
+	}
+	write("Makefile", "BOOTSTRAP_VERSION=60\n")
+	write("test.go", "flag.String(\"bootstrap-version\", \"60\", \"the version identifier to use for the docker images\")\n")
+	write("docker/bootstrap/CHANGELOG.md", "# Changelog\n")
+	flavors := []string{"mysql80", "mysql84", "percona80", "percona84"}
+	for _, flavor := range flavors {
+		write("docker/bootstrap/Dockerfile."+flavor, "ARG bootstrap_version=60\nARG image=\"vitess/bootstrap:${bootstrap_version}-common\"\n\nFROM $image\n")
+	}
+	t.Chdir(dir)
+
+	goVersion, err := version.NewVersion("1.27.1")
+	require.NoError(t, err)
+	require.NoError(t, updateBootstrapVersionInCodebase("60", "61", goVersion))
+
+	for _, flavor := range flavors {
+		content, err := os.ReadFile(filepath.Join(dir, "docker/bootstrap/Dockerfile."+flavor))
+		require.NoError(t, err)
+		require.Equal(t, "ARG bootstrap_version=61\nARG image=\"vitess/bootstrap:${bootstrap_version}-common\"\n\nFROM $image\n", string(content))
+	}
+	makefile, err := os.ReadFile(filepath.Join(dir, "Makefile"))
+	require.NoError(t, err)
+	require.Equal(t, "BOOTSTRAP_VERSION=61\n", string(makefile))
+}

--- a/go/tools/go-upgrade/go-upgrade_test.go
+++ b/go/tools/go-upgrade/go-upgrade_test.go
@@ -223,9 +223,6 @@ func TestUpgradeGoModFiles(t *testing.T) {
 	require.Equal(t, currentContent, got)
 }
 
-// TestUpdateBootstrapVersionInCodebaseKeepsDockerfileDefaultsInSync bumps the bootstrap version in a
-// fixture repository and checks that the flavor Dockerfiles' default bootstrap_version follows the
-// Makefile. The default is what lets a plain `docker build` of a flavor find the common image build.sh produces.
 func TestUpdateBootstrapVersionInCodebaseKeepsDockerfileDefaultsInSync(t *testing.T) {
 	dir := t.TempDir()
 	write := func(rel, content string) {


### PR DESCRIPTION
## Description

Every `docker_ci` run (on `main` too) carries this check warning:

```
InvalidDefaultArgInFrom: Default value for ARG $image results in empty or invalid base image name
```

GitHub pins the annotation on `docker/bootstrap/Dockerfile.common:18`, but the build log shows it comes from the flavor build. The flavor Dockerfiles declare `ARG bootstrap_version` with no default, so `ARG image="vitess/bootstrap:${bootstrap_version}-common"` defaults to `vitess/bootstrap:-common`, which isn't a valid reference. Locally, `docker buildx build --check -f docker/bootstrap/Dockerfile.mysql84 .` fails outright on that.

This gives `bootstrap_version` the same default as `BOOTSTRAP_VERSION` in the Makefile, and makes `go-upgrade` rewrite that default when it bumps the version. The tool already had the regex and replacement for `ARG bootstrap_version=N`, it just only ran it over the Makefile, so that branch was dead code. Now it also runs over the four flavor Dockerfiles, and a test pins that.

With the change, `docker buildx build --check` on a flavor Dockerfile reports no warnings (I overrode `image` with `debian:bookworm-slim` for the check, since Docker Hub stopped publishing `-common` tags at 51 and the default only resolves after `build.sh common` has built it locally). `build.sh` and `docker-bake.hcl` keep passing `bootstrap_version` explicitly, so nothing changes for CI.

#20981 has since merged and raised `BOOTSTRAP_VERSION` to 61, so the default here is 61 as well.

## Related Issue(s)

- #20981

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None for Vitess deployments. For people building the bootstrap images: a plain `docker build -f docker/bootstrap/Dockerfile.<flavor> .` without `--build-arg bootstrap_version=...` used to fail on an invalid base reference (`vitess/bootstrap:-common`); it now targets `vitess/bootstrap:<current BOOTSTRAP_VERSION>-common`, i.e. whatever `build.sh common` produced. `build.sh` and `docker-bake.hcl` still pass the version explicitly, so their behavior is unchanged.

### AI Disclosure

Most of this was written by Claude Code, I just provided direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WFEQBZgAgYxc3sPhdZeQp


