### PR TITLE
builtinbackupengine: close the compressor and decompressor once

### DIFF
--- a/go/ioutil/timeout_closer.go
+++ b/go/ioutil/timeout_closer.go
@@ -18,9 +18,18 @@ package ioutil
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"time"
 )
+
+// ErrCloseAbandoned is returned by TimeoutCloser.Close, wrapped together
+// with the context error, when the wrapped Close has not returned by the
+// time the timeout expires or the context is canceled. The wrapped Close
+// is still running at that point and may still be using whatever it was
+// closing, so the caller must not treat those resources as released.
+var ErrCloseAbandoned = errors.New("close abandoned, the wrapped Close has not returned")
 
 // TimeoutCloser is an io.Closer that has a timeout for executing the Close() function.
 type TimeoutCloser struct {
@@ -54,6 +63,6 @@ func (c *TimeoutCloser) Close() error {
 	case err := <-done:
 		return err
 	case <-ctx.Done():
-		return ctx.Err()
+		return fmt.Errorf("%w: %w", ErrCloseAbandoned, ctx.Err())
 	}
 }

--- a/go/ioutil/timeout_closer_test.go
+++ b/go/ioutil/timeout_closer_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,9 +47,8 @@ func TestTimeoutCloser(t *testing.T) {
 	{
 		closer := NewTimeoutCloser(ctx, &hangCloser{hang: true}, time.Second)
 		err := closer.Close()
-		require.Error(t, err)
-		assert.ErrorIs(t, err, context.DeadlineExceeded)
-		assert.ErrorIs(t, err, ErrCloseAbandoned)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.ErrorIs(t, err, ErrCloseAbandoned)
 	}
 }
 

