### PR TITLE
go: fix comment/log wording typos

### DIFF
--- a/go/cmd/vtctldclient/cli/tablets.go
+++ b/go/cmd/vtctldclient/cli/tablets.go
@@ -42,7 +42,7 @@ func TabletAliasesFromPosArgs(args []string) ([]*topodatapb.TabletAlias, error) 
 	return aliases, nil
 }
 
-// TabletTagsFromPosArgs takes a list of positional (non-flag) arguements and
+// TabletTagsFromPosArgs takes a list of positional (non-flag) arguments and
 // converts them to a map of tablet tags.
 func TabletTagsFromPosArgs(args []string) (map[string]string, error) {
 	if len(args) == 0 {

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -581,7 +581,7 @@ func ExecuteBackupInitSQL(ctx context.Context, params *BackupParams) error {
 		}
 		select {
 		case <-initCtx.Done():
-			params.Logger.Infof("Canceling init SQL work due to hitting the configured timeout of %v or the the backup itself having been canceled", initTimeout)
+			params.Logger.Infof("Canceling init SQL work due to hitting the configured timeout of %v or the backup itself having been canceled", initTimeout)
 		default:
 			params.Logger.Infof("Failed to execute init SQL queries %q: %v", queriesCSV, err)
 		}


### PR DESCRIPTION
- `go/cmd/vtctldclient/cli/tablets.go`: doc comment "**arguements**" → "arguments"
- `go/vt/mysqlctl/backup.go`: log string "or **the the** backup itself" → "or the backup itself"

The account predates the 365-day restriction noted in CONTRIBUTING.md for spelling-only fixes.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>