### PR TITLE
VTTablet: fail closed under strict table ACL when a statement's table set cannot be determined

### DIFF
--- a/go/test/endtoend/mysqlserver/main_test.go
+++ b/go/test/endtoend/mysqlserver/main_test.go
@@ -101,6 +101,10 @@ func TestMain(m *testing.M) {
 			"testuser2": {
 				"Password": "testpassword2",
 				"UserData": "vtgate client 2"
+			},
+			"testuser3": {
+				"Password": "testpassword3",
+				"UserData": "vtgate client 3"
 			}
 		}`
 		if err := createConfig(mysqlAuthServerStatic, SQLConfig); err != nil {
@@ -119,6 +123,11 @@ func TestMain(m *testing.M) {
 		clusterInstance.VtTabletExtraArgs = []string{
 			"--table-acl-config", clusterInstance.TmpDirectory + tableACLConfig,
 			"--queryserver-config-strict-table-acl",
+			// Under strict table ACL, CALL is denied to every caller the ACL does
+			// not exempt, since the tablet cannot determine a procedure body's
+			// tables; testuser3 ("vtgate client 3") is exempt so TestWarnings
+			// can CALL.
+			"--queryserver-config-acl-exempt-acl", "vtgate client 3",
 		}
 
 		// Start keyspace

--- a/go/test/endtoend/mysqlserver/mysql_server_test.go
+++ b/go/test/endtoend/mysqlserver/mysql_server_test.go
@@ -200,7 +200,7 @@ func TestSelectWithUnauthorizedUser(t *testing.T) {
 	_, err = conn.ExecuteFetch("CALL testing()", 1, false)
 	require.Errorf(t, err, "error expected, got nil")
 	assert.Contains(t, err.Error(), "CallProcedure command denied to user 'vtgate client 2'")
-	assert.Contains(t, err.Error(), "its table set cannot be determined for a table ACL check (ACL check error)")
+	assert.Contains(t, err.Error(), "for a table set that cannot be determined (ACL check error)")
 }
 
 // TestPartitionedTable validates that partitioned tables are recognized by schema engine

--- a/go/test/endtoend/mysqlserver/mysql_server_test.go
+++ b/go/test/endtoend/mysqlserver/mysql_server_test.go
@@ -135,7 +135,12 @@ func TestInvalidField(t *testing.T) {
 func TestWarnings(t *testing.T) {
 	ctx := t.Context()
 
-	conn, err := mysql.Connect(ctx, &vtParams)
+	// The CALLs below need a caller the table ACL exempts: under strict table
+	// ACL the tablet denies CALL to everyone else (see TestSelectWithUnauthorizedUser).
+	exemptVtParams := vtParams
+	exemptVtParams.Uname = "testuser3"
+	exemptVtParams.Pass = "testpassword3"
+	conn, err := mysql.Connect(ctx, &exemptVtParams)
 	require.NoError(t, err)
 	defer conn.Close()
 
@@ -188,6 +193,14 @@ func TestSelectWithUnauthorizedUser(t *testing.T) {
 	require.Errorf(t, err, "error expected, got nil")
 	assert.Contains(t, err.Error(), "Select command denied to user")
 	assert.Contains(t, err.Error(), "for table 'vt_insert_test' (ACL check error)")
+
+	// A CALL runs an opaque procedure body whose tables the tablet cannot
+	// determine, so under strict table ACL it is denied to any caller the ACL
+	// does not exempt, without a table to name.
+	_, err = conn.ExecuteFetch("CALL testing()", 1, false)
+	require.Errorf(t, err, "error expected, got nil")
+	assert.Contains(t, err.Error(), "CallProcedure command denied to user 'vtgate client 2'")
+	assert.Contains(t, err.Error(), "its table set cannot be determined for a table ACL check (ACL check error)")
 }
 
 // TestPartitionedTable validates that partitioned tables are recognized by schema engine

--- a/go/vt/vttablet/endtoend/acl_test.go
+++ b/go/vt/vttablet/endtoend/acl_test.go
@@ -39,7 +39,7 @@ func TestTableACL(t *testing.T) {
 	// caller the ACL does not exempt, whatever that caller's table grants: a
 	// CALL runs an opaque procedure body, DO can carry a table-reading
 	// subquery, and LOAD DATA writes a table the parser discards.
-	undeterminedErr := "command denied to user 'dev': its table set cannot be determined for a table ACL check"
+	undeterminedErr := "command denied to user 'dev' for a table set that cannot be determined"
 	execCases := []struct {
 		query string
 		err   string

--- a/go/vt/vttablet/endtoend/acl_test.go
+++ b/go/vt/vttablet/endtoend/acl_test.go
@@ -35,6 +35,11 @@ func TestTableACL(t *testing.T) {
 	client := framework.NewClient()
 
 	aclErr := "command denied to user 'dev' for table"
+	// Statements whose table set the tablet cannot determine are denied to any
+	// caller the ACL does not exempt, whatever that caller's table grants: a
+	// CALL runs an opaque procedure body, DO can carry a table-reading
+	// subquery, and LOAD DATA writes a table the parser discards.
+	undeterminedErr := "command denied to user 'dev': its table set cannot be determined for a table ACL check"
 	execCases := []struct {
 		query string
 		err   string
@@ -93,6 +98,16 @@ func TestTableACL(t *testing.T) {
 	}, {
 		query: "update vitess_acl_read_write join vitess_acl_read_only on 1!=1 set key1=1",
 		err:   aclErr,
+	}, {
+		query: "call proc_dml()",
+		err:   undeterminedErr,
+	}, {
+		query: "do (select intval from vitess_test limit 1)",
+		err:   undeterminedErr,
+	}, {
+		// Denied before it reaches MySQL, so the file need not exist.
+		query: "load data infile '/nonexistent' into table vitess_test",
+		err:   undeterminedErr,
 	}}
 
 	for _, tcase := range execCases {
@@ -120,6 +135,9 @@ func TestTableACL(t *testing.T) {
 		query: "select * from vitess_acl_unmatched where key1=1",
 	}, {
 		query: "select * from vitess_acl_all_user_read_only where key1=1",
+	}, {
+		query: "call proc_dml()",
+		err:   undeterminedErr,
 	}}
 	for _, tcase := range streamCases {
 		_, err := client.StreamExecute(tcase.query, nil)

--- a/go/vt/vttablet/endtoend/acl_test.go
+++ b/go/vt/vttablet/endtoend/acl_test.go
@@ -138,6 +138,11 @@ func TestTableACL(t *testing.T) {
 	}, {
 		query: "call proc_dml()",
 		err:   undeterminedErr,
+	}, {
+		// LOAD DATA streams through its own entry point (streamDML); it is
+		// denied before it reaches MySQL, so the file need not exist.
+		query: "load data infile '/nonexistent' into table vitess_test",
+		err:   undeterminedErr,
 	}}
 	for _, tcase := range streamCases {
 		_, err := client.StreamExecute(tcase.query, nil)

--- a/go/vt/vttablet/endtoend/call_test.go
+++ b/go/vt/vttablet/endtoend/call_test.go
@@ -77,8 +77,12 @@ var procSQL = []string{
 	END;`,
 }
 
