### PR TITLE
vttablet: reset connection settings with the DEFAULT keyword

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -49,7 +49,6 @@
         - [New `--demote-primary-lock-wait-timeout` flag](#vttablet-demote-primary-lock-wait-timeout)
         - [Schema engine table-count limit is now configurable](#vttablet-schema-max-table-count)
         - [Replicas are placed in a crash-safe state before shutdown](#vttablet-replica-crash-safe-shutdown)
-        - [Connections with session settings are reset instead of replaced](#vttablet-settings-reset-reuses-connection)
         - [Skip MySQL version check when restoring from a mysql-shell backup](#vttablet-mysql-shell-restore-skip-version-check)
         - [ApplySchema session variables](#vttablet-applyschema-session-variables)
     - **[VTCtld](#minor-changes-vtctld)**
@@ -495,14 +494,6 @@ A failed shutdown that leaves such a restoration pending can delay process exit 
 **Impact**: On a graceful replica shutdown that completes the preparation, `innodb_flush_log_at_trx_commit`, `sync_binlog`, and `sync_relay_log` are set to `1` and both replication threads are stopped, regardless of their prior runtime values; if the preparation cannot complete, it is skipped and logged. The preparation keys off `SHOW REPLICA STATUS`, so it applies to any mysqld with a replication source configured — which excludes a normally promoted `PRIMARY`, but includes a `PRIMARY` that keeps a replication channel configured (e.g. one replicating from an external source with `--disable_active_reparents`), whose replication is stopped by the preparation like any replica's.
 
 See [#20599](https://github.com/vitessio/vitess/pull/20599) for details.
-
-#### <a id="vttablet-settings-reset-reuses-connection"/>Connections with session settings are reset instead of replaced</a>
-
-When a pooled connection carrying session settings (from a `SET` on a reserved connection, or from settings forwarded by VTGate) is handed to a request that needs different settings or none, the tablet resets the settings first. The reset statement restored every setting other than `sql_mode` with the quoted string `'default'`, which MySQL rejects for these variables, so the reset always failed. The pool recovered by closing the connection and opening a new one, without logging, and the `ResetSetting` metric counted the attempt. In effect, every settings reset since v16 was a reconnect. The reset now uses the `DEFAULT` keyword, which MySQL accepts for every system variable, so the connection is reused.
-
-**Impact**: Workloads that mix requests with and without session settings on the same tablet see fewer MySQL connection open/close cycles. The `ResetSetting` and `DiffSetting` pool metrics now measure what their names say.
-
-See [#21026](https://github.com/vitessio/vitess/pull/21026) for details.
 
 #### <a id="vttablet-mysql-shell-restore-skip-version-check"/>Skip MySQL version check when restoring from a mysql-shell backup</a>
 

--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -49,6 +49,7 @@
         - [New `--demote-primary-lock-wait-timeout` flag](#vttablet-demote-primary-lock-wait-timeout)
         - [Schema engine table-count limit is now configurable](#vttablet-schema-max-table-count)
         - [Replicas are placed in a crash-safe state before shutdown](#vttablet-replica-crash-safe-shutdown)
+        - [Connections with session settings are reset instead of replaced](#vttablet-settings-reset-reuses-connection)
         - [Skip MySQL version check when restoring from a mysql-shell backup](#vttablet-mysql-shell-restore-skip-version-check)
         - [ApplySchema session variables](#vttablet-applyschema-session-variables)
     - **[VTCtld](#minor-changes-vtctld)**
@@ -494,6 +495,14 @@ A failed shutdown that leaves such a restoration pending can delay process exit 
 **Impact**: On a graceful replica shutdown that completes the preparation, `innodb_flush_log_at_trx_commit`, `sync_binlog`, and `sync_relay_log` are set to `1` and both replication threads are stopped, regardless of their prior runtime values; if the preparation cannot complete, it is skipped and logged. The preparation keys off `SHOW REPLICA STATUS`, so it applies to any mysqld with a replication source configured — which excludes a normally promoted `PRIMARY`, but includes a `PRIMARY` that keeps a replication channel configured (e.g. one replicating from an external source with `--disable_active_reparents`), whose replication is stopped by the preparation like any replica's.
 
 See [#20599](https://github.com/vitessio/vitess/pull/20599) for details.
+
+#### <a id="vttablet-settings-reset-reuses-connection"/>Connections with session settings are reset instead of replaced</a>
+
+When a pooled connection carrying session settings (from a `SET` on a reserved connection, or from settings forwarded by VTGate) is handed to a request that needs different settings or none, the tablet resets the settings first. The reset statement restored every setting other than `sql_mode` with the quoted string `'default'`, which MySQL rejects for these variables, so the reset always failed. The pool recovered by closing the connection and opening a new one, without logging, and the `ResetSetting` metric counted the attempt. In effect, every settings reset since v16 was a reconnect. The reset now uses the `DEFAULT` keyword, which MySQL accepts for every system variable, so the connection is reused.
+
+**Impact**: Workloads that mix requests with and without session settings on the same tablet see fewer MySQL connection open/close cycles. The `ResetSetting` and `DiffSetting` pool metrics now measure what their names say.
+
+See [#21026](https://github.com/vitessio/vitess/pull/21026) for details.
 
 #### <a id="vttablet-mysql-shell-restore-skip-version-check"/>Skip MySQL version check when restoring from a mysql-shell backup</a>
 

--- a/go/vt/vttablet/endtoend/settings_test.go
+++ b/go/vt/vttablet/endtoend/settings_test.go
@@ -114,6 +114,49 @@ func TestSetttingsReuseConnWithSettings(t *testing.T) {
 	}
 }
 
+// A plain request that finds no clean connection and no spare capacity is handed a
+// connection with settings applied, after the pool has reset them. The reset must
+// succeed on MySQL: when it fails, the pool silently replaces the connection, so the
+// client observes a new connection id instead of the reused one.
+func TestSettingsResetReusesConnection(t *testing.T) {
+	resetTxConnPool(t)
+
+	connectionIDQuery := "select connection_id(), @@sql_safe_updates"
+	setting := "set @@sql_safe_updates = 1"
+
+	// hold every connection but one, so the plain request below cannot be served
+	// from the clean stack or by opening a new connection
+	txPoolSize := framework.Server.Config().TxPool.Size
+	holders := make([]*framework.QueryClient, 0, txPoolSize-1)
+	for range txPoolSize - 1 {
+		holder := framework.NewClient()
+		_, err := holder.BeginExecute("select 1", nil, nil)
+		require.NoError(t, err)
+		holders = append(holders, holder)
+	}
+	t.Cleanup(func() {
+		for _, holder := range holders {
+			assert.NoError(t, holder.Release())
+		}
+	})
+
+	client := framework.NewClient()
+	defer client.Release()
+
+	withSetting, err := client.ReserveBeginExecute(connectionIDQuery, []string{setting}, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, client.Rollback())
+	require.Equal(t, "1", withSetting.Rows[0][1].ToString())
+
+	plain, err := client.BeginExecute(connectionIDQuery, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, client.Rollback())
+
+	// the same connection is reused, with its settings reset
+	assert.Equal(t, withSetting.Rows[0][0].ToString(), plain.Rows[0][0].ToString(), "expected the settings connection to be reused")
+	assert.Equal(t, "0", plain.Rows[0][1].ToString(), "expected sql_safe_updates to be reset")
+}
+
 // resetTxConnPool resets the settings pool by fetching all the connections from the pool with no settings.
 // this will make sure that the settings pool connections if any will be taken and settings are reset.
 func resetTxConnPool(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -411,7 +411,7 @@ func BuildSettingQuery(settings []string, parser *sqlparser.Parser) (query strin
 	}
 	var setExprs sqlparser.SetExprs
 	var resetSetExprs sqlparser.SetExprs
-	lDefault := sqlparser.NewStrLiteral("default")
+	defaultValue := &sqlparser.Default{}
 	for _, setting := range settings {
 		stmt, err := parser.Parse(setting)
 		if err != nil {
@@ -432,7 +432,7 @@ func BuildSettingQuery(settings []string, parser *sqlparser.Parser) (query strin
 			if sysVar.Scope != sqlparser.SessionScope && sysVar.Scope != sqlparser.NoScope {
 				return "", "", vterrors.Errorf(vtrpcpb.Code_INTERNAL, "[BUG]: session scope expected, got: %s", sysVar.Scope.ToString())
 			}
-			resetExpr := sqlparser.Expr(lDefault)
+			resetExpr := sqlparser.Expr(defaultValue)
 			if sysVar.Name.Lowered() == sysvars.SQLMode.Name {
 				// `default` would re-inherit the server's global sql_mode including its
 				// lexer modes, undoing the neutralization every Vitess-created

--- a/go/vt/vttablet/tabletserver/planbuilder/sql_mode_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/sql_mode_test.go
@@ -81,7 +81,19 @@ func TestBuildSettingQueryResetNeutralizesSQLMode(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, query, "sql_mode = 'STRICT_TRANS_TABLES'")
 	assert.Contains(t, resetQuery, "sql_mode = replace(replace(replace(replace(replace(replace(replace(@@global.sql_mode, 'NO_BACKSLASH_ESCAPES', ''), 'HIGH_NOT_PRECEDENCE', ''), 'PIPES_AS_CONCAT', ''), 'REAL_AS_FLOAT', ''), 'IGNORE_SPACE', ''), 'ANSI_QUOTES', ''), 'ANSI', '')")
-	assert.Contains(t, resetQuery, "sql_safe_updates = 'default'")
+	assert.Contains(t, resetQuery, "sql_safe_updates = default")
+}
+
+// Every setting other than sql_mode is reset with the DEFAULT keyword. MySQL accepts
+// `SET var = DEFAULT` for any system variable and rejects the string 'default' for
+// most of them, so the reset must use the keyword for the pool to be able to reuse the
+// connection rather than replace it.
+func TestBuildSettingQueryResetUsesDefaultKeyword(t *testing.T) {
+	parser := vtenv.NewTestEnv().Parser()
+
+	_, resetQuery, err := BuildSettingQuery([]string{"set sql_safe_updates = 1", "set @@session.sql_select_limit = 10"}, parser)
+	require.NoError(t, err)
+	assert.Equal(t, "set sql_safe_updates = default, @@sql_select_limit = default", resetQuery)
 }
 
 func TestSetPlanRejectsUnsupportedSQLModes(t *testing.T) {


### PR DESCRIPTION
## Description

When a pooled connection carrying session settings is handed to a request that needs different settings or none, the tablet runs a reset query first. `BuildSettingQuery` built that reset with the quoted string literal `'default'` for every variable other than `sql_mode`:

```sql
set sql_safe_updates = 'default', @@sql_select_limit = 'default'
```

MySQL rejects that value. Verified against MySQL 8.0.43 for eight variables, with zero successes:

```sql
SET sql_safe_updates = 'default';        -- ERROR 1231: can't be set to the value of 'default'
SET sql_select_limit = 'default';        -- ERROR 1232: Incorrect argument type
SET transaction_isolation = 'default';   -- ERROR 1231
SET wait_timeout = 'default';            -- ERROR 1232
SET character_set_results = 'default';   -- ERROR 1115: Unknown character set
SET sql_safe_updates = DEFAULT;          -- accepted
```

So the reset has always failed. The pool handles a failed reset by closing the connection and opening a new one, without logging, and the `ResetSetting` metric counts attempts rather than outcomes. The net effect is that every settings reset since the reset query was introduced in #11181 (v16) has actually been a reconnect, and `ResetSetting` has been counting reconnects. Nothing caught it because the unit test asserts the string and the end-to-end settings test only ever requests the same setting repeatedly, so the reset path never runs against a real MySQL.

This PR:

- Builds the reset with the `DEFAULT` keyword, which MySQL accepts for every system variable. The `sql_mode` half already used its own expression since #20883 and is unchanged.
- Adds an end-to-end test that drains the tx pool's spare capacity, releases one connection with a setting applied, then asks for a plain connection. Without the fix the client observes a different connection id; with it the same connection comes back with the setting reset.
- Pins the generated reset text in a unit test.

## Related Issue(s)

Introduced in #11181.

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

None. Workloads that mix requests with and without session settings on the same tablet will see fewer MySQL connection open/close cycles; nothing to act on.

This is a candidate for backporting: the bug is in every supported release, and the fix is a one-line change to the generated statement.

### AI Disclosure

This PR was written primarily by Claude Code, with direction and review by the author.
