### PR TITLE
vtgate: a qualified function call is a stored-function call

### DIFF
--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -36,6 +36,7 @@
         - [Stricter PROXY protocol v1 header validation](#vtgate-proxy-protocol-v1-strictness)
         - [MySQL-faithful validation and rejection of unsupported `sql_mode` values](#vtgate-sql-mode-rejection)
         - [New `VEXPLAIN MYSQLPLAN` statement](#vtgate-vexplain-mysqlplan)
+        - [A qualified function call is a stored-function call](#vtgate-qualified-function-call)
     - **[Reparent](#minor-changes-reparent)**
         - [`EmergencyReparentShard` no longer waits on replicas that cannot win the election](#ers-lagging-relay-log-wait)
         - [`EmergencyReparentShard` can explicitly recover from split brain](#ers-allow-split-brain-promotion)
@@ -380,6 +381,10 @@ For each `Route` in the plan, the per-shard `EXPLAIN` queries are run concurrent
 Because each per-shard `EXPLAIN` runs on a separate connection, a `VEXPLAIN MYSQLPLAN` issued inside an open transaction reflects the pre-transaction state of each shard rather than any uncommitted changes made in that transaction — the same limitation as `VEXPLAIN ALL`.
 
 Like a plain `EXPLAIN`, the per-shard `EXPLAIN FORMAT=JSON` queries `VEXPLAIN MYSQLPLAN` issues are not subject to table ACL checks on the explained tables, so `VEXPLAIN MYSQLPLAN` can return per-shard plan metadata (index names, row estimates, filtered percentages) for tables the caller could not otherwise read. For the same reason — the tablet plans an `EXPLAIN` without the explained table's identity — query denylist rules that are conditioned on a table name are not enforced against these per-shard `EXPLAIN` queries either; denylist rules conditioned on the query pattern still apply if their pattern matches the `explain format = json ...` query text. Unlike a plain `EXPLAIN`, which reaches a single arbitrary shard, `VEXPLAIN MYSQLPLAN` extends this to every resolved shard of every keyspace in the plan. Deployments that rely on table ACLs or table-scoped query denylist rules to restrict read access should restrict access to `VEXPLAIN MYSQLPLAN` accordingly.
+
+#### <a id="vtgate-qualified-function-call"/>A qualified function call is a stored-function call</a>
+
+A function call qualified with a schema name, such as `db.last_insert_id()` or `db.udf_aggr(col)`, names a stored function in that schema, whatever the name, and MySQL resolves and evaluates it. VTGate used to treat such a call like the unqualified built-in or aggregate UDF of the same name: the normalizer replaced `db.last_insert_id()`, `db.found_rows()` and `db.row_count()` with the session's own values, the evalengine computed `db.abs(-1)` itself, and a qualified call by the name of an aggregate UDF registered in the VSchema made the planner fail. Qualified calls are now always sent to MySQL as written.
 
 ### <a id="minor-changes-reparent"/>Reparent</a>
 

--- a/changelog/25.0/25.0.0/summary.md
+++ b/changelog/25.0/25.0.0/summary.md
@@ -36,7 +36,6 @@
         - [Stricter PROXY protocol v1 header validation](#vtgate-proxy-protocol-v1-strictness)
         - [MySQL-faithful validation and rejection of unsupported `sql_mode` values](#vtgate-sql-mode-rejection)
         - [New `VEXPLAIN MYSQLPLAN` statement](#vtgate-vexplain-mysqlplan)
-        - [A qualified function call is a stored-function call](#vtgate-qualified-function-call)
     - **[Reparent](#minor-changes-reparent)**
         - [`EmergencyReparentShard` no longer waits on replicas that cannot win the election](#ers-lagging-relay-log-wait)
         - [`EmergencyReparentShard` can explicitly recover from split brain](#ers-allow-split-brain-promotion)
@@ -381,10 +380,6 @@ For each `Route` in the plan, the per-shard `EXPLAIN` queries are run concurrent
 Because each per-shard `EXPLAIN` runs on a separate connection, a `VEXPLAIN MYSQLPLAN` issued inside an open transaction reflects the pre-transaction state of each shard rather than any uncommitted changes made in that transaction — the same limitation as `VEXPLAIN ALL`.
 
 Like a plain `EXPLAIN`, the per-shard `EXPLAIN FORMAT=JSON` queries `VEXPLAIN MYSQLPLAN` issues are not subject to table ACL checks on the explained tables, so `VEXPLAIN MYSQLPLAN` can return per-shard plan metadata (index names, row estimates, filtered percentages) for tables the caller could not otherwise read. For the same reason — the tablet plans an `EXPLAIN` without the explained table's identity — query denylist rules that are conditioned on a table name are not enforced against these per-shard `EXPLAIN` queries either; denylist rules conditioned on the query pattern still apply if their pattern matches the `explain format = json ...` query text. Unlike a plain `EXPLAIN`, which reaches a single arbitrary shard, `VEXPLAIN MYSQLPLAN` extends this to every resolved shard of every keyspace in the plan. Deployments that rely on table ACLs or table-scoped query denylist rules to restrict read access should restrict access to `VEXPLAIN MYSQLPLAN` accordingly.
-
-#### <a id="vtgate-qualified-function-call"/>A qualified function call is a stored-function call</a>
-
-A function call qualified with a schema name, such as `db.last_insert_id()` or `db.udf_aggr(col)`, names a stored function in that schema, whatever the name, and MySQL resolves and evaluates it. VTGate used to treat such a call like the unqualified built-in or aggregate UDF of the same name: the normalizer replaced `db.last_insert_id()`, `db.found_rows()` and `db.row_count()` with the session's own values, the evalengine computed `db.abs(-1)` itself, and a qualified call by the name of an aggregate UDF registered in the VSchema made the planner fail. Qualified calls are now always sent to MySQL as written.
 
 ### <a id="minor-changes-reparent"/>Reparent</a>
 

--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -2269,7 +2269,8 @@ func (node *Order) Format(buf *TrackedBuffer) {
 		return
 	}
 	if node, ok := node.Expr.(*FuncExpr); ok {
-		if node.Name.Lowered() == "rand" {
+		// the built-in rand() only: a qualified call is a stored function
+		if node.Qualifier.IsEmpty() && node.Name.Lowered() == "rand" {
 			buf.astPrintf(node, "%v", node)
 			return
 		}

--- a/go/vt/sqlparser/ast_format.go
+++ b/go/vt/sqlparser/ast_format.go
@@ -2269,7 +2269,6 @@ func (node *Order) Format(buf *TrackedBuffer) {
 		return
 	}
 	if node, ok := node.Expr.(*FuncExpr); ok {
-		// the built-in rand() only: a qualified call is a stored function
 		if node.Qualifier.IsEmpty() && node.Name.Lowered() == "rand" {
 			buf.astPrintf(node, "%v", node)
 			return

--- a/go/vt/sqlparser/ast_format_fast.go
+++ b/go/vt/sqlparser/ast_format_fast.go
@@ -2973,7 +2973,6 @@ func (node *Order) FormatFast(buf *TrackedBuffer) {
 		return
 	}
 	if node, ok := node.Expr.(*FuncExpr); ok {
-		// the built-in rand() only: a qualified call is a stored function
 		if node.Qualifier.IsEmpty() && node.Name.Lowered() == "rand" {
 			buf.printExpr(node, node, true)
 			return

--- a/go/vt/sqlparser/ast_format_fast.go
+++ b/go/vt/sqlparser/ast_format_fast.go
@@ -2973,7 +2973,8 @@ func (node *Order) FormatFast(buf *TrackedBuffer) {
 		return
 	}
 	if node, ok := node.Expr.(*FuncExpr); ok {
-		if node.Name.Lowered() == "rand" {
+		// the built-in rand() only: a qualified call is a stored function
+		if node.Qualifier.IsEmpty() && node.Name.Lowered() == "rand" {
 			buf.printExpr(node, node, true)
 			return
 		}

--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -773,7 +773,6 @@ func (nz *normalizer) udvRewrite(cursor *Cursor, node *Variable) {
 // funcRewrite replaces certain function expressions with bind variables.
 func (nz *normalizer) funcRewrite(cursor *Cursor, node *FuncExpr) {
 	if !node.Qualifier.IsEmpty() {
-		// a qualified call names a stored function, whatever the name: MySQL's to resolve
 		return
 	}
 	lowered := node.Name.Lowered()

--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -772,6 +772,10 @@ func (nz *normalizer) udvRewrite(cursor *Cursor, node *Variable) {
 
 // funcRewrite replaces certain function expressions with bind variables.
 func (nz *normalizer) funcRewrite(cursor *Cursor, node *FuncExpr) {
+	if !node.Qualifier.IsEmpty() {
+		// a qualified call names a stored function, whatever the name: MySQL's to resolve
+		return
+	}
 	lowered := node.Name.Lowered()
 	if lowered == "last_insert_id" && len(node.Exprs) > 0 {
 		// Do not rewrite LAST_INSERT_ID() when it has arguments.

--- a/go/vt/sqlparser/normalizer_test.go
+++ b/go/vt/sqlparser/normalizer_test.go
@@ -627,6 +627,10 @@ func TestRewrites(in *testing.T) {
 		expected: "SELECT :__lastInsertId as test",
 		liid:     true,
 	}, {
+		// a qualified call names a stored function, whatever the name
+		in:       "SELECT db.last_insert_id(), db.database(), db.found_rows(), db.row_count() from t",
+		expected: "SELECT db.last_insert_id(), db.database(), db.found_rows(), db.row_count() from t",
+	}, {
 		in:       "SELECT last_insert_id() + database()",
 		expected: "SELECT :__lastInsertId + :__vtdbname as `last_insert_id() + database()`",
 		db:       true, liid: true,

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -4188,6 +4188,11 @@ var validSQL = []struct {
 }, {
 	input:  "SELECT 1,2 UNION SELECT * from (VALUES ROW(10,15)) t",
 	output: "select 1, 2 from dual union select * from (values row(10, 15)) as t",
+}, {
+	// the direction is dropped for the built-in rand() only; a qualified
+	// call is a stored function, and is ordered by like any expression
+	input:  "select a from t order by rand() desc, db.rand() desc, rand(1) asc",
+	output: "select a from t order by rand(), db.rand() desc, rand(1)",
 }}
 
 func TestValid(t *testing.T) {

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -54,8 +54,6 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (IR, error) {
 		args = append(args, convertedExpr)
 	}
 
-	// A qualified call names a stored function, whatever the name: MySQL's to
-	// resolve and evaluate.
 	if fn.Qualifier.NotEmpty() {
 		return nil, translateExprNotSupported(fn)
 	}

--- a/go/vt/vtgate/evalengine/translate_builtin.go
+++ b/go/vt/vtgate/evalengine/translate_builtin.go
@@ -54,6 +54,12 @@ func (ast *astCompiler) translateFuncExpr(fn *sqlparser.FuncExpr) (IR, error) {
 		args = append(args, convertedExpr)
 	}
 
+	// A qualified call names a stored function, whatever the name: MySQL's to
+	// resolve and evaluate.
+	if fn.Qualifier.NotEmpty() {
+		return nil, translateExprNotSupported(fn)
+	}
+
 	method := fn.Name.Lowered()
 	call := CallExpr{Arguments: args, Method: method}
 

--- a/go/vt/vtgate/evalengine/translate_test.go
+++ b/go/vt/vtgate/evalengine/translate_test.go
@@ -399,6 +399,13 @@ func TestTranslationFailures(t *testing.T) {
 		}, {
 			expression:  "cast('3.4' as FLOAT(3))",
 			expectedErr: "Unsupported type conversion: FLOAT(3)",
+		}, {
+			// a qualified call names a stored function, whatever the name: MySQL evaluates it
+			expression:  "db.abs(-1)",
+			expectedErr: "expr cannot be translated, not supported: db.abs(-1)",
+		}, {
+			expression:  "db.user()",
+			expectedErr: "expr cannot be translated, not supported: db.user()",
 		},
 	}
 

--- a/go/vt/vtgate/planbuilder/operators/offset_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/offset_planning.go
@@ -66,7 +66,7 @@ func mustFetchFromInput(ctx *plancontext.PlanningContext, e sqlparser.SQLNode) b
 	case *sqlparser.ColName, sqlparser.AggrFunc:
 		return true
 	case *sqlparser.FuncExpr:
-		return fun.Name.EqualsAnyString(ctx.VSchema.GetAggregateUDFs())
+		return fun.Qualifier.IsEmpty() && fun.Name.EqualsAnyString(ctx.VSchema.GetAggregateUDFs())
 	default:
 		return false
 	}

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -769,7 +769,6 @@ func isSpecialOrderBy(o OrderBy) bool {
 		return true
 	}
 	f, isFunction := o.Inner.Expr.(*sqlparser.FuncExpr)
-	// the built-in rand() only: a qualified call is a stored function
 	return isFunction && f.Qualifier.IsEmpty() && f.Name.Lowered() == "rand"
 }
 

--- a/go/vt/vtgate/planbuilder/operators/route.go
+++ b/go/vt/vtgate/planbuilder/operators/route.go
@@ -769,7 +769,8 @@ func isSpecialOrderBy(o OrderBy) bool {
 		return true
 	}
 	f, isFunction := o.Inner.Expr.(*sqlparser.FuncExpr)
-	return isFunction && f.Name.Lowered() == "rand"
+	// the built-in rand() only: a qualified call is a stored function
+	return isFunction && f.Qualifier.IsEmpty() && f.Name.Lowered() == "rand"
 }
 
 func (r *Route) planOffsets(ctx *plancontext.PlanningContext) Operator {

--- a/go/vt/vtgate/planbuilder/plancontext/planning_context.go
+++ b/go/vt/vtgate/planbuilder/plancontext/planning_context.go
@@ -269,7 +269,6 @@ func (ctx *PlanningContext) IsAggr(e sqlparser.SQLNode) bool {
 	case sqlparser.AggrFunc:
 		return true
 	case *sqlparser.FuncExpr:
-		// a qualified call names a stored function, never the aggregate UDF
 		return node.Qualifier.IsEmpty() && node.Name.EqualsAnyString(ctx.VSchema.GetAggregateUDFs())
 	}
 

--- a/go/vt/vtgate/planbuilder/plancontext/planning_context.go
+++ b/go/vt/vtgate/planbuilder/plancontext/planning_context.go
@@ -269,7 +269,8 @@ func (ctx *PlanningContext) IsAggr(e sqlparser.SQLNode) bool {
 	case sqlparser.AggrFunc:
 		return true
 	case *sqlparser.FuncExpr:
-		return node.Name.EqualsAnyString(ctx.VSchema.GetAggregateUDFs())
+		// a qualified call names a stored function, never the aggregate UDF
+		return node.Qualifier.IsEmpty() && node.Name.EqualsAnyString(ctx.VSchema.GetAggregateUDFs())
 	}
 
 	return false

--- a/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/aggr_cases.json
@@ -7408,5 +7408,27 @@
         "user.user"
       ]
     }
+  },
+  {
+    "comment": "a qualified call names a stored function, not the aggregate UDF of the same name",
+    "query": "select db.udf_aggr(col2) from user",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select db.udf_aggr(col2) from user",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select db.udf_aggr(col2) from `user` where 1 != 1",
+        "Query": "select db.udf_aggr(col2) from `user`"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/postprocess_cases.json
@@ -2484,5 +2484,29 @@
         "user.user_extra"
       ]
     }
+  },
+  {
+    "comment": "ORDER BY a qualified rand() is a stored function: sorted like any expression, direction kept",
+    "query": "select col from user order by db.rand() desc",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select col from user order by db.rand() desc",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select col, db.rand(), weight_string(db.rand()) from `user` where 1 != 1",
+        "OrderBy": "(1|2) DESC",
+        "Query": "select col, db.rand(), weight_string(db.rand()) from `user` order by db.rand() desc",
+        "ResultColumns": 1
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    }
   }
 ]

--- a/go/vt/vtgate/semantics/analyzer_test.go
+++ b/go/vt/vtgate/semantics/analyzer_test.go
@@ -641,6 +641,13 @@ func TestQuerySignatureLastInsertID(t *testing.T) {
 	}, {
 		query:    "update user_extra set val = last_insert_id(123)",
 		expected: true,
+	}, {
+		// a qualified call is a stored function, not the built-in
+		query:    "select db.last_insert_id(123)",
+		expected: false,
+	}, {
+		query:    "update user_extra set val = db.last_insert_id(123)",
+		expected: false,
 	}}
 
 	for _, tc := range queries {

--- a/go/vt/vtgate/semantics/early_rewriter.go
+++ b/go/vt/vtgate/semantics/early_rewriter.go
@@ -538,7 +538,7 @@ func (r *earlyRewriter) rewriteAliasesInHaving(node sqlparser.Expr, sel *sqlpars
 			aggrTrack.popAggr()
 			return
 		case *sqlparser.FuncExpr:
-			if node.Name.EqualsAnyString(r.aggrUDFs) {
+			if node.Qualifier.IsEmpty() && node.Name.EqualsAnyString(r.aggrUDFs) {
 				aggrTrack.popAggr()
 			}
 			return
@@ -601,7 +601,7 @@ func (at *aggrTracker) down(node, _ sqlparser.SQLNode) bool {
 	case sqlparser.AggrFunc:
 		at.insideAggr = true
 	case *sqlparser.FuncExpr:
-		if node.Name.EqualsAnyString(at.aggrUDFs) {
+		if node.Qualifier.IsEmpty() && node.Name.EqualsAnyString(at.aggrUDFs) {
 			at.insideAggr = true
 		}
 	}

--- a/go/vt/vtgate/semantics/scoper.go
+++ b/go/vt/vtgate/semantics/scoper.go
@@ -96,7 +96,8 @@ func (s *scoper) down(cursor *sqlparser.Cursor) error {
 		if !s.currentScope().inHaving {
 			break
 		}
-		if node.Name.EqualsAnyString(s.si.GetAggregateUDFs()) {
+		// a qualified call names a stored function, never the aggregate UDF
+		if node.Qualifier.IsEmpty() && node.Name.EqualsAnyString(s.si.GetAggregateUDFs()) {
 			s.currentScope().inHavingAggr = true
 		}
 	case *sqlparser.Where:

--- a/go/vt/vtgate/semantics/scoper.go
+++ b/go/vt/vtgate/semantics/scoper.go
@@ -96,7 +96,6 @@ func (s *scoper) down(cursor *sqlparser.Cursor) error {
 		if !s.currentScope().inHaving {
 			break
 		}
-		// a qualified call names a stored function, never the aggregate UDF
 		if node.Qualifier.IsEmpty() && node.Name.EqualsAnyString(s.si.GetAggregateUDFs()) {
 			s.currentScope().inHavingAggr = true
 		}

--- a/go/vt/vtgate/semantics/table_collector.go
+++ b/go/vt/vtgate/semantics/table_collector.go
@@ -74,7 +74,8 @@ func (etc *earlyTableCollector) down(cursor *sqlparser.Cursor) bool {
 			}
 		}
 	case *sqlparser.FuncExpr:
-		if node.Name.EqualString("last_insert_id") && len(node.Exprs) == 1 {
+		// the built-in only: a qualified call is a stored function
+		if node.Qualifier.IsEmpty() && node.Name.EqualString("last_insert_id") && len(node.Exprs) == 1 {
 			etc.lastInsertIdWithArgument = true
 		}
 	}

--- a/go/vt/vtgate/semantics/table_collector.go
+++ b/go/vt/vtgate/semantics/table_collector.go
@@ -74,7 +74,6 @@ func (etc *earlyTableCollector) down(cursor *sqlparser.Cursor) bool {
 			}
 		}
 	case *sqlparser.FuncExpr:
-		// the built-in only: a qualified call is a stored function
 		if node.Qualifier.IsEmpty() && node.Name.EqualString("last_insert_id") && len(node.Exprs) == 1 {
 			etc.lastInsertIdWithArgument = true
 		}


### PR DESCRIPTION
## Description

A function call qualified with a schema name, like `db.last_insert_id()` or `db.udf_aggr(col)`, names a stored function in that schema, and MySQL resolves and evaluates it whatever the name is. VTGate looked only at the function name and treated such calls like the built-in or the aggregate UDF of the same name:

- the normalizer replaced `db.last_insert_id()`, `db.found_rows()` and `db.row_count()` with the session's own values,
- the evalengine computed `db.abs(-1)` and `db.user()` itself,
- the semantic analyzer and planner took `db.udf_aggr(col2)` for the aggregate UDF registered in the VSchema, and planning `select db.udf_aggr(col2) from user` died with a nil pointer dereference in the aggregator,
- `order by db.rand() desc` lost its direction and its merge-sort key, because the `rand()` special case matched by name alone,
- `db.last_insert_id(x)` made the tablet reset `LAST_INSERT_ID` to a sentinel around the query, as if the built-in had been called.

Every place that matches a `FuncExpr` by name now also requires the qualifier to be empty: the normalizer's function rewrites, the evalengine's built-in translation, the five aggregate-UDF checks in the scoper, the early rewriter, the planning context and offset planning, the two `rand()` ordering checks, and the table collector's `last_insert_id` detection. A qualified call goes to MySQL as written.

Each new test fails on `main` without the fix (the planner one with the panic above).

This is split out of #21018, which needs it before `db.now()` and `db.count(1)` can parse as qualified calls. #21070 is stacked on it. It stands on its own as a bug fix.

## Related Issue(s)

- #21018, which this is split out of
- #21070, stacked on this PR
- #21071, a keyspace-qualified stored-function call still reaches MySQL with the keyspace name (pre-existing, not changed here)

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [x] Tests were added or are not required
-   [x] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

A qualified function call is now always sent to MySQL as written. A query that relied on VTGate evaluating `ks.abs(x)` or rewriting `ks.last_insert_id()` itself now fails at MySQL with "FUNCTION ks.abs does not exist" unless such a stored function exists, which is what MySQL does for the same query. No schema or configuration change is needed.

### AI Disclosure

This PR was written primarily by Claude Code, with direction and review from the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
