### PR TITLE
vtexplain: run fake tablets with the temp-table idle timeout disabled

### DIFF
--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -119,6 +119,10 @@ func (vte *VTExplain) newTablet(ctx context.Context, env *vtenv.Environment, opt
 	}
 	config.EnableOnlineDDL = false
 	config.EnableTableGC = false
+	// Auto mode (the default) reads @@global.wait_timeout on a background
+	// goroutine, and that read would land in the recorded queries at a
+	// nondeterministic point; the fake tablets serve no real connections.
+	config.TempTableIdleTimeout = 0
 
 	// XXX much of this is cloned from the tabletserver tests
 	tsv := tabletserver.NewTabletServer(ctx, env, topoproto.TabletAliasString(t.Alias), config, ts, t.Alias, srvTopoCounts)

--- a/go/vt/vtexplain/vtexplain_vttablet_test.go
+++ b/go/vt/vtexplain/vtexplain_vttablet_test.go
@@ -258,9 +258,13 @@ func TestNewTabletDoesNotMirrorMysqlWaitTimeout(t *testing.T) {
 			Cell: Cell,
 		},
 	}, ts, srvTopoCounts)
-	defer tablet.tsv.StopService()
+	defer func() {
+		tablet.tsv.StopService()
+		tablet.tsv.Close(ctx)
+		tablet.db.Close()
+	}()
 
-	require.Zero(t, tablet.tsv.Config().TempTableIdleTimeout, "vtexplain tablets must not mirror mysqld's wait_timeout")
+	assert.Zero(t, tablet.tsv.Config().TempTableIdleTimeout, "vtexplain tablets must not mirror mysqld's wait_timeout")
 
 	// A schema broadcast is what triggers the background read in auto mode;
 	// the fake database reports any such read reaching the tablet.

--- a/go/vt/vtexplain/vtexplain_vttablet_test.go
+++ b/go/vt/vtexplain/vtexplain_vttablet_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"vitess.io/vitess/go/mysql/collations"
+	"vitess.io/vitess/go/sqltypes"
 	"vitess.io/vitess/go/stats"
 	"vitess.io/vitess/go/vt/sqlparser"
 	"vitess.io/vitess/go/vt/topo/memorytopo"
@@ -226,4 +227,55 @@ func TestErrParseSchema(t *testing.T) {
 
 	_, err = newTabletEnvironment(ddl, defaultTestOpts(), collations.MySQL8())
 	require.Error(t, err, "check your schema, table[t2] doesn't exist")
+}
+
+// TestNewTabletDoesNotMirrorMysqlWaitTimeout pins that vtexplain's fake
+// tablets run with the temp-table idle timeout disabled rather than in its
+// default auto mode. Auto mode reads @@global.wait_timeout on a background
+// goroutine at query-service open and on every schema reload, and vtexplain
+// records every query its fake tablets receive, so that read lands in the
+// explain output at a nondeterministic point and flakes the golden-output
+// tests. vtexplain serves no real connections, so there is nothing for the
+// idle timeout to govern.
+func TestNewTabletDoesNotMirrorMysqlWaitTimeout(t *testing.T) {
+	env := vtenv.NewTestEnv()
+	ddls, err := parseSchema("create table t1 (id int primary key)", &Options{StrictDDL: false}, env.Parser())
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	ts := memorytopo.NewServer(ctx, Cell)
+	vte := initTest(ctx, ts, ModeMulti, defaultTestOpts(), &testopts{}, t)
+	defer vte.Stop()
+
+	tabletEnv, err := newTabletEnvironment(ddls, defaultTestOpts(), env.CollationEnv())
+	require.NoError(t, err)
+	vte.setGlobalTabletEnv(tabletEnv)
+	srvTopoCounts := stats.NewCountersWithSingleLabel("", "Resilient srvtopo server operations", "type")
+	tablet := vte.newTablet(ctx, env, defaultTestOpts(), &topodatapb.Tablet{
+		Keyspace: "ks_sharded",
+		Shard:    "-80",
+		Alias: &topodatapb.TabletAlias{
+			Cell: Cell,
+		},
+	}, ts, srvTopoCounts)
+	defer tablet.tsv.StopService()
+
+	require.Zero(t, tablet.tsv.Config().TempTableIdleTimeout, "vtexplain tablets must not mirror mysqld's wait_timeout")
+
+	// A schema broadcast is what triggers the background read in auto mode;
+	// the fake database reports any such read reaching the tablet.
+	waitTimeoutRead := make(chan string, 1)
+	tablet.db.AddQueryPatternWithCallback(`(?i)select @@global\.wait_timeout`, &sqltypes.Result{}, func(query string) {
+		select {
+		case waitTimeoutRead <- query:
+		default:
+		}
+	})
+	tablet.tsv.SchemaEngine().BroadcastForTesting(nil, nil, nil, false)
+
+	select {
+	case query := <-waitTimeoutRead:
+		assert.Failf(t, "unexpected wait_timeout read", "the fake tablet received %q after a schema broadcast", query)
+	case <-time.After(300 * time.Millisecond):
+	}
 }


### PR DESCRIPTION
## Description

Since #20429 the query engine mirrors mysqld's `@@global.wait_timeout` for the temp-table idle timeout's auto mode: a background goroutine reads it at query-service open and on every schema reload. vtexplain builds its fake tablets with the default `TabletConfig`, so auto mode is on, and vtexplain records every query its fake tablets receive. The read therefore lands in the explain output at a nondeterministic point, and `TestExplain` fails when it does:

```
    vtexplain_test.go:133: Text output did not match (-want +got):
          	SELECT * from user
          	
        + 	0 ks_sharded/80-c0: select @@global.wait_timeout
          	1 ks_sharded/-40: select * from `user` limit 10001
```

I saw this in the `Unit Test (Race)` job on a fork that carries #20429; the code is identical on `main`, so the flake exists here too. It is the vtexplain sibling of #21024, which fixes the other flake #20429 introduced (`TestConfigChanges` / the endtoend short-timeout tests racing the same background goroutine).

vtexplain serves no real connections, so there is nothing for the idle timeout to govern: the fake tablets now run with it disabled (`0`, the pre-#20429 behavior), which skips the read entirely.

The new test builds a fake tablet, pins that the idle timeout is disabled, then fires a schema broadcast (what triggers the read in auto mode) and asserts the fake database never receives `select @@global.wait_timeout`. On `main` it fails on both checks; with this change it passes, as does the whole `go/vt/vtexplain` package under `-race`.

## Related Issue(s)

- Introduced by #20429
- Sibling fix: #21024

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

None. #20429 is only on `main`, so no backport.

### AI Disclosure

This PR was written by Claude Code, including the investigation of the CI failure; I provided direction and reviewed it.
