### PR TITLE
 vreplication: Fix --config-overrides silently erasing existing config keys

### DIFF
--- a/go/vt/vttablet/tabletmanager/rpc_vreplication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication.go
@@ -689,7 +689,7 @@ func getOptionSetString(config map[string]string) string {
 		clause += ")"
 	}
 	if len(keys) > 0 {
-		clause = fmt.Sprintf("json_set(%s, '$.config', json_object(), ", clause)
+		clause = fmt.Sprintf("json_set(json_insert(%s, '$.config', json_object()), ", clause)
 		var clauseSb688 strings.Builder
 		for i, k := range keys {
 			if i > 0 {

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
@@ -850,7 +850,7 @@ func TestGetOptionSetString(t *testing.T) {
 				"password": "secret",
 				"user":     "admin",
 			},
-			want: ", options = json_set(options, '$.config', json_object(), '$.config.\"password\"', 'secret', '$.config.\"user\"', 'admin')",
+			want: ", options = json_set(json_insert(options, '$.config', json_object()), '$.config.\"password\"', 'secret', '$.config.\"user\"', 'admin')",
 		},
 		{
 			name: "valid params, deleting two",
@@ -860,7 +860,7 @@ func TestGetOptionSetString(t *testing.T) {
 				"port":     "",
 				"host":     "",
 			},
-			want: ", options = json_set(json_remove(options, '$.config.\"host\"', '$.config.\"port\"'), '$.config', json_object(), '$.config.\"password\"', 'secret', '$.config.\"user\"', 'admin')",
+			want: ", options = json_set(json_insert(json_remove(options, '$.config.\"host\"', '$.config.\"port\"'), '$.config', json_object()), '$.config.\"password\"', 'secret', '$.config.\"user\"', 'admin')",
 		},
 		// Additional tests for handling escaping errors or complex scenarios can be added here
 	}

--- a/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_vreplication_test.go
@@ -1064,7 +1064,7 @@ func TestUpdateVReplicationWorkflow(t *testing.T) {
 					"password": "secret",
 				},
 			},
-			query: fmt.Sprintf(`update _vt.vreplication set state = 'Running', source = 'keyspace:"%s" shard:"%s" filter:{rules:{match:"corder" filter:"select * from corder"} rules:{match:"customer" filter:"select * from customer"}}', cell = '%s', tablet_types = '', message = '', options = json_set(options, '$.config', json_object(), '$.config."password"', 'secret', '$.config."user"', 'admin') where id in (%d)`,
+			query: fmt.Sprintf(`update _vt.vreplication set state = 'Running', source = 'keyspace:"%s" shard:"%s" filter:{rules:{match:"corder" filter:"select * from corder"} rules:{match:"customer" filter:"select * from customer"}}', cell = '%s', tablet_types = '', message = '', options = json_set(json_insert(options, '$.config', json_object()), '$.config."password"', 'secret', '$.config."user"', 'admin') where id in (%d)`,
 				keyspace, shard, "zone2", vreplID),
 		},
 		{


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

`--config-overrides` was silently wiping every existing key in `$.config` whenever you updated even a single key. Second call would completely replace the container, leaving only the newly-set key behind.

## Root cause
`getOptionSetString` generated:
```sql
json_set(options, '$.config', json_object(), '$.config."key"', 'val') 
```
MySQL applies json_set pairs left to right, so `'$.config', json_object()` nukes the existing container before the per-key pairs run.

  ## Fix

json_insert only creates `$.config` when it's absent, leaves an existing container untouched. 

```sql
json_set(json_insert(options, '$.config', json_object()), '$.config."key"', 'val')
```

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
Fixes #21002 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->

### AI Disclosure

<!-- 
  A sentence or two describing whether AI was used to author any of the code in this pull request
  Example: "This PR was written primarily by Claude Code" or "Tests written by GPT-5"
  For more information: https://github.com/vitessio/enhancements/blob/main/veps/vep-7.md
-->
