### PR TITLE
backup: add --backup-log-to-storage flag for separate backup engine logs

### DIFF
--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -56,6 +56,7 @@ Flags:
       --azblob-backup-parallelism int                               Azure Blob operation parallelism (requires extra memory when increased -- a multiple of azblob-backup-buffer-size). (default 1)
       --azblob-backup-storage-root string                           Root prefix for all backup-related Azure Blobs; this should exclude both initial and trailing '/' (e.g. just 'a/b' not '/a/b/').
       --backup-engine-implementation string                         Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup. (default "builtin")
+      --backup-log-to-storage                                      When set, backup and restore operations write engine-specific logs to a separate file and upload it to the backup storage directory alongside the backup data.
       --backup-storage-block-size int                               if backup-storage-compress is true, backup-storage-block-size sets the byte size for each block while compressing (default is 250000). (default 250000)
       --backup-storage-compress                                     if set, the backup files will be compressed. (default true)
       --backup-storage-implementation string                        Which backup storage implementation to use for creating and restoring backups.

--- a/go/flags/endtoend/vtbackup.txt
+++ b/go/flags/endtoend/vtbackup.txt
@@ -56,7 +56,7 @@ Flags:
       --azblob-backup-parallelism int                               Azure Blob operation parallelism (requires extra memory when increased -- a multiple of azblob-backup-buffer-size). (default 1)
       --azblob-backup-storage-root string                           Root prefix for all backup-related Azure Blobs; this should exclude both initial and trailing '/' (e.g. just 'a/b' not '/a/b/').
       --backup-engine-implementation string                         Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup. (default "builtin")
-      --backup-log-to-storage                                      When set, backup and restore operations write engine-specific logs to a separate file and upload it to the backup storage directory alongside the backup data.
+      --backup-log-to-storage                                      When set, backup operations write engine-specific logs to a separate file and upload it to the backup storage directory alongside the backup data.
       --backup-storage-block-size int                               if backup-storage-compress is true, backup-storage-block-size sets the byte size for each block while compressing (default is 250000). (default 250000)
       --backup-storage-compress                                     if set, the backup files will be compressed. (default true)
       --backup-storage-implementation string                        Which backup storage implementation to use for creating and restoring backups.

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -16,7 +16,7 @@ Flags:
       --app-idle-timeout duration                                        Idle timeout for app connections (default 1m0s)
       --app-pool-size int                                                Size of the connection pool for app connections (default 40)
       --backup-engine-implementation string                              Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup. (default "builtin")
-      --backup-log-to-storage                                            When set, backup and restore operations write engine-specific logs to a separate file and upload it to the backup storage directory alongside the backup data.
+      --backup-log-to-storage                                            When set, backup operations write engine-specific logs to a separate file and upload it to the backup storage directory alongside the backup data.
       --backup-storage-block-size int                                    if backup-storage-compress is true, backup-storage-block-size sets the byte size for each block while compressing (default is 250000). (default 250000)
       --backup-storage-compress                                          if set, the backup files will be compressed. (default true)
       --backup-storage-number-blocks int                                 if backup-storage-compress is true, backup-storage-number-blocks sets the number of blocks that can be processed, in parallel, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)

--- a/go/flags/endtoend/vtcombo.txt
+++ b/go/flags/endtoend/vtcombo.txt
@@ -16,6 +16,7 @@ Flags:
       --app-idle-timeout duration                                        Idle timeout for app connections (default 1m0s)
       --app-pool-size int                                                Size of the connection pool for app connections (default 40)
       --backup-engine-implementation string                              Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup. (default "builtin")
+      --backup-log-to-storage                                            When set, backup and restore operations write engine-specific logs to a separate file and upload it to the backup storage directory alongside the backup data.
       --backup-storage-block-size int                                    if backup-storage-compress is true, backup-storage-block-size sets the byte size for each block while compressing (default is 250000). (default 250000)
       --backup-storage-compress                                          if set, the backup files will be compressed. (default true)
       --backup-storage-number-blocks int                                 if backup-storage-compress is true, backup-storage-number-blocks sets the number of blocks that can be processed, in parallel, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -29,6 +29,7 @@ Flags:
       --azblob-backup-parallelism int                                    Azure Blob operation parallelism (requires extra memory when increased -- a multiple of azblob-backup-buffer-size). (default 1)
       --azblob-backup-storage-root string                                Root prefix for all backup-related Azure Blobs; this should exclude both initial and trailing '/' (e.g. just 'a/b' not '/a/b/').
       --backup-engine-implementation string                              Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup. (default "builtin")
+      --backup-log-to-storage                                            When set, backup and restore operations write engine-specific logs to a separate file and upload it to the backup storage directory alongside the backup data.
       --backup-storage-block-size int                                    if backup-storage-compress is true, backup-storage-block-size sets the byte size for each block while compressing (default is 250000). (default 250000)
       --backup-storage-compress                                          if set, the backup files will be compressed. (default true)
       --backup-storage-implementation string                             Which backup storage implementation to use for creating and restoring backups.

--- a/go/flags/endtoend/vtctld.txt
+++ b/go/flags/endtoend/vtctld.txt
@@ -29,7 +29,7 @@ Flags:
       --azblob-backup-parallelism int                                    Azure Blob operation parallelism (requires extra memory when increased -- a multiple of azblob-backup-buffer-size). (default 1)
       --azblob-backup-storage-root string                                Root prefix for all backup-related Azure Blobs; this should exclude both initial and trailing '/' (e.g. just 'a/b' not '/a/b/').
       --backup-engine-implementation string                              Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup. (default "builtin")
-      --backup-log-to-storage                                            When set, backup and restore operations write engine-specific logs to a separate file and upload it to the backup storage directory alongside the backup data.
+      --backup-log-to-storage                                            When set, backup operations write engine-specific logs to a separate file and upload it to the backup storage directory alongside the backup data.
       --backup-storage-block-size int                                    if backup-storage-compress is true, backup-storage-block-size sets the byte size for each block while compressing (default is 250000). (default 250000)
       --backup-storage-compress                                          if set, the backup files will be compressed. (default true)
       --backup-storage-implementation string                             Which backup storage implementation to use for creating and restoring backups.

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -50,7 +50,7 @@ Flags:
       --azblob-backup-parallelism int                                    Azure Blob operation parallelism (requires extra memory when increased -- a multiple of azblob-backup-buffer-size). (default 1)
       --azblob-backup-storage-root string                                Root prefix for all backup-related Azure Blobs; this should exclude both initial and trailing '/' (e.g. just 'a/b' not '/a/b/').
       --backup-engine-implementation string                              Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup. (default "builtin")
