### PR TITLE
vttablet: the wait_timeout publish no longer reads the transaction timeouts

### DIFF
--- a/go/vt/vttablet/tabletserver/tx_pool.go
+++ b/go/vt/vttablet/tabletserver/tx_pool.go
@@ -91,7 +91,7 @@ func NewTxPool(env tabletenv.Env, limiter txlimiter.TxLimiter) *TxPool {
 	axp := &TxPool{
 		env:     env,
 		scp:     NewStatefulConnPool(env),
-		ticks:   timer.NewTimer(txKillerTimeoutInterval(config, 0)),
+		ticks:   timer.NewTimer(txKillerTimeoutInterval(config)),
 		limiter: limiter,
 		txStats: env.Exporter().NewTimings("Transactions", "Transaction stats", "operation"),
 		tempTableIdleKills: env.Exporter().NewCounter("TempTableIdleTimeoutKills",
@@ -142,9 +142,15 @@ func (tp *TxPool) Close() {
 // one is tightened, so auto-governed connections always have a reaper.
 // The tick only ever shrinks here — a raised wait_timeout keeps the shorter
 // tick, which just checks a little more often than strictly needed.
+//
+// The current tick already reflects the configured timeouts (see
+// txKillerTimeoutInterval), so this derives the desired tick from the
+// wait_timeout alone rather than re-reading the transaction timeouts: this
+// runs on a background goroutine, and the endtoend short-timeout tests
+// rewrite those config fields at runtime.
 func (tp *TxPool) SetMysqlWaitTimeout(waitTimeout time.Duration) {
 	tp.scp.SetMysqlWaitTimeout(waitTimeout)
-	desired := txKillerTimeoutInterval(tp.env.Config(), waitTimeout)
+	desired := waitTimeout / 10
 	if desired <= 0 {
 		return
 	}
@@ -643,23 +649,18 @@ func (tp *TxPool) txComplete(conn *StatefulConnection, reason tx.ReleaseReason) 
 	conn.CleanTxState()
 }
 
-// txKillerTimeoutInterval derives the killer's tick from the shortest enabled
-// timeout it enforces: the OLTP and OLAP transaction timeouts plus the
-// temp-table idle timeout — the explicit flag value, or in auto mode the
-// published mysqld wait_timeout (autoWaitTimeout, zero until the first
-// successful read). Without the temp-table term, disabling both transaction
-// timeouts would leave the timer dormant and the temp-table timeout with no
-// reaper at all.
-func txKillerTimeoutInterval(config *tabletenv.TabletConfig, autoWaitTimeout time.Duration) time.Duration {
+// txKillerTimeoutInterval derives the killer's initial tick from the shortest
+// enabled timeout it enforces: the OLTP and OLAP transaction timeouts plus an
+// explicit temp-table idle timeout. In auto mode the temp-table term is
+// unknown until the first wait_timeout read lands, so the timer starts from
+// the transaction timeouts alone (dormant when both are disabled) and
+// SetMysqlWaitTimeout tightens it once the value is published.
+func txKillerTimeoutInterval(config *tabletenv.TabletConfig) time.Duration {
 	shortest := smallerTimeout(
 		config.TxTimeoutForWorkload(querypb.ExecuteOptions_OLAP),
 		config.TxTimeoutForWorkload(querypb.ExecuteOptions_OLTP),
 	)
-	tempTableIdle := config.TempTableIdleTimeout
-	if tempTableIdle < 0 {
-		tempTableIdle = autoWaitTimeout
-	}
-	if tempTableIdle > 0 {
+	if tempTableIdle := config.TempTableIdleTimeout; tempTableIdle > 0 {
 		shortest = smallerTimeout(shortest, tempTableIdle)
 	}
 	return shortest / 10

--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -1078,22 +1078,22 @@ func TestTxPoolGetAndLockWaitsOutKeepAlive(t *testing.T) {
 	held.Release(tx.ConnRelease)
 }
 
-// TestTxKillerTimeoutInterval pins the killer's tick derivation: the shortest
-// enabled timeout it enforces, including the temp-table idle timeout —
-// explicit or auto-published — so disabling both transaction timeouts does
-// not leave temp-table reservations without a reaper.
+// TestTxKillerTimeoutInterval pins the killer's initial tick derivation: the
+// shortest enabled timeout it enforces, including an explicit temp-table idle
+// timeout, so disabling both transaction timeouts does not leave temp-table
+// reservations without a reaper. Auto mode starts without the temp-table
+// term; TestTxPoolSetMysqlWaitTimeoutRetimesKiller covers the publish.
 func TestTxKillerTimeoutInterval(t *testing.T) {
 	cases := []struct {
-		name            string
-		oltp, olap      time.Duration
-		tempIdle        time.Duration
-		autoWaitTimeout time.Duration
-		want            time.Duration
+		name       string
+		oltp, olap time.Duration
+		tempIdle   time.Duration
+		want       time.Duration
 	}{
 		{name: "tx timeouts only", oltp: 30 * time.Second, olap: 30 * time.Second, tempIdle: 0, want: 3 * time.Second},
 		{name: "explicit temp idle with tx timeouts disabled", tempIdle: 100 * time.Second, want: 10 * time.Second},
-		{name: "auto temp idle with tx timeouts disabled", tempIdle: -1, autoWaitTimeout: 28800 * time.Second, want: 2880 * time.Second},
-		{name: "auto unknown keeps timer dormant", tempIdle: -1, want: 0},
+		{name: "auto mode starts dormant with tx timeouts disabled", tempIdle: -1, want: 0},
+		{name: "auto mode starts from the tx timeouts", oltp: 30 * time.Second, olap: 30 * time.Second, tempIdle: -1, want: 3 * time.Second},
 		{name: "everything disabled", tempIdle: 0, want: 0},
 		{name: "shorter temp idle tightens the tick", oltp: 30 * time.Second, olap: 30 * time.Second, tempIdle: 10 * time.Second, want: time.Second},
 	}
@@ -1103,7 +1103,7 @@ func TestTxKillerTimeoutInterval(t *testing.T) {
 			cfg.Oltp.TxTimeout = tc.oltp
 			cfg.Olap.TxTimeout = tc.olap
 			cfg.TempTableIdleTimeout = tc.tempIdle
-			assert.Equal(t, tc.want, txKillerTimeoutInterval(cfg, tc.autoWaitTimeout))
+			assert.Equal(t, tc.want, txKillerTimeoutInterval(cfg))
 		})
 	}
 }
@@ -1127,6 +1127,28 @@ func TestTxPoolSetMysqlWaitTimeoutRetimesKiller(t *testing.T) {
 
 	txPool.SetMysqlWaitTimeout(60 * time.Second)
 	require.Equal(t, 6*time.Second, txPool.ticks.Interval(), "a lowered wait_timeout must tighten the tick")
+}
+
+// TestTxPoolSetMysqlWaitTimeoutDoesNotReadTxTimeouts pins that the auto-mode
+// publisher, which runs on a background goroutine, never reads the
+// transaction timeouts off the config. The endtoend short-timeout tests
+// rewrite those at runtime, and the race detector flags the pair: this test
+// fails under -race when the publisher reads them.
+func TestTxPoolSetMysqlWaitTimeoutDoesNotReadTxTimeouts(t *testing.T) {
+	env := newEnv("TabletServerTest")
+	env.Config().TempTableIdleTimeout = -1
+	txPool, _ := newTxPoolWithEnv(env)
+
+	published := make(chan struct{})
+	go func() {
+		defer close(published)
+		txPool.SetMysqlWaitTimeout(600 * time.Second)
+	}()
+	env.Config().SetTxTimeoutForWorkload(10*time.Millisecond, querypb.ExecuteOptions_OLTP)
+	env.Config().SetTxTimeoutForWorkload(10*time.Millisecond, querypb.ExecuteOptions_OLAP)
+	<-published
+
+	require.Equal(t, 3*time.Second, txPool.ticks.Interval(), "the tick derived from the 30s OLTP timeout must not loosen to the 60s wait_timeout tick")
 }
 
 // TestTxPoolBeginWaitsOutKeepAlive verifies that starting a transaction on a


### PR DESCRIPTION
## Description

Since #20429 merged, every `e2e_race` failure on `main` and on PRs (9 of 9 logs I checked, including the merge commit's own run) is the same data race in `TestShortTxTimeoutOltp` / `TestShortTxTimeoutOlap`:

- #20429 added a background goroutine that mirrors mysqld's `@@global.wait_timeout` on every schema reload and publishes it into the transaction pool via `TxPool.SetMysqlWaitTimeout`. That publish re-derived the connection killer's tick through `txKillerTimeoutInterval`, which reads `Oltp.TxTimeout` / `Olap.TxTimeout` off the live `TabletConfig`.
- The two endtoend tests rewrite those exact fields at runtime via the test-only `SetTxTimeoutForWorkload`. In the endtoend framework the schema reload fires every 5s and after every DDL, so the two race often enough to fail roughly one run in eight.

The transaction timeouts are flag-only and never change at runtime outside tests, and the killer's tick already encodes them from construction. So the publish now derives its desired tick from the `wait_timeout` alone and, as before, only ever tightens the current tick. The result is identical to what `txKillerTimeoutInterval(config, waitTimeout)` computed, because the current tick is already the configured minimum. With that, `txKillerTimeoutInterval` loses its now-unused `autoWaitTimeout` parameter.

A new unit test calls the publisher concurrently with the config setter. Under `-race` it fails on `main` with the exact CI stack and passes with this change. The two endtoend tests are unchanged; I could not run them locally (no mysqld in my checkout), so CI's `e2e_race` job is the confirmation for those.

## Related Issue(s)

- Introduced by #20429
- Example failure: https://github.com/vitessio/vitess/actions/runs/34097037686/job/101670164483

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None. The connection killer's tick is unchanged in every configuration; #20429 is only on `main`, so no backport.

### AI Disclosure

This PR was written by Claude Code, including the investigation of the CI failures; I provided direction and reviewed it.
