### PR TITLE
test: fix 'arguement' typos in endtoend cluster helper comments

### DIFF
--- a/go/test/endtoend/cluster/vtadmin_process.go
+++ b/go/test/endtoend/cluster/vtadmin_process.go
@@ -52,7 +52,7 @@ type VtAdminProcess struct {
 	exit           chan error
 }
 
-// Setup starts orc process with required arguements
+// Setup starts orc process with required arguments
 func (vp *VtAdminProcess) Setup() (err error) {
 	// create the configuration file
 	timeNow := time.Now().UnixNano()

--- a/go/test/endtoend/cluster/vtbackup_process.go
+++ b/go/test/endtoend/cluster/vtbackup_process.go
@@ -54,7 +54,7 @@ type VtbackupProcess struct {
 	exit chan error
 }
 
-// Setup starts vtbackup process with required arguements
+// Setup starts vtbackup process with required arguments
 func (vtbackup *VtbackupProcess) Setup() (err error) {
 	flags := map[string]string{
 		"--topo-implementation":        vtbackup.TopoImplementation,


### PR DESCRIPTION
The endtoend cluster helpers (`vtadmin_process.go`, `vtbackup_process.go`) spell "arguments" as "arguements" in their flag comments.

The account predates the 365-day restriction in CONTRIBUTING.md for spelling-only fixes.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>