-      --backup-log-to-storage                                            When set, backup and restore operations write engine-specific logs to a separate file and upload it to the backup storage directory alongside the backup data.
+      --backup-log-to-storage                                            When set, backup operations write engine-specific logs to a separate file and upload it to the backup storage directory alongside the backup data.
       --backup-storage-block-size int                                    if backup-storage-compress is true, backup-storage-block-size sets the byte size for each block while compressing (default is 250000). (default 250000)
       --backup-storage-compress                                          if set, the backup files will be compressed. (default true)
       --backup-storage-implementation string                             Which backup storage implementation to use for creating and restoring backups.

--- a/go/flags/endtoend/vttablet.txt
+++ b/go/flags/endtoend/vttablet.txt
@@ -50,6 +50,7 @@ Flags:
       --azblob-backup-parallelism int                                    Azure Blob operation parallelism (requires extra memory when increased -- a multiple of azblob-backup-buffer-size). (default 1)
       --azblob-backup-storage-root string                                Root prefix for all backup-related Azure Blobs; this should exclude both initial and trailing '/' (e.g. just 'a/b' not '/a/b/').
       --backup-engine-implementation string                              Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup. (default "builtin")
+      --backup-log-to-storage                                            When set, backup and restore operations write engine-specific logs to a separate file and upload it to the backup storage directory alongside the backup data.
       --backup-storage-block-size int                                    if backup-storage-compress is true, backup-storage-block-size sets the byte size for each block while compressing (default is 250000). (default 250000)
       --backup-storage-compress                                          if set, the backup files will be compressed. (default true)
       --backup-storage-implementation string                             Which backup storage implementation to use for creating and restoring backups.

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -7,6 +7,7 @@ Flags:
       --app-idle-timeout duration                                        Idle timeout for app connections (default 1m0s)
       --app-pool-size int                                                Size of the connection pool for app connections (default 40)
       --backup-engine-implementation string                              Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup. (default "builtin")
+      --backup-log-to-storage                                            When set, backup and restore operations write engine-specific logs to a separate file and upload it to the backup storage directory alongside the backup data.
       --backup-storage-block-size int                                    if backup-storage-compress is true, backup-storage-block-size sets the byte size for each block while compressing (default is 250000). (default 250000)
       --backup-storage-compress                                          if set, the backup files will be compressed. (default true)
       --backup-storage-number-blocks int                                 if backup-storage-compress is true, backup-storage-number-blocks sets the number of blocks that can be processed, in parallel, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)

--- a/go/flags/endtoend/vttestserver.txt
+++ b/go/flags/endtoend/vttestserver.txt
@@ -7,7 +7,7 @@ Flags:
       --app-idle-timeout duration                                        Idle timeout for app connections (default 1m0s)
       --app-pool-size int                                                Size of the connection pool for app connections (default 40)
       --backup-engine-implementation string                              Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup. (default "builtin")
-      --backup-log-to-storage                                            When set, backup and restore operations write engine-specific logs to a separate file and upload it to the backup storage directory alongside the backup data.
+      --backup-log-to-storage                                            When set, backup operations write engine-specific logs to a separate file and upload it to the backup storage directory alongside the backup data.
       --backup-storage-block-size int                                    if backup-storage-compress is true, backup-storage-block-size sets the byte size for each block while compressing (default is 250000). (default 250000)
       --backup-storage-compress                                          if set, the backup files will be compressed. (default true)
       --backup-storage-number-blocks int                                 if backup-storage-compress is true, backup-storage-number-blocks sets the number of blocks that can be processed, in parallel, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)

--- a/go/vt/logutil/writer_logger.go
+++ b/go/vt/logutil/writer_logger.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logutil
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// WriterLogger is a Logger that writes log lines to an io.Writer.
+// It is thread-safe.
+type WriterLogger struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+// NewWriterLogger returns a Logger that writes formatted log lines to w.
+func NewWriterLogger(w io.Writer) *WriterLogger {
+	return &WriterLogger{w: w}
+}
+
+func (wl *WriterLogger) write(level, s string) {
+	ts := time.Now().UTC().Format("2006-01-02 15:04:05.000000")
+	wl.mu.Lock()
+	defer wl.mu.Unlock()
+	fmt.Fprintf(wl.w, "%s %s %s\n", level, ts, s)
+}
+
+func (wl *WriterLogger) InfoDepth(_ int, s string) {
+	wl.write("I", s)
+}
+
+func (wl *WriterLogger) WarningDepth(_ int, s string) {
+	wl.write("W", s)
+}
+
+func (wl *WriterLogger) ErrorDepth(_ int, s string) {
+	wl.write("E", s)
+}
+
+func (wl *WriterLogger) Infof(format string, v ...any) {
+	wl.write("I", fmt.Sprintf(format, v...))
+}
+
+func (wl *WriterLogger) Warningf(format string, v ...any) {
+	wl.write("W", fmt.Sprintf(format, v...))
+}
+
+func (wl *WriterLogger) Errorf(format string, v ...any) {
+	wl.write("E", fmt.Sprintf(format, v...))
+}
+
+func (wl *WriterLogger) Errorf2(err error, format string, v ...any) {
+	wl.write("E", fmt.Sprintf(format+": %+v", append(v, err)))
+}
+
+func (wl *WriterLogger) Error(err error) {
+	wl.write("E", fmt.Sprintf("%+v", err))
+}
+
+func (wl *WriterLogger) Printf(format string, v ...any) {
+	wl.mu.Lock()
+	defer wl.mu.Unlock()
+	fmt.Fprintf(wl.w, format, v...)
+}