--- a/go/ioutil/timeout_closer_test.go
+++ b/go/ioutil/timeout_closer_test.go
@@ -27,6 +27,7 @@ import (
 
 type hangCloser struct {
 	hang bool
+	err  error
 }
 
 func (c hangCloser) Close() error {
@@ -34,7 +35,7 @@ func (c hangCloser) Close() error {
 		ch := make(chan bool)
 		ch <- true // hang forever
 	}
-	return nil
+	return c.err
 }
 
 func TestTimeoutCloser(t *testing.T) {
@@ -49,5 +50,27 @@ func TestTimeoutCloser(t *testing.T) {
 		err := closer.Close()
 		require.Error(t, err)
 		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.ErrorIs(t, err, ErrCloseAbandoned)
+	}
+}
+
+// TestTimeoutCloserAbandoned pins what ErrCloseAbandoned means: it marks a
+// Close that the TimeoutCloser stopped waiting for, whether because of its
+// own timeout or because the context was canceled, and never a Close that
+// returned on its own, even one that failed with a context error.
+func TestTimeoutCloserAbandoned(t *testing.T) {
+	{
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		closer := NewTimeoutCloser(ctx, &hangCloser{hang: true}, time.Minute)
+		err := closer.Close()
+		require.ErrorIs(t, err, ErrCloseAbandoned)
+		require.ErrorIs(t, err, context.Canceled)
+	}
+	{
+		closer := NewTimeoutCloser(t.Context(), &hangCloser{err: context.DeadlineExceeded}, time.Minute)
+		err := closer.Close()
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.NotErrorIs(t, err, ErrCloseAbandoned, "a Close that returned is not abandoned")
 	}
 }

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -61,12 +61,13 @@ const (
 	RestoreState = "restore_in_progress"
 	// BackupTimestampFormat is the format in which we save BackupTime and FinishedTime
 	BackupTimestampFormat = "2006-01-02.150405"
-
-	// closeTimeout is the timeout for closing backup files after writing.
-	// The value is a bit arbitrary. How long does it make sense to wait for a Close()? With a cloud-based implementation,
-	// network might be an issue. _Seconds_ are probably too short. The whereabouts of a minute us a reasonable value.
-	closeTimeout = 1 * time.Minute
 )
+
+// closeTimeout is the timeout for closing backup files after writing.
+// The value is a bit arbitrary. How long does it make sense to wait for a Close()? With a cloud-based implementation,
+// network might be an issue. _Seconds_ are probably too short. The whereabouts of a minute us a reasonable value.
+// It is a variable so that tests can shorten it.
+var closeTimeout = 1 * time.Minute
 
 const (
 	// replicationStartDeadline is the deadline for starting replication

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -1117,12 +1117,22 @@ func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupPara
 				closeCompressorAt := time.Now()
 				// A compressor is closed once, without closeWithRetry: a failed
 				// close leaves the compressed stream broken, and closing again
-				// cannot repair it. The builtin compressors answer every later
-				// Close with the same error, and an external compressor's
-				// process has already exited. The file is retried as a whole
-				// by the caller instead.
+				// cannot repair it. Nor is a second Close safe for every
+				// implementation: the lz4 writer blocks forever on it in
+				// concurrent mode, and an external compressor's process has
+				// already exited. The file is retried as a whole by the caller
+				// instead.
 				if cerr := closer.Close(); cerr != nil {
-					cerr = vterrors.Wrapf(cerr, "failed to close compressor %v", label)
+					if errors.Is(cerr, ioutil.ErrCloseAbandoned) {
+						// The compressor's Close is still running and may still
+						// be flushing into this attempt's buffer and destination
+						// while they are closed below. The retry would write the
+						// same destination name, so nothing under it can be
+						// trusted any more: fail the backup instead.
+						cerr = vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "failed to close compressor %v within %v: %v", label, closeTimeout, cerr)
+					} else {
+						cerr = vterrors.Wrapf(cerr, "failed to close compressor %v", label)
+					}
 					params.Logger.Error(cerr)
 					createAndCopyErr = errors.Join(createAndCopyErr, cerr)
 					return
@@ -1614,7 +1624,12 @@ func createDecompressor(ctx context.Context, bm builtinBackupManifest, reader io
 			// A decompressor is closed once, without closeWithRetry: its Close
 			// reports the state of the stream it has read, and closing again
 			// cannot change that. The file is retried as a whole by the caller
-			// instead.
+			// instead. That holds for an abandoned Close too
+			// (ioutil.ErrCloseAbandoned): a decompressor never writes the
+			// destination, the source it may still be reading is this
+			// attempt's own and is closed by the caller, the retry opens a
+			// fresh one, and an external process is killed with the caller's
+			// context. Nothing the retry uses is shared with the stale Close.
 			cerr = closer.Close()
 			if cerr != nil {
 				cerr = vterrors.Wrapf(cerr, "failed to close decompressor %v", name)

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -1114,7 +1114,13 @@ func (be *BuiltinBackupEngine) backupFile(ctx context.Context, params BackupPara
 			defer func() {
 				params.Logger.Infof("Closing compressor for file: %s %s", label, retryStr)
 				closeCompressorAt := time.Now()
-				if cerr := closeWithRetry(ctx, params.Logger, closer, "compressor"); cerr != nil {
+				// A compressor is closed once, without closeWithRetry: a failed
+				// close leaves the compressed stream broken, and closing again
+				// cannot repair it. The builtin compressors answer every later
+				// Close with the same error, and an external compressor's
+				// process has already exited. The file is retried as a whole
+				// by the caller instead.
+				if cerr := closer.Close(); cerr != nil {
 					cerr = vterrors.Wrapf(cerr, "failed to close compressor %v", label)
 					params.Logger.Error(cerr)
 					createAndCopyErr = errors.Join(createAndCopyErr, cerr)
@@ -1599,7 +1605,11 @@ func createDecompressor(ctx context.Context, bm builtinBackupManifest, reader io
 	cleanup := func() error {
 		params.Logger.Infof("closing decompressor for %s", name)
 		closeAt := time.Now()
-		cerr := closeWithRetry(ctx, params.Logger, closer, "decompressor")
+		// A decompressor is closed once, without closeWithRetry: its Close
+		// reports the state of the stream it has read, and closing again
+		// cannot change that. The file is retried as a whole by the caller
+		// instead.
+		cerr := closer.Close()
 		if cerr != nil {
 			cerr = vterrors.Wrapf(cerr, "failed to close decompressor %v", name)
 			params.Logger.Error(cerr)

--- a/go/vt/mysqlctl/builtinbackupengine.go
+++ b/go/vt/mysqlctl/builtinbackupengine.go
@@ -33,6 +33,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -1602,19 +1603,25 @@ func createDecompressor(ctx context.Context, bm builtinBackupManifest, reader io
 	decompressStats := params.Stats.Scope(stats.Operation("Decompressor:Read"))
 	wrappedReader := ioutil.NewMeteredReader(decompressor, decompressStats.TimedIncrementBytes)
 
-	cleanup := func() error {
-		params.Logger.Infof("closing decompressor for %s", name)
-		closeAt := time.Now()
-		// A decompressor is closed once, without closeWithRetry: its Close
-		// reports the state of the stream it has read, and closing again
-		// cannot change that. The file is retried as a whole by the caller
-		// instead.
-		cerr := closer.Close()
-		if cerr != nil {
-			cerr = vterrors.Wrapf(cerr, "failed to close decompressor %v", name)
-			params.Logger.Error(cerr)
-		}
-		params.Stats.Scope(stats.Operation("Decompressor:Close")).TimedIncrement(time.Since(closeAt))
+	// The cleanup closes the decompressor the first time it is called and
+	// is a no-op afterwards, so the caller can close before checking the
+	// restored hash and still defer it for the error paths.
+	var closeOnce sync.Once
+	cleanup := func() (cerr error) {
+		closeOnce.Do(func() {
+			params.Logger.Infof("closing decompressor for %s", name)
+			closeAt := time.Now()
+			// A decompressor is closed once, without closeWithRetry: its Close
+			// reports the state of the stream it has read, and closing again
+			// cannot change that. The file is retried as a whole by the caller
+			// instead.
+			cerr = closer.Close()
+			if cerr != nil {
+				cerr = vterrors.Wrapf(cerr, "failed to close decompressor %v", name)
+				params.Logger.Error(cerr)
+			}
+			params.Stats.Scope(stats.Operation("Decompressor:Close")).TimedIncrement(time.Since(closeAt))
+		})
 		return cerr
 	}
 	return wrappedReader, cleanup, nil
@@ -1677,8 +1684,8 @@ func (be *BuiltinBackupEngine) restoreFile(ctx context.Context, params RestorePa
 	timedDest := ioutil.NewMeteredWriter(dest, writeStats.TimedIncrementBytes)
 	bufferedDest := bufio.NewWriterSize(timedDest, int(builtinBackupFileWriteBufferSize))
 
+	var decompressCleanup func() error
 	if !bm.SkipCompress {
-		var decompressCleanup func() error
 		reader, decompressCleanup, err = createDecompressor(ctx, bm, reader, params, name)
 		if err != nil {
 			return err
@@ -1692,6 +1699,16 @@ func (be *BuiltinBackupEngine) restoreFile(ctx context.Context, params RestorePa
 
 	if _, err := io.Copy(bufferedDest, reader); err != nil {
 		return vterrors.Wrap(err, "failed to copy file contents")
+	}
+
+	// The decompressor is closed before the hash is checked. An external
+	// decompressor is fed by a goroutine that is still reading the source,
+	// and so still writing the hash, until the process has been waited for;
+	// and a decompressor that failed makes the hash irrelevant anyway.
+	if decompressCleanup != nil {
+		if cerr := decompressCleanup(); cerr != nil {
+			return cerr
+		}
 	}
 
 	hash := br.HashString()
@@ -1775,8 +1792,8 @@ func (be *BuiltinBackupEngine) restoreFileChunk(ctx context.Context, params Rest
 	}()
 	var reader io.Reader = br
 
+	var decompressCleanup func() error
 	if !bm.SkipCompress {
-		var decompressCleanup func() error
 		reader, decompressCleanup, err = createDecompressor(ctx, bm, reader, params, chunk.StorageName)
 		if err != nil {
 			return err
@@ -1799,6 +1816,14 @@ func (be *BuiltinBackupEngine) restoreFileChunk(ctx context.Context, params Rest
 
 	if err := bufferedDest.Flush(); err != nil {
 		return vterrors.Wrapf(err, "failed to flush chunk %v", chunk.StorageName)
+	}
+
+	// The decompressor is closed before the hash is checked, for the same
+	// reasons as in restoreFile.
+	if decompressCleanup != nil {
+		if cerr := decompressCleanup(); cerr != nil {
+			return cerr
+		}
 	}
 
 	// Hash check first: a truncated read fails with INTERNAL (retryable).

--- a/go/vt/mysqlctl/compression.go
+++ b/go/vt/mysqlctl/compression.go
@@ -69,24 +69,18 @@ var (
 
 type (
 	// writeCloserOnly hides every method of the wrapped writer except
-	// Write and Close, and closes the wrapped writer at most once. The
-	// lz4 writer's ReadFrom only accepts a writer with nothing written
-	// to it yet, while io.Copy and io.CopyN select the destination's
-	// ReadFrom whenever the source has no visible WriteTo; repeated
-	// copies into one compressor — the striped xtrabackup backup
-	// round-robins io.CopyN over its destination writers — would then
-	// fail after the first copy. Hiding the method keeps every copy on
-	// the plain Write path. A second Close on the lz4 writer, which the
-	// builtin backup engine issues when it retries a failed close,
-	// blocks forever in concurrent mode: the goroutine that orders the
-	// compressed blocks exits during the first Close, and the second
-	// one waits on it. Every Close after the first returns the recorded
-	// result of the first instead.
-	writeCloserOnly struct {
-		io.WriteCloser
-		closeOnce sync.Once
-		closeErr  error
-	}
+	// Write and Close. The lz4 writer's ReadFrom only accepts a writer
+	// with nothing written to it yet, while io.Copy and io.CopyN select
+	// the destination's ReadFrom whenever the source has no visible
+	// WriteTo; repeated copies into one compressor — the striped
+	// xtrabackup backup round-robins io.CopyN over its destination
+	// writers — would then fail after the first copy. Hiding the method
+	// keeps every copy on the plain Write path. The lz4 writer must not
+	// be closed twice: in concurrent mode the goroutine that orders the
+	// compressed blocks exits during the first Close, and a second Close
+	// blocks forever waiting on it. The backup engines close each
+	// compressor exactly once.
+	writeCloserOnly struct{ io.WriteCloser }
 	// readCloserOnly hides every method of the wrapped reader except
 	// Read and Close. The lz4 reader's WriteTo accepts a reader that is
 	// already mid-stream but discards the bytes still buffered from the
@@ -95,13 +89,6 @@ type (
 	// plain Read path.
 	readCloserOnly struct{ io.ReadCloser }
 )
-
-func (w *writeCloserOnly) Close() error {
-	w.closeOnce.Do(func() {
-		w.closeErr = w.WriteCloser.Close()
-	})
-	return w.closeErr
-}
 
 func init() {
 	for _, cmd := range []string{"vtbackup", "vtcombo", "vttablet", "vttestserver"} {
@@ -334,7 +321,7 @@ func newBuiltinCompressor(engine string, writer io.Writer, logger logutil.Logger
 		); err != nil {
 			return compressor, vterrors.Wrap(err, "cannot create lz4 compressor")
 		}
-		compressor = &writeCloserOnly{WriteCloser: lz4Writer}
+		compressor = writeCloserOnly{lz4Writer}
 	case ZstdCompressor:
 		zst, err := zstd.NewWriter(writer, zstd.WithEncoderLevel(zstd.EncoderLevel(compressionLevel)))
 		if err != nil {

--- a/go/vt/mysqlctl/compression_test.go
+++ b/go/vt/mysqlctl/compression_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -35,23 +34,6 @@ import (
 
 	"vitess.io/vitess/go/vt/logutil"
 )
-
-type (
-	// failingWriter rejects every Write while armed, so a compressor's
-	// Close can be made to fail once and then be retried against a
-	// destination that accepts writes again.
-	failingWriter struct {
-		bytes.Buffer
-		fail bool
-	}
-)
-
-func (w *failingWriter) Write(p []byte) (int, error) {
-	if w.fail {
-		return 0, errors.New("destination unavailable")
-	}
-	return w.Buffer.Write(p)
-}
 
 func TestGetExtensionFromEngine(t *testing.T) {
 	tests := []struct {
@@ -201,44 +183,6 @@ func TestLz4ConcurrencyBlocksMapping(t *testing.T) {
 	require.Equal(t, -1, lz4ConcurrencyBlocks(-1))
 	require.Equal(t, 1, lz4ConcurrencyBlocks(1))
 	require.Equal(t, 2, lz4ConcurrencyBlocks(2))
-}
-
-// TestLz4CompressorCloseRetry closes an lz4 compressor whose destination
-// fails during the first Close, then closes it again the way the builtin
-// backup engine's closeWithRetry does. The lz4 v4 writer cannot be closed
-// twice in concurrent mode: the second Close blocks forever on a manager
-// goroutine that exited during the first one. The compressor must close
-// the writer once and answer every later Close with the recorded result,
-// so the retry loop fails fast with the original error.
-func TestLz4CompressorCloseRetry(t *testing.T) {
-	logger := logutil.NewMemoryLogger()
-	oldBlocks := backupCompressBlocks
-	backupCompressBlocks = 2
-	t.Cleanup(func() { backupCompressBlocks = oldBlocks })
-
-	dest := &failingWriter{}
-	compressor, err := newBuiltinCompressor(Lz4Compressor, dest, logger)
-	require.NoError(t, err)
-	_, err = compressor.Write(bytes.Repeat([]byte("lz4 backup data "), 4096))
-	require.NoError(t, err)
-
-	dest.fail = true
-	firstErr := compressor.Close()
-	require.ErrorContains(t, firstErr, "destination unavailable")
-
-	dest.fail = false
-	retried := make(chan error, 1)
-	go func() { retried <- compressor.Close() }()
-	var retriedErr error
-	require.Eventually(t, func() bool {
-		select {
-		case retriedErr = <-retried:
-			return true
-		default:
-			return false
-		}
-	}, 30*time.Second, 10*time.Millisecond, "retried Close did not return")
-	assert.Equal(t, firstErr, retriedErr)
 }
 
 // TestBuiltinDecompressorsPartialReadThenCopy reads a few bytes from each

--- a/go/vt/mysqlctl/file_close_test.go
+++ b/go/vt/mysqlctl/file_close_test.go
@@ -639,6 +639,101 @@ func TestRestoreFileWithCloseRetriesIntegration(t *testing.T) {
 	assert.Equal(t, content, restoredContent)
 }
 
+// TestBackupFileCompressorCloseNotRetried backs up a file through an
+// external compressor whose process exits with a failure, so that the
+// compressor's Close fails. Closing a compressor again cannot repair the
+// stream it was writing, and the compressors used here answer every later
+// Close with the same error, so the close must run once and surface its
+// own error. Running it through closeWithRetry would burn all
+// maxFileCloseRetries attempts and then replace that error with the
+// loop's "giving up" message.
+func TestBackupFileCompressorCloseNotRetried(t *testing.T) {
+	if _, err := validateExternalCmd("false"); err != nil {
+		t.Skip("Command not available in this host:", err)
+	}
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(path.Join(tmpDir, "source.txt"), []byte("test content"), 0o644))
+
+	oldCmd := ExternalCompressorCmd
+	oldMaxRetries := maxFileCloseRetries
+	t.Cleanup(func() {
+		ExternalCompressorCmd = oldCmd
+		maxFileCloseRetries = oldMaxRetries
+	})
+	ExternalCompressorCmd = "false"
+	maxFileCloseRetries = 0
+
+	bh := newMockBackupHandle()
+	bh.addFileReturn = newMockReadWriteCloser(0, nil)
+	params := BackupParams{
+		Cnf:         &Mycnf{DataDir: tmpDir},
+		Logger:      logutil.NewMemoryLogger(),
+		Stats:       backupstats.NoStats(),
+		Concurrency: 1,
+	}
+	fe := &FileEntry{
+		Base: backupData,
+		Name: "source.txt",
+	}
+
+	be := &BuiltinBackupEngine{}
+	err := be.backupFile(t.Context(), params, bh, fe, "0", -1)
+
+	require.ErrorContains(t, err, "failed to close compressor")
+	require.ErrorContains(t, err, "exit status 1")
+	assert.NotContains(t, err.Error(), "giving up")
+}
+
+// TestRestoreFileDecompressorCloseNotRetried restores a file through an
+// external decompressor whose process exits with a failure, so that the
+// decompressor's Close fails. As with the compressor, a second Close cannot
+// change the outcome, so the close must run once and surface its own error
+// instead of going through closeWithRetry.
+func TestRestoreFileDecompressorCloseNotRetried(t *testing.T) {
+	if _, err := validateExternalCmd("false"); err != nil {
+		t.Skip("Command not available in this host:", err)
+	}
+	tmpDir := t.TempDir()
+
+	oldCmd := ExternalDecompressorCmd
+	oldMaxRetries := maxFileCloseRetries
+	t.Cleanup(func() {
+		ExternalDecompressorCmd = oldCmd
+		maxFileCloseRetries = oldMaxRetries
+	})
+	ExternalDecompressorCmd = "false"
+	maxFileCloseRetries = 0
+
+	source := newMockReadOnlyCloser(0, nil)
+	bh := newMockBackupHandle()
+	bh.readFileReturn = source
+	params := RestoreParams{
+		Cnf:    &Mycnf{DataDir: tmpDir},
+		Logger: logutil.NewMemoryLogger(),
+		Stats:  backupstats.NoStats(),
+	}
+	// The hash covers the bytes read from the source, whether or not the
+	// external process consumed them.
+	bp := newBackupReader("test", 0, bytes.NewReader([]byte("test data")))
+	_, err := io.ReadAll(bp)
+	require.NoError(t, err)
+	fe := &FileEntry{
+		Base: backupData,
+		Name: "restored.txt",
+		Hash: bp.HashString(),
+	}
+	bm := builtinBackupManifest{
+		CompressionEngine: ExternalCompressor,
+	}
+
+	be := &BuiltinBackupEngine{}
+	err = be.restoreFile(t.Context(), params, bh, fe, bm, "0")
+
+	require.ErrorContains(t, err, "failed to close decompressor")
+	require.ErrorContains(t, err, "exit status 1")
+	assert.NotContains(t, err.Error(), "giving up")
+}
+
 // Helper function to create a test replication position.
 func testPosition() replication.Position {
 	return replication.Position{}

--- a/go/vt/mysqlctl/file_close_test.go
+++ b/go/vt/mysqlctl/file_close_test.go
@@ -688,7 +688,11 @@ func TestBackupFileCompressorCloseNotRetried(t *testing.T) {
 // external decompressor whose process exits with a failure, so that the
 // decompressor's Close fails. As with the compressor, a second Close cannot
 // change the outcome, so the close must run once and surface its own error
-// instead of going through closeWithRetry.
+// instead of going through closeWithRetry. The close also has to happen
+// before the restored file's hash is compared: the process can exit without
+// draining its input, so until it has been waited for, the source reader's
+// hash is still being written by the goroutine feeding the process and is
+// not the file's hash.
 func TestRestoreFileDecompressorCloseNotRetried(t *testing.T) {
 	if _, err := validateExternalCmd("false"); err != nil {
 		t.Skip("Command not available in this host:", err)
@@ -712,26 +716,70 @@ func TestRestoreFileDecompressorCloseNotRetried(t *testing.T) {
 		Logger: logutil.NewMemoryLogger(),
 		Stats:  backupstats.NoStats(),
 	}
-	// The hash covers the bytes read from the source, whether or not the
-	// external process consumed them.
-	bp := newBackupReader("test", 0, bytes.NewReader([]byte("test data")))
-	_, err := io.ReadAll(bp)
-	require.NoError(t, err)
+	// The expected hash is deliberately wrong: the decompressor's failure
+	// must be reported before the hash is compared, so the mismatch never
+	// shows up.
 	fe := &FileEntry{
 		Base: backupData,
 		Name: "restored.txt",
-		Hash: bp.HashString(),
+		Hash: "not the hash",
 	}
 	bm := builtinBackupManifest{
 		CompressionEngine: ExternalCompressor,
 	}
 
 	be := &BuiltinBackupEngine{}
-	err = be.restoreFile(t.Context(), params, bh, fe, bm, "0")
+	err := be.restoreFile(t.Context(), params, bh, fe, bm, "0")
 
 	require.ErrorContains(t, err, "failed to close decompressor")
 	require.ErrorContains(t, err, "exit status 1")
 	assert.NotContains(t, err.Error(), "giving up")
+	assert.NotContains(t, err.Error(), "hash mismatch")
+}
+
+// TestRestoreFileChunkDecompressorCloseNotRetried is the chunked-file
+// counterpart of TestRestoreFileDecompressorCloseNotRetried: a chunk's
+// decompressor is closed once, before the chunk's hash is compared, and its
+// own error comes back.
+func TestRestoreFileChunkDecompressorCloseNotRetried(t *testing.T) {
+	if _, err := validateExternalCmd("false"); err != nil {
+		t.Skip("Command not available in this host:", err)
+	}
+	tmpDir := t.TempDir()
+	destPath := path.Join(tmpDir, "restored.txt")
+	require.NoError(t, os.WriteFile(destPath, nil, 0o644))
+
+	oldCmd := ExternalDecompressorCmd
+	oldMaxRetries := maxFileCloseRetries
+	t.Cleanup(func() {
+		ExternalDecompressorCmd = oldCmd
+		maxFileCloseRetries = oldMaxRetries
+	})
+	ExternalDecompressorCmd = "false"
+	maxFileCloseRetries = 0
+
+	bh := newMockBackupHandle()
+	bh.readFileReturn = newMockReadOnlyCloser(0, nil)
+	params := RestoreParams{
+		Cnf:    &Mycnf{DataDir: tmpDir},
+		Logger: logutil.NewMemoryLogger(),
+		Stats:  backupstats.NoStats(),
+	}
+	chunk := &FileChunk{
+		StorageName: "0-0",
+		Hash:        "not the hash",
+	}
+	bm := builtinBackupManifest{
+		CompressionEngine: ExternalCompressor,
+	}
+
+	be := &BuiltinBackupEngine{}
+	err := be.restoreFileChunk(t.Context(), params, bh, chunk, bm, destPath)
+
+	require.ErrorContains(t, err, "failed to close decompressor")
+	require.ErrorContains(t, err, "exit status 1")
+	assert.NotContains(t, err.Error(), "giving up")
+	assert.NotContains(t, err.Error(), "hash mismatch")
 }
 
 // Helper function to create a test replication position.

--- a/go/vt/mysqlctl/file_close_test.go
+++ b/go/vt/mysqlctl/file_close_test.go
@@ -33,9 +33,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"vitess.io/vitess/go/ioutil"
 	"vitess.io/vitess/go/mysql/replication"
 	"vitess.io/vitess/go/vt/logutil"
 	"vitess.io/vitess/go/vt/mysqlctl/backupstats"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
 )
 
 // mockCloser is a mock implementation of io.Closer that can be configured
@@ -779,6 +781,97 @@ func TestRestoreFileChunkDecompressorCloseNotRetried(t *testing.T) {
 	require.ErrorContains(t, err, "failed to close decompressor")
 	require.ErrorContains(t, err, "exit status 1")
 	assert.NotContains(t, err.Error(), "giving up")
+	assert.NotContains(t, err.Error(), "hash mismatch")
+}
+
+// TestBackupFileCompressorCloseAbandonedIsFatal backs up a file through an
+// external compressor whose Close never returns: `sleep` neither exits nor
+// closes its stderr, so the compressor's Close blocks waiting for it and the
+// TimeoutCloser gives up. The abandoned Close may still be writing into this
+// attempt's buffer and destination, so the error must carry
+// FAILED_PRECONDITION to stop the caller from retrying the file, and not a
+// context code, which the dispatch would retry.
+func TestBackupFileCompressorCloseAbandonedIsFatal(t *testing.T) {
+	if _, err := validateExternalCmd("sleep"); err != nil {
+		t.Skip("Command not available in this host:", err)
+	}
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(path.Join(tmpDir, "source.txt"), []byte("test content"), 0o644))
+
+	oldCmd := ExternalCompressorCmd
+	oldTimeout := closeTimeout
+	t.Cleanup(func() {
+		ExternalCompressorCmd = oldCmd
+		closeTimeout = oldTimeout
+	})
+	ExternalCompressorCmd = "sleep 1000"
+	closeTimeout = 100 * time.Millisecond
+
+	bh := newMockBackupHandle()
+	bh.addFileReturn = newMockReadWriteCloser(0, nil)
+	params := BackupParams{
+		Cnf:         &Mycnf{DataDir: tmpDir},
+		Logger:      logutil.NewMemoryLogger(),
+		Stats:       backupstats.NoStats(),
+		Concurrency: 1,
+	}
+	fe := &FileEntry{
+		Base: backupData,
+		Name: "source.txt",
+	}
+
+	be := &BuiltinBackupEngine{}
+	err := be.backupFile(t.Context(), params, bh, fe, "0", -1)
+
+	require.ErrorContains(t, err, "failed to close compressor")
+	require.ErrorContains(t, err, ioutil.ErrCloseAbandoned.Error())
+	assert.True(t, hasErrorCode(err, vtrpcpb.Code_FAILED_PRECONDITION), "an abandoned compressor close must be fatal, got: %v", err)
+}
+
+// TestRestoreFileDecompressorCloseAbandonedRetries restores a file through
+// an external decompressor whose Close never returns: the shell closes its
+// stdout so the copy finishes, then replaces itself with a `sleep` that
+// keeps stderr open, so the decompressor's Close blocks and the
+// TimeoutCloser gives up. Unlike the compressor, a stale decompressor shares
+// nothing with the retry, so the error must come back without
+// FAILED_PRECONDITION and the caller's per-file retry gets its turn.
+func TestRestoreFileDecompressorCloseAbandonedRetries(t *testing.T) {
+	if _, err := validateExternalCmd("sh"); err != nil {
+		t.Skip("Command not available in this host:", err)
+	}
+	tmpDir := t.TempDir()
+
+	oldCmd := ExternalDecompressorCmd
+	oldTimeout := closeTimeout
+	t.Cleanup(func() {
+		ExternalDecompressorCmd = oldCmd
+		closeTimeout = oldTimeout
+	})
+	ExternalDecompressorCmd = "sh -c 'exec 1>&-; exec sleep 1000'"
+	closeTimeout = 100 * time.Millisecond
+
+	bh := newMockBackupHandle()
+	bh.readFileReturn = newMockReadOnlyCloser(0, nil)
+	params := RestoreParams{
+		Cnf:    &Mycnf{DataDir: tmpDir},
+		Logger: logutil.NewMemoryLogger(),
+		Stats:  backupstats.NoStats(),
+	}
+	fe := &FileEntry{
+		Base: backupData,
+		Name: "restored.txt",
+		Hash: "not the hash",
+	}
+	bm := builtinBackupManifest{
+		CompressionEngine: ExternalCompressor,
+	}
+
+	be := &BuiltinBackupEngine{}
+	err := be.restoreFile(t.Context(), params, bh, fe, bm, "0")
+
+	require.ErrorContains(t, err, "failed to close decompressor")
+	require.ErrorContains(t, err, ioutil.ErrCloseAbandoned.Error())
+	assert.False(t, hasErrorCode(err, vtrpcpb.Code_FAILED_PRECONDITION), "an abandoned decompressor close must stay retryable, got: %v", err)
 	assert.NotContains(t, err.Error(), "hash mismatch")
 }
 


### PR DESCRIPTION
## What's this?

Follows #20778, which landed first. Fixes #21027.

The builtin backup engine closes its compressor and decompressor through `closeWithRetry`, the loop written for backup storage file handles where a close can fail transiently on GCS and a retry can succeed. For a compressor or decompressor a retry can never change the outcome: a failed compressor close leaves the compressed stream broken, the builtin compressors return the same error on every later `Close`, and an external compressor's process has already exited. So every such failure ran all 20 attempts (about eight minutes of backoff), then replaced the real error with the loop's "giving up" message and a `FAILED_PRECONDITION` code that made the whole backup or restore fatal.

## How it works

The compressor and decompressor are now closed once, still through the existing `TimeoutCloser`. The retry loop stays in place for the source and destination file handles, which is what it was written for. The xtrabackup engine already closed its compressors once, so it is unchanged.

With that in place, the once-only `Close` that #20778 added to the lz4 compressor wrapper (to survive the retried close) has no caller left, so this PR removes it again along with its test. The wrapper goes back to only hiding `ReadFrom`, and its comment keeps the record that the lz4 writer must not be closed twice.

Two behavior changes on the error path, both intentional:

- The close error keeps its original text (for example the external command's exit status) instead of "failed to close the source file after 20 attempts, giving up".
- A failed compressor or decompressor close is no longer fatal for the whole backup or restore. It is joined into that file's error and the caller's per-file retry handles it like any other failure on that file, with a fresh compressor and destination file on the next attempt.

## A race on the restore side

The new restore test failed the race detector on its first CI run, and the race it found is a pre-existing one in `restoreFile` and `restoreFileChunk`, not something this PR introduced. This PR just added the first test that drives a restore through an external decompressor that fails.

Here is the shape of it. `restoreFile` wraps the backup storage reader in a `backupPipe`, whose `Read` feeds every byte it hands out into a CRC32 digest; that digest is what the hash check at the end compares against the manifest. For an external decompressor, `newExternalDecompressor` sets that `backupPipe` as the child process's `cmd.Stdin`. Because it is an `io.Reader` and not an `*os.File`, `os/exec` starts a goroutine of its own that copies from the `backupPipe` into the child's stdin pipe, and that goroutine only finishes when `cmd.Wait` is called, which happens in the decompressor's `Close`.

`restoreFile` did things in this order:

1. `io.Copy` the decompressor's stdout into the destination file, until the child closes its stdout.
2. Read the digest with `br.HashString()` and compare it to the manifest.
3. Close the decompressor from a deferred cleanup, which is where `cmd.Wait` runs.

So step 2 read the digest while the `os/exec` goroutine from step 1 could still be writing to it. The two never synchronize: the only thing connecting them is the kernel pipe into the child, which the Go memory model knows nothing about. The race detector's report is exactly that pair, `backupPipe.HashString` in the test goroutine against `backupPipe.Read` in `os/exec.(*Cmd).childStdin`'s `io.Copy`.

When does it bite? Whenever the child closes its stdout before it has drained its stdin. A decompressor that dies part-way through is the realistic case: `io.Copy` in step 1 returns as soon as stdout closes, the feeding goroutine is still pushing the rest of the file into a pipe nobody reads any more (it ends with `EPIPE`, which `os/exec` swallows), and the hash is compared against a digest that is somewhere between "nothing" and "the whole file" depending on scheduling. The test shows both ends of that range: on one run the digest covered the whole 9-byte input, on another nothing at all. A healthy decompressor reads all of stdin before it can finish writing stdout, so in practice the happy path always saw a complete digest, which is why nobody noticed. The builtin decompressors do not have the problem either: they read the source either in the calling goroutine or hand blocks over through channels, so the digest writes are ordered before `Read` returns.

What a user saw: a restore whose external decompressor failed reported `hash mismatch for <file>, got <partial crc> expected <crc>` first, with the decompressor's real error joined on afterwards, and the mismatch pointed at corrupt backup data that was not corrupt. It is not a memory-safety problem in practice, the digest is a single `uint32`, but it is a data race by the Go definition and a misleading error.

The fix is to move the close ahead of the hash check: both paths now call the decompressor's cleanup right after the copy and return its error before the hash is compared. Once `cmd.Wait` has returned, the feeding goroutine is done and the digest is final; and a decompressor that failed makes the hash irrelevant anyway. The cleanup returned by `createDecompressor` is guarded by a `sync.Once` so the deferred call stays in place for the early-return paths without closing twice. The backup side already had the right order: `backupFile` closes the compressor inside `createAndCopy` and reads the hash only after that returns.

## When the close does not return

`TimeoutCloser` runs the wrapped `Close` in a goroutine and, after `closeTimeout` (one minute) or when the context is canceled, returns without waiting for it. Until now it returned the bare context error, which a completed `Close` can return as well, so a caller could not tell "the close failed" from "the close is still running". It now returns `ioutil.ErrCloseAbandoned` wrapped together with the context error; `errors.Is` against the context errors keeps working for the xtrabackup engine, the other user of the type.

The builtin engine treats the two sides differently, on purpose:

- **Backup: an abandoned compressor `Close` is fatal** (`FAILED_PRECONDITION`, no per-file retry). The stale `Close` may still be flushing into this attempt's buffer and destination while `backupFile` closes them, and the retry would write the same destination name, so nothing under it can be trusted any more. That is the outcome the retry loop reached after its 20 attempts, in one minute instead of about nine.
- **Restore: an abandoned decompressor `Close` stays retryable.** A decompressor never writes the destination, the source it may still be reading belongs to this attempt and is closed by `restoreFile`, the retry opens a fresh one, and an external process is killed with the function's context. Nothing the retry uses is shared with the stale `Close`. This is a change from the old behavior, which went fatal after the 20 attempts; a full restore starting over because one file's close stalled once seemed the worse trade.

This is a classification of the abandoned state, not a removal of it: the concurrent access inside the failed attempt still happens, and a stuck external process lives until the function's context is canceled on return. #21051 tracks the cleaner fix, bounding the external command by stopping it instead of abandoning its `Close`, and dropping the timeout wrapper for the builtin compressors, which do not need it.

## Tests

`TestBackupFileCompressorCloseNotRetried`, `TestRestoreFileDecompressorCloseNotRetried` and `TestRestoreFileChunkDecompressorCloseNotRetried` drive the close through `backupFile`, `restoreFile` and `restoreFileChunk` with an external command that exits non-zero (`false`), and assert that the original error comes back untouched, without the retry loop's "giving up" text. The restore tests use a deliberately wrong expected hash and assert that no `hash mismatch` appears in the error: a hash comparison made before the close would show up there, so the ordering is pinned without depending on the race detector. All three fail on `main`.

`TestBackupFileCompressorCloseAbandonedIsFatal` and `TestRestoreFileDecompressorCloseAbandonedRetries` block the close with a real external command: `sleep` never exits and never closes its stderr, so the compressor's `Close` blocks waiting for it (the restore variant closes stdout first so the copy finishes). `closeTimeout` became a variable so they can run in a tenth of a second. Each asserts the error code for its side; the backup one fails without the classification. `TestTimeoutCloserAbandoned` in `go/ioutil` pins that the sentinel marks only a `Close` the wrapper stopped waiting for, never one that returned on its own with a context error. The package passes under `-race`.

## Related Issue(s)

Fixes #21027

Follow-up: #21051

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] Tests were added or are not required
- [x] Documentation was added or is not required

---
_Most of this was written by Claude Code - I just provided direction._




