### PR TITLE
ci: export the bootstrap BuildKit cache from one job on main and release branches only

### DIFF
--- a/.github/actions/build-bootstrap/action.yml
+++ b/.github/actions/build-bootstrap/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "Bootstrap image flavor (e.g. mysql84)"
     required: false
     default: "mysql84"
+  cache-export:
+    description: "Export the build cache to the GitHub Actions cache. Only one job per push should do this, and only on branches whose cache other builds can read (main and release branches)."
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -24,7 +28,7 @@ runs:
         load: true
         set: |
           *.cache-from=type=gha,scope=bootstrap
-          *.cache-to=type=gha,scope=bootstrap,mode=max
+          ${{ inputs.cache-export == 'true' && '*.cache-to=type=gha,scope=bootstrap,mode=max' || '' }}
       env:
         BOOTSTRAP_VERSION: ${{ inputs.bootstrap-version }}
         BOOTSTRAP_FLAVOR: ${{ inputs.bootstrap-flavor }}

--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           bootstrap-version: ${{ env.BOOTSTRAP_VERSION }}
           bootstrap-flavor: ${{ env.BOOTSTRAP_FLAVOR }}
+          cache-export: ${{ matrix.shard == 'java' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-')) }}
 
       - name: Set up Go
         if: steps.changes.outputs.end_to_end == 'true'


### PR DESCRIPTION
## Description

The `buildkit-blob-*` entries are most of our Actions cache usage: 9.5GB of the 11.6GB in use right now, and 9GB of that sits on `refs/pull/*` where nobody but that PR can read it.

The cause is the `build-bootstrap` composite action, the only `type=gha` user in the repo. All six jobs that call it (two in docker_ci, two each in local_example and region_example) export the cache with `mode=max` on every push. The `bootstrap.sh` and MySQL install layers aren't reproducible, so every rebuild produces a fresh ~200MB blob per layer per job, roughly 2.5GB per PR push. That keeps us over the 10GB quota, GitHub evicts main's blobs, and the next build misses again. The run logs show it directly: `ERROR: blob sha256:…: not found` during cache import, followed by a rebuild of both layers, including on main itself.

This PR makes the export opt-in via a `cache-export` input on the composite action and turns it on only from docker_ci's Java job, only when the ref is `main` or a `release-*` branch. Every job keeps reading the cache. The Java job is the writer because docker_ci's path filter is a superset of the example workflows' filter, so any push that invalidates the expensive layers also refreshes the cache.

Two notes:

- Workflow files are per branch, so release branches keep the old unconditional export until this is backported. Until then each push to a release branch still writes six sets of blobs. I'd suggest backporting to all supported release branches for that reason.
- The existing PR-scoped blobs won't disappear on merge; they age out after seven days unused, or can be removed right away with `gh cache delete`.

## Related Issue(s)

None.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None, CI only.

### AI Disclosure

The investigation and this change were done by Claude Code, with direction from me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5S59BHVCZaaQ5fGJcxVaL