+// The CALL tests run as framework.ExemptCallerID: under strict table ACL the
+// tablet cannot determine a procedure body's tables and denies CALL to every
+// caller the ACL does not exempt (TestTableACL pins that for "dev"). These tests
+// exercise CALL's own semantics, so they need a caller that is allowed to CALL.
 func TestCallProcedure(t *testing.T) {
-	client := framework.NewClient()
+	client := framework.NewExemptClient()
 	type testcases struct {
 		query   string
 		wantErr bool
@@ -101,7 +105,7 @@ func TestCallProcedure(t *testing.T) {
 		t.Run(tc.query, func(t *testing.T) {
 			_, err := client.Execute(tc.query, nil)
 			if tc.wantErr {
-				require.EqualError(t, err, "Multi-Resultset not supported in stored procedure (CallerID: dev)")
+				require.EqualError(t, err, "Multi-Resultset not supported in stored procedure (CallerID: acl-exempt)")
 				return
 			}
 			require.NoError(t, err)
@@ -110,7 +114,7 @@ func TestCallProcedure(t *testing.T) {
 }
 
 func TestCallProcedureStreaming(t *testing.T) {
-	client := framework.NewClient()
+	client := framework.NewExemptClient()
 	type testcases struct {
 		query   string
 		wantErr string
@@ -124,7 +128,7 @@ func TestCallProcedureStreaming(t *testing.T) {
 		// A multi-resultset procedure must be rejected, not silently truncated
 		// to its first resultset.
 		query:   "call proc_select4()",
-		wantErr: "Multi-Resultset not supported in stored procedure (CallerID: dev)",
+		wantErr: "Multi-Resultset not supported in stored procedure (CallerID: acl-exempt)",
 	}, {
 		// A procedure that returns no resultset and concludes its own transaction
 		// streams fine.
@@ -150,7 +154,7 @@ func TestCallProcedureStreaming(t *testing.T) {
 func TestCallProcedureStreamingMultiResultsetTxLeakClosesConnection(t *testing.T) {
 	setStreamPoolSize(t, 1)
 
-	client := framework.NewClient()
+	client := framework.NewExemptClient()
 	checkClient := framework.NewClient()
 	_, _ = checkClient.Execute("delete from vitess_test where intval = 8675309", nil)
 	t.Cleanup(func() {
@@ -163,7 +167,7 @@ func TestCallProcedureStreamingMultiResultsetTxLeakClosesConnection(t *testing.T
 	beforeConnID := qr.Rows[0][0].ToString()
 
 	_, err = client.StreamExecute("call proc_select2_tx_insert()", nil)
-	require.EqualError(t, err, "Multi-Resultset not supported in stored procedure (CallerID: dev)")
+	require.EqualError(t, err, "Multi-Resultset not supported in stored procedure (CallerID: acl-exempt)")
 
 	qr, err = client.StreamExecute("select connection_id()", nil)
 	require.NoError(t, err)
@@ -182,7 +186,7 @@ func TestCallProcedureStreamingMultiResultsetTxLeakClosesConnection(t *testing.T
 func TestCallProcedureStreamingMultiResultsetCleanConnectionReused(t *testing.T) {
 	setStreamPoolSize(t, 1)
 
-	client := framework.NewClient()
+	client := framework.NewExemptClient()
 
 	qr, err := client.StreamExecute("select connection_id()", nil)
 	require.NoError(t, err)
@@ -190,7 +194,7 @@ func TestCallProcedureStreamingMultiResultsetCleanConnectionReused(t *testing.T)
 	beforeConnID := qr.Rows[0][0].ToString()
 
 	_, err = client.StreamExecute("call proc_select4()", nil)
-	require.EqualError(t, err, "Multi-Resultset not supported in stored procedure (CallerID: dev)")
+	require.EqualError(t, err, "Multi-Resultset not supported in stored procedure (CallerID: acl-exempt)")
 
 	qr, err = client.StreamExecute("select connection_id()", nil)
 	require.NoError(t, err)
@@ -201,7 +205,7 @@ func TestCallProcedureStreamingMultiResultsetCleanConnectionReused(t *testing.T)
 func TestCallProcedureStreamingCallbackErrorClosesConnection(t *testing.T) {
 	setStreamPoolSize(t, 1)
 
-	client := framework.NewClient()
+	client := framework.NewExemptClient()
 
 	qr, err := client.StreamExecute("select connection_id()", nil)
 	require.NoError(t, err)
@@ -231,14 +235,14 @@ func setStreamPoolSize(t *testing.T, size int) {
 }
 
 func TestCallProcedureLeakTxStreaming(t *testing.T) {
-	client := framework.NewClient()
+	client := framework.NewExemptClient()
 
 	_, err := client.StreamExecute(`call proc_tx_begin()`, nil)
-	require.EqualError(t, err, "Transaction not concluded inside the stored procedure, leaking transaction from stored procedure is not allowed (CallerID: dev)")
+	require.EqualError(t, err, "Transaction not concluded inside the stored procedure, leaking transaction from stored procedure is not allowed (CallerID: acl-exempt)")
 }
 
 func TestCallProcedureChangedTxStreaming(t *testing.T) {
-	client := framework.NewClient()
+	client := framework.NewExemptClient()
 	defer client.Release()
 
 	queries := []string{
@@ -248,27 +252,27 @@ func TestCallProcedureChangedTxStreaming(t *testing.T) {
 	for _, query := range queries {
 		t.Run(query, func(t *testing.T) {
 			_, err := client.StreamBeginExecuteWithOptions(query, nil, nil, &querypb.ExecuteOptions{IncludedFields: querypb.ExecuteOptions_ALL})
-			require.EqualError(t, err, "Transaction state change inside the stored procedure is not allowed (CallerID: dev)")
+			require.EqualError(t, err, "Transaction state change inside the stored procedure is not allowed (CallerID: acl-exempt)")
 			client.Release()
 		})
 	}
 }
 
 func TestCallProcedureInsideTx(t *testing.T) {
-	client := framework.NewClient()
+	client := framework.NewExemptClient()
 	defer client.Release()
 
 	_, err := client.BeginExecute(`call proc_dml()`, nil, nil)
-	require.EqualError(t, err, "Transaction state change inside the stored procedure is not allowed (CallerID: dev)")
+	require.EqualError(t, err, "Transaction state change inside the stored procedure is not allowed (CallerID: acl-exempt)")
 
 	_, err = client.Execute(`select 1`, nil)
 	require.Contains(t, err.Error(), "ended")
 }
 
 func TestCallProcedureInsideReservedConn(t *testing.T) {
-	client := framework.NewClient()
+	client := framework.NewExemptClient()
 	_, err := client.ReserveBeginExecute(`call proc_dml()`, nil, nil, nil)
-	require.EqualError(t, err, "Transaction state change inside the stored procedure is not allowed (CallerID: dev)")
+	require.EqualError(t, err, "Transaction state change inside the stored procedure is not allowed (CallerID: acl-exempt)")
 	client.Release()
 
 	_, err = client.ReserveExecute(`call proc_dml()`, nil, nil)
@@ -281,18 +285,18 @@ func TestCallProcedureInsideReservedConn(t *testing.T) {
 }
 
 func TestCallProcedureLeakTx(t *testing.T) {
-	client := framework.NewClient()
+	client := framework.NewExemptClient()
 
 	_, err := client.Execute(`call proc_tx_begin()`, nil)
-	require.EqualError(t, err, "Transaction not concluded inside the stored procedure, leaking transaction from stored procedure is not allowed (CallerID: dev)")
+	require.EqualError(t, err, "Transaction not concluded inside the stored procedure, leaking transaction from stored procedure is not allowed (CallerID: acl-exempt)")
 }
 
 func TestCallProcedureChangedTx(t *testing.T) {
-	client := framework.NewClient()
+	client := framework.NewExemptClient()
 	defer client.Release()
 
 	_, err := client.Execute(`call proc_tx_begin()`, nil)
-	require.EqualError(t, err, "Transaction not concluded inside the stored procedure, leaking transaction from stored procedure is not allowed (CallerID: dev)")
+	require.EqualError(t, err, "Transaction not concluded inside the stored procedure, leaking transaction from stored procedure is not allowed (CallerID: acl-exempt)")
 
 	queries := []string{
 		`call proc_tx_commit()`,
@@ -301,7 +305,7 @@ func TestCallProcedureChangedTx(t *testing.T) {
 	for _, query := range queries {
 		t.Run(query, func(t *testing.T) {
 			_, err := client.BeginExecute(query, nil, nil)
-			require.EqualError(t, err, "Transaction state change inside the stored procedure is not allowed (CallerID: dev)")
+			require.EqualError(t, err, "Transaction state change inside the stored procedure is not allowed (CallerID: acl-exempt)")
 			client.Release()
 		})
 	}

--- a/go/vt/vttablet/endtoend/framework/client.go
+++ b/go/vt/vttablet/endtoend/framework/client.go
@@ -45,6 +45,26 @@ type QueryClient struct {
 	sessionStateChanges string
 }
 
+// ExemptCallerID is the immediate caller that Server's table ACL exempts
+// (see StartServer). Under strict table ACL the tablet denies statements whose
+// table set it cannot determine (CALL, DO, REPAIR, OPTIMIZE, LOAD DATA) to
+// every other caller, so tests that exercise those statements' own semantics
+// rather than the ACL run as this caller.
+const ExemptCallerID = "acl-exempt"
+
+// NewExemptClient creates a new client for Server that the table ACL exempts.
+func NewExemptClient() *QueryClient {
+	return &QueryClient{
+		ctx: callerid.NewContext(
+			context.Background(),
+			&vtrpcpb.CallerID{},
+			&querypb.VTGateCallerID{Username: ExemptCallerID},
+		),
+		target: Target,
+		server: Server,
+	}
+}
+
 // NewClient creates a new client for Server.
 func NewClient() *QueryClient {
 	return &QueryClient{

--- a/go/vt/vttablet/endtoend/framework/server.go
+++ b/go/vt/vttablet/endtoend/framework/server.go
@@ -108,6 +108,9 @@ func StartCustomServer(ctx context.Context, connParams, connAppDebugParams mysql
 func StartServer(ctx context.Context, connParams, connAppDebugParams mysql.ConnParams, dbName string) error {
 	config := tabletenv.NewDefaultConfig()
 	config.StrictTableACL = true
+	// Built by the query engine at start from the registered ACL factory, so
+	// the factory must be registered before StartServer is called.
+	config.TableACLExemptACL = ExemptCallerID
 	config.TwoPCAbandonAge = 1 * time.Second
 	config.HotRowProtection.Mode = tabletenv.Enable
 	config.TrackSchemaVersions = true

--- a/go/vt/vttablet/endtoend/framework/server.go
+++ b/go/vt/vttablet/endtoend/framework/server.go
@@ -30,6 +30,7 @@ import (
 	"vitess.io/vitess/go/vt/vtenv"
 	"vitess.io/vitess/go/yaml2"
 
+	"vitess.io/vitess/go/vt/tableacl"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
 	"vitess.io/vitess/go/vt/vterrors"
 
@@ -124,6 +125,13 @@ func StartServer(ctx context.Context, connParams, connAppDebugParams mysql.ConnP
 	config.SchemaReloadInterval = 5 * time.Second
 	gotBytes, _ := yaml2.Marshal(config)
 	log.Info(fmt.Sprintf("Config:\n%s", gotBytes))
+	// The engine builds the exempt ACL from the registered factory as it
+	// starts, and with none registered it only logs and runs with no exempt
+	// ACL, which would surface as every CALL test being denied. Fail here
+	// instead, so the mistake is reported at startup.
+	if _, err := tableacl.GetCurrentACLFactory(); err != nil {
+		return vterrors.Wrapf(err, "the table ACL factory must be registered before StartServer, or the exempt ACL for %q cannot be built", ExemptCallerID)
+	}
 	return StartCustomServer(ctx, connParams, connAppDebugParams, dbName, config)
 }
 

--- a/go/vt/vttablet/endtoend/main_test.go
+++ b/go/vt/vttablet/endtoend/main_test.go
@@ -88,6 +88,10 @@ func TestMain(m *testing.M) {
 		connAppDebugParams = cluster.MySQLAppDebugConnParams()
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		// The server builds its exempt table ACL at start from the registered
+		// factory, so register it first; the ACL config itself is loaded after
+		// the server is up (initTableACL) because its reload callback needs it.
+		tableacl.Register("simpleacl", &simpleacl.Factory{})
 		err = framework.StartServer(ctx, connParams, connAppDebugParams, cluster.DbName())
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%v", err)
@@ -120,7 +124,6 @@ func initTableACL() error {
 		return errors.New("table acl: short write")
 	}
 	file.Close()
-	tableacl.Register("simpleacl", &simpleacl.Factory{})
 	tableacl.Init(file.Name(), func() { framework.Server.ClearQueryPlanCache() })
 	return nil
 }

--- a/go/vt/vttablet/tabletserver/planbuilder/permission.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/permission.go
@@ -31,9 +31,10 @@ type Permission struct {
 }
 
 // BuildPermissions builds the list of required permissions for all the
-// tables referenced in a query.
-func BuildPermissions(stmt sqlparser.Statement) []Permission {
-	var permissions []Permission
+// tables referenced in a query. tablesUndetermined reports a statement whose
+// tables the parser discards, so that no permission could be derived for it;
+// the executor fails closed on such a statement under strict table ACL.
+func BuildPermissions(stmt sqlparser.Statement) (permissions []Permission, tablesUndetermined bool) {
 	// All Statement types myst be covered here.
 	switch node := stmt.(type) {
 	case *sqlparser.Select:
@@ -70,14 +71,23 @@ func BuildPermissions(stmt sqlparser.Statement) []Permission {
 		}
 	case *sqlparser.Analyze:
 		permissions = buildTableNamePermissions(node.Table, tableacl.WRITER, nil, permissions)
-	case *sqlparser.OtherAdmin, *sqlparser.CallProc, *sqlparser.Begin, *sqlparser.Commit, *sqlparser.Rollback,
-		*sqlparser.Load, *sqlparser.Savepoint, *sqlparser.Release, *sqlparser.SRollback, *sqlparser.Set, *sqlparser.Show, sqlparser.Explain,
+	case *sqlparser.OtherAdmin, *sqlparser.CallProc, *sqlparser.Load:
+		// The parser discards the tables these statements touch: DO's
+		// expressions and the tables REPAIR and OPTIMIZE name (OtherAdmin), a
+		// procedure body (CALL), and LOAD DATA's target table (a write, with
+		// vt_app holding the FILE privilege by default). No permission can be
+		// derived, so the statement is flagged and the executor denies it
+		// under strict table ACL rather than skip the check. A new statement
+		// type the parser leaves opaque belongs here, not in the arm below.
+		tablesUndetermined = true
+	case *sqlparser.Begin, *sqlparser.Commit, *sqlparser.Rollback,
+		*sqlparser.Savepoint, *sqlparser.Release, *sqlparser.SRollback, *sqlparser.Set, *sqlparser.Show, sqlparser.Explain,
 		*sqlparser.UnlockTables:
 		// no op
 	default:
 		panic(fmt.Errorf("BUG: unexpected statement type: %T", node))
 	}
-	return permissions
+	return permissions, tablesUndetermined
 }
 
 func buildSubqueryPermissions(stmt sqlparser.Statement, role tableacl.Role, permissions []Permission) []Permission {

--- a/go/vt/vttablet/tabletserver/planbuilder/permission_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/permission_test.go
@@ -28,8 +28,9 @@ import (
 
 func TestBuildPermissions(t *testing.T) {
 	tcases := []struct {
-		input  string
-		output []Permission
+		input        string
+		output       []Permission
+		undetermined bool
 	}{{
 		input: "select * from t",
 		output: []Permission{{
@@ -110,8 +111,9 @@ func TestBuildPermissions(t *testing.T) {
 			Role:      tableacl.ADMIN,
 		}},
 	}, {
-		input:  "repair t",
-		output: nil,
+		input:        "repair t",
+		output:       nil,
+		undetermined: true,
 	}, {
 		input: "select (select a from t2) from t1",
 		output: []Permission{{
@@ -228,14 +230,29 @@ func TestBuildPermissions(t *testing.T) {
 			TableName: "t1",
 			Role:      tableacl.READER,
 		}},
+	}, {
+		// Statements whose tables the parser discards derive no permission
+		// and are flagged instead, so the executor can fail closed on them.
+		input:        "do (select * from t)",
+		undetermined: true,
+	}, {
+		input:        "optimize table t",
+		undetermined: true,
+	}, {
+		input:        "call proc()",
+		undetermined: true,
+	}, {
+		input:        "load data infile 'x' into table t",
+		undetermined: true,
 	}}
 
 	for _, tcase := range tcases {
 		t.Run(tcase.input, func(t *testing.T) {
 			stmt, err := sqlparser.NewTestParser().Parse(tcase.input)
 			require.NoError(t, err)
-			got := BuildPermissions(stmt)
+			got, undetermined := BuildPermissions(stmt)
 			utils.MustMatch(t, tcase.output, got)
+			utils.MustMatch(t, tcase.undetermined, undetermined)
 		})
 	}
 }

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -186,6 +186,12 @@ type Plan struct {
 
 	// Permissions stores the permissions for the tables accessed in the query.
 	Permissions []Permission
+	// TablesUndetermined is set for a statement whose tables the parser
+	// discards (DO, CALL, REPAIR, OPTIMIZE, LOAD DATA): Permissions is empty
+	// because none could be derived, not because the statement touches no
+	// table. Under strict table ACL the executor denies such a statement
+	// rather than skip the check.
+	TablesUndetermined bool
 
 	// FullQuery will be set for all plans.
 	FullQuery *sqlparser.ParsedQuery
@@ -346,7 +352,7 @@ func BuildStreaming(env *vtenv.Environment, statement sqlparser.Statement, table
 		}
 	}
 	plan.AllTables = lookupAllTables(statement, tables)
-	plan.Permissions = BuildPermissions(statement)
+	plan.Permissions, plan.TablesUndetermined = BuildPermissions(statement)
 	return plan, nil
 }
 

--- a/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
@@ -50,6 +50,7 @@ func (p *Plan) MarshalJSON() ([]byte, error) {
 		WhereClause        *sqlparser.ParsedQuery `json:",omitempty"`
 		NeedsReservedConn  bool                   `json:",omitempty"`
 		KillsConnOnTimeout bool                   `json:",omitempty"`
+		TablesUndetermined bool                   `json:",omitempty"`
 	}{
 		PlanID:      p.PlanID,
 		TableName:   p.TableName(),
@@ -65,6 +66,9 @@ func (p *Plan) MarshalJSON() ([]byte, error) {
 	}
 	if p.KillsConnOnTimeout {
 		mplan.KillsConnOnTimeout = true
+	}
+	if p.TablesUndetermined {
+		mplan.TablesUndetermined = true
 	}
 	return json.Marshal(&mplan)
 }

--- a/go/vt/vttablet/tabletserver/planbuilder/testdata/exec_cases.txt
+++ b/go/vt/vttablet/tabletserver/planbuilder/testdata/exec_cases.txt
@@ -802,14 +802,16 @@ options:PassthroughDMLs
 "repair a"
 {
   "PlanID": "OtherAdmin",
-  "TableName": ""
+  "TableName": "",
+  "TablesUndetermined": true
 }
 
 # optimize
 "optimize a"
 {
   "PlanID": "OtherAdmin",
-  "TableName": ""
+  "TableName": "",
+  "TablesUndetermined": true
 }
 
 # syntax error
@@ -876,7 +878,8 @@ options:PassthroughDMLs
 "load data infile 'x.txt' into table a"
 {
     "PlanID":"Load",
-    "TableName":""
+    "TableName":"",
+    "TablesUndetermined":true
 }
 
 # alter view
@@ -967,7 +970,8 @@ options:PassthroughDMLs
 {
   "PlanID": "CallProcedure",
   "TableName": "",
-  "FullQuery": "call getAllTheThings()"
+  "FullQuery": "call getAllTheThings()",
+  "TablesUndetermined": true
 }
 
 # create table with function as a default value

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -954,12 +954,8 @@ func (qre *QueryExecutor) checkAccess(authorized *tableacl.ACLResult, tableName 
 		}
 
 		if qre.tsv.qe.strictTableACL {
-			groupStr := ""
-			if len(callerID.Groups) > 0 {
-				groupStr = fmt.Sprintf(", in groups [%s],", strings.Join(callerID.Groups, ", "))
-			}
 			aclState = acl.ACLDenied
-			errStr := fmt.Sprintf("%s command denied to user '%s'%s for table '%s' (ACL check error)", qre.plan.PlanID.String(), callerID.Username, groupStr, tableName)
+			errStr := fmt.Sprintf("%s command denied to user '%s'%s for table '%s' (ACL check error)", qre.plan.PlanID.String(), callerID.Username, aclGroupsSuffix(callerID), tableName)
 			qre.tsv.qe.accessCheckerLogger.Infof("%s", errStr)
 			return vterrors.Errorf(vtrpcpb.Code_PERMISSION_DENIED, "%s", errStr)
 		}
@@ -991,9 +987,18 @@ func (qre *QueryExecutor) checkUndeterminedTableAccess(callerID *querypb.VTGateC
 		return nil
 	}
 	aclState = acl.ACLDenied
-	errStr := fmt.Sprintf("%s command denied to user '%s': its table set cannot be determined for a table ACL check (ACL check error)", qre.plan.PlanID.String(), callerID.Username)
+	errStr := fmt.Sprintf("%s command denied to user '%s'%s for a table set that cannot be determined (ACL check error)", qre.plan.PlanID.String(), callerID.Username, aclGroupsSuffix(callerID))
 	qre.tsv.qe.accessCheckerLogger.Infof("%s", errStr)
 	return vterrors.Errorf(vtrpcpb.Code_PERMISSION_DENIED, "%s", errStr)
+}
+
+// aclGroupsSuffix renders the caller's groups for an ACL denial message, so
+// operators who manage the ACL by group can see which ones the caller carried.
+func aclGroupsSuffix(callerID *querypb.VTGateCallerID) string {
+	if len(callerID.Groups) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(", in groups [%s],", strings.Join(callerID.Groups, ", "))
 }
 
 func (qre *QueryExecutor) generateACLStatsKey(tableName string, authorized *tableacl.ACLResult, callerID *querypb.VTGateCallerID) []string {

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -919,21 +919,16 @@ func (qre *QueryExecutor) checkPermissions() error {
 		return nil
 	}
 
-	// Fail closed for statements whose table set the planner cannot
-	// determine. DO, CALL, REPAIR, OPTIMIZE and LOAD DATA are forwarded to
-	// MySQL as opaque text and can still read or modify tables (a
-	// table-reading subquery inside DO, a stored procedure body, the tables
-	// named by REPAIR/OPTIMIZE and the target table of LOAD DATA, all of which
-	// the parser discards), but BuildPermissions derives no permissions for
-	// them, so the per-table loop below has nothing to iterate and would let
-	// any authenticated caller run them under strict table ACL. LOAD DATA is
-	// the write side of that gap: the stock init_db.sql grants vt_app the FILE
-	// privilege, so a server-side INFILE into a denied table would succeed.
-	// When we cannot enumerate a statement's tables, deny it rather than skip
-	// the check; the exempt ACL applied above stays as the escape hatch for
-	// operators who need these statements.
-	switch qre.plan.PlanID {
-	case p.PlanOtherAdmin, p.PlanCallProc, p.PlanLoad:
+	// Fail closed for a statement whose table set the planner could not
+	// determine (DO, CALL, REPAIR, OPTIMIZE, LOAD DATA). It is forwarded to
+	// MySQL as opaque text and can still read or modify tables, but no
+	// permission could be derived for it, so the per-table loop below has
+	// nothing to iterate and would let any authenticated caller run it under
+	// strict table ACL. The planner flags such statements in the one switch
+	// that must account for every statement type (BuildPermissions), so this
+	// needs no list of its own. The exempt ACL applied above stays as the
+	// escape hatch for operators who need these statements.
+	if qre.plan.TablesUndetermined {
 		return qre.checkUndeterminedTableAccess(callerID)
 	}
 

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -920,17 +920,20 @@ func (qre *QueryExecutor) checkPermissions() error {
 	}
 
 	// Fail closed for statements whose table set the planner cannot
-	// determine. DO, CALL, REPAIR and OPTIMIZE are forwarded to MySQL as
-	// opaque text and can still read or modify tables (a table-reading
-	// subquery inside DO, a stored procedure body, the tables named by
-	// REPAIR/OPTIMIZE that the parser discards), but BuildPermissions derives
-	// no permissions for them, so the per-table loop below has nothing to
-	// iterate and would let any authenticated caller run them under strict
-	// table ACL. When we cannot enumerate a statement's tables, deny it rather
-	// than skip the check; the exempt ACL applied above stays as the escape
-	// hatch for operators who need these statements.
+	// determine. DO, CALL, REPAIR, OPTIMIZE and LOAD DATA are forwarded to
+	// MySQL as opaque text and can still read or modify tables (a
+	// table-reading subquery inside DO, a stored procedure body, the tables
+	// named by REPAIR/OPTIMIZE and the target table of LOAD DATA, all of which
+	// the parser discards), but BuildPermissions derives no permissions for
+	// them, so the per-table loop below has nothing to iterate and would let
+	// any authenticated caller run them under strict table ACL. LOAD DATA is
+	// the write side of that gap: the stock init_db.sql grants vt_app the FILE
+	// privilege, so a server-side INFILE into a denied table would succeed.
+	// When we cannot enumerate a statement's tables, deny it rather than skip
+	// the check; the exempt ACL applied above stays as the escape hatch for
+	// operators who need these statements.
 	switch qre.plan.PlanID {
-	case p.PlanOtherAdmin, p.PlanCallProc:
+	case p.PlanOtherAdmin, p.PlanCallProc, p.PlanLoad:
 		return qre.checkUndeterminedTableAccess(callerID)
 	}
 

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -919,6 +919,21 @@ func (qre *QueryExecutor) checkPermissions() error {
 		return nil
 	}
 
+	// Fail closed for statements whose table set the planner cannot
+	// determine. DO, CALL, REPAIR and OPTIMIZE are forwarded to MySQL as
+	// opaque text and can still read or modify tables (a table-reading
+	// subquery inside DO, a stored procedure body, the tables named by
+	// REPAIR/OPTIMIZE that the parser discards), but BuildPermissions derives
+	// no permissions for them, so the per-table loop below has nothing to
+	// iterate and would let any authenticated caller run them under strict
+	// table ACL. When we cannot enumerate a statement's tables, deny it rather
+	// than skip the check; the exempt ACL applied above stays as the escape
+	// hatch for operators who need these statements.
+	switch qre.plan.PlanID {
+	case p.PlanOtherAdmin, p.PlanCallProc:
+		return qre.checkUndeterminedTableAccess(callerID)
+	}
+
 	for i, auth := range qre.plan.Authorized {
 		if err := qre.checkAccess(auth, qre.plan.Permissions[i].TableName, callerID); err != nil {
 			return err
@@ -954,6 +969,31 @@ func (qre *QueryExecutor) checkAccess(authorized *tableacl.ACLResult, tableName 
 	}
 	aclState = acl.ACLAllow
 	return nil
+}
+
+// checkUndeterminedTableAccess enforces table ACL for a statement whose table
+// set could not be determined at planning time (see checkPermissions). It
+// mirrors checkAccess's dry-run and stats handling, but denies unconditionally
+// under strict table ACL: there is no table whose grants could authorize the
+// caller, and the caller has already been shown to be non-exempt.
+func (qre *QueryExecutor) checkUndeterminedTableAccess(callerID *querypb.VTGateCallerID) error {
+	var aclState acl.ACLState
+	defer func() {
+		statsKey := qre.generateACLStatsKey("", &tableacl.ACLResult{}, callerID)
+		qre.recordACLStats(statsKey, aclState)
+	}()
+
+	if qre.tsv.qe.enableTableACLDryRun {
+		aclState = acl.ACLPseudoDenied
+		return nil
+	}
+	if !qre.tsv.qe.strictTableACL {
+		return nil
+	}
+	aclState = acl.ACLDenied
+	errStr := fmt.Sprintf("%s command denied to user '%s': its table set cannot be determined for a table ACL check (ACL check error)", qre.plan.PlanID.String(), callerID.Username)
+	qre.tsv.qe.accessCheckerLogger.Infof("%s", errStr)
+	return vterrors.Errorf(vtrpcpb.Code_PERMISSION_DENIED, "%s", errStr)
 }
 
 func (qre *QueryExecutor) generateACLStatsKey(tableName string, authorized *tableacl.ACLResult, callerID *querypb.VTGateCallerID) []string {

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -974,8 +974,9 @@ func (qre *QueryExecutor) checkUndeterminedTableAccess(callerID *querypb.VTGateC
 	var aclState acl.ACLState
 	defer func() {
 		// There is no table to name; label the denial so operators can tell
-		// it apart from a per-table one in the TableACL* counters.
-		statsKey := qre.generateACLStatsKey("undetermined", &tableacl.ACLResult{}, callerID)
+		// it apart from a per-table one in the TableACL* counters. The label
+		// carries hyphens so that no unquoted table name can share the series.
+		statsKey := qre.generateACLStatsKey("undetermined-table-set", &tableacl.ACLResult{}, callerID)
 		qre.recordACLStats(statsKey, aclState)
 	}()
 

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -982,7 +982,9 @@ func (qre *QueryExecutor) checkAccess(authorized *tableacl.ACLResult, tableName 
 func (qre *QueryExecutor) checkUndeterminedTableAccess(callerID *querypb.VTGateCallerID) error {
 	var aclState acl.ACLState
 	defer func() {
-		statsKey := qre.generateACLStatsKey("", &tableacl.ACLResult{}, callerID)
+		// There is no table to name; label the denial so operators can tell
+		// it apart from a per-table one in the TableACL* counters.
+		statsKey := qre.generateACLStatsKey("undetermined", &tableacl.ACLResult{}, callerID)
 		qre.recordACLStats(statsKey, aclState)
 	}()
 

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1167,9 +1167,10 @@ func TestQueryExecutorTableAclPassthroughDenied(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			// The denial has no table to name, so it is recorded under an
-			// "undetermined" table label (and no group) rather than a blank.
-			statsKey := strings.Join([]string{"undetermined", "", tc.planID.String(), "u2"}, ".")
+			// The denial has no table to name, so it is recorded under a table
+			// label no unquoted table name can share (and no group), rather
+			// than a blank.
+			statsKey := strings.Join([]string{"undetermined-table-set", "", tc.planID.String(), "u2"}, ".")
 
 			// Strict table ACL: the caller has no grants, and the statement's
 			// table set is unknown, so it must be denied.

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1116,14 +1116,15 @@ func TestQueryExecutorTableAclNoPermission(t *testing.T) {
 }
 
 // TestQueryExecutorTableAclPassthroughDenied covers statements whose table set
-// the planner cannot determine (DO, CALL, REPAIR, OPTIMIZE). They are forwarded
-// to MySQL as opaque text and can still read or modify tables — a table-reading
-// subquery inside DO, a stored procedure body — but BuildPermissions derives no
-// permissions for them, so before this fix the ACL loop had nothing to check and
-// let any authenticated caller run them under strict table ACL, bypassing the
-// table ACL entirely (GHSA-w6mx-2f8x-pqf4). Under strict ACL these must now be
-// denied for a non-exempt caller; with strict ACL off they must still run, and a
-// dry run must not enforce.
+// the planner cannot determine (DO, CALL, REPAIR, OPTIMIZE, LOAD DATA). They are
+// forwarded to MySQL as opaque text and can still read or modify tables — a
+// table-reading subquery inside DO, a stored procedure body, LOAD DATA's target
+// table — but BuildPermissions derives no permissions for them, so before this
+// fix the ACL loop had nothing to check and let any authenticated caller run
+// them under strict table ACL, bypassing the table ACL entirely
+// (GHSA-w6mx-2f8x-pqf4). Under strict ACL these must now be denied for a
+// non-exempt caller; an exempt caller, a dry run, and strict ACL off must
+// still run them.
 func TestQueryExecutorTableAclPassthroughDenied(t *testing.T) {
 	aclName := fmt.Sprintf("simpleacl-test-%d", rand.Int64())
 	tableacl.Register(aclName, &simpleacl.Factory{})
@@ -1132,14 +1133,14 @@ func TestQueryExecutorTableAclPassthroughDenied(t *testing.T) {
 	defer db.Close()
 
 	// The opaque statements never reach the backend under strict ACL (they are
-	// denied first), but the non-strict and dry-run cases execute them, so the
-	// fake backend must answer both passthrough shapes.
+	// denied first), but the exempt, dry-run and non-strict cases execute them,
+	// so the fake backend must answer all three passthrough shapes.
 	db.AddQueryPattern("(?is)do .*", &sqltypes.Result{})
 	db.AddQueryPattern("(?is)call .*", &sqltypes.Result{})
 	db.AddQueryPattern("(?is)load data .*", &sqltypes.Result{})
 
-	// A subquery-reading DO and a stored-procedure CALL: the two statement
-	// shapes from the advisory, one per tablet plan type that skips the ACL.
+	// A subquery-reading DO, a stored-procedure CALL, and a LOAD DATA: one per
+	// tablet plan type whose statement the parser leaves opaque.
 	cases := []struct {
 		name   string
 		query  string
@@ -1165,6 +1166,16 @@ func TestQueryExecutorTableAclPassthroughDenied(t *testing.T) {
 	callerID := &querypb.VTGateCallerID{Username: "u2", Groups: []string{"eng", "beta"}}
 	ctx := callerid.NewContext(context.Background(), nil, callerID)
 
+	// newServer starts a tablet server for one sub-case and stops it when that
+	// sub-case ends, whether or not its assertions pass, so a failure cannot
+	// leak the server into the next one.
+	newServer := func(t *testing.T, flags executorFlags) *TabletServer {
+		t.Helper()
+		tsv := newTestTabletServer(ctx, flags, db)
+		t.Cleanup(tsv.StopService)
+		return tsv
+	}
+
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			// The denial has no table to name, so it is recorded under a table
@@ -1172,50 +1183,51 @@ func TestQueryExecutorTableAclPassthroughDenied(t *testing.T) {
 			// than a blank.
 			statsKey := strings.Join([]string{"undetermined-table-set", "", tc.planID.String(), "u2"}, ".")
 
-			// Strict table ACL: the caller has no grants, and the statement's
-			// table set is unknown, so it must be denied.
-			tsv := newTestTabletServer(ctx, enableStrictTableACL, db)
-			qre := newTestQueryExecutor(ctx, tsv, tc.query, 0)
-			require.Equal(t, tc.planID, qre.plan.PlanID)
-			deniedBefore := tsv.stats.TableaclDenied.Counts()[statsKey]
-			_, err := qre.Execute()
-			require.Error(t, err, "an authenticated caller with no grants must not run an opaque statement under strict table ACL")
-			assert.Equal(t, vtrpcpb.Code_PERMISSION_DENIED, vterrors.Code(err))
-			// The denial names the caller's groups like a per-table one does.
-			require.EqualError(t, err, tc.planID.String()+" command denied to user 'u2', in groups [eng, beta], for a table set that cannot be determined (ACL check error)")
-			assert.Equal(t, deniedBefore+1, tsv.stats.TableaclDenied.Counts()[statsKey], "the denial must be counted under the undetermined-table key")
-			tsv.StopService()
+			t.Run("strict table ACL denies", func(t *testing.T) {
+				// The caller has no grants and the statement's table set is
+				// unknown, so it must be denied.
+				tsv := newServer(t, enableStrictTableACL)
+				qre := newTestQueryExecutor(ctx, tsv, tc.query, 0)
+				require.Equal(t, tc.planID, qre.plan.PlanID)
+				require.True(t, qre.plan.TablesUndetermined, "the planner must flag the statement's table set as undetermined")
+				deniedBefore := tsv.stats.TableaclDenied.Counts()[statsKey]
+				_, err := qre.Execute()
+				require.Error(t, err, "an authenticated caller with no grants must not run an opaque statement under strict table ACL")
+				assert.Equal(t, vtrpcpb.Code_PERMISSION_DENIED, vterrors.Code(err))
+				// The denial names the caller's groups like a per-table one does.
+				require.EqualError(t, err, tc.planID.String()+" command denied to user 'u2', in groups [eng, beta], for a table set that cannot be determined (ACL check error)")
+				assert.Equal(t, deniedBefore+1, tsv.stats.TableaclDenied.Counts()[statsKey], "the denial must be counted under the undetermined-table key")
+			})
 
-			// Strict table ACL with an exempt caller: the escape hatch the
-			// gate relies on is applied before it, so the statement runs.
-			tsv = newTestTabletServer(ctx, enableStrictTableACL, db)
-			f, err := tableacl.GetCurrentACLFactory()
-			require.NoError(t, err)
-			tsv.qe.exemptACL, err = f.New([]string{"exempt-acl"})
-			require.NoError(t, err)
-			exemptCtx := callerid.NewContext(context.Background(), nil, &querypb.VTGateCallerID{Username: "exempt-acl"})
-			qre = newTestQueryExecutor(exemptCtx, tsv, tc.query, 0)
-			_, err = qre.Execute()
-			require.NoError(t, err, "an exempt caller must still be able to run the statement under strict table ACL")
-			tsv.StopService()
+			t.Run("exempt caller runs", func(t *testing.T) {
+				// The escape hatch the gate relies on is applied before it.
+				tsv := newServer(t, enableStrictTableACL)
+				f, err := tableacl.GetCurrentACLFactory()
+				require.NoError(t, err)
+				tsv.qe.exemptACL, err = f.New([]string{"exempt-acl"})
+				require.NoError(t, err)
+				exemptCtx := callerid.NewContext(context.Background(), nil, &querypb.VTGateCallerID{Username: "exempt-acl"})
+				qre := newTestQueryExecutor(exemptCtx, tsv, tc.query, 0)
+				_, err = qre.Execute()
+				require.NoError(t, err, "an exempt caller must still be able to run the statement under strict table ACL")
+			})
 
-			// Strict table ACL with dry run on: the denial is only recorded,
-			// not enforced, so the statement runs.
-			tsv = newTestTabletServer(ctx, enableStrictTableACL, db)
-			tsv.qe.enableTableACLDryRun = true
-			qre = newTestQueryExecutor(ctx, tsv, tc.query, 0)
-			pseudoBefore := tsv.stats.TableaclPseudoDenied.Counts()[statsKey]
-			_, err = qre.Execute()
-			require.NoError(t, err, "a dry run must not enforce the ACL")
-			assert.Equal(t, pseudoBefore+1, tsv.stats.TableaclPseudoDenied.Counts()[statsKey], "a dry run must count the denial under the undetermined-table key")
-			tsv.StopService()
+			t.Run("dry run only records", func(t *testing.T) {
+				tsv := newServer(t, enableStrictTableACL)
+				tsv.qe.enableTableACLDryRun = true
+				qre := newTestQueryExecutor(ctx, tsv, tc.query, 0)
+				pseudoBefore := tsv.stats.TableaclPseudoDenied.Counts()[statsKey]
+				_, err := qre.Execute()
+				require.NoError(t, err, "a dry run must not enforce the ACL")
+				assert.Equal(t, pseudoBefore+1, tsv.stats.TableaclPseudoDenied.Counts()[statsKey], "a dry run must count the denial under the undetermined-table key")
+			})
 
-			// Strict table ACL off: the statement runs as before.
-			tsv = newTestTabletServer(ctx, noFlags, db)
-			qre = newTestQueryExecutor(ctx, tsv, tc.query, 0)
-			_, err = qre.Execute()
-			require.NoError(t, err, "with strict table ACL off the statement must still run")
-			tsv.StopService()
+			t.Run("strict table ACL off runs", func(t *testing.T) {
+				tsv := newServer(t, noFlags)
+				qre := newTestQueryExecutor(ctx, tsv, tc.query, 0)
+				_, err := qre.Execute()
+				require.NoError(t, err, "with strict table ACL off the statement must still run")
+			})
 		})
 	}
 }

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1191,8 +1191,12 @@ func TestQueryExecutorTableAclPassthroughDenied(t *testing.T) {
 				require.Equal(t, tc.planID, qre.plan.PlanID)
 				require.True(t, qre.plan.TablesUndetermined, "the planner must flag the statement's table set as undetermined")
 				deniedBefore := tsv.stats.TableaclDenied.Counts()[statsKey]
+				calledBefore := db.GetQueryCalledNum(tc.query)
 				_, err := qre.Execute()
 				require.Error(t, err, "an authenticated caller with no grants must not run an opaque statement under strict table ACL")
+				// Denied means denied before execution: the backend must not have
+				// seen the statement at all.
+				assert.Equal(t, calledBefore, db.GetQueryCalledNum(tc.query), "the backend must not see a statement the ACL denied")
 				assert.Equal(t, vtrpcpb.Code_PERMISSION_DENIED, vterrors.Code(err))
 				// The denial names the caller's groups like a per-table one does.
 				require.EqualError(t, err, tc.planID.String()+" command denied to user 'u2', in groups [eng, beta], for a table set that cannot be determined (ACL check error)")
@@ -1208,8 +1212,10 @@ func TestQueryExecutorTableAclPassthroughDenied(t *testing.T) {
 				require.NoError(t, err)
 				exemptCtx := callerid.NewContext(context.Background(), nil, &querypb.VTGateCallerID{Username: "exempt-acl"})
 				qre := newTestQueryExecutor(exemptCtx, tsv, tc.query, 0)
+				calledBefore := db.GetQueryCalledNum(tc.query)
 				_, err = qre.Execute()
 				require.NoError(t, err, "an exempt caller must still be able to run the statement under strict table ACL")
+				assert.Equal(t, calledBefore+1, db.GetQueryCalledNum(tc.query), "the statement must reach the backend")
 			})
 
 			t.Run("dry run only records", func(t *testing.T) {
@@ -1217,16 +1223,20 @@ func TestQueryExecutorTableAclPassthroughDenied(t *testing.T) {
 				tsv.qe.enableTableACLDryRun = true
 				qre := newTestQueryExecutor(ctx, tsv, tc.query, 0)
 				pseudoBefore := tsv.stats.TableaclPseudoDenied.Counts()[statsKey]
+				calledBefore := db.GetQueryCalledNum(tc.query)
 				_, err := qre.Execute()
 				require.NoError(t, err, "a dry run must not enforce the ACL")
+				assert.Equal(t, calledBefore+1, db.GetQueryCalledNum(tc.query), "the statement must reach the backend")
 				assert.Equal(t, pseudoBefore+1, tsv.stats.TableaclPseudoDenied.Counts()[statsKey], "a dry run must count the denial under the undetermined-table key")
 			})
 
 			t.Run("strict table ACL off runs", func(t *testing.T) {
 				tsv := newServer(t, noFlags)
 				qre := newTestQueryExecutor(ctx, tsv, tc.query, 0)
+				calledBefore := db.GetQueryCalledNum(tc.query)
 				_, err := qre.Execute()
 				require.NoError(t, err, "with strict table ACL off the statement must still run")
+				assert.Equal(t, calledBefore+1, db.GetQueryCalledNum(tc.query), "the statement must reach the backend")
 			})
 		})
 	}

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1162,7 +1162,7 @@ func TestQueryExecutorTableAclPassthroughDenied(t *testing.T) {
 		}},
 	}
 	require.NoError(t, tableacl.InitFromProto(config))
-	callerID := &querypb.VTGateCallerID{Username: "u2"}
+	callerID := &querypb.VTGateCallerID{Username: "u2", Groups: []string{"eng", "beta"}}
 	ctx := callerid.NewContext(context.Background(), nil, callerID)
 
 	for _, tc := range cases {
@@ -1180,6 +1180,8 @@ func TestQueryExecutorTableAclPassthroughDenied(t *testing.T) {
 			_, err := qre.Execute()
 			require.Error(t, err, "an authenticated caller with no grants must not run an opaque statement under strict table ACL")
 			assert.Equal(t, vtrpcpb.Code_PERMISSION_DENIED, vterrors.Code(err))
+			// The denial names the caller's groups like a per-table one does.
+			require.EqualError(t, err, tc.planID.String()+" command denied to user 'u2', in groups [eng, beta], for a table set that cannot be determined (ACL check error)")
 			assert.Equal(t, deniedBefore+1, tsv.stats.TableaclDenied.Counts()[statsKey], "the denial must be counted under the undetermined-table key")
 			tsv.StopService()
 

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1136,6 +1136,7 @@ func TestQueryExecutorTableAclPassthroughDenied(t *testing.T) {
 	// fake backend must answer both passthrough shapes.
 	db.AddQueryPattern("(?is)do .*", &sqltypes.Result{})
 	db.AddQueryPattern("(?is)call .*", &sqltypes.Result{})
+	db.AddQueryPattern("(?is)load data .*", &sqltypes.Result{})
 
 	// A subquery-reading DO and a stored-procedure CALL: the two statement
 	// shapes from the advisory, one per tablet plan type that skips the ACL.
@@ -1146,6 +1147,10 @@ func TestQueryExecutorTableAclPassthroughDenied(t *testing.T) {
 	}{
 		{"do with table subquery", "do (select email from test_table where pk = 3 limit 1)", planbuilder.PlanOtherAdmin},
 		{"call stored procedure", "call test_proc()", planbuilder.PlanCallProc},
+		// LOAD DATA is the same gap on the write side: the parser discards
+		// everything after LOAD DATA, and the stock init_db.sql grants vt_app
+		// the FILE privilege, so a server-side INFILE into a denied table runs.
+		{"load data into table", "load data infile '/var/lib/mysql-files/x.csv' into table test_table", planbuilder.PlanLoad},
 	}
 
 	// test_table is readable only by "superuser"; the caller "u2" is in no group.

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1115,6 +1115,82 @@ func TestQueryExecutorTableAclNoPermission(t *testing.T) {
 	require.Equalf(t, vtrpcpb.Code_PERMISSION_DENIED, vterrors.Code(err), "qre.Execute: %v, want %v", vterrors.Code(err), vtrpcpb.Code_PERMISSION_DENIED)
 }
 
+// TestQueryExecutorTableAclPassthroughDenied covers statements whose table set
+// the planner cannot determine (DO, CALL, REPAIR, OPTIMIZE). They are forwarded
+// to MySQL as opaque text and can still read or modify tables — a table-reading
+// subquery inside DO, a stored procedure body — but BuildPermissions derives no
+// permissions for them, so before this fix the ACL loop had nothing to check and
+// let any authenticated caller run them under strict table ACL, bypassing the
+// table ACL entirely (GHSA-w6mx-2f8x-pqf4). Under strict ACL these must now be
+// denied for a non-exempt caller; with strict ACL off they must still run, and a
+// dry run must not enforce.
+func TestQueryExecutorTableAclPassthroughDenied(t *testing.T) {
+	aclName := fmt.Sprintf("simpleacl-test-%d", rand.Int64())
+	tableacl.Register(aclName, &simpleacl.Factory{})
+	tableacl.SetDefaultACL(aclName)
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+
+	// The opaque statements never reach the backend under strict ACL (they are
+	// denied first), but the non-strict and dry-run cases execute them, so the
+	// fake backend must answer both passthrough shapes.
+	db.AddQueryPattern("(?is)do .*", &sqltypes.Result{})
+	db.AddQueryPattern("(?is)call .*", &sqltypes.Result{})
+
+	// A subquery-reading DO and a stored-procedure CALL: the two statement
+	// shapes from the advisory, one per tablet plan type that skips the ACL.
+	cases := []struct {
+		name   string
+		query  string
+		planID planbuilder.PlanType
+	}{
+		{"do with table subquery", "do (select email from test_table where pk = 3 limit 1)", planbuilder.PlanOtherAdmin},
+		{"call stored procedure", "call test_proc()", planbuilder.PlanCallProc},
+	}
+
+	// test_table is readable only by "superuser"; the caller "u2" is in no group.
+	config := &tableaclpb.Config{
+		TableGroups: []*tableaclpb.TableGroupSpec{{
+			Name:                 "group02",
+			TableNamesOrPrefixes: []string{"test_table"},
+			Readers:              []string{"superuser"},
+		}},
+	}
+	require.NoError(t, tableacl.InitFromProto(config))
+	callerID := &querypb.VTGateCallerID{Username: "u2"}
+	ctx := callerid.NewContext(context.Background(), nil, callerID)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Strict table ACL: the caller has no grants, and the statement's
+			// table set is unknown, so it must be denied.
+			tsv := newTestTabletServer(ctx, enableStrictTableACL, db)
+			qre := newTestQueryExecutor(ctx, tsv, tc.query, 0)
+			require.Equal(t, tc.planID, qre.plan.PlanID)
+			_, err := qre.Execute()
+			require.Error(t, err, "an authenticated caller with no grants must not run an opaque statement under strict table ACL")
+			assert.Equal(t, vtrpcpb.Code_PERMISSION_DENIED, vterrors.Code(err))
+			tsv.StopService()
+
+			// Strict table ACL with dry run on: the denial is only recorded,
+			// not enforced, so the statement runs.
+			tsv = newTestTabletServer(ctx, enableStrictTableACL, db)
+			tsv.qe.enableTableACLDryRun = true
+			qre = newTestQueryExecutor(ctx, tsv, tc.query, 0)
+			_, err = qre.Execute()
+			require.NoError(t, err, "a dry run must not enforce the ACL")
+			tsv.StopService()
+
+			// Strict table ACL off: the statement runs as before.
+			tsv = newTestTabletServer(ctx, noFlags, db)
+			qre = newTestQueryExecutor(ctx, tsv, tc.query, 0)
+			_, err = qre.Execute()
+			require.NoError(t, err, "with strict table ACL off the statement must still run")
+			tsv.StopService()
+		})
+	}
+}
+
 func TestQueryExecutorTableAclDualTableExempt(t *testing.T) {
 	aclName := fmt.Sprintf("simpleacl-test-%d", rand.Int64())
 	tableacl.Register(aclName, &simpleacl.Factory{})

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1167,14 +1167,33 @@ func TestQueryExecutorTableAclPassthroughDenied(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			// The denial has no table to name, so it is recorded under an
+			// "undetermined" table label (and no group) rather than a blank.
+			statsKey := strings.Join([]string{"undetermined", "", tc.planID.String(), "u2"}, ".")
+
 			// Strict table ACL: the caller has no grants, and the statement's
 			// table set is unknown, so it must be denied.
 			tsv := newTestTabletServer(ctx, enableStrictTableACL, db)
 			qre := newTestQueryExecutor(ctx, tsv, tc.query, 0)
 			require.Equal(t, tc.planID, qre.plan.PlanID)
+			deniedBefore := tsv.stats.TableaclDenied.Counts()[statsKey]
 			_, err := qre.Execute()
 			require.Error(t, err, "an authenticated caller with no grants must not run an opaque statement under strict table ACL")
 			assert.Equal(t, vtrpcpb.Code_PERMISSION_DENIED, vterrors.Code(err))
+			assert.Equal(t, deniedBefore+1, tsv.stats.TableaclDenied.Counts()[statsKey], "the denial must be counted under the undetermined-table key")
+			tsv.StopService()
+
+			// Strict table ACL with an exempt caller: the escape hatch the
+			// gate relies on is applied before it, so the statement runs.
+			tsv = newTestTabletServer(ctx, enableStrictTableACL, db)
+			f, err := tableacl.GetCurrentACLFactory()
+			require.NoError(t, err)
+			tsv.qe.exemptACL, err = f.New([]string{"exempt-acl"})
+			require.NoError(t, err)
+			exemptCtx := callerid.NewContext(context.Background(), nil, &querypb.VTGateCallerID{Username: "exempt-acl"})
+			qre = newTestQueryExecutor(exemptCtx, tsv, tc.query, 0)
+			_, err = qre.Execute()
+			require.NoError(t, err, "an exempt caller must still be able to run the statement under strict table ACL")
 			tsv.StopService()
 
 			// Strict table ACL with dry run on: the denial is only recorded,
@@ -1182,8 +1201,10 @@ func TestQueryExecutorTableAclPassthroughDenied(t *testing.T) {
 			tsv = newTestTabletServer(ctx, enableStrictTableACL, db)
 			tsv.qe.enableTableACLDryRun = true
 			qre = newTestQueryExecutor(ctx, tsv, tc.query, 0)
+			pseudoBefore := tsv.stats.TableaclPseudoDenied.Counts()[statsKey]
 			_, err = qre.Execute()
 			require.NoError(t, err, "a dry run must not enforce the ACL")
+			assert.Equal(t, pseudoBefore+1, tsv.stats.TableaclPseudoDenied.Counts()[statsKey], "a dry run must count the denial under the undetermined-table key")
 			tsv.StopService()
 
 			// Strict table ACL off: the statement runs as before.


### PR DESCRIPTION
## Description

Under strict table ACL, vttablet enforces access only on the tables its planner derives for a statement. `DO`, `CALL`, `REPAIR`, `OPTIMIZE` and `LOAD DATA` are parsed into nodes that discard their table-bearing text, so no permissions are derived and the ACL loop had nothing to check. Any authenticated caller could therefore run them against denied tables with vttablet's own MySQL privileges: a `DO` with a table-reading subquery or a `CALL` into a procedure body to read, and a server-side `LOAD DATA INFILE` to write.

`checkPermissions` now fails closed for these statements: when the tablet cannot enumerate a statement's tables, it denies it under strict table ACL rather than skipping the check. Dry-run mode still only records the denial, nothing changes when strict table ACL is off, and the exempt ACL remains the way operators run these statements. Note that this also denies callers who do hold grants on the affected tables, since the tablet cannot confirm which tables the statement touches.

## Related Issue(s)

  - Fixes: https://github.com/vitessio/vitess/security/advisories/GHSA-w6mx-2f8x-pqf4 (this PR is the first half: statements whose tables the parser discards; #21139 is the second)

This is one of a set of changes that came out of one investigation into what a stored procedure, or any statement whose tables the planner never sees, can do on a vttablet. They reference each other so the whole picture is reachable from any one of them.

**Table ACL — GHSA-w6mx-2f8x-pqf4**
- #21053 — fail closed under strict table ACL for statements whose tables the parser discards (`DO`, `CALL`, `REPAIR`, `OPTIMIZE`, `LOAD DATA`)
- #21139 — stacked on #21053: check the reads embedded in statements the planner does parse (`CREATE TABLE ... AS SELECT`, `EXPLAIN ANALYZE`, `SHOW ... WHERE`, `SET`), reject connection settings that carry a subquery, and have a targeted vtgate session store a `SET`'s value rather than its expression
- #21134 — still open: a stored function invoked inside an expression runs its body outside the table ACL
- #21138 — still open: parse the `CREATE TABLE` source forms the grammar only partially accepts, which #21139 has to deny outright today
- #21140 — still open: `ALTER`/`REVERT VITESS_MIGRATION` derive no permissions, so any authenticated caller can control Online DDL migrations; split out of #21053's review

**Stored-procedure session residue**
- #21046 — procedure-body session state (`SET SESSION`, temp tables) persists on pooled connections after `CALL`
- #21062 — fixes #21046 by discarding the pooled connection after `CALL`
- #21063 — still open: the same residue on a transaction connection recycled at commit
- #21066 — still open: the pooled-connection baseline differs between fresh and settings-reset connections on servers using `init_connect`
## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

This only changes behavior when strict table ACL is enabled (`--queryserver-config-strict-table-acl`). With it on, `DO`, `CALL`, `REPAIR`, `OPTIMIZE` and `LOAD DATA` are now denied for every caller that is not in the exempt ACL (`--queryserver-config-acl-exempt-acl`), including callers whose table grants would otherwise have been sufficient: the tablet cannot determine which tables these statements touch, so it fails closed rather than skipping the check. Operators who need these statements should issue them as a caller in the exempt ACL. With `--queryserver-config-enable-table-acl-dry-run` the denial is only recorded and the statement still runs. Nothing changes when strict table ACL is off. The same applies on the release branches this is backported to.

These denials have no table to name, so they are counted under a new `TableName` label, `undetermined-table-set`, in `TableACLDenied`. With dry-run on, every non-exempt `DO`, `CALL`, `REPAIR`, `OPTIMIZE` and `LOAD DATA` from a request that carries a caller id increments `TableACLPseudoDenied` under that same label, whether or not strict table ACL is on, so operators sizing a strict-ACL rollout will see a new series appear. A request without a caller id is handled before this gate, as it is for per-table checks: denied under strict table ACL, and neither denied nor counted with it off. The new series carries an empty `TableGroup` label value, as denials for tables that match no ACL entry already do; an exporter that drops metrics with empty label values will drop this series, so check the exporter before relying on it to size a rollout.

The exported `planbuilder.BuildPermissions` now returns a second result, `tablesUndetermined bool`, alongside the permissions it already returned. This is a breaking change for any out-of-tree caller: it is deliberately not kept as a one-result compatibility wrapper, because a caller left on the old signature would silently keep the behavior this fix closes — no permissions derived, and no way to learn the table set was undetermined. Callers should take the new result and deny the statement when it is true.

This closes the gap for statements. It does not cover stored **functions**: `CALL` is now denied, but a function invoked inside an expression (`SELECT f()`, a `WHERE` clause, a `SET` in DML) still runs its body with vttablet's MySQL privileges while the ACL checks only the tables the statement itself names. Vitess does not parse `CREATE FUNCTION`, so this applies to functions defined directly in MySQL. That gap is tracked in #21134.

### AI Disclosure

I worked with Claude and Fable 5.1 on the work and Codex and GPT-5.6 on reviews.









