### PR TITLE
sql_mode: judge unquoted mode names as constants at vtgate and vttablet

### DIFF
--- a/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
+++ b/go/test/endtoend/vtgate/reservedconn/sysvar_test.go
@@ -51,6 +51,10 @@ func TestSetSysVarSingle(t *testing.T) {
 		expr:     "@charvar",
 		expected: []string{`[[VARCHAR("utf8mb4")]]`, `[[VARCHAR("utf8")]]`},
 	}, {
+		name:     "sql_mode", // use reserved conn; an unquoted mode name is the equivalent string
+		expr:     "TRADITIONAL",
+		expected: []string{`[[VARCHAR("TRADITIONAL")]]`},
+	}, {
 		name:     "sql_mode", // use reserved conn
 		expr:     "''",
 		expected: []string{`[[VARCHAR("")]]`},

--- a/go/vt/vtgate/planbuilder/set.go
+++ b/go/vt/vtgate/planbuilder/set.go
@@ -65,6 +65,11 @@ func buildSetPlan(stmt *sqlparser.Set, vschema plancontext.VSchema) (*planResult
 		// we have a UDV. If the original query didn't explicitly specify the scope, it
 		// would have been explicitly set to sqlparser.SessionStr before reaching this
 		// phase of planning
+		if expr.Var.Scope != sqlparser.VariableScope {
+			if err := rejectQualifiedName(expr); err != nil {
+				return nil, err
+			}
+		}
 		switch expr.Var.Scope {
 		case sqlparser.GlobalScope:
 			if vschema.IsSystemVariableDenied(expr.Var.Name.Lowered()) {
@@ -129,6 +134,20 @@ func buildSetPlan(stmt *sqlparser.Set, vschema plancontext.VSchema) (*planResult
 	}), nil
 }
 
+// rejectQualifiedName rejects a system variable assignment whose value is a qualified
+// name, such as `set autocommit = t.off`. MySQL accepts an unqualified bare identifier
+// as the equivalent string, and the plan functions coerce it the same way (on/off,
+// enumeration values, mode names); a qualified name is never a value, and MySQL rejects
+// it as the wrong argument type, whatever the qualifier. This runs before any of that
+// coercion, so no plan function has to repeat the check.
+func rejectQualifiedName(expr *sqlparser.SetExpr) error {
+	colName, ok := expr.Expr.(*sqlparser.ColName)
+	if !ok || colName.Qualifier.IsEmpty() {
+		return nil
+	}
+	return vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.WrongTypeForVar, "Incorrect argument type to variable '%s'", expr.Var.Name.Lowered())
+}
+
 func buildSetOpReadOnly(setting) planFunc {
 	return func(expr *sqlparser.SetExpr, schema plancontext.VSchema, _ *expressionConverter) (engine.SetOp, error) {
 		return nil, vterrors.VT03010(expr.Var.Name)
@@ -185,10 +204,10 @@ func planSysVarCheckIgnore(expr *sqlparser.SetExpr, schema plancontext.VSchema, 
 // execution time, once their value is known.
 func validateSQLModePlan(inner planFunc) planFunc {
 	return func(expr *sqlparser.SetExpr, vschema plancontext.VSchema, ec *expressionConverter) (engine.SetOp, error) {
-		if colName, ok := expr.Expr.(*sqlparser.ColName); ok && colName.Qualifier.IsEmpty() {
+		if colName, ok := expr.Expr.(*sqlparser.ColName); ok {
 			// MySQL accepts an unquoted mode name as the equivalent string: a constant,
-			// judged here like its quoted spelling. A qualified name is never a mode
-			// name; extractValue rejects it as MySQL does.
+			// judged here like its quoted spelling. Qualified names never get here
+			// (see rejectQualifiedName).
 			if _, err := sqlmode.Validate(sqltypes.NewVarChar(colName.Name.String())); err != nil {
 				return nil, err
 			}
@@ -307,14 +326,10 @@ func extractValue(expr *sqlparser.SetExpr, boolean bool) (string, error) {
 		case "off":
 			return "0", nil
 		}
-		// a qualified name is never a value: MySQL rejects it as the wrong argument
-		// type, whatever the qualifier
-		if !node.Qualifier.IsEmpty() {
-			return "", vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.WrongTypeForVar, "Incorrect argument type to variable '%s'", expr.Var.Name.Lowered())
-		}
 		// the identifier's own text, not its formatted form: formatting backticks a
 		// name that is a keyword in the Vitess grammar, and MySQL would take the
-		// backticks as part of the string value
+		// backticks as part of the string value. Qualified names never get here
+		// (see rejectQualifiedName).
 		return sqltypes.EncodeStringSQL(node.Name.String()), nil
 
 	case *sqlparser.Default:

--- a/go/vt/vtgate/planbuilder/set.go
+++ b/go/vt/vtgate/planbuilder/set.go
@@ -65,15 +65,13 @@ func buildSetPlan(stmt *sqlparser.Set, vschema plancontext.VSchema) (*planResult
 		// we have a UDV. If the original query didn't explicitly specify the scope, it
 		// would have been explicitly set to sqlparser.SessionStr before reaching this
 		// phase of planning
-		if expr.Var.Scope != sqlparser.VariableScope {
-			if err := rejectQualifiedName(expr); err != nil {
-				return nil, err
-			}
-		}
 		switch expr.Var.Scope {
 		case sqlparser.GlobalScope:
 			if vschema.IsSystemVariableDenied(expr.Var.Name.Lowered()) {
 				return nil, vterrors.VT12001(fmt.Sprintf("system setting: %s", expr.Var.Name))
+			}
+			if err := rejectQualifiedName(expr); err != nil {
+				return nil, err
 			}
 			setOp, err := planSysVarCheckIgnore(expr, vschema, true)
 			if err != nil {
@@ -107,6 +105,9 @@ func buildSetPlan(stmt *sqlparser.Set, vschema plancontext.VSchema) (*planResult
 				vschema.PlannerWarning("converted 'next transaction' scope to 'session' scope")
 			}
 		case sqlparser.VitessMetadataScope:
+			if err := rejectQualifiedName(expr); err != nil {
+				return nil, err
+			}
 			value, err := getValueFor(expr)
 			if err != nil {
 				return nil, err
@@ -138,14 +139,28 @@ func buildSetPlan(stmt *sqlparser.Set, vschema plancontext.VSchema) (*planResult
 // name, such as `set autocommit = t.off`. MySQL accepts an unqualified bare identifier
 // as the equivalent string, and the plan functions coerce it the same way (on/off,
 // enumeration values, mode names); a qualified name is never a value, and MySQL rejects
-// it as the wrong argument type, whatever the qualifier. This runs before any of that
-// coercion, so no plan function has to repeat the check.
+// it as the wrong argument type, whatever the qualifier. As in MySQL, the variable is
+// resolved first: an unknown or denied variable is reported as such, whatever its value,
+// so for session-scope variables this runs from rejectQualifiedNamePlan, which wraps
+// every known variable's plan function, ahead of any coercion.
 func rejectQualifiedName(expr *sqlparser.SetExpr) error {
 	colName, ok := expr.Expr.(*sqlparser.ColName)
 	if !ok || colName.Qualifier.IsEmpty() {
 		return nil
 	}
 	return vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.WrongTypeForVar, "Incorrect argument type to variable '%s'", expr.Var.Name.Lowered())
+}
+
+// rejectQualifiedNamePlan wraps a known system variable's plan function with
+// rejectQualifiedName, so a qualified name is rejected before the plan function coerces
+// the value.
+func rejectQualifiedNamePlan(inner planFunc) planFunc {
+	return func(expr *sqlparser.SetExpr, vschema plancontext.VSchema, ec *expressionConverter) (engine.SetOp, error) {
+		if err := rejectQualifiedName(expr); err != nil {
+			return nil, err
+		}
+		return inner(expr, vschema, ec)
+	}
 }
 
 func buildSetOpReadOnly(setting) planFunc {

--- a/go/vt/vtgate/planbuilder/set.go
+++ b/go/vt/vtgate/planbuilder/set.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"vitess.io/vitess/go/mysql/sqlmode"
+	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/key"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/sysvars"
@@ -30,6 +31,8 @@ import (
 	"vitess.io/vitess/go/vt/vtgate/evalengine"
 	"vitess.io/vitess/go/vt/vtgate/planbuilder/plancontext"
 	"vitess.io/vitess/go/vt/vtgate/vindexes"
+
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
 type (
@@ -182,6 +185,15 @@ func planSysVarCheckIgnore(expr *sqlparser.SetExpr, schema plancontext.VSchema, 
 // execution time, once their value is known.
 func validateSQLModePlan(inner planFunc) planFunc {
 	return func(expr *sqlparser.SetExpr, vschema plancontext.VSchema, ec *expressionConverter) (engine.SetOp, error) {
+		if colName, ok := expr.Expr.(*sqlparser.ColName); ok && colName.Qualifier.IsEmpty() {
+			// MySQL accepts an unquoted mode name as the equivalent string: a constant,
+			// judged here like its quoted spelling. A qualified name is never a mode
+			// name; extractValue rejects it as MySQL does.
+			if _, err := sqlmode.Validate(sqltypes.NewVarChar(colName.Name.String())); err != nil {
+				return nil, err
+			}
+			return inner(expr, vschema, ec)
+		}
 		evalExpr, err := evalengine.Translate(expr.Expr, &evalengine.Config{
 			Collation:   vschema.ConnCollation(),
 			Environment: vschema.Environment(),
@@ -295,7 +307,15 @@ func extractValue(expr *sqlparser.SetExpr, boolean bool) (string, error) {
 		case "off":
 			return "0", nil
 		}
-		return fmt.Sprintf("'%s'", sqlparser.String(expr.Expr)), nil
+		// a qualified name is never a value: MySQL rejects it as the wrong argument
+		// type, whatever the qualifier
+		if !node.Qualifier.IsEmpty() {
+			return "", vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.WrongTypeForVar, "Incorrect argument type to variable '%s'", expr.Var.Name.Lowered())
+		}
+		// the identifier's own text, not its formatted form: formatting backticks a
+		// name that is a keyword in the Vitess grammar, and MySQL would take the
+		// backticks as part of the string value
+		return sqltypes.EncodeStringSQL(node.Name.String()), nil
 
 	case *sqlparser.Default:
 		return "", vterrors.VT12001(defaultNotSupportedErrFmt, expr.Var.Name)

--- a/go/vt/vtgate/planbuilder/system_variables.go
+++ b/go/vt/vtgate/planbuilder/system_variables.go
@@ -86,6 +86,12 @@ func (pc *sysvarPlanCache) init(env *vtenv.Environment) {
 		// planning time, so an invalid or unsupported value fails the SET before any
 		// assignment executes, regardless of whether system settings are enabled.
 		pc.funcs[sysvars.SQLMode.Name] = validateSQLModePlan(pc.funcs[sysvars.SQLMode.Name])
+		// a qualified name is never a value; once the variable is resolved as known, the
+		// value is rejected before any plan function, the sql_mode validation included,
+		// coerces it (see rejectQualifiedName)
+		for name, pf := range pc.funcs {
+			pc.funcs[name] = rejectQualifiedNamePlan(pf)
+		}
 	})
 }
 

--- a/go/vt/vtgate/planbuilder/system_variables_test.go
+++ b/go/vt/vtgate/planbuilder/system_variables_test.go
@@ -94,6 +94,19 @@ func TestDeniedSystemVariables(t *testing.T) {
 		query:    "set not_a_real_sysvar = 1",
 		wantErr:  "VT05006: unknown system variable '@@not_a_real_sysvar = 1'",
 		wantCode: vtrpcpb.Code_NOT_FOUND,
+	}, {
+		// The variable is resolved before its value is judged, as in MySQL: an unknown
+		// variable is reported as such even when the value is a qualified name.
+		name:     "unknown sysvar with a qualified value still returns unknown-variable error",
+		query:    "set not_a_real_sysvar = t.x",
+		wantErr:  "VT05006: unknown system variable '@@not_a_real_sysvar = t.x'",
+		wantCode: vtrpcpb.Code_NOT_FOUND,
+	}, {
+		name:     "denied sysvar with a qualified value still returns the denylist error",
+		denied:   map[string]struct{}{"unique_checks": {}},
+		query:    "set unique_checks = t.x",
+		wantErr:  "VT12001: unsupported: system setting: unique_checks",
+		wantCode: vtrpcpb.Code_UNIMPLEMENTED,
 	}}
 
 	for _, tc := range cases {

--- a/go/vt/vtgate/planbuilder/testdata/set_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/set_cases.json
@@ -142,6 +142,35 @@
     }
   },
   {
+    "comment": "an unquoted mode name is the equivalent string; rendered without the backticks the formatter adds for a keyword",
+    "query": "set @@sql_mode = TRADITIONAL",
+    "plan": {
+      "Type": "MultiShard",
+      "QueryType": "SET",
+      "Original": "set @@sql_mode = TRADITIONAL",
+      "Instructions": {
+        "OperatorType": "Set",
+        "Ops": [
+          {
+            "Type": "SysVarSet",
+            "Name": "sql_mode",
+            "Keyspace": {
+              "Name": "main",
+              "Sharded": false
+            },
+            "Expr": "'TRADITIONAL'",
+            "SupportSetVar": true
+          }
+        ],
+        "Inputs": [
+          {
+            "OperatorType": "SingleRow"
+          }
+        ]
+      }
+    }
+  },
+  {
     "comment": "multiple sysvar cases",
     "query": "SET @@SESSION.sql_mode = CONCAT(CONCAT(@@sql_mode, ',STRICT_ALL_TABLES'), ',NO_AUTO_VALUE_ON_ZERO'), @@SESSION.sql_safe_updates = 0",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -468,5 +468,20 @@
     "comment": "unknown sql_mode names fail with MySQL's error",
     "query": "set sql_mode = 'BOGUS'",
     "plan": "Variable 'sql_mode' can't be set to the value of 'BOGUS'"
+  },
+  {
+    "comment": "an unquoted mode name is a constant, judged at plan time like its quoted spelling",
+    "query": "set sql_mode = ANSI",
+    "plan": "setting the ANSI sql_mode is unsupported"
+  },
+  {
+    "comment": "a qualified name is never a mode name; MySQL rejects it as the wrong argument type",
+    "query": "set sql_mode = t.TRADITIONAL",
+    "plan": "Incorrect argument type to variable 'sql_mode'"
+  },
+  {
+    "comment": "a qualified name is never a value for any system variable",
+    "query": "set @@sql_safe_updates = t.x",
+    "plan": "Incorrect argument type to variable 'sql_safe_updates'"
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json
@@ -483,5 +483,20 @@
     "comment": "a qualified name is never a value for any system variable",
     "query": "set @@sql_safe_updates = t.x",
     "plan": "Incorrect argument type to variable 'sql_safe_updates'"
+  },
+  {
+    "comment": "a qualified name is rejected before on/off coercion of a reserved-connection boolean",
+    "query": "set foreign_key_checks = t.off",
+    "plan": "Incorrect argument type to variable 'foreign_key_checks'"
+  },
+  {
+    "comment": "a qualified name is rejected before on/off coercion of a Vitess-aware boolean",
+    "query": "set autocommit = t.off",
+    "plan": "Incorrect argument type to variable 'autocommit'"
+  },
+  {
+    "comment": "a qualified name is rejected for global-scope assignments too",
+    "query": "set global sql_safe_updates = t.x",
+    "plan": "Incorrect argument type to variable 'sql_safe_updates'"
   }
 ]

--- a/go/vt/vttablet/tabletserver/planbuilder/sql_mode.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/sql_mode.go
@@ -18,6 +18,7 @@ package planbuilder
 
 import (
 	"vitess.io/vitess/go/mysql/sqlmode"
+	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/sysvars"
 	"vitess.io/vitess/go/vt/vterrors"
@@ -100,9 +101,11 @@ func validateSetStatementSQLMode(set *sqlparser.Set) (verify bool, err error) {
 }
 
 // validateSetExprsSQLMode rejects session-scope sql_mode assignments whose constant value
-// fails sqlmode.Validate. Assignments whose value is not a constant cannot be judged here;
-// for those it returns verify=true, asking the executor to read back and validate the
-// applied value after the statement runs.
+// fails sqlmode.Validate. A constant is a literal or an unquoted mode name: MySQL accepts
+// `SET sql_mode = TRADITIONAL` as `SET sql_mode = 'TRADITIONAL'`, and the parser yields
+// the unquoted name as a bare, unqualified column name. Assignments whose value is not a
+// constant cannot be judged here; for those it returns verify=true, asking the executor to
+// read back and validate the applied value after the statement runs.
 func validateSetExprsSQLMode(exprs sqlparser.SetExprs) (verify bool, err error) {
 	for _, expr := range exprs {
 		if expr.Var.Name.Lowered() != sysvars.SQLMode.Name {
@@ -114,13 +117,8 @@ func validateSetExprsSQLMode(exprs sqlparser.SetExprs) (verify bool, err error) 
 			// the global scope is the operator's domain, not a vtgate session's
 			continue
 		}
-		lit, ok := expr.Expr.(*sqlparser.Literal)
+		value, ok := constantSQLModeValue(expr.Expr)
 		if !ok {
-			verify = true
-			continue
-		}
-		value, err := sqlparser.LiteralToValue(lit)
-		if err != nil {
 			verify = true
 			continue
 		}
@@ -129,4 +127,24 @@ func validateSetExprsSQLMode(exprs sqlparser.SetExprs) (verify bool, err error) 
 		}
 	}
 	return verify, nil
+}
+
+// constantSQLModeValue returns the value of a constant sql_mode expression: a literal, or
+// an unquoted mode name, which MySQL accepts as the equivalent string. A qualified name is
+// not a mode name and, like any other expression, is left for MySQL to judge.
+func constantSQLModeValue(expr sqlparser.Expr) (sqltypes.Value, bool) {
+	switch node := expr.(type) {
+	case *sqlparser.Literal:
+		value, err := sqlparser.LiteralToValue(node)
+		if err != nil {
+			return sqltypes.Value{}, false
+		}
+		return value, true
+	case *sqlparser.ColName:
+		if !node.Qualifier.IsEmpty() {
+			return sqltypes.Value{}, false
+		}
+		return sqltypes.NewVarChar(node.Name.String()), true
+	}
+	return sqltypes.Value{}, false
 }

--- a/go/vt/vttablet/tabletserver/planbuilder/sql_mode.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/sql_mode.go
@@ -103,7 +103,8 @@ func validateSetStatementSQLMode(set *sqlparser.Set) (verify bool, err error) {
 // validateSetExprsSQLMode rejects session-scope sql_mode assignments whose constant value
 // fails sqlmode.Validate. A constant is a literal or an unquoted mode name: MySQL accepts
 // `SET sql_mode = TRADITIONAL` as `SET sql_mode = 'TRADITIONAL'`, and the parser yields
-// the unquoted name as a bare, unqualified column name. Assignments whose value is not a
+// the unquoted name as a bare, unqualified column name. A qualified name is rejected the
+// way MySQL rejects it (see constantSQLModeValue). Assignments whose value is not a
 // constant cannot be judged here; for those it returns verify=true, asking the executor to
 // read back and validate the applied value after the statement runs.
 func validateSetExprsSQLMode(exprs sqlparser.SetExprs) (verify bool, err error) {
@@ -117,7 +118,10 @@ func validateSetExprsSQLMode(exprs sqlparser.SetExprs) (verify bool, err error) 
 			// the global scope is the operator's domain, not a vtgate session's
 			continue
 		}
-		value, ok := constantSQLModeValue(expr.Expr)
+		value, ok, err := constantSQLModeValue(expr.Expr)
+		if err != nil {
+			return false, err
+		}
 		if !ok {
 			verify = true
 			continue
@@ -131,20 +135,21 @@ func validateSetExprsSQLMode(exprs sqlparser.SetExprs) (verify bool, err error) 
 
 // constantSQLModeValue returns the value of a constant sql_mode expression: a literal, or
 // an unquoted mode name, which MySQL accepts as the equivalent string. A qualified name is
-// not a mode name and, like any other expression, is left for MySQL to judge.
-func constantSQLModeValue(expr sqlparser.Expr) (sqltypes.Value, bool) {
+// never a mode name: MySQL rejects it as the wrong argument type, whatever the qualifier,
+// and so does this, with MySQL's error. Any other expression is not a constant.
+func constantSQLModeValue(expr sqlparser.Expr) (value sqltypes.Value, ok bool, err error) {
 	switch node := expr.(type) {
 	case *sqlparser.Literal:
 		value, err := sqlparser.LiteralToValue(node)
 		if err != nil {
-			return sqltypes.Value{}, false
+			return sqltypes.Value{}, false, nil
 		}
-		return value, true
+		return value, true, nil
 	case *sqlparser.ColName:
 		if !node.Qualifier.IsEmpty() {
-			return sqltypes.Value{}, false
+			return sqltypes.Value{}, false, vterrors.NewErrorf(vtrpcpb.Code_INVALID_ARGUMENT, vterrors.WrongTypeForVar, "Incorrect argument type to variable '%s'", sysvars.SQLMode.Name)
 		}
-		return sqltypes.NewVarChar(node.Name.String()), true
+		return sqltypes.NewVarChar(node.Name.String()), true, nil
 	}
-	return sqltypes.Value{}, false
+	return sqltypes.Value{}, false, nil
 }

--- a/go/vt/vttablet/tabletserver/planbuilder/sql_mode_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/sql_mode_test.go
@@ -67,6 +67,10 @@ func TestBuildSettingQueryRejectsUnsupportedSQLModes(t *testing.T) {
 	}, {
 		settings:    []string{"set sql_mode = BOGUS"},
 		expectedErr: "Variable 'sql_mode' can't be set to the value of 'BOGUS'",
+	}, {
+		// a qualified name is never a mode name; MySQL rejects it as the wrong type
+		settings:    []string{"set sql_mode = t.TRADITIONAL"},
+		expectedErr: "Incorrect argument type to variable 'sql_mode'",
 	}}
 	for _, tc := range tests {
 		t.Run(tc.settings[len(tc.settings)-1], func(t *testing.T) {
@@ -153,9 +157,16 @@ func TestSetPlanRejectsUnsupportedSQLModes(t *testing.T) {
 	}, {
 		sql: "set @@sql_safe_updates = if(1 = 1, 0, 1), @@sql_mode = STRICT_TRANS_TABLES",
 	}, {
-		// a qualified name is not a mode name; it is left for MySQL to judge
-		sql:          "set @@sql_mode = t.sql_mode",
-		verifySQLMod: true,
+		// a qualified name is never a mode name: MySQL rejects it as the wrong argument
+		// type, whatever the qualifier, and so does the plan
+		sql:         "set @@sql_mode = t.TRADITIONAL",
+		expectedErr: "Incorrect argument type to variable 'sql_mode'",
+	}, {
+		sql:         "set sql_mode = a.b.c",
+		expectedErr: "Incorrect argument type to variable 'sql_mode'",
+	}, {
+		sql:         "set @@sql_safe_updates = 1, @@sql_mode = t.TRADITIONAL",
+		expectedErr: "Incorrect argument type to variable 'sql_mode'",
 	}}
 	for _, tc := range tests {
 		t.Run(tc.sql, func(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/planbuilder/sql_mode_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/sql_mode_test.go
@@ -56,6 +56,17 @@ func TestBuildSettingQueryRejectsUnsupportedSQLModes(t *testing.T) {
 		// judged upfront is rejected
 		settings:    []string{"set sql_safe_updates = 1", "set sql_mode = concat('AN', 'SI')"},
 		expectedErr: "non-constant sql_mode value in connection settings: set sql_mode = concat('AN', 'SI')",
+	}, {
+		// MySQL accepts an unquoted mode name as the equivalent string: it is a constant
+		settings: []string{"set sql_mode = TRADITIONAL"},
+	}, {
+		settings: []string{"set sql_mode = strict_trans_tables"},
+	}, {
+		settings:    []string{"set sql_mode = ANSI"},
+		expectedErr: "setting the ANSI sql_mode is unsupported",
+	}, {
+		settings:    []string{"set sql_mode = BOGUS"},
+		expectedErr: "Variable 'sql_mode' can't be set to the value of 'BOGUS'",
 	}}
 	for _, tc := range tests {
 		t.Run(tc.settings[len(tc.settings)-1], func(t *testing.T) {
@@ -127,6 +138,24 @@ func TestSetPlanRejectsUnsupportedSQLModes(t *testing.T) {
 	}, {
 		// a constant sql_mode in a multi-assignment SET is judged at plan time as usual
 		sql: "set @@sql_safe_updates = if(1 = 1, 0, 1), @@sql_mode = 'STRICT_TRANS_TABLES'",
+	}, {
+		// MySQL accepts an unquoted mode name as the equivalent string: it is a constant,
+		// judged at plan time like its quoted spelling
+		sql: "set @@sql_mode = TRADITIONAL",
+	}, {
+		sql: "set sql_mode = strict_trans_tables",
+	}, {
+		sql:         "set @@sql_mode = ANSI",
+		expectedErr: "setting the ANSI sql_mode is unsupported",
+	}, {
+		sql:         "set session sql_mode = BOGUS",
+		expectedErr: "Variable 'sql_mode' can't be set to the value of 'BOGUS'",
+	}, {
+		sql: "set @@sql_safe_updates = if(1 = 1, 0, 1), @@sql_mode = STRICT_TRANS_TABLES",
+	}, {
+		// a qualified name is not a mode name; it is left for MySQL to judge
+		sql:          "set @@sql_mode = t.sql_mode",
+		verifySQLMod: true,
 	}}
 	for _, tc := range tests {
 		t.Run(tc.sql, func(t *testing.T) {


### PR DESCRIPTION
## Description

MySQL accepts an unquoted mode name in a `sql_mode` assignment as the equivalent string. Verified against MySQL 8.0.43:

```sql
SET sql_mode = TRADITIONAL;                                 -- same as 'TRADITIONAL'
SET sql_mode = ANSI;                                        -- same as 'ANSI'
SET sql_mode = STRICT_TRANS_TABLES, @@wait_timeout = 100;   -- accepted
SET sql_mode = BOGUS;                                       -- ERROR 1231, same as 'BOGUS'
SET sql_mode = t.TRADITIONAL;                               -- ERROR 1232, Incorrect argument type
SET sql_mode = a.b.c;                                       -- ERROR 1232, whatever the qualifier
```

The Vitess parser yields an unquoted name as a bare column name, and neither side treated that as a constant:

**vttablet.** The `sql_mode` validation from #20883 only recognized literals as constants, so an unquoted name was treated as a non-constant expression. In connection settings and in multi-assignment `SET` statements, where a value that cannot be judged upfront is rejected, supported modes written unquoted were falsely rejected: `set sql_mode = TRADITIONAL` failed with "non-constant sql_mode value in connection settings". In a sole-assignment `SET`, the statement ran and was verified by reading the applied value back, a needless round trip for a value that can be judged at plan time.

**vtgate.** The set planner rendered an identifier value by formatting the AST node and wrapping the result in quotes. Formatting an identifier that is a keyword in the Vitess grammar adds backticks, so `set sql_mode = TRADITIONAL` was sent to the shard as ``'`TRADITIONAL`'``, which MySQL rejects as an unknown mode. `TRADITIONAL` is the only MySQL 8 mode name that is a Vitess keyword, so it was the only mode affected, but the rendering path serves every system variable that accepts identifier values. Separately, plan-time `sql_mode` validation only saw expressions the evalengine can translate, which excludes bare identifiers, so unquoted names were judged only at execution time by the read-back.

This PR:

- On both sides, judges an unqualified bare identifier as the string it stands for, at plan time like its quoted spelling, with the same errors.
- Rejects a qualified name (`t.TRADITIONAL`, `a.b.c`) with MySQL's error 1232, "Incorrect argument type to variable '...'", on every path. On vtgate this applies to every system variable, since the previous rendering produced a quoted string either way; on vttablet it applies to `sql_mode`, the only variable it judges.
- Renders identifier values on vtgate from the identifier's own text, without the backticks the formatter adds for keywords.

## Related Issue(s)

Follow-up to #20883.

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

None. This only affects the unreleased validation added in #20883.

### AI Disclosure

This PR was written primarily by Claude Code, with direction and review by the author.
