### PR TITLE
schema: retry tracker startup position lookup

### DIFF
--- a/go/vt/vttablet/tabletserver/schema/tracker.go
+++ b/go/vt/vttablet/tabletserver/schema/tracker.go
@@ -121,10 +121,19 @@ func (tr *Tracker) Enable(enabled bool) {
 func (tr *Tracker) process(ctx context.Context) {
 	defer tr.env.LogError()
 	defer tr.wg.Done()
-	startupGTID, err := tr.startupPosition(ctx)
-	if err != nil {
+	var startupGTID string
+	for {
+		var err error
+		startupGTID, err = tr.startupPosition(ctx)
+		if err == nil {
+			break
+		}
+
+		tr.env.Stats().ErrorCounters.Add(vtrpcpb.Code_INTERNAL.String(), 1)
 		log.Error(fmt.Sprintf("error getting the schema tracker's startup position: %v", err))
-		return
+		if !tr.wait(ctx, 5*time.Second) {
+			return
+		}
 	}
 
 	filter := &binlogdatapb.Filter{

--- a/go/vt/vttablet/tabletserver/schema/tracker.go
+++ b/go/vt/vttablet/tabletserver/schema/tracker.go
@@ -128,6 +128,9 @@ func (tr *Tracker) process(ctx context.Context) {
 		if err == nil {
 			break
 		}
+		if ctx.Err() != nil {
+			return
+		}
 
 		tr.env.Stats().ErrorCounters.Add(vtrpcpb.Code_INTERNAL.String(), 1)
 		log.Error(fmt.Sprintf("error getting the schema tracker's startup position: %v", err))

--- a/go/vt/vttablet/tabletserver/schema/tracker_test.go
+++ b/go/vt/vttablet/tabletserver/schema/tracker_test.go
@@ -102,6 +102,62 @@ func TestTracker(t *testing.T) {
 	require.True(t, initialSchemaInserted)
 }
 
+func TestTrackerRetriesStartupPosition(t *testing.T) {
+	se, db, cancel := getTestSchemaEngine(t, 0)
+	defer cancel()
+
+	const (
+		startupGTID  = "MySQL56/7b04699f-f5e9-11e9-bf88-9cb6d089e1c3:1-3"
+		startupQuery = "select pos from _vt.schema_version order by id desc limit 1"
+	)
+
+	// Fail the initial startup-position lookup.
+	db.RejectQueryPattern(startupQuery, "transient startup position failure")
+
+	vs := &fakeVstreamer{
+		done:   make(chan struct{}),
+		events: [][]*binlogdatapb.VEvent{{}},
+	}
+
+	cfg := se.env.Config()
+	cfg.TrackSchemaVersions = true
+	env := tabletenv.NewEnv(vtenv.NewTestEnv(), cfg, "TrackerStartupRetryTest")
+	tracker := NewTracker(env, vs, se)
+	initialErrors := env.Stats().ErrorCounters.Counts()["INTERNAL"]
+
+	var waitCalls int
+	var waitDuration time.Duration
+	tracker.wait = func(ctx context.Context, d time.Duration) bool {
+		waitCalls++
+		waitDuration = d
+
+		// Make the second startup-position lookup succeed.
+		db.RemoveQueryPattern(startupQuery)
+		db.AddQuery(startupQuery, sqltypes.MakeTestResult(
+			sqltypes.MakeTestFields("pos", "varchar"),
+			startupGTID,
+		))
+		return waitWithContext(ctx, 0)
+	}
+
+	tracker.Open()
+
+	select {
+	case <-vs.done:
+	case <-time.After(time.Second):
+		tracker.Close()
+		require.FailNow(t, "VStream was not called after the startup-position failure")
+	}
+
+	tracker.Close()
+	finalErrors := env.Stats().ErrorCounters.Counts()["INTERNAL"]
+	require.Equal(t, initialErrors+1, finalErrors)
+
+	require.Equal(t, 1, waitCalls)
+	require.Equal(t, 5*time.Second, waitDuration)
+	require.Equal(t, []string{startupGTID}, vs.getStartPositions())
+}
+
 func TestTrackerRetriesAfterFailedSchemaSave(t *testing.T) {
 	se, db, cancel := getTestSchemaEngine(t, 0)
 	defer cancel()

--- a/go/vt/vttablet/tabletserver/schema/tracker_test.go
+++ b/go/vt/vttablet/tabletserver/schema/tracker_test.go
@@ -103,6 +103,8 @@ func TestTracker(t *testing.T) {
 }
 
 func TestTrackerRetriesStartupPosition(t *testing.T) {
+	// Verify that a transient startup-position failure is retried and that
+	// VStream starts from the position returned by the successful attempt.
 	se, db, cancel := getTestSchemaEngine(t, 0)
 	defer cancel()
 
@@ -141,21 +143,69 @@ func TestTrackerRetriesStartupPosition(t *testing.T) {
 	}
 
 	tracker.Open()
-
-	select {
-	case <-vs.done:
-	case <-time.After(time.Second):
-		tracker.Close()
-		require.FailNow(t, "VStream was not called after the startup-position failure")
-	}
+	streamStarted := assert.Eventually(
+		t,
+		func() bool {
+			select {
+			case <-vs.done:
+				return true
+			default:
+				return false
+			}
+		},
+		30*time.Second,
+		10*time.Millisecond,
+		"VStream was not called after the startup-position failure",
+	)
 
 	tracker.Close()
+	if !streamStarted {
+		return
+	}
+
 	finalErrors := env.Stats().ErrorCounters.Counts()["INTERNAL"]
 	require.Equal(t, initialErrors+1, finalErrors)
 
 	require.Equal(t, 1, waitCalls)
 	require.Equal(t, 5*time.Second, waitDuration)
 	require.Equal(t, []string{startupGTID}, vs.getStartPositions())
+}
+
+func TestTrackerStartupPositionCancellationDoesNotCountError(t *testing.T) {
+	// Verify that cancellation during the startup-position lookup is treated as
+	// normal shutdown and does not increment errors, retry, or start VStream.
+	se, db, cancelEngine := getTestSchemaEngine(t, 0)
+	defer cancelEngine()
+
+	const startupQuery = "select pos from _vt.schema_version order by id desc limit 1"
+	db.RejectQueryPattern(startupQuery, "startup position cancelled")
+
+	vs := &fakeVstreamer{
+		done: make(chan struct{}),
+	}
+
+	cfg := se.env.Config()
+	cfg.TrackSchemaVersions = true
+	env := tabletenv.NewEnv(vtenv.NewTestEnv(), cfg, "TrackerStartupCancellationTest")
+	tracker := NewTracker(env, vs, se)
+	initialErrors := env.Stats().ErrorCounters.Counts()["INTERNAL"]
+
+	var waitCalls int
+	tracker.wait = func(ctx context.Context, d time.Duration) bool {
+		waitCalls++
+		return waitWithContext(ctx, 0)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	tracker.wg.Add(1)
+	tracker.process(ctx)
+
+	finalErrors := env.Stats().ErrorCounters.Counts()["INTERNAL"]
+	require.Equal(t, initialErrors, finalErrors)
+	require.Zero(t, waitCalls)
+	require.Empty(t, vs.getStartPositions())
 }
 
 func TestTrackerRetriesAfterFailedSchemaSave(t *testing.T) {


### PR DESCRIPTION

## Description


The schema tracker previously exited permanently when its initial startupPosition() lookup encountered a transient error. As a result, schema tracking remained inactive until VTTablet was restarted.

This change:

Retries startupPosition() after waiting five seconds.
Continues retrying until the lookup succeeds or the tracker context is cancelled.
Increments the existing INTERNAL error counter for every non-cancellation failed attempt.
Leaves the existing VStream resume and replay behavior unchanged.

A regression test simulates a failed first lookup followed by a successful second lookup. It verifies that the retry uses the expected five-second duration, increments the error counter, and eventually starts VStream from the position returned by the successful attempt.

Before the implementation change, the regression test failed because VStream was never called. It passes after the fix.

Backport consideration: the issue reports that the affected code path is also present in supported release branches. If maintainers choose to backport this change, the justification is to prevent transient startup failures from permanently disabling schema tracking.

## Related Issue(s)

Fixes #21061

## Testing

The following checks passed locally:

go test ./go/vt/vttablet/tabletserver/schema -run '^TestTrackerRetriesStartupPosition$' -count=1
go test ./go/vt/vttablet/tabletserver/schema -run '^TestTrackerRetriesStartupPosition$' -count=20
go test -race ./go/vt/vttablet/tabletserver/schema -run '^TestTrackerRetriesStartupPosition$' -count=1 -v
go test ./go/vt/vttablet/tabletserver/schema -count=1
go test -race ./go/vt/vttablet/tabletserver/schema -count=1
go vet ./go/vt/vttablet/tabletserver/schema
gofmt and git diff --check

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI? Local tests passed; CI is pending.
- [x] Documentation was added or is not required

## Deployment Notes

After upgrading, VTTablet's schema tracker automatically retries transient startup-position lookup failures instead of stopping permanently. Operators no longer need to restart VTTablet to recover schema tracking from this condition.

No database migrations, configuration changes, or deployment-specific actions are required.

### AI Disclosure

OpenAI Codex was used to assist with drafting and reviewing the implementation, regression test, and pull request description. The author manually applied, reviewed, and validated the changes.