--- a/go/vt/logutil/writer_logger_test.go
+++ b/go/vt/logutil/writer_logger_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logutil
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriterLogger(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewWriterLogger(&buf)
+
+	logger.Infof("info message %d", 1)
+	logger.Warningf("warning message %s", "test")
+	logger.Errorf("error message")
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	require.Len(t, lines, 3)
+
+	assert.True(t, strings.HasPrefix(lines[0], "I "), "expected info line to start with 'I ', got: %s", lines[0])
+	assert.Contains(t, lines[0], "info message 1")
+
+	assert.True(t, strings.HasPrefix(lines[1], "W "), "expected warning line to start with 'W ', got: %s", lines[1])
+	assert.Contains(t, lines[1], "warning message test")
+
+	assert.True(t, strings.HasPrefix(lines[2], "E "), "expected error line to start with 'E ', got: %s", lines[2])
+	assert.Contains(t, lines[2], "error message")
+}
+
+func TestWriterLoggerDepthMethods(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewWriterLogger(&buf)
+
+	logger.InfoDepth(0, "depth info")
+	logger.WarningDepth(0, "depth warning")
+	logger.ErrorDepth(0, "depth error")
+
+	output := buf.String()
+	assert.Contains(t, output, "I ")
+	assert.Contains(t, output, "depth info")
+	assert.Contains(t, output, "W ")
+	assert.Contains(t, output, "depth warning")
+	assert.Contains(t, output, "E ")
+	assert.Contains(t, output, "depth error")
+}
+
+func TestWriterLoggerError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewWriterLogger(&buf)
+
+	err := errors.New("test error")
+	logger.Error(err)
+	assert.Contains(t, buf.String(), "test error")
+}
+
+func TestWriterLoggerErrorf2(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewWriterLogger(&buf)
+
+	err := errors.New("root cause")
+	logger.Errorf2(err, "wrapping context")
+	output := buf.String()
+	assert.Contains(t, output, "wrapping context")
+	assert.Contains(t, output, "root cause")
+}
+
+func TestWriterLoggerPrintf(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewWriterLogger(&buf)
+
+	logger.Printf("raw output %d", 42)
+	assert.Equal(t, "raw output 42", buf.String())
+}
+
+func TestWriterLoggerThreadSafety(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewWriterLogger(&buf)
+
+	done := make(chan struct{})
+	for i := range 10 {
+		go func(n int) {
+			defer func() { done <- struct{}{} }()
+			for j := range 100 {
+				logger.Infof("goroutine %d iteration %d", n, j)
+			}
+		}(i)
+	}
+
+	for range 10 {
+		<-done
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	assert.Len(t, lines, 1000)
+}

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -157,6 +157,20 @@ func Backup(ctx context.Context, params BackupParams) error {
 	}
 	params.Logger.Infof("Starting backup %v", bh.Name())
 
+	// If backup-log-to-storage is enabled, tee logs to a temporary file that
+	// will be uploaded alongside the backup data.
+	var backupLogFile *os.File
+	if BackupLogToStorage() {
+		var err error
+		backupLogFile, err = os.CreateTemp("", "backup-log-*.txt")
+		if err != nil {
+			params.Logger.Warningf("Failed to create backup log file, continuing without separate log: %v", err)
+		} else {
+			fileLogger := logutil.NewWriterLogger(backupLogFile)
+			params.Logger = logutil.NewTeeLogger(params.Logger, fileLogger)
+		}
+	}
+
 	// Scope stats to selected backup engine.
 	beParams := params.Copy()
 	beParams.Stats = params.Stats.Scope(
@@ -180,6 +194,24 @@ func Backup(ctx context.Context, params BackupParams) error {
 	// Take the backup, and either AbortBackup or EndBackup.
 	backupResult, err := be.ExecuteBackup(ctx, beParams, bh)
 	logger := params.Logger
+
+	// Upload backup log to storage before finalizing. For usable backups, the
+	// log is uploaded and then the temp file is cleaned up. For unusable
+	// backups, AbortBackup removes the storage directory anyway, so we keep the
+	// local log file for debugging instead.
+	if backupLogFile != nil {
+		switch backupResult {
+		case BackupUsable:
+			uploadBackupLog(ctx, logger, backupLogFile, bh)
+			os.Remove(backupLogFile.Name())
+		case BackupUnusable:
+			uploadBackupLog(ctx, logger, backupLogFile, bh)
+			logger.Infof("Backup log retained locally at %s", backupLogFile.Name())
+		case BackupEmpty:
+			os.Remove(backupLogFile.Name())
+		}
+	}
+
 	var finishErr error
 	switch backupResult {
 	case BackupUnusable:
@@ -207,6 +239,40 @@ func Backup(ctx context.Context, params BackupParams) error {
 	backupstats.DeprecatedBackupDurationS.Set(int64(time.Since(startTs).Seconds()))
 	params.Stats.Scope(backupstats.Operation("Backup")).TimedIncrement(time.Since(startTs))
 	return finishErr
+}
+
+const backupLogFileName = "BACKUP.log"
+
+func uploadBackupLog(ctx context.Context, logger logutil.Logger, logFile *os.File, bh backupstorage.BackupHandle) {
+	if err := logFile.Sync(); err != nil {
+		logger.Warningf("Failed to sync backup log file: %v", err)
+		return
+	}
+
+	fi, err := logFile.Stat()
+	if err != nil {
+		logger.Warningf("Failed to stat backup log file: %v", err)
+		return
+	}
+
+	if _, err := logFile.Seek(0, io.SeekStart); err != nil {
+		logger.Warningf("Failed to seek backup log file: %v", err)
+		return
+	}
+
+	wc, err := bh.AddFile(ctx, backupLogFileName, fi.Size())
+	if err != nil {
+		logger.Warningf("Failed to add backup log file to storage: %v", err)
+		return
+	}
+	defer wc.Close()
+
+	if _, err := io.Copy(wc, logFile); err != nil {
+		logger.Warningf("Failed to upload backup log file: %v", err)
+		return
+	}
+
+	logger.Infof("Backup log uploaded to storage as %s", backupLogFileName)
 }
 
 // ParseBackupName parses the backup name for a given dir/name, according to

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -196,18 +196,15 @@ func Backup(ctx context.Context, params BackupParams) error {
 	backupResult, err := be.ExecuteBackup(ctx, beParams, bh)
 	logger := params.Logger
 
-	// Close the backup log file and restore the original logger so
-	// subsequent log lines don't write to the temp file.
-	if backupLogFile != nil {
+	// For usable backups, close the log file and restore the original
+	// logger before uploading (the upload reads the closed file by path).
+	// For unusable backups, keep the tee active so the failure error
+	// logged below is captured in the backup log file.
+	var backupLogUploaded bool
+	if backupLogFile != nil && backupResult == BackupUsable {
 		backupLogFile.Close()
 		logger = originalLogger
-	}
-
-	// For usable backups, upload the log to storage before EndBackup.
-	// For unusable/empty backups, skip the upload: AbortBackup removes the
-	// storage directory, so only the local copy is useful for debugging.
-	if backupLogFile != nil && backupResult == BackupUsable {
-		uploadBackupLog(ctx, logger, backupLogFile.Name(), bh)
+		backupLogUploaded = uploadBackupLog(ctx, logger, backupLogFile.Name(), bh)
 	}
 
 	var finishErr error
@@ -224,13 +221,20 @@ func Backup(ctx context.Context, params BackupParams) error {
 		finishErr = bh.EndBackup(ctx)
 	}
 
-	// Clean up the local backup log file. For usable backups, EndBackup
-	// has confirmed all async uploads (including BACKUP.log) landed in
-	// storage, so the local copy is safe to remove. For unusable backups,
-	// retain locally since the storage copy was not attempted.
+	// Close the backup log file for unusable/empty results (usable was
+	// already closed above before upload). Restore the original logger.
+	if backupLogFile != nil && backupResult != BackupUsable {
+		backupLogFile.Close()
+		logger = originalLogger
+	}
+
+	// Clean up the local backup log file. For usable backups, remove
+	// only if both the upload and EndBackup succeeded (some backends
+	// like GCS finalize uploads in Close, not EndBackup). For unusable
+	// backups, retain locally since the upload was skipped.
 	if backupLogFile != nil {
 		switch {
-		case backupResult == BackupUsable && finishErr == nil:
+		case backupResult == BackupUsable && backupLogUploaded && finishErr == nil:
 			os.Remove(backupLogFile.Name())
 		case backupResult == BackupEmpty:
 			os.Remove(backupLogFile.Name())
@@ -256,38 +260,39 @@ func Backup(ctx context.Context, params BackupParams) error {
 
 const backupLogFileName = "BACKUP.log"
 
-func uploadBackupLog(ctx context.Context, logger logutil.Logger, logFilePath string, bh backupstorage.BackupHandle) {
+func uploadBackupLog(ctx context.Context, logger logutil.Logger, logFilePath string, bh backupstorage.BackupHandle) bool {
 	f, err := os.Open(logFilePath)
 	if err != nil {
 		logger.Warningf("Failed to open backup log file for upload: %v", err)
-		return
+		return false
 	}
 	defer f.Close()
 
 	fi, err := f.Stat()
 	if err != nil {
 		logger.Warningf("Failed to stat backup log file: %v", err)
-		return
+		return false
 	}
 
 	wc, err := bh.AddFile(ctx, backupLogFileName, fi.Size())
 	if err != nil {
 		logger.Warningf("Failed to add backup log file to storage: %v", err)
-		return
+		return false
 	}
 
 	if _, err := io.Copy(wc, f); err != nil {
 		wc.Close()
 		logger.Warningf("Failed to copy backup log to storage: %v", err)
-		return
+		return false
 	}
 
 	if err := wc.Close(); err != nil {
 		logger.Warningf("Failed to finalize backup log upload: %v", err)
-		return
+		return false
 	}
 
 	logger.Infof("Backup log uploaded to storage as %s", backupLogFileName)
+	return true
 }
 
 // ParseBackupName parses the backup name for a given dir/name, according to

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -157,21 +157,6 @@ func Backup(ctx context.Context, params BackupParams) error {
 	}
 	params.Logger.Infof("Starting backup %v", bh.Name())
 
-	// If backup-log-to-storage is enabled, tee logs to a temporary file that
-	// will be uploaded alongside the backup data.
-	var backupLogFile *os.File
-	originalLogger := params.Logger
-	if BackupLogToStorage() {
-		var err error
-		backupLogFile, err = os.CreateTemp("", fmt.Sprintf("vtbackup-%s-*.log", bh.Name()))
-		if err != nil {
-			params.Logger.Warningf("Failed to create backup log file, continuing without separate log: %v", err)
-		} else {
-			fileLogger := logutil.NewWriterLogger(backupLogFile)
-			params.Logger = logutil.NewTeeLogger(params.Logger, fileLogger)
-		}
-	}
-
 	// Scope stats to selected backup engine.
 	beParams := params.Copy()
 	beParams.Stats = params.Stats.Scope(
@@ -190,6 +175,22 @@ func Backup(ctx context.Context, params BackupParams) error {
 		}
 	}
 
+	// If backup-log-to-storage is enabled, tee logs to a temporary file that
+	// will be uploaded alongside the backup data. Created after engine
+	// validation so early-return errors don't leak the temp file.
+	var backupLogFile *os.File
+	originalLogger := params.Logger
+	if BackupLogToStorage() {
+		var err error
+		backupLogFile, err = os.CreateTemp("", fmt.Sprintf("vtbackup-%s-*.log", bh.Name()))
+		if err != nil {
+			params.Logger.Warningf("Failed to create backup log file, continuing without separate log: %v", err)
+		} else {
+			fileLogger := logutil.NewWriterLogger(backupLogFile)
+			params.Logger = logutil.NewTeeLogger(params.Logger, fileLogger)
+		}
+	}
+
 	params.Logger.Infof("Using backup engine %q", be.Name())
 
 	// Take the backup, and either AbortBackup or EndBackup.
@@ -202,9 +203,13 @@ func Backup(ctx context.Context, params BackupParams) error {
 	// logged below is captured in the backup log file.
 	var backupLogUploaded bool
 	if backupLogFile != nil && backupResult == BackupUsable {
-		backupLogFile.Close()
+		closeErr := backupLogFile.Close()
 		logger = originalLogger
-		backupLogUploaded = uploadBackupLog(ctx, logger, backupLogFile.Name(), bh)
+		if closeErr != nil {
+			logger.Warningf("Failed to close backup log file, skipping upload: %v", closeErr)
+		} else {
+			backupLogUploaded = uploadBackupLog(ctx, logger, backupLogFile.Name(), bh)
+		}
 	}
 
 	var finishErr error
@@ -224,7 +229,9 @@ func Backup(ctx context.Context, params BackupParams) error {
 	// Close the backup log file for unusable/empty results (usable was
 	// already closed above before upload). Restore the original logger.
 	if backupLogFile != nil && backupResult != BackupUsable {
-		backupLogFile.Close()
+		if err := backupLogFile.Close(); err != nil {
+			logger.Warningf("Failed to close backup log file: %v", err)
+		}
 		logger = originalLogger
 	}
 
@@ -258,7 +265,7 @@ func Backup(ctx context.Context, params BackupParams) error {
 	return finishErr
 }
 
-const backupLogFileName = "BACKUP.log"
+const backupLogFileName = "BACKUP-log"
 
 func uploadBackupLog(ctx context.Context, logger logutil.Logger, logFilePath string, bh backupstorage.BackupHandle) bool {
 	f, err := os.Open(logFilePath)

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -198,16 +198,20 @@ func Backup(ctx context.Context, params BackupParams) error {
 
 	// Upload backup log to storage before finalizing. Close the file and
 	// restore the original logger first so subsequent log lines don't write
-	// to the temp file. For usable backups, the log is uploaded and cleaned up.
-	// For unusable backups, AbortBackup removes the storage directory anyway,
-	// so we keep the local log file for debugging instead.
+	// to the temp file. For usable backups, the log is uploaded and cleaned
+	// up only if the upload fully succeeds. For unusable backups, AbortBackup
+	// removes the storage directory anyway, so we keep the local log file
+	// for debugging instead.
 	if backupLogFile != nil {
 		backupLogFile.Close()
 		logger = originalLogger
 		switch backupResult {
 		case BackupUsable:
-			uploadBackupLog(ctx, logger, backupLogFile.Name(), bh)
-			os.Remove(backupLogFile.Name())
+			if uploadBackupLog(ctx, logger, backupLogFile.Name(), bh) {
+				os.Remove(backupLogFile.Name())
+			} else {
+				logger.Infof("Backup log retained locally at %s", backupLogFile.Name())
+			}
 		case BackupUnusable:
 			uploadBackupLog(ctx, logger, backupLogFile.Name(), bh)
 			logger.Infof("Backup log retained locally at %s", backupLogFile.Name())
@@ -247,33 +251,39 @@ func Backup(ctx context.Context, params BackupParams) error {
 
 const backupLogFileName = "BACKUP.log"
 
-func uploadBackupLog(ctx context.Context, logger logutil.Logger, logFilePath string, bh backupstorage.BackupHandle) {
+func uploadBackupLog(ctx context.Context, logger logutil.Logger, logFilePath string, bh backupstorage.BackupHandle) bool {
 	f, err := os.Open(logFilePath)
 	if err != nil {
 		logger.Warningf("Failed to open backup log file for upload: %v", err)
-		return
+		return false
 	}
 	defer f.Close()
 
 	fi, err := f.Stat()
 	if err != nil {
 		logger.Warningf("Failed to stat backup log file: %v", err)
-		return
+		return false
 	}
 
 	wc, err := bh.AddFile(ctx, backupLogFileName, fi.Size())
 	if err != nil {
 		logger.Warningf("Failed to add backup log file to storage: %v", err)
-		return
+		return false
 	}
-	defer wc.Close()
 
 	if _, err := io.Copy(wc, f); err != nil {
+		wc.Close()
 		logger.Warningf("Failed to upload backup log file: %v", err)
-		return
+		return false
+	}
+
+	if err := wc.Close(); err != nil {
+		logger.Warningf("Failed to finalize backup log upload: %v", err)
+		return false
 	}
 
 	logger.Infof("Backup log uploaded to storage as %s", backupLogFileName)
+	return true
 }
 
 // ParseBackupName parses the backup name for a given dir/name, according to

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -163,7 +163,7 @@ func Backup(ctx context.Context, params BackupParams) error {
 	originalLogger := params.Logger
 	if BackupLogToStorage() {
 		var err error
-		backupLogFile, err = os.CreateTemp("", "backup-log-*.txt")
+		backupLogFile, err = os.CreateTemp("", fmt.Sprintf("vtbackup-%s-*.log", bh.Name()))
 		if err != nil {
 			params.Logger.Warningf("Failed to create backup log file, continuing without separate log: %v", err)
 		} else {
@@ -196,28 +196,18 @@ func Backup(ctx context.Context, params BackupParams) error {
 	backupResult, err := be.ExecuteBackup(ctx, beParams, bh)
 	logger := params.Logger
 
-	// Upload backup log to storage before finalizing. Close the file and
-	// restore the original logger first so subsequent log lines don't write
-	// to the temp file. For usable backups, the log is uploaded and cleaned
-	// up only if the upload fully succeeds. For unusable backups, AbortBackup
-	// removes the storage directory anyway, so we keep the local log file
-	// for debugging instead.
+	// Close the backup log file and restore the original logger so
+	// subsequent log lines don't write to the temp file.
 	if backupLogFile != nil {
 		backupLogFile.Close()
 		logger = originalLogger
-		switch backupResult {
-		case BackupUsable:
-			if uploadBackupLog(ctx, logger, backupLogFile.Name(), bh) {
-				os.Remove(backupLogFile.Name())
-			} else {
-				logger.Infof("Backup log retained locally at %s", backupLogFile.Name())
-			}
-		case BackupUnusable:
-			uploadBackupLog(ctx, logger, backupLogFile.Name(), bh)
-			logger.Infof("Backup log retained locally at %s", backupLogFile.Name())
-		case BackupEmpty:
-			os.Remove(backupLogFile.Name())
-		}
+	}
+
+	// For usable backups, upload the log to storage before EndBackup.
+	// For unusable/empty backups, skip the upload: AbortBackup removes the
+	// storage directory, so only the local copy is useful for debugging.
+	if backupLogFile != nil && backupResult == BackupUsable {
+		uploadBackupLog(ctx, logger, backupLogFile.Name(), bh)
 	}
 
 	var finishErr error
@@ -232,6 +222,21 @@ func Backup(ctx context.Context, params BackupParams) error {
 		finishErr = bh.AbortBackup(ctx)
 	case BackupUsable:
 		finishErr = bh.EndBackup(ctx)
+	}
+
+	// Clean up the local backup log file. For usable backups, EndBackup
+	// has confirmed all async uploads (including BACKUP.log) landed in
+	// storage, so the local copy is safe to remove. For unusable backups,
+	// retain locally since the storage copy was not attempted.
+	if backupLogFile != nil {
+		switch {
+		case backupResult == BackupUsable && finishErr == nil:
+			os.Remove(backupLogFile.Name())
+		case backupResult == BackupEmpty:
+			os.Remove(backupLogFile.Name())
+		default:
+			logger.Infof("Backup log retained at %s", backupLogFile.Name())
+		}
 	}
 	if err != nil {
 		if finishErr != nil {
@@ -251,39 +256,38 @@ func Backup(ctx context.Context, params BackupParams) error {
 
 const backupLogFileName = "BACKUP.log"
 
-func uploadBackupLog(ctx context.Context, logger logutil.Logger, logFilePath string, bh backupstorage.BackupHandle) bool {
+func uploadBackupLog(ctx context.Context, logger logutil.Logger, logFilePath string, bh backupstorage.BackupHandle) {
 	f, err := os.Open(logFilePath)
 	if err != nil {
 		logger.Warningf("Failed to open backup log file for upload: %v", err)
-		return false
+		return
 	}
 	defer f.Close()
 
 	fi, err := f.Stat()
 	if err != nil {
 		logger.Warningf("Failed to stat backup log file: %v", err)
-		return false
+		return
 	}
 
 	wc, err := bh.AddFile(ctx, backupLogFileName, fi.Size())
 	if err != nil {
 		logger.Warningf("Failed to add backup log file to storage: %v", err)
-		return false
+		return
 	}
 
 	if _, err := io.Copy(wc, f); err != nil {
 		wc.Close()
-		logger.Warningf("Failed to upload backup log file: %v", err)
-		return false
+		logger.Warningf("Failed to copy backup log to storage: %v", err)
+		return
 	}
 
 	if err := wc.Close(); err != nil {
 		logger.Warningf("Failed to finalize backup log upload: %v", err)
-		return false
+		return
 	}
 
 	logger.Infof("Backup log uploaded to storage as %s", backupLogFileName)
-	return true
 }
 
 // ParseBackupName parses the backup name for a given dir/name, according to

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -160,6 +160,7 @@ func Backup(ctx context.Context, params BackupParams) error {
 	// If backup-log-to-storage is enabled, tee logs to a temporary file that
 	// will be uploaded alongside the backup data.
 	var backupLogFile *os.File
+	originalLogger := params.Logger
 	if BackupLogToStorage() {
 		var err error
 		backupLogFile, err = os.CreateTemp("", "backup-log-*.txt")
@@ -195,17 +196,20 @@ func Backup(ctx context.Context, params BackupParams) error {
 	backupResult, err := be.ExecuteBackup(ctx, beParams, bh)
 	logger := params.Logger
 
-	// Upload backup log to storage before finalizing. For usable backups, the
-	// log is uploaded and then the temp file is cleaned up. For unusable
-	// backups, AbortBackup removes the storage directory anyway, so we keep the
-	// local log file for debugging instead.
+	// Upload backup log to storage before finalizing. Close the file and
+	// restore the original logger first so subsequent log lines don't write
+	// to the temp file. For usable backups, the log is uploaded and cleaned up.
+	// For unusable backups, AbortBackup removes the storage directory anyway,
+	// so we keep the local log file for debugging instead.
 	if backupLogFile != nil {
+		backupLogFile.Close()
+		logger = originalLogger
 		switch backupResult {
 		case BackupUsable:
-			uploadBackupLog(ctx, logger, backupLogFile, bh)
+			uploadBackupLog(ctx, logger, backupLogFile.Name(), bh)
 			os.Remove(backupLogFile.Name())
 		case BackupUnusable:
-			uploadBackupLog(ctx, logger, backupLogFile, bh)
+			uploadBackupLog(ctx, logger, backupLogFile.Name(), bh)
 			logger.Infof("Backup log retained locally at %s", backupLogFile.Name())
 		case BackupEmpty:
 			os.Remove(backupLogFile.Name())
@@ -243,20 +247,17 @@ func Backup(ctx context.Context, params BackupParams) error {
 
 const backupLogFileName = "BACKUP.log"
 
-func uploadBackupLog(ctx context.Context, logger logutil.Logger, logFile *os.File, bh backupstorage.BackupHandle) {
-	if err := logFile.Sync(); err != nil {
-		logger.Warningf("Failed to sync backup log file: %v", err)
+func uploadBackupLog(ctx context.Context, logger logutil.Logger, logFilePath string, bh backupstorage.BackupHandle) {
+	f, err := os.Open(logFilePath)
+	if err != nil {
+		logger.Warningf("Failed to open backup log file for upload: %v", err)
 		return
 	}
+	defer f.Close()
 
-	fi, err := logFile.Stat()
+	fi, err := f.Stat()
 	if err != nil {
 		logger.Warningf("Failed to stat backup log file: %v", err)
-		return
-	}
-
-	if _, err := logFile.Seek(0, io.SeekStart); err != nil {
-		logger.Warningf("Failed to seek backup log file: %v", err)
 		return
 	}
 
@@ -267,7 +268,7 @@ func uploadBackupLog(ctx context.Context, logger logutil.Logger, logFile *os.Fil
 	}
 	defer wc.Close()
 
-	if _, err := io.Copy(wc, logFile); err != nil {
+	if _, err := io.Copy(wc, f); err != nil {
 		logger.Warningf("Failed to upload backup log file: %v", err)
 		return
 	}

--- a/go/vt/mysqlctl/backup_test.go
+++ b/go/vt/mysqlctl/backup_test.go
@@ -797,6 +797,122 @@ func TestBackupWithLogToStorage(t *testing.T) {
 	assert.Contains(t, uploaded.String(), "Using backup engine")
 }
 
+func TestUploadBackupLog_MissingFile(t *testing.T) {
+	logger := logutil.NewMemoryLogger()
+	bh := &FakeBackupHandle{}
+
+	ok := uploadBackupLog(t.Context(), logger, "/nonexistent/path.log", bh)
+
+	assert.False(t, ok)
+	assert.Empty(t, bh.AddFileCalls)
+}
+
+func TestUploadBackupLog_AddFileError(t *testing.T) {
+	logger := logutil.NewMemoryLogger()
+
+	logFile, err := os.CreateTemp(t.TempDir(), "backup-log-*.txt")
+	require.NoError(t, err)
+	_, err = logFile.WriteString("some content")
+	require.NoError(t, err)
+	logFile.Close()
+
+	bh := &FakeBackupHandle{
+		AddFileReturn: FakeBackupHandleAddFileReturn{
+			Err: errors.New("storage unavailable"),
+		},
+	}
+
+	ok := uploadBackupLog(t.Context(), logger, logFile.Name(), bh)
+
+	assert.False(t, ok)
+}
+
+func TestUploadBackupLog_CopyError(t *testing.T) {
+	logger := logutil.NewMemoryLogger()
+
+	logFile, err := os.CreateTemp(t.TempDir(), "backup-log-*.txt")
+	require.NoError(t, err)
+	_, err = logFile.WriteString("some content")
+	require.NoError(t, err)
+	logFile.Close()
+
+	bh := &FakeBackupHandle{
+		AddFileReturnF: func(filename string) FakeBackupHandleAddFileReturn {
+			return FakeBackupHandleAddFileReturn{
+				WriteCloser: &errWriteCloser{writeErr: errors.New("write failed")},
+			}
+		},
+	}
+
+	ok := uploadBackupLog(t.Context(), logger, logFile.Name(), bh)
+
+	assert.False(t, ok)
+}
+
+func TestUploadBackupLog_CloseError(t *testing.T) {
+	logger := logutil.NewMemoryLogger()
+
+	logFile, err := os.CreateTemp(t.TempDir(), "backup-log-*.txt")
+	require.NoError(t, err)
+	_, err = logFile.WriteString("some content")
+	require.NoError(t, err)
+	logFile.Close()
+
+	bh := &FakeBackupHandle{
+		AddFileReturnF: func(filename string) FakeBackupHandleAddFileReturn {
+			return FakeBackupHandleAddFileReturn{
+				WriteCloser: &errWriteCloser{closeErr: errors.New("close failed")},
+			}
+		},
+	}
+
+	ok := uploadBackupLog(t.Context(), logger, logFile.Name(), bh)
+
+	assert.False(t, ok)
+}
+
+type errWriteCloser struct {
+	writeErr error
+	closeErr error
+}
+
+func (e *errWriteCloser) Write(p []byte) (int, error) {
+	if e.writeErr != nil {
+		return 0, e.writeErr
+	}
+	return len(p), nil
+}
+
+func (e *errWriteCloser) Close() error {
+	return e.closeErr
+}
+
+func TestBackupWithLogToStorage_UnusableRetainsLog(t *testing.T) {
+	env := createFakeBackupRestoreEnv(t)
+
+	previousValue := backupLogToStorage
+	backupLogToStorage = true
+	t.Cleanup(func() { backupLogToStorage = previousValue })
+
+	env.backupEngine.ExecuteBackupReturn = FakeBackupEngineExecuteBackupReturn{
+		Res: BackupUnusable,
+		Err: errors.New("engine failure"),
+	}
+
+	startBackupHandle := env.backupStorage.StartBackupReturn.BackupHandle.(*FakeBackupHandle)
+	startBackupHandle.AddFileReturnF = func(filename string) FakeBackupHandleAddFileReturn {
+		return FakeBackupHandleAddFileReturn{
+			WriteCloser: &writerAsWriteCloser{Writer: io.Discard},
+		}
+	}
+
+	err := Backup(env.ctx, env.backupParams)
+	require.Error(t, err)
+
+	assert.NotEmpty(t, startBackupHandle.AbortBackupCalls)
+	assert.Empty(t, startBackupHandle.EndBackupCalls)
+}
+
 func TestExecuteBackupInitSQL(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/go/vt/mysqlctl/backup_test.go
+++ b/go/vt/mysqlctl/backup_test.go
@@ -750,7 +750,9 @@ func TestUploadBackupLog(t *testing.T) {
 		},
 	}
 
-	uploadBackupLog(t.Context(), logger, logFile, bh)
+	logFile.Close()
+
+	uploadBackupLog(t.Context(), logger, logFile.Name(), bh)
 
 	require.Len(t, bh.AddFileCalls, 1)
 	assert.Equal(t, backupLogFileName, bh.AddFileCalls[0].Filename)

--- a/go/vt/mysqlctl/backup_test.go
+++ b/go/vt/mysqlctl/backup_test.go
@@ -772,6 +772,10 @@ func TestBackupWithLogToStorage(t *testing.T) {
 	backupLogToStorage = true
 	t.Cleanup(func() { backupLogToStorage = previousValue })
 
+	env.backupEngine.ExecuteBackupReturn = FakeBackupEngineExecuteBackupReturn{
+		Res: BackupUsable,
+	}
+
 	var uploaded bytes.Buffer
 	startBackupHandle := env.backupStorage.StartBackupReturn.BackupHandle.(*FakeBackupHandle)
 	startBackupHandle.AddFileReturnF = func(filename string) FakeBackupHandleAddFileReturn {

--- a/go/vt/mysqlctl/backup_test.go
+++ b/go/vt/mysqlctl/backup_test.go
@@ -744,7 +744,7 @@ func TestUploadBackupLog(t *testing.T) {
 	bh := &FakeBackupHandle{
 		AddFileReturnF: func(filename string) FakeBackupHandleAddFileReturn {
 			return FakeBackupHandleAddFileReturn{
-				WriteCloser: &nopWriteCloser{Writer: &uploaded},
+				WriteCloser: &writerAsWriteCloser{Writer: &uploaded},
 				Err:         nil,
 			}
 		},
@@ -759,11 +759,11 @@ func TestUploadBackupLog(t *testing.T) {
 	assert.Equal(t, "line 1\nline 2\nline 3\n", uploaded.String())
 }
 
-type nopWriteCloser struct {
+type writerAsWriteCloser struct {
 	io.Writer
 }
 
-func (nwc *nopWriteCloser) Close() error { return nil }
+func (w *writerAsWriteCloser) Close() error { return nil }
 
 func TestBackupWithLogToStorage(t *testing.T) {
 	env := createFakeBackupRestoreEnv(t)
@@ -777,12 +777,12 @@ func TestBackupWithLogToStorage(t *testing.T) {
 	startBackupHandle.AddFileReturnF = func(filename string) FakeBackupHandleAddFileReturn {
 		if filename == backupLogFileName {
 			return FakeBackupHandleAddFileReturn{
-				WriteCloser: &nopWriteCloser{Writer: &uploaded},
+				WriteCloser: &writerAsWriteCloser{Writer: &uploaded},
 				Err:         nil,
 			}
 		}
 		return FakeBackupHandleAddFileReturn{
-			WriteCloser: &nopWriteCloser{Writer: io.Discard},
+			WriteCloser: &writerAsWriteCloser{Writer: io.Discard},
 			Err:         nil,
 		}
 	}

--- a/go/vt/mysqlctl/backup_test.go
+++ b/go/vt/mysqlctl/backup_test.go
@@ -731,6 +731,66 @@ func TestScanLinesToLogger(t *testing.T) {
 	}
 }
 
+func TestUploadBackupLog(t *testing.T) {
+	logger := logutil.NewMemoryLogger()
+
+	logFile, err := os.CreateTemp(t.TempDir(), "backup-log-*.txt")
+	require.NoError(t, err)
+
+	_, err = logFile.WriteString("line 1\nline 2\nline 3\n")
+	require.NoError(t, err)
+
+	var uploaded bytes.Buffer
+	bh := &FakeBackupHandle{
+		AddFileReturnF: func(filename string) FakeBackupHandleAddFileReturn {
+			return FakeBackupHandleAddFileReturn{
+				WriteCloser: &nopWriteCloser{Writer: &uploaded},
+				Err:         nil,
+			}
+		},
+	}
+
+	uploadBackupLog(t.Context(), logger, logFile, bh)
+
+	require.Len(t, bh.AddFileCalls, 1)
+	assert.Equal(t, backupLogFileName, bh.AddFileCalls[0].Filename)
+	assert.Equal(t, "line 1\nline 2\nline 3\n", uploaded.String())
+}
+
+type nopWriteCloser struct {
+	io.Writer
+}
+
+func (nwc *nopWriteCloser) Close() error { return nil }
+
+func TestBackupWithLogToStorage(t *testing.T) {
+	env := createFakeBackupRestoreEnv(t)
+
+	previousValue := backupLogToStorage
+	backupLogToStorage = true
+	t.Cleanup(func() { backupLogToStorage = previousValue })
+
+	var uploaded bytes.Buffer
+	startBackupHandle := env.backupStorage.StartBackupReturn.BackupHandle.(*FakeBackupHandle)
+	startBackupHandle.AddFileReturnF = func(filename string) FakeBackupHandleAddFileReturn {
+		if filename == backupLogFileName {
+			return FakeBackupHandleAddFileReturn{
+				WriteCloser: &nopWriteCloser{Writer: &uploaded},
+				Err:         nil,
+			}
+		}
+		return FakeBackupHandleAddFileReturn{
+			WriteCloser: &nopWriteCloser{Writer: io.Discard},
+			Err:         nil,
+		}
+	}
+
+	require.NoError(t, Backup(env.ctx, env.backupParams))
+
+	// The backup log should have been uploaded with engine-specific log content.
+	assert.Contains(t, uploaded.String(), "Using backup engine")
+}
+
 func TestExecuteBackupInitSQL(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/go/vt/mysqlctl/backupengine.go
+++ b/go/vt/mysqlctl/backupengine.go
@@ -48,8 +48,8 @@ import (
 // backupEngineImplementation is the implementation to use for BackupEngine
 var backupEngineImplementation = builtinBackupEngineName
 
-// backupLogToStorage controls whether backup/restore logs are written to a
-// separate file and uploaded to the backup storage directory.
+// backupLogToStorage controls whether backup logs are written to a separate
+// file and uploaded to the backup storage directory.
 var backupLogToStorage bool
 
 type BackupResult int
@@ -222,7 +222,7 @@ func isIncrementalBackup(params BackupParams) bool {
 
 func registerBackupEngineFlags(fs *pflag.FlagSet) {
 	utils.SetFlagStringVar(fs, &backupEngineImplementation, "backup-engine-implementation", backupEngineImplementation, "Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup.")
-	fs.BoolVar(&backupLogToStorage, "backup-log-to-storage", backupLogToStorage, "When set, backup and restore operations write engine-specific logs to a separate file and upload it to the backup storage directory alongside the backup data.")
+	utils.SetFlagBoolVar(fs, &backupLogToStorage, "backup-log-to-storage", backupLogToStorage, "When set, backup operations write engine-specific logs to a separate file and upload it to the backup storage directory alongside the backup data.")
 }
 
 // BackupLogToStorage returns whether backup logs should be written to storage.

--- a/go/vt/mysqlctl/backupengine.go
+++ b/go/vt/mysqlctl/backupengine.go
@@ -48,6 +48,10 @@ import (
 // backupEngineImplementation is the implementation to use for BackupEngine
 var backupEngineImplementation = builtinBackupEngineName
 
+// backupLogToStorage controls whether backup/restore logs are written to a
+// separate file and uploaded to the backup storage directory.
+var backupLogToStorage bool
+
 type BackupResult int
 
 const (
@@ -218,6 +222,12 @@ func isIncrementalBackup(params BackupParams) bool {
 
 func registerBackupEngineFlags(fs *pflag.FlagSet) {
 	utils.SetFlagStringVar(fs, &backupEngineImplementation, "backup-engine-implementation", backupEngineImplementation, "Specifies which implementation to use for creating new backups (builtin or xtrabackup). Restores will always be done with whichever engine created a given backup.")
+	fs.BoolVar(&backupLogToStorage, "backup-log-to-storage", backupLogToStorage, "When set, backup and restore operations write engine-specific logs to a separate file and upload it to the backup storage directory alongside the backup data.")
+}
+
+// BackupLogToStorage returns whether backup logs should be written to storage.
+func BackupLogToStorage() bool {
+	return backupLogToStorage
 }
 
 // GetBackupEngine returns the BackupEngine implementation that should be used


### PR DESCRIPTION
## Description

When `--backup-log-to-storage` is enabled, backup operations write engine-specific logs to a separate file and upload it as `BACKUP-log` alongside the backup data in the storage directory. This makes it easier to diagnose backup failures without searching through the full vttablet log.

### Behavior by backup result

| Result | Log uploaded? | Local file |
|--------|--------------|------------|
| Success (`BackupUsable`) | Yes (confirmed by `EndBackup`) | Cleaned up after both upload and `EndBackup` succeed |
| Failure (`BackupUnusable`) | No (skipped — `AbortBackup` would delete it) | Retained locally |
| Empty (`BackupEmpty`) | No | Cleaned up |

On failure, the upload is skipped because `AbortBackup` removes the storage directory. The local file is retained for debugging instead. The tee logger remains active through the failure error logging so the reason for the failure is captured in the log file.

### Local log file location

When the backup log is retained locally (on failure, or if upload/`EndBackup` reports an error), it is written to the system temp directory (`os.TempDir()`, typically `/tmp` on Linux) with the naming pattern:

```
vtbackup-{backupName}-{random}.log
```

For example: `/tmp/vtbackup-2026-09-12.143015.zone1-0000000100-1234567890.log`

The backup name includes the timestamp and tablet alias, so logs from different backup invocations (e.g., xtrabackup vs mysqlshell) are always separate files — they are never appended or overwritten. The exact local path is logged to vttablet's log when the file is retained.

### Implementation

- New `WriterLogger` in `go/vt/logutil/` that implements `logutil.Logger` and writes formatted log lines to any `io.Writer`
- After engine validation, if the flag is set, a temp file is created and a `TeeLogger` wraps the existing logger so all engine output goes to both the original logger and the file
- For usable backups, the file is closed and uploaded via `BackupHandle.AddFile()` before `EndBackup`; local file is only deleted after both upload and `EndBackup` succeed
- For unusable backups, the tee logger stays active through failure logging, then the file is closed and retained locally
- `Close()` errors are checked on both paths; upload is skipped if close fails
- Local file cleanup is deferred until after `EndBackup` confirms all async uploads (S3, Ceph, Azure use pipe-based async uploads that complete during `EndBackup`, not on writer close)
- Zero changes to any backup engine — the feature works through the existing `Logger` interface

### Flag

```
--backup-log-to-storage    When set, backup operations write engine-specific logs to a separate
                           file and upload it to the backup storage directory alongside the
                           backup data. (default false)
```

Registered for: `vttablet`, `vtctld`, `vtbackup`, `vtcombo`, `vttestserver`

## Related Issue(s)

Fixes #21078

## Checklist

- [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
- [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [ ] Documentation was added or is not required

## Deployment Notes

New opt-in flag `--backup-log-to-storage` (default `false`). No behavioral change unless explicitly enabled. No migrations required.

When enabled, on backup failure the log is retained in the system temp directory (e.g., `/tmp/vtbackup-{backupName}-{random}.log`). Operators should monitor or rotate these files in long-running vttablet processes.

### AI Disclosure

This PR was written primarily by Claude Code with direction from @maksimov.