### PR TITLE
ci: run the cluster end-to-end shards on arm64 as well

### DIFF
--- a/.github/actions/setup-minio/action.yml
+++ b/.github/actions/setup-minio/action.yml
@@ -3,26 +3,46 @@ description: 'Set up Minio for use in GitHub Actions workflows'
 runs:
   using: "composite"
   steps:
+    - name: Pick the minio package for this architecture
+      id: minio-package
+      shell: bash -e {0}
+      run: |
+        ARCH="$(dpkg --print-architecture)"
+        case "$ARCH" in
+          # checksum - source: https://dl.min.io/community/server/minio/release/linux-amd64/minio_20250907161309.0.0_amd64.deb.sha256sum
+          amd64) SHA256="eeda08f699f6592d1b868ac8bda864ae2cacdb5ee1b888663366e8c8ff566249" ;;
+          # checksum - source: https://dl.min.io/community/server/minio/release/linux-arm64/minio_20250907161309.0.0_arm64.deb.sha256sum
+          arm64) SHA256="f9466ed832ac4926c8870b3b8378d77861a87b41529fecae7789b9bc54acd78b" ;;
+          *) echo "Unsupported architecture for minio: $ARCH"; exit 1 ;;
+        esac
+        echo "package=minio_20250907161309.0.0_${ARCH}.deb" >> "$GITHUB_OUTPUT"
+        echo "url=https://dl.min.io/community/server/minio/release/linux-${ARCH}/minio_20250907161309.0.0_${ARCH}.deb" >> "$GITHUB_OUTPUT"
+        echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
+
     - name: Cache minio package
       id: cache-minio
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
-        path: minio_20250907161309.0.0_amd64.deb
-        key: minio_20250907161309.0.0_amd64.deb
+        path: ${{ steps.minio-package.outputs.package }}
+        key: ${{ steps.minio-package.outputs.package }}
 
     - name: Get Minio (on cache miss)
       if: steps.cache-minio.outputs.cache-hit != 'true'
       shell: bash -e {0}
+      env:
+        PACKAGE: ${{ steps.minio-package.outputs.package }}
+        URL: ${{ steps.minio-package.outputs.url }}
+        SHA256: ${{ steps.minio-package.outputs.sha256 }}
       run: |
-        curl -sLo minio_20250907161309.0.0_amd64.deb.tmp https://dl.min.io/community/server/minio/release/linux-amd64/minio_20250907161309.0.0_amd64.deb
-
-        # checksum - source: https://dl.min.io/community/server/minio/release/linux-amd64/minio_20250907161309.0.0_amd64.deb.sha256sum
-        sha256sum minio_20250907161309.0.0_amd64.deb.tmp | grep -q ^eeda08f699f6592d1b868ac8bda864ae2cacdb5ee1b888663366e8c8ff566249
-        [[ "$?" -eq 0 ]] && mv minio_20250907161309.0.0_amd64.deb.tmp minio_20250907161309.0.0_amd64.deb
+        curl -sLo "${PACKAGE}.tmp" "$URL"
+        echo "${SHA256}  ${PACKAGE}.tmp" | sha256sum --check
+        mv "${PACKAGE}.tmp" "$PACKAGE"
 
     - name: Install Minio package
       shell: bash -e {0}
+      env:
+        PACKAGE: ${{ steps.minio-package.outputs.package }}
       run: |
-        sudo dpkg -i minio_20250907161309.0.0_amd64.deb
+        sudo dpkg -i "$PACKAGE"
         sudo systemctl disable minio
         sudo systemctl stop minio

--- a/.github/actions/setup-mysql/action.yml
+++ b/.github/actions/setup-mysql/action.yml
@@ -50,15 +50,52 @@ runs:
         sudo rm -rf /var/lib/mysql
         sudo rm -rf /etc/mysql
 
+        # Set when MySQL is unpacked from a tarball instead of installed from a
+        # package: there is then no mysql service or apparmor profile to disable.
+        MYSQL_FROM_TARBALL=""
+
         if [[ "$(dpkg --print-architecture)" == "arm64" ]]; then
