### PR TITLE
vtctldclient: parse materialize --table-settings once every flag is applied

### DIFF
--- a/go/cmd/vtctldclient/command/vreplication/materialize/create.go
+++ b/go/cmd/vtctldclient/command/vreplication/materialize/create.go
@@ -17,7 +17,6 @@ limitations under the License.
 package materialize
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -34,7 +33,8 @@ import (
 var (
 	createOptions = struct {
 		SourceKeyspace string
-		TableSettings  tableSettings
+		TableSettings  jsonFlag
+		tableSettings  []*vtctldatapb.TableMaterializeSettings
 	}{}
 
 	// create makes a MaterializeCreate gRPC call to a vtctld.
@@ -77,7 +77,7 @@ should be copied as-is from the source keyspace. Here's an example value for tab
 			if err := common.ParseAndValidateCreateOptions(cmd); err != nil {
 				return err
 			}
-			return nil
+			return parseTableSettings(cmd)
 		},
 		RunE: commandCreate,
 	}
@@ -104,22 +104,13 @@ func commandCreate(cmd *cobra.Command, args []string) error {
 		MaterializationIntent:     vtctldatapb.MaterializationIntent_CUSTOM,
 		TargetKeyspace:            common.BaseOptions.TargetKeyspace,
 		SourceKeyspace:            createOptions.SourceKeyspace,
-		TableSettings:             createOptions.TableSettings.val,
+		TableSettings:             createOptions.tableSettings,
 		StopAfterCopy:             common.CreateOptions.StopAfterCopy,
 		Cell:                      strings.Join(common.CreateOptions.Cells, ","),
 		TabletTypes:               topoproto.MakeStringTypeCSV(common.CreateOptions.TabletTypes),
 		TabletSelectionPreference: tsp,
 		ReferenceTables:           common.CreateOptions.ReferenceTables,
 		WorkflowOptions:           workflowOptions,
-	}
-
-	createOptions.TableSettings.parser, err = sqlparser.New(sqlparser.Options{
-		MySQLServerVersion: common.CreateOptions.MySQLServerVersion,
-		TruncateUILen:      common.CreateOptions.TruncateUILen,
-		TruncateErrLen:     common.CreateOptions.TruncateErrLen,
-	})
-	if err != nil {
-		return err
 	}
 
 	req := &vtctldatapb.MaterializeCreateRequest{
@@ -149,24 +140,38 @@ func commandCreate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// tableSettings is a wrapper around a slice of TableMaterializeSettings
-// proto messages that implements the pflag.Value interface.
-type tableSettings struct {
-	val    []*vtctldatapb.TableMaterializeSettings
-	parser *sqlparser.Parser
-}
-
-func (ts *tableSettings) String() string {
-	tsj, _ := json.Marshal(ts.val)
-	return string(tsj)
-}
-
-func (ts *tableSettings) Set(v string) error {
-	var err error
-	ts.val, err = common.ParseTableMaterializeSettings(v, ts.parser)
+// parseTableSettings validates the --table-settings flag with a parser
+// configured from the other flags. Flags are applied in the order given on
+// the command line, so this runs once every flag has been applied.
+func parseTableSettings(cmd *cobra.Command) error {
+	if !cmd.Flags().Changed("table-settings") {
+		return nil
+	}
+	parser, err := sqlparser.New(sqlparser.Options{
+		MySQLServerVersion: common.CreateOptions.MySQLServerVersion,
+		TruncateUILen:      common.CreateOptions.TruncateUILen,
+		TruncateErrLen:     common.CreateOptions.TruncateErrLen,
+	})
+	if err != nil {
+		return err
+	}
+	createOptions.tableSettings, err = common.ParseTableMaterializeSettings(string(createOptions.TableSettings), parser)
 	return err
 }
 
-func (ts *tableSettings) Type() string {
+// jsonFlag is a pflag.Value that holds a flag's JSON text as given and shows
+// the flag's type as JSON in the command's help.
+type jsonFlag string
+
+func (j *jsonFlag) String() string {
+	return string(*j)
+}
+
+func (j *jsonFlag) Set(v string) error {
+	*j = jsonFlag(v)
+	return nil
+}
+
+func (j *jsonFlag) Type() string {
 	return "JSON"
 }

--- a/go/cmd/vtctldclient/command/vreplication/materialize/create_test.go
+++ b/go/cmd/vtctldclient/command/vreplication/materialize/create_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package materialize
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testRoot     *cobra.Command
+	testRootOnce sync.Once
+)
+
+// testCommands registers the Materialize commands once per test binary: the
+// commands are package globals, and registering their flags twice panics.
+func testCommands() *cobra.Command {
+	testRootOnce.Do(func() {
+		testRoot = &cobra.Command{Use: "test"}
+		registerCommands(testRoot)
+	})
+	return testRoot
+}
+
+// The table settings are validated with a parser configured by
+// --mysql-server-version, and flags are applied in the order given on the
+// command line, so the settings can only be parsed once every flag has been
+// applied. The source expression below is only valid when the parser skips
+// the version comment, which it does for a MySQL version below 8.0.
+func TestTableSettingsParsedAfterAllFlags(t *testing.T) {
+	createCmd, _, err := testCommands().Find([]string{"Materialize", "create"})
+	require.NoError(t, err)
+
+	// Restore the flags before each parse so the cases do not depend on each
+	// other's ordering.
+	parse := func(t *testing.T, args ...string) error {
+		t.Helper()
+		for _, name := range []string{"table-settings", "mysql-server-version"} {
+			f := createCmd.Flags().Lookup(name)
+			require.NotNil(t, f)
+			require.NoError(t, f.Value.Set(f.DefValue))
+			f.Changed = false
+		}
+		createOptions.tableSettings = nil
+		require.NoError(t, createCmd.ParseFlags(args))
+		return parseTableSettings(createCmd)
+	}
+	settings := `[{"target_table": "rollup", "source_expression": "select count(*) as kount /*!80000 from nowhere at all */ from customer"}]`
+
+	t.Run("the version given after the settings is honoured", func(t *testing.T) {
+		require.NoError(t, parse(t, "--table-settings", settings, "--mysql-server-version", "5.7.31"))
+		require.Len(t, createOptions.tableSettings, 1)
+		assert.Equal(t, "rollup", createOptions.tableSettings[0].TargetTable)
+	})
+
+	t.Run("the version given before the settings is honoured", func(t *testing.T) {
+		require.NoError(t, parse(t, "--mysql-server-version", "5.7.31", "--table-settings", settings))
+		require.Len(t, createOptions.tableSettings, 1)
+		assert.Equal(t, "rollup", createOptions.tableSettings[0].TargetTable)
+	})
+
+	t.Run("the default version parses the version comment", func(t *testing.T) {
+		require.ErrorContains(t, parse(t, "--table-settings", settings), "invalid source_expression")
+	})
+
+	t.Run("an absent flag leaves the settings empty", func(t *testing.T) {
+		require.NoError(t, parse(t))
+		assert.Nil(t, createOptions.tableSettings)
+	})
+
+	t.Run("an explicitly empty flag is an error", func(t *testing.T) {
+		require.ErrorContains(t, parse(t, "--table-settings", ""), "table-settings")
+	})
+}

--- a/go/cmd/vtctldclient/command/vreplication/materialize/materialize_test.go
+++ b/go/cmd/vtctldclient/command/vreplication/materialize/materialize_test.go
@@ -19,7 +19,6 @@ package materialize
 import (
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,10 +27,7 @@ import (
 // explicitly asks for it. The request must always carry keep_data, because an
 // omitted keep_data is resolved server-side to false and drops the data.
 func TestCancelKeepData(t *testing.T) {
-	root := &cobra.Command{Use: "test"}
-	registerCommands(root)
-
-	cancelCmd, _, err := root.Find([]string{"Materialize", "cancel"})
+	cancelCmd, _, err := testCommands().Find([]string{"Materialize", "cancel"})
 	require.NoError(t, err)
 
 	keepDataFlag := cancelCmd.Flags().Lookup("keep-data")


### PR DESCRIPTION
## Description

A small vtctldclient fix split out of #20884. The `materialize create --table-settings` flag validated its source expressions from a custom `pflag.Value`'s `Set` method, which runs while the command line is parsed. The parser it validates with is configured by `--mysql-server-version` and the truncation flags, so it could only be built in `RunE`, which is too late: `Set` always ran with a nil parser, which nothing dereferenced until the parser started reading its own mode bits while lexing.

The flag's value type now only holds the text as given and names its type `JSON` for the help output. The settings are parsed in the command's `PreRunE` next to the other create options, once every flag has been applied. The parser is a local used once. Flag order no longer matters: `--mysql-server-version` may come before or after `--table-settings`.

### How the flag is handled now

`--table-settings` is still parsed as JSON and validated exactly as before. Only *when* that happens has changed.

1. While pflag applies the command line, the flag's `Set` method just stores the text. `jsonFlag` in `create.go` is a string type whose only extra behaviour is reporting `JSON` as its type in `--help`.
2. Cobra runs the create command's `PreRunE`. After `common.ParseAndValidateCreateOptions` it calls `parseTableSettings`, which builds a `sqlparser.Parser` from the now-final `--mysql-server-version`, `--sql-max-length-ui` and `--sql-max-length-errors` values and hands the stored text to `common.ParseTableMaterializeSettings`. That helper is unchanged: it unmarshals the JSON array into `TableMaterializeSettings` protos, rejects invalid JSON and an empty array, requires `target_table` and `source_expression` on each entry, parses each source expression, and refuses two expressions over the same table. The result is kept in `createOptions.tableSettings`.
3. `RunE` (`commandCreate`) puts `createOptions.tableSettings` on the `MaterializeCreateRequest`.

An omitted flag skips step 2 and leaves the settings empty, as before; vtctld reports the missing settings. An explicitly empty value is still rejected on the client.

Previously steps 1 and 2 were one step inside `Set`, which is why the parser was always nil there: `Set` runs during command-line parsing, before `RunE` could build it.

Testing: a unit test in `go/cmd/vtctldclient/command/vreplication/materialize` drives the real `create` flag set. Its source expression is only valid when the parser skips a `/*!80000 ... */` version comment, so it proves the version given on the command line is the one used, in both flag orders.

## Related Issue(s)

Split out of #20884, where the nil parser turned into a crash of the CLI in the vreplication end-to-end suites.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches (not needed: the latent nil parser is harmless on the release branches' lexer)
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None. The flag's accepted values, behaviour, and help output are unchanged.

### AI Disclosure

Most of this was written by Claude Code (Claude Fable 5.1); I provided direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


