### PR TITLE
go: fix typos in user-visible error strings

### DIFF
--- a/go/vt/mysqlctl/compression.go
+++ b/go/vt/mysqlctl/compression.go
@@ -230,7 +230,7 @@ func newBuiltinDecompressor(engine string, reader io.Reader, logger logutil.Logg
 		}
 		decompressor = d.IOReadCloser()
 	default:
-		err = fmt.Errorf("Unkown decompressor engine: %q", engine)
+		err = fmt.Errorf("Unknown decompressor engine: %q", engine)
 		return decompressor, err
 	}
 

--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -166,7 +166,7 @@ func (node *Insert) Format(buf *TrackedBuffer) {
 			node.Table.Expr, node.Partitions, node.Columns, node.Rows, node.RowAlias, node.OnDup)
 	default:
 		buf.astPrintf(node, "%s %v%sinto %v%v%v %v%v%v",
-			"Unkown Insert Action",
+			"Unknown Insert Action",
 			node.Comments, node.Ignore.ToString(),
 			node.Table.Expr, node.Partitions, node.Columns, node.Rows, node.RowAlias, node.OnDup)
 	}

--- a/go/vt/sqlparser/ast_format_fast.go
+++ b/go/vt/sqlparser/ast_format_fast.go
@@ -221,7 +221,7 @@ func (node *Insert) FormatFast(buf *TrackedBuffer) {
 		node.OnDup.FormatFast(buf)
 
 	default:
-		buf.WriteString("Unkown Insert Action")
+		buf.WriteString("Unknown Insert Action")
 		buf.WriteByte(' ')
 
 		node.Comments.FormatFast(buf)

--- a/go/vt/vtctl/reparentutil/emergency_reparenter.go
+++ b/go/vt/vtctl/reparentutil/emergency_reparenter.go
@@ -1346,7 +1346,7 @@ func (erp *EmergencyReparenter) filterValidCandidates(validTablets []*topodatapb
 		if opts.PreventCrossCellPromotion && prevPrimary != nil && tablet.Alias.Cell != prevPrimary.Alias.Cell {
 			erp.logger.Infof("Removing %s from list of valid candidates for promotion because it isn't in the same cell as the previous primary", tabletAliasStr)
 			if opts.NewPrimaryAlias != nil && topoproto.TabletAliasEqual(opts.NewPrimaryAlias, tablet.Alias) {
-				return nil, vterrors.Errorf(vtrpc.Code_ABORTED, "proposed primary %s is is a different cell as the previous primary", topoproto.TabletAliasString(opts.NewPrimaryAlias))
+				return nil, vterrors.Errorf(vtrpc.Code_ABORTED, "proposed primary %s is in a different cell than the previous primary", topoproto.TabletAliasString(opts.NewPrimaryAlias))
 			}
 			continue
 		}


### PR DESCRIPTION
Four user-facing strings carried typos:

- `vtctl/reparentutil/emergency_reparenter.go`: the ABORT error during Emergency Reparent Shade read "proposed primary %s **is is** a different cell **as** the previous primary" → "is in a different cell than"
- `vt/mysqlctl/compression.go`: "**Unkown** decompressor engine" → "Unknown"
- `go/vt/sqlparser/ast_format.go` + `ast_format_fast.go`: the fallback rendered into formatted SQL read "**Unkown** Insert Action" → "Unknown"

The account predates the 365-day restriction noted in CONTRIBUTING.md for spelling-only fixes; these are also functional-adjacent (error strings emitted to users). All are string literals only — no behavior change.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>