-          # Oracle's apt repo only publishes amd64 packages for Ubuntu, so on
-          # arm64 we install MySQL from the Ubuntu archive instead, which only
-          # ships MySQL 8.0.
-          if [[ "$FLAVOR" != "mysql-8.0" ]]; then
+          # Oracle's apt repo only publishes amd64 packages for Ubuntu. On arm64
+          # we install MySQL 8.0 from the Ubuntu archive (the only version it
+          # ships on noble) and MySQL 8.4 from Oracle's generic Linux aarch64
+          # tarball.
+          if [[ "$FLAVOR" == "mysql-8.0" ]]; then
+            sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
+          elif [[ "$FLAVOR" == "mysql-8.4" ]]; then
+            MYSQL_FROM_TARBALL="1"
+            MYSQL_TARBALL="mysql-8.4.11-linux-glibc2.28-aarch64.tar.xz"
+            MYSQL_TARBALL_SHA256="04b2f9791d314167a9eb83abcb476f45a7cd9e4aa88fa7a638cba40d1bc2a109"
+
+            # The tarball's mysqld links against libaio.so.1 and libnuma.so.1,
+            # and its client against libncurses.so.6. noble's libaio1t64 no
+            # longer provides libaio.so.1 (see the libaio1 note in the amd64
+            # branch below), so we install the older libaio1 package from the
+            # Ubuntu ports archive.
+            sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y libnuma1 libncurses6 xz-utils
+            download_with_ip_failover \
+              https://ports.ubuntu.com/pool/main/liba/libaio/libaio1_0.3.112-13build1_arm64.deb \
+              libaio1_0.3.112-13build1_arm64.deb || {
+              echo "Failed to download libaio1. The pinned version may have been superseded and removed from ports.ubuntu.com; check https://ports.ubuntu.com/pool/main/liba/libaio/ for the current version."
+              exit 1
+            }
+            echo "1bcb0d9c08aa35298741b1c68904844e9b71ebf64f15b3e05e6ec6f3fa01d93b  libaio1_0.3.112-13build1_arm64.deb" | sha256sum --check
+            sudo dpkg -i libaio1_0.3.112-13build1_arm64.deb
+            rm libaio1_0.3.112-13build1_arm64.deb
+
+            # dev.mysql.com/get redirects to cdn.mysql.com.
+            curl -fsSL --retry 3 --retry-delay 5 -o "$MYSQL_TARBALL" "https://dev.mysql.com/get/Downloads/MySQL-8.4/${MYSQL_TARBALL}"
+            echo "${MYSQL_TARBALL_SHA256}  ${MYSQL_TARBALL}" | sha256sum --check
+            sudo tar -xJf "$MYSQL_TARBALL" -C /usr/local
+            rm "$MYSQL_TARBALL"
+            sudo ln -sfn "/usr/local/${MYSQL_TARBALL%.tar.xz}" /usr/local/mysql
+
+            # Later steps, and the Vitess binaries they start, find mysqld and
+            # the client tools through PATH.
+            echo "/usr/local/mysql/bin" >> "$GITHUB_PATH"
+          else
             echo "Unsupported MySQL flavor on arm64: $FLAVOR"
             exit 1
           fi
-          sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-server mysql-client
         else
           # We have to install this old version of libaio1. See also:
           # https://bugs.launchpad.net/ubuntu/+source/libaio/+bug/2067501
@@ -114,7 +151,9 @@ runs:
           fi
         fi
 
-        sudo service mysql stop
-        sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
-        sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
+        if [[ -z "$MYSQL_FROM_TARBALL" ]]; then
+          sudo service mysql stop
+          sudo bash -c "echo '/usr/sbin/mysqld { }' > /etc/apparmor.d/usr.sbin.mysqld" # https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1806263
+          sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld || echo "could not remove mysqld profile"
+        fi

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -194,11 +194,13 @@ jobs:
       - name: Get dependencies
         if: steps.changes.outputs.end_to_end == 'true'
         timeout-minutes: 10
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
           # Install mysql-shell for non-XtraBackup shards. Oracle's apt repo
           # has no arm64 packages, and the one shard that needs mysql-shell
           # is excluded from the arm64 matrix.
