### PR TITLE
sqlparser: recognize the national-string introducer only before a single quote

### DIFF
--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -7198,3 +7198,29 @@ func parsePartial(r *bufio.Reader, readType []string, lineno int, fileName strin
 func locateFile(name string) string {
 	return "testdata/" + name
 }
+
+// MySQL recognizes the national-character string introducer only as N'…'. In
+// N"…" the N is an identifier followed by "…" — a string, which MySQL reads as
+// an alias — so the lexer must not take the national-string path on a double
+// quote.
+func TestNationalStringRequiresSingleQuote(t *testing.T) {
+	parser := NewTestParser()
+	for _, in := range []string{`select N'foo' from t`, `select n'foo' from t`} {
+		stmt, err := parser.Parse(in)
+		require.NoError(t, err, in)
+		expr := stmt.(*Select).SelectExprs.Exprs[0].(*AliasedExpr).Expr
+		nstr, ok := expr.(*UnaryExpr)
+		require.True(t, ok, "%s: got %T", in, expr)
+		assert.Equal(t, NStringOp, nstr.Operator)
+		assert.Equal(t, "select N'foo' from t", String(stmt))
+	}
+	for _, in := range []string{`select N"foo" from t`, `select n"foo" from t`} {
+		stmt, err := parser.Parse(in)
+		require.NoError(t, err, in)
+		ae := stmt.(*Select).SelectExprs.Exprs[0].(*AliasedExpr)
+		col, ok := ae.Expr.(*ColName)
+		require.True(t, ok, "%s: got %T", in, ae.Expr)
+		assert.True(t, col.Name.EqualString("n"), in)
+		assert.Equal(t, "foo", ae.As.String(), in)
+	}
+}

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -202,12 +202,14 @@ func (tkn *Tokenizer) Scan() (int, string) {
 					return tkn.scanBitLiteral()
 				}
 			}
-			// N\'literal' is used to create a string in the national character set
+			// N'literal' is a string in the national character set. MySQL
+			// recognizes the introducer only before a single quote: N"…" is the
+			// identifier N followed by a double-quoted token, whatever the mode
+			// makes of that token.
 			if ch == 'N' || ch == 'n' {
-				nxt := tkn.peek(1)
-				if nxt == '\'' || nxt == '"' {
+				if tkn.peek(1) == '\'' {
 					tkn.skip(2)
-					return tkn.scanString(nxt, NCHAR_STRING)
+					return tkn.scanString('\'', NCHAR_STRING)
 				}
 			}
 			return tkn.scanIdentifier(false)


### PR DESCRIPTION
## Description

A one-commit lexer fix split out of #20884: MySQL recognizes the national-character string introducer only as `N'...'`. In `N"..."` the `N` is an identifier followed by a string, which MySQL reads as an alias (`select N"foo"` returns a column `N` aliased `foo`). The Vitess lexer took the national-string path on either quote.

The tokenizer now checks for a single quote after `N`/`n` before treating it as an introducer; a double quote falls through to the identifier path. Verified against MySQL 8.0.46.

Testing: `TestNationalStringRequiresSingleQuote` covers both quotes and both cases of the letter.

## Related Issue(s)

Split out of #20884 (and then out of #21018). The `ANSI_QUOTES` case of the same rule, where `"..."` is a quoted identifier, follows with the sql_mode parser support.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches (not to be backported)
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

`select N"foo"` now parses as a column `N` aliased `foo`, as in MySQL, instead of a national-character string literal. No migrations, flags or wire changes.

### AI Disclosure

Most of this was written by Claude Code (Claude Fable 5.1); I provided direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
