### PR TITLE
cache: remove write-only timestamp from LRUCache entries

### DIFF
--- a/go/cache/lru_cache.go
+++ b/go/cache/lru_cache.go
@@ -26,7 +26,6 @@ package cache
 import (
 	"container/list"
 	"sync"
-	"time"
 )
 
 // LRUCache is a typical LRU cache implementation.  If the cache
@@ -39,7 +38,6 @@ type LRUCache[T any] struct {
 	list  *list.List
 	table map[string]*list.Element
 
-	size      int64
 	capacity  int64
 	evictions int64
 	hits      int64
@@ -53,9 +51,8 @@ type Item[T any] struct {
 }
 
 type entry[T any] struct {
-	key          string
-	value        T
-	timeAccessed time.Time
+	key   string
+	value T
 }
 
 // NewLRUCache creates a new empty cache with the given capacity.
@@ -109,7 +106,6 @@ func (lru *LRUCache[T]) delete(key string) bool {
 
 	lru.list.Remove(element)
 	delete(lru.table, key)
-	lru.size--
 	return true
 }
 
@@ -127,7 +123,7 @@ func (lru *LRUCache[T]) Len() int {
 
 // SetCapacity will set the capacity of the cache. If the capacity is
 // smaller, and the current cache size exceed that capacity, the cache
-// will be shrank.
+// will be shrunk.
 func (lru *LRUCache[T]) SetCapacity(capacity int64) {
 	lru.mu.Lock()
 	defer lru.mu.Unlock()
@@ -136,9 +132,11 @@ func (lru *LRUCache[T]) SetCapacity(capacity int64) {
 	lru.checkCapacity()
 }
 
-// UsedCapacity returns the size of the cache (in bytes)
+// UsedCapacity returns the size of the cache (in entries)
 func (lru *LRUCache[T]) UsedCapacity() int64 {
-	return lru.size
+	lru.mu.Lock()
+	defer lru.mu.Unlock()
+	return int64(lru.list.Len())
 }
 
 // MaxCapacity returns the cache maximum capacity.
@@ -191,25 +189,22 @@ func (lru *LRUCache[T]) updateInplace(element *list.Element, value T) {
 
 func (lru *LRUCache[T]) moveToFront(element *list.Element) {
 	lru.list.MoveToFront(element)
-	element.Value.(*entry[T]).timeAccessed = time.Now()
 }
 
 func (lru *LRUCache[T]) addNew(key string, value T) {
-	newEntry := &entry[T]{key, value, time.Now()}
+	newEntry := &entry[T]{key, value}
 	element := lru.list.PushFront(newEntry)
 	lru.table[key] = element
-	lru.size++
 	lru.checkCapacity()
 }
 
 func (lru *LRUCache[T]) checkCapacity() {
 	// Partially duplicated from Delete
-	for lru.size > lru.capacity {
+	for lru.list.Len() > 0 && int64(lru.list.Len()) > lru.capacity {
 		delElem := lru.list.Back()
 		delValue := delElem.Value.(*entry[T])
 		lru.list.Remove(delElem)
 		delete(lru.table, delValue.key)
-		lru.size--
 		lru.evictions++
 	}
 }

--- a/go/cache/lru_cache_test.go
+++ b/go/cache/lru_cache_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cache
 
 import (
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -169,4 +171,98 @@ func TestLRUIsEvicted(t *testing.T) {
 
 	m := cache.Misses()
 	assert.EqualValues(t, 1, m)
+}
+
+func TestZeroCapacityEvictsImmediately(t *testing.T) {
+	cache := NewLRUCache[*CacheValue](0)
+	cache.Set("key", &CacheValue{1})
+
+	assert.Zero(t, cache.Len())
+	assert.Zero(t, cache.UsedCapacity())
+	assert.EqualValues(t, 1, cache.Evictions())
+
+	_, ok := cache.Get("key")
+	assert.False(t, ok)
+}
+
+func TestNegativeCapacityDoesNotPanic(t *testing.T) {
+	cache := NewLRUCache[*CacheValue](-1)
+	assert.NotPanics(t, func() { cache.Set("key", &CacheValue{1}) })
+	assert.Zero(t, cache.Len())
+
+	cache = NewLRUCache[*CacheValue](10)
+	cache.Set("key1", &CacheValue{1})
+	cache.Set("key2", &CacheValue{1})
+	assert.NotPanics(t, func() { cache.SetCapacity(-1) })
+	assert.Zero(t, cache.Len())
+	assert.EqualValues(t, 2, cache.Evictions())
+}
+
+// Fails under -race if UsedCapacity stops holding the lock.
+func TestUsedCapacityConcurrentWithSet(t *testing.T) {
+	cache := NewLRUCache[*CacheValue](64)
+	value := &CacheValue{1}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := range 10000 {
+			cache.Set(strconv.Itoa(i), value)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 10000 {
+			_ = cache.UsedCapacity()
+		}
+	}()
+	wg.Wait()
+
+	assert.EqualValues(t, cache.Len(), cache.UsedCapacity())
+	assert.EqualValues(t, 64, cache.Len())
+}
+
+func BenchmarkLRUCacheGetHit(b *testing.B) {
+	const n = 1024
+	cache := NewLRUCache[*CacheValue](n)
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i] = strconv.Itoa(i)
+		cache.Set(keys[i], &CacheValue{1})
+	}
+	b.ReportAllocs()
+	i := 0
+	for b.Loop() {
+		cache.Get(keys[i%n])
+		i++
+	}
+}
+
+func BenchmarkLRUCacheSetExisting(b *testing.B) {
+	const n = 1024
+	cache := NewLRUCache[*CacheValue](n)
+	value := &CacheValue{1}
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i] = strconv.Itoa(i)
+		cache.Set(keys[i], value)
+	}
+	b.ReportAllocs()
+	i := 0
+	for b.Loop() {
+		cache.Set(keys[i%n], value)
+		i++
+	}
+}
+
+func BenchmarkLRUCacheSetNewEvict(b *testing.B) {
+	cache := NewLRUCache[*CacheValue](1024)
+	value := &CacheValue{1}
+	b.ReportAllocs()
+	i := 0
+	for b.Loop() {
+		cache.Set(strconv.Itoa(i), value)
+		i++
+	}
 }


### PR DESCRIPTION
## Description

`entry.timeAccessed` in `go/cache/lru_cache.go` is written on every `Get` hit and every `Set`, and nothing has read it since January 2021.

Its two readers, `Oldest()` and `StatsJSON()`, were removed in cbbba9ed ("cache: abstract into a Cache interface", 2021-01-18). The field itself survived, including through the generics rewrite in #14850. It's redundant rather than merely unused: recency is already fully encoded in the list's ordering, which is what `MoveToFront` maintains and what `Back()` reads during eviction. The timestamp was a second copy of a fact the cache still tracks.

It isn't free. [`time.Now()`](https://github.com/vitessio/vitess/blob/a7a96c44a81fadab7ba426c71d0b2f940ca0e3d9/go/cache/lru_cache.go#L194) reads both a wall and a monotonic clock, which costs more than all the pointer work around it, and it happens *inside* the cache's single `sync.Mutex`. Every `Get` in an LRU is a writer because it reorders the list, so that mutex serializes the entire cache and its hold time bounds throughput.

Benchmarks added in this PR. Apple M4 Pro, `go1.25.4 darwin/arm64`, `-benchtime 1s -count 6 -cpu 8`, mean ± stddev:

| benchmark | before | after | delta |
|---|---|---|---|
| `LRUCacheGetHit-8` | 38.72 ± 0.27 ns/op | 13.24 ± 0.17 ns/op | **−66%** |
| `LRUCacheSetExisting-8` | 39.76 ± 0.15 ns/op | 16.26 ± 0.27 ns/op | **−59%** |
| `LRUCacheSetNewEvict-8` | 139.23 ± 1.41 ns/op | 101.82 ± 1.08 ns/op | **−27%** |
| `LRUCacheSetNewEvict-8` | 103 B/op | 79 B/op | **−24 B** |

The 24 B is exactly `unsafe.Sizeof(time.Time{})`; `entry[T]` shrinks 48 → 24 bytes for a pointer-sized `T`. These are single-machine numbers on Apple silicon, where `time.Now()` is relatively expensive — the ratio will be smaller on linux/amd64, though the direction and the allocation figures won't change.

This type is on the tablet query path: `sync2.ConsolidatorCache` (hit by `Record` for every consolidated query), `txserializer`, and `pools.Numbered.recentlyUnregistered`.

### Two latent defects in the same few lines

Both are on exported methods that have no in-tree callers today, so neither is currently reachable in Vitess. I've fixed them here because each is a one-line change in code this PR already touches, and leaving a known nil-deref in an exported API seemed worse than the small scope creep.

**1. Unsynchronised read.** [`UsedCapacity()`](https://github.com/vitessio/vitess/blob/a7a96c44a81fadab7ba426c71d0b2f940ca0e3d9/go/cache/lru_cache.go#L140-L142) read `lru.size` without holding `lru.mu`, while `Set` and `checkCapacity` wrote it under the lock. `go test -race` reports it.

Instead of adding the missing lock, I deleted the `size` field. It was always exactly equal to `lru.list.Len()` — every `size++` pairs with a `PushFront`, every `size--` with a `Remove`, and `MoveToFront` touches neither — and `container/list` maintains its own O(1) length counter. Removing the duplicate counter removes the state that could be read unsynchronised in the first place.

**2. Nil dereference on negative capacity.** [`checkCapacity`](https://github.com/vitessio/vitess/blob/a7a96c44a81fadab7ba426c71d0b2f940ca0e3d9/go/cache/lru_cache.go#L205-L215)'s condition `lru.size > lru.capacity` stays true after the cache is empty when capacity is negative, so `lru.list.Back()` returns `nil` and the following line dereferences it. `NewLRUCache[T](-1)` followed by any `Set` panics, as does `SetCapacity(-1)` on a non-empty cache.

Added a `lru.list.Len() > 0` guard, which is the loop's actual termination condition. Behaviour is unchanged everywhere the code currently works, including capacity 0 (evict immediately, stay empty).

Also corrected two comments this diff makes wrong or already-wrong: `UsedCapacity` was documented as returning bytes, true before #14850 removed the per-entry `cost` accounting and false since; and "shrank" → "shrunk".

## Decisions

- **Kept `Set`'s unused `bool` return, and the `delete`/`Delete` pair.** Both are dead — nothing in the tree reads the bool, and `Delete` just discards `delete`'s result — but removing them changes an exported signature, which doesn't belong in a diff whose whole argument is "this state is provably unread." Happy to follow up separately if you'd like them gone.
- **Guarded the eviction loop rather than clamping capacity in `SetCapacity`.** Clamping to 0 would make `MaxCapacity()` return 0 after `SetCapacity(-1)`, a visible behaviour change. The guard removes the panic and nothing else.
- **Left `container/list` in place.** Replacing it with an intrusive list (prev/next on `entry[T]` itself) would remove one heap allocation per insert and the four remaining `.(*entry[T])` assertions. That's a rewrite of the internals rather than a deletion, with a smaller payoff that needs its own benchmarks, so it belongs in its own PR rather than riding along with this one.
- **Not proposing a backport.** No user-visible bug is being fixed on a release branch: the perf win is a steady-state improvement and both defects are unreachable from current call sites.

## Tests

Three tests and three benchmarks. Two of the tests fail on `main`, which I checked by running them against the unmodified file:

- `TestNegativeCapacityDoesNotPanic` → `runtime error: invalid memory address or nil pointer dereference`
- `TestUsedCapacityConcurrentWithSet` → `WARNING: DATA RACE` under `-race`
- `TestZeroCapacityEvictsImmediately` passes on `main` as well — it's a characterization test that pins the capacity-0 behaviour the new guard has to preserve.

Verified locally: `go test -race -count=3 ./go/cache/` (33/33 pass, no race warnings), `go vet`, `staticcheck 2025.1.1` with this repo's check set from `.golangci.yml`, and `gofmt`/`gofumpt`/`goimports -local vitess.io/vitess` all clean.

**One thing for reviewers to confirm, since I couldn't.** `go.mod` requires go 1.27.1 and I only have 1.25.4 available, so I ran everything above against a lowered `go` directive in a scratch clone — that change is not part of this PR. `go/cache` depends only on the standard library and testify, so I don't expect a version-dependent difference, but CI is the authority here. For the same reason I couldn't run `golangci-lint` end to end (`scripts/fmt` shells out to `go tool` on 1.27) and ran its formatters plus staticcheck individually instead, which leaves `modernize`, `prealloc`, `whitespace` and `testifylint` unverified locally.

## Related Issue(s)

Fixes #21077

## Checklist

- [x] "Backport to:" labels have been added if this change should be back-ported to release branches
- [x] If this change is to be back-ported to previous releases, a justification is included in the PR description
- [x] Tests were added or are not required
- [x] Did the new or modified tests pass consistently locally and on CI?
- [x] Documentation was added or is not required

## Deployment Notes

None. No flags, schema, or API changes. `LRUCache`'s exported method set is unchanged.

### AI Disclosure

This PR was written primarily by Claude Code (investigation, patch, tests and benchmarks), with direction and review from me.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