-          if [[ "${{ contains(matrix.needs, 'xtrabackup') }}" != "true" && "${{ matrix.arch }}" != "arm64" ]]; then
+          if [[ "${{ contains(matrix.needs, 'xtrabackup') }}" != "true" && "$ARCH" != "arm64" ]]; then
             sudo apt-get -qq install -y mysql-shell
           fi
 

--- a/.github/workflows/cluster_endtoend.yml
+++ b/.github/workflows/cluster_endtoend.yml
@@ -51,8 +51,20 @@ jobs:
             "tabletmanager_disk_health_monitor"
           ]'
 
-          # Build matrix
-          matrix=$(jq -c -s --argjson exclude "$EXCLUDE_SHARDS" '
+          # Shards additionally excluded on arm64, because a dependency has no
+          # arm64 packages yet:
+          #   - Percona Server / XtraBackup: backup_pitr_xtrabackup, xb_backup, xb_recovery
+          #   - mysql-shell (Oracle apt repo only): backup_pitr_mysqlshell
+          ARM64_EXCLUDE_SHARDS='[
+            "backup_pitr_xtrabackup",
+            "xb_backup",
+            "xb_recovery",
+            "backup_pitr_mysqlshell"
+          ]'
+
+          # Build matrix: every shard on amd64, and every shard not excluded
+          # above on arm64.
+          matrix=$(jq -c -s --argjson exclude "$EXCLUDE_SHARDS" --argjson arm64_exclude "$ARM64_EXCLUDE_SHARDS" '
             map(.Tests) | add | to_entries
             | group_by(.value.Shard)
             | map(select(.[0].value.Shard as $s | ($s != null) and ($exclude | index($s) | not)))
@@ -61,6 +73,7 @@ jobs:
                 needs: ([.[].value.Needs // []] | add | unique // []),
                 buildTag: ([.[].value.BuildTag // null] | map(select(. != null)) | first // "")
               })
+            | map(. + {arch: "amd64"}) + map(select(.shard as $s | $arm64_exclude | index($s) | not) | . + {arch: "arm64"})
           ' test/config.json test/config_partial_keyspace.json)
 
           echo "matrix={\"include\":$matrix}" >> $GITHUB_OUTPUT
@@ -73,8 +86,8 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
 
-    name: Run endtoend tests on Cluster (${{ matrix.shard }})
-    runs-on: ${{ contains(matrix.needs, 'larger-runner') && github.repository == 'vitessio/vitess' && 'oracle-vm-16cpu-64gb-x86-64' || 'ubuntu-24.04' }}
+    name: Run endtoend tests on Cluster (${{ matrix.shard }}${{ matrix.arch == 'arm64' && ', arm64' || '' }})
+    runs-on: ${{ matrix.arch == 'arm64' && (contains(matrix.needs, 'larger-runner') && github.repository == 'vitessio/vitess' && 'oracle-vm-16cpu-64gb-arm64' || 'ubuntu-24.04-arm') || (contains(matrix.needs, 'larger-runner') && github.repository == 'vitessio/vitess' && 'oracle-vm-16cpu-64gb-x86-64' || 'ubuntu-24.04') }}
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -139,6 +152,14 @@ jobs:
         if: steps.changes.outputs.end_to_end == 'true'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
 
+      - name: Avoid the Oracle Cloud apt mirror
+        if: steps.changes.outputs.end_to_end == 'true' && matrix.arch == 'arm64'
+        run: |
+          # The Oracle Cloud regional apt mirror (e.g. us-sanjose-1-ad-1.clouds.ports.ubuntu.com)
+          # is extremely slow; point apt at the default Ubuntu ports archive instead.
+          sudo grep -rl '\.clouds\.ports\.ubuntu\.com' /etc/apt --include='*.list' --include='*.sources' \
+            | xargs -r sudo sed -i 's|https\?://[^/ ]*\.clouds\.ports\.ubuntu\.com|http://ports.ubuntu.com|g'
+
       - name: Tune the OS
         if: steps.changes.outputs.end_to_end == 'true'
         timeout-minutes: 5
@@ -174,8 +195,10 @@ jobs:
         if: steps.changes.outputs.end_to_end == 'true'
         timeout-minutes: 10
         run: |
-          # Install mysql-shell for non-XtraBackup shards
-          if [[ "${{ contains(matrix.needs, 'xtrabackup') }}" != "true" ]]; then
+          # Install mysql-shell for non-XtraBackup shards. Oracle's apt repo
+          # has no arm64 packages, and the one shard that needs mysql-shell
+          # is excluded from the arm64 matrix.
+          if [[ "${{ contains(matrix.needs, 'xtrabackup') }}" != "true" && "${{ matrix.arch }}" != "arm64" ]]; then
             sudo apt-get -qq install -y mysql-shell
           fi
 

--- a/go/test/endtoend/vault/vault_download_test.go
+++ b/go/test/endtoend/vault/vault_download_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vault
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVaultRelease(t *testing.T) {
+	amd64, err := vaultRelease("linux", "amd64")
+	require.NoError(t, err)
+	assert.Equal(t, "https://releases.hashicorp.com/vault/1.6.1/vault_1.6.1_linux_amd64.zip", amd64.url)
+	assert.Equal(t, "75cd2b8c5527577c0da1105e11fba3c31f4112514a910c4f7ec527c9a8bf42d1", amd64.sha256)
+
+	arm64, err := vaultRelease("linux", "arm64")
+	require.NoError(t, err)
+	assert.Equal(t, "https://releases.hashicorp.com/vault/1.6.1/vault_1.6.1_linux_arm64.zip", arm64.url)
+	assert.Equal(t, "09e9fc0a69350d49a5db90c51b19a2a63b1da060eeeed700109fb43e544ba947", arm64.sha256)
+
+	_, err = vaultRelease("linux", "riscv64")
+	require.ErrorContains(t, err, "linux/riscv64")
+}

--- a/go/test/endtoend/vault/vault_server.go
+++ b/go/test/endtoend/vault/vault_server.go
@@ -17,13 +17,17 @@ limitations under the License.
 package vault
 
 import (
+	"archive/zip"
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
 	"path"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -34,8 +38,7 @@ import (
 
 const (
 	vaultExecutableName = "vault"
-	vaultDownloadSource = "https://vitess-operator.storage.googleapis.com/install/vault"
-	vaultDownloadSize   = 132738840
+	vaultVersion        = "1.6.1"
 	vaultDirName        = "vault"
 	vaultConfigFileName = "vault.hcl"
 	vaultCertFileName   = "vault-cert.pem"
@@ -43,6 +46,33 @@ const (
 	vaultKeyFileName    = "vault-key.pem"
 	vaultSetupScript    = "vault-setup.sh"
 )
+
+// vaultReleaseChecksums holds the sha256 of each Vault release zip we can run,
+// keyed by GOOS/GOARCH, taken from
+// https://releases.hashicorp.com/vault/1.6.1/vault_1.6.1_SHA256SUMS
+var vaultReleaseChecksums = map[string]string{
+	"linux/amd64": "75cd2b8c5527577c0da1105e11fba3c31f4112514a910c4f7ec527c9a8bf42d1",
+	"linux/arm64": "09e9fc0a69350d49a5db90c51b19a2a63b1da060eeeed700109fb43e544ba947",
+}
+
+// vaultReleaseArtifact is the Vault release zip for one platform.
+type vaultReleaseArtifact struct {
+	url    string
+	sha256 string
+}
+
+// vaultRelease returns the Vault release zip for the given platform.
+func vaultRelease(goos, goarch string) (vaultReleaseArtifact, error) {
+	platform := fmt.Sprintf("%s/%s", goos, goarch)
+	sum, ok := vaultReleaseChecksums[platform]
+	if !ok {
+		return vaultReleaseArtifact{}, fmt.Errorf("no Vault %s release known for %s", vaultVersion, platform)
+	}
+	return vaultReleaseArtifact{
+		url:    fmt.Sprintf("https://releases.hashicorp.com/vault/%s/vault_%s_%s_%s.zip", vaultVersion, vaultVersion, goos, goarch),
+		sha256: sum,
+	}, nil
+}
 
 // Server : Basic parameters for the running the Vault server
 type Server struct {
@@ -60,10 +90,15 @@ type Server struct {
 func (vs *Server) start() error {
 	// Download and unpack vault binary
 	vs.execPath = path.Join(os.Getenv("EXTRA_BIN"), vaultExecutableName)
-	fileStat, err := os.Stat(vs.execPath)
-	if err != nil || fileStat.Size() != vaultDownloadSize {
-		log.Warn(fmt.Sprintf("Downloading Vault binary to: %v", vs.execPath))
-		err := downloadExecFile(vs.execPath, vaultDownloadSource)
+	_, err := os.Stat(vs.execPath)
+	if err != nil {
+		release, err := vaultRelease(runtime.GOOS, runtime.GOARCH)
+		if err != nil {
+			log.Error(fmt.Sprint(err))
+			return err
+		}
+		log.Warn(fmt.Sprintf("Downloading Vault binary from %s to: %v", release.url, vs.execPath))
+		err = downloadVault(vs.execPath, release)
 		if err != nil {
 			log.Error(fmt.Sprint(err))
 			return err
@@ -146,24 +181,64 @@ func (vs *Server) stop() error {
 	}
 }
 
-// Download file from url to path; making it executable
-func downloadExecFile(path string, url string) error {
-	resp, err := http.Get(url)
+// downloadVault downloads the Vault release zip, verifies its checksum and
+// extracts the executable to execPath. The executable only appears at execPath
+// once it is complete, so a partial download is never mistaken for a binary.
+func downloadVault(execPath string, release vaultReleaseArtifact) error {
+	resp, err := http.Get(release.url)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("downloading %s: unexpected status %s", release.url, resp.Status)
+	}
 
-	err = os.WriteFile(path, []byte(""), 0o700)
+	dir := path.Dir(execPath)
+	zipFile, err := os.CreateTemp(dir, vaultExecutableName+"-*.zip")
 	if err != nil {
 		return err
 	}
-	out, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
+	defer os.Remove(zipFile.Name())
+	hash := sha256.New()
+	_, err = io.Copy(io.MultiWriter(zipFile, hash), resp.Body)
+	zipFile.Close()
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	if got := hex.EncodeToString(hash.Sum(nil)); got != release.sha256 {
+		return fmt.Errorf("checksum mismatch for %s: got %s, want %s", release.url, got, release.sha256)
+	}
 
-	_, err = io.Copy(out, resp.Body)
-	return err
+	zipReader, err := zip.OpenReader(zipFile.Name())
+	if err != nil {
+		return err
+	}
+	defer zipReader.Close()
+	for _, file := range zipReader.File {
+		if file.Name != vaultExecutableName {
+			continue
+		}
+		in, err := file.Open()
+		if err != nil {
+			return err
+		}
+		defer in.Close()
+		out, err := os.CreateTemp(dir, vaultExecutableName+"-*")
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(out, in)
+		out.Close()
+		if err != nil {
+			os.Remove(out.Name())
+			return err
+		}
+		if err := os.Chmod(out.Name(), 0o700); err != nil {
+			os.Remove(out.Name())
+			return err
+		}
+		return os.Rename(out.Name(), execPath)
+	}
+	return fmt.Errorf("%s does not contain a %s executable", release.url, vaultExecutableName)
 }

--- a/go/test/endtoend/vreplication/cluster_test.go
+++ b/go/test/endtoend/vreplication/cluster_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vreplication
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -226,39 +227,70 @@ func getDBTypeVersionInUse() (string, error) {
 	return dbTypeMajorVersion, nil
 }
 
-// downloadDBTypeVersion downloads a recent major version release build for the specified
-// DB type.
+// dbArtifact is a prebuilt database release the tests can download.
+type dbArtifact struct {
+	url  string
+	file string
+}
+
+// errNoDBTypeVersionArtifact is wrapped by dbTypeVersionArtifact when the
+// requested database version exists but has no prebuilt release for the
+// platform the tests run on, so callers can skip instead of fail.
+var errNoDBTypeVersionArtifact = errors.New("no prebuilt database release")
+
+// dbTypeVersionArtifact returns the prebuilt release of the given database type
+// and major version for the given platform.
+func dbTypeVersionArtifact(dbType, majorVersion, goos, goarch string) (dbArtifact, error) {
+	dbType = strings.ToLower(dbType)
+	dbTypeMajorVersion := fmt.Sprintf("%s-%s", dbType, majorVersion)
+	platform := fmt.Sprintf("%s/%s", goos, goarch)
+	noArtifact := fmt.Errorf("%w of %s for %s", errNoDBTypeVersionArtifact, dbTypeMajorVersion, platform)
+
+	knownVersion := (dbType == "mysql" && (majorVersion == "5.7" || majorVersion == "8.0")) ||
+		(dbType == "mariadb" && majorVersion == "10.10")
+	if !knownVersion {
+		return dbArtifact{}, fmt.Errorf("invalid/unsupported major version: %s for database: %s", majorVersion, dbType)
+	}
+	if goos != "linux" {
+		return dbArtifact{}, noArtifact
+	}
+
+	var url, file string
+	switch {
+	case dbType == "mysql" && majorVersion == "5.7" && goarch == "amd64":
+		file = "mysql-5.7.37-linux-glibc2.12-x86_64.tar.gz"
+		url = "https://dev.mysql.com/get/Downloads/MySQL-5.7/" + file
+	case dbType == "mysql" && majorVersion == "8.0" && goarch == "amd64":
+		file = "mysql-8.0.28-linux-glibc2.17-x86_64-minimal.tar.xz"
+		url = "https://dev.mysql.com/get/Downloads/MySQL-8.0/" + file
+	case dbType == "mysql" && majorVersion == "8.0" && goarch == "arm64":
+		// Oracle publishes neither a minimal build nor 8.0.28 for aarch64, so
+		// arm64 uses the current 8.0 release's full tarball.
+		file = "mysql-8.0.46-linux-glibc2.28-aarch64.tar.xz"
+		url = "https://dev.mysql.com/get/Downloads/MySQL-8.0/" + file
+	case dbType == "mariadb" && majorVersion == "10.10" && goarch == "amd64":
+		file = "mariadb-10.10.3-linux-systemd-x86_64.tar.gz"
+		url = "https://github.com/vitessio/vitess-resources/releases/download/v5.0/" + file
+	default:
+		// MySQL 5.7 never shipped a Linux aarch64 build, and neither the
+		// vitess-resources mirror nor MariaDB publish an aarch64 10.10 tarball.
+		return dbArtifact{}, noArtifact
+	}
+	return dbArtifact{url: url, file: file}, nil
+}
+
+// downloadDBTypeVersion downloads a prebuilt database release.
 // If the file already exists, it will not download it again.
 // The artifact will be downloaded and extracted in the specified path. So e.g. if you
-// pass /tmp as the path and 5.7 as the majorVersion, mysqld will be installed in:
-// /tmp/mysql-5.7/bin/mysqld
-// You should then call setVtMySQLRoot() and setDBFlavor() to ensure that this new
+// specify path as /tmp/mysql-8.0 then the resulting mysqld binary would be
+// /tmp/mysql-8.0/bin/mysqld. You can then set VT_MYSQL_ROOT to /tmp/mysql-8.0 and that
 // binary is used by mysqlctl along with the correct flavor specific config file.
-func downloadDBTypeVersion(dbType string, majorVersion string, path string) error {
+func downloadDBTypeVersion(artifact dbArtifact, path string) error {
 	client := http.Client{
 		Timeout: 10 * time.Minute,
 	}
-	var url, file, versionFile string
-	dbType = strings.ToLower(dbType)
-
-	// This currently only supports x86_64 linux
-	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
-		return fmt.Errorf("downloadDBTypeVersion() only supports x86_64 linux, current test environment is %s %s", runtime.GOARCH, runtime.GOOS)
-	}
-
-	if dbType == "mysql" && majorVersion == "5.7" {
-		versionFile = "mysql-5.7.37-linux-glibc2.12-x86_64.tar.gz"
-		url = "https://dev.mysql.com/get/Downloads/MySQL-5.7/" + versionFile
-	} else if dbType == "mysql" && majorVersion == "8.0" {
-		versionFile = "mysql-8.0.28-linux-glibc2.17-x86_64-minimal.tar.xz"
-		url = "https://dev.mysql.com/get/Downloads/MySQL-8.0/" + versionFile
-	} else if dbType == "mariadb" && majorVersion == "10.10" {
-		versionFile = "mariadb-10.10.3-linux-systemd-x86_64.tar.gz"
-		url = "https://github.com/vitessio/vitess-resources/releases/download/v5.0/" + versionFile
-	} else {
-		return fmt.Errorf("invalid/unsupported major version: %s for database: %s", majorVersion, dbType)
-	}
-	file = fmt.Sprintf("%s/%s", path, versionFile)
+	url := artifact.url
+	file := fmt.Sprintf("%s/%s", path, artifact.file)
 	// Let's not download the file again if we already have it
 	if _, err := os.Stat(file); err == nil {
 		return nil
@@ -949,13 +981,18 @@ func setupDBTypeVersion(t *testing.T, value string) func() {
 		t.Logf("Requsted database version %s is already installed, doing nothing.", dbTypeMajorVersion)
 		return func() {}
 	}
+	artifact, err := dbTypeVersionArtifact(dbType, majorVersion, runtime.GOOS, runtime.GOARCH)
+	if errors.Is(err, errNoDBTypeVersionArtifact) {
+		t.Skipf("Skipping: %v", err)
+	}
+	require.NoError(t, err)
 	path := "/tmp/" + dbTypeMajorVersion
 	// Set the root path and create it if needed
 	if err := setVtMySQLRoot(path); err != nil {
 		require.FailNowf(t, "Could not set VT_MYSQL_ROOT", "Could not set VT_MYSQL_ROOT to %s, error: %v", path, err)
 	}
 	// Download and extract the version artifact if needed
-	if err := downloadDBTypeVersion(dbType, majorVersion, path); err != nil {
+	if err := downloadDBTypeVersion(artifact, path); err != nil {
 		require.FailNowf(t, "Could not download", "Could not download %s, error: %v", majorVersion, err)
 	}
 	return func() {

--- a/go/test/endtoend/vreplication/dbversion_artifact_test.go
+++ b/go/test/endtoend/vreplication/dbversion_artifact_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vreplication
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDBTypeVersionArtifact(t *testing.T) {
+	t.Run("mysql 8.0 has a build for both architectures", func(t *testing.T) {
+		amd64, err := dbTypeVersionArtifact("mysql", "8.0", "linux", "amd64")
+		require.NoError(t, err)
+		assert.Equal(t, "mysql-8.0.28-linux-glibc2.17-x86_64-minimal.tar.xz", amd64.file)
+		assert.Equal(t, "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.28-linux-glibc2.17-x86_64-minimal.tar.xz", amd64.url)
+
+		arm64, err := dbTypeVersionArtifact("mysql", "8.0", "linux", "arm64")
+		require.NoError(t, err)
+		assert.Equal(t, "mysql-8.0.46-linux-glibc2.28-aarch64.tar.xz", arm64.file)
+		assert.Equal(t, "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.46-linux-glibc2.28-aarch64.tar.xz", arm64.url)
+	})
+
+	t.Run("mysql 5.7 and mariadb 10.10 only exist for amd64", func(t *testing.T) {
+		for _, tc := range []struct{ dbType, major string }{
+			{"mysql", "5.7"},
+			{"mariadb", "10.10"},
+		} {
+			_, err := dbTypeVersionArtifact(tc.dbType, tc.major, "linux", "amd64")
+			require.NoError(t, err, "%s-%s on amd64", tc.dbType, tc.major)
+
+			_, err = dbTypeVersionArtifact(tc.dbType, tc.major, "linux", "arm64")
+			require.ErrorIs(t, err, errNoDBTypeVersionArtifact, "%s-%s on arm64", tc.dbType, tc.major)
+			require.ErrorContains(t, err, tc.dbType+"-"+tc.major)
+			require.ErrorContains(t, err, "linux/arm64")
+		}
+	})
+
+	t.Run("unsupported OS is not a version we can skip over", func(t *testing.T) {
+		_, err := dbTypeVersionArtifact("mysql", "8.0", "darwin", "arm64")
+		require.ErrorIs(t, err, errNoDBTypeVersionArtifact)
+	})
+
+	t.Run("unknown version is an error, not a skip", func(t *testing.T) {
+		_, err := dbTypeVersionArtifact("mysql", "9.9", "linux", "amd64")
+		require.Error(t, err)
+		require.NotErrorIs(t, err, errNoDBTypeVersionArtifact)
+		require.ErrorContains(t, err, "unsupported major version")
+	})
+}

--- a/test/config.json
+++ b/test/config.json
@@ -2256,6 +2256,25 @@
         "binlog-compression"
       ]
     },
+    "vreplication_db_type_version_artifact": {
+      "File": "unused.go",
+      "Packages": [
+        "vitess.io/vitess/go/test/endtoend/vreplication"
+      ],
+      "Args": [
+        "-run",
+        "TestDBTypeVersionArtifact"
+      ],
+      "Command": [],
+      "Manual": false,
+      "Shard": "vreplication_basic",
+      "Tags": [],
+      "Needs": [
+        "larger-runner",
+        "limit-resources",
+        "binlog-compression"
+      ]
+    },
     "multi_vstreams_keyspace_reshard": {
       "File": "unused.go",
       "Packages": [


### PR DESCRIPTION
## Description

A trial of running the cluster end-to-end shards on arm64, next to the existing amd64 runs. Opened as a draft to see how the matrix behaves on the actual runners.

- `cluster_endtoend.yml` gets an `arch` matrix dimension. amd64 jobs keep their names; arm64 jobs get a `, arm64` suffix and run on `ubuntu-24.04-arm`, or on `oracle-vm-16cpu-64gb-arm64` for the larger-runner shards.
- Oracle publishes no arm64 Debian packages, and Ubuntu 24.04 only ships MySQL 8.0, so on arm64 the `setup-mysql` action installs MySQL 8.4 from Oracle's generic Linux aarch64 tarball (sha256 pinned). It also installs the older `libaio1` package the tarball's `mysqld` links against, the same workaround the amd64 path already uses. Vitess finds `mysqld` through `PATH`.
- `setup-minio` picks its `.deb` by architecture.
- The vreplication tests that pin a database version now pick the build for the platform they run on. MySQL 8.0 has an aarch64 build (8.0.46; Oracle publishes neither 8.0.28 nor a minimal build for aarch64). MySQL 5.7 and MariaDB 10.10 have no aarch64 build anywhere, so those tests skip on arm64 instead of failing.
- The Vault test downloads the 1.6.1 release zip for its platform from HashiCorp, verified against the published sha256, instead of a fixed x86_64 binary.
- The XtraBackup shards and `backup_pitr_mysqlshell` stay amd64-only for now: Percona Server is not wired up for arm64 here, and mysql-shell only comes from Oracle's amd64 apt repo.

Checked so far: the `mysql84`, `backup_pitr` and `mysql_server_vault` shards pass locally on an arm64 Ubuntu 24.04 machine against the tarball mysqld. The first CI run had every arm64 shard pass except the version-pinned vreplication tests and the Vault test, which the second commit addresses.

## Related Issue(s)

None yet. This started as a question about how much work arm64 CI coverage would be.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None. CI-only change, no user-facing behaviour is affected.

### AI Disclosure

This PR was written primarily by Claude Code, with direction and review from me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)