### PR TITLE
test: print every attempt's output when an e2e shard ran zero tests

### DIFF
--- a/tools/assert_tests_ran.sh
+++ b/tools/assert_tests_ran.sh
@@ -20,6 +20,16 @@
 # TESTS_TOTAL is set by gotestsum and counts skipped tests too, so a shard
 # whose tests all t.Skip does not trip this.
 if [[ "${TESTS_TOTAL:-0}" -eq 0 ]]; then
-	echo "ERROR: gotestsum ran 0 tests for $PACKAGES: flag ordering or -run filtering may have broken package selection"
+	echo "ERROR: gotestsum ran 0 tests for $PACKAGES: flag ordering or -run filtering may have broken package selection, or TestMain failed and its rerun had no tests to select"
+	# The console format drops the output of a failed attempt once a rerun
+	# passes, so print it from the JSON log gotestsum wrote.
+	if [[ -r "${GOTESTSUM_JSONFILE:-}" ]]; then
+		echo "Output of every attempt, from $GOTESTSUM_JSONFILE:"
+		if command -v jq >/dev/null; then
+			jq -rj 'select(.Action == "output") | .Output' "$GOTESTSUM_JSONFILE"
+		else
+			grep '"Action":"output"' "$GOTESTSUM_JSONFILE"
+		fi
+	fi
 	exit 1
 fi

--- a/tools/e2e_go_test.sh
+++ b/tools/e2e_go_test.sh
@@ -23,6 +23,17 @@ if [[ -n "$JUNIT_OUTPUT" ]]; then
 	GOTESTSUM_ARGS+=("--junitfile" "$JUNIT_OUTPUT")
 fi
 
+# Record every attempt's output. When TestMain fails and the rerun then runs
+# zero tests, the console format drops the failed attempt's output entirely;
+# assert_tests_ran.sh prints it from this file (gotestsum passes the path to
+# the post-run command as GOTESTSUM_JSONFILE).
+if [[ -n "$JUNIT_OUTPUT" ]]; then
+	JSON_OUTPUT="${JUNIT_OUTPUT%.xml}.json"
+else
+	JSON_OUTPUT="$(mktemp)"
+fi
+GOTESTSUM_ARGS+=("--jsonfile" "$JSON_OUTPUT")
+
 # The test packages must come before "$@" on the go test command line: "$@"
 # can contain test-binary flags such as --topo-flavor or -keep-data, which
 # go test only forwards to the test binary when they appear after the package


### PR DESCRIPTION
## Description

When `TestMain` fails in an end-to-end package, gotestsum retries the package with a `-run` filter built from the failed test names. There are none, so the retry runs zero tests, `TestMain` succeeds on that attempt, and gotestsum reports a pass while dropping the failed attempt's output entirely. The `assert_tests_ran` hook from #20556 correctly fails the shard, but the job log then contains nothing about what actually went wrong. We hit this three times on #21036 with no way to tell why cluster startup had failed.

This passes `--jsonfile` to gotestsum next to the existing `--junitfile`, and has the hook print every attempt's output from that file when it fires. Its error message now also names the `TestMain` case.

Checked with a minimal `TestMain` that fails once and passes on retry, under the exact gotestsum flags from `tools/e2e_go_test.sh`: the first attempt's stderr, which the console format drops, is printed by the hook.

## Related Issue(s)

Follow-up to #20556. Motivated by the zero-test failures on #21036.

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None. CI tooling only.

### AI Disclosure

This PR was written primarily by Claude Code, with direction and review from me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)