### PR TITLE
tabletmanager: stop background goroutines when Start fails

### DIFF
--- a/go/vt/vttablet/tabletmanager/tm_init.go
+++ b/go/vt/vttablet/tabletmanager/tm_init.go
@@ -443,6 +443,19 @@ func (tm *TabletManager) Start(tablet *topodatapb.Tablet, config *tabletenv.Tabl
 	if err != nil {
 		return err
 	}
+	// From here on Start spawns background goroutines (keyspace rebuild, shard
+	// sync, shard health monitor) that use the topo server. None of them may
+	// outlive a failed Start: the caller is free to close the topo server as
+	// soon as Start has returned.
+	startSucceeded := false
+	defer func() {
+		if startSucceeded {
+			return
+		}
+		tm.stopShardHealthMonitor()
+		tm.stopShardSync()
+		tm.stopRebuildKeyspace()
+	}()
 	if err := tm.checkPrimaryShip(ctx, si); err != nil {
 		return err
 	}
@@ -535,12 +548,6 @@ func (tm *TabletManager) Start(tablet *topodatapb.Tablet, config *tabletenv.Tabl
 		}
 		tm.shardHealthMonitor.Start(tm.BatchCtx)
 	}
-	startSucceeded := false
-	defer func() {
-		if !startSucceeded {
-			tm.stopShardHealthMonitor()
-		}
-	}()
 
 	restoring, err := tm.handleRestore(tm.BatchCtx, config)
 	if err != nil {

--- a/go/vt/vttablet/tabletmanager/tm_init_test.go
+++ b/go/vt/vttablet/tabletmanager/tm_init_test.go
@@ -1364,3 +1364,49 @@ func TestValidateFlags(t *testing.T) {
 	demotePrimaryLockWaitTimeout = time.Second
 	require.NoError(t, validateFlags())
 }
+
+// TestStartFailureStopsBackgroundGoroutines checks that a failed Start does not
+// leave the keyspace rebuild and shard sync goroutines running. They use the
+// topo server, which the caller may close as soon as Start has returned.
+func TestStartFailureStopsBackgroundGoroutines(t *testing.T) {
+	defer func(saved time.Duration) { rebuildKeyspaceRetryInterval = saved }(rebuildKeyspaceRetryInterval)
+	rebuildKeyspaceRetryInterval = 10 * time.Millisecond
+	// --restore-from-backup without a my.cnf makes Start fail in handleRestore,
+	// after createKeyspaceShard and startShardSync have spawned their goroutines.
+	defer func(saved bool) { restoreFromBackup = saved }(restoreFromBackup)
+	restoreFromBackup = true
+
+	ctx := t.Context()
+	ts := memorytopo.NewServer(ctx, "cell1")
+	// With only one of two shards populated the keyspace rebuild keeps
+	// retrying, so its goroutine never exits on its own.
+	tablet := newTestTablet(t, 1, "ks", "-80", nil)
+	fakeDb := newTestMysqlDaemon(t, 1)
+	tm := &TabletManager{
+		BatchCtx:            ctx,
+		TopoServer:          ts,
+		MysqlDaemon:         fakeDb,
+		DBConfigs:           &dbconfigs.DBConfigs{},
+		SemiSyncMonitor:     semisyncmonitor.CreateTestSemiSyncMonitor(fakeDb.DB(), exporter),
+		QueryServiceControl: tabletservermock.NewController(),
+	}
+
+	err := tm.Start(tablet, nil)
+	require.ErrorContains(t, err, "without a my.cnf file")
+
+	tm.mutex.Lock()
+	rebuildDone, shardSyncDone := tm._rebuildKeyspaceDone, tm._shardSyncDone
+	tm.mutex.Unlock()
+	require.NotNil(t, rebuildDone, "Start should have started a keyspace rebuild before failing")
+	require.NotNil(t, shardSyncDone, "Start should have started the shard sync loop before failing")
+
+	assertStopped := func(name string, done <-chan struct{}) {
+		select {
+		case <-done:
+		default:
+			assert.Fail(t, name+" goroutine is still running after Start failed")
+		}
+	}
+	assertStopped("rebuildKeyspace", rebuildDone)
+	assertStopped("shardSyncLoop", shardSyncDone)
+}


### PR DESCRIPTION
## Description

`TabletManager.Start` spawns background goroutines before it can still fail: `createKeyspaceShard` starts the keyspace rebuild loop and `startShardSync` starts the shard sync loop, and only then does `handleRestore` reject, for example, `--restore-from-backup` without a my.cnf. On that path the goroutines were left running. They keep using the topo server, which the caller closes as soon as `Start` has returned.

That's the race behind the `TestRunFailsToStartTabletManager` flake: the rebuild goroutine gets past the `ctx.Err()` guard in `topo.(*Server).GetKeyspace`, `topo.Server.Close` nils the global cell connection, and the next line dereferences it:

```
panic: runtime error: invalid memory address or nil pointer dereference
vitess.io/vitess/go/vt/topo.(*Server).GetKeyspace(...)
	go/vt/topo/keyspace.go:111
vitess.io/vitess/go/vt/topotools.RebuildKeyspace(...)
vitess.io/vitess/go/vt/vttablet/tabletmanager.(*TabletManager).rebuildKeyspace(...)
created by vitess.io/vitess/go/vt/vttablet/tabletmanager.(*TabletManager).createKeyspaceShard
```

#17165 narrowed this window with context checks but couldn't close it, since the goroutine isn't cancelled at all on the failure path. `Start` already had a `startSucceeded` guard for the shard health monitor, but it was registered late and only covered the monitor.

This moves that guard to right after the first goroutine is spawned and has it stop the keyspace rebuild and shard sync too. The new `TestStartFailureStopsBackgroundGoroutines` fails deterministically on `main` (both goroutines still running after `Start` returned an error) and passes with the fix. `TestRunFailsToStartTabletManager` passed 30/30 separate `-race` runs with the fix.

This is a small, self-contained fix for a flaky unit test that fails on release branches too, so it's a backport candidate. I've left the backport labels off for now.

## Related Issue(s)

- #17165
- #17167

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

None.

### AI Disclosure

This PR was written by Claude Code, with direction and review from me.