### PR TITLE
vtgate: apply connection settings per statement instead of pinning the session

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -31,6 +31,7 @@
         - [Preparing a statement no longer starts an implicit transaction](#vtgate-prepare-no-implicit-tx)
         - [Stricter validation of SQL-level PREPARE statements](#vtgate-prepare-stricter-validation)
         - [Stricter PROXY protocol v1 header validation](#vtgate-proxy-protocol-v1-strictness)
+        - [Connection settings are applied per statement](#vtgate-settings-per-statement)
         - [MySQL-faithful validation and rejection of unsupported `sql_mode` values](#vtgate-sql-mode-rejection)
         - [New `VEXPLAIN MYSQLPLAN` statement](#vtgate-vexplain-mysqlplan)
     - **[Reparent](#minor-changes-reparent)**
@@ -306,6 +307,12 @@ Specification-conformant v1 headers, as emitted by HAProxy, AWS load balancers, 
 **Impact**: Deployments whose proxy emits one of the forms above — most notably the nginx stream module proxying between IPv6 clients and IPv4 upstreams — will have those connections rejected before the MySQL handshake. Configure the proxy to emit specification-conformant headers (for nginx, listen on a matching address family or on a v4-mapped socket so addresses are rendered in IPv6 form).
 
 See [#20733](https://github.com/vitessio/vitess/pull/20733) for details.
+
+#### <a id="vtgate-settings-per-statement"/>Connection settings are applied per statement</a>
+
+A statement that cannot carry the session's system variables in a `SET_VAR` optimizer hint (DDL, `CALL`, `FLUSH`, `LOAD DATA`, ...) runs with them applied to its connection through vttablet's connection settings. Previously the first such statement switched the whole session to reserved connections: every later query of the session, hint-capable or not, went through a settings connection on each shard it touched. Now only that statement carries the settings, and later queries keep using `SET_VAR` hints on pooled connections.
+
+A session is pinned to a reserved connection only when a tablet actually reserved one for the statement, which `GET_LOCK()`, `LOCK TABLES`, `FLUSH TABLES WITH READ LOCK` and temporary tables still need. Deployments with `--enable-set-var=false`, or backends without `SET_VAR`, keep using settings connections for every query, as before.
 
 #### <a id="vtgate-sql-mode-rejection"/>MySQL-faithful validation and rejection of unsupported `sql_mode` values</a>
 

--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -310,7 +310,7 @@ See [#20733](https://github.com/vitessio/vitess/pull/20733) for details.
 
 #### <a id="vtgate-settings-per-statement"/>Connection settings are applied per statement</a>
 
-A statement that cannot carry the session's system variables in a `SET_VAR` optimizer hint (DDL, `CALL`, `FLUSH`, `LOAD DATA`, ...) runs with them applied to its connection through vttablet's connection settings. Previously the first such statement switched the whole session to reserved connections: every later query of the session, hint-capable or not, went through a settings connection on each shard it touched. Now only that statement carries the settings, and later queries keep using `SET_VAR` hints on pooled connections.
+A statement that cannot carry the session's system variables in a `SET_VAR` optimizer hint (DDL, `CALL`, `FLUSH`, `LOAD DATA`, ...) runs with them applied to its connection through vttablet's connection settings. Previously the first such statement switched the whole session to reserved connections: every later query of the session, hint-capable or not, went through a settings connection on each shard it touched. Now only that statement carries the settings, and later queries keep using `SET_VAR` hints on pooled connections. Statements that never needed the settings but could not carry the hint either, `PREPARE`, `USE` and `EXPLAIN` among them, pinned the session the same way and no longer do.
 
 A session is pinned to a reserved connection only when a tablet actually reserved one for the statement, which `GET_LOCK()`, `LOCK TABLES`, `FLUSH TABLES WITH READ LOCK` and temporary tables still need. Deployments with `--enable-set-var=false`, or backends without `SET_VAR`, keep using settings connections for every query, as before.
 

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -143,6 +143,11 @@ type cxtKey int
 
 const (
 	IgnoreReserveTxn cxtKey = iota
+	// SessionSettingsForStatement asks the transport to apply the session's system
+	// variables to the connection for this statement only: the statement cannot carry
+	// them in a SET_VAR hint. The session is pinned to that connection only when the
+	// tablet answers that it reserved one.
+	SessionSettingsForStatement
 )
 
 func (route *Route) executeShards(

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -141,15 +141,8 @@ func (route *Route) TryExecute(ctx context.Context, vcursor VCursor, bindVars ma
 
 type cxtKey int
 
-// Context markers read by the scatter connection when it decides what a shard
-// needs for a statement; see actionInfo in vtgate/scatter_conn.go.
 const (
 	IgnoreReserveTxn cxtKey = iota
-	// SessionSettingsForStatement asks the transport to apply the session's system
-	// variables to the connection for this statement only: the statement cannot carry
-	// them in a SET_VAR hint. The session is pinned to that connection only when the
-	// tablet answers that it reserved one.
-	SessionSettingsForStatement
 )
 
 func (route *Route) executeShards(

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -141,6 +141,8 @@ func (route *Route) TryExecute(ctx context.Context, vcursor VCursor, bindVars ma
 
 type cxtKey int
 
+// Context markers read by the scatter connection when it decides what a shard
+// needs for a statement; see actionInfo in vtgate/scatter_conn.go.
 const (
 	IgnoreReserveTxn cxtKey = iota
 	// SessionSettingsForStatement asks the transport to apply the session's system

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -810,7 +810,7 @@ func (e *Executor) executeSPInAllSessions(ctx context.Context, safeSession *econ
 			})
 			queries = append(queries, &querypb.BoundQuery{Sql: sql})
 		}
-		qr, errs = e.ExecuteMultiShard(ctx, nil, rss, queries, safeSession, false /*autocommit*/, ignoreMaxMemoryRows, nullResultsObserver{}, false)
+		qr, errs = e.ExecuteMultiShard(ctx, nil, rss, queries, safeSession, false /*autocommit*/, false /*settingsForStatement*/, ignoreMaxMemoryRows, nullResultsObserver{}, false)
 		err := vterrors.Aggregate(errs)
 		if err != nil {
 			return nil, err
@@ -1835,8 +1835,8 @@ func parseAndValidateQuery(query string, parser *sqlparser.Parser) (sqlparser.St
 }
 
 // ExecuteMultiShard implements the IExecutor interface
-func (e *Executor) ExecuteMultiShard(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, session *econtext.SafeSession, autocommit bool, ignoreMaxMemoryRows bool, resultsObserver econtext.ResultsObserver, fetchLastInsertID bool) (qr *sqltypes.Result, errs []error) {
-	return e.scatterConn.ExecuteMultiShard(ctx, primitive, rss, queries, session, autocommit, ignoreMaxMemoryRows, resultsObserver, fetchLastInsertID)
+func (e *Executor) ExecuteMultiShard(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, session *econtext.SafeSession, autocommit bool, settingsForStatement bool, ignoreMaxMemoryRows bool, resultsObserver econtext.ResultsObserver, fetchLastInsertID bool) (qr *sqltypes.Result, errs []error) {
+	return e.scatterConn.ExecuteMultiShard(ctx, primitive, rss, queries, session, autocommit, settingsForStatement, ignoreMaxMemoryRows, resultsObserver, fetchLastInsertID)
 }
 
 // ExecuteMultiShardPerShard implements the IExecutor interface
@@ -1845,8 +1845,8 @@ func (e *Executor) ExecuteMultiShardPerShard(ctx context.Context, primitive engi
 }
 
 // StreamExecuteMulti implements the IExecutor interface
-func (e *Executor) StreamExecuteMulti(ctx context.Context, primitive engine.Primitive, query string, rss []*srvtopo.ResolvedShard, vars []map[string]*querypb.BindVariable, session *econtext.SafeSession, autocommit bool, callback func(reply *sqltypes.Result) error, resultsObserver econtext.ResultsObserver, fetchLastInsertID bool) []error {
-	return e.scatterConn.StreamExecuteMulti(ctx, primitive, query, rss, vars, session, autocommit, callback, resultsObserver, fetchLastInsertID)
+func (e *Executor) StreamExecuteMulti(ctx context.Context, primitive engine.Primitive, query string, rss []*srvtopo.ResolvedShard, vars []map[string]*querypb.BindVariable, session *econtext.SafeSession, autocommit bool, settingsForStatement bool, callback func(reply *sqltypes.Result) error, resultsObserver econtext.ResultsObserver, fetchLastInsertID bool) []error {
+	return e.scatterConn.StreamExecuteMulti(ctx, primitive, query, rss, vars, session, autocommit, settingsForStatement, callback, resultsObserver, fetchLastInsertID)
 }
 
 // ExecuteLock implements the IExecutor interface

--- a/go/vt/vtgate/executor_set_test.go
+++ b/go/vt/vtgate/executor_set_test.go
@@ -620,6 +620,8 @@ func createMap(keys []string, values []any) map[string]*querypb.BindVariable {
 func TestSetVar(t *testing.T) {
 	executor, _, _, sbc, ctx := createCustomExecutor(t, "{}", "8.0.0")
 	executor.config.Normalize = true
+	// the DDL runs on a settings-pool connection: the tablet reserves nothing
+	sbc.NoReservation = true
 
 	session := econtext.NewAutocommitSession(&vtgatepb.Session{EnableSystemSettings: true, TargetString: KsTestUnsharded})
 
@@ -631,8 +633,8 @@ func TestSetVar(t *testing.T) {
 	require.NoError(t, err)
 
 	tcases := []struct {
-		sql string
-		rc  bool
+		sql      string
+		settings bool
 	}{
 		{sql: "select 1 from user"},
 		{sql: "update user set col = 2"},
@@ -641,19 +643,61 @@ func TestSetVar(t *testing.T) {
 		{sql: "replace into user(id, col) values (1, 'new')"},
 		{sql: "set autocommit = 0"},
 		{sql: "show create table user"}, // reserved connection should not be set.
-		{sql: "create table foo(bar bigint)", rc: true},
+		{sql: "create table foo(bar bigint)", settings: true},
 	}
 
 	for _, tc := range tcases {
 		t.Run(tc.sql, func(t *testing.T) {
-			// reset reserved conn need.
-			session.SetReservedConn(false)
-
+			sbc.ReserveCount.Store(0)
 			_, err = executorExecSession(ctx, executor, session, tc.sql, map[string]*querypb.BindVariable{})
 			require.NoError(t, err)
-			assert.Equal(t, tc.rc, session.InReservedConn())
+			assert.False(t, session.InReservedConn())
+			assert.Equal(t, tc.settings, sbc.ReserveCount.Load() == 1, "settings carried by the statement")
 		})
 	}
+}
+
+// A statement that cannot carry a SET_VAR hint runs with the session's system
+// variables applied to its connection, for itself only: the session is not pinned,
+// and the next hint-capable query carries the hint again. The session gets pinned
+// when the tablet reserved a connection for the statement.
+func TestHintIncapableStatementCarriesTheSettingsForItself(t *testing.T) {
+	executor, _, _, sbc, ctx := createCustomExecutor(t, "{}", "8.0.0")
+	executor.config.Normalize = true
+	session := econtext.NewAutocommitSession(&vtgatepb.Session{EnableSystemSettings: true, TargetString: KsTestUnsharded})
+	sbc.SetResults([]*sqltypes.Result{sqltypes.MakeTestResult(sqltypes.MakeTestFields("orig|new", "varchar|varchar"), "|only_full_group_by")})
+	_, err := executorExecSession(ctx, executor, session, "set @@sql_mode = only_full_group_by", nil)
+	require.NoError(t, err)
+	sbc.Queries = nil
+
+	sbc.NoReservation = true
+	_, err = executorExecSession(ctx, executor, session, "create table foo(bar bigint)", nil)
+	require.NoError(t, err)
+	assert.False(t, session.InReservedConn())
+	assert.Empty(t, session.ShardSessions)
+	var sqls []string
+	for _, q := range sbc.Queries {
+		sqls = append(sqls, q.Sql)
+	}
+	assert.Equal(t, []string{"set sql_mode = 'only_full_group_by'", "create table foo (\n\tbar bigint\n)"}, sqls)
+
+	sbc.Queries = nil
+	_, err = executorExecSession(ctx, executor, session, "select 1 from user", nil)
+	require.NoError(t, err)
+	require.Len(t, sbc.Queries, 1)
+	assert.Equal(t, "select /*+ SET_VAR(sql_mode = 'only_full_group_by') */ :vtg1 /* INT64 */ from `user`", sbc.Queries[0].Sql)
+	assert.EqualValues(t, 1, sbc.ReserveCount.Load())
+
+	// a tablet that reserved a connection for the statement pins the session to it
+	sbc.NoReservation = false
+	_, err = executorExecSession(ctx, executor, session, "create table baz(bar bigint)", nil)
+	require.NoError(t, err)
+	assert.True(t, session.InReservedConn())
+	require.Len(t, session.ShardSessions, 1)
+	assert.NotZero(t, session.ShardSessions[0].ReservedId)
+	_, err = executorExecSession(ctx, executor, session, "select 1 from user", nil)
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, sbc.ReserveCount.Load(), "the query rode the reserved connection")
 }
 
 func TestSetVarShowVariables(t *testing.T) {

--- a/go/vt/vtgate/executor_set_test.go
+++ b/go/vt/vtgate/executor_set_test.go
@@ -695,9 +695,12 @@ func TestHintIncapableStatementCarriesTheSettingsForItself(t *testing.T) {
 	assert.True(t, session.InReservedConn())
 	require.Len(t, session.ShardSessions, 1)
 	assert.NotZero(t, session.ShardSessions[0].ReservedId)
+	reservedID := session.ShardSessions[0].ReservedId
 	_, err = executorExecSession(ctx, executor, session, "select 1 from user", nil)
 	require.NoError(t, err)
-	assert.EqualValues(t, 2, sbc.ReserveCount.Load(), "the query rode the reserved connection")
+	assert.EqualValues(t, 2, sbc.ReserveCount.Load(), "no new reservation for the query")
+	require.Len(t, session.ShardSessions, 1)
+	assert.Equal(t, reservedID, session.ShardSessions[0].ReservedId, "the query kept the reserved connection")
 }
 
 func TestSetVarShowVariables(t *testing.T) {

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -162,17 +162,21 @@ type (
 	// VCursorImpl implements the VCursor functionality used by dependent
 	// packages to call back into VTGate.
 	VCursorImpl struct {
-		config         VCursorConfig
-		SafeSession    *SafeSession
-		keyspace       string
-		tabletType     topodatapb.TabletType
-		destination    key.ShardDestination
-		marginComments sqlparser.MarginComments
-		executor       iExecute
-		resolver       Resolver
-		topoServer     *topo.Server
-		logStats       *logstats.LogStats
-		metrics        Metrics
+		config      VCursorConfig
+		SafeSession *SafeSession
+		// settingsForStatement makes the statement carry the session's system variables
+		// on the connection it runs on, without pinning the session; see
+		// NeedsSessionSettings.
+		settingsForStatement bool
+		keyspace             string
+		tabletType           topodatapb.TabletType
+		destination          key.ShardDestination
+		marginComments       sqlparser.MarginComments
+		executor             iExecute
+		resolver             Resolver
+		topoServer           *topo.Server
+		logStats             *logstats.LogStats
+		metrics              Metrics
 
 		// fkChecksState stores the state of foreign key checks variable.
 		// This state is meant to be the final fk checks state after consulting the
@@ -895,7 +899,7 @@ func (vc *VCursorImpl) ExecuteMultiShard(ctx context.Context, primitive engine.P
 		return nil, []error{err}
 	}
 
-	qr, errs := vc.executor.ExecuteMultiShard(ctx, primitive, rss, commentedShardQueries(queries, vc.marginComments), vc.SafeSession, canAutocommit, vc.ignoreMaxMemoryRows, vc.observer, fetchLastInsertID)
+	qr, errs := vc.executor.ExecuteMultiShard(vc.transportContext(ctx), primitive, rss, commentedShardQueries(queries, vc.marginComments), vc.SafeSession, canAutocommit, vc.ignoreMaxMemoryRows, vc.observer, fetchLastInsertID)
 	vc.setRollbackOnPartialExecIfRequired(len(errs) != len(rss), rollbackOnError)
 	vc.logShardsQueried(primitive, len(rss))
 	if qr != nil && qr.InsertIDUpdated() {
@@ -934,7 +938,7 @@ func (vc *VCursorImpl) StreamExecuteMulti(ctx context.Context, primitive engine.
 		return []error{err}
 	}
 
-	errs := vc.executor.StreamExecuteMulti(ctx, primitive, vc.marginComments.Leading+query+vc.marginComments.Trailing, rss, bindVars, vc.SafeSession, autocommit, callback, vc.observer, fetchLastInsertID)
+	errs := vc.executor.StreamExecuteMulti(vc.transportContext(ctx), primitive, vc.marginComments.Leading+query+vc.marginComments.Trailing, rss, bindVars, vc.SafeSession, autocommit, callback, vc.observer, fetchLastInsertID)
 	vc.setRollbackOnPartialExecIfRequired(len(errs) != len(rss), rollbackOnError)
 
 	return errs
@@ -1138,8 +1142,27 @@ func (vc *VCursorImpl) CheckForReservedConnection(setVarComment string, stmt sql
 		*sqlparser.SRollback, *sqlparser.Release, *sqlparser.Set, *sqlparser.Show,
 		sqlparser.SupportOptimizerHint:
 	default:
-		vc.NeedsReservedConn()
+		vc.NeedsSessionSettings()
 	}
+}
+
+// NeedsSessionSettings makes this request's statement run with the session's system
+// variables applied to its connection through the tablet's connection settings: the
+// statement cannot carry them in a SET_VAR hint. Unlike NeedsReservedConn it does not
+// pin the session; a later hint-capable query goes back to carrying the hint. The
+// session gets pinned only when a tablet answers that it reserved a connection for
+// the statement, which a lock or a temporary table needs and a DDL does not.
+func (vc *VCursorImpl) NeedsSessionSettings() {
+	vc.settingsForStatement = true
+}
+
+// transportContext marks the context for the scatter connection when the statement
+// wants the session's settings on its connection.
+func (vc *VCursorImpl) transportContext(ctx context.Context) context.Context {
+	if !vc.settingsForStatement {
+		return ctx
+	}
+	return context.WithValue(ctx, engine.SessionSettingsForStatement, true)
 }
 
 // NeedsReservedConn implements the SessionActions interface

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -106,9 +106,9 @@ type (
 	// vcursor_impl needs these facilities to be able to be able to execute queries for vindexes
 	iExecute interface {
 		Execute(ctx context.Context, mysqlCtx vtgateservice.MySQLConnection, method string, session *SafeSession, s string, vars map[string]*querypb.BindVariable, prepared bool) (*sqltypes.Result, error)
-		ExecuteMultiShard(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, session *SafeSession, autocommit bool, ignoreMaxMemoryRows bool, resultsObserver ResultsObserver, fetchLastInsertID bool) (qr *sqltypes.Result, errs []error)
+		ExecuteMultiShard(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, session *SafeSession, autocommit bool, settingsForStatement bool, ignoreMaxMemoryRows bool, resultsObserver ResultsObserver, fetchLastInsertID bool) (qr *sqltypes.Result, errs []error)
 		ExecuteMultiShardPerShard(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, session *SafeSession, autocommit bool, resultsObserver ResultsObserver, fetchLastInsertID bool) (results []*sqltypes.Result, errs []error)
-		StreamExecuteMulti(ctx context.Context, primitive engine.Primitive, query string, rss []*srvtopo.ResolvedShard, vars []map[string]*querypb.BindVariable, session *SafeSession, autocommit bool, callback func(reply *sqltypes.Result) error, observer ResultsObserver, fetchLastInsertID bool) []error
+		StreamExecuteMulti(ctx context.Context, primitive engine.Primitive, query string, rss []*srvtopo.ResolvedShard, vars []map[string]*querypb.BindVariable, session *SafeSession, autocommit bool, settingsForStatement bool, callback func(reply *sqltypes.Result) error, observer ResultsObserver, fetchLastInsertID bool) []error
 		ExecuteLock(ctx context.Context, rs *srvtopo.ResolvedShard, query *querypb.BoundQuery, session *SafeSession, lockFuncType sqlparser.LockingFuncType) (*sqltypes.Result, error)
 		Commit(ctx context.Context, safeSession *SafeSession) error
 		ExecuteMessageStream(ctx context.Context, rss []*srvtopo.ResolvedShard, name string, callback func(*sqltypes.Result) error) error
@@ -170,7 +170,7 @@ type (
 		// SetReservedConn it does not pin the session; a later hint-capable query
 		// carries the hint again. The session is pinned only when a tablet answers
 		// that it reserved a connection for the statement, which a lock or a
-		// temporary table needs and a DDL does not. See transportContext.
+		// temporary table needs and a DDL does not.
 		settingsForStatement bool
 		keyspace             string
 		tabletType           topodatapb.TabletType
@@ -903,7 +903,7 @@ func (vc *VCursorImpl) ExecuteMultiShard(ctx context.Context, primitive engine.P
 		return nil, []error{err}
 	}
 
-	qr, errs := vc.executor.ExecuteMultiShard(vc.transportContext(ctx), primitive, rss, commentedShardQueries(queries, vc.marginComments), vc.SafeSession, canAutocommit, vc.ignoreMaxMemoryRows, vc.observer, fetchLastInsertID)
+	qr, errs := vc.executor.ExecuteMultiShard(ctx, primitive, rss, commentedShardQueries(queries, vc.marginComments), vc.SafeSession, canAutocommit, vc.settingsForStatement, vc.ignoreMaxMemoryRows, vc.observer, fetchLastInsertID)
 	vc.setRollbackOnPartialExecIfRequired(len(errs) != len(rss), rollbackOnError)
 	vc.logShardsQueried(primitive, len(rss))
 	if qr != nil && qr.InsertIDUpdated() {
@@ -942,7 +942,7 @@ func (vc *VCursorImpl) StreamExecuteMulti(ctx context.Context, primitive engine.
 		return []error{err}
 	}
 
-	errs := vc.executor.StreamExecuteMulti(vc.transportContext(ctx), primitive, vc.marginComments.Leading+query+vc.marginComments.Trailing, rss, bindVars, vc.SafeSession, autocommit, callback, vc.observer, fetchLastInsertID)
+	errs := vc.executor.StreamExecuteMulti(ctx, primitive, vc.marginComments.Leading+query+vc.marginComments.Trailing, rss, bindVars, vc.SafeSession, autocommit, vc.settingsForStatement, callback, vc.observer, fetchLastInsertID)
 	vc.setRollbackOnPartialExecIfRequired(len(errs) != len(rss), rollbackOnError)
 
 	return errs
@@ -965,7 +965,7 @@ func (vc *VCursorImpl) ExecuteStandalone(ctx context.Context, primitive engine.P
 	}
 	// The autocommit flag is always set to false because we currently don't
 	// execute DMLs through ExecuteStandalone.
-	qr, errs := vc.executor.ExecuteMultiShard(ctx, primitive, rss, bqs, NewAutocommitSession(vc.SafeSession.Session), false /* autocommit */, vc.ignoreMaxMemoryRows, vc.observer, fetchLastInsertID)
+	qr, errs := vc.executor.ExecuteMultiShard(ctx, primitive, rss, bqs, NewAutocommitSession(vc.SafeSession.Session), false /* autocommit */, false /* settingsForStatement */, vc.ignoreMaxMemoryRows, vc.observer, fetchLastInsertID)
 	vc.logShardsQueried(primitive, len(rss))
 	if qr.InsertIDUpdated() {
 		vc.SafeSession.LastInsertId = qr.InsertID
@@ -1148,15 +1148,6 @@ func (vc *VCursorImpl) CheckForReservedConnection(setVarComment string, stmt sql
 	default:
 		vc.settingsForStatement = true
 	}
-}
-
-// transportContext marks the context for the scatter connection when the statement
-// wants the session's settings on its connection.
-func (vc *VCursorImpl) transportContext(ctx context.Context) context.Context {
-	if !vc.settingsForStatement {
-		return ctx
-	}
-	return context.WithValue(ctx, engine.SessionSettingsForStatement, true)
 }
 
 // NeedsReservedConn implements the SessionActions interface

--- a/go/vt/vtgate/executorcontext/vcursor_impl.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl.go
@@ -164,9 +164,13 @@ type (
 	VCursorImpl struct {
 		config      VCursorConfig
 		SafeSession *SafeSession
-		// settingsForStatement makes the statement carry the session's system variables
-		// on the connection it runs on, without pinning the session; see
-		// NeedsSessionSettings.
+		// settingsForStatement makes the statement run with the session's system
+		// variables applied to its connection through the tablet's connection
+		// settings: the statement cannot carry them in a SET_VAR hint. Unlike
+		// SetReservedConn it does not pin the session; a later hint-capable query
+		// carries the hint again. The session is pinned only when a tablet answers
+		// that it reserved a connection for the statement, which a lock or a
+		// temporary table needs and a DDL does not. See transportContext.
 		settingsForStatement bool
 		keyspace             string
 		tabletType           topodatapb.TabletType
@@ -1142,18 +1146,8 @@ func (vc *VCursorImpl) CheckForReservedConnection(setVarComment string, stmt sql
 		*sqlparser.SRollback, *sqlparser.Release, *sqlparser.Set, *sqlparser.Show,
 		sqlparser.SupportOptimizerHint:
 	default:
-		vc.NeedsSessionSettings()
+		vc.settingsForStatement = true
 	}
-}
-
-// NeedsSessionSettings makes this request's statement run with the session's system
-// variables applied to its connection through the tablet's connection settings: the
-// statement cannot carry them in a SET_VAR hint. Unlike NeedsReservedConn it does not
-// pin the session; a later hint-capable query goes back to carrying the hint. The
-// session gets pinned only when a tablet answers that it reserved a connection for
-// the statement, which a lock or a temporary table needs and a DDL does not.
-func (vc *VCursorImpl) NeedsSessionSettings() {
-	vc.settingsForStatement = true
 }
 
 // transportContext marks the context for the scatter connection when the statement

--- a/go/vt/vtgate/executorcontext/vcursor_impl_test.go
+++ b/go/vt/vtgate/executorcontext/vcursor_impl_test.go
@@ -333,7 +333,7 @@ func (f fakeExecutor) Execute(ctx context.Context, mysqlCtx vtgateservice.MySQLC
 	panic("implement me")
 }
 
-func (f fakeExecutor) ExecuteMultiShard(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, session *SafeSession, autocommit bool, ignoreMaxMemoryRows bool, resultsObserver ResultsObserver, fetchLastInsertID bool) (qr *sqltypes.Result, errs []error) {
+func (f fakeExecutor) ExecuteMultiShard(ctx context.Context, primitive engine.Primitive, rss []*srvtopo.ResolvedShard, queries []*querypb.BoundQuery, session *SafeSession, autocommit bool, settingsForStatement bool, ignoreMaxMemoryRows bool, resultsObserver ResultsObserver, fetchLastInsertID bool) (qr *sqltypes.Result, errs []error) {
 	// TODO implement me
 	panic("implement me")
 }
@@ -343,7 +343,7 @@ func (f fakeExecutor) ExecuteMultiShardPerShard(ctx context.Context, primitive e
 	panic("implement me")
 }
 
-func (f fakeExecutor) StreamExecuteMulti(ctx context.Context, primitive engine.Primitive, query string, rss []*srvtopo.ResolvedShard, vars []map[string]*querypb.BindVariable, session *SafeSession, autocommit bool, callback func(reply *sqltypes.Result) error, observer ResultsObserver, fetchLastInsertID bool) []error {
+func (f fakeExecutor) StreamExecuteMulti(ctx context.Context, primitive engine.Primitive, query string, rss []*srvtopo.ResolvedShard, vars []map[string]*querypb.BindVariable, session *SafeSession, autocommit bool, settingsForStatement bool, callback func(reply *sqltypes.Result) error, observer ResultsObserver, fetchLastInsertID bool) []error {
 	// TODO implement me
 	panic("implement me")
 }

--- a/go/vt/vtgate/legacy_scatter_conn_test.go
+++ b/go/vt/vtgate/legacy_scatter_conn_test.go
@@ -100,7 +100,7 @@ func TestLegacyExecuteFailOnAutocommit(t *testing.T) {
 		},
 		Autocommit: false,
 	}
-	_, errs := sc.ExecuteMultiShard(ctx, nil, rss, queries, econtext.NewSafeSession(session), true /*autocommit*/, false, nullResultsObserver{}, false)
+	_, errs := sc.ExecuteMultiShard(ctx, nil, rss, queries, econtext.NewSafeSession(session), true /*autocommit*/, false, false, nullResultsObserver{}, false)
 	err := vterrors.Aggregate(errs)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "in autocommit mode, transactionID should be zero but was: 123")
@@ -124,7 +124,7 @@ func TestScatterConnExecuteMulti(t *testing.T) {
 			}
 		}
 
-		qr, errs := sc.ExecuteMultiShard(ctx, nil, rss, queries, econtext.NewSafeSession(nil), false /*autocommit*/, false, nullResultsObserver{}, false)
+		qr, errs := sc.ExecuteMultiShard(ctx, nil, rss, queries, econtext.NewSafeSession(nil), false /*autocommit*/, false, false, nullResultsObserver{}, false)
 		return qr, vterrors.Aggregate(errs)
 	})
 }
@@ -139,7 +139,7 @@ func TestScatterConnStreamExecuteMulti(t *testing.T) {
 		bvs := make([]map[string]*querypb.BindVariable, len(rss))
 		qr := new(sqltypes.Result)
 		var mu sync.Mutex
-		errors := sc.StreamExecuteMulti(ctx, nil, "query", rss, bvs, econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true}), true /* autocommit */, func(r *sqltypes.Result) error {
+		errors := sc.StreamExecuteMulti(ctx, nil, "query", rss, bvs, econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true}), true /* autocommit */, false, func(r *sqltypes.Result) error {
 			mu.Lock()
 			defer mu.Unlock()
 			qr.AppendResult(r)
@@ -293,7 +293,7 @@ func TestMaxMemoryRows(t *testing.T) {
 		sbc0.SetResults([]*sqltypes.Result{tworows, tworows})
 		sbc1.SetResults([]*sqltypes.Result{tworows, tworows})
 
-		_, errs := sc.ExecuteMultiShard(ctx, nil, rss, queries, session, false, test.ignoreMaxMemoryRows, nullResultsObserver{}, false)
+		_, errs := sc.ExecuteMultiShard(ctx, nil, rss, queries, session, false, false, test.ignoreMaxMemoryRows, nullResultsObserver{}, false)
 		if test.ignoreMaxMemoryRows {
 			require.NoError(t, err)
 		} else {
@@ -325,7 +325,7 @@ func TestLegaceHealthCheckFailsOnReservedConnections(t *testing.T) {
 		})
 	}
 
-	_, errs := sc.ExecuteMultiShard(ctx, nil, rss, queries, session, false, false, nullResultsObserver{}, false)
+	_, errs := sc.ExecuteMultiShard(ctx, nil, rss, queries, session, false, false, false, nullResultsObserver{}, false)
 	require.Error(t, vterrors.Aggregate(errs))
 }
 
@@ -348,7 +348,7 @@ func executeOnShardsReturnsErr(t *testing.T, ctx context.Context, res *srvtopo.R
 		})
 	}
 
-	_, errs := sc.ExecuteMultiShard(ctx, nil, rss, queries, session, false, false, nullResultsObserver{}, false)
+	_, errs := sc.ExecuteMultiShard(ctx, nil, rss, queries, session, false, false, false, nullResultsObserver{}, false)
 	return vterrors.Aggregate(errs)
 }
 
@@ -413,7 +413,7 @@ func TestMultiExecs(t *testing.T) {
 	observer := recordingResultsObserver{}
 
 	session := econtext.NewSafeSession(&vtgatepb.Session{})
-	_, err := sc.ExecuteMultiShard(ctx, nil, rss, queries, session, false, false, &observer, false)
+	_, err := sc.ExecuteMultiShard(ctx, nil, rss, queries, session, false, false, false, &observer, false)
 	require.NoError(t, vterrors.Aggregate(err))
 	if len(sbc0.Queries) == 0 || len(sbc1.Queries) == 0 {
 		require.Fail(t, "didn't get expected query")
@@ -459,7 +459,7 @@ func TestMultiExecs(t *testing.T) {
 	}
 
 	observer = recordingResultsObserver{}
-	_ = sc.StreamExecuteMulti(ctx, nil, "query", rss, bvs, session, false /* autocommit */, func(*sqltypes.Result) error {
+	_ = sc.StreamExecuteMulti(ctx, nil, "query", rss, bvs, session, false /* autocommit */, false, func(*sqltypes.Result) error {
 		return nil
 	}, &observer, false)
 	assert.Equal(t, wantVars0, sbc0.Queries[0].BindVariables, "got %+v, want %+v", sbc0.Queries[0].BindVariables, wantVars0)
@@ -488,27 +488,27 @@ func TestScatterConnSingleDB(t *testing.T) {
 	// TransactionMode_SINGLE in session
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true, TransactionMode: vtgatepb.TransactionMode_SINGLE})
 	queries := []*querypb.BoundQuery{{Sql: "query1"}}
-	_, errors := sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	_, errors := sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 	require.Empty(t, errors)
-	_, errors = sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, nullResultsObserver{}, false)
+	_, errors = sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, false, nullResultsObserver{}, false)
 	require.Error(t, errors[0])
 	assert.Contains(t, errors[0].Error(), want)
 
 	// TransactionMode_SINGLE in txconn
 	sc.txConn.txMode = &StaticConfig{TxMode: vtgatepb.TransactionMode_SINGLE}
 	session = econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
-	_, errors = sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	_, errors = sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 	require.Empty(t, errors)
-	_, errors = sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, nullResultsObserver{}, false)
+	_, errors = sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, false, nullResultsObserver{}, false)
 	require.Error(t, errors[0])
 	assert.Contains(t, errors[0].Error(), want)
 
 	// TransactionMode_MULTI in txconn. Should not fail.
 	sc.txConn.txMode = &StaticConfig{TxMode: vtgatepb.TransactionMode_MULTI}
 	session = econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
-	_, errors = sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	_, errors = sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 	require.Empty(t, errors)
-	_, errors = sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, nullResultsObserver{}, false)
+	_, errors = sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, false, nullResultsObserver{}, false)
 	require.Empty(t, errors)
 }
 

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -150,6 +150,7 @@ func (stc *ScatterConn) ExecuteMultiShard(
 	queries []*querypb.BoundQuery,
 	session *econtext.SafeSession,
 	autocommit bool,
+	settingsForStatement bool,
 	ignoreMaxMemoryRows bool,
 	resultsObserver econtext.ResultsObserver,
 	fetchLastInsertID bool,
@@ -159,7 +160,7 @@ func (stc *ScatterConn) ExecuteMultiShard(
 	}
 
 	qr = new(sqltypes.Result)
-	allErrors := stc.executeMultiShard(ctx, primitive, rss, queries, session, autocommit, resultsObserver, fetchLastInsertID,
+	allErrors := stc.executeMultiShard(ctx, primitive, rss, queries, session, autocommit, settingsForStatement, resultsObserver, fetchLastInsertID,
 		func(_ int, innerqr *sqltypes.Result) {
 			// Don't append more rows if row count is exceeded.
 			if ignoreMaxMemoryRows || len(qr.Rows) <= maxMemoryRows {
@@ -196,7 +197,7 @@ func (stc *ScatterConn) ExecuteMultiShardPerShard(
 	}
 
 	results = make([]*sqltypes.Result, len(rss))
-	allErrors := stc.executeMultiShard(ctx, primitive, rss, queries, session, autocommit, resultsObserver, fetchLastInsertID,
+	allErrors := stc.executeMultiShard(ctx, primitive, rss, queries, session, autocommit, false /* settingsForStatement */, resultsObserver, fetchLastInsertID,
 		func(i int, innerqr *sqltypes.Result) {
 			results[i] = innerqr
 		},
@@ -218,6 +219,7 @@ func (stc *ScatterConn) executeMultiShard(
 	queries []*querypb.BoundQuery,
 	session *econtext.SafeSession,
 	autocommit bool,
+	settingsForStatement bool,
 	resultsObserver econtext.ResultsObserver,
 	fetchLastInsertID bool,
 	collect func(i int, innerqr *sqltypes.Result),
@@ -248,6 +250,7 @@ func (stc *ScatterConn) executeMultiShard(
 		rss,
 		session,
 		autocommit,
+		settingsForStatement,
 		func(rs *srvtopo.ResolvedShard, i int, info *shardActionInfo) (*shardActionInfo, error) {
 			var (
 				innerqr *sqltypes.Result
@@ -444,6 +447,7 @@ func (stc *ScatterConn) StreamExecuteMulti(
 	bindVars []map[string]*querypb.BindVariable,
 	session *econtext.SafeSession,
 	autocommit bool,
+	settingsForStatement bool,
 	callback func(reply *sqltypes.Result) error,
 	resultsObserver econtext.ResultsObserver,
 	fetchLastInsertID bool,
@@ -478,6 +482,7 @@ func (stc *ScatterConn) StreamExecuteMulti(
 		rss,
 		session,
 		autocommit,
+		settingsForStatement,
 		func(rs *srvtopo.ResolvedShard, i int, info *shardActionInfo) (*shardActionInfo, error) {
 			var (
 				err   error
@@ -742,6 +747,7 @@ func (stc *ScatterConn) multiGoTransaction(
 	rss []*srvtopo.ResolvedShard,
 	session *econtext.SafeSession,
 	autocommit bool,
+	settingsForStatement bool,
 	action shardActionTransactionFunc,
 ) (allErrors *concurrency.AllErrorRecorder) {
 	numShards := len(rss)
@@ -755,7 +761,7 @@ func (stc *ScatterConn) multiGoTransaction(
 		startTime, statsKey := stc.startAction(name, rs.Target)
 		defer stc.endAction(startTime, allErrors, statsKey, &err, session)
 
-		info, shardSession, err := actionInfo(ctx, rs.Target, session, autocommit, stc.txConn.txMode.TransactionMode())
+		info, shardSession, err := actionInfo(ctx, rs.Target, session, autocommit, settingsForStatement, stc.txConn.txMode.TransactionMode())
 		if err != nil {
 			return
 		}
@@ -930,11 +936,10 @@ func requireNewQS(err error, target *querypb.Target) bool {
 	return false
 }
 
-// actionInfo looks at the current session, and returns information about what needs to be done for this tablet
-func actionInfo(ctx context.Context, target *querypb.Target, session *econtext.SafeSession, autocommit bool, txMode vtgatepb.TransactionMode) (*shardActionInfo, *vtgatepb.Session_ShardSession, error) {
-	// A statement that cannot carry the session's system variables in a hint runs
-	// with them applied to its connection, for this statement only.
-	settingsForStatement := ctx.Value(engine.SessionSettingsForStatement) != nil
+// actionInfo looks at the current session, and returns information about what needs to be done for this tablet.
+// settingsForStatement asks for the session's system variables on the shard's connection for this
+// statement only: the statement cannot carry them in a hint. It does not pin the session.
+func actionInfo(ctx context.Context, target *querypb.Target, session *econtext.SafeSession, autocommit, settingsForStatement bool, txMode vtgatepb.TransactionMode) (*shardActionInfo, *vtgatepb.Session_ShardSession, error) {
 	if !session.InTransaction() && !session.InReservedConn() && !settingsForStatement {
 		// Check for tablet-specific routing for non-transactional queries
 		if alias := session.GetTargetTabletAlias(); alias != nil {

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -772,9 +772,9 @@ func (stc *ScatterConn) multiGoTransaction(
 			shardSession.RowsAffected = info.rowsAffected
 		}
 		if info.reservedID != 0 && !session.InReservedConn() {
-			// The statement only asked for the session's settings on its connection,
-			// but the tablet reserved one for it (a lock, a temporary table): the
-			// session is pinned to it from here on.
+			// A shard holding a reserved connection pins the session. The session
+			// only asked for its settings, but the tablet reserved a connection for
+			// the statement (a lock, a temporary table).
 			session.SetReservedConn(true)
 		}
 		if info.actionNeeded != nothing && (info.transactionID != 0 || info.reservedID != 0) {

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -771,6 +771,12 @@ func (stc *ScatterConn) multiGoTransaction(
 			// We need to track if rows were affected in the transaction.
 			shardSession.RowsAffected = info.rowsAffected
 		}
+		if info.reservedID != 0 && !session.InReservedConn() {
+			// The statement only asked for the session's settings on its connection,
+			// but the tablet reserved one for it (a lock, a temporary table): the
+			// session is pinned to it from here on.
+			session.SetReservedConn(true)
+		}
 		if info.actionNeeded != nothing && (info.transactionID != 0 || info.reservedID != 0) {
 			appendErr := session.AppendOrUpdate(rs.Target, info, shardSession, stc.txConn.txMode.TransactionMode())
 			if appendErr != nil {
@@ -926,7 +932,10 @@ func requireNewQS(err error, target *querypb.Target) bool {
 
 // actionInfo looks at the current session, and returns information about what needs to be done for this tablet
 func actionInfo(ctx context.Context, target *querypb.Target, session *econtext.SafeSession, autocommit bool, txMode vtgatepb.TransactionMode) (*shardActionInfo, *vtgatepb.Session_ShardSession, error) {
-	if !session.InTransaction() && !session.InReservedConn() {
+	// A statement that cannot carry the session's system variables in a hint runs
+	// with them applied to its connection, for this statement only.
+	settingsForStatement := ctx.Value(engine.SessionSettingsForStatement) != nil
+	if !session.InTransaction() && !session.InReservedConn() && !settingsForStatement {
 		// Check for tablet-specific routing for non-transactional queries
 		if alias := session.GetTargetTabletAlias(); alias != nil {
 			return &shardActionInfo{
@@ -949,7 +958,7 @@ func actionInfo(ctx context.Context, target *querypb.Target, session *econtext.S
 		return nil, nil, err
 	}
 
-	shouldReserve := session.InReservedConn() && (shardSession == nil || shardSession.ReservedId == 0)
+	shouldReserve := (session.InReservedConn() || settingsForStatement) && (shardSession == nil || shardSession.ReservedId == 0)
 	shouldBegin := session.InTransaction() && (shardSession == nil || shardSession.TransactionId == 0) && !autocommit
 
 	act := nothing

--- a/go/vt/vtgate/scatter_conn_test.go
+++ b/go/vt/vtgate/scatter_conn_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vtgate
 
 import (
+	"context"
 	"log/slog"
 	"sync"
 	"testing"
@@ -36,6 +37,7 @@ import (
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/vterrors"
+	"vitess.io/vitess/go/vt/vtgate/engine"
 	econtext "vitess.io/vitess/go/vt/vtgate/executorcontext"
 )
 
@@ -755,5 +757,104 @@ func TestActionInfoWithTabletAlias(t *testing.T) {
 		assert.Nil(t, shardSession)
 		assert.Equal(t, nothing, info.actionNeeded)
 		assert.Nil(t, info.alias)
+	})
+}
+
+// A statement that asks for the session's settings on its connection gets a reserve
+// action for itself, in or out of a transaction, without the session being pinned.
+func TestActionInfoSettingsForStatement(t *testing.T) {
+	ctx := utils.LeakCheckContext(t)
+	target := &querypb.Target{Keyspace: "ks", Shard: "-80", TabletType: topodatapb.TabletType_PRIMARY}
+	withSettings := context.WithValue(ctx, engine.SessionSettingsForStatement, true)
+
+	t.Run("plain session", func(t *testing.T) {
+		session := econtext.NewSafeSession(&vtgatepb.Session{})
+		info, _, err := actionInfo(withSettings, target, session, false, vtgatepb.TransactionMode_MULTI)
+		require.NoError(t, err)
+		assert.Equal(t, reserve, info.actionNeeded)
+		assert.False(t, session.InReservedConn())
+	})
+
+	t.Run("in a transaction the settings go on the transaction's connection", func(t *testing.T) {
+		session := econtext.NewSafeSession(&vtgatepb.Session{
+			InTransaction: true,
+			ShardSessions: []*vtgatepb.Session_ShardSession{{Target: target, TransactionId: 12345}},
+		})
+		info, _, err := actionInfo(withSettings, target, session, false, vtgatepb.TransactionMode_MULTI)
+		require.NoError(t, err)
+		assert.Equal(t, reserve, info.actionNeeded)
+		assert.EqualValues(t, 12345, info.transactionID)
+	})
+
+	t.Run("a new transaction reserves and begins", func(t *testing.T) {
+		session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
+		info, _, err := actionInfo(withSettings, target, session, false, vtgatepb.TransactionMode_MULTI)
+		require.NoError(t, err)
+		assert.Equal(t, reserveBegin, info.actionNeeded)
+	})
+
+	t.Run("a pinned session keeps its connection", func(t *testing.T) {
+		session := econtext.NewSafeSession(&vtgatepb.Session{
+			InReservedConn: true,
+			ShardSessions:  []*vtgatepb.Session_ShardSession{{Target: target, ReservedId: 7}},
+		})
+		info, _, err := actionInfo(withSettings, target, session, false, vtgatepb.TransactionMode_MULTI)
+		require.NoError(t, err)
+		assert.Equal(t, nothing, info.actionNeeded)
+		assert.EqualValues(t, 7, info.reservedID)
+	})
+
+	t.Run("without the request the session decides", func(t *testing.T) {
+		session := econtext.NewSafeSession(&vtgatepb.Session{})
+		info, _, err := actionInfo(ctx, target, session, false, vtgatepb.TransactionMode_MULTI)
+		require.NoError(t, err)
+		assert.Equal(t, nothing, info.actionNeeded)
+	})
+}
+
+// The settings travel with the statement; whether the session ends up pinned is the
+// tablet's answer: none for a statement served from the settings pool, a reserved
+// id for one that needed a connection of its own.
+func TestSettingsForStatementPinsOnlyWhenTheTabletReserved(t *testing.T) {
+	ctx := utils.LeakCheckContext(t)
+	keyspace := "keyspace"
+	createSandbox(keyspace)
+	hc := discovery.NewFakeHealthCheck(nil)
+	sc := newTestScatterConn(ctx, hc, newSandboxForCells(ctx, []string{"aa"}), "aa")
+	sbc := hc.AddTestTablet("aa", "0", 1, keyspace, "0", topodatapb.TabletType_REPLICA, true, 1, nil)
+	res := srvtopo.NewResolver(newSandboxForCells(ctx, []string{"aa"}), sc.gateway, "aa")
+	destinations := []key.ShardDestination{key.DestinationShard("0")}
+	withSettings := context.WithValue(ctx, engine.SessionSettingsForStatement, true)
+	newSession := func() *econtext.SafeSession {
+		return econtext.NewSafeSession(&vtgatepb.Session{SystemVariables: map[string]string{"sql_safe_updates": "1"}})
+	}
+
+	t.Run("served from the settings pool", func(t *testing.T) {
+		sbc.NoReservation = true
+		defer func() { sbc.NoReservation = false }()
+		sbc.ReserveCount.Store(0)
+		session := newSession()
+		executeOnShards(t, withSettings, res, keyspace, sc, session, destinations)
+		assert.EqualValues(t, 1, sbc.ReserveCount.Load())
+		assert.False(t, session.InReservedConn())
+		assert.Empty(t, session.ShardSessions)
+
+		// the next statement of the session is a plain execute again
+		executeOnShards(t, ctx, res, keyspace, sc, session, destinations)
+		assert.EqualValues(t, 1, sbc.ReserveCount.Load())
+	})
+
+	t.Run("reserved by the tablet", func(t *testing.T) {
+		sbc.ReserveCount.Store(0)
+		session := newSession()
+		executeOnShards(t, withSettings, res, keyspace, sc, session, destinations)
+		assert.EqualValues(t, 1, sbc.ReserveCount.Load())
+		assert.True(t, session.InReservedConn())
+		require.Len(t, session.ShardSessions, 1)
+		assert.NotZero(t, session.ShardSessions[0].ReservedId)
+
+		// the next statement of the session runs on the reserved connection
+		executeOnShards(t, ctx, res, keyspace, sc, session, destinations)
+		assert.EqualValues(t, 1, sbc.ReserveCount.Load())
 	})
 }

--- a/go/vt/vtgate/scatter_conn_test.go
+++ b/go/vt/vtgate/scatter_conn_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vtgate
 
 import (
-	"context"
 	"log/slog"
 	"sync"
 	"testing"
@@ -37,7 +36,6 @@ import (
 	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 	"vitess.io/vitess/go/vt/srvtopo"
 	"vitess.io/vitess/go/vt/vterrors"
-	"vitess.io/vitess/go/vt/vtgate/engine"
 	econtext "vitess.io/vitess/go/vt/vtgate/executorcontext"
 )
 
@@ -99,7 +97,7 @@ func TestExecuteFailOnAutocommit(t *testing.T) {
 		},
 		Autocommit: false,
 	}
-	_, errs := sc.ExecuteMultiShard(ctx, nil, rss, queries, econtext.NewSafeSession(session), true /*autocommit*/, false, nullResultsObserver{}, false)
+	_, errs := sc.ExecuteMultiShard(ctx, nil, rss, queries, econtext.NewSafeSession(session), true /*autocommit*/, false, false, nullResultsObserver{}, false)
 	err := vterrors.Aggregate(errs)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "in autocommit mode, transactionID should be zero but was: 123")
@@ -200,7 +198,7 @@ func TestFetchLastInsertIDResets(t *testing.T) {
 				sbc0.Options = nil
 			}
 
-			_, errs := sc.ExecuteMultiShard(ctx, nil, rss, queries, session, true /*autocommit*/, false, nullResultsObserver{}, tt.fetchLastInsertID)
+			_, errs := sc.ExecuteMultiShard(ctx, nil, rss, queries, session, true /*autocommit*/, false, false, nullResultsObserver{}, tt.fetchLastInsertID)
 			require.NoError(t, vterrors.Aggregate(errs))
 
 			// The shared session options must not be mutated by the call; the
@@ -260,13 +258,13 @@ func TestScatterConnSharedOptionsNoRace(t *testing.T) {
 	for i := range 16 {
 		fetchLastInsertID := i%2 == 0
 		wg.Go(func() {
-			errs := sc.StreamExecuteMulti(ctx, nil, "query", rss, bindVars, session, true /*autocommit*/, func(*sqltypes.Result) error {
+			errs := sc.StreamExecuteMulti(ctx, nil, "query", rss, bindVars, session, true /*autocommit*/, false, func(*sqltypes.Result) error {
 				return nil
 			}, nullResultsObserver{}, fetchLastInsertID)
 			assert.NoError(t, vterrors.Aggregate(errs))
 		})
 		wg.Go(func() {
-			_, errs := sc.ExecuteMultiShard(ctx, nil, rss, queries, session, true /*autocommit*/, false, nullResultsObserver{}, fetchLastInsertID)
+			_, errs := sc.ExecuteMultiShard(ctx, nil, rss, queries, session, true /*autocommit*/, false, false, nullResultsObserver{}, fetchLastInsertID)
 			assert.NoError(t, vterrors.Aggregate(errs))
 		})
 	}
@@ -345,7 +343,7 @@ func TestExecutePanic(t *testing.T) {
 	}
 
 	assert.Panics(t, func() {
-		_, _ = sc.ExecuteMultiShard(ctx, nil, rss, queries, econtext.NewSafeSession(session), true /*autocommit*/, false, nullResultsObserver{}, false)
+		_, _ = sc.ExecuteMultiShard(ctx, nil, rss, queries, econtext.NewSafeSession(session), true /*autocommit*/, false, false, nullResultsObserver{}, false)
 	})
 	require.Contains(t, logMessage, "(*ScatterConn).multiGoTransaction")
 }
@@ -714,7 +712,7 @@ func TestActionInfoWithTabletAlias(t *testing.T) {
 		session := econtext.NewSafeSession(&vtgatepb.Session{})
 		session.SetTargetTabletAlias(tabletAlias)
 
-		info, shardSession, err := actionInfo(ctx, target, session, false, vtgatepb.TransactionMode_MULTI)
+		info, shardSession, err := actionInfo(ctx, target, session, false, false, vtgatepb.TransactionMode_MULTI)
 		require.NoError(t, err)
 		assert.Nil(t, shardSession)
 		assert.Equal(t, nothing, info.actionNeeded)
@@ -727,7 +725,7 @@ func TestActionInfoWithTabletAlias(t *testing.T) {
 		})
 		session.SetTargetTabletAlias(tabletAlias)
 
-		info, shardSession, err := actionInfo(ctx, target, session, false, vtgatepb.TransactionMode_MULTI)
+		info, shardSession, err := actionInfo(ctx, target, session, false, false, vtgatepb.TransactionMode_MULTI)
 		require.NoError(t, err)
 		assert.Nil(t, shardSession)
 		assert.Equal(t, begin, info.actionNeeded)
@@ -745,14 +743,14 @@ func TestActionInfoWithTabletAlias(t *testing.T) {
 		})
 		session.SetTargetTabletAlias(tabletAlias) // zone1-100, different from zone1-50
 
-		_, _, err := actionInfo(ctx, target, session, false, vtgatepb.TransactionMode_MULTI)
+		_, _, err := actionInfo(ctx, target, session, false, false, vtgatepb.TransactionMode_MULTI)
 		require.ErrorContains(t, err, "cannot change tablet target mid-transaction")
 	})
 
 	t.Run("no tablet alias - existing behavior", func(t *testing.T) {
 		session := econtext.NewSafeSession(&vtgatepb.Session{})
 
-		info, shardSession, err := actionInfo(ctx, target, session, false, vtgatepb.TransactionMode_MULTI)
+		info, shardSession, err := actionInfo(ctx, target, session, false, false, vtgatepb.TransactionMode_MULTI)
 		require.NoError(t, err)
 		assert.Nil(t, shardSession)
 		assert.Equal(t, nothing, info.actionNeeded)
@@ -765,11 +763,10 @@ func TestActionInfoWithTabletAlias(t *testing.T) {
 func TestActionInfoSettingsForStatement(t *testing.T) {
 	ctx := utils.LeakCheckContext(t)
 	target := &querypb.Target{Keyspace: "ks", Shard: "-80", TabletType: topodatapb.TabletType_PRIMARY}
-	withSettings := context.WithValue(ctx, engine.SessionSettingsForStatement, true)
 
 	t.Run("plain session", func(t *testing.T) {
 		session := econtext.NewSafeSession(&vtgatepb.Session{})
-		info, _, err := actionInfo(withSettings, target, session, false, vtgatepb.TransactionMode_MULTI)
+		info, _, err := actionInfo(ctx, target, session, false, true, vtgatepb.TransactionMode_MULTI)
 		require.NoError(t, err)
 		assert.Equal(t, reserve, info.actionNeeded)
 		assert.False(t, session.InReservedConn())
@@ -780,7 +777,7 @@ func TestActionInfoSettingsForStatement(t *testing.T) {
 			InTransaction: true,
 			ShardSessions: []*vtgatepb.Session_ShardSession{{Target: target, TransactionId: 12345}},
 		})
-		info, _, err := actionInfo(withSettings, target, session, false, vtgatepb.TransactionMode_MULTI)
+		info, _, err := actionInfo(ctx, target, session, false, true, vtgatepb.TransactionMode_MULTI)
 		require.NoError(t, err)
 		assert.Equal(t, reserve, info.actionNeeded)
 		assert.EqualValues(t, 12345, info.transactionID)
@@ -788,7 +785,7 @@ func TestActionInfoSettingsForStatement(t *testing.T) {
 
 	t.Run("a new transaction reserves and begins", func(t *testing.T) {
 		session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
-		info, _, err := actionInfo(withSettings, target, session, false, vtgatepb.TransactionMode_MULTI)
+		info, _, err := actionInfo(ctx, target, session, false, true, vtgatepb.TransactionMode_MULTI)
 		require.NoError(t, err)
 		assert.Equal(t, reserveBegin, info.actionNeeded)
 	})
@@ -798,7 +795,7 @@ func TestActionInfoSettingsForStatement(t *testing.T) {
 			InReservedConn: true,
 			ShardSessions:  []*vtgatepb.Session_ShardSession{{Target: target, ReservedId: 7}},
 		})
-		info, _, err := actionInfo(withSettings, target, session, false, vtgatepb.TransactionMode_MULTI)
+		info, _, err := actionInfo(ctx, target, session, false, true, vtgatepb.TransactionMode_MULTI)
 		require.NoError(t, err)
 		assert.Equal(t, nothing, info.actionNeeded)
 		assert.EqualValues(t, 7, info.reservedID)
@@ -806,7 +803,7 @@ func TestActionInfoSettingsForStatement(t *testing.T) {
 
 	t.Run("without the request the session decides", func(t *testing.T) {
 		session := econtext.NewSafeSession(&vtgatepb.Session{})
-		info, _, err := actionInfo(ctx, target, session, false, vtgatepb.TransactionMode_MULTI)
+		info, _, err := actionInfo(ctx, target, session, false, false, vtgatepb.TransactionMode_MULTI)
 		require.NoError(t, err)
 		assert.Equal(t, nothing, info.actionNeeded)
 	})
@@ -823,8 +820,14 @@ func TestSettingsForStatementPinsOnlyWhenTheTabletReserved(t *testing.T) {
 	sc := newTestScatterConn(ctx, hc, newSandboxForCells(ctx, []string{"aa"}), "aa")
 	sbc := hc.AddTestTablet("aa", "0", 1, keyspace, "0", topodatapb.TabletType_REPLICA, true, 1, nil)
 	res := srvtopo.NewResolver(newSandboxForCells(ctx, []string{"aa"}), sc.gateway, "aa")
-	destinations := []key.ShardDestination{key.DestinationShard("0")}
-	withSettings := context.WithValue(ctx, engine.SessionSettingsForStatement, true)
+	rss, _, err := res.ResolveDestinations(ctx, keyspace, topodatapb.TabletType_REPLICA, nil, []key.ShardDestination{key.DestinationShard("0")})
+	require.NoError(t, err)
+	queries := []*querypb.BoundQuery{{Sql: "query1", BindVariables: map[string]*querypb.BindVariable{}}}
+	execute := func(t *testing.T, session *econtext.SafeSession, settingsForStatement bool) {
+		t.Helper()
+		_, errs := sc.ExecuteMultiShard(ctx, nil, rss, queries, session, false, settingsForStatement, false, nullResultsObserver{}, false)
+		require.NoError(t, vterrors.Aggregate(errs))
+	}
 	newSession := func() *econtext.SafeSession {
 		return econtext.NewSafeSession(&vtgatepb.Session{SystemVariables: map[string]string{"sql_safe_updates": "1"}})
 	}
@@ -834,27 +837,27 @@ func TestSettingsForStatementPinsOnlyWhenTheTabletReserved(t *testing.T) {
 		defer func() { sbc.NoReservation = false }()
 		sbc.ReserveCount.Store(0)
 		session := newSession()
-		executeOnShards(t, withSettings, res, keyspace, sc, session, destinations)
+		execute(t, session, true)
 		assert.EqualValues(t, 1, sbc.ReserveCount.Load())
 		assert.False(t, session.InReservedConn())
 		assert.Empty(t, session.ShardSessions)
 
 		// the next statement of the session is a plain execute again
-		executeOnShards(t, ctx, res, keyspace, sc, session, destinations)
+		execute(t, session, false)
 		assert.EqualValues(t, 1, sbc.ReserveCount.Load())
 	})
 
 	t.Run("reserved by the tablet", func(t *testing.T) {
 		sbc.ReserveCount.Store(0)
 		session := newSession()
-		executeOnShards(t, withSettings, res, keyspace, sc, session, destinations)
+		execute(t, session, true)
 		assert.EqualValues(t, 1, sbc.ReserveCount.Load())
 		assert.True(t, session.InReservedConn())
 		require.Len(t, session.ShardSessions, 1)
 		assert.NotZero(t, session.ShardSessions[0].ReservedId)
 
 		// the next statement of the session runs on the reserved connection
-		executeOnShards(t, ctx, res, keyspace, sc, session, destinations)
+		execute(t, session, false)
 		assert.EqualValues(t, 1, sbc.ReserveCount.Load())
 	})
 }

--- a/go/vt/vtgate/tx_conn_test.go
+++ b/go/vt/vtgate/tx_conn_test.go
@@ -60,7 +60,7 @@ func TestTxConnBegin(t *testing.T) {
 	require.NoError(t, err)
 	wantSession := vtgatepb.Session{InTransaction: true}
 	utils.MustMatch(t, &wantSession, session, "Session")
-	_, errors := sc.ExecuteMultiShard(ctx, nil, rss0, queries, safeSession, false, false, nullResultsObserver{}, false)
+	_, errors := sc.ExecuteMultiShard(ctx, nil, rss0, queries, safeSession, false, false, false, nullResultsObserver{}, false)
 	require.Empty(t, errors)
 
 	// Begin again should cause a commit and a new begin.
@@ -80,7 +80,7 @@ func TestTxConnCommitFailure(t *testing.T) {
 	// Sequence the executes to ensure commit order
 
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
-	sc.ExecuteMultiShard(ctx, nil, rssm[0], queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rssm[0], queries, session, false, false, false, nullResultsObserver{}, false)
 	wantSession := vtgatepb.Session{
 		InTransaction: true,
 		ShardSessions: []*vtgatepb.Session_ShardSession{{
@@ -95,7 +95,7 @@ func TestTxConnCommitFailure(t *testing.T) {
 	}
 	utils.MustMatch(t, &wantSession, session.Session, "Session")
 
-	sc.ExecuteMultiShard(ctx, nil, rssm[1], queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rssm[1], queries, session, false, false, false, nullResultsObserver{}, false)
 	wantSession = vtgatepb.Session{
 		InTransaction: true,
 		ShardSessions: []*vtgatepb.Session_ShardSession{{
@@ -118,7 +118,7 @@ func TestTxConnCommitFailure(t *testing.T) {
 	}
 	utils.MustMatch(t, &wantSession, session.Session, "Session")
 
-	sc.ExecuteMultiShard(ctx, nil, rssa, threeQueries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rssa, threeQueries, session, false, false, false, nullResultsObserver{}, false)
 	wantSession = vtgatepb.Session{
 		InTransaction: true,
 		ShardSessions: []*vtgatepb.Session_ShardSession{{
@@ -187,7 +187,7 @@ func TestTxConnCommitFailureAfterNonAtomicCommitMaxShards(t *testing.T) {
 	}
 
 	for i := range 18 {
-		sc.ExecuteMultiShard(ctx, nil, rssm[i], queries, session, false, false, nullResultsObserver{}, false)
+		sc.ExecuteMultiShard(ctx, nil, rssm[i], queries, session, false, false, false, nullResultsObserver{}, false)
 		wantSession.ShardSessions = append(wantSession.ShardSessions, &vtgatepb.Session_ShardSession{
 			Target: &querypb.Target{
 				Keyspace:   "TestTxConn",
@@ -241,7 +241,7 @@ func TestTxConnCommitFailureBeforeNonAtomicCommitMaxShards(t *testing.T) {
 	}
 
 	for i := range 17 {
-		sc.ExecuteMultiShard(ctx, nil, rssm[i], queries, session, false, false, nullResultsObserver{}, false)
+		sc.ExecuteMultiShard(ctx, nil, rssm[i], queries, session, false, false, false, nullResultsObserver{}, false)
 		wantSession.ShardSessions = append(wantSession.ShardSessions, &vtgatepb.Session_ShardSession{
 			Target: &querypb.Target{
 				Keyspace:   "TestTxConn",
@@ -287,7 +287,7 @@ func TestTxConnCommitSuccess(t *testing.T) {
 
 	// Sequence the executes to ensure commit order
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 	wantSession := vtgatepb.Session{
 		InTransaction: true,
 		ShardSessions: []*vtgatepb.Session_ShardSession{{
@@ -301,7 +301,7 @@ func TestTxConnCommitSuccess(t *testing.T) {
 		}},
 	}
 	utils.MustMatch(t, &wantSession, session.Session, "Session")
-	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, false, nullResultsObserver{}, false)
 	wantSession = vtgatepb.Session{
 		InTransaction: true,
 		ShardSessions: []*vtgatepb.Session_ShardSession{{
@@ -340,7 +340,7 @@ func TestTxConnReservedCommitSuccess(t *testing.T) {
 
 	// Sequence the executes to ensure commit order
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true, InReservedConn: true})
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 	wantSession := vtgatepb.Session{
 		InTransaction:  true,
 		InReservedConn: true,
@@ -356,7 +356,7 @@ func TestTxConnReservedCommitSuccess(t *testing.T) {
 		}},
 	}
 	utils.MustMatch(t, &wantSession, session.Session, "Session")
-	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, false, nullResultsObserver{}, false)
 	wantSession = vtgatepb.Session{
 		InTransaction:  true,
 		InReservedConn: true,
@@ -427,9 +427,9 @@ func TestTxConnReservedOn2ShardTxOn1ShardAndCommit(t *testing.T) {
 	session := econtext.NewSafeSession(&vtgatepb.Session{InReservedConn: true})
 
 	// this will create reserved connections against all tablets
-	_, errs := sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, nullResultsObserver{}, false)
+	_, errs := sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, false, nullResultsObserver{}, false)
 	require.Empty(t, errs)
-	_, errs = sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	_, errs = sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 	require.Empty(t, errs)
 
 	wantSession := vtgatepb.Session{
@@ -457,7 +457,7 @@ func TestTxConnReservedOn2ShardTxOn1ShardAndCommit(t *testing.T) {
 	session.Session.InTransaction = true
 
 	// start a transaction against rss0
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 	wantSession = vtgatepb.Session{
 		InTransaction:  true,
 		InReservedConn: true,
@@ -522,9 +522,9 @@ func TestTxConnReservedOn2ShardTxOn1ShardAndRollback(t *testing.T) {
 	session := econtext.NewSafeSession(&vtgatepb.Session{InReservedConn: true})
 
 	// this will create reserved connections against all tablets
-	_, errs := sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, nullResultsObserver{}, false)
+	_, errs := sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, false, nullResultsObserver{}, false)
 	require.Empty(t, errs)
-	_, errs = sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	_, errs = sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 	require.Empty(t, errs)
 
 	wantSession := vtgatepb.Session{
@@ -552,7 +552,7 @@ func TestTxConnReservedOn2ShardTxOn1ShardAndRollback(t *testing.T) {
 	session.Session.InTransaction = true
 
 	// start a transaction against rss0
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 	wantSession = vtgatepb.Session{
 		InTransaction:  true,
 		InReservedConn: true,
@@ -616,13 +616,13 @@ func TestTxConnCommitOrderFailure1(t *testing.T) {
 
 	// Sequence the executes to ensure commit order
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 
 	session.SetCommitOrder(vtgatepb.CommitOrder_PRE)
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 
 	session.SetCommitOrder(vtgatepb.CommitOrder_POST)
-	sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, false, nullResultsObserver{}, false)
 
 	sbc0.MustFailCodes[vtrpcpb.Code_INVALID_ARGUMENT] = 1
 	err := sc.txConn.Commit(ctx, session)
@@ -651,13 +651,13 @@ func TestTxConnCommitOrderFailure2(t *testing.T) {
 
 	// Sequence the executes to ensure commit order
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
-	sc.ExecuteMultiShard(t.Context(), nil, rss1, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(t.Context(), nil, rss1, queries, session, false, false, false, nullResultsObserver{}, false)
 
 	session.SetCommitOrder(vtgatepb.CommitOrder_PRE)
-	sc.ExecuteMultiShard(t.Context(), nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(t.Context(), nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 
 	session.SetCommitOrder(vtgatepb.CommitOrder_POST)
-	sc.ExecuteMultiShard(t.Context(), nil, rss1, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(t.Context(), nil, rss1, queries, session, false, false, false, nullResultsObserver{}, false)
 
 	sbc1.MustFailCodes[vtrpcpb.Code_INVALID_ARGUMENT] = 1
 	err := sc.txConn.Commit(ctx, session)
@@ -685,13 +685,13 @@ func TestTxConnCommitOrderFailure3(t *testing.T) {
 
 	// Sequence the executes to ensure commit order
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 
 	session.SetCommitOrder(vtgatepb.CommitOrder_PRE)
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 
 	session.SetCommitOrder(vtgatepb.CommitOrder_POST)
-	sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, false, nullResultsObserver{}, false)
 
 	sbc1.MustFailCodes[vtrpcpb.Code_INVALID_ARGUMENT] = 1
 	require.NoError(t,
@@ -727,7 +727,7 @@ func TestTxConnCommitOrderSuccess(t *testing.T) {
 
 	// Sequence the executes to ensure commit order
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 	wantSession := vtgatepb.Session{
 		InTransaction: true,
 		ShardSessions: []*vtgatepb.Session_ShardSession{{
@@ -743,7 +743,7 @@ func TestTxConnCommitOrderSuccess(t *testing.T) {
 	utils.MustMatch(t, &wantSession, session.Session, "Session")
 
 	session.SetCommitOrder(vtgatepb.CommitOrder_PRE)
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 	wantSession = vtgatepb.Session{
 		InTransaction: true,
 		PreSessions: []*vtgatepb.Session_ShardSession{{
@@ -768,7 +768,7 @@ func TestTxConnCommitOrderSuccess(t *testing.T) {
 	utils.MustMatch(t, &wantSession, session.Session, "Session")
 
 	session.SetCommitOrder(vtgatepb.CommitOrder_POST)
-	sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, false, nullResultsObserver{}, false)
 	wantSession = vtgatepb.Session{
 		InTransaction: true,
 		PreSessions: []*vtgatepb.Session_ShardSession{{
@@ -802,7 +802,7 @@ func TestTxConnCommitOrderSuccess(t *testing.T) {
 	utils.MustMatch(t, &wantSession, session.Session, "Session")
 
 	// Ensure nothing changes if we reuse a transaction.
-	sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, false, nullResultsObserver{}, false)
 	utils.MustMatch(t, &wantSession, session.Session, "Session")
 
 	require.NoError(t,
@@ -825,7 +825,7 @@ func TestTxConnReservedCommitOrderSuccess(t *testing.T) {
 
 	// Sequence the executes to ensure commit order
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true, InReservedConn: true})
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 	wantSession := vtgatepb.Session{
 		InTransaction:  true,
 		InReservedConn: true,
@@ -843,7 +843,7 @@ func TestTxConnReservedCommitOrderSuccess(t *testing.T) {
 	utils.MustMatch(t, &wantSession, session.Session, "Session")
 
 	session.SetCommitOrder(vtgatepb.CommitOrder_PRE)
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 	wantSession = vtgatepb.Session{
 		InTransaction:  true,
 		InReservedConn: true,
@@ -871,7 +871,7 @@ func TestTxConnReservedCommitOrderSuccess(t *testing.T) {
 	utils.MustMatch(t, &wantSession, session.Session, "Session")
 
 	session.SetCommitOrder(vtgatepb.CommitOrder_POST)
-	sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, false, nullResultsObserver{}, false)
 	wantSession = vtgatepb.Session{
 		InTransaction:  true,
 		InReservedConn: true,
@@ -909,7 +909,7 @@ func TestTxConnReservedCommitOrderSuccess(t *testing.T) {
 	utils.MustMatch(t, &wantSession, session.Session, "Session")
 
 	// Ensure nothing changes if we reuse a transaction.
-	sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, false, nullResultsObserver{}, false)
 	utils.MustMatch(t, &wantSession, session.Session, "Session")
 
 	require.NoError(t,
@@ -962,8 +962,8 @@ func TestTxConnCommit2PC(t *testing.T) {
 	sc, sbc0, sbc1, rss0, _, rss01 := newTestTxConnEnv(t, ctx, "TestTxConnCommit2PC")
 
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
-	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, false, nullResultsObserver{}, false)
 	session.TransactionMode = vtgatepb.TransactionMode_TWOPC
 	require.NoError(t,
 		sc.txConn.Commit(ctx, session))
@@ -979,7 +979,7 @@ func TestTxConnCommit2PCOneParticipant(t *testing.T) {
 
 	sc, sbc0, _, rss0, _, _ := newTestTxConnEnv(t, ctx, "TestTxConnCommit2PCOneParticipant")
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
 	session.TransactionMode = vtgatepb.TransactionMode_TWOPC
 	require.NoError(t,
 		sc.txConn.Commit(ctx, session))
@@ -992,8 +992,8 @@ func TestTxConnCommit2PCCreateTransactionFail(t *testing.T) {
 	sc, sbc0, sbc1, rss0, rss1, _ := newTestTxConnEnv(t, ctx, "TestTxConnCommit2PCCreateTransactionFail")
 
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
-	sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss1, queries, session, false, false, false, nullResultsObserver{}, false)
 
 	sbc0.MustFailCreateTransaction = 1
 	session.TransactionMode = vtgatepb.TransactionMode_TWOPC
@@ -1014,8 +1014,8 @@ func TestTxConnCommit2PCPrepareFail(t *testing.T) {
 	sc, sbc0, sbc1, rss0, _, rss01 := newTestTxConnEnv(t, ctx, "TestTxConnCommit2PCPrepareFail")
 
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
-	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, false, nullResultsObserver{}, false)
 
 	sbc1.MustFailPrepare = 1
 	session.TransactionMode = vtgatepb.TransactionMode_TWOPC
@@ -1040,8 +1040,8 @@ func TestTxConnCommit2PCStartCommitFail(t *testing.T) {
 	sc, sbc0, sbc1, rss0, _, rss01 := newTestTxConnEnv(t, ctx, "TestTxConnCommit2PCStartCommitFail")
 
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
-	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, false, nullResultsObserver{}, false)
 
 	sbc0.MustFailStartCommit = 1
 	session.TransactionMode = vtgatepb.TransactionMode_TWOPC
@@ -1059,8 +1059,8 @@ func TestTxConnCommit2PCStartCommitFail(t *testing.T) {
 	sbc1.ResetCounter()
 
 	session = econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
-	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, false, nullResultsObserver{}, false)
 
 	// Here the StartCommit failure is in uncertain state so rollback is not called and neither conclude.
 	sbc0.MustFailStartCommitUncertain = 1
@@ -1082,8 +1082,8 @@ func TestTxConnCommit2PCCommitPreparedFail(t *testing.T) {
 	sc, sbc0, sbc1, rss0, _, rss01 := newTestTxConnEnv(t, ctx, "TestTxConnCommit2PCCommitPreparedFail")
 
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
-	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, false, nullResultsObserver{}, false)
 
 	sbc1.MustFailCommitPrepared = 1
 	session.TransactionMode = vtgatepb.TransactionMode_TWOPC
@@ -1102,8 +1102,8 @@ func TestTxConnCommit2PCConcludeTransactionFail(t *testing.T) {
 	sc, sbc0, sbc1, rss0, _, rss01 := newTestTxConnEnv(t, ctx, "TestTxConnCommit2PCConcludeTransactionFail")
 
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
-	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, false, nullResultsObserver{}, false)
 
 	sbc0.MustFailConcludeTransaction = 1
 	session.TransactionMode = vtgatepb.TransactionMode_TWOPC
@@ -1122,8 +1122,8 @@ func TestTxConnRollback(t *testing.T) {
 	sc, sbc0, sbc1, rss0, _, rss01 := newTestTxConnEnv(t, ctx, "TxConnRollback")
 
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true})
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
-	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, false, nullResultsObserver{}, false)
 	require.NoError(t,
 		sc.txConn.Rollback(ctx, session))
 	wantSession := vtgatepb.Session{}
@@ -1138,8 +1138,8 @@ func TestTxConnReservedRollback(t *testing.T) {
 	sc, sbc0, sbc1, rss0, _, rss01 := newTestTxConnEnv(t, ctx, "TxConnReservedRollback")
 
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true, InReservedConn: true})
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
-	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, false, nullResultsObserver{}, false)
 	require.NoError(t,
 		sc.txConn.Rollback(ctx, session))
 	wantSession := vtgatepb.Session{
@@ -1175,8 +1175,8 @@ func TestTxConnReservedRollbackFailure(t *testing.T) {
 	sc, sbc0, sbc1, rss0, rss1, rss01 := newTestTxConnEnv(t, ctx, "TxConnReservedRollback")
 
 	session := econtext.NewSafeSession(&vtgatepb.Session{InTransaction: true, InReservedConn: true})
-	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, nullResultsObserver{}, false)
-	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss0, queries, session, false, false, false, nullResultsObserver{}, false)
+	sc.ExecuteMultiShard(ctx, nil, rss01, twoQueries, session, false, false, false, nullResultsObserver{}, false)
 
 	sbc1.MustFailCodes[vtrpcpb.Code_INVALID_ARGUMENT] = 1
 	require.Error(t,
@@ -1608,7 +1608,7 @@ func TestTxConnMetrics(t *testing.T) {
 			safeSession := econtext.NewAutocommitSession(session)
 			err := sc.txConn.Begin(ctx, safeSession, nil)
 			require.NoError(t, err)
-			_, errors := sc.ExecuteMultiShard(ctx, nil, tc.rss, tc.queries, safeSession, false, false, nullResultsObserver{}, false)
+			_, errors := sc.ExecuteMultiShard(ctx, nil, tc.rss, tc.queries, safeSession, false, false, false, nullResultsObserver{}, false)
 			require.Empty(t, errors)
 			require.NoError(t,
 				sc.txConn.Commit(ctx, safeSession))

--- a/go/vt/vttablet/sandboxconn/sandboxconn.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn.go
@@ -131,6 +131,11 @@ type SandboxConn struct {
 	// reserve id generator
 	ReserveID atomic.Int64
 
+	// NoReservation makes a reserve apply its pre-queries and answer without a
+	// reserved id, the way a tablet does for a statement that does not need a
+	// pinned connection and runs on a connection from its settings pool.
+	NoReservation bool
+
 	mapMu     sync.Mutex // protects the map txIDToRID
 	txIDToRID map[int64]int64
 
@@ -799,6 +804,9 @@ func (sbc *SandboxConn) reserve(ctx context.Context, session queryservice.Sessio
 	sbc.ReserveCount.Add(1)
 	for _, query := range preQueries {
 		sbc.Execute(ctx, session, target, query, bindVariables, transactionID, 0, options)
+	}
+	if sbc.NoReservation {
+		return 0
 	}
 	if transactionID != 0 {
 		return transactionID

--- a/go/vt/vttablet/sandboxconn/sandboxconn.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn.go
@@ -134,6 +134,9 @@ type SandboxConn struct {
 	// NoReservation makes a reserve apply its pre-queries and answer without a
 	// reserved id, the way a tablet does for a statement that does not need a
 	// pinned connection and runs on a connection from its settings pool.
+	// Without it the sandbox always reserves, and inside a transaction it
+	// answers with the transaction id. A tablet never does that: it applies the
+	// settings to the transaction's connection and reserves nothing.
 	NoReservation bool
 
 	mapMu     sync.Mutex // protects the map txIDToRID


### PR DESCRIPTION
## Description

Statements that cannot carry the session's system variables in a `SET_VAR` hint (DDL, `CALL`, `FLUSH`, `LOAD DATA`, ...) used to flip the whole session into "reserved connection" mode. From then on every query of that session, hint-capable or not, went through a settings connection on each shard, and vtgate decided that on its own guess of what the statement needed.

This makes the settings transport per statement. The statement runs with the session's settings applied to its connection, and the session is pinned only when the tablet actually reserved a connection for it (locks, temporary tables). Later queries go back to `SET_VAR` on pooled connections.

- `CheckForReservedConnection` asks the vcursor for the session's settings for this statement instead of pinning the session. The vcursor marks the context for the scatter connection, next to the existing `IgnoreReserveTxn` marker.
- `actionInfo` treats that marker like the session flag when deciding to reserve. After the RPC, a non-zero reserved id from the tablet pins the session; a zero one (vttablet served the statement from its settings pool) leaves it alone.
- `FLUSH TABLES WITH READ LOCK`, `GET_LOCK()`, temporary tables and `SET` without `SET_VAR` keep pinning the session as before.
- The sandbox tablet gains `NoReservation`, so unit tests can tell "served from the settings pool" from "reserved by the tablet".

One thing to know: inside a transaction the settings land on the transaction's connection, which keeps them for the rest of the transaction. That is what a reserved session's connection did before too.

Testing: unit tests for the scatter connection decision and both tablet answers, an executor test for the DDL-then-SELECT sequence, and the `vtgate/reservedconn` end-to-end suite run locally against built binaries.

## Related Issue(s)

Came out of the review of #20880, which wants to send every backend `SHOW` with the session's settings and needs this to be cheap.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches (not to be backported)
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required (changelog entry under VTGate)

## Deployment Notes

After a DDL, `CALL`, `FLUSH` or `LOAD DATA` on a session that has system variables set, later queries of that session use `SET_VAR` hints on pooled connections instead of settings connections. Sessions that hold a lock or a temporary table keep their reserved connection as before, and so do deployments with `--enable-set-var=false` or backends without `SET_VAR`. No migrations, flags or wire changes.

### AI Disclosure

Most of this was written by Claude Code (Claude Fable 5.1); I provided direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
