### PR TITLE
flagutil: keep the first value passed to StringSetFlag.Set

### DIFF
--- a/go/flagutil/sets.go
+++ b/go/flagutil/sets.go
@@ -57,7 +57,6 @@ func (set *StringSetFlag) ToSet() sets.Set[string] {
 func (set *StringSetFlag) Set(s string) error {
 	if set.set == nil {
 		set.set = sets.New[string]()
-		return nil
 	}
 
 	set.set.Insert(s)

--- a/go/flagutil/sets_test.go
+++ b/go/flagutil/sets_test.go
@@ -19,7 +19,10 @@ package flagutil
 import (
 	"testing"
 
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/sets"
 )
 
 func TestStringSetFlag(t *testing.T) {
@@ -46,9 +49,46 @@ func TestStringSetFlagWithEmptySet(t *testing.T) {
 
 	err := strSetFlag.Set("tmp")
 	require.NoError(t, err)
-	require.Empty(t, strSetFlag.ToSet())
+	require.Equal(t, "tmp", strSetFlag.String())
 
 	err = strSetFlag.Set("guvava")
 	require.NoError(t, err)
-	require.Equal(t, "guvava", strSetFlag.String())
+	require.Equal(t, "guvava, tmp", strSetFlag.String())
+}
+
+// A repeated flag must collect every occurrence, including the first one.
+func TestStringSetFlagRepeatedOnCommandLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected []string
+	}{
+		{
+			name:     "single occurrence",
+			args:     []string{"--foo", "x"},
+			expected: []string{"x"},
+		},
+		{
+			name:     "two occurrences",
+			args:     []string{"--foo", "x", "--foo", "y"},
+			expected: []string{"x", "y"},
+		},
+		{
+			name:     "repeated value",
+			args:     []string{"--foo", "x", "--foo", "y", "--foo", "x"},
+			expected: []string{"x", "y"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var strSetFlag StringSetFlag
+
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			fs.Var(&strSetFlag, "foo", "")
+			require.NoError(t, fs.Parse(tt.args))
+
+			require.Equal(t, tt.expected, sets.List(strSetFlag.ToSet()))
+		})
+	}
 }

--- a/go/vt/vtadmin/http/debug/env_test.go
+++ b/go/vt/vtadmin/http/debug/env_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/flagutil"
+	vtadmindebug "vitess.io/vitess/go/vt/vtadmin/debug"
+)
+
+func TestReadEnvHonorsASinglyPassedFlag(t *testing.T) {
+	t.Setenv("VTADMIN_TEST_OMIT", "omitted-value")
+	t.Setenv("VTADMIN_TEST_SANITIZE", "sanitized-value")
+
+	OmitEnv, SanitizeEnv = flagutil.StringSetFlag{}, flagutil.StringSetFlag{}
+	t.Cleanup(func() {
+		OmitEnv, SanitizeEnv = flagutil.StringSetFlag{}, flagutil.StringSetFlag{}
+	})
+
+	fs := pflag.NewFlagSet("vtadmin", pflag.ContinueOnError)
+	fs.Var(&OmitEnv, "http-debug-omit-env", "")
+	fs.Var(&SanitizeEnv, "http-debug-sanitize-env", "")
+	require.NoError(t, fs.Parse([]string{
+		"--http-debug-omit-env", "VTADMIN_TEST_OMIT",
+		"--http-debug-sanitize-env", "VTADMIN_TEST_SANITIZE",
+	}))
+
+	env := make(map[string]string)
+	for _, kv := range readEnv() {
+		env[kv[0]] = kv[1]
+	}
+
+	// Assert per key: failing on the whole map would print the entire environment.
+	_, omitted := env["VTADMIN_TEST_OMIT"]
+	require.False(t, omitted, "VTADMIN_TEST_OMIT should have been omitted from the env listing")
+	require.Equal(t, vtadmindebug.SanitizeString("sanitized-value"), env["VTADMIN_TEST_SANITIZE"])
+}


### PR DESCRIPTION
## Description

`StringSetFlag.Set` allocated the set in its nil branch and returned before inserting, so the **first** occurrence of a repeated flag was thrown away:

```go
func (set *StringSetFlag) Set(s string) error {
	if set.set == nil {
		set.set = sets.New[string]()
		return nil          // s is dropped
	}
	set.set.Insert(s)
	return nil
}
```

The type's own doc comment (`go/flagutil/sets.go:29-37`) says `-foo x -foo y -foo x` gives `{x, y}`. It gave `{y}`. `ToSet()` ten lines above does the same nil-initialisation and doesn't swallow anything, which is what makes `Set` the odd one out.

This has been a regression since Feb 2023. `fdbdc4cb31` wrote the branch as `sets.NewString(s)` — allocating a set *containing* `s` — and `e596c1d9c8` ("Update Go dependencies (#12215)") rewrote it to `sets.New[string]()` for the generics migration, dropping the argument but keeping the `return`.

The only two users of the type are vtadmin's `--http-debug-omit-env` and `--http-debug-sanitize-env` (`go/cmd/vtadmin/main.go:198-199`), so passing either one once had no effect at all — the variable still showed up in `/debug/env`. Passing it twice worked, which is presumably why nobody hit it.

One thing to flag for review: `TestStringSetFlagWithEmptySet` asserted `require.Empty(t, strSetFlag.ToSet())` after `Set("tmp")`. That test arrived in #15046 (Jan 2024), a year after the regression, so it recorded the behaviour rather than the documented contract. I corrected it rather than working around it — happy to discuss if you read it the other way.

Probably worth backporting, since the release branches carry the same regression, but I'll leave that call to you.

## Related Issue(s)

None — found by reading `go/flagutil`.

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

Tests: corrected `TestStringSetFlagWithEmptySet`, added `TestStringSetFlagRepeatedOnCommandLine` (driven through pflag), and added `go/vt/vtadmin/http/debug/env_test.go`, which that package didn't have.

On `main` the new tests fail with `expected: []string{"x"}, actual: []string{}` for a single occurrence and `expected: []string{"x", "y"}, actual: []string{"y"}` for two. The `repeated_value` subtest passes on `main` too — the doc comment's own example is degenerate because `x` is repeated — so it's there to catch the opposite mistake: reallocating on every call fails it, and dropping the nil guard entirely panics with `assignment to entry in nil map`.

`go test ./go/flagutil/... ./go/vt/vtadmin/http/debug/...` passes with and without `-race`, `go test ./go/vt/vtadmin/...` has no failures, `go vet` and `gofmt` are clean, and `golangci-lint run` reports 0 issues using the version pinned in `tools/golangci-lint/go.mod`.

## Deployment Notes

None. Anyone who worked around this by passing the flag twice keeps the same result.

### AI Disclosure

This PR was written primarily by Claude Code — the fix, the tests and this description. I've reviewed all of it and verified every claim above by running it against `main` and against this branch.
